### PR TITLE
fix(agents): preserve atomic compaction and truthful bounded diagnostics

### DIFF
--- a/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantMessageEventStream } from "../../llm.js";
+import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
+import type { AgentMessage } from "../../types.js";
+import type { SessionTreeEntry } from "../types.js";
+import { generateBranchSummary, prepareBranchEntries } from "./branch-summarization.js";
+
+function createModel(contextWindow: number, maxTokens = 8000): Model {
+  return {
+    id: "branch-summary-model",
+    name: "Branch Summary Model",
+    api: "test-api",
+    provider: "test-provider",
+    baseUrl: "https://example.test",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens,
+  };
+}
+
+function createMessageEntry(message: AgentMessage, index: number): SessionTreeEntry {
+  return {
+    type: "message",
+    id: `entry-${index}`,
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    timestamp: new Date(message.timestamp).toISOString(),
+    message,
+  };
+}
+
+function createResponse(model: Model): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "Branch summary" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+function createCapturingStream(model: Model) {
+  let prompt = "";
+  let systemPrompt = "";
+  let maxOutputTokens: number | undefined;
+  const streamFn = vi.fn<StreamFn>((_model, context, options) => {
+    const userMessage = context.messages[0];
+    if (!userMessage || userMessage.role !== "user") {
+      throw new Error("expected a user message containing the branch summary prompt");
+    }
+    prompt =
+      typeof userMessage.content === "string"
+        ? userMessage.content
+        : userMessage.content.map((block) => (block.type === "text" ? block.text : "")).join("");
+    systemPrompt = context.systemPrompt ?? "";
+    maxOutputTokens = options?.maxTokens;
+    const stream = createAssistantMessageEventStream();
+    stream.push({ type: "done", reason: "stop", message: createResponse(model) });
+    stream.end();
+    return stream;
+  });
+  return {
+    streamFn,
+    readCapture: () => ({ prompt, systemPrompt, maxOutputTokens }),
+  };
+}
+
+function createLongBranchEntries(count: number): SessionTreeEntry[] {
+  return Array.from({ length: count }, (_, index) =>
+    createMessageEntry(
+      { role: "user", content: `turn-${index} ${"x".repeat(3500)}`, timestamp: index + 1 },
+      index,
+    ),
+  );
+}
+
+describe("branch summarization", () => {
+  it("retains failed tool results when preparing a branch", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "run deployment", timestamp: 1 }, 0),
+      createMessageEntry(
+        {
+          role: "toolResult",
+          toolCallId: "deploy-call",
+          toolName: "deploy",
+          content: [{ type: "text", text: "ERROR: deployment timed out" }],
+          details: { privateDiagnostic: "never send internal metadata" },
+          isError: true,
+          timestamp: 2,
+        },
+        1,
+      ),
+    ];
+
+    const preparation = prepareBranchEntries(entries);
+
+    expect(preparation.messages.map((message) => message.role)).toEqual(["user", "toolResult"]);
+  });
+
+  it("summarizes tool failures without exposing private result details", async () => {
+    const model = createModel(128_000);
+    const capture = createCapturingStream(model);
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "run deployment", timestamp: 1 }, 0),
+      createMessageEntry(
+        {
+          role: "toolResult",
+          toolCallId: "deploy-call",
+          toolName: "deploy",
+          content: [{ type: "text", text: "ERROR: deployment timed out" }],
+          details: { privateDiagnostic: "never send internal metadata" },
+          isError: true,
+          timestamp: 2,
+        },
+        1,
+      ),
+    ];
+
+    const result = await generateBranchSummary(entries, {
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      streamFn: capture.streamFn,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.readCapture().prompt).toContain("ERROR: deployment timed out");
+    expect(capture.readCapture().prompt).not.toContain("never send internal metadata");
+    expect(capture.readCapture().maxOutputTokens).toBe(2048);
+  });
+
+  it("bounds history when the default reservation exceeds a small context window", async () => {
+    const model = createModel(8192);
+    const capture = createCapturingStream(model);
+
+    const result = await generateBranchSummary(createLongBranchEntries(12), {
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      streamFn: capture.streamFn,
+    });
+
+    const { prompt, systemPrompt, maxOutputTokens } = capture.readCapture();
+    expect(result.ok).toBe(true);
+    expect(prompt).toContain("turn-11");
+    expect(prompt).not.toContain("turn-0");
+    expect(maxOutputTokens).toBe(2048);
+    expect(
+      Math.ceil((prompt.length + systemPrompt.length) / 4) + (maxOutputTokens ?? 0),
+    ).toBeLessThanOrEqual(model.contextWindow);
+  });
+
+  it("scales output headroom to narrow model contexts and model output caps", async () => {
+    const model = createModel(4096, 512);
+    const capture = createCapturingStream(model);
+
+    const result = await generateBranchSummary(createLongBranchEntries(8), {
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      streamFn: capture.streamFn,
+    });
+
+    const { prompt, systemPrompt, maxOutputTokens } = capture.readCapture();
+    expect(result.ok).toBe(true);
+    expect(maxOutputTokens).toBe(512);
+    expect(prompt).not.toContain("turn-0");
+    expect(
+      Math.ceil((prompt.length + systemPrompt.length) / 4) + (maxOutputTokens ?? 0),
+    ).toBeLessThanOrEqual(model.contextWindow);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
@@ -161,6 +161,24 @@ describe("branch summarization", () => {
     ).toBeLessThanOrEqual(model.contextWindow);
   });
 
+  it("preserves usable caller reservations larger than half the context window", async () => {
+    const model = createModel(8192);
+    const capture = createCapturingStream(model);
+
+    const result = await generateBranchSummary(createLongBranchEntries(12), {
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 6144,
+      streamFn: capture.streamFn,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.readCapture().prompt).toContain("turn-11");
+    expect(capture.readCapture().prompt).not.toContain("turn-9");
+    expect(capture.readCapture().maxOutputTokens).toBe(2048);
+  });
+
   it("scales output headroom to narrow model contexts and model output caps", async () => {
     const model = createModel(4096, 512);
     const capture = createCapturingStream(model);

--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -242,12 +242,11 @@ export async function generateBranchSummary(
     Math.max(1, Math.floor(contextWindow / 4)),
     model.maxTokens > 0 ? model.maxTokens : 2048,
   );
-  // A reservation larger than a small model's window must not become the
-  // nonpositive sentinel that makes prepareBranchEntries retain all history.
-  const effectiveReserveTokens = Math.max(
-    maxSummaryOutputTokens,
-    Math.min(reserveTokens, Math.floor(contextWindow / 2)),
-  );
+  // Preserve usable caller reservations; only an impossible reservation may
+  // fall back before its nonpositive budget disables history bounds entirely.
+  const usableReserveTokens =
+    reserveTokens < contextWindow ? reserveTokens : Math.floor(contextWindow / 2);
+  const effectiveReserveTokens = Math.max(maxSummaryOutputTokens, usableReserveTokens);
   const tokenBudget = Math.max(1, contextWindow - effectiveReserveTokens);
 
   const { messages, fileOps } = prepareBranchEntries(entries, tokenBudget);

--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -104,9 +104,6 @@ export function collectEntriesForBranchSummaryFromBranches<TEntry extends Branch
 function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined {
   switch (entry.type) {
     case "message":
-      if (entry.message.role === "toolResult") {
-        return undefined;
-      }
       return entry.message;
 
     case "custom_message":
@@ -240,7 +237,18 @@ export async function generateBranchSummary(
     reserveTokens = 16384,
   } = options;
   const contextWindow = model.contextWindow || 128000;
-  const tokenBudget = contextWindow - reserveTokens;
+  const maxSummaryOutputTokens = Math.min(
+    2048,
+    Math.max(1, Math.floor(contextWindow / 4)),
+    model.maxTokens > 0 ? model.maxTokens : 2048,
+  );
+  // A reservation larger than a small model's window must not become the
+  // nonpositive sentinel that makes prepareBranchEntries retain all history.
+  const effectiveReserveTokens = Math.max(
+    maxSummaryOutputTokens,
+    Math.min(reserveTokens, Math.floor(contextWindow / 2)),
+  );
+  const tokenBudget = Math.max(1, contextWindow - effectiveReserveTokens);
 
   const { messages, fileOps } = prepareBranchEntries(entries, tokenBudget);
 
@@ -267,7 +275,7 @@ export async function generateBranchSummary(
     },
   ];
   const context = { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages };
-  const streamOptions = { apiKey, headers, signal, maxTokens: 2048 };
+  const streamOptions = { apiKey, headers, signal, maxTokens: maxSummaryOutputTokens };
   const response = options.streamFn
     ? await (await options.streamFn(model, context, streamOptions)).result()
     : await resolveAgentCoreCompleteFn(options.runtime)(model, context, streamOptions);

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -93,8 +93,23 @@ describe("serializeConversation", () => {
     expect(serializeConversation(messages)).toContain("ERROR: earlier failure");
   });
 
-  it("does not let routine completion output evict an earlier failure", () => {
-    const output = `${"h".repeat(1500)}ERROR: deployment failed${"m".repeat(1500)}\ndone`;
+  it.each(["done", "exit code 0", "1 failed"])(
+    "does not let routine '%s' output evict an earlier failure",
+    (footer) => {
+      const output = `${"h".repeat(1500)}ERROR: deployment failed${"m".repeat(1500)}\n${footer}`;
+      const messages = [
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: output }],
+        },
+      ] as unknown as Message[];
+
+      expect(serializeConversation(messages)).toContain("ERROR: deployment failed");
+    },
+  );
+
+  it("preserves a terminal failure when no earlier diagnostic would be displaced", () => {
+    const output = `${"h".repeat(1500)}${"m".repeat(1500)}\nERROR: terminal failure`;
     const messages = [
       {
         role: "toolResult",
@@ -102,6 +117,6 @@ describe("serializeConversation", () => {
       },
     ] as unknown as Message[];
 
-    expect(serializeConversation(messages)).toContain("ERROR: deployment failed");
+    expect(serializeConversation(messages)).toContain("ERROR: terminal failure");
   });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -119,4 +119,21 @@ describe("serializeConversation", () => {
 
     expect(serializeConversation(messages)).toContain("ERROR: terminal failure");
   });
+
+  it("retains terminal errors followed by more than 600 characters of stack frames", () => {
+    const output = `${"progress ".repeat(300)}\nERROR: terminal failure\n${"  at applicationFrame()\n".repeat(45)}`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    const serialized = serializeConversation(messages);
+
+    expect(serialized).toContain("ERROR: terminal failure");
+    expect(serialized).toContain("applicationFrame()");
+    expect(serialized).toContain("middle/trailing characters truncated");
+    expect(serialized.length).toBeLessThan(2100);
+  });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -92,4 +92,16 @@ describe("serializeConversation", () => {
 
     expect(serializeConversation(messages)).toContain("ERROR: earlier failure");
   });
+
+  it("does not let routine completion output evict an earlier failure", () => {
+    const output = `${"h".repeat(1500)}ERROR: deployment failed${"m".repeat(1500)}\ndone`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    expect(serializeConversation(messages)).toContain("ERROR: deployment failed");
+  });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -80,4 +80,16 @@ describe("serializeConversation", () => {
     expect(serialized).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
     expect(serialized).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
   });
+
+  it("retains earlier diagnostics when they are outside the preserved tail", () => {
+    const output = `${"h".repeat(1500)}ERROR: earlier failure${"m".repeat(1500)}`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    expect(serializeConversation(messages)).toContain("ERROR: earlier failure");
+  });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -136,4 +136,19 @@ describe("serializeConversation", () => {
     expect(serialized).toContain("middle/trailing characters truncated");
     expect(serialized.length).toBeLessThan(2100);
   });
+
+  it("does not duplicate early errors into an overlapping diagnostic window", () => {
+    const output = `${"h".repeat(600)}ERROR: early failure${"m".repeat(1900)}`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    const serialized = serializeConversation(messages);
+
+    expect(serialized.split("ERROR: early failure")).toHaveLength(2);
+    expect(serialized).toContain(`[... ${output.length - 2000} more characters truncated]`);
+  });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -47,4 +47,37 @@ describe("serializeConversation", () => {
       `[Tool result]: ${prefix}\n\n[... 6 more characters truncated]`,
     );
   });
+
+  it("preserves terminal failures when truncating long tool results", () => {
+    const output = `command started\n${"progress ".repeat(450)}\nFATAL: missing deployment token`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    const serialized = serializeConversation(messages);
+
+    expect(serialized).toContain("command started");
+    expect(serialized).toContain("FATAL: missing deployment token");
+    expect(serialized).toMatch(/\[\.\.\. \d+ more characters truncated\]/);
+    expect(serialized.length).toBeLessThan(2100);
+  });
+
+  it("keeps both diagnostic truncation boundaries UTF-16 safe", () => {
+    const output = `${"h".repeat(1399)}🚀${"m".repeat(1600)}🚀\nERROR: failed safely`;
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: output }],
+      },
+    ] as unknown as Message[];
+
+    const serialized = serializeConversation(messages);
+
+    expect(serialized).toContain("ERROR: failed safely");
+    expect(serialized).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(serialized).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+  });
 });

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -87,7 +87,7 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 
 const TOOL_RESULT_MAX_CHARS = 2000;
 const IMPORTANT_TOOL_RESULT_TAIL =
-  /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code|total|summary|result|complete|finished|done)\b/i;
+  /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/i;
 
 function safeJsonStringify(value: unknown): string {
   try {

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -87,7 +87,7 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 
 const TOOL_RESULT_MAX_CHARS = 2000;
 const IMPORTANT_TOOL_RESULT_TAIL =
-  /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/i;
+  /(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)/i;
 
 function safeJsonStringify(value: unknown): string {
   try {
@@ -105,10 +105,15 @@ function truncateForSummary(text: string, maxChars: number): string {
   const tail = sliceUtf16Safe(text, -tailChars);
   if (IMPORTANT_TOOL_RESULT_TAIL.test(tail)) {
     const head = truncateUtf16Safe(text, maxChars - tailChars);
-    const truncatedChars = text.length - head.length - tail.length;
-    // Commands usually report their actual failure last; preserve that tail
-    // so branch and ordinary compaction summaries can explain what failed.
-    return `${head}\n\n[... ${truncatedChars} more characters truncated]\n\n${tail}`;
+    const displacedHead = sliceUtf16Safe(text, Math.max(0, head.length - 32), maxChars);
+    // A routine footer can match failure words. Never shorten the original
+    // retained head when doing so would discard an existing diagnostic.
+    if (!IMPORTANT_TOOL_RESULT_TAIL.test(displacedHead)) {
+      const truncatedChars = text.length - head.length - tail.length;
+      // Commands usually report their actual failure last; preserve that tail
+      // so branch and ordinary compaction summaries can explain what failed.
+      return `${head}\n\n[... ${truncatedChars} more characters truncated]\n\n${tail}`;
+    }
   }
   const sliced = truncateUtf16Safe(text, maxChars);
   const truncatedChars = text.length - sliced.length;

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -102,17 +102,29 @@ function truncateForSummary(text: string, maxChars: number): string {
     return text;
   }
   const tailChars = Math.min(Math.floor(maxChars * 0.3), 600);
-  const tail = sliceUtf16Safe(text, -tailChars);
-  if (IMPORTANT_TOOL_RESULT_TAIL.test(tail)) {
+  const diagnosticSearch = sliceUtf16Safe(text, -maxChars);
+  const diagnosticMatches = Array.from(
+    diagnosticSearch.matchAll(new RegExp(IMPORTANT_TOOL_RESULT_TAIL.source, "gi")),
+  );
+  const diagnosticMatch =
+    diagnosticMatches
+      .toReversed()
+      .find((match) => /^(error|exception|fatal|panic|errno)$/i.test(match[0])) ??
+    diagnosticMatches.at(-1);
+  if (diagnosticMatch) {
     const head = truncateUtf16Safe(text, maxChars - tailChars);
     const displacedHead = sliceUtf16Safe(text, Math.max(0, head.length - 32), maxChars);
     // A routine footer can match failure words. Never shorten the original
     // retained head when doing so would discard an existing diagnostic.
     if (!IMPORTANT_TOOL_RESULT_TAIL.test(displacedHead)) {
+      const diagnosticOffset = text.length - diagnosticSearch.length + (diagnosticMatch.index ?? 0);
+      const tailStart = Math.min(diagnosticOffset, text.length - tailChars);
+      const tail = sliceUtf16Safe(text, tailStart, tailStart + tailChars);
       const truncatedChars = text.length - head.length - tail.length;
+      const omissionPosition = tailStart + tail.length < text.length ? "middle/trailing" : "more";
       // Commands usually report their actual failure last; preserve that tail
       // so branch and ordinary compaction summaries can explain what failed.
-      return `${head}\n\n[... ${truncatedChars} more characters truncated]\n\n${tail}`;
+      return `${head}\n\n[... ${truncatedChars} ${omissionPosition} characters truncated]\n\n${tail}`;
     }
   }
   const sliced = truncateUtf16Safe(text, maxChars);

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@openclaw/llm-core";
 // Agent Core helper module supports utils behavior.
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { AgentMessage } from "../../types.js";
 import type { FileOperations } from "../types.js";
 
@@ -86,6 +86,8 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 }
 
 const TOOL_RESULT_MAX_CHARS = 2000;
+const IMPORTANT_TOOL_RESULT_TAIL =
+  /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code|total|summary|result|complete|finished|done)\b/i;
 
 function safeJsonStringify(value: unknown): string {
   try {
@@ -98,6 +100,15 @@ function safeJsonStringify(value: unknown): string {
 function truncateForSummary(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
+  }
+  if (IMPORTANT_TOOL_RESULT_TAIL.test(sliceUtf16Safe(text, -maxChars))) {
+    const tailChars = Math.min(Math.floor(maxChars * 0.3), 600);
+    const head = truncateUtf16Safe(text, maxChars - tailChars);
+    const tail = sliceUtf16Safe(text, -tailChars);
+    const truncatedChars = text.length - head.length - tail.length;
+    // Commands usually report their actual failure last; preserve that tail
+    // so branch and ordinary compaction summaries can explain what failed.
+    return `${head}\n\n[... ${truncatedChars} more characters truncated]\n\n${tail}`;
   }
   const sliced = truncateUtf16Safe(text, maxChars);
   const truncatedChars = text.length - sliced.length;

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -119,12 +119,16 @@ function truncateForSummary(text: string, maxChars: number): string {
     if (!IMPORTANT_TOOL_RESULT_TAIL.test(displacedHead)) {
       const diagnosticOffset = text.length - diagnosticSearch.length + (diagnosticMatch.index ?? 0);
       const tailStart = Math.min(diagnosticOffset, text.length - tailChars);
-      const tail = sliceUtf16Safe(text, tailStart, tailStart + tailChars);
-      const truncatedChars = text.length - head.length - tail.length;
-      const omissionPosition = tailStart + tail.length < text.length ? "middle/trailing" : "more";
-      // Commands usually report their actual failure last; preserve that tail
-      // so branch and ordinary compaction summaries can explain what failed.
-      return `${head}\n\n[... ${truncatedChars} ${omissionPosition} characters truncated]\n\n${tail}`;
+      // An early diagnostic already lives in the retained prefix; reusing it
+      // as a tail would overlap the head and miscount omitted characters.
+      if (tailStart >= head.length) {
+        const tail = sliceUtf16Safe(text, tailStart, tailStart + tailChars);
+        const truncatedChars = text.length - head.length - tail.length;
+        const omissionPosition = tailStart + tail.length < text.length ? "middle/trailing" : "more";
+        // Commands usually report their actual failure last; preserve that tail
+        // so branch and ordinary compaction summaries can explain what failed.
+        return `${head}\n\n[... ${truncatedChars} ${omissionPosition} characters truncated]\n\n${tail}`;
+      }
     }
   }
   const sliced = truncateUtf16Safe(text, maxChars);

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -101,10 +101,10 @@ function truncateForSummary(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  if (IMPORTANT_TOOL_RESULT_TAIL.test(sliceUtf16Safe(text, -maxChars))) {
-    const tailChars = Math.min(Math.floor(maxChars * 0.3), 600);
+  const tailChars = Math.min(Math.floor(maxChars * 0.3), 600);
+  const tail = sliceUtf16Safe(text, -tailChars);
+  if (IMPORTANT_TOOL_RESULT_TAIL.test(tail)) {
     const head = truncateUtf16Safe(text, maxChars - tailChars);
-    const tail = sliceUtf16Safe(text, -tailChars);
     const truncatedChars = text.length - head.length - tail.length;
     // Commands usually report their actual failure last; preserve that tail
     // so branch and ordinary compaction summaries can explain what failed.

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -106,6 +106,65 @@ function normalizeCompactionParts(parts: number, messageCount: number): number {
   return Math.min(Math.max(1, Math.floor(parts)), Math.max(1, messageCount));
 }
 
+type CompactionMessageGroup = {
+  messages: AgentMessage[];
+  tokens: number;
+};
+
+function groupCompactionMessages(
+  messages: AgentMessage[],
+  perMessageTokens: number[],
+): CompactionMessageGroup[] {
+  const groups: CompactionMessageGroup[] = [];
+  let current: AgentMessage[] = [];
+  let currentTokens = 0;
+  let pendingToolCallIds = new Set<string>();
+
+  const finishCurrentGroup = () => {
+    if (current.length === 0) {
+      return;
+    }
+    groups.push({ messages: current, tokens: currentTokens });
+    current = [];
+    currentTokens = 0;
+  };
+
+  for (const [index, message] of messages.entries()) {
+    const messageTokens = perMessageTokens.at(index);
+    if (messageTokens === undefined) {
+      throw new Error("Compaction token estimates are out of sync with messages");
+    }
+
+    current.push(message);
+    currentTokens += messageTokens;
+
+    if (message.role === "assistant") {
+      const stopReason = (message as { stopReason?: unknown }).stopReason;
+      const toolCalls =
+        stopReason === "aborted" || stopReason === "error"
+          ? []
+          : extractToolCallsFromAssistant(message);
+      pendingToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
+    } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
+      const resultId = extractToolResultId(message);
+      if (resultId) {
+        pendingToolCallIds.delete(resultId);
+      } else {
+        pendingToolCallIds.clear();
+      }
+    }
+
+    // A displaced user turn still belongs to an unfinished call/result batch;
+    // splitting it would make one of the resulting provider transcripts invalid.
+    if (pendingToolCallIds.size === 0) {
+      finishCurrentGroup();
+    }
+  }
+
+  finishCurrentGroup();
+  return groups;
+}
+
 /** Splits messages into roughly equal token-share chunks without separating active tool pairs. */
 function splitMessagesByTokenShare(
   messages: AgentMessage[],
@@ -128,85 +187,19 @@ function splitMessagesByTokenShare(
   let current: AgentMessage[] = [];
   let currentTokens = 0;
 
-  let pendingToolCallIds = new Set<string>();
-  let pendingChunkStartIndex: number | null = null;
-  // Token count for each message currently buffered in `current`, kept in lockstep so a
-  // boundary split can re-sum without re-estimating.
-  let currentTokenCounts: number[] = [];
-
-  const splitCurrentAtPendingBoundary = (): boolean => {
+  for (const group of groupCompactionMessages(messages, perMessageTokens)) {
     if (
-      pendingChunkStartIndex === null ||
-      pendingChunkStartIndex <= 0 ||
-      chunks.length >= normalizedParts - 1
-    ) {
-      return false;
-    }
-    // Keep an assistant tool_use and its following tool_result responses in the same chunk.
-    chunks.push(current.slice(0, pendingChunkStartIndex));
-    current = current.slice(pendingChunkStartIndex);
-    currentTokenCounts = currentTokenCounts.slice(pendingChunkStartIndex);
-    currentTokens = currentTokenCounts.reduce((sum, tokens) => sum + tokens, 0);
-    pendingChunkStartIndex = 0;
-    return true;
-  };
-
-  for (const [index, message] of messages.entries()) {
-    const messageTokens = perMessageTokens.at(index);
-    if (messageTokens === undefined) {
-      throw new Error("Compaction token estimates are out of sync with messages");
-    }
-
-    if (
-      pendingToolCallIds.size === 0 &&
       chunks.length < normalizedParts - 1 &&
       current.length > 0 &&
-      currentTokens + messageTokens > targetTokens
+      currentTokens + group.tokens > targetTokens
     ) {
       chunks.push(current);
       current = [];
-      currentTokenCounts = [];
       currentTokens = 0;
-      pendingChunkStartIndex = null;
     }
 
-    current.push(message);
-    currentTokenCounts.push(messageTokens);
-    currentTokens += messageTokens;
-
-    if (message.role === "assistant") {
-      const toolCalls = extractToolCallsFromAssistant(message);
-      const stopReason = (message as { stopReason?: unknown }).stopReason;
-      const keepsPending =
-        stopReason !== "aborted" && stopReason !== "error" && toolCalls.length > 0;
-      pendingToolCallIds = new Set();
-      if (keepsPending) {
-        for (const toolCall of toolCalls) {
-          pendingToolCallIds.add(toolCall.id);
-        }
-      }
-      pendingChunkStartIndex = keepsPending ? current.length - 1 : null;
-    } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
-      const resultId = extractToolResultId(message);
-      if (!resultId) {
-        pendingToolCallIds = new Set();
-        pendingChunkStartIndex = null;
-      } else {
-        pendingToolCallIds.delete(resultId);
-      }
-      if (
-        pendingToolCallIds.size === 0 &&
-        chunks.length < normalizedParts - 1 &&
-        currentTokens > targetTokens
-      ) {
-        splitCurrentAtPendingBoundary();
-        pendingChunkStartIndex = null;
-      }
-    }
-  }
-
-  if (pendingToolCallIds.size > 0 && currentTokens > targetTokens) {
-    splitCurrentAtPendingBoundary();
+    current.push(...group.messages);
+    currentTokens += group.tokens;
   }
 
   if (current.length > 0) {
@@ -233,22 +226,19 @@ function chunkMessagesByMaxTokens(messages: AgentMessage[], maxTokens: number): 
   let currentChunk: AgentMessage[] = [];
   let currentTokens = 0;
 
-  for (const [index, message] of messages.entries()) {
-    const messageTokens = perMessageTokens.at(index);
-    if (messageTokens === undefined) {
-      throw new Error("Compaction token estimates are out of sync with messages");
-    }
-    if (currentChunk.length > 0 && currentTokens + messageTokens > effectiveMax) {
+  for (const group of groupCompactionMessages(messages, perMessageTokens)) {
+    if (currentChunk.length > 0 && currentTokens + group.tokens > effectiveMax) {
       chunks.push(currentChunk);
       currentChunk = [];
       currentTokens = 0;
     }
 
-    currentChunk.push(message);
-    currentTokens += messageTokens;
+    currentChunk.push(...group.messages);
+    currentTokens += group.tokens;
 
-    if (messageTokens > effectiveMax) {
-      // Split oversized messages to avoid unbounded chunk growth.
+    if (group.tokens > effectiveMax) {
+      // A tool batch is indivisible even above the heuristic budget; the
+      // oversized-summary fallback can handle it without orphaning its result.
       chunks.push(currentChunk);
       currentChunk = [];
       currentTokens = 0;

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -8,10 +8,11 @@ import "./test-helpers/agent-session-token-mock.js";
 let estimateMessagesTokens: typeof import("./compaction-planning.js").estimateMessagesTokens;
 let buildHistoryPrunePlan: typeof import("./compaction-planning.js").buildHistoryPrunePlan;
 let buildStageSplitPlan: typeof import("./compaction-planning.js").buildStageSplitPlan;
+let buildSummaryChunks: typeof import("./compaction-planning.js").buildSummaryChunks;
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ buildHistoryPrunePlan, buildStageSplitPlan, estimateMessagesTokens } =
+  ({ buildHistoryPrunePlan, buildStageSplitPlan, buildSummaryChunks, estimateMessagesTokens } =
     await import("./compaction-planning.js"));
 });
 
@@ -254,6 +255,64 @@ describe("splitMessagesByTokenShare", () => {
     expect(parts.length).toBe(2);
     expect(parts[0]?.map((m) => m.timestamp)).toEqual([1]);
     expect(parts[1]?.map((m) => m.timestamp)).toEqual([2, 3]);
+  });
+});
+
+describe("buildSummaryChunks", () => {
+  it("keeps a tool call with its result when their combined size exceeds the chunk budget", () => {
+    const messages: AgentMessage[] = [
+      makeMessage(1, 800),
+      makeAssistantToolCall(2, "call_summary", "a".repeat(1800)),
+      makeToolResult(3, "call_summary", "r".repeat(1800)),
+      makeMessage(4, 800),
+    ];
+
+    const chunks = buildSummaryChunks({ messages, maxChunkTokens: 700 });
+
+    expect(chunks.map((chunk) => chunk.map((message) => message.timestamp))).toEqual([
+      [1],
+      [2, 3],
+      [4],
+    ]);
+  });
+
+  it("keeps displaced and multiple results inside their assistant's atomic summary chunk", () => {
+    const assistant = makeAgentAssistantMessage({
+      content: [
+        { type: "toolCall", id: "call_first", name: "first", arguments: {} },
+        { type: "toolCall", id: "call_second", name: "second", arguments: {} },
+      ],
+      model: "gpt-5.4",
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const messages: AgentMessage[] = [
+      makeMessage(1, 1000),
+      assistant,
+      makeToolResult(3, "call_first", "r".repeat(1200)),
+      makeMessage(4, 500),
+      makeToolResult(5, "call_second", "r".repeat(1200)),
+      makeMessage(6, 1000),
+    ];
+
+    const chunks = buildSummaryChunks({ messages, maxChunkTokens: 500 });
+
+    expect(chunks.map((chunk) => chunk.map((message) => message.timestamp))).toEqual([
+      [1],
+      [2, 3, 4, 5],
+      [6],
+    ]);
+  });
+
+  it("does not pin later messages to aborted tool-call assistants", () => {
+    const messages: AgentMessage[] = [
+      makeAssistantToolCall(1, "call_aborted", "a".repeat(1800), "aborted"),
+      makeMessage(2, 1800),
+    ];
+
+    const chunks = buildSummaryChunks({ messages, maxChunkTokens: 700 });
+
+    expect(chunks.map((chunk) => chunk.map((message) => message.timestamp))).toEqual([[1], [2]]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users returning to a compacted agent conversation could lose tool-call/result relationships, receive branch summaries that silently omitted failed tool outcomes, or miss the actual failure because it appeared near the end of long command output. Users of smaller-context models could also exceed the model's context window because the default branch-summary reservation disabled history limits instead of bounding them.

## Why This Change Was Made

Both compaction splitters now share one atomic assistant/tool-result owner, including displaced and multiple results. Branch summaries retain model-visible tool results without exposing private result metadata, and result serialization preserves bounded, UTF-16-safe diagnostic windows without discarding earlier failures, duplicating retained text, or misreporting omissions. Small-model summary requests now bound input and output while preserving valid operator-configured reservations, opaque provider reasoning signatures, existing public contracts, and aggregate context defaults.

## User Impact

Agents retain the outcome of their tool calls after compaction, explain real branch failures, preserve useful error and stack-trace details, and remain within the limits of smaller models. Existing explicit reservation settings, signed-content replay, and private tool-result metadata continue to behave safely.

## Evidence

- Frozen baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact candidate: `45fe618863be95bbe06c97b25310d0cc72aa1634`.
- Direct production-owner execution: **55 assertions passed**, including displaced/multiple/aborted tool-call batches, real failed-result retention, private-details exclusion, unchanged opaque thinking signatures, 8K/4K context and output limits, valid explicit reservations, six earlier-error offsets, misleading `done` / `exit code 0` / `1 failed` footers, long post-error stack traces, non-overlapping diagnostic windows, and accurate omitted-character counts.
- All six changed files passed focused `oxfmt --check`, Node 24 `--experimental-strip-types --check`, and frozen-base `git diff --check`.
- Full-stack structured Codex autoreview: **clean, no accepted/actionable findings**; TruffleHog credential scan: **clean**; independent strict exact-commit review: **clean**.
- Direct Codex contract inspection: `../codex/codex-rs/core/src/context_manager/history.rs:193`, `../codex/codex-rs/core/src/context_manager/normalize.rs:45`, and `../codex/codex-rs/utils/output-truncation/src/lib.rs:25`.
- **Focused hosted CI and focused hosted Vitest suites are pending. No hosted test pass or remote execution is claimed.**
