### PR TITLE
fix(ui): preserve usable previews and modal sizing on narrow screens

### DIFF
--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -5,7 +5,8 @@ import type { OpenClawModalDialog } from "./modal-dialog.ts";
 import "./file-preview-modal-registration.ts";
 
 const browserMode = "__vitest_browser__" in globalThis;
-const initialFilePath = "templates/digest.md";
+const initialFilePath =
+  "templates/customer-success/quarterly-reviews/complete-digest-template-with-a-long-name.md";
 
 const files = [
   {
@@ -17,6 +18,11 @@ const files = [
     path: "filters/auto-senders.txt",
     size: "418 B",
     contents: "noreply@example.com",
+  },
+  {
+    path: "assets/empty-preview.png",
+    size: "0 B",
+    contents: "",
   },
 ];
 
@@ -39,14 +45,14 @@ async function resolveRenderedDialog(modal: OpenClawModalDialog) {
   return dialog!;
 }
 
-async function mountPreview(width: number) {
+async function mountPreview(width: number, activePath = initialFilePath) {
   const { page } = await import("vitest/browser");
   await page.viewport(width, 844);
 
   const preview = document.createElement("openclaw-file-preview-modal") as OpenClawFilePreviewModal;
   preview.style.setProperty("--wa-transition-normal", "150ms");
   preview.files = files;
-  preview.activePath = initialFilePath;
+  preview.activePath = activePath;
   document.body.append(preview);
   await preview.updateComplete;
 
@@ -83,64 +89,103 @@ async function mountModal(
 }
 
 describe.runIf(browserMode)("file preview modal responsive layout", () => {
-  it.each([390, 320])("keeps source and copy visible at a %dpx viewport", async (width) => {
-    const { preview, dialog } = await mountPreview(width);
-    const list = preview.shadowRoot?.querySelector<HTMLElement>(".list");
-    const detail = preview.shadowRoot?.querySelector<HTMLElement>(".detail");
-    const copy = preview.shadowRoot?.querySelector<HTMLButtonElement>(".chat-copy-btn");
-    const search = preview.shadowRoot?.querySelector<HTMLInputElement>(".search");
-    const source = preview.shadowRoot?.querySelector<HTMLElement>(".code-chunk");
-    expect(list).toBeInstanceOf(HTMLElement);
-    expect(detail).toBeInstanceOf(HTMLElement);
-    expect(copy).toBeInstanceOf(HTMLButtonElement);
-    expect(search).toBeInstanceOf(HTMLInputElement);
-    expect(source).toBeInstanceOf(HTMLElement);
+  it.each([320, 375, 390, 640])(
+    "keeps source and copy visible at a %dpx viewport",
+    async (width) => {
+      const { preview, dialog } = await mountPreview(width);
+      const list = preview.shadowRoot?.querySelector<HTMLElement>(".list");
+      const detail = preview.shadowRoot?.querySelector<HTMLElement>(".detail");
+      const copy = preview.shadowRoot?.querySelector<HTMLButtonElement>(".chat-copy-btn");
+      const search = preview.shadowRoot?.querySelector<HTMLInputElement>(".search");
+      const source = preview.shadowRoot?.querySelector<HTMLElement>(".code-chunk");
+      const activeItem = preview.shadowRoot?.querySelector<HTMLElement>(".item.is-active");
+      const title = preview.shadowRoot?.querySelector<HTMLElement>(".title");
+      expect(list).toBeInstanceOf(HTMLElement);
+      expect(detail).toBeInstanceOf(HTMLElement);
+      expect(copy).toBeInstanceOf(HTMLButtonElement);
+      expect(search).toBeInstanceOf(HTMLInputElement);
+      expect(source).toBeInstanceOf(HTMLElement);
+      expect(activeItem).toBeInstanceOf(HTMLElement);
+      expect(title).toBeInstanceOf(HTMLElement);
 
-    const dialogBounds = dialog.getBoundingClientRect();
-    const listBounds = list!.getBoundingClientRect();
-    const detailBounds = detail!.getBoundingClientRect();
-    const copyBounds = copy!.getBoundingClientRect();
-    const searchBounds = search!.getBoundingClientRect();
-    const sourceBounds = source!.getBoundingClientRect();
-    const sourceTextRange = document.createRange();
-    sourceTextRange.selectNodeContents(source!);
-    const sourceTextBounds = sourceTextRange.getBoundingClientRect();
+      const dialogBounds = dialog.getBoundingClientRect();
+      const listBounds = list!.getBoundingClientRect();
+      const detailBounds = detail!.getBoundingClientRect();
+      const copyBounds = copy!.getBoundingClientRect();
+      const searchBounds = search!.getBoundingClientRect();
+      const sourceBounds = source!.getBoundingClientRect();
+      const activeItemBounds = activeItem!.getBoundingClientRect();
+      const titleBounds = title!.getBoundingClientRect();
+      const sourceTextRange = document.createRange();
+      sourceTextRange.selectNodeContents(source!);
+      const sourceTextBounds = sourceTextRange.getBoundingClientRect();
 
-    expect(dialogBounds.left).toBeGreaterThanOrEqual(0);
-    expect(dialogBounds.right).toBeLessThanOrEqual(window.innerWidth + 1);
-    expect(dialogBounds.top).toBeGreaterThanOrEqual(0);
-    expect(dialogBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
-    expect(detailBounds.top).toBeGreaterThanOrEqual(listBounds.bottom - 1);
-    expect(detailBounds.width).toBeGreaterThan(200);
-    expect(copyBounds.top).toBeGreaterThanOrEqual(0);
-    expect(copyBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
-    expect(copyBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
-    expect(copyBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
-    expect(searchBounds.width).toBeGreaterThan(80);
-    expect(searchBounds.left).toBeGreaterThanOrEqual(0);
-    expect(searchBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
-    expect(searchBounds.top).toBeGreaterThanOrEqual(0);
-    expect(searchBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
-    expect(sourceBounds.width).toBeGreaterThan(100);
-    expect(sourceBounds.height).toBeGreaterThan(0);
-    expect(sourceBounds.top).toBeGreaterThanOrEqual(0);
-    expect(sourceBounds.top).toBeLessThan(window.innerHeight);
-    expect(sourceTextBounds.width).toBeGreaterThan(0);
-    expect(sourceTextBounds.height).toBeGreaterThan(0);
-    expect(sourceTextBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
-    expect(sourceTextBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
-    expect(sourceTextBounds.top).toBeGreaterThanOrEqual(0);
-    expect(sourceTextBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
-    expect(source?.textContent).toContain("Review the complete support-file contents.");
+      expect(dialogBounds.left).toBeGreaterThanOrEqual(0);
+      expect(dialogBounds.right).toBeLessThanOrEqual(window.innerWidth + 1);
+      expect(dialogBounds.top).toBeGreaterThanOrEqual(0);
+      expect(dialogBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+      expect(detailBounds.top).toBeGreaterThanOrEqual(listBounds.bottom - 1);
+      expect(detailBounds.width).toBeGreaterThan(200);
+      expect(copyBounds.top).toBeGreaterThanOrEqual(0);
+      expect(copyBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+      expect(copyBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+      expect(copyBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(searchBounds.width).toBeGreaterThan(80);
+      expect(searchBounds.left).toBeGreaterThanOrEqual(0);
+      expect(searchBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(searchBounds.top).toBeGreaterThanOrEqual(0);
+      expect(searchBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+      expect(activeItemBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+      expect(activeItemBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(titleBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+      expect(titleBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(title?.textContent).toBe(initialFilePath);
+      expect(sourceBounds.width).toBeGreaterThan(100);
+      expect(sourceBounds.height).toBeGreaterThan(0);
+      expect(sourceBounds.top).toBeGreaterThanOrEqual(0);
+      expect(sourceBounds.top).toBeLessThan(window.innerHeight);
+      expect(sourceTextBounds.width).toBeGreaterThan(0);
+      expect(sourceTextBounds.height).toBeGreaterThan(0);
+      expect(sourceTextBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+      expect(sourceTextBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(sourceTextBounds.top).toBeGreaterThanOrEqual(0);
+      expect(sourceTextBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+      expect(source?.textContent).toContain("Review the complete support-file contents.");
 
-    const selected = vi.fn();
-    preview.addEventListener("file-preview-select", selected);
-    search?.focus();
-    const { userEvent } = await import("vitest/browser");
-    await userEvent.keyboard("{ArrowDown}");
-    expect(selected).toHaveBeenCalledOnce();
-    expect(selected.mock.calls[0]?.[0].detail).toBe("filters/auto-senders.txt");
-  });
+      const selected = vi.fn();
+      preview.addEventListener("file-preview-select", selected);
+      search?.focus();
+      const { userEvent } = await import("vitest/browser");
+      await userEvent.keyboard("{ArrowDown}");
+      expect(selected).toHaveBeenCalledOnce();
+      expect(selected.mock.calls[0]?.[0].detail).toBe("filters/auto-senders.txt");
+    },
+  );
+
+  it.each([375, 640])(
+    "keeps an empty non-text preview reachable at a %dpx viewport",
+    async (width) => {
+      const { preview, dialog } = await mountPreview(width, "assets/empty-preview.png");
+      const detail = preview.shadowRoot?.querySelector<HTMLElement>(".detail");
+      const title = preview.shadowRoot?.querySelector<HTMLElement>(".title");
+      const kind = preview.shadowRoot?.querySelector<HTMLElement>(".chip.accent");
+      const detailBody = preview.shadowRoot?.querySelector<HTMLElement>(".detail-body");
+      expect(detail).toBeInstanceOf(HTMLElement);
+      expect(title?.textContent).toBe("assets/empty-preview.png");
+      expect(kind?.textContent).toBe("PNG");
+      expect(detailBody).toBeInstanceOf(HTMLElement);
+      expect(preview.shadowRoot?.querySelector(".chat-copy-btn")).toBeNull();
+      expect(preview.shadowRoot?.querySelector(".code-chunk")?.textContent).toBe("");
+
+      const dialogBounds = dialog.getBoundingClientRect();
+      const detailBounds = detail!.getBoundingClientRect();
+      const detailBodyBounds = detailBody!.getBoundingClientRect();
+      expect(detailBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+      expect(detailBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+      expect(detailBodyBounds.top).toBeGreaterThanOrEqual(0);
+      expect(detailBodyBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+    },
+  );
 
   it("preserves the desktop side-by-side file layout", async () => {
     const { preview, dialog } = await mountPreview(1280);

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -1,0 +1,194 @@
+import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenClawFilePreviewModal } from "./file-preview-modal.ts";
+import type { OpenClawModalDialog } from "./modal-dialog.ts";
+import "./file-preview-modal-registration.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+const initialFilePath = "templates/digest.md";
+
+const files = [
+  {
+    path: initialFilePath,
+    size: "2.1 KB",
+    contents: "Review the complete support-file contents.",
+  },
+  {
+    path: "filters/auto-senders.txt",
+    size: "418 B",
+    contents: "noreply@example.com",
+  },
+];
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function resolveRenderedDialog(modal: OpenClawModalDialog) {
+  await modal.updateComplete;
+  const webAwesomeDialog = modal.shadowRoot?.querySelector<WaDialog>("wa-dialog");
+  expect(webAwesomeDialog).toBeInstanceOf(HTMLElement);
+  await webAwesomeDialog?.updateComplete;
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+  const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
+  expect(dialog?.open).toBe(true);
+  // Web Awesome opens at 80% scale; measure the settled dialog, not its first animation frame.
+  await Promise.all(dialog!.getAnimations().map((animation) => animation.finished));
+  return dialog!;
+}
+
+async function mountPreview(width: number) {
+  const { page } = await import("vitest/browser");
+  await page.viewport(width, 844);
+
+  const preview = document.createElement("openclaw-file-preview-modal") as OpenClawFilePreviewModal;
+  preview.style.setProperty("--wa-transition-normal", "150ms");
+  preview.files = files;
+  preview.activePath = initialFilePath;
+  document.body.append(preview);
+  await preview.updateComplete;
+
+  const ownerDialog =
+    preview.shadowRoot?.querySelector<OpenClawModalDialog>("openclaw-modal-dialog");
+  expect(ownerDialog).toBeInstanceOf(HTMLElement);
+  const dialog = await resolveRenderedDialog(ownerDialog!);
+  return { preview, dialog };
+}
+
+async function mountModal(
+  width: number,
+  options: {
+    fullscreen?: boolean;
+    kind?: "drawer" | "nav-drawer";
+    modalWidth: string;
+  },
+) {
+  const { page } = await import("vitest/browser");
+  await page.viewport(width, 844);
+
+  const modal = document.createElement("openclaw-modal-dialog");
+  modal.label = "Preview";
+  modal.style.setProperty("--wa-transition-normal", "150ms");
+  modal.style.setProperty("--openclaw-modal-width", options.modalWidth);
+  modal.classList.toggle("fullscreen", options.fullscreen === true);
+  modal.classList.toggle("drawer", options.kind !== undefined);
+  modal.classList.toggle("nav-drawer", options.kind === "nav-drawer");
+  const content = document.createElement("div");
+  content.style.cssText = "width: 100%; height: 80px;";
+  modal.append(content);
+  document.body.append(modal);
+  return await resolveRenderedDialog(modal);
+}
+
+describe.runIf(browserMode)("file preview modal responsive layout", () => {
+  it.each([390, 320])("keeps source and copy visible at a %dpx viewport", async (width) => {
+    const { preview, dialog } = await mountPreview(width);
+    const list = preview.shadowRoot?.querySelector<HTMLElement>(".list");
+    const detail = preview.shadowRoot?.querySelector<HTMLElement>(".detail");
+    const copy = preview.shadowRoot?.querySelector<HTMLButtonElement>(".chat-copy-btn");
+    const search = preview.shadowRoot?.querySelector<HTMLInputElement>(".search");
+    const source = preview.shadowRoot?.querySelector<HTMLElement>(".code-chunk");
+    expect(list).toBeInstanceOf(HTMLElement);
+    expect(detail).toBeInstanceOf(HTMLElement);
+    expect(copy).toBeInstanceOf(HTMLButtonElement);
+    expect(search).toBeInstanceOf(HTMLInputElement);
+    expect(source).toBeInstanceOf(HTMLElement);
+
+    const dialogBounds = dialog.getBoundingClientRect();
+    const listBounds = list!.getBoundingClientRect();
+    const detailBounds = detail!.getBoundingClientRect();
+    const copyBounds = copy!.getBoundingClientRect();
+    const searchBounds = search!.getBoundingClientRect();
+    const sourceBounds = source!.getBoundingClientRect();
+    const sourceTextRange = document.createRange();
+    sourceTextRange.selectNodeContents(source!);
+    const sourceTextBounds = sourceTextRange.getBoundingClientRect();
+
+    expect(dialogBounds.left).toBeGreaterThanOrEqual(0);
+    expect(dialogBounds.right).toBeLessThanOrEqual(window.innerWidth + 1);
+    expect(dialogBounds.top).toBeGreaterThanOrEqual(0);
+    expect(dialogBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+    expect(detailBounds.top).toBeGreaterThanOrEqual(listBounds.bottom - 1);
+    expect(detailBounds.width).toBeGreaterThan(200);
+    expect(copyBounds.top).toBeGreaterThanOrEqual(0);
+    expect(copyBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+    expect(copyBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+    expect(copyBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+    expect(searchBounds.width).toBeGreaterThan(80);
+    expect(searchBounds.left).toBeGreaterThanOrEqual(0);
+    expect(searchBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+    expect(searchBounds.top).toBeGreaterThanOrEqual(0);
+    expect(searchBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+    expect(sourceBounds.width).toBeGreaterThan(100);
+    expect(sourceBounds.height).toBeGreaterThan(0);
+    expect(sourceBounds.top).toBeGreaterThanOrEqual(0);
+    expect(sourceBounds.top).toBeLessThan(window.innerHeight);
+    expect(sourceTextBounds.width).toBeGreaterThan(0);
+    expect(sourceTextBounds.height).toBeGreaterThan(0);
+    expect(sourceTextBounds.left).toBeGreaterThanOrEqual(dialogBounds.left - 1);
+    expect(sourceTextBounds.right).toBeLessThanOrEqual(dialogBounds.right + 1);
+    expect(sourceTextBounds.top).toBeGreaterThanOrEqual(0);
+    expect(sourceTextBounds.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+    expect(source?.textContent).toContain("Review the complete support-file contents.");
+
+    const selected = vi.fn();
+    preview.addEventListener("file-preview-select", selected);
+    search?.focus();
+    const { userEvent } = await import("vitest/browser");
+    await userEvent.keyboard("{ArrowDown}");
+    expect(selected).toHaveBeenCalledOnce();
+    expect(selected.mock.calls[0]?.[0].detail).toBe("filters/auto-senders.txt");
+  });
+
+  it("preserves the desktop side-by-side file layout", async () => {
+    const { preview, dialog } = await mountPreview(1280);
+    const list = preview.shadowRoot?.querySelector<HTMLElement>(".list");
+    const detail = preview.shadowRoot?.querySelector<HTMLElement>(".detail");
+    expect(list).toBeInstanceOf(HTMLElement);
+    expect(detail).toBeInstanceOf(HTMLElement);
+
+    const listBounds = list!.getBoundingClientRect();
+    const detailBounds = detail!.getBoundingClientRect();
+    expect(listBounds.width).toBeCloseTo(360, 0);
+    expect(detailBounds.left).toBeGreaterThanOrEqual(listBounds.right - 1);
+    expect(detailBounds.right).toBeLessThanOrEqual(dialog.getBoundingClientRect().right + 1);
+  });
+
+  it.each([1280, 390])("expands fullscreen previews at a %dpx viewport", async (width) => {
+    const dialog = await mountModal(width, {
+      fullscreen: true,
+      modalWidth: "min(1040px, calc(100vw - 32px))",
+    });
+
+    expect(dialog.getBoundingClientRect().width).toBeGreaterThanOrEqual(width - 21);
+  });
+
+  it("preserves narrower owner-defined modal widths on phones", async () => {
+    const dialog = await mountModal(390, { modalWidth: "200px" });
+
+    expect(dialog.getBoundingClientRect().width).toBeCloseTo(200, 0);
+  });
+
+  it.each([
+    { viewport: 390, expectedWidth: 390 },
+    { viewport: 1280, expectedWidth: 460 },
+  ])("keeps workboard drawers edge-to-edge on phones", async ({ viewport, expectedWidth }) => {
+    const dialog = await mountModal(viewport, {
+      kind: "drawer",
+      modalWidth: "min(460px, 100vw)",
+    });
+
+    expect(dialog.getBoundingClientRect().width).toBeCloseTo(expectedWidth, 0);
+  });
+
+  it("preserves the navigation drawer's narrower owned width", async () => {
+    const dialog = await mountModal(390, {
+      kind: "nav-drawer",
+      modalWidth: "min(460px, 100vw)",
+    });
+
+    expect(dialog.getBoundingClientRect().width).toBeCloseTo(320, 0);
+  });
+});

--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -90,6 +90,17 @@ describe("openclaw-file-preview-modal", () => {
     expect(closeButton?.querySelector(".kbd")?.textContent).toBe("esc");
   });
 
+  it("stacks the file list above its preview on narrow screens", () => {
+    const styles = OpenClawFilePreviewModal.styles.cssText;
+
+    expect(styles).toMatch(
+      /@media\s*\(max-width:\s*640px\)\s*\{[\s\S]*?\.body\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);[^}]*grid-template-rows:/u,
+    );
+    expect(styles).toMatch(
+      /@media\s*\(max-width:\s*640px\)\s*\{[\s\S]*?\.list\s*\{[^}]*border-right:\s*0;[^}]*border-bottom:/u,
+    );
+  });
+
   it("emits controlled query, select, and close events", async () => {
     const modal = await renderPreview();
     const onQuery = vi.fn();

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -70,6 +70,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
     .search {
       flex: 1;
+      min-width: 0;
       background: transparent;
       border: none;
       outline: none;
@@ -435,6 +436,33 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       font-size: 13px;
       color: var(--muted);
       max-width: 380px;
+    }
+
+    @media (max-width: 640px) {
+      .head {
+        padding: 12px;
+      }
+
+      .body {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: minmax(0, min(180px, 30dvh)) minmax(0, 1fr);
+      }
+
+      .list {
+        min-width: 0;
+        border-right: 0;
+        border-bottom: 1px solid var(--border);
+        padding: 10px 8px;
+      }
+
+      .item {
+        min-width: 0;
+      }
+
+      .foot {
+        gap: 8px;
+        padding: 10px 12px;
+      }
     }
   `;
 

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -114,6 +114,23 @@ describe("openclaw-modal-dialog", () => {
     );
   });
 
+  it("keeps responsive width and maximum-width limits owned by the same variant", () => {
+    const styles = OpenClawModalDialog.styles.cssText;
+
+    expect(styles).toMatch(
+      /:host\(\.fullscreen\)\s+wa-dialog::part\(dialog\)\s*\{[^}]*max-width:\s*calc\(100vw\s*-\s*20px\);/u,
+    );
+    expect(styles).toMatch(
+      /@media\s*\(max-width:\s*640px\)\s*\{[\s\S]*?wa-dialog\s*\{[^}]*--width:\s*min\(var\(--openclaw-modal-width,\s*540px\),\s*calc\(100vw\s*-\s*24px\)\);[\s\S]*?wa-dialog::part\(dialog\)\s*\{[^}]*max-width:\s*var\(--openclaw-modal-max-width,\s*calc\(100vw\s*-\s*24px\)\);/u,
+    );
+    expect(styles).toMatch(
+      /:host\(\.drawer\)\s+wa-dialog\s*\{[^}]*--width:\s*min\(var\(--openclaw-modal-width,\s*100vw\),\s*100vw\);/u,
+    );
+    expect(styles).toMatch(
+      /:host\(\.drawer\)\s+wa-dialog::part\(dialog\)\s*\{[^}]*max-width:\s*100vw;/u,
+    );
+  });
+
   it("emits modal-cancel on Escape", async () => {
     const { modal, dialog } = await renderModal();
     const onCancel = vi.fn();

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -49,6 +49,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     }
 
     :host(.fullscreen) wa-dialog::part(dialog) {
+      max-width: calc(100vw - 20px);
       max-height: calc(100dvh - 20px);
     }
 
@@ -57,8 +58,13 @@ export class OpenClawModalDialog extends OpenClawLitElement {
       margin-block-end: auto;
     }
 
+    :host(.drawer) wa-dialog {
+      --width: min(var(--openclaw-modal-width, 100vw), 100vw);
+    }
+
     :host(.drawer) wa-dialog::part(dialog) {
       height: 100dvh;
+      max-width: 100vw;
       max-height: 100dvh;
       margin: 0 0 0 auto;
       border-radius: 0;
@@ -90,10 +96,11 @@ export class OpenClawModalDialog extends OpenClawLitElement {
 
     @media (max-width: 640px) {
       wa-dialog {
-        --width: calc(100vw - 24px);
+        --width: min(var(--openclaw-modal-width, 540px), calc(100vw - 24px));
       }
 
       wa-dialog::part(dialog) {
+        max-width: var(--openclaw-modal-max-width, calc(100vw - 24px));
         max-height: 90dvh;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Three independently reproduced Control UI owner defects make common preview and modal workflows unusable or misleading:

1. Skill Workshop support-file previews retain a fixed 360 px desktop sidebar on 320 px and 390 px phones, hiding readable source content and the Copy action.
2. Fullscreen Agent-file previews remain constrained by the ordinary modal maximum width, and mobile modal sizing ignores narrower widths explicitly requested by its owning surface.
3. Workboard detail drawers inherit ordinary centered-dialog phone gutters even though their owner explicitly requests an edge-to-edge full-height drawer.

## Why This Change Was Made

The support-file preview owner had no narrow-screen layout. The shared dialog owner selected width and maximum width through unrelated variant rules, so fullscreen, edge drawer, and narrow modal contracts disagreed. Repair both canonical owners directly: stack a bounded file list above its source on phones; keep owner-requested width and viewport limits aligned; give fullscreen and drawer variants their complete intended sizing; preserve navigation-drawer specificity.

## User Impact

- At 320 px and 390 px, source text, the file list, search, Copy, and keyboard file navigation remain visible and usable.
- Agent file previews expand to their intended near-full-screen dimensions on phones and desktops.
- Workboard detail drawers occupy the complete phone viewport while retaining their 460 px desktop width.
- Smaller owner-sized dialogs remain small; the navigation drawer retains its existing 320 px limit; the desktop file sidebar remains 360 px wide.

## Evidence

- Frozen source: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Candidate: `c0cf249a2918cf08917bfa6ce193d2b908f4d2b1` on `codex/qa200-ui-preview-modal-responsive`.
- Baseline real Chromium: **five failing scenarios** confirmed hidden phone previews, fullscreen widths of 1232 px instead of 1260 px and 342 px instead of 370 px, and a 200 px owner-sized phone dialog incorrectly rendered at 342 px.
- Independent additional baseline Chromium proof confirmed a Workboard drawer rendered at 366 px instead of its 390 px full-width contract.
- Final actual Chrome: **9 passing scenarios** across 320 px, 390 px, and 1280 px, including readable rendered source glyphs, Copy/search bounds, ArrowDown navigation, fullscreen sizing, explicit owner width, edge drawers, and unchanged navigation drawer/Desktop sidebar behavior.
- Focused owner and sibling proof: **37 tests passed** across file-preview, shared-modal, image-lightbox, and command-palette owners.
- Targeted `oxfmt --check`, `oxlint`, Lit-template `stylelint`, and `git diff --check`: clean; no max-lines suppression.
- The initial remote gate exposed one owner-attributable test-fixture indexing error under `noUncheckedIndexedAccess`; the fixture now carries its authoritative initial path directly, and all 37 owner tests plus nine actual Chrome scenarios were rerun green on the amended candidate.
- Genuine TruffleHog 3.96.0-backed structured amended-commit Codex autoreview: **CLEAN**, zero findings, confidence **0.91**.
- Exact five-file remote Blacksmith Testbox changed/typecheck/lint gate: **PASSED**, exit **0**, Testbox `tbx_01kyw9f0xw3fndf86fxp49ff5n`, command **395.720 seconds**, total **398.482 seconds**; run https://github.com/openclaw/openclaw/actions/runs/30639049192. Passed both strict core-test and UI TypeScript projects, i18n, max-lines ratchet, dead-export guards, formatting, package/dependency policy, and type-aware five-file lint with **0 warnings and 0 errors**; the one-shot Testbox stopped after successful proof.

No public configuration, protocol, authentication, storage, dependency, or internationalization-catalog changes.
