### PR TITLE
fix(browser): recover Copilot storage queues after failed writes

### DIFF
--- a/extensions/browser/chrome-extension/modules/copilot-background.test.ts
+++ b/extensions/browser/chrome-extension/modules/copilot-background.test.ts
@@ -448,6 +448,7 @@ describe("browser copilot background", () => {
     const gatewayScope = "ws://127.0.0.1:18789/";
     const revokeDebugger = vi.fn(async () => undefined);
     const request = vi.fn(async () => ({ ok: true }));
+    const localStorage = storageArea();
     const gateway = {
       ready: true,
       onEvent: vi.fn(),
@@ -460,7 +461,7 @@ describe("browser copilot background", () => {
       chromeApi: {
         runtime: { onConnect: eventHook() },
         tabs: { query: vi.fn(async () => [{ id: 12 }]) },
-        storage: { local: storageArea(), session: storageArea() },
+        storage: { local: localStorage, session: storageArea() },
       } as never,
       getConfig: vi.fn(async () => ({
         relayUrl: "ws://127.0.0.1:18792/browser/extension",
@@ -479,6 +480,7 @@ describe("browser copilot background", () => {
     await controller.onRelayStatus({ ready: true, label: "Browser relay connected" });
     await controller.registry.put(12, { gatewayScope, sessionKey: "session-12" });
     await controller.registry.startRun(12, gatewayScope, "run-12");
+    localStorage.set.mockRejectedValueOnce(new Error("transient session storage failure"));
 
     await controller.onRelayStatus({ ready: false, label: "Browser relay reconnecting" });
 
@@ -488,6 +490,10 @@ describe("browser copilot background", () => {
       runId: "run-12",
     });
     expect(controller.registry.pendingAborts(gatewayScope)).toEqual([]);
+    await expect(
+      controller.onRelayStatus({ ready: true, label: "Browser relay connected" }),
+    ).resolves.toBeUndefined();
+    expect(controller.registry.get(12, gatewayScope)).not.toHaveProperty("activeRunId");
   });
 
   it("restores durable debugger denial before a suspended worker reconnects", async () => {

--- a/extensions/browser/chrome-extension/modules/copilot-session-registry.js
+++ b/extensions/browser/chrome-extension/modules/copilot-session-registry.js
@@ -6,13 +6,23 @@ function emptyState() {
   return { sessions: {}, pendingArchives: [] };
 }
 
+function createStorageWriteQueue() {
+  let tail = Promise.resolve();
+  return (operation) => {
+    const result = tail.then(operation);
+    // Preserve this caller's error while keeping later writes ordered and runnable.
+    tail = result.catch(() => undefined);
+    return result;
+  };
+}
+
 /** Browser-instance-only capabilities bind same-path panel documents to tabs. */
 export class CopilotPanelBindingRegistry {
   constructor(storage = chrome.storage.session) {
     this.storage = storage;
     this.byTab = {};
     this.ready = null;
-    this.writeChain = Promise.resolve();
+    this.enqueueWrite = createStorageWriteQueue();
   }
 
   async initialize() {
@@ -27,19 +37,23 @@ export class CopilotPanelBindingRegistry {
 
   async bind(tabId) {
     await this.initialize();
-    let token;
-    this.writeChain = this.writeChain.then(async () => {
-      const current = this.byTab[String(tabId)];
+    return await this.enqueueWrite(async () => {
+      const key = String(tabId);
+      const current = this.byTab[key];
       if (typeof current === "string" && current) {
-        token = current;
-        return;
+        return current;
       }
-      token = crypto.randomUUID();
-      this.byTab[String(tabId)] = token;
-      await this.storage.set({ [PANEL_BINDINGS_KEY]: this.byTab });
+      const token = crypto.randomUUID();
+      this.byTab[key] = token;
+      try {
+        await this.storage.set({ [PANEL_BINDINGS_KEY]: this.byTab });
+      } catch (error) {
+        // An undurable capability must not make a queued bind skip persistence.
+        delete this.byTab[key];
+        throw error;
+      }
+      return token;
     });
-    await this.writeChain;
-    return token;
   }
 
   async resolve(token) {
@@ -60,11 +74,10 @@ export class CopilotPanelBindingRegistry {
   }
 
   async #mutate(run) {
-    this.writeChain = this.writeChain.then(async () => {
+    await this.enqueueWrite(async () => {
       run();
       await this.storage.set({ [PANEL_BINDINGS_KEY]: this.byTab });
     });
-    await this.writeChain;
   }
 }
 
@@ -75,7 +88,7 @@ export class CopilotSessionRegistry {
     this.state = emptyState();
     this.instanceId = null;
     this.ready = null;
-    this.writeChain = Promise.resolve();
+    this.enqueueWrite = createStorageWriteQueue();
   }
 
   async initialize(existingTabIds) {
@@ -145,7 +158,7 @@ export class CopilotSessionRegistry {
     await this.#mutate(() => {
       const current = this.state.sessions[String(tabId)];
       if (current && current.gatewayScope !== entry.gatewayScope) {
-        // The write chain transfers old-scope custody to the durable archive
+        // The write queue transfers old-scope custody to the durable archive
         // queue before replacement, so concurrent recovery cannot lose it.
         this.#queueArchive(current);
       }
@@ -332,11 +345,10 @@ export class CopilotSessionRegistry {
   }
 
   async #mutate(run) {
-    this.writeChain = this.writeChain.then(async () => {
+    await this.enqueueWrite(async () => {
       run();
       await this.#persist();
     });
-    await this.writeChain;
   }
 
   async #persist() {

--- a/extensions/browser/chrome-extension/modules/copilot-session-registry.test.ts
+++ b/extensions/browser/chrome-extension/modules/copilot-session-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CopilotPanelBindingRegistry, CopilotSessionRegistry } from "./copilot-session-registry.js";
 
 const GATEWAY_SCOPE = "ws://127.0.0.1:18789/";
@@ -209,6 +209,52 @@ describe("CopilotSessionRegistry", () => {
     await expect(registry.finishRun(GATEWAY_SCOPE, "session-10", "run-10")).resolves.toBe(true);
     expect(registry.pendingAborts(GATEWAY_SCOPE)).toEqual([]);
   });
+
+  it("continues queued lifecycle writes after preserving a storage failure", async () => {
+    const mock = storage();
+    const registry = new CopilotSessionRegistry(mock as never);
+    await registry.initialize(new Set([10]));
+    await registry.put(10, { gatewayScope: GATEWAY_SCOPE, sessionKey: "session-10" });
+    await registry.startRun(10, GATEWAY_SCOPE, "run-10");
+    const baselineWrites = mock.local.setCalls.length;
+    const persist = mock.local.set.bind(mock.local);
+    const failure = new Error("transient session storage failure");
+    let rejectWrite!: () => void;
+    const failedWrite = new Promise<void>((_resolve, reject) => {
+      rejectWrite = () => reject(failure);
+    });
+    let failNextWrite = true;
+    mock.local.set = async (update) => {
+      if (failNextWrite) {
+        failNextWrite = false;
+        await failedWrite;
+        return;
+      }
+      await persist(update);
+    };
+
+    const failedCancellation = registry.queueAbort(10, GATEWAY_SCOPE);
+    const finishedRun = registry.finishRun(GATEWAY_SCOPE, "session-10", "run-10");
+    const closedTab = registry.closeTab(10);
+    await vi.waitFor(() => expect(registry.pendingAborts(GATEWAY_SCOPE)).toHaveLength(1));
+    expect(registry.get(10, GATEWAY_SCOPE)).toHaveProperty("activeRunId", "run-10");
+    expect(registry.pendingArchives(GATEWAY_SCOPE)).toEqual([]);
+
+    const outcomes = Promise.allSettled([failedCancellation, finishedRun, closedTab]);
+    rejectWrite();
+    const [cancellationOutcome, finishedOutcome, closedOutcome] = await outcomes;
+    expect(cancellationOutcome).toEqual({ status: "rejected", reason: failure });
+    expect(finishedOutcome).toEqual({ status: "fulfilled", value: true });
+    expect(closedOutcome).toMatchObject({
+      status: "fulfilled",
+      value: { sessionKey: "session-10" },
+    });
+
+    expect(mock.local.setCalls).toHaveLength(baselineWrites + 2);
+    expect(registry.pendingArchives(GATEWAY_SCOPE)).toEqual([
+      expect.objectContaining({ sessionKey: "session-10", tabId: 10 }),
+    ]);
+  });
 });
 
 describe("CopilotPanelBindingRegistry", () => {
@@ -225,5 +271,46 @@ describe("CopilotPanelBindingRegistry", () => {
     await expect(bindings.resolve(first)).resolves.toBe(7);
     await bindings.remove(7);
     await expect(bindings.resolve(first)).resolves.toBeNull();
+  });
+
+  it("rolls back an undurable capability and persists the queued retry", async () => {
+    const area = storageArea();
+    const persist = area.set.bind(area);
+    const failure = new Error("transient panel storage failure");
+    let failNextWrite = true;
+    area.set = async (update) => {
+      if (failNextWrite) {
+        failNextWrite = false;
+        throw failure;
+      }
+      await persist(update);
+    };
+    const failedToken = "00000000-0000-4000-8000-000000000001";
+    const durableToken = "00000000-0000-4000-8000-000000000002";
+    const randomUUID = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce(failedToken)
+      .mockReturnValueOnce(durableToken);
+    try {
+      const bindings = new CopilotPanelBindingRegistry(area as never);
+      const failedBinding = bindings.bind(17);
+      const recoveredBinding = bindings.bind(17);
+
+      const [failedOutcome, recoveredOutcome] = await Promise.allSettled([
+        failedBinding,
+        recoveredBinding,
+      ]);
+      expect(failedOutcome).toEqual({ status: "rejected", reason: failure });
+      expect(recoveredOutcome).toEqual({ status: "fulfilled", value: durableToken });
+      await expect(bindings.resolve(failedToken)).resolves.toBeNull();
+      await expect(bindings.resolve(durableToken)).resolves.toBe(17);
+      expect(area.setCalls).toHaveLength(1);
+
+      await bindings.remove(17);
+      expect(area.setCalls).toHaveLength(2);
+      await expect(bindings.resolve(durableToken)).resolves.toBeNull();
+    } finally {
+      randomUUID.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

A rejected Chrome storage write permanently poisoned the Copilot session and panel registry promise chains. Every later cancellation, run completion, archive, bind, or removal operation attached only a success handler to that rejected tail, so it never ran and inherited the stale earlier error.

## Why This Change Was Made

Both registries now use one module-local FIFO write queue. Each operation returns its own original promise, preserving the initiating Chrome storage error, while the queue's private tail is normalized back to fulfillment so later already-queued writes still execute in order.

Session custody mutations remain fail-closed in memory so the next successful full-state write can persist the cumulative safe state. A newly minted panel capability is different: if its first persistence fails, that undurable token is rolled back before the queued bind retries and persists a fresh token.

## User Impact

- A transient Copilot storage failure rejects only the affected operation.
- Later cancellation, run completion, archival, panel binding, and removal writes recover without worker restart.
- The real relay-disconnect path can still abort and release debugger custody after a failed write.
- Failed panel capabilities are never reported as durable.
- No configuration, default, command, public/plugin API, Chrome permission, auth/credential, debugger ownership, SQLite, protocol, or security boundary changes.

## Evidence

- Rewritten base: `eec454489ad30f86ca704a534a312f255117578d`; rewritten head before publication: `5008fcc0fa3d67e3b24b57d56361755468389d87`.
- Regression before the production fix:
  - `node scripts/run-vitest.mjs extensions/browser/chrome-extension/modules/copilot-session-registry.test.ts`
  - 2 failed, 8 passed; queued session and panel operations inherited the first storage error.
  - `node scripts/run-vitest.mjs extensions/browser/chrome-extension/modules/copilot-background.test.ts`
  - 1 failed, 15 passed; the aborted run remained pending after relay disconnect.
- Regression after the fix:
  - registry suite — 10 passed.
  - background controller suite — 16 passed.
- Changed-file gate:
  - `node scripts/check-changed.mjs`
  - Passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31322868197
- Autoreview: clean after one round; no accepted/actionable findings.
- Production delta: +29/-17. Tests: +95/-2.

Rank-up moves applied: stale head/parent evidence was replaced with the rewritten revision; per-caller error identity, FIFO recovery, session cancellation/finish/archive order, panel capability rollback/retry/removal, real background-controller custody release, and required checks are covered.

Named follow-up: both registries also cache rejected initialization promises until the MV3 worker restarts. That is a separate initialization-lifecycle owner involving controller wrapper caches, not this post-initialization write-queue invariant.

Release-note context: Copilot session and panel storage queues now recover after a failed Chrome write while preserving the original caller's error.
