### PR TITLE
fix(ui): recover session observers after failures and reconnects

### DIFF
--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -1,9 +1,111 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
+import {
+  GatewayRequestError,
+  type GatewayBrowserClient,
+  type GatewayHelloOk,
+} from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createSessionCapability } from "./index.ts";
+
+function emptySessionsResult(): SessionsListResult {
+  return {
+    ts: 1,
+    path: "(multiple)",
+    count: 0,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [],
+  };
+}
+
+function runningSessionsResult(): SessionsListResult {
+  return {
+    ...emptySessionsResult(),
+    count: 1,
+    sessions: [
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 1,
+        hasActiveRun: true,
+        activeRunIds: ["run-1"],
+        status: "running",
+        startedAt: 1,
+      },
+    ],
+  };
+}
+
+function createSubscriptionHydrationHarness(request: GatewayBrowserClient["request"]) {
+  const client = { request } as GatewayBrowserClient;
+  let snapshot = {
+    client: null as GatewayBrowserClient | null,
+    phase: "reconnecting" as "connected" | "reconnecting",
+    sessionKey: "agent:main:main",
+    assistantAgentId: "main" as string | null,
+    hello: null as GatewayHelloOk | null,
+  };
+  let gatewayListener: ((next: typeof snapshot) => void) | undefined;
+  const sessions = createSessionCapability({
+    get snapshot() {
+      return snapshot;
+    },
+    subscribe(listener) {
+      gatewayListener = listener;
+      return () => {
+        gatewayListener = undefined;
+      };
+    },
+    subscribeEvents: () => () => undefined,
+  });
+  return {
+    client,
+    sessions,
+    connect: () => {
+      snapshot = { ...snapshot, client, phase: "connected" };
+      gatewayListener?.(snapshot);
+    },
+    disconnect: () => {
+      snapshot = { ...snapshot, phase: "reconnecting" };
+      gatewayListener?.(snapshot);
+    },
+  };
+}
+
+const targetedSessionReconciliationCases = [
+  {
+    description: "targeted session changes",
+    reconcile: (sessions: ReturnType<typeof createSessionCapability>) => {
+      expect(
+        sessions.reconcileChanged(
+          {
+            sessionKey: "agent:main:main",
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 2,
+            hasActiveRun: false,
+            status: "done",
+          },
+          { resultAgentId: "main" },
+        ).applied,
+      ).toBe(true);
+    },
+  },
+  {
+    description: "targeted run-terminal reconciliation",
+    reconcile: (sessions: ReturnType<typeof createSessionCapability>) => {
+      expect(
+        sessions.reconcileRunTerminal({
+          sessionKeys: ["agent:main:main"],
+          runId: "run-1",
+          status: "done",
+          endedAt: 2,
+        }),
+      ).toBe(true);
+    },
+  },
+];
 
 describe("session connection hydration", () => {
   it("uses the selected agent before a session key is available", async () => {
@@ -16,7 +118,7 @@ describe("session connection hydration", () => {
     };
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return result;
@@ -72,7 +174,7 @@ describe("session connection hydration", () => {
     };
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         listCalls += 1;
@@ -130,7 +232,7 @@ describe("session connection hydration", () => {
     };
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         listCalls += 1;
@@ -174,5 +276,440 @@ describe("session connection hydration", () => {
     await waitForFast(() => expect(sessions.state.result).toBe(result));
 
     sessions.dispose();
+  });
+
+  it("preserves a failed session observer through hydration and retries the current connection", async () => {
+    vi.useFakeTimers();
+    const result = emptySessionsResult();
+    const recoveredResult: SessionsListResult = {
+      ...result,
+      count: 1,
+      sessions: [{ key: "agent:main:recovered", kind: "direct", updatedAt: 2 }],
+    };
+    let subscriptionCalls = 0;
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        if (subscriptionCalls === 1) {
+          throw new GatewayRequestError({
+            code: "UNAVAILABLE",
+            message: "session observer temporarily unavailable",
+            retryable: true,
+            retryAfterMs: 100,
+          });
+        }
+        return { subscribed: true };
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 1 ? result : recoveredResult;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sessions.state.result).toBe(result);
+      expect(sessions.state.error).toBe(
+        "GatewayRequestError: session observer temporarily unavailable",
+      );
+      expect(subscriptionCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(subscriptionCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(subscriptionCalls).toBe(2);
+      expect(sessions.state.error).toBeNull();
+      expect(sessions.state.result).toBe(recoveredResult);
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { description: "an explicitly declined", response: { subscribed: false } },
+    { description: "an unacknowledged", response: {} },
+    { description: "a missing", response: null },
+  ])(
+    "rejects $description session observer and retries until acknowledged",
+    async ({ response }) => {
+      vi.useFakeTimers();
+      let subscriptionCalls = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.subscribe") {
+          subscriptionCalls += 1;
+          return subscriptionCalls === 1 ? response : { subscribed: true };
+        }
+        if (method === "sessions.list") {
+          return emptySessionsResult();
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const { sessions, connect } = createSubscriptionHydrationHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+
+      try {
+        connect();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(subscriptionCalls).toBe(1);
+        expect(sessions.state.result).not.toBeNull();
+        expect(sessions.state.error).toContain("did not activate the session event subscription");
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(subscriptionCalls).toBe(2);
+        expect(sessions.state.error).toBeNull();
+        expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        sessions.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("retires observer retries on disconnect before the same client reconnects", async () => {
+    vi.useFakeTimers();
+    let subscriptionCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        if (subscriptionCalls === 1) {
+          throw new GatewayRequestError({
+            code: "UNAVAILABLE",
+            message: "session observer temporarily unavailable",
+            retryable: true,
+            retryAfterMs: 100,
+          });
+        }
+        return { subscribed: true };
+      }
+      if (method === "sessions.list") {
+        return emptySessionsResult();
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect, disconnect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(subscriptionCalls).toBe(1);
+      expect(vi.getTimerCount()).toBe(1);
+
+      disconnect();
+      expect(sessions.state.error).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(subscriptionCalls).toBe(1);
+
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(subscriptionCalls).toBe(2);
+      expect(sessions.state.error).toBeNull();
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not recreate a retry timer when an observer-error listener disposes its owner", async () => {
+    vi.useFakeTimers();
+    let subscriptionCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        throw new GatewayRequestError({
+          code: "UNAVAILABLE",
+          message: "observer unavailable during teardown",
+          retryable: true,
+          retryAfterMs: 100,
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+    sessions.subscribe((next) => {
+      if (next.error) {
+        sessions.dispose();
+      }
+    });
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(subscriptionCalls).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(subscriptionCalls).toBe(1);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(targetedSessionReconciliationCases)(
+    "preserves an active observer failure across $description",
+    async ({ reconcile }) => {
+      vi.useFakeTimers();
+      let subscriptionCalls = 0;
+      const result = runningSessionsResult();
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.subscribe") {
+          subscriptionCalls += 1;
+          if (subscriptionCalls === 1) {
+            throw new GatewayRequestError({
+              code: "UNAVAILABLE",
+              message: "broad session observer unavailable",
+              retryable: true,
+              retryAfterMs: 100,
+            });
+          }
+          return { subscribed: true };
+        }
+        if (method === "sessions.list") {
+          return result;
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const { sessions, connect } = createSubscriptionHydrationHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+
+      try {
+        connect();
+        await vi.advanceTimersByTimeAsync(0);
+        const observerError = "GatewayRequestError: broad session observer unavailable";
+        expect(sessions.state.error).toBe(observerError);
+
+        reconcile(sessions);
+        expect(sessions.state.error).toBe(observerError);
+
+        await vi.advanceTimersByTimeAsync(100);
+        expect(subscriptionCalls).toBe(2);
+        expect(sessions.state.error).toBeNull();
+      } finally {
+        sessions.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(targetedSessionReconciliationCases)(
+    "preserves a newer operation failure across $description",
+    async ({ reconcile }) => {
+      vi.useFakeTimers();
+      let subscriptionCalls = 0;
+      let listCalls = 0;
+      const result = runningSessionsResult();
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.subscribe") {
+          subscriptionCalls += 1;
+          if (subscriptionCalls === 1) {
+            throw new GatewayRequestError({
+              code: "UNAVAILABLE",
+              message: "broad session observer unavailable",
+              retryable: true,
+              retryAfterMs: 100,
+            });
+          }
+          return { subscribed: true };
+        }
+        if (method === "sessions.list") {
+          listCalls += 1;
+          if (listCalls === 2) {
+            throw new Error("newer session list failure");
+          }
+          return result;
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const { sessions, connect } = createSubscriptionHydrationHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+
+      try {
+        connect();
+        await vi.advanceTimersByTimeAsync(0);
+        await sessions.refresh({ force: true });
+        const operationError = "Error: newer session list failure";
+        expect(sessions.state.error).toBe(operationError);
+
+        reconcile(sessions);
+        expect(sessions.state.error).toBe(operationError);
+
+        await vi.advanceTimersByTimeAsync(100);
+        expect(subscriptionCalls).toBe(2);
+        expect(sessions.state.error).toBeNull();
+      } finally {
+        sessions.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("keeps newer session-list failures visible across repeated observer retry failures", async () => {
+    vi.useFakeTimers();
+    let subscriptionCalls = 0;
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        throw new GatewayRequestError({
+          code: "UNAVAILABLE",
+          message: `observer unavailable ${subscriptionCalls}`,
+          retryable: true,
+          retryAfterMs: 100,
+        });
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        if (listCalls > 1) {
+          throw new Error("newer session list failure");
+        }
+        return emptySessionsResult();
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+      await sessions.refresh({ force: true });
+      expect(sessions.state.error).toBe("Error: newer session list failure");
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(subscriptionCalls).toBe(2);
+      expect(sessions.state.error).toBe("Error: newer session list failure");
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clear an unrelated list error with the same observer error message", async () => {
+    vi.useFakeTimers();
+    let completeCatchUpList: (result: SessionsListResult) => void = () => undefined;
+    const pendingCatchUpList = new Promise<SessionsListResult>((resolve) => {
+      completeCatchUpList = resolve;
+    });
+    const sharedError = new GatewayRequestError({
+      code: "UNAVAILABLE",
+      message: "same failure message",
+      retryable: true,
+      retryAfterMs: 100,
+    });
+    let subscriptionCalls = 0;
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        if (subscriptionCalls === 1) {
+          throw sharedError;
+        }
+        return { subscribed: true };
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        if (listCalls === 2) {
+          throw sharedError;
+        }
+        return listCalls === 3 ? await pendingCatchUpList : emptySessionsResult();
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+      await sessions.refresh({ force: true });
+      expect(sessions.state.error).toBe("GatewayRequestError: same failure message");
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(subscriptionCalls).toBe(2);
+      expect(listCalls).toBe(3);
+      expect(sessions.state.error).toBe("GatewayRequestError: same failure message");
+      completeCatchUpList(emptySessionsResult());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sessions.state.error).toBeNull();
+    } finally {
+      completeCatchUpList(emptySessionsResult());
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores an outdated observer refusal after the same client reconnects", async () => {
+    vi.useFakeTimers();
+    let settleRetiredSubscription: (response: { subscribed: boolean }) => void = () => undefined;
+    const retiredSubscription = new Promise<{ subscribed: boolean }>((resolve) => {
+      settleRetiredSubscription = resolve;
+    });
+    let subscriptionCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        subscriptionCalls += 1;
+        return subscriptionCalls === 1 ? await retiredSubscription : { subscribed: true };
+      }
+      if (method === "sessions.list") {
+        return emptySessionsResult();
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { sessions, connect, disconnect } = createSubscriptionHydrationHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(subscriptionCalls).toBe(1);
+
+      disconnect();
+      connect();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(subscriptionCalls).toBe(2);
+      expect(sessions.state.result).not.toBeNull();
+
+      settleRetiredSubscription({ subscribed: false });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sessions.state.error).toBeNull();
+      expect(subscriptionCalls).toBe(2);
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      settleRetiredSubscription({ subscribed: false });
+      sessions.dispose();
+      vi.useRealTimers();
+    }
   });
 });

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -225,7 +225,7 @@ describe("createSessionCapability", () => {
         return await renamed.promise;
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -253,7 +253,7 @@ describe("createSessionCapability", () => {
         return await replaced.promise;
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -449,7 +449,7 @@ describe("createSessionCapability", () => {
     let listCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         listCalls += 1;
@@ -482,7 +482,7 @@ describe("createSessionCapability", () => {
         return await staleCreate.promise;
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -583,7 +583,7 @@ describe("createSessionCapability", () => {
         return await staleReset.promise;
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -609,7 +609,7 @@ describe("createSessionCapability", () => {
         throw new Error("post-commit lifecycle failed");
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -632,7 +632,7 @@ describe("createSessionCapability", () => {
         return await stalePatch.promise;
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);
@@ -665,7 +665,7 @@ describe("createSessionCapability", () => {
         return { ok: true, path: "", key: "agent:main:main", entry: {} };
       }
       if (method === "sessions.subscribe") {
-        return {};
+        return { subscribed: true };
       }
       if (method === "sessions.list") {
         return sessionsResult([], 2);

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -50,6 +50,7 @@ import {
   type SessionChangedResult,
   type SessionReconcileOptions,
 } from "./reconcile.ts";
+import { createSessionEventSubscriptionOwner } from "./session-event-subscription.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
@@ -740,7 +741,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const swarmActivity = new SwarmActivityTracker();
   const pullRequestSummaries = new Map<string, SessionCatalogPullRequestSummary>();
   const pullRequestEpochs = new Map<string, symbol>();
-  let subscribedClient: GatewayBrowserClient | null = null;
+  let hydratedClient: GatewayBrowserClient | null = null;
+  let sessionEventSubscriptionError: string | null = null;
+  let publishedErrorSource: "session-observer" | "operation" | null = null;
   let lastListOptions: SessionListOptions = {};
   let hasForegroundListOptions = false;
   let hasSeededListOptions = false;
@@ -776,12 +779,40 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return isCurrentConnection(scope) ? swarmActivity.decorate(result ?? null) : null;
   };
 
-  const publish = (next: SessionState) => {
+  const publish = (next: SessionState, errorSource?: "session-observer" | "operation") => {
+    if (next.error === null) {
+      publishedErrorSource = null;
+    } else if (errorSource || next.error !== state.error) {
+      publishedErrorSource = errorSource ?? "operation";
+    }
     state = next;
     for (const listener of listeners) {
       listener(state);
     }
   };
+
+  const sessionEventSubscription = createSessionEventSubscriptionOwner({
+    isCurrent: isCurrentConnection,
+    retryDelayMs: (error) => sessionRetryDelayMs(error),
+    onError: (scope, error) => {
+      if (!isCurrentConnection(scope)) {
+        return;
+      }
+      const previousError = sessionEventSubscriptionError;
+      sessionEventSubscriptionError = error;
+      const observerOwnsVisibleError = publishedErrorSource === "session-observer";
+      if (error !== null && (state.error === null || observerOwnsVisibleError)) {
+        publish({ ...state, error }, "session-observer");
+      } else if (error === null && observerOwnsVisibleError) {
+        publish({ ...state, error: null });
+      }
+      if (previousError !== null && error === null) {
+        // Events lost while the observer was unavailable are not replayed;
+        // one canonical catch-up list closes that reconnect visibility gap.
+        void refresh({ ...lastListOptions, backgroundHydrate: true, force: true });
+      }
+    },
+  });
 
   const pullRequestSummary = (key: string): SessionCatalogPullRequestSummary | undefined =>
     pullRequestSummaries.get(key.trim());
@@ -907,7 +938,15 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       hasSeededListOptions = true;
     }
     if (!backgroundHydrate) {
-      publish({ ...state, loading: true, error: null, deletedSessions: [] });
+      publish(
+        {
+          ...state,
+          loading: true,
+          error: sessionEventSubscriptionError,
+          deletedSessions: [],
+        },
+        sessionEventSubscriptionError ? "session-observer" : undefined,
+      );
     }
     try {
       const result = await requestSessionList(scope.client, requestOptions);
@@ -961,24 +1000,30 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         }
       }
       canonicalListRevision += 1;
-      publish({
-        result: nextResult,
-        agentId: requestOptions.agentId?.trim() ? normalizeAgentId(requestOptions.agentId) : null,
-        modelOverrides: state.modelOverrides,
-        loading: backgroundHydrate ? state.loading : false,
-        error: null,
-        deletedSessions: [],
-        groups: state.groups,
-        sectionOrder: state.sectionOrder,
-      });
+      publish(
+        {
+          result: nextResult,
+          agentId: requestOptions.agentId?.trim() ? normalizeAgentId(requestOptions.agentId) : null,
+          modelOverrides: state.modelOverrides,
+          loading: backgroundHydrate ? state.loading : false,
+          error: sessionEventSubscriptionError,
+          deletedSessions: [],
+          groups: state.groups,
+          sectionOrder: state.sectionOrder,
+        },
+        sessionEventSubscriptionError ? "session-observer" : undefined,
+      );
     } catch (error) {
       if (isCurrentConnection(scope)) {
-        publish({
-          ...state,
-          loading: backgroundHydrate ? state.loading : false,
-          error: String(error),
-          deletedSessions: [],
-        });
+        publish(
+          {
+            ...state,
+            loading: backgroundHydrate ? state.loading : false,
+            error: String(error),
+            deletedSessions: [],
+          },
+          "operation",
+        );
       }
     }
   };
@@ -1141,7 +1186,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (options.reconciliation === "background") {
         void reconcileCreatedSession().catch((error: unknown) => {
           if (isCurrentConnection(scope)) {
-            publish({ ...state, error: String(error) });
+            publish({ ...state, error: String(error) }, "operation");
           }
         });
       } else {
@@ -1153,7 +1198,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return result;
     } catch (error) {
       if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) });
+        publish({ ...state, error: String(error) }, "operation");
       }
       return null;
     }
@@ -1164,9 +1209,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const LEGACY_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
   const GROUPS_LIST_METHOD = "sessions.groups.list";
-  const GROUPS_RETRY_DEFAULT_MS = 500;
-  const GROUPS_RETRY_MIN_MS = 100;
-  const GROUPS_RETRY_MAX_MS = 30_000;
+  const SESSION_RETRY_DEFAULT_MS = 500;
+  const SESSION_RETRY_MIN_MS = 100;
+  const SESSION_RETRY_MAX_MS = 30_000;
   let groupsLoadedEpoch = -1;
   let groupsLoadGeneration = 0;
   let groupsRetryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -1184,15 +1229,15 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     clearGroupsRetry();
   };
 
-  const groupsRetryDelayMs = (error: unknown): number | null => {
+  const sessionRetryDelayMs = (error: unknown): number | null => {
     if (!(error instanceof GatewayRequestError) || !error.retryable) {
       return null;
     }
     const requested =
       typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
         ? error.retryAfterMs
-        : GROUPS_RETRY_DEFAULT_MS;
-    return Math.min(Math.max(requested, GROUPS_RETRY_MIN_MS), GROUPS_RETRY_MAX_MS);
+        : SESSION_RETRY_DEFAULT_MS;
+    return Math.min(Math.max(requested, SESSION_RETRY_MIN_MS), SESSION_RETRY_MAX_MS);
   };
 
   const publishGroupCatalog = (groups: readonly string[], sectionOrder: readonly string[]) => {
@@ -1215,7 +1260,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!current) {
       return "stale";
     }
-    publish({ ...state, error: String(error) });
+    publish({ ...state, error: String(error) }, "operation");
     throw error;
   };
 
@@ -1278,7 +1323,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         return;
       }
       groupsLoadedEpoch = -1;
-      const retryDelayMs = groupsRetryDelayMs(error);
+      const retryDelayMs = sessionRetryDelayMs(error);
       if (retryDelayMs === null) {
         return;
       }
@@ -1433,7 +1478,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return null;
       }
-      publish({ ...state, error: String(error) });
+      publish({ ...state, error: String(error) }, "operation");
       throw error;
     }
   };
@@ -1459,6 +1504,17 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return true;
   };
 
+  const publishReconciledSessionState = (next: SessionState) => {
+    // Targeted events can outlive a failed broad observer; preserve its outage
+    // unless a newer operation already owns the visible failure.
+    const operationOwnsError = publishedErrorSource === "operation";
+    const error = operationOwnsError ? state.error : sessionEventSubscriptionError;
+    publish(
+      { ...next, error },
+      error === null ? undefined : operationOwnsError ? "operation" : "session-observer",
+    );
+  };
+
   const reconcileChanged = (
     payload: unknown,
     options?: SessionReconcileOptions,
@@ -1477,13 +1533,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       retirePullRequestSummary(reconciled.deletedKey);
     }
     if (reconciled.applied && (reconciled.result !== state.result || reconciled.deletedKey)) {
-      publish({
+      publishReconciledSessionState({
         ...state,
         result: reconciled.result,
         agentId: options?.resultAgentId?.trim()
           ? normalizeAgentId(options.resultAgentId)
           : state.agentId,
-        error: null,
         deletedSessions: reconciled.deletedKey
           ? [{ key: reconciled.deletedKey, agentId: reconciled.agentId ?? undefined }]
           : [],
@@ -1497,7 +1552,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (result === state.result) {
       return false;
     }
-    publish({ ...state, result, error: null });
+    publishReconciledSessionState({ ...state, result });
     return true;
   };
 
@@ -1530,7 +1585,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return { deleted: false };
       }
-      publish({ ...state, error: String(error) });
+      publish({ ...state, error: String(error) }, "operation");
       throw error;
     }
   };
@@ -1597,7 +1652,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return isCurrentConnection(scope) ? "completed" : "uncertain";
     } catch (error) {
       if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) });
+        publish({ ...state, error: String(error) }, "operation");
       }
       // The gateway commits the new session identity before every awaited
       // post-reset lifecycle step finishes. Once requested, even a rejection
@@ -1831,6 +1886,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
       eventRefreshCoordinator.reset();
       connectionEpoch += 1;
+      sessionEventSubscription.reset();
+      sessionEventSubscriptionError = null;
       if (previousClient) {
         resetGatewaySessionMessageSubscriptionCoordinator(previousClient);
       }
@@ -1851,7 +1908,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       }
     }
     if (!connected || !next.client) {
-      subscribedClient = null;
+      hydratedClient = null;
       publish({
         result: null,
         agentId: null,
@@ -1864,32 +1921,25 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       });
       return;
     }
-    if (subscribedClient !== next.client) {
+    if (hydratedClient !== next.client) {
       const scope = captureConnection();
       if (!scope) {
         return;
       }
-      subscribedClient = scope.client;
+      hydratedClient = scope.client;
       void (async () => {
-        try {
-          await scope.client.request("sessions.subscribe", {});
-        } catch (error) {
-          if (isCurrentConnection(scope)) {
-            publish({ ...state, error: String(error) });
-          }
-        } finally {
-          if (isCurrentConnection(scope)) {
-            const sessionKey = gateway.snapshot.sessionKey?.trim();
-            const agentScope = sessionKey
-              ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
-              : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
-            await refresh({
-              ...agentScope,
-              includeDerivedTitles: true,
-              backgroundHydrate: true,
-              force: true,
-            });
-          }
+        await sessionEventSubscription.ensure(scope);
+        if (isCurrentConnection(scope)) {
+          const sessionKey = gateway.snapshot.sessionKey?.trim();
+          const agentScope = sessionKey
+            ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
+            : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
+          await refresh({
+            ...agentScope,
+            includeDerivedTitles: true,
+            backgroundHydrate: true,
+            force: true,
+          });
         }
       })();
     }
@@ -2034,12 +2084,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       inFlight = null;
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
-      subscribedClient = null;
+      hydratedClient = null;
       pendingModelPatches.clear();
       preparedWorkSessionKeys.clear();
       swarmActivity.clear();
       pullRequestSummaries.clear();
       pullRequestEpochs.clear();
+      sessionEventSubscription.dispose();
       stopGateway();
       stopEvents();
       createdListeners.clear();

--- a/ui/src/lib/sessions/session-event-subscription.ts
+++ b/ui/src/lib/sessions/session-event-subscription.ts
@@ -1,0 +1,96 @@
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+
+type SessionEventSubscriptionScope = {
+  client: GatewayBrowserClient;
+  epoch: number;
+};
+
+type SessionEventSubscriptionOwner = {
+  ensure: (scope: SessionEventSubscriptionScope) => Promise<void>;
+  reset: () => void;
+  dispose: () => void;
+};
+
+/** Keeps one acknowledged broad session observer alive for its connection generation. */
+export function createSessionEventSubscriptionOwner(params: {
+  isCurrent: (scope: SessionEventSubscriptionScope) => boolean;
+  onError: (scope: SessionEventSubscriptionScope, error: string | null) => void;
+  retryDelayMs: (error: unknown) => number | null;
+}): SessionEventSubscriptionOwner {
+  let generation = 0;
+  let confirmed: SessionEventSubscriptionScope | null = null;
+  let pending: { generation: number; promise: Promise<void> } | null = null;
+  let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  const clearRetry = () => {
+    if (retryTimer !== null) {
+      globalThis.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const isCurrent = (scope: SessionEventSubscriptionScope, expectedGeneration: number): boolean =>
+    generation === expectedGeneration && params.isCurrent(scope);
+
+  const ensure = (scope: SessionEventSubscriptionScope): Promise<void> => {
+    if (confirmed?.client === scope.client && confirmed.epoch === scope.epoch) {
+      return Promise.resolve();
+    }
+    if (pending?.generation === generation) {
+      return pending.promise;
+    }
+    clearRetry();
+    const expectedGeneration = generation;
+    const request = (async () => {
+      try {
+        const response = await scope.client.request<{ subscribed?: boolean }>(
+          "sessions.subscribe",
+          {},
+        );
+        if (!isCurrent(scope, expectedGeneration)) {
+          return;
+        }
+        if (response?.subscribed !== true) {
+          throw new GatewayRequestError({
+            code: "UNAVAILABLE",
+            message: "Gateway did not activate the session event subscription",
+            retryable: true,
+          });
+        }
+        confirmed = scope;
+        params.onError(scope, null);
+      } catch (error) {
+        if (!isCurrent(scope, expectedGeneration)) {
+          return;
+        }
+        params.onError(scope, String(error));
+        const delayMs = params.retryDelayMs(error);
+        if (delayMs === null || !isCurrent(scope, expectedGeneration)) {
+          return;
+        }
+        // A retired connection must never revive an observer on its replacement.
+        retryTimer = globalThis.setTimeout(() => {
+          retryTimer = null;
+          if (isCurrent(scope, expectedGeneration)) {
+            void ensure(scope);
+          }
+        }, delayMs);
+      }
+    })().finally(() => {
+      if (pending?.promise === request) {
+        pending = null;
+      }
+    });
+    pending = { generation: expectedGeneration, promise: request };
+    return request;
+  };
+
+  const reset = () => {
+    generation += 1;
+    confirmed = null;
+    pending = null;
+    clearRetry();
+  };
+
+  return { ensure, reset, dispose: reset };
+}

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -184,6 +184,30 @@ describe("mock gateway stateful config", () => {
 });
 
 describe("mock gateway stateful sessions", () => {
+  it("acknowledges broad session observation with the real Gateway response", async () => {
+    const script = createControlUiMockGatewayInitScript({});
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
+    new Function(script)();
+
+    const socket = new WebSocket("ws://mock-gateway");
+    const frames: ResponseFrame[] = [];
+    socket.addEventListener("message", (event) => {
+      frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
+    });
+    await flushMockTimers();
+
+    socket.send(
+      JSON.stringify({ type: "req", id: "subscribe-events", method: "sessions.subscribe" }),
+    );
+    await flushMockTimers();
+
+    expect(frames.find((frame) => frame.id === "subscribe-events")?.payload).toEqual({
+      subscribed: true,
+    });
+    socket.close();
+  });
+
   it("makes a successfully adopted catalog session visible to the next sessions.list", async () => {
     const sessionKey = "agent:main:adopted-codex";
     const script = createControlUiMockGatewayInitScript({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1362,7 +1362,7 @@ function installControlUiMockGateway(
         return { ok: true, updatedSessions: 0, ...groupsPayload() };
       }
       case "sessions.subscribe":
-        return { ok: true };
+        return { subscribed: true };
       case "sessions.messages.subscribe":
         return {
           key: isRecord(params) && typeof params.key === "string" ? params.key : "",


### PR DESCRIPTION
## What Problem This Solves

A failed broad `sessions.subscribe` permanently disabled Control UI session updates while successful list hydration erased the only visible error. Independent targeted message observers can still deliver session changes and terminal updates during that outage, and both reconciliation paths also erased the active broad-observer error. Even when observation eventually recovered, events lost during the outage were never reconciled.

## Why This Change Was Made

- Give the broad Gateway session observer one canonical, connection-scoped owner for pending, acknowledged, failed, and retrying work.
- Require the actual Gateway contract's affirmative `subscribed: true`; reject false, omitted, and null acknowledgments.
- Reuse the existing bounded retry policy while retiring stale requests and timers across same-client reconnects, connection replacement, disposal, and reentrant teardown.
- Track observer-versus-operation error ownership explicitly so successful hydration, targeted session changes, terminal reconciliation, newer operation failures, and identical error messages cannot silently erase the wrong diagnostic.
- Force one canonical filtered session-list catch-up after the observer recovers, closing the unreplayed-event gap without a second steady-state refresh path.

## User Impact

Connected operators see accurate session freshness and an actionable observer outage instead of a silently stale Control UI. Once the broad observer recovers, missing sessions and terminal changes reconcile automatically. No Gateway protocol, authentication, public configuration, plugin ownership, or persistent-state contract changes.

## Evidence

- Current Gateway response and targeted-message subscriber contracts directly inspected in `src/gateway/server-methods/sessions-subscriptions.ts` and `src/gateway/server-session-events.ts`.
- Final amended candidate: `fd47466ca57c58cae837c85ba3278df4ed83b422` on `codex/qa200-session-observer`.
- Focused final exact-content owner suites: **45 tests passed**. Both newly added targeted-reconciliation regressions failed on the prior exact candidate and pass after the canonical fix.
- Previous full focused owner, caller, and direct Gateway dependency validation: **105 tests passed**; only the two owner paths and their targeted regressions changed afterward.
- Fake-timer and boundary regressions cover affirmative/false/empty/null subscription acknowledgments, retryable rejection, list hydration, targeted session updates, run-terminal updates, same-client reconnect, stale acknowledgment retirement, reentrant disposal, operation-error ownership, equal-message collisions, and recovery catch-up.
- Final exact-commit structured Codex autoreview: **CLEAN** (confidence 0.93); TruffleHog, targeted oxlint, oxfmt, `git diff --check`, and isolated-worktree guards clean.

## Distinct Root Causes

1. Broad session observation could fail permanently while hydration and targeted reconciliation hid the outage.
2. Recovering observation did not reconcile session events missed while the broad observer was inactive.
