### PR TITLE
fix(gateway): apply conditional requests consistently to media

### DIFF
--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -72,6 +72,24 @@ describe("Control UI assistant media e2e", () => {
         expect(head.headers.get("etag")).toBe(ranged.headers.get("etag"));
         expect(await head.text()).toBe("");
 
+        for (const method of ["GET", "HEAD"]) {
+          const notModified = await fetch(
+            `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
+            {
+              method,
+              headers: {
+                "If-None-Match": `W/${ranged.headers.get("etag")}`,
+                Range: "bytes=9-15",
+                "If-Range": '"stale"',
+              },
+            },
+          );
+          expect(notModified.status).toBe(304);
+          expect(notModified.headers.get("etag")).toBe(ranged.headers.get("etag"));
+          expect(notModified.headers.get("content-length")).toBeNull();
+          expect(await notModified.text()).toBe("");
+        }
+
         const emptyFilePath = path.join(mediaDir, "empty.bin");
         await fs.writeFile(emptyFilePath, Buffer.alloc(0));
         const empty = await fetch(`${route}?source=${encodeURIComponent(emptyFilePath)}`, {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -567,6 +567,44 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it.each(["GET", "HEAD"] as const)(
+    "revalidates assistant media ETags before ranges for %s",
+    async (method) => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-conditional-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "photo.png");
+          await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
+          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
+          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
+          expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+
+          const conditional = await runAssistantMediaRequest({
+            url,
+            method,
+            auth,
+            headers: {
+              "if-none-match": `W/${String(etag)}`,
+              range: "bytes=0-3",
+              "if-range": '"stale"',
+            },
+          });
+
+          expect(conditional.handled).toBe(true);
+          expect(conditional.res.statusCode).toBe(304);
+          expect(conditional.setHeader).toHaveBeenCalledWith("ETag", etag);
+          expect(conditional.setHeader).not.toHaveBeenCalledWith(
+            "Content-Length",
+            expect.anything(),
+          );
+          expect(conditional.end).toHaveBeenCalledWith();
+        },
+      });
+    },
+  );
+
   it("returns 202 while assistant playback media is preparing", async () => {
     resolvePlaybackTranscodeMock.mockResolvedValueOnce({ kind: "preparing" });
     await withAllowedAssistantMediaRoot({

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -735,9 +735,15 @@ export async function handleControlUiAssistantMediaRequest(
       method: req.method,
       rangeHeader: req.headers.range,
       ifRangeHeader: req.headers["if-range"],
+      ifNoneMatchHeader: req.headers["if-none-match"],
     });
     writeByteHeaders(res, byteResponse);
-    if (req.method === "HEAD" || byteResponse.kind === "unsatisfiable" || opened.stat.size === 0) {
+    if (
+      req.method === "HEAD" ||
+      byteResponse.kind === "not-modified" ||
+      byteResponse.kind === "unsatisfiable" ||
+      opened.stat.size === 0
+    ) {
       await closeOpenedHandle();
       res.end();
       return true;

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -87,6 +87,60 @@ describe("resolveByteResponse", () => {
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
+
+  it.each([
+    { label: "exact", header: (etag: string) => etag },
+    { label: "weak", header: (etag: string) => `W/${etag}` },
+    { label: "wildcard", header: () => "*" },
+    { label: "list", header: (etag: string) => `"other", ${etag}` },
+    { label: "multiple headers", header: (etag: string) => ['"other"', `W/${etag}`] },
+  ])("returns 304 for a matching $label If-None-Match validator", ({ header }) => {
+    const etag = resolveByteResponse({ file: FILE }).etag;
+    const plan = resolveByteResponse({
+      file: FILE,
+      method: "GET",
+      ifNoneMatchHeader: header(etag),
+    });
+
+    expect(plan).toEqual({ kind: "not-modified", statusCode: 304, etag });
+    const setHeader = vi.fn();
+    const res = { statusCode: 0, setHeader } as unknown as ServerResponse;
+    writeByteHeaders(res, plan);
+    expect(res.statusCode).toBe(304);
+    expect(setHeader).toHaveBeenCalledWith("ETag", etag);
+    expect(setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
+  });
+
+  it.each(["GET", "HEAD"])(
+    "evaluates matching If-None-Match before Range and If-Range for %s",
+    (method) => {
+      const etag = resolveByteResponse({ file: FILE }).etag;
+
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          method,
+          rangeHeader: "bytes=1-2",
+          ifRangeHeader: '"stale"',
+          ifNoneMatchHeader: etag,
+        }),
+      ).toEqual({ kind: "not-modified", statusCode: 304, etag });
+    },
+  );
+
+  it("keeps the requested range when If-None-Match does not match", () => {
+    const etag = resolveByteResponse({ file: FILE }).etag;
+
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        rangeHeader: "bytes=1-2",
+        ifRangeHeader: etag,
+        ifNoneMatchHeader: '"stale"',
+      }),
+    ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
+  });
 });
 
 describe("byte ETag generation", () => {

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { ServerResponse } from "node:http";
+import { matchesHttpIfNoneMatch } from "./http-conditional.js";
 
 type FileIdentity = {
   size: number;
@@ -32,6 +33,11 @@ type ByteResponsePlan =
       contentLength: 0;
       etag: string;
       size: number;
+    }
+  | {
+      kind: "not-modified";
+      statusCode: 304;
+      etag: string;
     };
 
 function createByteEtag(file: FileIdentity): string {
@@ -80,8 +86,16 @@ export function resolveByteResponse(params: {
   method?: string;
   rangeHeader?: string | string[];
   ifRangeHeader?: string | string[];
+  ifNoneMatchHeader?: string | string[];
 }): ByteResponsePlan {
   const etag = createByteEtag(params.file);
+  if (
+    (params.method === "GET" || params.method === "HEAD") &&
+    matchesHttpIfNoneMatch(params.ifNoneMatchHeader, etag)
+  ) {
+    // RFC 9110 evaluates representation validators before Range or If-Range.
+    return { kind: "not-modified", statusCode: 304, etag };
+  }
   const full = {
     kind: "full",
     statusCode: 200,
@@ -122,6 +136,9 @@ export function writeByteHeaders(res: ServerResponse, plan: ByteResponsePlan): v
   res.statusCode = plan.statusCode;
   res.setHeader("Accept-Ranges", "bytes");
   res.setHeader("ETag", plan.etag);
+  if (plan.kind === "not-modified") {
+    return;
+  }
   res.setHeader("Content-Length", String(plan.contentLength));
   if (plan.kind === "partial") {
     res.setHeader("Content-Range", `bytes ${plan.range.start}-${plan.range.end}/${plan.size}`);

--- a/src/gateway/http-conditional.ts
+++ b/src/gateway/http-conditional.ts
@@ -1,0 +1,14 @@
+// HTTP conditional requests use weak entity-tag comparison for representation reuse.
+export function matchesHttpIfNoneMatch(
+  header: string | string[] | undefined,
+  etag: string,
+): boolean {
+  const value = Array.isArray(header) ? header.join(",") : header;
+  if (!value) {
+    return false;
+  }
+  return value.split(",").some((candidate) => {
+    const tag = candidate.trim();
+    return tag === "*" || tag === etag || (tag.startsWith("W/") && tag.slice(2) === etag);
+  });
+}

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -416,6 +416,39 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.body.toString("utf8")).toBe("image");
   });
 
+  it.each(["GET", "HEAD"])(
+    "revalidates managed media ETags before ranges for %s",
+    async (method) => {
+      const { attachmentId, sessionKey } = await createFixture(stateDir);
+      const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+      const initial = await requestManagedImage({
+        stateDir,
+        pathName,
+        authResponse: { authMethod: "token" },
+      });
+      const etag = initial.result.headers.etag;
+      expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName,
+        method,
+        authResponse: { authMethod: "token" },
+        headers: {
+          "if-none-match": `W/${String(etag)}`,
+          range: "bytes=0-3",
+          "if-range": '"stale"',
+        },
+      });
+
+      expect(result.statusCode).toBe(304);
+      expect(result.headers.etag).toBe(etag);
+      expect(result.headers["content-length"]).toBeUndefined();
+      expect(result.headers["content-range"]).toBeUndefined();
+      expect(result.body).toHaveLength(0);
+    },
+  );
+
   it("serves a ticketed byte range from managed audio", async () => {
     const body = Buffer.from("original-audio");
     const { attachmentId, sessionKey } = await createFixture(stateDir, {

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1518,9 +1518,15 @@ export async function handleManagedOutgoingMediaHttpRequest(
     method: req.method,
     rangeHeader: req.headers.range,
     ifRangeHeader: req.headers["if-range"],
+    ifNoneMatchHeader: req.headers["if-none-match"],
   });
   writeByteHeaders(res, byteResponse);
-  if (req.method === "HEAD" || byteResponse.kind === "unsatisfiable" || opened.stat.size === 0) {
+  if (
+    req.method === "HEAD" ||
+    byteResponse.kind === "not-modified" ||
+    byteResponse.kind === "unsatisfiable" ||
+    opened.stat.size === 0
+  ) {
     await closeOpenedHandle();
     res.end();
     return true;

--- a/src/gateway/user-profiles-http.ts
+++ b/src/gateway/user-profiles-http.ts
@@ -12,6 +12,7 @@ import {
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { matchesHttpIfNoneMatch } from "./http-conditional.js";
 import {
   authorizeScopedGatewayHttpRequestOrReply,
   resolveSharedSecretHttpOperatorScopes,
@@ -267,7 +268,7 @@ function sendAvatar(
   avatar: { bytes: Uint8Array; mime: string; etag: string },
   cacheControl: string,
 ): void {
-  if (ifNoneMatchMatches(req.headers["if-none-match"], avatar.etag)) {
+  if (matchesHttpIfNoneMatch(req.headers["if-none-match"], avatar.etag)) {
     // Carry the success cache policy so a 304 does not inherit the miss-path
     // no-store and force the client to re-download an unchanged avatar.
     res.writeHead(304, { ETag: avatar.etag, "Cache-Control": cacheControl });
@@ -403,17 +404,4 @@ export async function handleUserProfileAvatarHttpRequest(
     error: { type: transientFailure ? "avatar_upstream_unavailable" : "not_found" },
   });
   return true;
-}
-
-// RFC 9110 §13.1.2 weak comparison: wildcard, comma-separated lists, and W/ prefixes
-// all revalidate; exact-string matching alone would miss proxy-normalized headers.
-function ifNoneMatchMatches(header: string | string[] | undefined, etag: string): boolean {
-  const value = Array.isArray(header) ? header.join(",") : header;
-  if (!value) {
-    return false;
-  }
-  return value.split(",").some((candidate) => {
-    const tag = candidate.trim();
-    return tag === "*" || tag === etag || (tag.startsWith("W/") && tag.slice(2) === etag);
-  });
 }


### PR DESCRIPTION
## Summary

- Fix one shared Gateway media-validator root cause affecting both assistant-media downloads and managed outgoing attachments.
- Extract the already-working avatar validator into one canonical lightweight HTTP conditional owner; remove duplicate matching logic across all three Gateway representation owners.
- Honor exact, weak, wildcard, comma-list, and repeated `If-None-Match` validators for both `GET` and `HEAD` before considering `Range` or `If-Range`.
- Return a bodyless `304 Not Modified` without `Content-Length`, close the existing verified file descriptor, and preserve stale-validator `206` ranges, authentication, path ownership, playback behavior, and cache policy.

## Root cause

`src/gateway/http-byte-range.ts` generated and advertised strong media ETags, but its response-planning contract accepted only `Range` and `If-Range`. Both `src/gateway/control-ui.ts` and `src/gateway/managed-image-attachments.ts` consequently resent complete or partial representations for a matching browser validator. Assistant media additionally advertises `Cache-Control: no-cache`, so every ordinary browser revalidation retransmitted the full file.

RFC 9110 section 13.1.2 requires matching `If-None-Match` validators on `GET` or `HEAD` to produce `304`; section 13.2.2 evaluates representation preconditions before byte ranges. The existing avatar sibling already implemented the correct weak-comparison contract privately. This refactor moves that contract into `src/gateway/http-conditional.ts` and makes the avatar and both media owners consume the same authoritative decision.

## Verification

- Frozen canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Branch: `codex/qa100-gateway-media-conditional`.
- Candidate commit: `c9f8e8de9c968a4cd38c1f07553162b4a3469709`; its direct parent and merge base are the frozen canonical baseline `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Current-main owner reproduction: a matching `GET` incorrectly returned **206**, while a matching `HEAD` incorrectly returned **200**; both must return `304` before range processing.
- Exact rebased commit shared conditional/byte owner and existing avatar sibling proof: **48 passed, zero failed**.
- Separate exact rebased commit assistant and managed-media authenticated real HTTP `GET`/`HEAD` owner proof: **12 passed, zero failed**.
- Full actual Gateway HTTP transport E2E on the identical patch before its conflict-free rebase: **1 passed**; ticketed conditional `GET` and `HEAD` both return **304** with no `Content-Length`, while weak validators correctly take precedence over `Range` and stale `If-Range`.
- Genuine TruffleHog 3.96.0 scanned all nine changed files (**396,209 bytes; zero verified or unverified secrets**). Targeted `oxfmt --check` on all nine changed paths, `git diff --check`, and separate fresh independent exact-head owner review: clean.

## Root causes fixed

**1** shared media conditional-validator planning defect; two HTTP owners are affected siblings, not two separate roots.
