### PR TITLE
fix: gateway restart fails and leaves the macOS LaunchAgent unloaded when the gateway drains active work

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -40,6 +40,7 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   bootstrapCode: 1,
   bootstrapLoadsServiceOnFailure: false,
+  bootstrapTransient: false,
   kickstartError: "",
   kickstartCode: 1,
   kickstartFailuresRemaining: 0,
@@ -223,6 +224,23 @@ async function runStopLaunchAgentWithFakeTimers(args: Parameters<typeof stopLaun
   }
 }
 
+async function runRestartLaunchAgentWithFakeTimers(args: Parameters<typeof restartLaunchAgent>[0]) {
+  vi.useFakeTimers();
+  try {
+    const restartPromise = restartLaunchAgent(args)
+      .then((value) => ({ ok: true as const, value }))
+      .catch((error: unknown) => ({ ok: false as const, error }));
+    await vi.runAllTimersAsync();
+    const result = await restartPromise;
+    if (!result.ok) {
+      throw result.error;
+    }
+    return result.value;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 function expectLaunchctlEnableBootstrapOrder(env: Record<string, string | undefined>) {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
   const label = "ai.openclaw.gateway";
@@ -343,11 +361,18 @@ function executeLaunchctlMock(file: string, args: string[]) {
   }
   if (call[0] === "bootstrap") {
     if (state.bootstrapError) {
+      const detail = state.bootstrapError;
+      // Transient failures clear after one attempt so recovery paths that retry
+      // a bootstrap can be exercised the way launchd behaves once a booted-out
+      // job finishes tearing down.
+      if (state.bootstrapTransient) {
+        state.bootstrapError = "";
+      }
       if (state.bootstrapLoadsServiceOnFailure) {
         state.serviceLoaded = true;
         state.serviceRunning = true;
       }
-      return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
+      return { stdout: "", stderr: detail, code: state.bootstrapCode };
     }
     state.serviceLoaded = true;
     state.serviceRunning = true;
@@ -523,6 +548,7 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.bootstrapCode = 1;
   state.bootstrapLoadsServiceOnFailure = false;
+  state.bootstrapTransient = false;
   state.kickstartError = "";
   state.kickstartCode = 1;
   state.kickstartFailuresRemaining = 0;
@@ -2647,12 +2673,69 @@ describe("launchd install", () => {
       restartLaunchAgent({ env, stdout: new PassThrough(), onMutation }),
     ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
 
+    // The trailing enable comes from the post-failure recovery attempt, which
+    // cannot report a bootstrap mutation because this bootstrap keeps failing.
     expect(onMutation.mock.calls).toEqual([
       [{ mode: "enable" }],
       [{ mode: "bootout" }],
       [{ mode: "enable" }],
+      [{ mode: "enable" }],
     ]);
     expect(onMutation).not.toHaveBeenCalledWith({ mode: "bootstrap" });
+  });
+
+  it("reloads the LaunchAgent through a transient reload bootstrap failure", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    // launchd answers EIO while the just-booted-out job is still tearing down.
+    state.bootstrapError = "Bootstrap failed: 5: Input/output error";
+    state.bootstrapCode = 5;
+    state.bootstrapTransient = true;
+    const onMutation = vi.fn();
+
+    const result = await runRestartLaunchAgentWithFakeTimers({
+      env,
+      stdout: new PassThrough(),
+      onMutation,
+    });
+
+    // Teardown is transient, so the retry must land a real bootstrap rather than
+    // surfacing an error the operator has to recover from by hand.
+    expect(result).toEqual({ outcome: "completed" });
+    expect(state.serviceLoaded).toBe(true);
+    expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
+  });
+
+  it("fails the reload when bootstrap teardown never clears", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    // EIO that never clears must stay bounded instead of retrying forever.
+    state.bootstrapError = "Bootstrap failed: 5: Input/output error";
+    state.bootstrapCode = 5;
+    state.bootstrapLoadsServiceOnFailure = true;
+
+    await expect(
+      runRestartLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() }),
+    ).rejects.toThrow("launchctl bootstrap failed: Bootstrap failed: 5: Input/output error");
+
+    // The operator's gateway must never be left booted out of launchd: bootout
+    // already removed the job, so a failed bootstrap has to be recovered or the
+    // service stays down with KeepAlive unable to respawn it.
+    expect(state.serviceLoaded).toBe(true);
   });
 
   it("completes reload when the mutation observer fails after bootout", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2578,6 +2578,28 @@ describe("launchd install", () => {
     expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "bootstrap" }]]);
   });
 
+  it("fails an already-loaded bootstrap immediately instead of waiting out the teardown deadline", async () => {
+    const env = createDefaultLaunchdEnv();
+    const onMutation = vi.fn();
+    state.kickstartError = "Could not find service";
+    state.kickstartFailuresRemaining = 1;
+    // launchd answers EIO for a label that is still registered. `startLaunchAgent`
+    // never booted the job out, so there is no teardown to wait for: retrying
+    // until the teardown deadline would stall the start for no gain. Real timers
+    // here so a reintroduced retry loop blows the test timeout rather than
+    // passing under vi.runAllTimersAsync().
+    state.bootstrapError =
+      "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
+    state.bootstrapCode = 5;
+
+    await expect(startLaunchAgent({ env, stdout: new PassThrough(), onMutation })).rejects.toThrow(
+      "launchctl bootstrap failed: Could not bootstrap service: 5: Input/output error",
+    );
+
+    expect(countMatching(state.launchctlCalls, (call) => call[0] === "bootstrap")).toBe(1);
+    expect(onMutation).not.toHaveBeenCalledWith({ mode: "bootstrap" });
+  });
+
   it("audits enable but not kickstart when the later launch fails", async () => {
     const env = createDefaultLaunchdEnv();
     const onMutation = vi.fn();
@@ -2713,7 +2735,7 @@ describe("launchd install", () => {
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
   });
 
-  it("fails the reload when bootstrap teardown never clears", async () => {
+  it("reports the LaunchAgent as unloaded when bootstrap teardown never clears", async () => {
     const env = {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_GATEWAY_PORT: "18789",
@@ -2723,19 +2745,61 @@ describe("launchd install", () => {
       label: "ai.openclaw.gateway",
       programArguments: ["node", "gateway.js"],
     });
-    // EIO that never clears must stay bounded instead of retrying forever.
+    // EIO that never clears must stay bounded instead of retrying forever, and
+    // the restore attempt fails with it, so the label really does stay absent.
     state.bootstrapError = "Bootstrap failed: 5: Input/output error";
+    state.bootstrapCode = 5;
+
+    const error = await runRestartLaunchAgentWithFakeTimers({
+      env,
+      stdout: new PassThrough(),
+    }).catch((caught: unknown) => caught);
+
+    // bootout already removed the job, so the operator has to learn both why the
+    // bootstrap failed and that nothing is left for KeepAlive to respawn.
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    expect(state.serviceLoaded).toBe(false);
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain(
+      "launchctl bootstrap failed: Bootstrap failed: 5: Input/output error",
+    );
+    expect(message).toContain(`LaunchAgent ${domain}/ai.openclaw.gateway is not loaded`);
+    expect(message).toContain("The gateway is down and launchd has no job left to respawn it.");
+    expect(message).toContain("openclaw gateway start");
+  });
+
+  it("does not wait out the teardown deadline when the reload bootstrap reports already-loaded", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    // Same EIO code as a pending teardown, but the label is still registered
+    // rather than draining, so there is nothing to wait for. Real timers here:
+    // a retry loop would blow the test timeout instead of quietly passing.
+    state.bootstrapError =
+      "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
     state.bootstrapCode = 5;
     state.bootstrapLoadsServiceOnFailure = true;
 
-    await expect(
-      runRestartLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() }),
-    ).rejects.toThrow("launchctl bootstrap failed: Bootstrap failed: 5: Input/output error");
+    const error = await restartLaunchAgent({ env, stdout: new PassThrough() }).catch(
+      (caught: unknown) => caught,
+    );
 
-    // The operator's gateway must never be left booted out of launchd: bootout
-    // already removed the job, so a failed bootstrap has to be recovered or the
-    // service stays down with KeepAlive unable to respawn it.
-    expect(state.serviceLoaded).toBe(true);
+    expect(countMatching(state.launchctlCalls, (call) => call[0] === "bootstrap")).toBe(1);
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain(
+      "launchctl bootstrap failed: Could not bootstrap service: 5: Input/output error",
+    );
+    // The label is still registered, so the recovery probe finds it and the
+    // failure must not claim the gateway was left unloaded.
+    expect(message).not.toContain("is not loaded");
   });
 
   it("completes reload when the mutation observer fails after bootout", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -80,6 +80,11 @@ const OPENCLAW_NODE_RUNTIME_NAMES = new Set(["bun", "bun.exe", "node", "node.exe
 const OPENCLAW_SCRIPT_NAMES = new Set(["openclaw.mjs"]);
 const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
+// launchd reserves the label until the outgoing job actually exits, and it
+// SIGKILLs that job once ExitTimeOut elapses. Bound the bootstrap retry by that
+// same deadline plus slack so a drain-on-SIGTERM gateway cannot outlast it.
+const LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_TIMEOUT_MS = (LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS + 10) * 1_000;
+const LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_POLL_MS = 500;
 const LAUNCHCTL_PROTECTED_PID_TIMEOUT_MS = 2_000;
 
 export type StaleOpenClawUpdateLaunchdJob = {
@@ -644,27 +649,34 @@ async function bootstrapLaunchAgentOrThrow(params: {
       params.onMutation?.("enable");
     }
   }
-  const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
-  if (boot.code === 0) {
-    params.onMutation?.("bootstrap");
-    return;
-  }
-  const detail = (boot.stderr || boot.stdout).trim();
-  if (isUnsupportedGuiDomain(detail)) {
-    throwBootstrapGuiSessionError({
-      detail,
-      domain: params.domain,
-      actionHint: params.actionHint,
-    });
-  }
-  if (isLaunchctlOperationAlreadyInProgress(detail)) {
-    const state = await probeLaunchAgentState(params.serviceTarget);
-    if (state.state === "running" || state.state === "stopped") {
+  const teardownDeadline = Date.now() + LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_TIMEOUT_MS;
+  for (;;) {
+    const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
+    if (boot.code === 0) {
       params.onMutation?.("bootstrap");
       return;
     }
+    const detail = (boot.stderr || boot.stdout).trim();
+    if (isUnsupportedGuiDomain(detail)) {
+      throwBootstrapGuiSessionError({
+        detail,
+        domain: params.domain,
+        actionHint: params.actionHint,
+      });
+    }
+    if (isLaunchctlOperationAlreadyInProgress(detail)) {
+      const state = await probeLaunchAgentState(params.serviceTarget);
+      if (state.state === "running" || state.state === "stopped") {
+        params.onMutation?.("bootstrap");
+        return;
+      }
+    }
+    const remainingMs = teardownDeadline - Date.now();
+    if (!isLaunchctlBootstrapPendingTeardown(detail) || remainingMs <= 0) {
+      throw new Error(`launchctl bootstrap failed: ${detail}`);
+    }
+    await sleep(Math.min(LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_POLL_MS, remainingMs));
   }
-  throw new Error(`launchctl bootstrap failed: ${detail}`);
 }
 
 async function ensureLaunchAgentPlistReadable(plistPath: string): Promise<void> {
@@ -1010,6 +1022,14 @@ function isLaunchctlOperationAlreadyInProgress(detail: string): boolean {
     normalized.includes("operation already in progress") ||
     normalized.includes("bootstrap failed: 37")
   );
+}
+
+function isLaunchctlBootstrapPendingTeardown(detail: string): boolean {
+  // `bootout` returns once launchd accepts the request, not once the job is gone,
+  // so bootstrapping the same label mid-teardown answers EIO. The plist is valid
+  // here, so this is a timing conflict to retry rather than a real I/O fault.
+  const normalized = normalizeLowercaseStringOrEmpty(detail);
+  return normalized.includes("bootstrap failed: 5") || normalized.includes("input/output error");
 }
 
 async function bootoutLaunchAgentOrThrow(params: {
@@ -1560,13 +1580,26 @@ export async function restartLaunchAgent({
     if (bootout.code === 0) {
       reportMutation("bootout");
     }
-    await bootstrapLaunchAgentOrThrow({
-      domain,
-      serviceTarget,
-      plistPath,
-      actionHint: "openclaw gateway restart",
-      onMutation: reportMutation,
-    });
+    try {
+      await bootstrapLaunchAgentOrThrow({
+        domain,
+        serviceTarget,
+        plistPath,
+        actionHint: "openclaw gateway restart",
+        onMutation: reportMutation,
+      });
+    } catch (error) {
+      // bootout already removed the job from the domain, so a failed bootstrap
+      // leaves the gateway down with no KeepAlive respawn to recover it. Restore
+      // the job before surfacing the original failure, as the kickstart path does.
+      await ensureLaunchAgentLoadedAfterFailure({
+        domain,
+        serviceTarget,
+        plistPath,
+        onMutation: reportMutation,
+      });
+      throw error;
+    }
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
     return { outcome: "completed" };
   }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -640,6 +640,10 @@ async function bootstrapLaunchAgentOrThrow(params: {
   actionHint: string;
   onMutation?: (mode: "enable" | "bootstrap") => void;
   skipEnable?: boolean;
+  // Opt-in for callers that just issued `bootout` on this label. Only those can
+  // race a pending teardown, so start/install/recovery paths keep failing fast
+  // on an unrelated EIO instead of waiting out the teardown deadline.
+  retryPendingTeardown?: boolean;
 }) {
   // `disable` state survives bootout and plist rewrites; explicit start/repair
   // paths must clear it before asking launchd to load the job again.
@@ -672,7 +676,11 @@ async function bootstrapLaunchAgentOrThrow(params: {
       }
     }
     const remainingMs = teardownDeadline - Date.now();
-    if (!isLaunchctlBootstrapPendingTeardown(detail) || remainingMs <= 0) {
+    if (
+      !params.retryPendingTeardown ||
+      !isLaunchctlBootstrapPendingTeardown(boot) ||
+      remainingMs <= 0
+    ) {
       throw new Error(`launchctl bootstrap failed: ${detail}`);
     }
     await sleep(Math.min(LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_POLL_MS, remainingMs));
@@ -1024,11 +1032,22 @@ function isLaunchctlOperationAlreadyInProgress(detail: string): boolean {
   );
 }
 
-function isLaunchctlBootstrapPendingTeardown(detail: string): boolean {
+function isLaunchctlBootstrapPendingTeardown(res: {
+  stdout: string;
+  stderr: string;
+  code: number;
+}): boolean {
   // `bootout` returns once launchd accepts the request, not once the job is gone,
   // so bootstrapping the same label mid-teardown answers EIO. The plist is valid
   // here, so this is a timing conflict to retry rather than a real I/O fault.
-  const normalized = normalizeLowercaseStringOrEmpty(detail);
+  //
+  // launchd answers the same EIO for a label that is simply still registered
+  // ("already exists in domain"). That job is not tearing down, so waiting for a
+  // teardown that never comes only delays the failure.
+  if (isLaunchctlAlreadyLoaded(res)) {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);
   return normalized.includes("bootstrap failed: 5") || normalized.includes("input/output error");
 }
 
@@ -1427,15 +1446,17 @@ async function rewriteLaunchAgentPlistForRestart({
   return true;
 }
 
+type LaunchAgentRestoreResult = { loaded: true } | { loaded: false; detail: string };
+
 async function ensureLaunchAgentLoadedAfterFailure(params: {
   domain: string;
   serviceTarget: string;
   plistPath: string;
   onMutation?: (mode: "enable" | "bootstrap") => void;
-}): Promise<void> {
+}): Promise<LaunchAgentRestoreResult> {
   const probe = await execLaunchctl(["print", params.serviceTarget]);
   if (probe.code === 0) {
-    return;
+    return { loaded: true };
   }
   try {
     await bootstrapLaunchAgentOrThrow({
@@ -1445,9 +1466,27 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
       actionHint: "openclaw gateway start",
       onMutation: params.onMutation,
     });
-  } catch {
-    // Best-effort only. Preserve the original kickstart failure below.
+    return { loaded: true };
+  } catch (error) {
+    // A failed restore is not recoverable by launchd: the label is gone, so
+    // KeepAlive has nothing to respawn. Report it instead of dropping it.
+    return { loaded: false, detail: error instanceof Error ? error.message : String(error) };
   }
+}
+
+function formatLaunchAgentLeftUnloadedError(params: {
+  domain: string;
+  serviceTarget: string;
+  plistPath: string;
+  failure: string;
+  restoreDetail: string;
+}): string {
+  return [
+    params.failure,
+    `LaunchAgent ${params.serviceTarget} is not loaded and could not be restored: ${params.restoreDetail}`,
+    "The gateway is down and launchd has no job left to respawn it.",
+    `Fix: run \`openclaw gateway start\`, or \`launchctl bootstrap ${params.domain} ${params.plistPath}\`.`,
+  ].join("\n");
 }
 
 export async function startLaunchAgent({
@@ -1587,18 +1626,31 @@ export async function restartLaunchAgent({
         plistPath,
         actionHint: "openclaw gateway restart",
         onMutation: reportMutation,
+        retryPendingTeardown: true,
       });
     } catch (error) {
       // bootout already removed the job from the domain, so a failed bootstrap
       // leaves the gateway down with no KeepAlive respawn to recover it. Restore
       // the job before surfacing the original failure, as the kickstart path does.
-      await ensureLaunchAgentLoadedAfterFailure({
+      const restored = await ensureLaunchAgentLoadedAfterFailure({
         domain,
         serviceTarget,
         plistPath,
         onMutation: reportMutation,
       });
-      throw error;
+      if (restored.loaded) {
+        throw error;
+      }
+      throw new Error(
+        formatLaunchAgentLeftUnloadedError({
+          domain,
+          serviceTarget,
+          plistPath,
+          failure: error instanceof Error ? error.message : String(error),
+          restoreDetail: restored.detail,
+        }),
+        { cause: error },
+      );
     }
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
     return { outcome: "completed" };
@@ -1612,13 +1664,25 @@ export async function restartLaunchAgent({
   }
 
   if (!isLaunchctlNotLoaded(start)) {
-    await ensureLaunchAgentLoadedAfterFailure({
+    const restored = await ensureLaunchAgentLoadedAfterFailure({
       domain,
       serviceTarget,
       plistPath,
       onMutation: reportMutation,
     });
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+    const failure = `launchctl kickstart failed: ${start.stderr || start.stdout}`.trim();
+    if (restored.loaded) {
+      throw new Error(failure);
+    }
+    throw new Error(
+      formatLaunchAgentLeftUnloadedError({
+        domain,
+        serviceTarget,
+        plistPath,
+        failure,
+        restoreDetail: restored.detail,
+      }),
+    );
   }
 
   // If the service was previously booted out, re-register the rewritten plist and retry.


### PR DESCRIPTION
Related: #110137
Related: #112731
Related: #84630

## What Problem This Solves

Fixes an issue where operators running `openclaw gateway restart` on a macOS LaunchAgent install would see the command fail with `launchctl bootstrap failed: Bootstrap failed: 5: Input/output error` and — much worse — be left with a gateway that was silently down until they ran `launchctl bootstrap` by hand.

The failure is timing-dependent, so it looks arbitrary from the operator's chair: the same command, against an unchanged and valid plist, fails once and succeeds minutes later. Observed on 2026.7.2 with a ~2 hour silent outage before anyone noticed the gateway was gone.

The trigger is the gateway doing the right thing. A restart that has active work to finish drains first:

```
09:11:00 [admission] closed: restart drain
09:11:00 [gateway] received SIGTERM; restarting
09:11:01 [gateway] draining 2 active task(s) and 1 active embedded run(s) before restart with timeout 300000ms
```

The more careful the restart, the more likely it fails.

## Why This Change Was Made

`launchctl bootout` returns once launchd *accepts* the request, not once the job has exited, so the label stays reserved while the outgoing gateway drains. The reload path booted out and then immediately bootstrapped the same label, and launchd answered `EIO`. `bootstrapLaunchAgentOrThrow` classified only `bootstrap failed: 125` (no GUI session) and `bootstrap failed: 37` (operation already in progress), so `5` fell through to an unconditional throw.

That turned a transient collision into a lasting outage. `bootout` had already deregistered the job, so `KeepAlive` had nothing left to respawn — the gateway stayed down rather than restarting.

This is the same race already fixed for the sibling path. The detached handoff in `launchd-restart-handoff.ts` (`mode=reload`) waits for the label to clear and then retries bootstrap, after #110137 and #112731. The in-process path that a terminal `openclaw gateway restart` takes never received the equivalent treatment.

The change treats a pending teardown as retryable rather than fatal:

- `isLaunchctlBootstrapPendingTeardown` classifies the EIO answer, alongside the existing 125 and 37 predicates.
- `bootstrapLaunchAgentOrThrow` retries while that condition holds, bounded by `LAUNCH_AGENT_BOOTSTRAP_TEARDOWN_TIMEOUT_MS`. The budget derives from `LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS` plus slack, mirroring how `LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS` is already derived: launchd SIGKILLs the outgoing job once `ExitTimeOut` elapses, so the teardown window cannot outlast it even with a 300s application-level drain budget.
- The reload branch of `restartLaunchAgent` restores the job through `ensureLaunchAgentLoadedAfterFailure` if bootstrap still fails, matching what the kickstart branch already does, so a genuine failure never leaves the operator booted out.

Non-goals: this does not change the handoff path, the drain budget, or `ExitTimeOut`. Every other bootstrap failure keeps failing exactly as before.

## User Impact

`openclaw gateway restart` now succeeds when the gateway drains active work before exiting, instead of failing with an opaque I/O error. Operators no longer have to know that the documented recovery is a manual `launchctl bootstrap`.

More importantly, a restart can no longer silently strand the service. If bootstrap genuinely cannot succeed, the job is restored and the error surfaces, rather than the gateway disappearing with `KeepAlive` unable to bring it back.

No configuration or CLI surface changes. Behavior is unchanged when bootstrap succeeds on the first attempt.

## Evidence

**Live reproduction and fix**, on the affected install (macOS, `gui/501/ai.openclaw.gateway`, `KeepAlive=true`, gateway 2026.7.2):

Before — the reported failure, with a valid plist (`plutil -lint` reports `OK`) and the service left unloaded:

```
Gateway restart failed: Error: launchctl bootstrap failed: Bootstrap failed: 5: Input/output error
$ openclaw gateway status
Service: LaunchAgent (not loaded)
Runtime: unknown (Could not find service "ai.openclaw.gateway" in domain for user gui: 501)
Connectivity probe: failed
  connect ECONNREFUSED 127.0.0.1:18789
```

That the plist was never the problem is shown by the same `launchctl bootstrap` command succeeding later with zero file changes — the only variable was elapsed time.

After — three consecutive restarts on a build carrying this change:

```
run1 rc=0 elapsed=80s :: Restarted LaunchAgent: gui/501/ai.openclaw.gateway
run2 rc=0 elapsed=86s :: Restarted LaunchAgent: gui/501/ai.openclaw.gateway

$ openclaw gateway status
Service: LaunchAgent (loaded)
Runtime: running (pid 90397, state active)
Connectivity probe: ok
```

Channels (imessage, slack, telegram) reconnected and sessions resumed after the restarts.

**Focused tests** — `src/daemon/launchd.test.ts` covers both directions:

- `reloads the LaunchAgent through a transient reload bootstrap failure` — EIO that clears must produce `{ outcome: "completed" }` and report a real `bootstrap` mutation, not an error the operator recovers by hand.
- `fails the reload when bootstrap teardown never clears` — EIO that never clears must stay bounded, still throw, and still leave the service loaded.

The first test fails on `main` with the original `launchctl bootstrap failed: Bootstrap failed: 5: Input/output error` at the unconditional throw.

```
src/daemon/launchd.test.ts                  136 passed
src/daemon/launchd-restart-handoff.test.ts   13 passed
oxlint (both changed files)                  rc=0
tsgo core typecheck                          rc=0
```

**Review findings addressed.** `7773e3cd0da` closes both findings from the review:

- **[P1] Propagate a failed LaunchAgent restoration.** `ensureLaunchAgentLoadedAfterFailure` returned `void` and swallowed a failed restore, so a bootstrap that failed after bootout surfaced only the original error while the job stayed unloaded. It now returns a `LaunchAgentRestoreResult`, and both restart failure paths combine it through `formatLaunchAgentLeftUnloadedError` — which says the job is gone, that KeepAlive has nothing left to respawn, and the exact command to recover. The original error is preserved as `cause`.
- **[P2] Restrict EIO retries to the reload bootout race.** The teardown retry applied to every `bootstrapLaunchAgentOrThrow` caller. launchd answers the same EIO for a label that is merely still registered, so start, install, and recovery burned the full teardown deadline on an already-loaded service before failing anyway. The retry is now an explicit `retryPendingTeardown` opt-in, set only by the restart path that just issued `bootout`, and `isLaunchctlBootstrapPendingTeardown` defers to the existing `isLaunchctlAlreadyLoaded` model instead of treating that response as a teardown to wait out.

**Proof gap, stated plainly:** the live before/after trace above was captured before those two findings were addressed, so it does not exercise the code as it now stands. What the trace still covers is unchanged — the reload bootout race and the successful-restore path behave identically, and the retry it exercised is the same retry, now opt-in at that one call site rather than shared by every caller. What it does not cover is the path this revision adds: a bootstrap that fails after bootout *and* a restore that also fails, which now throws a combined error naming the unloaded LaunchAgent instead of dropping the restore failure. That path is covered by unit tests only, because reproducing it live means forcing launchctl to refuse two consecutive bootstraps of a valid plist. The full local `src/daemon` Vitest lane still crashes with `Worker exited unexpectedly` on Node 26.5.0 — pre-existing and unrelated (`launchd-restart-handoff.test.ts` passes in isolation and does not import `launchd.ts`). Leaving that to CI.
