### PR TITLE
Wake parent sessions on ACP task completion

### DIFF
--- a/src/agents/internal-event-contract.ts
+++ b/src/agents/internal-event-contract.ts
@@ -3,6 +3,7 @@
 export const AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION = "task_completion" as const;
 
 const AGENT_INTERNAL_EVENT_SOURCES = [
+  "acp",
   "subagent",
   "cron",
   "image_generation",

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -1,4 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  type AgentInternalEventStatus,
+} from "../agents/internal-event-contract.js";
+import { formatAgentInternalEventsForPlainPrompt } from "../agents/internal-events.js";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
 import { channelSupportsThreadDelivery } from "../channels/thread-addressing.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
@@ -163,6 +168,87 @@ function queueTaskSystemEvent(task: TaskRecord, text: string) {
   return true;
 }
 
+function resolveAcpTaskInternalEventStatus(task: TaskRecord): AgentInternalEventStatus {
+  if (task.status === "succeeded" && task.terminalOutcome !== "blocked") {
+    return "ok";
+  }
+  if (task.status === "timed_out") {
+    return "timeout";
+  }
+  if (
+    task.status === "failed" ||
+    task.status === "cancelled" ||
+    task.status === "lost" ||
+    task.terminalOutcome === "blocked"
+  ) {
+    return "error";
+  }
+  return "unknown";
+}
+
+function formatAcpTerminalContinuationEvent(task: TaskRecord): string {
+  const taskRef = [
+    task.runId ? `runId=${task.runId}` : "",
+    task.childSessionKey ? `childSessionKey=${task.childSessionKey}` : "",
+    task.runId ? "" : `taskId=${task.taskId}`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const result = [
+    "No child output is embedded here.",
+    "Inspect the task/run/session records and artifacts before deciding what to do next.",
+    taskRef,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  return formatAgentInternalEventsForPlainPrompt([
+    {
+      type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+      source: "acp",
+      childSessionKey: task.childSessionKey ?? "",
+      childSessionId: task.sourceId,
+      announceType: "ACP background task",
+      taskLabel: "ACP background task",
+      status: resolveAcpTaskInternalEventStatus(task),
+      statusLabel:
+        task.terminalOutcome === "blocked" ? "blocked" : task.status.replaceAll("_", " "),
+      result,
+      replyInstruction:
+        "A completed ACP task is ready for parent review. Inspect and verify the child task/run/session artifacts before deciding whether the original request is done. If additional action is required, continue the workflow and report a concise blocker only after checking those artifacts.",
+    },
+  ]);
+}
+
+function queueAcpTerminalContinuation(task: TaskRecord) {
+  if (task.runtime !== "acp") {
+    return false;
+  }
+  const owner = resolveTaskDeliveryOwner(task);
+  const ownerKey = owner.sessionKey?.trim();
+  if (!ownerKey) {
+    return false;
+  }
+  const text = formatAcpTerminalContinuationEvent(task);
+  if (!text.trim()) {
+    return false;
+  }
+  const terminalOutcome =
+    task.terminalOutcome ?? (task.status === "succeeded" ? "succeeded" : "none");
+  const continuationKey = task.runId?.trim() || task.taskId;
+  enqueueSystemEvent(text, {
+    sessionKey: ownerKey,
+    contextKey: `task:${continuationKey}:acp-terminal-continuation:${task.status}:${terminalOutcome}`,
+    deliveryContext: owner.requesterOrigin,
+  });
+  requestHeartbeat({
+    source: "background-task",
+    intent: "immediate",
+    reason: "background-task-acp-terminal",
+    sessionKey: ownerKey,
+  });
+  return true;
+}
+
 function queueBlockedTaskFollowup(task: TaskRecord) {
   const followupText = formatTaskBlockedFollowupMessage(task);
   if (!followupText) {
@@ -281,6 +367,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
     if ((shouldRouteParentReview && !shouldDeliverParentReviewDirect) || !canDeliverDirect) {
       try {
         queueTaskSystemEvent(latest, sessionEventText);
+        queueAcpTerminalContinuation(latest);
         if (latest.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(latest);
         }
@@ -327,6 +414,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       if (!afterSend || !shouldAutoDeliverTaskTerminalUpdate(afterSend)) {
         return afterSend ? cloneTaskRecord(afterSend) : null;
       }
+      queueAcpTerminalContinuation(afterSend);
       if (afterSend.terminalOutcome === "blocked") {
         queueBlockedTaskFollowup(afterSend);
       }
@@ -347,6 +435,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       }
       try {
         queueTaskSystemEvent(beforeFallback, sessionEventText);
+        queueAcpTerminalContinuation(beforeFallback);
         if (beforeFallback.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(beforeFallback);
         }

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -503,12 +503,29 @@ async function flushHeartbeatWakeRequests(): Promise<void> {
 }
 
 function expectHeartbeatWake(
-  source: "background-task" | "background-task-blocked",
+  reason: "background-task" | "background-task-acp-terminal" | "background-task-blocked",
   sessionKey: string,
 ) {
+  const source = reason === "background-task-acp-terminal" ? "background-task" : reason;
   expect(heartbeatWakeRequests).toContainEqual(
-    expect.objectContaining({ source, reason: source, sessionKey }),
+    expect.objectContaining({ source, reason, sessionKey }),
   );
+}
+
+function expectAcpContinuationEvent(value: string): void {
+  expect(value).toContain("source: acp");
+  expect(value).toContain("No child output is embedded here.");
+  expect(value).toContain("Inspect the task/run/session records and artifacts");
+}
+
+function expectAcpTerminalSessionEvents(events: string[], terminalMessage: string | RegExp): void {
+  expect(events).toHaveLength(2);
+  if (typeof terminalMessage === "string") {
+    expect(events[0]).toContain(terminalMessage);
+  } else {
+    expect(events[0]).toMatch(terminalMessage);
+  }
+  expectAcpContinuationEvent(events[1] ?? "");
 }
 
 describe("task-registry", () => {
@@ -1703,9 +1720,10 @@ describe("task-registry", () => {
         }),
       );
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -1726,9 +1744,10 @@ describe("task-registry", () => {
         });
 
         await waitForAssertion(() =>
-          expect(peekSystemEvents("agent:main:main")).toEqual([
-            expect.stringContaining("Background task ready for review: ACP background task"),
-          ]),
+          expectAcpTerminalSessionEvents(
+            peekSystemEvents("agent:main:main"),
+            "Background task ready for review: ACP background task",
+          ),
         );
         expectRecordFields(requireTaskById(task.taskId), {
           deliveryStatus: "pending",
@@ -1741,9 +1760,10 @@ describe("task-registry", () => {
         expectRecordFields(requireTaskById(task.taskId), {
           deliveryStatus: "pending",
         });
-        expect(peekSystemEvents("agent:main:main")).toEqual([
-          expect.stringContaining("Background task ready for review: ACP background task"),
-        ]);
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:main"),
+          "Background task ready for review: ACP background task",
+        );
         expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       },
       { durableStore: true },
@@ -1797,7 +1817,7 @@ describe("task-registry", () => {
       expectRecordFields(message.mirror, {
         sessionKey: "agent:main:main",
       });
-      expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[0] ?? "");
     });
   });
 
@@ -1871,7 +1891,7 @@ describe("task-registry", () => {
       expect(String(message.content)).toContain(
         "Next: parent will review/verify before calling it done.",
       );
-      expect(peekSystemEvents(origin.ownerKey)).toStrictEqual([]);
+      expectAcpContinuationEvent(peekSystemEvents(origin.ownerKey)[0] ?? "");
     });
   });
 
@@ -1920,9 +1940,10 @@ describe("task-registry", () => {
         expect(task.deliveryStatus).toBe("session_queued");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:guildchat:channel:room-9")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:guildchat:channel:room-9"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -1968,9 +1989,10 @@ describe("task-registry", () => {
         expect(task.deliveryStatus).toBe("session_queued");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -2044,11 +2066,12 @@ describe("task-registry", () => {
         expect(task.deliveryStatus).toBe("session_queued");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents(ownerKey)).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents(ownerKey),
+        "Background task ready for review: ACP background task",
+      );
       await flushHeartbeatWakeRequests();
-      expectHeartbeatWake("background-task", ownerKey);
+      expectHeartbeatWake("background-task-acp-terminal", ownerKey);
     });
   });
 
@@ -2082,9 +2105,10 @@ describe("task-registry", () => {
         }),
       );
       await waitForAssertion(() => {
-        const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
-        expect(events[0]).toContain("Background task failed: ACP background task");
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:main"),
+          "Background task failed: ACP background task",
+        );
       });
     });
   });
@@ -2112,8 +2136,10 @@ describe("task-registry", () => {
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
         "Background task blocked: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[1] ?? "");
       await flushHeartbeatWakeRequests();
       expectHeartbeatWake("background-task-blocked", "agent:main:main");
     });
@@ -2144,9 +2170,10 @@ describe("task-registry", () => {
           deliveryStatus: "session_queued",
         }),
       );
-      const events = peekSystemEvents("agent:main:main");
-      expect(events).toHaveLength(1);
-      expect(events[0]).toContain("Background task ready for review: ACP background task");
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
+        "Background task ready for review: ACP background task",
+      );
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
   });
@@ -2171,8 +2198,10 @@ describe("task-registry", () => {
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
         "Background task blocked: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[1] ?? "");
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       await flushHeartbeatWakeRequests();
       expectHeartbeatWake("background-task-blocked", "agent:main:main");
@@ -2214,9 +2243,8 @@ describe("task-registry", () => {
       });
 
       await waitForAssertion(() => {
-        const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
-        expect(events[0]).toBe(
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:main"),
           "Background task ready for review: ACP background task (run run-deta). Next: parent will review/verify before calling it done.",
         );
       });
@@ -2249,8 +2277,10 @@ describe("task-registry", () => {
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-bloc). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[0] ?? "");
       await flushHeartbeatWakeRequests();
       expectHeartbeatWake("background-task-blocked", "agent:main:main");
     });
@@ -2275,15 +2305,14 @@ describe("task-registry", () => {
       });
 
       await waitForAssertion(() => {
-        const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
-        expect(events[0]).toBe(
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:main"),
           "Background task ready for review: ACP background task (run run-succ). Created /tmp/file.txt and verified contents. Next: parent will review/verify before calling it done.",
         );
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       await flushHeartbeatWakeRequests();
-      expectHeartbeatWake("background-task", "agent:main:main");
+      expectHeartbeatWake("background-task-acp-terminal", "agent:main:main");
       expect(heartbeatWakeRequests).not.toContainEqual(
         expect.objectContaining({ source: "background-task-blocked" }),
       );
@@ -2394,9 +2423,10 @@ describe("task-registry", () => {
         task: "Spawn ACP child",
         deliveryStatus: "pending",
       });
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -3821,9 +3851,10 @@ describe("task-registry", () => {
       await flushAsyncWork();
 
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
         "Background task ready for review: ACP background task (run run-quie). Next: parent will review/verify before calling it done.",
-      ]);
+      );
       relay.dispose();
       vi.useRealTimers();
     });
@@ -3866,7 +3897,7 @@ describe("task-registry", () => {
         content:
           "Background task failed: ACP background task (run run-fail). Permission denied by ACP runtime",
       });
-      expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[0] ?? "");
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

ACP `mode=run` completions could deliver a short background-task notification without waking the requester session to inspect the child run, verify artifacts, continue the workflow, or report a precise blocker. That made successful child runs easy to strand behind a status message.

## Summary

- Queue an internal ACP completion event for the parent/requester session whenever an ACP task reaches terminal delivery.
- Preserve existing direct/background task notifications while adding a private parent-review continuation prompt.
- Keep blocked follow-up behavior intact and avoid exposing internal completion context in user-facing task status text.

## Evidence

- `pnpm exec vitest run src/tasks/task-registry.test.ts src/tasks/task-status.test.ts src/auto-reply/reply/session.test.ts` passed locally after rebasing: 287/287 tests.
- `pnpm tsgo` passed locally after rebasing.
- Ported onto current upstream `50771abc6a08786a8384811902da26cce0e29790b` after the original review branch proved stale.
