### PR TITLE
fix(providers): preserve realtime transcripts and final tool arguments

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -2794,6 +2794,83 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it("surfaces input transcription failures with their provider error details", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+      onEvent,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.failed",
+          item_id: "item_speech",
+          error: { code: "decoder_failure", message: "speech decoder exploded" },
+        }),
+      ),
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "speech decoder exploded" }),
+    );
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "server",
+      type: "conversation.item.input_audio_transcription.failed",
+      itemId: "item_speech",
+      detail: "speech decoder exploded",
+    });
+  });
+
+  it("preserves corrected final text from legacy realtime text events", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.text.delta", delta: "draft assistant" })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.text.done", text: "corrected assistant" })),
+    );
+
+    expect(onTranscript.mock.calls).toEqual([
+      ["assistant", "draft assistant", false],
+      ["assistant", "corrected assistant", true],
+    ]);
+  });
+
   it.each([
     ["invalid alphabet", "not-base64!"],
     ["non-canonical pad bits", "ZE=="],
@@ -3028,6 +3105,80 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       args: { question: "delegate this" },
     });
   });
+
+  it.each([
+    {
+      name: "corrected streamed arguments",
+      delta: '{"city":"draft"}',
+      finalArguments: '{"city":"Paris"}',
+      expectedArguments: { city: "Paris" },
+    },
+    {
+      name: "truncated streamed arguments",
+      delta: '{"city":',
+      finalArguments: '{"city":"Paris"}',
+      expectedArguments: { city: "Paris" },
+    },
+    {
+      name: "an explicitly empty completed payload",
+      delta: '{"city":"draft"}',
+      finalArguments: "",
+      expectedArguments: {},
+    },
+  ])(
+    "uses authoritative completed tool arguments for $name",
+    async ({ delta, finalArguments, expectedArguments }) => {
+      const provider = buildOpenAIRealtimeVoiceProvider();
+      const onToolCall = vi.fn();
+      const bridge = provider.createBridge({
+        providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onToolCall,
+      });
+      const connecting = bridge.connect();
+      const socket = FakeWebSocket.instances[0];
+      if (!socket) {
+        throw new Error("expected bridge to create a websocket");
+      }
+      socket.readyState = FakeWebSocket.OPEN;
+      socket.emit("open");
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+      await connecting;
+
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.delta",
+            item_id: "item_tool_1",
+            call_id: "call_1",
+            name: "lookup_weather",
+            delta,
+          }),
+        ),
+      );
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: "item_tool_1",
+            call_id: "call_1",
+            name: "lookup_weather",
+            arguments: finalArguments,
+          }),
+        ),
+      );
+
+      expect(onToolCall).toHaveBeenCalledWith({
+        itemId: "item_tool_1",
+        callId: "call_1",
+        name: "lookup_weather",
+        args: expectedArguments,
+      });
+    },
+  );
 
   it("creates an explicit user item and response for manual speech", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1388,6 +1388,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         return;
 
       case "conversation.output_transcript.delta":
+      case "response.text.delta":
       case "response.output_text.delta":
       case "response.audio_transcript.delta":
       case "response.output_audio_transcript.delta":
@@ -1396,6 +1397,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         }
         return;
 
+      case "response.text.done":
       case "response.output_text.done":
       case "response.audio_transcript.done":
       case "response.output_audio_transcript.done":
@@ -1418,6 +1420,10 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         if (event.transcript) {
           this.config.onTranscript?.("user", event.transcript, true);
         }
+        return;
+
+      case "conversation.item.input_audio_transcription.failed":
+        this.config.onError?.(new Error(readRealtimeErrorDetail(event.error)));
         return;
 
       case "response.cancelled":
@@ -1456,7 +1462,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           itemId: event.item_id,
           callId: buffered?.callId || event.call_id,
           name: buffered?.name || event.name,
-          rawArgs: buffered?.args || event.arguments,
+          // The done payload owns the final JSON; streamed chunks may be stale or incomplete.
+          rawArgs: event.arguments ?? buffered?.args,
         });
         this.toolCallBuffers.delete(key);
         return;
@@ -1765,7 +1772,10 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private describeServerEvent(event: RealtimeEvent): string | undefined {
-    if (event.type === "error") {
+    if (
+      event.type === "error" ||
+      event.type === "conversation.item.input_audio_transcription.failed"
+    ) {
       return readRealtimeErrorDetail(event.error);
     }
     if (event.type === "response.done") {

--- a/extensions/xai/realtime-transcription-provider.test.ts
+++ b/extensions/xai/realtime-transcription-provider.test.ts
@@ -38,9 +38,10 @@ async function createRealtimeSttServer(params?: {
   onRequest?: (url: URL, headers: Record<string, string | string[] | undefined>) => void;
   onBinary?: (audio: Buffer) => void;
   initialEvent?: unknown;
+  transcriptionEvents?: readonly Record<string, unknown>[];
 }) {
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 16 * 1024 * 1024 });
   const clients = new Set<WebSocket>();
   const done = vi.fn();
   let resolveDone: (() => void) | undefined;
@@ -63,22 +64,23 @@ async function createRealtimeSttServer(params?: {
             : Buffer.from(data);
         if (isBinary) {
           params?.onBinary?.(buffer);
-          ws.send(
-            JSON.stringify({
+          const events = params?.transcriptionEvents ?? [
+            {
               type: "transcript.partial",
               text: "hello openclaw",
               is_final: false,
               speech_final: false,
-            }),
-          );
-          ws.send(
-            JSON.stringify({
+            },
+            {
               type: "transcript.partial",
               text: "hello openclaw final",
               is_final: true,
               speech_final: true,
-            }),
-          );
+            },
+          ];
+          for (const event of events) {
+            ws.send(JSON.stringify(event));
+          }
           return;
         }
         const event = JSON.parse(buffer.toString()) as { type?: string };
@@ -206,6 +208,30 @@ describe("xai realtime transcription provider", () => {
     expect(onSpeechStart).toHaveBeenCalled();
     expect(onPartial).toHaveBeenCalledWith("hello openclaw");
     vi.unstubAllEnvs();
+  });
+
+  it("preserves identical final transcripts from separate speech turns", async () => {
+    const server = await createRealtimeSttServer({
+      transcriptionEvents: [
+        { type: "transcript.partial", text: "yes", is_final: true, speech_final: true },
+        { type: "transcript.partial", text: "yes", is_final: true, speech_final: true },
+      ],
+    });
+    const onTranscript = vi.fn();
+    const onSpeechStart = vi.fn();
+    const session = buildXaiRealtimeTranscriptionProvider().createSession({
+      providerConfig: { apiKey: "xai-test-key", baseUrl: server.baseUrl },
+      onTranscript,
+      onSpeechStart,
+    });
+
+    await session.connect();
+    session.sendAudio(Buffer.from("two speech turns"));
+    await vi.waitFor(() => expect(onSpeechStart).toHaveBeenCalledTimes(2));
+    session.close();
+    await server.donePromise;
+
+    expect(onTranscript.mock.calls).toEqual([["yes"], ["yes"]]);
   });
 
   it("rejects setup errors before the stream is ready", async () => {

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -174,6 +174,8 @@ function createXaiRealtimeTranscriptionSession(
           return;
         }
         if (!speechStarted) {
+          // Dedupe final/terminal echoes within one utterance, not identical later turns.
+          lastTranscript = undefined;
           speechStarted = true;
           config.onSpeechStart?.();
         }

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -100,9 +100,15 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
           this.appendAssistantTranscriptDelta(event.delta);
         }
         return;
+      case "response.text.done":
       case "response.output_text.done":
       case "response.output_audio_transcript.done":
         this.flushAssistantTranscript(event.transcript ?? event.text);
+        return;
+      case "conversation.item.input_audio_transcription.delta":
+        if (event.delta) {
+          this.config.onTranscript?.("user", event.delta, false);
+        }
         return;
       case "conversation.item.input_audio_transcription.updated":
         if (event.transcript) {
@@ -118,6 +124,10 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         }
         return;
       }
+      case "conversation.item.input_audio_transcription.failed":
+        this.inputTranscriptReplacements.delete(this.inputTranscriptKey(event));
+        this.config.onError?.(new Error(readXaiRealtimeErrorDetail(event.error)));
+        return;
       case "response.done":
         this.flushAssistantTranscript();
         this.responseActive = false;
@@ -146,7 +156,8 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
           itemId: event.item_id,
           callId: buffered?.callId || event.call_id,
           name: buffered?.name || event.name,
-          rawArgs: buffered?.args || event.arguments,
+          // The done payload owns the final JSON; streamed chunks may be stale or incomplete.
+          rawArgs: event.arguments ?? buffered?.args,
         });
         this.toolCallBuffers.delete(key);
         return;
@@ -209,7 +220,10 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
   }
 
   private describeServerEvent(event: XaiRealtimeEvent): string | undefined {
-    if (event.type === "error") {
+    if (
+      event.type === "error" ||
+      event.type === "conversation.item.input_audio_transcription.failed"
+    ) {
       return readXaiRealtimeErrorDetail(event.error);
     }
     if (event.type !== "response.done") {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -493,6 +493,90 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(onTranscript).toHaveBeenCalledWith("user", "OpenClaw", true);
   });
 
+  it("forwards standard incremental input-transcription events", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+    });
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.delta",
+          item_id: "item_speech",
+          delta: "open claw",
+        }),
+      ),
+    );
+
+    expect(onTranscript).toHaveBeenCalledWith("user", "open claw", false);
+  });
+
+  it("surfaces input transcription failures and discards their stale replacement text", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+      onError,
+      onEvent,
+    });
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.updated",
+          item_id: "item_speech",
+          transcript: "stale speech",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.failed",
+          item_id: "item_speech",
+          error: { code: "decoder_failure", message: "speech decoder exploded" },
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: "item_speech",
+        }),
+      ),
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "speech decoder exploded" }),
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "server",
+      type: "conversation.item.input_audio_transcription.failed",
+      itemId: "item_speech",
+      detail: "speech decoder exploded",
+    });
+  });
+
   it("buffers assistant transcript deltas and finalizes them when done has no text", async () => {
     const provider = buildXaiRealtimeVoiceProvider();
     const onTranscript = vi.fn();
@@ -536,6 +620,35 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(onTranscript).toHaveBeenNthCalledWith(2, "assistant", "OpenClaw", false);
     expect(onTranscript).toHaveBeenNthCalledWith(3, "assistant", "Hello OpenClaw", true);
     expect(onTranscript).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves corrected final text from legacy realtime text events", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+    });
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.text.delta", delta: "draft assistant" })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.text.done", text: "corrected assistant" })),
+    );
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+
+    expect(onTranscript.mock.calls).toEqual([
+      ["assistant", "draft assistant", false],
+      ["assistant", "corrected assistant", true],
+    ]);
   });
 
   it.each([
@@ -810,6 +923,73 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       args: { question: "delegate this" },
     });
   });
+
+  it.each([
+    {
+      name: "corrected streamed arguments",
+      delta: '{"city":"draft"}',
+      finalArguments: '{"city":"Paris"}',
+      expectedArguments: { city: "Paris" },
+    },
+    {
+      name: "truncated streamed arguments",
+      delta: '{"city":',
+      finalArguments: '{"city":"Paris"}',
+      expectedArguments: { city: "Paris" },
+    },
+    {
+      name: "an explicitly empty completed payload",
+      delta: '{"city":"draft"}',
+      finalArguments: "",
+      expectedArguments: {},
+    },
+  ])(
+    "uses authoritative completed tool arguments for $name",
+    async ({ delta, finalArguments, expectedArguments }) => {
+      const provider = buildXaiRealtimeVoiceProvider();
+      const onToolCall = vi.fn();
+      const bridge = provider.createBridge({
+        providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onToolCall,
+      });
+      const { connecting, socket } = await openRealtimeBridge(bridge);
+      await connecting;
+
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.delta",
+            item_id: "item_tool_1",
+            call_id: "call_1",
+            name: "lookup_weather",
+            delta,
+          }),
+        ),
+      );
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: "item_tool_1",
+            call_id: "call_1",
+            name: "lookup_weather",
+            arguments: finalArguments,
+          }),
+        ),
+      );
+
+      expect(onToolCall).toHaveBeenCalledWith({
+        itemId: "item_tool_1",
+        callId: "call_1",
+        name: "lookup_weather",
+        args: expectedArguments,
+      });
+    },
+  );
 
   it("waits for all parallel tool results before sending response.create", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret


### PR DESCRIPTION
## Summary

- Surface official input-audio transcription failures and actionable decoder details in both OpenAI and xAI realtime provider owners; discard failed xAI transcript replacements.
- Execute the authoritative completed function-call arguments instead of stale or truncated streaming deltas in both providers.
- Preserve standard xAI user transcript deltas and finalized legacy assistant text across both OpenAI-style realtime bridges.
- Keep identical phrases from separate xAI streaming-transcription turns while still suppressing duplicate final/terminal events inside one turn.
- Preserve provider/plugin ownership and existing public realtime event, SDK, protocol, authentication, configuration, and persistence contracts.

## Distinct root causes

1. Provider-owned input transcription failures were silently dropped.
2. Draft streamed tool arguments incorrectly overrode authoritative completed arguments.
3. xAI dropped standard user-transcript delta events.
4. Legacy finalized assistant text events were ignored.
5. xAI deduplicated identical user speech across distinct utterances.

## Verification

- Frozen clean baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact local candidate: `b99da311b8100d5a71cea59afb3868f6ae69b117`.
- Read-only localhost WebSocket proof first reproduced all five user-visible failures directly on frozen canonical `main`; no hosted model or live provider was called.
- Exact-candidate localhost WebSocket proof observed `speech decoder exploded` for both providers, corrected `{ city: "Paris" }` tool calls and authoritative empty `{}` final arguments, xAI `user partial`, corrected `corrected assistant` final text, and independent `["yes", "yes"]` streaming-transcription turns.
- OpenAI focused private realtime provider suite: **96/96 passed**.
- xAI focused voice/transcription run: **53 tests passed**; the sole new test failure was an incorrect expectation that provider callbacks survive an intentional close. Its expectation was corrected to the actually observed two successful final speech turns. Exact corrected-suite rerun remains queued for remote capacity because the coordinator prohibited further local suites under critical host disk/load pressure.
- Six-file `oxfmt --check`, `git diff --check`, exact parent SHA, and clean isolated worktree checks passed.
- Direct upstream SDK inspection: `node_modules/openai/src/resources/realtime/realtime.ts:462`, `node_modules/openai/src/resources/realtime/realtime.ts:4730`, `node_modules/openai/src/resources/realtime/realtime.ts:4770`, and `node_modules/openai/src/resources/beta/realtime/realtime.ts:2112`.
- Direct Codex protocol inspection: `../codex/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v1.rs:42`, `../codex/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:32`, `../codex/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:39`, and `../codex/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs:1215`.
- Initial genuine structured review and official shared TruffleHog scan completed; its one actionable explicitly-empty final-arguments finding was fixed for both providers. Final exact-commit Codex gpt-5.6-sol/high structured autoreview: **clean, zero findings, 0.94 confidence**; campaign-shared official TruffleHog preflight: **clean**.

## Explicit exclusions

The already-landed Mistral final-transcript fix and held cross-owner public `response.done` terminal-status event-contract change are untouched. Equivalent Deepgram/ElevenLabs repeated-phrase deduplication remains a separately scoped provider-owner follow-up.
