### PR TITLE
fix(telegram): enforce parsed caption limits across delivery paths

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -31,7 +31,7 @@ import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "../button-types.js";
-import { splitTelegramCaption } from "../caption.js";
+import { resolveTelegramPlainCaption, splitTelegramCaption } from "../caption.js";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
@@ -449,16 +449,19 @@ async function deliverMediaReply(params: {
     });
     const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
     const file = new InputFile(media.buffer, fileName);
-    const { caption, followUpText } = splitTelegramCaption(
-      isFirstMedia ? (params.reply.text ?? undefined) : undefined,
-    );
-    const htmlCaption = caption
+    const captionText = isFirstMedia ? (params.reply.text ?? undefined) : undefined;
+    const trimmedCaption = captionText?.trim();
+    const renderedCaption = trimmedCaption
       ? params.textMode === "html"
-        ? caption
-        : renderTelegramHtmlText(caption, { tableMode: params.tableMode })
+        ? trimmedCaption
+        : renderTelegramHtmlText(trimmedCaption, { tableMode: params.tableMode })
       : undefined;
-    const plainCaption =
-      caption && params.textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption;
+    const { caption, followUpText } = splitTelegramCaption(captionText, renderedCaption);
+    const htmlCaption = caption ? renderedCaption : undefined;
+    const plainCaption = resolveTelegramPlainCaption(
+      caption && params.textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption,
+      htmlCaption,
+    );
     if (followUpText) {
       pendingFollowUpText = followUpText;
     }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -932,35 +932,73 @@ describe("deliverReplies", () => {
     });
   });
 
-  it("falls back to a plain media caption when Telegram rejects caption HTML", async () => {
+  it("keeps formatted media replies within Telegram's parsed-caption limit", async () => {
     const runtime = createRuntime();
-    const sendPhoto = vi
-      .fn()
-      .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
-      .mockResolvedValueOnce({
-        message_id: 3,
-        chat: { id: "123" },
-      });
-    const bot = createBot({ sendPhoto });
+    const visibleCaption = "x".repeat(1022);
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 2, chat: { id: "123" } });
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendPhoto, sendMessage });
 
     mockMediaLoad("photo.jpg", "image/jpeg", "image");
 
     await deliverWith({
-      replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "hi **boss**" }],
+      replies: [{ mediaUrl: "https://example.com/photo.jpg", text: `**${visibleCaption}**` }],
       runtime,
       bot,
     });
 
-    expect(sendPhoto).toHaveBeenCalledTimes(2);
     expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
-      caption: "hi <b>boss</b>",
+      caption: `<b>${visibleCaption}</b>`,
       parse_mode: "HTML",
     });
-    expectRecordFields(mockCallArg(sendPhoto, 1, 2), {
-      caption: "hi **boss**",
-    });
-    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("parse_mode");
+    expect(sendMessage).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      kind: "ordinary Markdown",
+      caption: "hi **boss**",
+      htmlCaption: "hi <b>boss</b>",
+      plainCaption: "hi **boss**",
+    },
+    {
+      kind: "markup-heavy Markdown",
+      caption: `**${"x".repeat(1022)}**`,
+      htmlCaption: `<b>${"x".repeat(1022)}</b>`,
+      plainCaption: "x".repeat(1022),
+    },
+  ])(
+    "falls back to a valid $kind media caption when Telegram rejects HTML",
+    async ({ caption, htmlCaption, plainCaption }) => {
+      const runtime = createRuntime();
+      const sendPhoto = vi
+        .fn()
+        .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
+        .mockResolvedValueOnce({
+          message_id: 3,
+          chat: { id: "123" },
+        });
+      const bot = createBot({ sendPhoto });
+
+      mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+      await deliverWith({
+        replies: [{ mediaUrl: "https://example.com/photo.jpg", text: caption }],
+        runtime,
+        bot,
+      });
+
+      expect(sendPhoto).toHaveBeenCalledTimes(2);
+      expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
+        caption: htmlCaption,
+        parse_mode: "HTML",
+      });
+      expectRecordFields(mockCallArg(sendPhoto, 1, 2), {
+        caption: plainCaption,
+      });
+      expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("parse_mode");
+    },
+  );
 
   it("passes probed dimensions to video reply sends", async () => {
     const runtime = createRuntime();

--- a/extensions/telegram/src/caption.ts
+++ b/extensions/telegram/src/caption.ts
@@ -1,7 +1,12 @@
 // Telegram plugin module implements caption behavior.
+import { countTelegramHtmlVisibleCharacters, resolveTelegramHtmlVisibleText } from "./format.js";
+
 const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
 
-export function splitTelegramCaption(text?: string): {
+export function splitTelegramCaption(
+  text?: string,
+  renderedHtml?: string,
+): {
   caption?: string;
   followUpText?: string;
 } {
@@ -9,8 +14,25 @@ export function splitTelegramCaption(text?: string): {
   if (!trimmed) {
     return { caption: undefined, followUpText: undefined };
   }
-  if (trimmed.length > TELEGRAM_MAX_CAPTION_LENGTH) {
+  const visibleLength =
+    renderedHtml === undefined ? trimmed.length : countTelegramHtmlVisibleCharacters(renderedHtml);
+  if (visibleLength > TELEGRAM_MAX_CAPTION_LENGTH) {
     return { caption: undefined, followUpText: trimmed };
   }
   return { caption: trimmed, followUpText: undefined };
+}
+
+export function resolveTelegramPlainCaption(
+  caption: string | undefined,
+  renderedHtml: string | undefined,
+): string | undefined {
+  if (
+    caption === undefined ||
+    caption.length <= TELEGRAM_MAX_CAPTION_LENGTH ||
+    renderedHtml === undefined
+  ) {
+    return caption;
+  }
+  // A markup-heavy source can fit only after parsing; its plain retry must fit too.
+  return resolveTelegramHtmlVisibleText(renderedHtml);
 }

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -345,6 +345,15 @@ function stripTelegramHtmlForPlainText(html: string): string {
   );
 }
 
+export function countTelegramHtmlVisibleCharacters(html: string): number {
+  // Telegram limits UTF-16 caption characters after stripping markup and decoding entities.
+  return stripTelegramHtmlForPlainText(html).length;
+}
+
+export function resolveTelegramHtmlVisibleText(html: string): string {
+  return stripTelegramHtmlForPlainText(html);
+}
+
 function encodePlainTextForTelegramHtmlStrip(text: string): string {
   return text.replace(/[&<>]/g, (char) => {
     switch (char) {

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -3,7 +3,7 @@ import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runt
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
-import { splitTelegramCaption } from "./caption.js";
+import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
@@ -251,19 +251,24 @@ async function sendMessageTelegramWithContext(
       media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
     const file = new InputFileCtor(media.buffer, fileName);
     let caption: string | undefined;
+    let htmlCaption: string | undefined;
     let followUpText: string | undefined;
 
     if (isVideoNote) {
       caption = undefined;
       followUpText = text.trim() ? text : undefined;
     } else {
-      const split = splitTelegramCaption(text);
+      const trimmedText = text.trim();
+      const renderedCaption = trimmedText ? renderHtmlText(trimmedText) : undefined;
+      const split = splitTelegramCaption(text, renderedCaption);
       caption = split.caption;
       followUpText = split.followUpText;
+      htmlCaption = caption ? renderedCaption : undefined;
     }
-    const htmlCaption = caption ? renderHtmlText(caption) : undefined;
-    const plainCaption =
-      caption && textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption;
+    const plainCaption = resolveTelegramPlainCaption(
+      caption && textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption,
+      htmlCaption,
+    );
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2315,6 +2315,37 @@ describe("sendMessageTelegram", () => {
     expect(res.messageId).toBe("72");
   });
 
+  it("keeps formatted media captions within Telegram's parsed-character limit", async () => {
+    const chatId = "123";
+    const visibleCaption = "B".repeat(1022);
+    const formattedCaption = `**${visibleCaption}**`;
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 72, chat: { id: chatId } });
+    const sendMessage = vi.fn();
+    const api = { sendPhoto, sendMessage } as unknown as {
+      sendPhoto: typeof sendPhoto;
+      sendMessage: typeof sendMessage;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    await sendMessageTelegram(chatId, formattedCaption, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expectMediaSendCall(firstMockCall(sendPhoto, "send photo call"), "send photo call", chatId, {
+      caption: `<b>${visibleCaption}</b>`,
+      parse_mode: "HTML",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("renders markdown in media captions", async () => {
     const chatId = "123";
     const caption = "hi **boss**";
@@ -2346,52 +2377,67 @@ describe("sendMessageTelegram", () => {
     });
   });
 
-  it("falls back to a plain media caption when Telegram rejects caption HTML", async () => {
-    const chatId = "123";
-    const caption = "hi **boss**";
-    const sendPhoto = vi
-      .fn()
-      .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
-      .mockResolvedValueOnce({
-        message_id: 91,
-        chat: { id: chatId },
+  it.each([
+    {
+      kind: "ordinary Markdown",
+      caption: "hi **boss**",
+      htmlCaption: "hi <b>boss</b>",
+      plainCaption: "hi **boss**",
+    },
+    {
+      kind: "markup-heavy Markdown",
+      caption: `**${"x".repeat(1022)}**`,
+      htmlCaption: `<b>${"x".repeat(1022)}</b>`,
+      plainCaption: "x".repeat(1022),
+    },
+  ])(
+    "falls back to a valid $kind media caption when Telegram rejects HTML",
+    async ({ caption, htmlCaption, plainCaption }) => {
+      const chatId = "123";
+      const sendPhoto = vi
+        .fn()
+        .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
+        .mockResolvedValueOnce({
+          message_id: 91,
+          chat: { id: chatId },
+        });
+      const api = { sendPhoto } as unknown as {
+        sendPhoto: typeof sendPhoto;
+      };
+
+      mockLoadedMedia({
+        buffer: Buffer.from("fake-image"),
+        contentType: "image/jpeg",
+        fileName: "photo.jpg",
       });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
 
-    mockLoadedMedia({
-      buffer: Buffer.from("fake-image"),
-      contentType: "image/jpeg",
-      fileName: "photo.jpg",
-    });
+      const result = await sendMessageTelegram(chatId, caption, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        mediaUrl: "https://example.com/photo.jpg",
+      });
 
-    const result = await sendMessageTelegram(chatId, caption, {
-      cfg: TELEGRAM_TEST_CFG,
-      token: "tok",
-      api,
-      mediaUrl: "https://example.com/photo.jpg",
-    });
-
-    expectMediaSendCall(
-      firstMockCall(sendPhoto, "first send photo call"),
-      "send photo call",
-      chatId,
-      {
-        caption: "hi <b>boss</b>",
-        parse_mode: "HTML",
-      },
-    );
-    expectMediaSendCall(
-      mockCall(sendPhoto, 1, "second send photo call"),
-      "send photo retry call",
-      chatId,
-      {
-        caption,
-      },
-    );
-    expect(result).toEqual({ messageId: "91", chatId });
-  });
+      expectMediaSendCall(
+        firstMockCall(sendPhoto, "first send photo call"),
+        "send photo call",
+        chatId,
+        {
+          caption: htmlCaption,
+          parse_mode: "HTML",
+        },
+      );
+      expectMediaSendCall(
+        mockCall(sendPhoto, 1, "second send photo call"),
+        "send photo retry call",
+        chatId,
+        {
+          caption: plainCaption,
+        },
+      );
+      expect(result).toEqual({ messageId: "91", chatId });
+    },
+  );
 
   it("sends video notes when requested and regular videos otherwise", async () => {
     const chatId = "123";

--- a/extensions/telegram/src/voice.test.ts
+++ b/extensions/telegram/src/voice.test.ts
@@ -1,6 +1,6 @@
 // Telegram tests cover voice plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { splitTelegramCaption } from "./caption.js";
+import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
 
 const TELEGRAM_CAPTION_LIMIT = 1024;
@@ -26,6 +26,48 @@ describe("splitTelegramCaption", () => {
       caption: undefined,
       followUpText: text,
     });
+  });
+
+  it.each([
+    {
+      mode: "Markdown formatting",
+      text: `**${"x".repeat(TELEGRAM_CAPTION_LIMIT - 2)}**`,
+      renderedHtml: `<b>${"x".repeat(TELEGRAM_CAPTION_LIMIT - 2)}</b>`,
+    },
+    {
+      mode: "HTML formatting",
+      text: `<b>${"x".repeat(TELEGRAM_CAPTION_LIMIT - 2)}</b>`,
+      renderedHtml: `<b>${"x".repeat(TELEGRAM_CAPTION_LIMIT - 2)}</b>`,
+    },
+    {
+      mode: "HTML entities and links",
+      text: `&amp;<a href="https://example.com/long-path">${"x".repeat(1022)}</a>`,
+      renderedHtml: `&amp;<a href="https://example.com/long-path">${"x".repeat(1022)}</a>`,
+    },
+  ])("budgets $mode after Telegram parses entities", ({ text, renderedHtml }) => {
+    expect(splitTelegramCaption(text, renderedHtml)).toEqual({
+      caption: text,
+      followUpText: undefined,
+    });
+  });
+
+  it("counts visible Unicode in Telegram's UTF-16 code units", () => {
+    const fitting = "😀".repeat(TELEGRAM_CAPTION_LIMIT / 2);
+    const overflowing = `${fitting}😀`;
+
+    expect(splitTelegramCaption(fitting, `<b>${fitting}</b>`).caption).toBe(fitting);
+    expect(splitTelegramCaption(overflowing, `<b>${overflowing}</b>`)).toEqual({
+      caption: undefined,
+      followUpText: overflowing,
+    });
+  });
+
+  it("keeps plain caption retries within the parsed caption budget", () => {
+    const visible = "x".repeat(1022);
+    const markupHeavy = `**${visible}**`;
+
+    expect(resolveTelegramPlainCaption(markupHeavy, `<b>${visible}</b>`)).toBe(visible);
+    expect(resolveTelegramPlainCaption("hi **boss**", "hi <b>boss</b>")).toBe("hi **boss**");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Telegram's caption limit is **1024 UTF-16 characters after entity parsing**. A Markdown caption containing 1022 visible characters can nevertheless occupy 1026 source characters, while an equivalent HTML caption occupies 1029. OpenClaw counted source characters, so both normal durable sends and streaming replies unnecessarily detached valid captions from their media and moved their text, reply context, and inline buttons to a separate message.

## Why This Change Was Made

Refactor the existing private Telegram formatting and caption owners: count rendered visible text after stripping markup and decoding entities, without incorrectly counting link destinations. Pass that authoritative fact into both delivery funnels and keep truly oversized captions on the existing separate-message path. When Telegram rejects HTML, derive a bounded visible plain-caption retry so the newly accepted formatted captions still fall back successfully.

## Evidence

- Exact candidate: `cf207b51940fd658b3c441896bda219667b26fc0`.
- Branch: `codex/qa200-telegram-visible-caption-budget`.
- Frozen base: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Installed `@grammyjs/types` declares Telegram's caption contract as **0–1024 characters after entities parsing**.
- Frozen-main direct owner reproduction: legal Markdown (`1026 source / 1022 visible`) and HTML (`1029 source / 1022 visible`) captions both detach incorrectly.
- Exact candidate direct production proof covers Markdown, HTML, decoded entities, link destinations, a valid 512-emoji caption, an overflowing 513-emoji caption, and 1025 visible-character overflow (**6 scenarios**).
- Every accepted scenario additionally proves the plain HTML-rejection retry stays within Telegram's 1024 UTF-16-unit limit.
- Focused source regressions cover both durable and streaming media delivery and each funnel's ordinary/markup-heavy HTML parse-failure fallback.
- Targeted `oxfmt`, `oxlint`, `git diff --check`, immutable commit, clean checkout, and a sub-12-MiB sparse worktree pass.
- Initial structured review correctly found an oversized plain-caption retry; that owner-local blocker was fixed. Fresh exact-head structured commit-mode autoreview is **CLEAN**, `gpt-5.6-sol`/high, confidence **0.91**; genuine TruffleHog scan clean.
- Focused remote/hosted Vitest and exact-head CI remain required before landing.
