### PR TITLE
fix(cron): retain final outcomes when jobs remove themselves

### DIFF
--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -554,22 +554,14 @@ export function applyOutcomeToStoredJob(
       tryFinishCronTaskRunWithoutHistory(state, result);
       return undefined;
     }
-    if (result.status === "ok") {
-      // A manual/queued run may finish after the job was removed. Preserve the
-      // successful run-history state without resurrecting the job in the store.
-      applyJobResult(state, result.job, result);
-      emitJobFinished(state, result.job, result, result.startedAt);
-      state.deps.log.info(
-        { jobId: result.jobId },
-        "cron: finalized successful run after job was removed during execution",
-      );
-      return undefined;
-    }
-    state.deps.log.warn(
-      { jobId: result.jobId },
-      "cron: applyOutcomeToStoredJob — job not found after forceReload, result discarded",
+    // A run may finish after its job disappears; finalize the admitted job
+    // snapshot so operator history survives without reviving the stored job.
+    applyJobResult(state, result.job, result);
+    emitJobFinished(state, result.job, result, result.startedAt);
+    state.deps.log.info(
+      { jobId: result.jobId, status: result.status },
+      "cron: finalized run after job was removed during execution",
     );
-    tryFinishCronTaskRunWithoutHistory(state, result);
     return undefined;
   }
 

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -27,6 +27,8 @@ import {
 import * as schedule from "../schedule.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
 import { cancelActiveCronTaskRun } from "./active-run-cancellation.js";
 import { resetActiveCronTaskRunsForTests } from "./active-run-cancellation.test-support.js";
@@ -2712,8 +2714,8 @@ describe("cron service timer regressions", () => {
       ),
     ).toBe(false);
     expect(log.info).toHaveBeenCalledWith(
-      { jobId: selfRemovingJob.id },
-      "cron: finalized successful run after job was removed during execution",
+      { jobId: selfRemovingJob.id, status: "ok" },
+      "cron: finalized run after job was removed during execution",
     );
     const event = events.find(
       (candidate) => candidate.jobId === selfRemovingJob.id && candidate.action === "finished",
@@ -2728,54 +2730,92 @@ describe("cron service timer regressions", () => {
     expect(event.deliveryStatus).toBe("delivered");
   });
 
-  it("keeps missing-job discard semantics for failed isolated outcomes", async () => {
-    const store = timerRegressionFixtures.makeStorePath();
-    const dueAt = Date.parse("2026-02-06T10:05:01.000Z");
-    const failedJob = createDueIsolatedJob({
-      id: "self-removing-failure",
-      nowMs: dueAt,
-      nextRunAtMs: dueAt,
-    });
-    await saveCronStore(store.storePath, { version: 1, jobs: [failedJob] });
+  it.each([
+    {
+      outcome: "failure",
+      status: "error",
+      error: "agent failed after removal",
+      taskStatus: "failed",
+    },
+    {
+      outcome: "timeout",
+      status: "error",
+      error: "cron: job execution timed out",
+      taskStatus: "timed_out",
+    },
+    {
+      outcome: "skip",
+      status: "skipped",
+      error: "agent skipped after removal",
+      taskStatus: "succeeded",
+    },
+  ] as const)(
+    "finalizes a removed job's $outcome outcome in operator history",
+    async ({ outcome, status, error, taskStatus }) => {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:01.000Z");
+      const failedJob = createDueIsolatedJob({
+        id: `self-removing-${outcome}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [failedJob] });
 
-    const events: CronEvent[] = [];
-    const log = {
-      ...noopLogger,
-      warn: vi.fn(),
-    };
-    const state = createCronServiceState({
-      cronEnabled: true,
-      storePath: store.storePath,
-      log,
-      nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
-      onEvent: (evt) => {
-        events.push(evt);
-      },
-      runIsolatedAgentJob: vi.fn(async () => {
-        const persisted = await loadCronStore(store.storePath);
-        await saveCronStore(store.storePath, {
-          ...persisted,
-          jobs: persisted.jobs.filter((job) => job.id !== failedJob.id),
-        });
-        return { status: "error" as const, error: "agent failed after removal" };
-      }),
-    });
+      const events: CronEvent[] = [];
+      const log = {
+        ...noopLogger,
+        warn: vi.fn(),
+      };
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log,
+        nowMs: () => dueAt,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onEvent: (evt) => {
+          events.push(evt);
+        },
+        runIsolatedAgentJob: vi.fn(async () => {
+          const persisted = await loadCronStore(store.storePath);
+          await saveCronStore(store.storePath, {
+            ...persisted,
+            jobs: persisted.jobs.filter((job) => job.id !== failedJob.id),
+          });
+          return { status, error };
+        }),
+      });
 
-    await onTimer(state);
+      await onTimer(state);
 
-    expect(state.store?.jobs).toStrictEqual([]);
-    expect(log.warn).toHaveBeenCalledWith(
-      { jobId: failedJob.id },
-      "cron: applyOutcomeToStoredJob — job not found after forceReload, result discarded",
-    );
-    expect(
-      events.some(
-        (evt) => evt.jobId === failedJob.id && evt.action === "finished" && evt.status === "error",
-      ),
-    ).toBe(false);
-  });
+      expect(state.store?.jobs).toStrictEqual([]);
+      expect(
+        log.warn.mock.calls.some(
+          ([, message]) =>
+            message ===
+            "cron: applyOutcomeToStoredJob — job not found after forceReload, result discarded",
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          jobId: failedJob.id,
+          action: "finished",
+          status,
+          error,
+        }),
+      );
+      const history = readCronTaskRunHistoryPage({
+        storeKey: cronStoreKey(store.storePath),
+        jobId: failedJob.id,
+      });
+      expect(history.entries).toEqual([
+        expect.objectContaining({ jobId: failedJob.id, status, error }),
+      ]);
+      expect(listTaskRecords().find((task) => task.sourceId === failedJob.id)?.status).toBe(
+        taskStatus,
+      );
+    },
+  );
 
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");


### PR DESCRIPTION
# fix(cron): retain terminal history after job removal

## Summary

- Finalize failed, timed-out, and skipped cron runs even when the running job removes itself or disappears before completion.
- Route every real terminal outcome through the existing shared cron completion owner, preserving completion events, durable operator-visible run history, task status classification, and failure-alert behavior without resurrecting removed jobs.
- Keep quiet, non-firing trigger evaluations intentionally absent from run history and preserve same-ID replacement isolation.

## Root cause

The cron completion owner already finalized successful removed-job runs but explicitly discarded every other terminal outcome. The task ledger received a terminal status without canonical cron history detail, making failed, timed-out, and skipped runs disappear from `cron.runs`.

## Verification

- RED: all three new failure, timeout, and skipped removed-job regressions failed against the current frozen `main`.
- GREEN: **9 focused tests pass across 3 cron suites**, covering those three outcomes, successful self-removal, four same-ID replacement permutations, and quiet-trigger completion semantics.
- Independent read-only review: **CLEAN**; verified completion ownership, failure alerts, replacement isolation, timeout/skipped task classification, quiet-trigger history, and the public Gateway history path.
- Structured autoreview: **CLEAN**, including a verified **TruffleHog clean** credential scan.
- Targeted formatting and `git diff --check`: **CLEAN**.

## Landing identity

- Branch: `codex/auto-qa-cron-runs`
- Commit: `bc2adcd1b5323d141cf47a81d3df5195c8a76b49`
- Pinned parent: `e051a7bb4a6ba69b87391e990b00813114b1d482`
- Root causes fixed: **1 shared cron completion-owner defect**.
- No SQLite/schema, protocol, configuration, security, fetch, push, or `main` changes.
