### PR TITLE
fix(line): preserve provider delivery receipts and completed sends

### DIFF
--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
@@ -137,6 +138,79 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
 }
 
 describe("line outbound sendPayload", () => {
+  it("returns the provider receipt for a Flex-only legacy text send", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = {
+      channels: { line: { channelAccessToken: "line-fixture-token" } },
+    } as OpenClawConfig;
+    const providerResponse = new Response(JSON.stringify({ sentMessages: [{ id: "m-flex" }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    const fetch = vi.fn(async () => providerResponse);
+    vi.stubGlobal("fetch", fetch);
+    const onDeliveryResult = vi.fn();
+
+    const result = await lineOutboundAdapter.sendText!({
+      to: "line:user:U123",
+      text: "| Name | Status |\n|---|---|\n| OpenClaw | ready |",
+      accountId: "default",
+      cfg,
+      onDeliveryResult,
+    });
+
+    expect(result.messageId).toBe("m-flex");
+    expect(result.receipt?.platformMessageIds).toEqual(["m-flex"]);
+    expect(result.receipt?.threadId).toBe("c1");
+    expect(mocks.pushFlexMessage).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(expect.objectContaining({ messageId: "m-flex" }));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("publishes completed Flex receipts before a later legacy text send fails", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = {
+      channels: { line: { channelAccessToken: "line-fixture-token" } },
+    } as OpenClawConfig;
+    const laterFailure = new Error("second LINE Flex send failed");
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sentMessages: [{ id: "m-first-flex" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockRejectedValueOnce(laterFailure);
+    vi.stubGlobal("fetch", fetch);
+    mocks.pushFlexMessage
+      .mockResolvedValueOnce(lineResult("m-first-flex"))
+      .mockRejectedValueOnce(laterFailure);
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      lineOutboundAdapter.sendText!({
+        to: "line:user:U123",
+        text: "```js\nfirst()\n```\n\n```js\nsecond()\n```",
+        accountId: "default",
+        cfg,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second LINE Flex send failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "m-first-flex",
+        receipt: expect.objectContaining({ platformMessageIds: ["m-first-flex"] }),
+      }),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("sends flex message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
@@ -193,6 +267,62 @@ describe("line outbound sendPayload", () => {
       "m-text",
       "m-media",
     ]);
+  });
+
+  it("preserves every provider receipt and conversation for an inline LINE batch", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const providerMessageIds = ["line-provider-first", "line-provider-second"] as const;
+    mocks.pushMessagesLine.mockResolvedValueOnce({
+      messageId: providerMessageIds[0],
+      chatId: "C123",
+      receipt: createLineSendReceipt({
+        messageId: providerMessageIds[0],
+        messageIds: providerMessageIds,
+        chatId: "C123",
+        kind: "card",
+        messageCount: 2,
+      }),
+    });
+    const onDeliveryResult = vi.fn();
+
+    const result = await lineOutboundAdapter.sendPayload!({
+      to: "line:group:C123",
+      text: "",
+      payload: {
+        text: "",
+        channelData: {
+          line: {
+            quickReplies: ["Confirm"],
+            flexMessage: { altText: "Review", contents: { type: "bubble" } },
+            location: {
+              title: "Meet here",
+              address: "1 Main Street",
+              latitude: 37.7,
+              longitude: -122.4,
+            },
+          },
+        },
+      },
+      accountId: "default",
+      cfg,
+      onDeliveryResult,
+    });
+
+    expect(result.messageId).toBe("line-provider-first");
+    expect(result.receipt?.platformMessageIds).toEqual(providerMessageIds);
+    expect(result.receipt?.parts.map((part) => part.platformMessageId)).toEqual(providerMessageIds);
+    expect(result.receipt?.threadId).toBe("C123");
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "line-provider-first",
+        receipt: expect.objectContaining({
+          platformMessageIds: providerMessageIds,
+          threadId: "C123",
+        }),
+      }),
+    );
   });
 
   it("sends template message without dropping text", async () => {

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -275,35 +275,13 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
   },
   ...createAttachedChannelResultAdapter({
     channel: "line",
-    sendText: async ({ cfg, to, text, accountId }) => {
-      const outboundRuntime = await loadLineOutboundRuntime();
-      const sendText = outboundRuntime.pushMessageLine;
-      const sendFlex = outboundRuntime.pushFlexMessage;
-      const processed = outboundRuntime.processLineMessage(text);
-      let result: LineSendResult;
-      if (processed.text.trim()) {
-        result = await sendText(to, processed.text, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
-      } else {
-        result = {
-          messageId: "processed",
-          chatId: to,
-          receipt: createLineSendReceipt({ messageId: "processed", chatId: to, kind: "card" }),
-        };
-      }
-      for (const flexMsg of processed.flexMessages) {
-        const flexContents = flexMsg.contents;
-        await sendFlex(to, flexMsg.altText, flexContents, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
-      }
-      return result;
-    },
+    // The payload owner records each physical send before the next fallible step;
+    // bypassing it fabricates Flex-only ids and loses partial-delivery evidence.
+    sendText: async (ctx) =>
+      await lineOutboundAdapter.sendPayload!({
+        ...ctx,
+        payload: { text: ctx.text },
+      }),
     sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) =>
       await (
         await loadLineOutboundRuntime()

--- a/extensions/line/src/send-receipt.ts
+++ b/extensions/line/src/send-receipt.ts
@@ -7,26 +7,25 @@ import {
 
 export function createLineSendReceipt(params: {
   messageId: string;
+  messageIds?: readonly string[];
   chatId: string;
   kind?: MessageReceiptPartKind;
   messageCount?: number;
 }): MessageReceipt {
-  const messageId = params.messageId.trim();
+  const messageIds = (params.messageIds ?? [params.messageId])
+    .map((messageId) => messageId.trim())
+    .filter(Boolean);
   const chatId = params.chatId.trim();
   return createMessageReceiptFromOutboundResults({
-    results: messageId
-      ? [
-          {
-            channel: "line",
-            messageId,
-            chatId,
-            conversationId: chatId,
-            meta: {
-              messageCount: params.messageCount ?? 1,
-            },
-          },
-        ]
-      : [],
+    results: messageIds.map((messageId) => ({
+      channel: "line",
+      messageId,
+      chatId,
+      conversationId: chatId,
+      meta: {
+        messageCount: params.messageCount ?? 1,
+      },
+    })),
     ...(chatId ? { threadId: chatId } : {}),
     kind: params.kind ?? "unknown",
   });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -560,6 +560,37 @@ describe("LINE send helpers", () => {
       provider.mockResolvedValueOnce({ sentMessages: [] });
 
       await expect(send()).rejects.toThrow(/sent message id/i);
+      expect(recordChannelActivityMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      label: "push",
+      send: () =>
+        sendModule.pushMessagesLine("U123", [{ type: "text", text: "Hello" }], {
+          cfg: LINE_TEST_CFG,
+        }),
+      provider: pushMessageMock,
+    },
+    {
+      label: "reply",
+      send: () =>
+        sendModule.sendMessageLine("U123", "Hello", {
+          cfg: LINE_TEST_CFG,
+          replyToken: "reply-token",
+        }),
+      provider: replyMessageMock,
+    },
+  ])(
+    "rejects a partially invalid $label provider receipt without recording delivery",
+    async ({ send, provider }) => {
+      provider.mockResolvedValueOnce({
+        sentMessages: [{ id: "line-provider-delivered" }, { id: "   " }],
+      });
+
+      await expect(send()).rejects.toThrow(/sent message id/i);
+      expect(recordChannelActivityMock).not.toHaveBeenCalled();
     },
   );
 

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -149,8 +149,8 @@ describe("LINE send helpers", () => {
       hostname: "example.com",
       addresses: ["93.184.216.34"],
     });
-    pushMessageMock.mockResolvedValue({});
-    replyMessageMock.mockResolvedValue({});
+    pushMessageMock.mockResolvedValue({ sentMessages: [{ id: "push" }] });
+    replyMessageMock.mockResolvedValue({ sentMessages: [{ id: "reply" }] });
     showLoadingAnimationMock.mockResolvedValue({});
   });
 
@@ -445,6 +445,24 @@ describe("LINE send helpers", () => {
     });
   });
 
+  it("preserves every provider message id returned by a LINE push", async () => {
+    pushMessageMock.mockResolvedValueOnce({
+      sentMessages: [{ id: "613452345678901234" }, { id: "613452345678901235" }],
+    });
+
+    const result = await sendModule.pushMessagesLine(
+      "line:user:U123",
+      [
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+      ],
+      { cfg: LINE_TEST_CFG },
+    );
+
+    expect(result.messageId).toBe("613452345678901234");
+    expect(result.receipt.platformMessageIds).toEqual(["613452345678901234", "613452345678901235"]);
+  });
+
   it("replies when reply token is provided", async () => {
     const result = await sendModule.sendMessageLine("line:group:C1", "Hello", {
       cfg: LINE_TEST_CFG,
@@ -505,6 +523,45 @@ describe("LINE send helpers", () => {
       },
     });
   });
+
+  it("preserves every provider message id returned by a LINE reply", async () => {
+    replyMessageMock.mockResolvedValueOnce({
+      sentMessages: [{ id: "713452345678901234" }, { id: "713452345678901235" }],
+    });
+
+    const result = await sendModule.sendMessageLine("line:group:C1", "Hello", {
+      cfg: LINE_TEST_CFG,
+      replyToken: "reply-token",
+      mediaUrl: "https://example.com/media.jpg",
+    });
+
+    expect(result.messageId).toBe("713452345678901234");
+    expect(result.receipt.platformMessageIds).toEqual(["713452345678901234", "713452345678901235"]);
+  });
+
+  it.each([
+    {
+      label: "push",
+      send: () => sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }),
+      provider: pushMessageMock,
+    },
+    {
+      label: "reply",
+      send: () =>
+        sendModule.sendMessageLine("U123", "Hello", {
+          cfg: LINE_TEST_CFG,
+          replyToken: "reply-token",
+        }),
+      provider: replyMessageMock,
+    },
+  ])(
+    "rejects a $label response that omits its provider message ids",
+    async ({ send, provider }) => {
+      provider.mockResolvedValueOnce({ sentMessages: [] });
+
+      await expect(send()).rejects.toThrow(/sent message id/i);
+    },
+  );
 
   it("preserves literal internal-looking text in low-level sends", async () => {
     const text = "⚠️ 🛠️ `search repos (agent)` failed";

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -75,6 +75,18 @@ interface LineReplyBehavior {
   verboseMessage?: (messageCount: number) => string;
 }
 
+function resolveLineProviderMessageIds(
+  response: messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse,
+  operation: "push" | "reply",
+): { messageId: string; messageIds: string[] } {
+  const messageIds = response?.sentMessages?.map(({ id }) => id.trim()) ?? [];
+  const messageId = messageIds[0];
+  if (!messageId || messageIds.some((id) => !id)) {
+    throw new Error(`LINE ${operation} response did not include a sent message id`);
+  }
+  return { messageId, messageIds };
+}
+
 function normalizeTarget(to: string): string {
   const trimmed = to.trim();
   if (!trimmed) {
@@ -247,14 +259,13 @@ async function pushLineMessages(
     messages: normalizedMessages,
   });
 
-  if (behavior.errorContext) {
-    await pushRequest.catch((err: unknown) => {
-      logLineHttpError(err, behavior.errorContext!);
-      throw err;
-    });
-  } else {
-    await pushRequest;
-  }
+  const response = behavior.errorContext
+    ? await pushRequest.catch((err: unknown) => {
+        logLineHttpError(err, behavior.errorContext!);
+        throw err;
+      })
+    : await pushRequest;
+  const { messageId, messageIds } = resolveLineProviderMessageIds(response, "push");
 
   recordLineOutboundActivity(account.accountId);
 
@@ -266,10 +277,11 @@ async function pushLineMessages(
   }
 
   return {
-    messageId: "push",
+    messageId,
     chatId,
     receipt: createLineSendReceipt({
-      messageId: "push",
+      messageId,
+      messageIds,
       chatId,
       kind: resolveLineReceiptKind(messages),
       messageCount: messages.length,
@@ -282,14 +294,15 @@ async function replyLineMessages(
   messages: Message[],
   opts: LinePushOpts,
   behavior: LineReplyBehavior = {},
-): Promise<void> {
+): Promise<{ messageId: string; messageIds: string[] }> {
   const { account, client } = createLineMessagingClient(opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
 
-  await client.replyMessage({
+  const response = await client.replyMessage({
     replyToken,
     messages: normalizedMessages,
   });
+  const result = resolveLineProviderMessageIds(response, "reply");
 
   recordLineOutboundActivity(account.accountId);
 
@@ -299,6 +312,8 @@ async function replyLineMessages(
         `line: replied with ${messages.length} messages`,
     );
   }
+
+  return result;
 }
 
 export async function sendMessageLine(
@@ -346,15 +361,16 @@ export async function sendMessageLine(
   }
 
   if (opts.replyToken) {
-    await replyLineMessages(opts.replyToken, messages, opts, {
+    const { messageId, messageIds } = await replyLineMessages(opts.replyToken, messages, opts, {
       verboseMessage: () => `line: replied to ${chatId}`,
     });
 
     return {
-      messageId: "reply",
+      messageId,
       chatId,
       receipt: createLineSendReceipt({
-        messageId: "reply",
+        messageId,
+        messageIds,
         chatId,
         kind: resolveLineReceiptKind(messages),
         messageCount: messages.length,


### PR DESCRIPTION
Branch: `codex/auto-qa-line-provider-receipts`
Commit: `247ec36f48fc629e979a5bcfaf0ac9e07817fad7`
Base: `e051a7bb4a6ba69b87391e990b00813114b1d482`

## Summary

- Use actual LINE provider-assigned IDs for both push and reply sends, returning the first physical ID as the primary result and every ordered ID in the existing receipt.
- Preserve conversation/thread metadata and completed physical-send callbacks for batched and partial deliveries.
- Route the legacy text adapter through the existing canonical payload owner, deleting its duplicated sender, fabricated `processed` Flex-only receipt, and missing partial-delivery reporting.
- Reject empty or partially invalid provider identity responses before recording successful outbound activity.

## Root cause and dependency proof

1. **Discarded LINE provider send identities:** the canonical push/reply owner ignored required SDK responses and manufactured literal `push`/`reply` message IDs, losing every actual physical delivery identity.
2. **Duplicated legacy LINE text delivery owner:** the separate legacy text implementation fabricated `processed` for Flex-only Markdown and bypassed the canonical physical-send progress callback, so completed delivery evidence disappeared when a later Flex send failed.

The installed LINE SDK requires `sentMessages: Array<SentMessage>` with **1–5** entries for pushes at `node_modules/@line/bot-sdk/lib/messaging-api/model/pushMessageResponse.ts:18` and replies at `node_modules/@line/bot-sdk/lib/messaging-api/model/replyMessageResponse.ts:18`; `node_modules/@line/bot-sdk/lib/messaging-api/model/sentMessage.ts:13` requires each provider `id: string`.

`extensions/line/src/send.ts:78` validates that contract for both operations, `extensions/line/src/send-receipt.ts:8` keeps ordered physical receipt parts, and `extensions/line/src/outbound.ts:278` delegates the legacy sender to the canonical payload owner without changing public SDK, configuration, protocol, or authentication contracts.

## Verification

- Independently reproduced the existing provider-ID failures and two additional red-before legacy-owner regressions: `processed` instead of `m-flex`, and zero completed-send callbacks before a second Flex send failed.
- `node scripts/run-vitest.mjs extensions/line/src/send.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/auto-reply-delivery.test.ts extensions/line/src/auto-reply-delivery-recovery.test.ts extensions/line/src/markdown-to-line.test.ts`: **107 tests passed on final commit `247ec36f48fc629e979a5bcfaf0ac9e07817fad7`** using supported Node 24.18.
- Coverage includes push/reply IDs, ordered multi-message receipt parts, conversation/thread preservation, malformed partial responses, Flex-only legacy delivery, exactly-once successful callbacks, completed-send evidence before later failure, auto-reply recovery, and Markdown conversion.
- `git merge-base e051a7bb4a6ba69b87391e990b00813114b1d482 HEAD` returns `e051a7bb4a6ba69b87391e990b00813114b1d482`; the branch diff contains only five `extensions/line` files.
- Targeted `oxfmt --check` and `git diff --check` pass; the branch worktree is clean.
- Genuine structured commit-mode Codex autoreview on the exact final head: **TruffleHog clean; no accepted/actionable findings; patch correct at 0.94 confidence**. An earlier speculative duplicate-callback concern was disproven by `src/plugin-sdk/channel-send-result.ts:68` and an explicit passing exactly-once delivery-callback regression.

## Root causes fixed

**2 distinct canonical LINE provider-identity and legacy-delivery-owner defects.**
