### PR TITLE
fix(telegram): recover rejected photos and preserve media filenames

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -44,6 +44,7 @@ import {
   canonicalizeTelegramPresentationPayload,
   resolveTelegramInteractiveTextFallback,
 } from "../interactive-fallback.js";
+import { resolveTelegramOutboundMediaFilename } from "../outbound-media.js";
 import type { TelegramPromptContextProjectionSequence } from "../prompt-context-projection.js";
 import type { TelegramRichBlocksDegradationReason } from "../rich-block-model.js";
 import {
@@ -53,6 +54,7 @@ import {
   type TelegramInputRichMessage,
 } from "../rich-message.js";
 import { isTelegramHtmlParseError } from "../rich-plain-fallback.js";
+import { isTelegramPhotoLimitError } from "../send-error-predicates.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { resolveTelegramTargetChatType } from "../targets.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
@@ -349,7 +351,7 @@ async function sendTelegramCaptionedMediaWithFallback<T>(params: {
       send: params.send,
     });
   if (!params.plainCaption) {
-    return await sendMedia(params.requestParams);
+    return await sendMedia(params.requestParams, params.shouldLog);
   }
   try {
     return await sendMedia(
@@ -368,7 +370,10 @@ async function sendTelegramCaptionedMediaWithFallback<T>(params: {
         err,
       )}`,
     );
-    return await sendMedia(buildPlainCaptionParams(params.requestParams, params.plainCaption));
+    return await sendMedia(
+      buildPlainCaptionParams(params.requestParams, params.plainCaption),
+      params.shouldLog,
+    );
   }
 }
 
@@ -447,7 +452,12 @@ async function deliverMediaReply(params: {
       contentType: media.contentType,
       fileName: media.fileName,
     });
-    const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
+    const fileName = resolveTelegramOutboundMediaFilename({
+      fileName: media.fileName,
+      contentType: media.contentType,
+      kind,
+      isGif,
+    });
     const file = new InputFile(media.buffer, fileName);
     const captionText = isFirstMedia ? (params.reply.text ?? undefined) : undefined;
     const trimmedCaption = captionText?.trim();
@@ -498,14 +508,34 @@ async function deliverMediaReply(params: {
           params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
       });
     } else if (kind === "image") {
-      await deliverAcceptedMedia({
-        operation: "sendPhoto",
-        requestParams: mediaParams,
-        plainCaption,
-        text: plainCaption,
-        send: (effectiveParams) =>
-          params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
-      });
+      try {
+        await deliverAcceptedMedia({
+          operation: "sendPhoto",
+          requestParams: mediaParams,
+          plainCaption,
+          text: plainCaption,
+          shouldLog: (error) => !isTelegramPhotoLimitError(error),
+          send: (effectiveParams) =>
+            params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
+        });
+      } catch (error) {
+        if (!isTelegramPhotoLimitError(error)) {
+          throw error;
+        }
+        // Let Telegram validate photo limits without decoding image buffers;
+        // retry the same accepted caption, topic, quote, and markup as a file.
+        logVerbose(
+          `telegram sendPhoto exceeded photo limits; retrying as document: ${formatErrorMessage(error)}`,
+        );
+        await deliverAcceptedMedia({
+          operation: "sendDocument",
+          requestParams: mediaParams,
+          plainCaption,
+          text: plainCaption,
+          send: (effectiveParams) =>
+            params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
+        });
+      }
     } else if (kind === "video") {
       await deliverAcceptedMedia({
         operation: "sendVideo",

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -69,7 +69,7 @@ vi.mock("grammy", () => ({
   InputFile: class {
     constructor(
       public buffer: Buffer,
-      public fileName?: string,
+      public filename?: string,
     ) {}
   },
   GrammyError: class GrammyError extends Error {
@@ -932,6 +932,32 @@ describe("deliverReplies", () => {
     });
   });
 
+  it.each([
+    { contentType: "image/png", filename: "image.png", method: "sendPhoto" },
+    { contentType: "video/quicktime", filename: "video.mov", method: "sendVideo" },
+    { contentType: "audio/mpeg", filename: "audio.mp3", method: "sendAudio" },
+    { contentType: "application/pdf", filename: "file.pdf", method: "sendDocument" },
+    { contentType: "image/gif", filename: "animation.gif", method: "sendAnimation" },
+    { contentType: "application/x-custom", filename: "file.bin", method: "sendDocument" },
+  ])("preserves MIME-derived filenames for streaming $contentType", async (testCase) => {
+    const sendMedia = vi.fn().mockResolvedValue({
+      message_id: 2,
+      chat: { id: "123" },
+    });
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("media"),
+      contentType: testCase.contentType,
+    });
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/media", text: "caption" }],
+      runtime: createRuntime(),
+      bot: createBot({ [testCase.method]: sendMedia }),
+    });
+
+    expect(firstMockCallArg(sendMedia, 1)).toMatchObject({ filename: testCase.filename });
+  });
+
   it("keeps formatted media replies within Telegram's parsed-caption limit", async () => {
     const runtime = createRuntime();
     const visibleCaption = "x".repeat(1022);
@@ -999,6 +1025,116 @@ describe("deliverReplies", () => {
       expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("parse_mode");
     },
   );
+
+  it.each(["PHOTO_INVALID_DIMENSIONS", "PHOTO_TOO_BIG"])(
+    "falls back to a document when Telegram rejects a photo with %s",
+    async (providerReason) => {
+      const runtime = createRuntime();
+      const sendPhoto = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            `GrammyError: Call to 'sendPhoto' failed! (400: Bad Request: ${providerReason})`,
+          ),
+        );
+      const sendDocument = vi.fn().mockResolvedValue({
+        message_id: 9,
+        chat: { id: "123" },
+      });
+      const bot = createBot({ sendPhoto, sendDocument });
+      const records: unknown[] = [];
+      const promptContextSequence = createObservedPromptContextSequence((record) =>
+        records.push(record),
+      );
+
+      mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+      await deliverWith({
+        replies: [
+          {
+            mediaUrl: "https://example.com/photo.jpg",
+            text: "hi **boss**",
+            replyToId: "512",
+            channelData: {
+              telegram: {
+                buttons: [[{ text: "Retry", callback_data: "retry" }]],
+              },
+            },
+          },
+        ],
+        runtime,
+        bot,
+        replyToMode: "all",
+        thread: { id: 42, scope: "forum" },
+        promptContextSequence,
+      });
+      await promptContextSequence.finish();
+
+      expect(sendPhoto).toHaveBeenCalledOnce();
+      expect(sendDocument).toHaveBeenCalledOnce();
+      expectRecordFields(mockCallArg(sendDocument, 0, 2), {
+        caption: "hi <b>boss</b>",
+        parse_mode: "HTML",
+        message_thread_id: 42,
+        reply_to_message_id: 512,
+        reply_markup: {
+          inline_keyboard: [[{ text: "Retry", callback_data: "retry" }]],
+        },
+      });
+      expect(records).toEqual([expect.objectContaining({ messageId: 9, text: "hi **boss**" })]);
+      expect(runtime.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps recovered photo-limit failures quiet after a plain-caption retry", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
+      .mockRejectedValueOnce(
+        new Error(
+          "GrammyError: Call to 'sendPhoto' failed! (400: Bad Request: PHOTO_INVALID_DIMENSIONS)",
+        ),
+      );
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 9,
+      chat: { id: "123" },
+    });
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "hi **boss**" }],
+      runtime,
+      bot: createBot({ sendPhoto, sendDocument }),
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendPhoto, 1, 2), { caption: "hi **boss**" });
+    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("parse_mode");
+    expect(sendDocument).toHaveBeenCalledOnce();
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to a document for unrelated Telegram photo failures", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockRejectedValueOnce(createThreadNotFoundError("sendPhoto"));
+    const sendDocument = vi.fn();
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "caption" }],
+        runtime,
+        bot: createBot({ sendPhoto, sendDocument }),
+        thread: { id: 42, scope: "forum" },
+      }),
+    ).rejects.toThrow("message thread not found");
+
+    expect(sendPhoto).toHaveBeenCalledOnce();
+    expect(sendDocument).not.toHaveBeenCalled();
+  });
 
   it("passes probed dimensions to video reply sends", async () => {
     const runtime = createRuntime();

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -1,0 +1,31 @@
+import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
+
+export function resolveTelegramOutboundMediaFilename(params: {
+  fileName?: string;
+  contentType?: string;
+  kind?: MediaKind;
+  isGif: boolean;
+}): string {
+  if (params.fileName) {
+    return params.fileName;
+  }
+  if (params.isGif) {
+    return "animation.gif";
+  }
+
+  // Telegram receives only the multipart filename, so preserve the detected
+  // MIME extension instead of labeling every anonymous upload as another format.
+  const basename =
+    params.kind === "image" || params.kind === "video" || params.kind === "audio"
+      ? params.kind
+      : "file";
+  const defaultExtension =
+    params.kind === "image"
+      ? ".jpg"
+      : params.kind === "video"
+        ? ".mp4"
+        : params.kind === "audio"
+          ? ".ogg"
+          : ".bin";
+  return `${basename}${extensionForMime(params.contentType) ?? defaultExtension}`;
+}

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -575,8 +575,12 @@ export function createRequestWithChatNotFound(params: {
   chatId: string;
   input: string;
 }) {
-  return async <T>(fn: () => Promise<T>, label: string) =>
-    params.requestWithDiag(fn, label).catch((err: unknown) => {
+  return async <T>(
+    fn: () => Promise<T>,
+    label: string,
+    options?: { shouldLog?: (err: unknown) => boolean },
+  ) =>
+    params.requestWithDiag(fn, label, options).catch((err: unknown) => {
       throw wrapTelegramChatNotFoundError(err, {
         chatId: params.chatId,
         input: params.input,

--- a/extensions/telegram/src/send-error-predicates.ts
+++ b/extensions/telegram/src/send-error-predicates.ts
@@ -1,0 +1,13 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+
+const TELEGRAM_PHOTO_LIMIT_ERROR_RE = /\b(?:PHOTO_INVALID_DIMENSIONS|PHOTO_TOO_BIG)\b/i;
+
+export function isTelegramPhotoLimitError(error: unknown): boolean {
+  const description =
+    error && typeof error === "object" && "description" in error
+      ? (error as { description?: unknown }).description
+      : undefined;
+  return TELEGRAM_PHOTO_LIMIT_ERROR_RE.test(
+    typeof description === "string" ? description : formatErrorMessage(error),
+  );
+}

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -6,6 +6,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
+import { resolveTelegramOutboundMediaFilename } from "./outbound-media.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from "./outbound-message-context.js";
 import {
@@ -28,6 +29,7 @@ import {
   type TelegramApiContext,
   type TelegramThreadScopedParams,
 } from "./send-context.js";
+import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
 import {
@@ -36,7 +38,6 @@ import {
   isGifMedia,
   kindFromMime,
   loadWebMedia,
-  type MediaKind,
   probeVideoDimensions,
   resolveMarkdownTableMode,
 } from "./send.runtime.js";
@@ -247,8 +248,12 @@ async function sendMessageTelegramWithContext(
       sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
     }
     const isVideoNote = deliveryKind === "video" && opts.asVideoNote === true;
-    const fileName =
-      media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
+    const fileName = resolveTelegramOutboundMediaFilename({
+      fileName: media.fileName,
+      contentType: media.contentType,
+      kind,
+      isGif,
+    });
     const file = new InputFileCtor(media.buffer, fileName);
     let caption: string | undefined;
     let htmlCaption: string | undefined;
@@ -310,6 +315,9 @@ async function sendMessageTelegramWithContext(
             requestWithChatNotFound(
               () => sender(effectiveParams as TelegramThreadScopedParams),
               effectiveLabel,
+              label === "photo"
+                ? { shouldLog: (error) => !isTelegramPhotoLimitError(error) }
+                : undefined,
             ),
         });
       if (!htmlCaption || !plainCaption) {
@@ -325,6 +333,17 @@ async function sendMessageTelegramWithContext(
       });
     };
 
+    const documentSender = {
+      label: "document",
+      sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+        api.sendDocument(
+          chatId,
+          file,
+          (opts.forceDocument
+            ? { ...effectiveParams, disable_content_type_detection: true }
+            : effectiveParams) as Parameters<typeof api.sendDocument>[2],
+        ) as Promise<TelegramMessageLike>,
+    };
     const mediaSender = (() => {
       if (isGif && deliveryKind !== "document") {
         return {
@@ -398,22 +417,26 @@ async function sendMessageTelegramWithContext(
             ) as Promise<TelegramMessageLike>,
         };
       }
-      return {
-        label: "document",
-        sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-          api.sendDocument(
-            chatId,
-            file,
-            (opts.forceDocument
-              ? { ...effectiveParams, disable_content_type_detection: true }
-              : effectiveParams) as Parameters<typeof api.sendDocument>[2],
-          ) as Promise<TelegramMessageLike>,
-      };
+      return documentSender;
     })();
 
+    let deliveredMediaSender = mediaSender;
     let mediaDelivery: Awaited<ReturnType<typeof sendMedia>>;
     try {
-      mediaDelivery = await sendMedia(mediaSender.label, mediaSender.sender);
+      try {
+        mediaDelivery = await sendMedia(mediaSender.label, mediaSender.sender);
+      } catch (error) {
+        if (mediaSender.label !== "photo" || !isTelegramPhotoLimitError(error)) {
+          throw error;
+        }
+        // The provider is authoritative for photo size/dimensions; keep the
+        // same bytes, caption, quote, keyboard, and topic when retrying as a file.
+        logVerbose(
+          `telegram sendPhoto exceeded photo limits; retrying as document: ${formatErrorMessage(error)}`,
+        );
+        deliveredMediaSender = documentSender;
+        mediaDelivery = await sendMedia(documentSender.label, documentSender.sender);
+      }
     } catch (error) {
       opts.promptContextProjectionPlan?.cursor.invalidate();
       throw error;
@@ -442,11 +465,11 @@ async function sendMessageTelegramWithContext(
       accountId: account.accountId,
       chatId: resolvedChatId,
       messageId: String(mediaMessageId),
-      operation: `send${mediaSender.label
+      operation: `send${deliveredMediaSender.label
         .split("_")
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join("")}`,
-      deliveryKind: mediaSender.label,
+      deliveryKind: deliveredMediaSender.label,
       messageThreadId: acceptedMediaParams?.message_thread_id,
       replyToMessageId: opts.replyToMessageId,
       silent: opts.silent,
@@ -482,17 +505,4 @@ async function sendMessageTelegramWithContext(
     direction: "outbound",
   });
   return textResult;
-}
-
-function inferFilename(kind: MediaKind) {
-  switch (kind) {
-    case "image":
-      return "image.jpg";
-    case "video":
-      return "video.mp4";
-    case "audio":
-      return "audio.ogg";
-    default:
-      return "file.bin";
-  }
 }

--- a/extensions/telegram/src/send.runtime.ts
+++ b/extensions/telegram/src/send.runtime.ts
@@ -2,7 +2,7 @@
 export { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-export type { PollInput, MediaKind } from "openclaw/plugin-sdk/media-runtime";
+export type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 export {
   buildOutboundMediaLoadOptions,
   getImageMetadata,

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -160,7 +160,12 @@ vi.mock("grammy", () => ({
   GrammyError: class GrammyError extends Error {
     description = "";
   },
-  InputFile: function InputFile() {},
+  InputFile: class InputFile {
+    constructor(
+      public readonly fileData: Buffer,
+      public readonly filename?: string,
+    ) {}
+  },
 }));
 
 vi.mock("undici", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2962,6 +2962,86 @@ describe("sendMessageTelegram", () => {
   });
 
   it.each([
+    { contentType: "image/png", filename: "image.png", method: "sendPhoto" },
+    { contentType: "video/quicktime", filename: "video.mov", method: "sendVideo" },
+    { contentType: "audio/mpeg", filename: "audio.mp3", method: "sendAudio" },
+    { contentType: "application/pdf", filename: "file.pdf", method: "sendDocument" },
+    { contentType: "image/gif", filename: "animation.gif", method: "sendAnimation" },
+    { contentType: "application/x-custom", filename: "file.bin", method: "sendDocument" },
+  ])("preserves MIME-derived filenames for durable $contentType", async (testCase) => {
+    const sendMedia = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const api = { [testCase.method]: sendMedia } as TelegramApiOverride;
+    mockLoadedMedia({ contentType: testCase.contentType });
+
+    await sendMessageTelegram("123", "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/media",
+    });
+
+    expect(firstMockCall(sendMedia, testCase.method)[1]).toMatchObject({
+      filename: testCase.filename,
+    });
+  });
+
+  it.each(["PHOTO_INVALID_DIMENSIONS", "PHOTO_TOO_BIG"])(
+    "falls back to a document when Telegram rejects a durable photo with %s",
+    async (reason) => {
+      const sendPhoto = vi.fn().mockRejectedValueOnce(new Error(`400: Bad Request: ${reason}`));
+      const sendDocument = vi.fn().mockResolvedValue({
+        message_id: 10,
+        chat: { id: "123" },
+      });
+      mockLoadedMedia({ contentType: "image/png", fileName: "photo.png" });
+
+      const result = await sendMessageTelegram("123", "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendPhoto, sendDocument },
+        mediaUrl: "https://example.com/photo.png",
+        messageThreadId: 42,
+        replyToMessageId: 512,
+      });
+
+      expect(sendPhoto).toHaveBeenCalledOnce();
+      expectMediaSendCall(
+        firstMockCall(sendDocument, "fallback document"),
+        "fallback document",
+        "123",
+        {
+          caption: "caption",
+          parse_mode: "HTML",
+          message_thread_id: 42,
+          reply_to_message_id: 512,
+          allow_sending_without_reply: true,
+        },
+      );
+      expect(result.messageId).toBe("10");
+    },
+  );
+
+  it("does not retry unrelated durable photo failures as documents", async () => {
+    const sendPhoto = vi.fn().mockRejectedValueOnce(new Error("400: Bad Request: chat migrated"));
+    const sendDocument = vi.fn();
+    mockLoadedMedia({ contentType: "image/png", fileName: "photo.png" });
+
+    await expect(
+      sendMessageTelegram("123", "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendPhoto, sendDocument },
+        mediaUrl: "https://example.com/photo.png",
+      }),
+    ).rejects.toThrow("chat migrated");
+
+    expect(sendDocument).not.toHaveBeenCalled();
+  });
+
+  it.each([
     {
       name: "images",
       buffer: Buffer.from("fake-image"),


### PR DESCRIPTION
## What Problem This Solves

Telegram's two outbound funnels diverged on recoverable photo failures and upload metadata:

1. Streaming photo replies disappeared when Telegram rejected provider-only size or dimension limits.
2. Durable photo replies independently failed on those same explicit provider rejections.
3. Anonymous uploads received extensionless or incorrect filenames, including PNG labeled JPG, MOV labeled MP4, MP3 labeled OGG, and PDF labeled BIN.

## Why This Change Was Made

Keep photo rejection classification and MIME-derived upload filenames in shared Telegram-plugin owners, then reuse them from both delivery funnels. Retry only `PHOTO_INVALID_DIMENSIONS` and `PHOTO_TOO_BIG` through the existing document transport. Preserve the original buffer, caption fallback, topic, accepted reply metadata, inline controls, prompt-context record, and accurate successful-operation logging; leave unrelated provider errors fail-closed.

## Evidence

- Exact commit: `99feaf4a1bc102bcafe13a471325d3a451108be6`.
- Branch: `codex/qa200-telegram-stream-media-owner`.
- Immutable base: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Distinct reproduced roots: **3**.
- Immutable-base regressions demonstrated five streaming filename failures, four durable filename failures, and two durable photo-provider rejections.
- Exact-head durable focused proof: **9 passed**.
- Exact-head streaming focused proof: **13 passed**.
- A broader combined owner run passed **272 tests**; two unrelated pre-existing Markdown tests timed out under shared-host contention and two initial new assertions were corrected to match canonical accepted reply metadata, followed by clean exact-head targeted reruns.
- Installed grammY API types define the provider photo limits, while grammY multipart and `InputFile` source prove filename ownership and Buffer-backed retry safety.
- Independent strict exact-head owner review: **CLEAN**, covering all three root causes.
- Genuine structured exact-commit autoreview: **CLEAN**, `gpt-5.6-sol`, high reasoning; overall patch correctness **0.91** with no accepted or actionable findings.
- Genuine TruffleHog secret scan: **CLEAN**.
- Targeted formatting, committed `git diff --check`, frozen-base ancestry, and clean worktree passed.
- Remote changed gates and hosted CI must complete before landing.
