### PR TITLE
fix(providers): preserve Bedrock caching and OpenRouter usage facts

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -1,0 +1,482 @@
+// Bedrock provider-owner regressions cover reasoning replay, prompt caches, and token accounting.
+import {
+  BedrockRuntimeClient,
+  CacheTTL,
+  ConversationRole,
+  StopReason as BedrockStopReason,
+} from "@aws-sdk/client-bedrock-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BedrockOptions } from "./bedrock-options.js";
+import { streamSimpleBedrock } from "./stream.runtime.js";
+import { streamTesting as testing } from "./test-support.js";
+
+function bedrockModel(overrides: Record<string, unknown>) {
+  return {
+    api: "bedrock-converse-stream",
+    provider: "amazon-bedrock",
+    id: "amazon.nova-micro-v1:0",
+    name: "Nova Micro",
+    baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 4096,
+    ...overrides,
+  } as never;
+}
+
+function signedThinkingContext(modelId: string) {
+  const highSurrogate = String.fromCharCode(0xd83d);
+  return {
+    messages: [
+      {
+        role: "assistant",
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        model: modelId,
+        content: [
+          {
+            type: "thinking",
+            thinking: `private${highSurrogate}reasoning`,
+            thinkingSignature: "sig-1",
+          },
+        ],
+      },
+    ],
+  } as never;
+}
+
+async function* streamEvents(events: unknown[]) {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function streamBedrockForTest(
+  model: Parameters<typeof streamSimpleBedrock>[0],
+  context: Parameters<typeof streamSimpleBedrock>[1],
+  options: BedrockOptions = {},
+) {
+  return streamSimpleBedrock(model, context, options as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Bedrock reasoning replay", () => {
+  it("preserves streamed redacted reasoning and replays its opaque bytes unchanged", async () => {
+    const modelId = "anthropic.claude-haiku-4-5-20251001-v1:0";
+    const opaqueReasoning = Uint8Array.from([0xde, 0xad, 0xbe, 0xef]);
+    const model = bedrockModel({ id: modelId, name: "Claude Haiku 4.5" });
+    const encodeOpaqueReasoning = vi.spyOn(globalThis, "btoa");
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { redactedContent: opaqueReasoning.slice(0, 2) } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { redactedContent: opaqueReasoning.slice(2) } },
+          },
+        },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+
+    const result = await streamBedrockForTest(model, {
+      messages: [{ role: "user", content: "Think privately", timestamp: 0 }],
+    } as never).result();
+
+    expect(result.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "[Reasoning redacted]",
+        thinkingSignature: "3q2+7w==",
+        redacted: true,
+      },
+    ]);
+    expect(encodeOpaqueReasoning).toHaveBeenCalledTimes(1);
+
+    send.mockResolvedValueOnce({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+    await streamBedrockForTest(model, {
+      messages: [result, { role: "user", content: "Continue", timestamp: 1 }],
+    } as never).result();
+
+    const replayCommand = send.mock.calls[1]?.[0] as {
+      input?: { messages?: Array<{ content?: unknown[] }> };
+    };
+    expect(replayCommand.input?.messages?.[0]?.content).toEqual([
+      { reasoningContent: { redactedContent: opaqueReasoning } },
+    ]);
+  });
+
+  it("preserves signed reasoning for Claude profile descriptors", () => {
+    const modelId =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/profile-abc";
+    const messages = testing.convertMessages(
+      signedThinkingContext(modelId),
+      bedrockModel({
+        id: modelId,
+        name: "Claude Sonnet application profile",
+      }),
+      "none",
+    );
+
+    expect(messages[0]?.content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: `private${String.fromCharCode(0xd83d)}reasoning`,
+            signature: "sig-1",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("replays signed reasoning as plain text for non-Claude models", () => {
+    const modelId = "amazon.nova-micro-v1:0";
+    const messages = testing.convertMessages(
+      signedThinkingContext(modelId),
+      bedrockModel({ id: modelId, name: "Nova Micro" }),
+      "none",
+    );
+
+    expect(messages[0]?.content).toEqual([{ text: "privatereasoning" }]);
+  });
+
+  it.each(["3q2+7w==", undefined])(
+    "drops opaque Claude reasoning when switching to an unsupported model (signature: %s)",
+    (thinkingSignature) => {
+      const modelId = "amazon.nova-micro-v1:0";
+      const messages = testing.convertMessages(
+        {
+          messages: [
+            {
+              role: "assistant",
+              api: "bedrock-converse-stream",
+              provider: "amazon-bedrock",
+              model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "[Reasoning redacted]",
+                  thinkingSignature,
+                  redacted: true,
+                },
+                { type: "text", text: "Safe visible response" },
+              ],
+            },
+          ],
+        } as never,
+        bedrockModel({ id: modelId, name: "Nova Micro" }),
+        "none",
+      );
+
+      expect(messages[0]?.content).toEqual([{ text: "Safe visible response" }]);
+    },
+  );
+
+  it.each(["3q2+7w==", undefined])(
+    "drops model-bound opaque reasoning when switching between Claude models (signature: %s)",
+    (thinkingSignature) => {
+      const targetModelId = "anthropic.claude-sonnet-4-5-20250929-v1:0";
+      const messages = testing.convertMessages(
+        {
+          messages: [
+            {
+              role: "assistant",
+              api: "bedrock-converse-stream",
+              provider: "amazon-bedrock",
+              model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "[Reasoning redacted]",
+                  thinkingSignature,
+                  redacted: true,
+                },
+                { type: "text", text: "Safe visible response" },
+              ],
+            },
+          ],
+        } as never,
+        bedrockModel({ id: targetModelId, name: "Claude Sonnet 4.5" }),
+        "none",
+      );
+
+      expect(messages[0]?.content).toEqual([{ text: "Safe visible response" }]);
+    },
+  );
+
+  it("preserves signature-only Fable reasoning blocks", () => {
+    const modelId = "anthropic.claude-fable-5";
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "bedrock-converse-stream",
+            provider: "amazon-bedrock",
+            model: modelId,
+            content: [
+              {
+                type: "thinking",
+                thinking: "",
+                thinkingSignature: " sig-fable ",
+              },
+            ],
+          },
+        ],
+      } as never,
+      bedrockModel({ id: modelId, name: "Claude Fable 5" }),
+      "none",
+    );
+
+    expect(messages[0]?.content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: "",
+            signature: " sig-fable ",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("drops synthetic reasoning placeholders from Claude replay", () => {
+    const modelId = "anthropic.claude-fable-5";
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "bedrock-converse-stream",
+            provider: "amazon-bedrock",
+            model: modelId,
+            content: [
+              {
+                type: "thinking",
+                thinking: "hidden compatibility reasoning",
+                thinkingSignature: "reasoning_content",
+              },
+            ],
+          },
+        ],
+      } as never,
+      bedrockModel({ id: modelId, name: "Claude Fable 5" }),
+      "none",
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("Bedrock prompt cache ownership", () => {
+  const model = () =>
+    bedrockModel({ id: "anthropic.claude-haiku-4-5-20251001-v1:0", name: "Claude Haiku 4.5" });
+
+  it("anchors prompt caching on the last stable user turn instead of transient runtime context", () => {
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          { role: "user", content: "stable operator request", timestamp: 0 },
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            runtimeContextCarrier: true,
+            timestamp: 1,
+          },
+        ],
+      },
+      model(),
+      "short",
+    );
+
+    expect(messages).toEqual([
+      {
+        role: ConversationRole.USER,
+        content: [{ text: "stable operator request" }, { cachePoint: { type: "default" } }],
+      },
+      { role: ConversationRole.USER, content: [{ text: "volatile current-turn metadata" }] },
+    ]);
+  });
+
+  it("does not cache a runtime-context carrier when no stable user turn exists", () => {
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            runtimeContextCarrier: true,
+            timestamp: 0,
+          },
+        ],
+      },
+      model(),
+      "short",
+    );
+
+    expect(messages).toEqual([
+      { role: ConversationRole.USER, content: [{ text: "volatile current-turn metadata" }] },
+    ]);
+  });
+
+  it("never includes a runtime-context carrier in the cached prefix of a later user turn", () => {
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          { role: "user", content: "stable operator request", timestamp: 0 },
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            runtimeContextCarrier: true,
+            timestamp: 1,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_follow_up",
+            toolName: "read",
+            content: [{ type: "text", text: "later stable tool output" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } as never,
+      model(),
+      "long",
+    );
+
+    expect(messages[0]?.content).toEqual([
+      { text: "stable operator request" },
+      { cachePoint: { type: "default", ttl: "1h" } },
+    ]);
+    expect(messages[1]?.content).toEqual([{ text: "volatile current-turn metadata" }]);
+    expect(messages[2]?.content).toEqual([
+      {
+        toolResult: {
+          toolUseId: "call_follow_up",
+          content: [{ text: "later stable tool output" }],
+          status: "success",
+        },
+      },
+    ]);
+  });
+
+  it("does not cache a later stable turn when volatile context starts the prefix", () => {
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            runtimeContextCarrier: true,
+            timestamp: 0,
+          },
+          { role: "user", content: "later stable operator request", timestamp: 1 },
+        ],
+      },
+      model(),
+      "long",
+    );
+
+    expect(messages).toEqual([
+      { role: ConversationRole.USER, content: [{ text: "volatile current-turn metadata" }] },
+      { role: ConversationRole.USER, content: [{ text: "later stable operator request" }] },
+    ]);
+  });
+});
+
+describe("Bedrock token usage", () => {
+  it("includes cached prompt tokens in authoritative total and context usage", async () => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          metadata: {
+            usage: {
+              inputTokens: 20,
+              outputTokens: 5,
+              totalTokens: 25,
+              cacheReadInputTokens: 70,
+              cacheWriteInputTokens: 10,
+            },
+          },
+        },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+
+    const result = await streamBedrockForTest(bedrockModel({}), {
+      messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+    } as never).result();
+
+    expect(result.usage).toMatchObject({
+      input: 20,
+      output: 5,
+      cacheRead: 70,
+      cacheWrite: 10,
+      totalTokens: 105,
+      contextUsage: { state: "available", promptTokens: 100, totalTokens: 105 },
+    });
+  });
+
+  it("prices one-hour cache writes from the provider's authoritative TTL breakdown", async () => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          metadata: {
+            usage: {
+              inputTokens: 20,
+              outputTokens: 5,
+              totalTokens: 25,
+              cacheReadInputTokens: 70,
+              cacheWriteInputTokens: 10,
+              cacheDetails: [
+                { ttl: CacheTTL.ONE_HOUR, inputTokens: 6 },
+                { ttl: CacheTTL.FIVE_MINUTES, inputTokens: 4 },
+              ],
+            },
+          },
+        },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+
+    const result = await streamBedrockForTest(
+      bedrockModel({
+        cost: { input: 1_000_000, output: 2_000_000, cacheRead: 500_000, cacheWrite: 1_250_000 },
+      }),
+      { messages: [{ role: "user", content: "Hello", timestamp: 0 }] } as never,
+    ).result();
+
+    expect(result.usage.cacheWrite1h).toBe(6);
+    expect(result.usage.cost).toMatchObject({
+      input: 20,
+      output: 10,
+      cacheRead: 35,
+      cacheWrite: 17,
+      total: 82,
+    });
+  });
+});

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -26,27 +26,6 @@ function bedrockModel(overrides: Record<string, unknown>) {
   } as never;
 }
 
-function signedThinkingContext(modelId: string) {
-  const highSurrogate = String.fromCharCode(0xd83d);
-  return {
-    messages: [
-      {
-        role: "assistant",
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        model: modelId,
-        content: [
-          {
-            type: "thinking",
-            thinking: `private${highSurrogate}reasoning`,
-            thinkingSignature: "sig-1",
-          },
-        ],
-      },
-    ],
-  } as never;
-}
-
 async function* streamEvents(events: unknown[]) {
   for (const event of events) {
     yield event;
@@ -225,106 +204,6 @@ describe("Bedrock tool-result replay", () => {
     });
     expect(JSON.stringify(messages)).not.toContain('"image"');
     expect(JSON.stringify(messages)).not.toContain("see attached image");
-  });
-});
-
-describe("Bedrock reasoning replay", () => {
-  it("preserves signed reasoning for Claude profile descriptors", () => {
-    const modelId =
-      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/profile-abc";
-    const messages = testing.convertMessages(
-      signedThinkingContext(modelId),
-      bedrockModel({
-        id: modelId,
-        name: "Claude Sonnet application profile",
-      }),
-      "none",
-    );
-
-    expect(messages[0]?.content).toEqual([
-      {
-        reasoningContent: {
-          reasoningText: {
-            text: `private${String.fromCharCode(0xd83d)}reasoning`,
-            signature: "sig-1",
-          },
-        },
-      },
-    ]);
-  });
-
-  it("replays signed reasoning as plain text for non-Claude models", () => {
-    const modelId = "amazon.nova-micro-v1:0";
-    const messages = testing.convertMessages(
-      signedThinkingContext(modelId),
-      bedrockModel({ id: modelId, name: "Nova Micro" }),
-      "none",
-    );
-
-    expect(messages[0]?.content).toEqual([{ text: "privatereasoning" }]);
-  });
-
-  it("preserves signature-only Fable reasoning blocks", () => {
-    const modelId = "anthropic.claude-fable-5";
-    const messages = testing.convertMessages(
-      {
-        messages: [
-          {
-            role: "assistant",
-            api: "bedrock-converse-stream",
-            provider: "amazon-bedrock",
-            model: modelId,
-            content: [
-              {
-                type: "thinking",
-                thinking: "",
-                thinkingSignature: " sig-fable ",
-              },
-            ],
-          },
-        ],
-      } as never,
-      bedrockModel({ id: modelId, name: "Claude Fable 5" }),
-      "none",
-    );
-
-    expect(messages[0]?.content).toEqual([
-      {
-        reasoningContent: {
-          reasoningText: {
-            text: "",
-            signature: " sig-fable ",
-          },
-        },
-      },
-    ]);
-  });
-
-  it("drops synthetic reasoning placeholders from Claude replay", () => {
-    const modelId = "anthropic.claude-fable-5";
-    const messages = testing.convertMessages(
-      {
-        messages: [
-          {
-            role: "assistant",
-            api: "bedrock-converse-stream",
-            provider: "amazon-bedrock",
-            model: modelId,
-            content: [
-              {
-                type: "thinking",
-                thinking: "hidden compatibility reasoning",
-                thinkingSignature: "reasoning_content",
-              },
-            ],
-          },
-        ],
-      } as never,
-      bedrockModel({ id: modelId, name: "Claude Fable 5" }),
-      "none",
-    );
-
-    expect(messages).toEqual([]);
   });
 });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -160,6 +160,7 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
     };
 
     const blocks = output.content as Block[];
+    const redactedReasoningChunks = new Map<number, Uint8Array[]>();
     const fable5 = usesClaudeFable5BedrockContract(model);
     // Claude classifiers may refuse after partial output. Hold every event until
     // messageStop proves the response is safe to expose.
@@ -299,9 +300,21 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
         } else if (item.contentBlockStart) {
           handleContentBlockStart(item.contentBlockStart, blocks, output, eventSink);
         } else if (item.contentBlockDelta) {
-          handleContentBlockDelta(item.contentBlockDelta, blocks, output, eventSink);
+          handleContentBlockDelta(
+            item.contentBlockDelta,
+            blocks,
+            output,
+            eventSink,
+            redactedReasoningChunks,
+          );
         } else if (item.contentBlockStop) {
-          handleContentBlockStop(item.contentBlockStop, blocks, output, eventSink);
+          handleContentBlockStop(
+            item.contentBlockStop,
+            blocks,
+            output,
+            eventSink,
+            redactedReasoningChunks,
+          );
         } else if (item.messageStop) {
           sawMessageStop = true;
           if ((item.messageStop.stopReason as string | undefined) === "refusal") {
@@ -512,6 +525,7 @@ function handleContentBlockDelta(
   blocks: Block[],
   output: AssistantMessage,
   stream: BedrockEventSink,
+  redactedReasoningChunks: Map<number, Uint8Array[]>,
 ): void {
   const contentBlockIndex = event.contentBlockIndex!;
   const delta = event.delta;
@@ -571,6 +585,16 @@ function handleContentBlockDelta(
         thinkingBlock.thinkingSignature =
           (thinkingBlock.thinkingSignature || "") + delta.reasoningContent.signature;
       }
+      if (delta.reasoningContent.redactedContent) {
+        const chunks = redactedReasoningChunks.get(contentBlockIndex);
+        if (chunks) {
+          chunks.push(delta.reasoningContent.redactedContent);
+        } else {
+          redactedReasoningChunks.set(contentBlockIndex, [delta.reasoningContent.redactedContent]);
+        }
+        thinkingBlock.thinking = "[Reasoning redacted]";
+        thinkingBlock.redacted = true;
+      }
     }
   }
 }
@@ -585,7 +609,24 @@ function handleMetadata(
     output.usage.output = event.usage.outputTokens || 0;
     output.usage.cacheRead = event.usage.cacheReadInputTokens || 0;
     output.usage.cacheWrite = event.usage.cacheWriteInputTokens || 0;
-    output.usage.totalTokens = event.usage.totalTokens || output.usage.input + output.usage.output;
+    const promptTokens = output.usage.input + output.usage.cacheRead + output.usage.cacheWrite;
+    output.usage.totalTokens = Math.max(
+      event.usage.totalTokens || 0,
+      promptTokens + output.usage.output,
+    );
+    output.usage.contextUsage = {
+      state: "available",
+      promptTokens,
+      totalTokens: promptTokens + output.usage.output,
+    };
+    const cacheWrite1h = event.usage.cacheDetails?.reduce(
+      (total, detail) =>
+        detail.ttl === CacheTTL.ONE_HOUR ? total + (detail.inputTokens ?? 0) : total,
+      0,
+    );
+    if (cacheWrite1h) {
+      output.usage.cacheWrite1h = cacheWrite1h;
+    }
     calculateCost(model, output.usage);
   }
 }
@@ -595,6 +636,7 @@ function handleContentBlockStop(
   blocks: Block[],
   output: AssistantMessage,
   stream: BedrockEventSink,
+  redactedReasoningChunks: Map<number, Uint8Array[]>,
 ): void {
   const index = blocks.findIndex((b) => b.index === event.contentBlockIndex);
   const block = blocks[index];
@@ -608,6 +650,20 @@ function handleContentBlockStop(
       stream.push({ type: "text_end", contentIndex: index, content: block.text, partial: output });
       break;
     case "thinking":
+      if (block.redacted) {
+        const chunks = redactedReasoningChunks.get(event.contentBlockIndex!);
+        if (chunks) {
+          // Encode once at the block boundary; encoding every streamed prefix is quadratic.
+          let opaqueReasoning = "";
+          for (const chunk of chunks) {
+            for (const byte of chunk) {
+              opaqueReasoning += String.fromCharCode(byte);
+            }
+          }
+          block.thinkingSignature = btoa(opaqueReasoning);
+          redactedReasoningChunks.delete(event.contentBlockIndex!);
+        }
+      }
       stream.push({
         type: "thinking_end",
         contentIndex: index,
@@ -835,6 +891,7 @@ function convertMessages(
   cacheRetention: CacheRetention,
 ): Message[] {
   const result: Message[] = [];
+  let firstVolatileMessageIndex: number | undefined;
   const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 
   for (let i = 0; i < transformedMessages.length; i++) {
@@ -861,6 +918,9 @@ function convertMessages(
         }
         if (content.length === 0) {
           continue;
+        }
+        if (m.runtimeContextCarrier === true && firstVolatileMessageIndex === undefined) {
+          firstVolatileMessageIndex = result.length;
         }
         result.push({
           role: ConversationRole.USER,
@@ -890,6 +950,27 @@ function convertMessages(
               });
               break;
             case "thinking": {
+              if (c.redacted) {
+                // transformMessages already strips opaque reasoning after a model
+                // switch; this also rejects routes that cannot consume the format.
+                if (!supportsThinkingSignature(model)) {
+                  continue;
+                }
+                if (!c.thinkingSignature) {
+                  throw new Error(
+                    "Bedrock redacted reasoning block is missing its opaque signature",
+                  );
+                }
+                contentBlocks.push({
+                  reasoningContent: {
+                    redactedContent: decodeBedrockBase64(
+                      c.thinkingSignature,
+                      "Bedrock redacted reasoning block has a malformed opaque signature",
+                    ),
+                  },
+                });
+                break;
+              }
               const thinkingSignature = c.thinkingSignature;
               const normalizedThinkingSignature = thinkingSignature?.trim();
               const supportsSignature = supportsThinkingSignature(model);
@@ -974,11 +1055,20 @@ function convertMessages(
     }
   }
 
-  // Add cache point to the last user message for supported Claude models when caching is enabled
-  if (cacheRetention !== "none" && supportsPromptCaching(model) && result.length > 0) {
-    const lastMessage = expectDefined(result.at(-1), "non-empty converted message list");
-    if (lastMessage.role === ConversationRole.USER && lastMessage.content) {
-      lastMessage.content.push({
+  // Cache points include their entire prefix, so anchors after transient runtime
+  // context would still cache volatile bytes even when those anchors are stable.
+  if (
+    cacheRetention !== "none" &&
+    supportsPromptCaching(model) &&
+    result.at(-1)?.role === ConversationRole.USER
+  ) {
+    const cacheAnchor = result.findLast(
+      (message, index) =>
+        message.role === ConversationRole.USER &&
+        (firstVolatileMessageIndex === undefined || index < firstVolatileMessageIndex),
+    );
+    if (cacheAnchor?.content) {
+      cacheAnchor.content.push({
         cachePoint: {
           type: CachePointType.DEFAULT,
           ...(cacheRetention === "long" ? { ttl: CacheTTL.ONE_HOUR } : {}),
@@ -1204,18 +1294,26 @@ function createImageBlock(mimeType: string, data: string) {
       throw new Error(`Unknown image type: ${mimeType}`);
   }
 
+  return {
+    source: {
+      bytes: decodeBedrockBase64(data, "Amazon Bedrock image content has malformed base64"),
+    },
+    format,
+  };
+}
+
+function decodeBedrockBase64(data: string, errorMessage: string): Uint8Array {
   // Validate before portable decoding so browser runtimes keep working without leaking atob errors.
   const canonicalBase64 = canonicalizeBase64(data);
   if (!canonicalBase64) {
-    throw new Error("Amazon Bedrock image content has malformed base64");
+    throw new Error(errorMessage);
   }
   const binaryString = atob(canonicalBase64);
   const bytes = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i++) {
     bytes[i] = binaryString.charCodeAt(i);
   }
-
-  return { source: { bytes }, format };
+  return bytes;
 }
 
 /** Test-only hooks for Bedrock runtime conversion and endpoint policy. */

--- a/extensions/openrouter/usage.test.ts
+++ b/extensions/openrouter/usage.test.ts
@@ -149,6 +149,65 @@ describe("OpenRouter usage", () => {
     ]);
   });
 
+  it.each([
+    { period: "daily", usageKey: "usage_daily", byokKey: "byok_usage_daily" },
+    { period: "weekly", usageKey: "usage_weekly", byokKey: "byok_usage_weekly" },
+    { period: "monthly", usageKey: "usage_monthly", byokKey: "byok_usage_monthly" },
+    { period: undefined, usageKey: "usage", byokKey: "byok_usage" },
+  ])(
+    "includes $period BYOK spend in key budgets when remaining credits are unavailable",
+    async ({ period, usageKey, byokKey }) => {
+      const snapshot = await fetchOpenRouterUsage({
+        token: "router-key",
+        timeoutMs: 5000,
+        fetchFn: vi.fn(async (input: string | URL | Request) =>
+          requestUrl(input).endsWith("/credits")
+            ? new Response(null, { status: 403 })
+            : Response.json({
+                data: {
+                  limit: 20,
+                  ...(period ? { limit_reset: period } : {}),
+                  [usageKey]: 5,
+                  [byokKey]: 4,
+                  include_byok_in_limit: true,
+                },
+              }),
+        ) as unknown as typeof fetch,
+      });
+
+      expect(snapshot.windows[0]?.usedPercent).toBe(45);
+      expect(snapshot.billing?.[0]).toMatchObject({
+        type: "budget",
+        used: 9,
+        limit: 20,
+        ...(period ? { period } : {}),
+      });
+    },
+  );
+
+  it("excludes BYOK spend from key budgets when the key does not count it", async () => {
+    const snapshot = await fetchOpenRouterUsage({
+      token: "router-key",
+      timeoutMs: 5000,
+      fetchFn: vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/credits")
+          ? new Response(null, { status: 403 })
+          : Response.json({
+              data: {
+                limit: 20,
+                limit_reset: "monthly",
+                usage_monthly: 5,
+                byok_usage_monthly: 4,
+                include_byok_in_limit: false,
+              },
+            }),
+      ) as unknown as typeof fetch,
+    });
+
+    expect(snapshot.windows[0]?.usedPercent).toBe(25);
+    expect(snapshot.billing?.[0]).toMatchObject({ type: "budget", used: 5, limit: 20 });
+  });
+
   it("keeps key usage when account credits are unavailable", async () => {
     const snapshot = await fetchOpenRouterUsage({
       token: "router-key",

--- a/extensions/openrouter/usage.ts
+++ b/extensions/openrouter/usage.ts
@@ -19,6 +19,7 @@ type OpenRouterKeyData = {
   usage_daily?: unknown;
   usage_weekly?: unknown;
   usage_monthly?: unknown;
+  byok_usage?: unknown;
   byok_usage_daily?: unknown;
   byok_usage_weekly?: unknown;
   byok_usage_monthly?: unknown;
@@ -68,9 +69,23 @@ function resolveKeyBudget(
         : period === "monthly"
           ? nonNegativeNumber(data?.usage_monthly)
           : nonNegativeNumber(data?.usage);
+  const byokUsage =
+    data?.include_byok_in_limit !== true
+      ? undefined
+      : period === "daily"
+        ? nonNegativeNumber(data.byok_usage_daily)
+        : period === "weekly"
+          ? nonNegativeNumber(data.byok_usage_weekly)
+          : period === "monthly"
+            ? nonNegativeNumber(data.byok_usage_monthly)
+            : nonNegativeNumber(data.byok_usage);
   const remaining = nonNegativeNumber(data?.limit_remaining);
   // `limit_remaining` already incorporates BYOK usage when the key is configured to count it.
-  const used = remaining === undefined ? periodUsage : Math.max(0, limit - remaining);
+  const usage =
+    periodUsage === undefined && byokUsage === undefined
+      ? undefined
+      : (periodUsage ?? 0) + (byokUsage ?? 0);
+  const used = remaining === undefined ? usage : Math.max(0, limit - remaining);
   return used === undefined ? undefined : { used, limit, ...(period ? { period } : {}) };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where OpenRouter operators received understated BYOK-inclusive budget utilization and Amazon Bedrock users saw incorrect cached-token/context totals, underpriced one-hour cache writes, broken encrypted-reasoning continuation, or repeated cache charges when volatile runtime metadata entered a cached prompt prefix.

These are five independent provider-owner defects. They affect real budget visibility, context/compaction decisions, cache billing, multi-turn Claude continuity, and prompt-cache reuse without requiring any public configuration or API changes.

## Why This Change Was Made

Use each provider's existing authoritative contract at its owner boundary: OpenRouter key metadata decides whether period-matched BYOK usage counts toward the configured limit; AWS Bedrock usage and TTL details determine normalized prompt totals and cache pricing; the Bedrock Converse `redactedContent` union preserves encrypted same-model reasoning; and cache points may only anchor before the first transient runtime-context carrier because each point caches its entire preceding prefix.

The encrypted stream owner accumulates opaque byte chunks per active block and Base64-encodes once at block completion. Canonical `transformMessages` continues to strip model-bound encrypted reasoning on provider/model switches before Bedrock-specific replay. Existing public plugin SDK, configuration, authentication, provider routing, Gateway protocol, and storage contracts are unchanged.

## User Impact

- OpenRouter daily, weekly, monthly, and lifetime API-key budget utilization includes BYOK charges precisely when the key opts into BYOK-inclusive limits; keys without that option retain their existing behavior.
- Bedrock prompt/context and total-token accounting includes uncached input, cache reads, cache writes, and output rather than silently undercounting cached prompts.
- One-hour Bedrock cache writes receive the provider's authoritative TTL-specific price instead of the cheaper short-cache rate.
- Encrypted Claude reasoning survives same-model multi-turn continuation, remains removed after unsupported-model or Claude-to-Claude model switches, and no longer incurs quadratic repeated Base64 work while streaming.
- Volatile current-turn runtime metadata never enters a Bedrock cached prefix, even when a later stable user/tool-result turn follows it; stable preceding history remains cacheable.

## Evidence

- Frozen canonical baseline and direct commit parent: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact isolated branch: `codex/qa200-bedrock-openrouter-provider`.
- Exact independently reviewed candidate: `ef3747bc1e809df2ce7f83a7a12d42528ae0ff9f`.
- Full focused provider proof: **2 test files, 78/78 tests passed** on the final immutable commit.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs \
  --config test/vitest/vitest.extension-providers.config.ts \
  extensions/openrouter/usage.test.ts \
  extensions/amazon-bedrock/stream.runtime.test.ts
```

- OpenRouter regressions cover daily, weekly, monthly, and lifetime usage plus `include_byok_in_limit: false`; authoritative `limit_remaining` remains preferred.
- Bedrock regressions assert a `20` uncached-input / `70` cache-read / `10` cache-write / `5` output response normalizes to **100 prompt tokens and 105 total tokens**.
- TTL pricing regression verifies six one-hour cache-write tokens and the expected normalized **82** total cost.
- Split opaque bytes `de ad be ef` survive streamed ingestion and same-model Converse replay unchanged, with a spy proving exactly **one** Base64 encoding; unsupported-model and different-Claude-model replay remains safely stripped.
- Prompt-cache regressions cover trailing transient carriers, later tool-result turns, carrier-first prefixes, and authoritative one-hour cache-point TTL placement.
- Installed AWS SDK source contracts were inspected directly at `node_modules/@aws-sdk/client-bedrock-runtime/dist-types/models/models_0.d.ts:2439`, `node_modules/@aws-sdk/client-bedrock-runtime/dist-types/models/models_0.d.ts:2455`, `node_modules/@aws-sdk/client-bedrock-runtime/dist-types/models/models_0.d.ts:3643`, and `node_modules/@aws-sdk/client-bedrock-runtime/dist-types/models/models_0.d.ts:3889`.
- Official dependency contracts: [Amazon Bedrock prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) and [OpenRouter current-key metadata](https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key).
- Targeted four-file `oxfmt --check`, `git diff HEAD^ HEAD --check`, clean isolated-worktree inspection, immutable-parent verification, and unchanged clean canonical `main` all passed.
- Final exact-commit structured Codex `gpt-5.6-sol` / high autoreview: **clean, zero actionable findings, 0.94 confidence**; official TruffleHog exact-content preflight: **clean**.
- Separate strict independent whole-owner review on the same immutable SHA: **clean**.
- No live hosted-model/provider request was made; AWS SDK streaming and HTTP budgets were exercised through focused provider-owner regressions.

## Distinct Root Causes

1. OpenRouter fallback budget math omitted BYOK usage even when the key explicitly included BYOK in its active limit.
2. Bedrock trusted `totalTokens` despite AWS reporting cache-read/cache-write prompt buckets separately from uncached `inputTokens`.
3. Bedrock ignored the authoritative one-hour `usage.cacheDetails` TTL breakdown during cache-write pricing.
4. Bedrock discarded streamed encrypted reasoning bytes and failed to replay the provider's opaque `redactedContent` union.
5. Bedrock cache-point placement allowed volatile runtime-context carriers into an otherwise stable cached prefix.

## Explicit Exclusions

Previously merged truncated Bedrock stream and audio-result issues are not part of this change. No dependency, public SDK/API, Gateway protocol, configuration, authentication, provider routing, persistence, SQLite schema, or live-provider integration behavior is changed.
