### PR TITLE
fix(imessage): preserve voice intent and provider delivery failures

### DIFF
--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -129,6 +129,28 @@ describe("deliverReplies", () => {
     ]);
   });
 
+  it("forwards voice-note payloads to the canonical iMessage media sender", async () => {
+    await deliverReplies({
+      cfg: IMESSAGE_TEST_CFG,
+      replies: [{ mediaUrl: "https://example.com/voice.caf", audioAsVoice: true }],
+      target: "chat_id:20",
+      accountId: "acct-2",
+      runtime,
+      maxBytes: 8192,
+      textLimit: 4000,
+    });
+
+    expect(sendMessageIMessageMock).toHaveBeenCalledWith(
+      "chat_id:20",
+      "",
+      expect.objectContaining({
+        accountId: "acct-2",
+        audioAsVoice: true,
+        mediaUrl: "https://example.com/voice.caf",
+      }),
+    );
+  });
+
   it("records durable outbound sends in the sent-message cache", async () => {
     const remember = vi.fn();
     const send = createIMessageEchoCachingSend({

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -62,6 +62,7 @@ export async function deliverReplies(params: {
         const sent = await sendMessageIMessage(target, caption ?? "", {
           config: params.cfg,
           mediaUrl,
+          ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
           maxBytes,
           accountId,
           replyToId: payload.replyToId,

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -573,6 +573,52 @@ describe("sendMessageIMessage receipts", () => {
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { name: "media", audioAsVoice: false, sendTransport: "bridge" },
+    { name: "media", audioAsVoice: false, sendTransport: "applescript" },
+    { name: "voice", audioAsVoice: true, sendTransport: "bridge" },
+    { name: "voice", audioAsVoice: true, sendTransport: "applescript" },
+  ] as const)(
+    "honors the configured $sendTransport transport for $name attachment sends",
+    async ({ audioAsVoice, sendTransport }) => {
+      const client = createClient({ message_id: 12345 });
+      const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/configured-media-guid" });
+      const mediaPath = audioAsVoice ? "/tmp/voice.caf" : "/tmp/image.png";
+
+      await sendMessageIMessage("chat_guid:chat-1", "", {
+        config: {
+          channels: {
+            imessage: {
+              sendTransport: sendTransport === "bridge" ? "applescript" : "bridge",
+              accounts: { work: { sendTransport } },
+            },
+          },
+        },
+        accountId: "work",
+        client,
+        mediaUrl: mediaPath,
+        audioAsVoice,
+        resolveAttachmentImpl: async () => ({
+          path: mediaPath,
+          contentType: audioAsVoice ? "audio/x-caf" : "image/png",
+        }),
+        runCliJson,
+      });
+
+      expect(runCliJson).toHaveBeenCalledWith([
+        "send-attachment",
+        "--chat",
+        "chat-1",
+        "--file",
+        mediaPath,
+        ...(audioAsVoice ? ["--audio"] : []),
+        "--transport",
+        sendTransport,
+      ]);
+      expect(getClientMocks(client).request).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves audioAsVoice media when replying to an iMessage thread", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/threaded-voice-guid" });
@@ -608,6 +654,59 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.replyToId).toBe("p:0/reply-guid");
     expect(result.receipt.parts.map((part) => part.kind)).toEqual(["voice"]);
     expect(client["request"]).not.toHaveBeenCalled();
+  });
+
+  it("falls back to an unthreaded AppleScript voice send when threaded replies are unsupported", async () => {
+    const unsupportedReply = new Error(
+      "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+    );
+    const client = createClient({ guid: "p:0/unthreaded-voice-guid" });
+    const clientMocks = getClientMocks(client);
+    clientMocks.request.mockRejectedValueOnce(unsupportedReply);
+    const runCliJson = vi.fn().mockRejectedValueOnce(unsupportedReply);
+
+    const result = await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: { channels: { imessage: { sendTransport: "applescript" } } },
+      client,
+      conversationReadOrigin: "direct-operator",
+      mediaUrl: "/tmp/voice.caf",
+      audioAsVoice: true,
+      replyToId: "p:0/reply-guid",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/voice.caf", contentType: "audio/x-caf" }),
+      runCliJson,
+    });
+
+    expect(runCliJson).toHaveBeenCalledWith([
+      "send-attachment",
+      "--chat",
+      "chat-1",
+      "--file",
+      "/tmp/voice.caf",
+      "--audio",
+      "--reply-to",
+      "p:0/reply-guid",
+      "--transport",
+      "applescript",
+    ]);
+    expect(clientMocks.request).toHaveBeenNthCalledWith(
+      1,
+      "send",
+      expect.objectContaining({
+        chat_guid: "chat-1",
+        file: "/tmp/voice.caf",
+        reply_to: "p:0/reply-guid",
+        transport: "applescript",
+      }),
+      expect.any(Object),
+    );
+    expect(clientMocks.request).toHaveBeenNthCalledWith(
+      2,
+      "send",
+      expect.not.objectContaining({ reply_to: expect.anything() }),
+      expect.any(Object),
+    );
+    expect(result.messageId).toBe("p:0/unthreaded-voice-guid");
+    expect(result.receipt.replyToId).toBeUndefined();
   });
 
   it("drops reply metadata from media sends when reply actions are disabled", async () => {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -596,7 +596,6 @@ describe("sendMessageIMessage receipts", () => {
     { name: "media", audioAsVoice: false, sendTransport: "bridge" },
     { name: "media", audioAsVoice: false, sendTransport: "applescript" },
     { name: "voice", audioAsVoice: true, sendTransport: "bridge" },
-    { name: "voice", audioAsVoice: true, sendTransport: "applescript" },
   ] as const)(
     "honors the configured $sendTransport transport for $name attachment sends",
     async ({ audioAsVoice, sendTransport }) => {
@@ -632,7 +631,7 @@ describe("sendMessageIMessage receipts", () => {
         mediaPath,
         ...(audioAsVoice ? ["--audio"] : []),
         "--transport",
-        sendTransport,
+        sendTransport === "bridge" ? "dylib" : sendTransport,
       ]);
       expect(getClientMocks(client).request).not.toHaveBeenCalled();
     },
@@ -675,57 +674,52 @@ describe("sendMessageIMessage receipts", () => {
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
-  it("falls back to an unthreaded AppleScript voice send when threaded replies are unsupported", async () => {
-    const unsupportedReply = new Error(
-      "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
-    );
-    const client = createClient({ guid: "p:0/unthreaded-voice-guid" });
-    const clientMocks = getClientMocks(client);
-    clientMocks.request.mockRejectedValueOnce(unsupportedReply);
-    const runCliJson = vi.fn().mockRejectedValueOnce(unsupportedReply);
+  it.each([undefined, "p:0/reply-guid"])(
+    "rejects AppleScript voice notes without downgrading native audio (reply: %s)",
+    async (replyToId) => {
+      const client = createClient({ guid: "should-not-send" });
+      const runCliJson = vi.fn();
 
-    const result = await sendMessageIMessage("chat_guid:chat-1", "", {
-      config: { channels: { imessage: { sendTransport: "applescript" } } },
-      client,
-      conversationReadOrigin: "direct-operator",
-      mediaUrl: "/tmp/voice.caf",
-      audioAsVoice: true,
-      replyToId: "p:0/reply-guid",
-      resolveAttachmentImpl: async () => ({ path: "/tmp/voice.caf", contentType: "audio/x-caf" }),
-      runCliJson,
-    });
+      await expect(
+        sendMessageIMessage("chat_guid:chat-1", "", {
+          config: { channels: { imessage: { sendTransport: "applescript" } } },
+          client,
+          conversationReadOrigin: "direct-operator",
+          mediaUrl: "/tmp/voice.caf",
+          audioAsVoice: true,
+          replyToId,
+          resolveAttachmentImpl: async () => ({
+            path: "/tmp/voice.caf",
+            contentType: "audio/x-caf",
+          }),
+          runCliJson,
+        }),
+      ).rejects.toThrow("voice messages require bridge transport");
 
-    expect(runCliJson).toHaveBeenCalledWith([
-      "send-attachment",
-      "--chat",
-      "chat-1",
-      "--file",
-      "/tmp/voice.caf",
-      "--audio",
-      "--reply-to",
-      "p:0/reply-guid",
-      "--transport",
-      "applescript",
-    ]);
-    expect(clientMocks.request).toHaveBeenNthCalledWith(
-      1,
-      "send",
-      expect.objectContaining({
-        chat_guid: "chat-1",
-        file: "/tmp/voice.caf",
-        reply_to: "p:0/reply-guid",
-        transport: "applescript",
+      expect(runCliJson).not.toHaveBeenCalled();
+      expect(getClientMocks(client).request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not downgrade voice notes when the native attachment bridge is unavailable", async () => {
+    const client = createClient({ guid: "should-not-send" });
+    const runCliJson = vi.fn().mockRejectedValueOnce(new Error("private API bridge unavailable"));
+
+    await expect(
+      sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        mediaUrl: "/tmp/voice.caf",
+        audioAsVoice: true,
+        resolveAttachmentImpl: async () => ({
+          path: "/tmp/voice.caf",
+          contentType: "audio/x-caf",
+        }),
+        runCliJson,
       }),
-      expect.any(Object),
-    );
-    expect(clientMocks.request).toHaveBeenNthCalledWith(
-      2,
-      "send",
-      expect.not.objectContaining({ reply_to: expect.anything() }),
-      expect.any(Object),
-    );
-    expect(result.messageId).toBe("p:0/unthreaded-voice-guid");
-    expect(result.receipt.replyToId).toBeUndefined();
+    ).rejects.toThrow("private API bridge unavailable");
+
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
   it("drops reply metadata from media sends when reply actions are disabled", async () => {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -135,6 +135,25 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it("rejects an unsuccessful RPC send instead of acknowledging a delivered message", async () => {
+    const client = createClient({ success: false, error: "recipient is not registered" });
+
+    await expect(
+      sendMessageIMessage("+15551234567", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+      }),
+    ).rejects.toThrow("recipient is not registered");
+
+    expect(
+      hasPersistedIMessageEcho({
+        scope: "default:imessage:+15551234567",
+        text: "hello",
+        includePendingText: true,
+      }),
+    ).toBe(false);
+  });
+
   it("drops reply metadata from text sends when reply actions are disabled", async () => {
     const client = createClient({ guid: "p:0/imsg-plain" });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -454,7 +454,7 @@ function resolveOutboundEchoScope(params: {
   return `${params.accountId}:imessage:${params.target.to}`;
 }
 
-function resolveIMessageCliFailure(result: Record<string, unknown>): string | null {
+function resolveIMessageSendFailure(result: Record<string, unknown>): string | null {
   if (result.success !== false) {
     return null;
   }
@@ -625,7 +625,7 @@ async function trySendAttachmentForTarget(params: {
     }
     throw error;
   }
-  const failure = resolveIMessageCliFailure(result);
+  const failure = resolveIMessageSendFailure(result);
   if (failure) {
     const error = new Error(failure);
     forgetPersistedIMessageEchoKey(pendingEchoKey);
@@ -874,6 +874,16 @@ export async function sendMessageIMessage(
     closedClient = true;
     await client.stop();
   };
+  const requestSuccessfulSend = async (sendParams: Record<string, unknown>) => {
+    const response = await client.request<Record<string, unknown>>("send", sendParams, {
+      timeoutMs,
+    });
+    const failure = resolveIMessageSendFailure(response);
+    if (failure) {
+      throw new Error(failure);
+    }
+    return response;
+  };
   let result: Record<string, unknown>;
   const sendStartedAtMs = Date.now();
   let pendingEchoKey: string | undefined;
@@ -888,9 +898,7 @@ export async function sendMessageIMessage(
           pending: true,
         });
       }
-      result = await client.request<Record<string, unknown>>("send", params, {
-        timeoutMs,
-      });
+      result = await requestSuccessfulSend(params);
     } catch (error) {
       if (resolvedReplyToId && isThreadedReplyUnsupportedError(error)) {
         // #99638: the transport cannot deliver a threaded reply, so resend the
@@ -899,9 +907,7 @@ export async function sendMessageIMessage(
         // reply_to stripped, keeping any file; a further failure propagates.
         const plainParams = { ...params };
         delete plainParams.reply_to;
-        result = await client.request<Record<string, unknown>>("send", plainParams, {
-          timeoutMs,
-        });
+        result = await requestSuccessfulSend(plainParams);
         effectiveReplyToId = undefined;
       } else if (filePath || !isIMessageRpcSendTimeout(error)) {
         throw error;

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -506,14 +506,10 @@ function resolvePendingPersistedEchoTtlMs(timeoutMs: number): number {
   );
 }
 
-function isAttachmentCommandFallbackError(error: unknown, replyToId?: string): boolean {
+function isAttachmentCommandFallbackError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    /(?:unknown|unrecognized|invalid|unsupported)\s+(?:command|subcommand)|not a recognized command|send-attachment.*(?:not found|unsupported|unavailable)|private api bridge.*unavailable|requires the imsg private api bridge|run imsg launch/iu.test(
-      message,
-    ) ||
-    // Let threaded voice rejection reach the existing RPC owner's unthreaded retry.
-    (Boolean(replyToId) && isThreadedReplyUnsupportedError(error))
+  return /(?:unknown|unrecognized|invalid|unsupported)\s+(?:command|subcommand)|not a recognized command|send-attachment.*(?:not found|unsupported|unavailable)|private api bridge.*unavailable|requires the imsg private api bridge|run imsg launch/iu.test(
+    message,
   );
 }
 
@@ -574,6 +570,11 @@ async function trySendAttachmentForTarget(params: {
   runCliJson: (args: readonly string[]) => Promise<Record<string, unknown>>;
   resolveMessageGuidImpl?: IMessageSendOpts["resolveMessageGuidImpl"];
 }): Promise<IMessageSendResult | null> {
+  if (params.audioAsVoice && params.sendTransport === "applescript") {
+    throw new Error(
+      "iMessage voice messages require bridge transport; AppleScript cannot send native voice notes. Set sendTransport to bridge or auto.",
+    );
+  }
   let attachmentChatTarget: string | null;
   try {
     attachmentChatTarget = await resolveAttachmentChatTarget({
@@ -582,12 +583,15 @@ async function trySendAttachmentForTarget(params: {
       runCliJson: params.runCliJson,
     });
   } catch (error) {
-    if (isAttachmentCommandFallbackError(error)) {
+    if (!params.audioAsVoice && isAttachmentCommandFallbackError(error)) {
       return null;
     }
     throw error;
   }
   if (!attachmentChatTarget) {
+    if (params.audioAsVoice) {
+      throw new Error("iMessage voice messages require an existing chat and bridge transport.");
+    }
     return null;
   }
 
@@ -616,11 +620,12 @@ async function trySendAttachmentForTarget(params: {
       ...(params.audioAsVoice ? ["--audio"] : []),
       ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
       "--transport",
-      params.sendTransport,
+      // One-shot imsg names its private-API transport dylib; JSON-RPC calls it bridge.
+      params.sendTransport === "bridge" ? "dylib" : params.sendTransport,
     ]);
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);
-    if (isAttachmentCommandFallbackError(error, params.replyToId)) {
+    if (!params.audioAsVoice && isAttachmentCommandFallbackError(error)) {
       return null;
     }
     throw error;
@@ -629,7 +634,7 @@ async function trySendAttachmentForTarget(params: {
   if (failure) {
     const error = new Error(failure);
     forgetPersistedIMessageEchoKey(pendingEchoKey);
-    if (isAttachmentCommandFallbackError(error, params.replyToId)) {
+    if (!params.audioAsVoice && isAttachmentCommandFallbackError(error)) {
       return null;
     }
     throw error;

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -506,10 +506,14 @@ function resolvePendingPersistedEchoTtlMs(timeoutMs: number): number {
   );
 }
 
-function isAttachmentCommandFallbackError(error: unknown): boolean {
+function isAttachmentCommandFallbackError(error: unknown, replyToId?: string): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /(?:unknown|unrecognized|invalid|unsupported)\s+(?:command|subcommand)|not a recognized command|send-attachment.*(?:not found|unsupported|unavailable)|private api bridge.*unavailable|requires the imsg private api bridge|run imsg launch/iu.test(
-    message,
+  return (
+    /(?:unknown|unrecognized|invalid|unsupported)\s+(?:command|subcommand)|not a recognized command|send-attachment.*(?:not found|unsupported|unavailable)|private api bridge.*unavailable|requires the imsg private api bridge|run imsg launch/iu.test(
+      message,
+    ) ||
+    // Let threaded voice rejection reach the existing RPC owner's unthreaded retry.
+    (Boolean(replyToId) && isThreadedReplyUnsupportedError(error))
   );
 }
 
@@ -560,6 +564,7 @@ async function trySendAttachmentForTarget(params: {
   dbPath?: string;
   target: ReturnType<typeof parseIMessageTarget>;
   service?: IMessageService;
+  sendTransport: IMessageSendTransport;
   filePath: string;
   audioAsVoice?: boolean;
   replyToId?: string;
@@ -611,11 +616,11 @@ async function trySendAttachmentForTarget(params: {
       ...(params.audioAsVoice ? ["--audio"] : []),
       ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
       "--transport",
-      "auto",
+      params.sendTransport,
     ]);
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);
-    if (isAttachmentCommandFallbackError(error)) {
+    if (isAttachmentCommandFallbackError(error, params.replyToId)) {
       return null;
     }
     throw error;
@@ -624,7 +629,7 @@ async function trySendAttachmentForTarget(params: {
   if (failure) {
     const error = new Error(failure);
     forgetPersistedIMessageEchoKey(pendingEchoKey);
-    if (isAttachmentCommandFallbackError(error)) {
+    if (isAttachmentCommandFallbackError(error, params.replyToId)) {
       return null;
     }
     throw error;
@@ -789,6 +794,7 @@ export async function sendMessageIMessage(
       dbPath: chatDbLookupPath,
       target,
       service,
+      sendTransport,
       filePath,
       audioAsVoice: opts.audioAsVoice,
       ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),


### PR DESCRIPTION
## What Problem This Solves

iMessage already supports existing account-scoped `sendTransport` preferences (`auto`, `bridge`, and `applescript`) and applies them to normal RPC text sends. Attachment sends hardcode `--transport auto`, JSON-RPC send results reporting `success: false` are acknowledged as delivered, and monitor-originated voice-note payloads silently lose `audioAsVoice` before reaching the iMessage sender.

## Why This Change Was Made

Carry the already-resolved account transport from `sendMessageIMessage` into its existing private attachment helper, mapping OpenClaw's `bridge` spelling to the upstream one-shot CLI's `dylib` spelling without changing JSON-RPC's `bridge` contract. Reject AppleScript/native-voice combinations visibly and never downgrade a requested voice note to a generic attachment. Normalize explicit provider failure results at the canonical RPC request owner, and preserve the `audioAsVoice` fact through monitor reply delivery.

No new configuration, public API, authorization, storage, provider route, or fallback behavior is introduced.

## User Impact

Ordinary attachments honor configured `bridge` or `applescript` preferences, including account-specific overrides; native voice notes use an audio-capable bridge or fail with actionable guidance. Failed sends surface their real provider error instead of a false successful receipt, and monitored TTS/voice replies retain native voice-note delivery.

## Evidence

- Branch: `codex/auto-qa-imessage-round2`.
- Exact candidate SHA: `52406cfcc6ae53999ca8cd54a315853c427aef8a`.
- Exact frozen current-main base: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Actual current-owner RED: configured attachment commands received `--transport auto`; unsuccessful RPC sends resolved with `messageId: "unknown"`; monitor voice payloads reached the sender without `audioAsVoice`.
- Official upstream source directly inspected: `BridgeAttachmentCommand.swift:40-46,53-71` accepts `auto|dylib|applescript`, rejects AppleScript audio, and never silently downgrades native audio; `RPCServer+Handlers.swift:175-188,261-286` uses RPC `bridge` and has no native-audio field.
- Final exact-head Blacksmith Testbox `tbx_01kywa1hz59adnajcwast8ed8x`: **79/79 tests passed across four complete iMessage owner suites**:

  ```text
  pnpm test extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/client.test.ts extensions/imessage/src/channel.runtime.test.ts
  ```

- Final exact-head validation: [Blacksmith GitHub Actions run](https://github.com/openclaw/openclaw/actions/runs/30639769210); final timing JSON confirms exit code 0 and the one-shot lease stopped successfully.
- Coverage verifies account precedence, upstream bridge/dylib translation, native voice transport rejection, default auto behavior, truthful failed RPC outcomes, pending-echo cleanup, and monitor voice propagation.
- Fresh strict independent exact-head whole-owner and upstream dependency review: **CLEAN**. Exact-branch structured Codex autoreview: **CLEAN**, correctness confidence **0.98**; genuine TruffleHog **3.96.0** secret scan clean.
- Committed worktree, targeted formatting, and `git diff --check` are clean.

## Root Causes Fixed

**3 distinct plugin-owner roots:**

1. The private attachment command ignored account-resolved transport and failed to translate OpenClaw `bridge` into upstream one-shot `dylib`.
2. JSON-RPC results explicitly declaring unsuccessful delivery were acknowledged as successful.
3. Monitor-originated voice-note replies lost the canonical `audioAsVoice` delivery flag.

## Authorized Scope And Non-Goals

Existing iMessage plugin send/result/monitor-delivery ownership only. No authentication or admission changes, persistent-state ownership, configuration/database schemas, provider routes, public APIs, or unrelated message behavior.
