### PR TITLE
feat(plugins): externalize ComfyUI provider

### DIFF
--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -650,7 +650,7 @@ Docker runners below with an explicit `OPENCLAW_PROFILE_FILE`.
 - Test: `extensions/comfy/comfy.live.test.ts`
 - Enable: `OPENCLAW_LIVE_TEST=1 COMFY_LIVE_TEST=1 pnpm test:live -- extensions/comfy/comfy.live.test.ts`
 - Scope:
-  - Exercises the bundled comfy image, video, and `music_generate` paths
+  - Exercises the comfy image, video, and `music_generate` paths
   - Skips each capability unless `plugins.entries.comfy.config.<capability>` is configured
   - Useful after changing comfy workflow submission, polling, downloads, or plugin registration
 

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-60 plugins
+59 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -70,8 +70,6 @@ Each entry lists the package, distribution route, and description.
 - **[canvas](/plugins/reference/canvas)** (`@openclaw/canvas-plugin`) - included in OpenClaw. Experimental Canvas control and A2UI rendering surfaces for paired nodes.
 
 - **[clawrouter](/plugins/reference/clawrouter)** (`@openclaw/clawrouter`) - included in OpenClaw. Adds ClawRouter model provider support to OpenClaw.
-
-- **[comfy](/plugins/reference/comfy)** (`@openclaw/comfy-provider`) - included in OpenClaw. Adds ComfyUI model provider support to OpenClaw.
 
 - **[copilot-proxy](/plugins/reference/copilot-proxy)** (`@openclaw/copilot-proxy`) - included in OpenClaw. Adds Copilot Proxy model provider support to OpenClaw.
 
@@ -175,7 +173,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-85 plugins
+86 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -206,6 +204,8 @@ Each entry lists the package, distribution route, and description.
 - **[codex](/plugins/reference/codex)** (`@openclaw/codex`) - npm; ClawHub. Codex app-server harness and native session catalog.
 
 - **[cohere](/plugins/reference/cohere)** (`@openclaw/cohere-provider`) - npm; ClawHub: `clawhub:@openclaw/cohere-provider`. OpenClaw Cohere provider plugin.
+
+- **[comfy](/plugins/reference/comfy)** (`@openclaw/comfy-provider`) - npm; ClawHub: `clawhub:@openclaw/comfy-provider`. Adds ComfyUI model provider support to OpenClaw.
 
 - **[copilot](/plugins/reference/copilot)** (`@openclaw/copilot`) - npm; ClawHub: `clawhub:@openclaw/copilot`. Registers the GitHub Copilot agent runtime.
 

--- a/docs/plugins/reference/comfy.md
+++ b/docs/plugins/reference/comfy.md
@@ -12,7 +12,7 @@ Adds ComfyUI model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/comfy-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/comfy-provider`
 
 ## Surface
 

--- a/docs/providers/comfy.md
+++ b/docs/providers/comfy.md
@@ -4,11 +4,17 @@ title: "ComfyUI"
 read_when:
   - You want to use local ComfyUI workflows with OpenClaw
   - You want to use Comfy Cloud with image, video, or music workflows
-  - You need the bundled comfy plugin config keys
+  - You need the comfy plugin config keys
 ---
 
-OpenClaw ships a bundled `comfy` plugin for workflow-driven ComfyUI runs. The
-plugin is entirely workflow-driven: OpenClaw does not map generic `size`,
+Install the official `comfy` plugin for workflow-driven ComfyUI runs:
+
+```bash
+openclaw plugins install @openclaw/comfy-provider
+openclaw gateway restart
+```
+
+The plugin is entirely workflow-driven: OpenClaw does not map generic `size`,
 `aspectRatio`, `resolution`, `durationSeconds`, or TTS-style controls onto
 your graph.
 

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -271,9 +271,8 @@ Automatic fallback across authenticated providers is always enabled. A per-call
 <AccordionGroup>
   <Accordion title="ComfyUI">
     Workflow-driven and depends on the configured graph plus node mapping
-    for prompt/output fields. The bundled `comfy` plugin plugs into the
-    shared `music_generate` tool through the music-generation provider
-    registry.
+    for prompt/output fields. The `comfy` plugin plugs into the shared
+    `music_generate` tool through the music-generation provider registry.
   </Accordion>
   <Accordion title="fal">
     Uses fal model endpoints through the shared provider auth path. The

--- a/extensions/comfy/README.md
+++ b/extensions/comfy/README.md
@@ -1,0 +1,26 @@
+# @openclaw/comfy-provider
+
+Official ComfyUI image, video, and music generation provider plugin for
+OpenClaw.
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/comfy-provider
+openclaw gateway restart
+```
+
+## Configure
+
+Local ComfyUI workflows do not require credentials. Comfy Cloud workflows use
+`COMFY_API_KEY` or `COMFY_CLOUD_API_KEY`.
+
+Full workflow, model, and provider configuration:
+
+- https://docs.openclaw.ai/providers/comfy
+
+## Package
+
+- Plugin id: `comfy`
+- Package: `@openclaw/comfy-provider`
+- Minimum OpenClaw host: `2026.7.2`

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/comfy-provider",
   "version": "2026.7.2",
-  "private": true,
-  "description": "OpenClaw ComfyUI provider plugin",
+  "description": "OpenClaw ComfyUI provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/comfy-provider",
+      "npmSpec": "@openclaw/comfy-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "!dist/extensions/cerebras/**",
     "!dist/extensions/chutes/**",
     "!dist/extensions/cohere/**",
+    "!dist/extensions/comfy/**",
     "!dist/extensions/clickclack/**",
     "!dist/extensions/cloudflare-ai-gateway/**",
     "!dist/extensions/codex/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -472,6 +472,69 @@
       }
     },
     {
+      "name": "@openclaw/comfy-provider",
+      "description": "OpenClaw ComfyUI provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "comfy",
+          "label": "ComfyUI"
+        },
+        "providers": [
+          {
+            "id": "comfy",
+            "name": "ComfyUI",
+            "docs": "/providers/comfy",
+            "categories": [
+              "local",
+              "cloud",
+              "media"
+            ],
+            "envVars": [
+              "COMFY_API_KEY",
+              "COMFY_CLOUD_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "cloud-api-key",
+                "choiceId": "comfy-cloud-api-key",
+                "choiceLabel": "Comfy Cloud API key",
+                "choiceHint": "Required for cloud workflows",
+                "groupId": "comfy",
+                "groupLabel": "ComfyUI",
+                "groupHint": "Local or cloud workflows",
+                "optionKey": "comfyApiKey",
+                "cliFlag": "--comfy-api-key",
+                "cliOption": "--comfy-api-key <key>",
+                "cliDescription": "Comfy Cloud API key",
+                "onboardingScopes": [
+                  "image-generation"
+                ]
+              }
+            ]
+          }
+        ],
+        "contracts": {
+          "imageGenerationProviders": [
+            "comfy"
+          ],
+          "musicGenerationProviders": [
+            "comfy"
+          ],
+          "videoGenerationProviders": [
+            "comfy"
+          ]
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/comfy-provider",
+          "npmSpec": "@openclaw/comfy-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/deepinfra-provider",
       "description": "OpenClaw DeepInfra provider plugin.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -209,6 +209,38 @@ describe("listPersistedBundledPluginLocationBridges", () => {
     },
   );
 
+  it("externalizes the shipped bundled ComfyUI plugin while preserving default enablement", async () => {
+    readPersistedInstalledPluginIndexMock.mockResolvedValue(
+      makeIndex({
+        pluginId: "comfy",
+        manifestPath: "/app/dist/extensions/comfy/openclaw.plugin.json",
+        manifestHash: "hash",
+        source: "/app/dist/extensions/comfy/index.js",
+        rootDir: "/app/dist/extensions/comfy",
+        origin: "bundled",
+        enabled: true,
+        enabledByDefault: true,
+        startup: startupInfo,
+        compat: [],
+        packageInstall: {
+          warnings: [],
+        },
+      }),
+    );
+    loadPluginManifestRegistryForInstalledIndexMock.mockReturnValue(makeRegistry("comfy", []));
+
+    await expect(listPersistedBundledPluginLocationBridges({})).resolves.toEqual([
+      {
+        bundledPluginId: "comfy",
+        pluginId: "comfy",
+        preferredSource: "npm",
+        npmSpec: "@openclaw/comfy-provider",
+        clawhubSpec: "clawhub:@openclaw/comfy-provider",
+        enabledByDefault: true,
+      },
+    ]);
+  });
+
   it("does not create a relocation bridge without persisted or official install metadata", async () => {
     readPersistedInstalledPluginIndexMock.mockResolvedValue(
       makeIndex({

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2129,6 +2129,24 @@ describe("official external plugin catalog", () => {
     ]);
   });
 
+  it("lists ComfyUI as an official external media provider", () => {
+    const comfy = expectCatalogEntry("comfy");
+    const manifest = getOfficialExternalPluginCatalogManifest(comfy);
+
+    expect(resolveOfficialExternalPluginId(comfy)).toBe("comfy");
+    expect(resolveOfficialExternalPluginInstall(comfy)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/comfy-provider",
+      npmSpec: "@openclaw/comfy-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+    expect(manifest?.contracts).toMatchObject({
+      imageGenerationProviders: ["comfy"],
+      musicGenerationProviders: ["comfy"],
+      videoGenerationProviders: ["comfy"],
+    });
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -357,6 +357,12 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).not.toContain("dist/extensions/vydra/package.json");
   });
 
+  it("excludes the externalized ComfyUI provider from bundled artifacts", () => {
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expectNoPrefixMatches(artifacts, "dist/extensions/comfy/");
+  });
+
   it("excludes externalized meeting plugins from bundled artifacts", () => {
     const artifacts = listBundledPluginPackArtifacts();
 


### PR DESCRIPTION
## What Problem This Solves

ComfyUI currently ships inside the core OpenClaw npm package even though its
workflow runtime, configuration, and media-provider contracts are fully owned
by the `comfy` plugin. This keeps optional provider code in every core install
and prevents ComfyUI from following the official external plugin release path.

## Why This Change Was Made

This change makes `@openclaw/comfy-provider` an official external plugin,
excludes its runtime from the core package, and preserves the existing
installation transition for operators with persisted bundled-plugin state. The
official catalog retains ComfyUI's local/cloud setup, cloud API-key onboarding,
and image, music, and video generation contracts.

## User Impact

Operators who use ComfyUI install `@openclaw/comfy-provider` and restart the
Gateway. Existing bundled installations retain default enablement during the
relocation. Operators who do not use ComfyUI no longer receive its runtime in
the core npm package.

## Evidence

- Exact base: `e93de3608161e7d20f7017e5799f570fa7b419db`
- Exact reviewed head: `708d2906e4d9622c45dc9d71619cfbeddb80f266`
- `node scripts/run-vitest.mjs extensions/comfy`: 42 tests passed
- Catalog and persisted-location bridge tests: 88 tests passed
- Packaging, release metadata, and bundled-artifact tests: 87 tests passed
- Extension import-boundary guards: clean
- Plugin inventory generation check and `git diff --check`: clean
- Native npm pack dry run: five runtime entries, eight expected package files,
  no bundled dependency payload
- Selected npm release metadata check and release plan: passed for
  `@openclaw/comfy-provider@2026.7.2`
- Exact-head Codex autoreview: clean, no actionable findings, confidence 0.88

AI-assisted: yes. The implementation, generated outputs, package contents, and
review findings were inspected and verified before opening this PR.
