### PR TITLE
fix(sessions): preserve transcript turn and child-session ownership

### DIFF
--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -190,6 +190,52 @@ describe("readSubagentOutput", () => {
     );
   });
 
+  it("does not replay an older assistant reply after a newer user turn", async () => {
+    installOutputDeps({
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "Completed the old task." }] },
+        { role: "user", content: [{ type: "text", text: "Start the next task." }] },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+  });
+
+  it("does not treat a projected inter-session input as an assistant completion", async () => {
+    installOutputDeps({
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "Completed the old task." }] },
+        {
+          role: "assistant",
+          provenance: { kind: "inter_session", sourceSessionKey: "agent:main:main" },
+          content: [{ type: "text", text: "Start the next task." }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+  });
+
+  it("reports only tool calls belonging to the latest user turn", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "old-call", name: "read", arguments: {} }],
+        },
+        { role: "user", content: [{ type: "text", text: "Start the next task." }] },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "current-call", name: "exec", arguments: {} }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
+      "1 tool call(s) made without visible output.",
+    );
+  });
+
   it("does not fall back to tool output when the last assistant turn is empty", async () => {
     installOutputDeps({
       messages: [
@@ -397,6 +443,29 @@ describe("buildChildCompletionFindings", () => {
 
     expect(findings).toContain("1. visible task");
     expect(findings).not.toContain("2. visible task");
+  });
+
+  it("orders same-timestamp child completions by stable session identity", () => {
+    const laterKey = {
+      childSessionKey: "agent:main:subagent:z",
+      task: "Z task",
+      createdAt: 1_000,
+      endedAt: 2_000,
+      completion: { resultText: "Z result" },
+      outcome: { status: "ok" as const },
+    };
+    const earlierKey = {
+      ...laterKey,
+      childSessionKey: "agent:main:subagent:a",
+      task: "A task",
+      completion: { resultText: "A result" },
+    };
+
+    const forward = buildChildCompletionFindings([laterKey, earlierKey]);
+    const reverse = buildChildCompletionFindings([earlierKey, laterKey]);
+
+    expect(forward).toBe(reverse);
+    expect(forward).toMatch(/1\. A task[\s\S]*2\. Z task/);
   });
 });
 

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -146,6 +146,23 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       continue;
     }
     const role = (message as { role?: unknown }).role;
+    const provenance = (message as { provenance?: unknown }).provenance;
+    if (
+      role === "user" ||
+      (provenance &&
+        typeof provenance === "object" &&
+        !Array.isArray(provenance) &&
+        (provenance as { kind?: unknown }).kind === "inter_session")
+    ) {
+      // A fresh input owns a new turn; never announce an older turn's reply
+      // when the current run fails or completes without visible output.
+      snapshot.latestAssistantText = undefined;
+      snapshot.latestSilentText = undefined;
+      snapshot.latestToolCallCount = undefined;
+      snapshot.waitingForContinuation = false;
+      previousAssistantCalledYield = false;
+      continue;
+    }
     if (role === "assistant") {
       if (assistantCallsSessionsYield(message)) {
         snapshot.latestAssistantText = undefined;
@@ -400,7 +417,16 @@ export function buildChildCompletionFindings(
     }
     const aEnded = typeof a.endedAt === "number" ? a.endedAt : Number.MAX_SAFE_INTEGER;
     const bEnded = typeof b.endedAt === "number" ? b.endedAt : Number.MAX_SAFE_INTEGER;
-    return aEnded - bEnded;
+    if (aEnded !== bEnded) {
+      return aEnded - bEnded;
+    }
+    // Parallel children commonly share millisecond timestamps; their stable
+    // session identity keeps parent-visible findings and prompt bytes ordered.
+    return a.childSessionKey < b.childSessionKey
+      ? -1
+      : a.childSessionKey > b.childSessionKey
+        ? 1
+        : 0;
   });
 
   const sections: string[] = [];

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -418,6 +418,19 @@ function addChildSessionKey(
   childSessionsByKey.set(parentKey, [childKey]);
 }
 
+export function isCurrentSessionChildOwner(params: {
+  entry: Pick<SessionEntry, "parentSessionKey">;
+  ownerSessionKey: string;
+  controllerSessionKey: string | undefined;
+}): boolean {
+  // Live control supersedes stale spawnedBy, but explicit navigation lineage
+  // remains authoritative so dashboard parents can discover controlled children.
+  return (
+    params.controllerSessionKey === params.ownerSessionKey ||
+    normalizeOptionalString(params.entry.parentSessionKey) === params.ownerSessionKey
+  );
+}
+
 export function buildStoreChildSessionIndex(
   store: Record<string, SessionEntry>,
   now = Date.now(),
@@ -457,7 +470,14 @@ export function buildStoreChildSessionIndex(
       continue;
     }
     for (const parentKey of parentKeys) {
-      if (latestControllerSessionKey && latestControllerSessionKey !== parentKey) {
+      if (
+        latestControllerSessionKey &&
+        !isCurrentSessionChildOwner({
+          entry,
+          ownerSessionKey: parentKey,
+          controllerSessionKey: latestControllerSessionKey,
+        })
+      ) {
         continue;
       }
       addChildSessionKey(childSessionsByKey, parentKey, key);
@@ -483,7 +503,13 @@ export function resolveStoreChildSessionKeysFromCandidates(params: {
       const latestControllerSessionKey =
         normalizeOptionalString(latest.controllerSessionKey) ||
         normalizeOptionalString(latest.requesterSessionKey);
-      if (latestControllerSessionKey !== params.key) {
+      if (
+        !isCurrentSessionChildOwner({
+          entry,
+          ownerSessionKey: params.key,
+          controllerSessionKey: latestControllerSessionKey,
+        })
+      ) {
         continue;
       }
       if (

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -32,6 +32,7 @@ import type {
 import {
   deriveSessionTitle,
   isFinitePositiveTimestamp,
+  isCurrentSessionChildOwner,
   shouldKeepStoreOnlyChildLink,
 } from "./session-utils-core.js";
 import { getSessionDefaults } from "./session-utils-model.js";
@@ -241,8 +242,13 @@ function filterSessionEntries(params: {
         ? filterRowContext.subagentRuns.getDisplaySubagentRun(key)
         : getSessionDisplaySubagentRunByChildSessionKey(key);
       const keepSpawned = latest
-        ? (normalizeOptionalString(latest.controllerSessionKey) ||
-            normalizeOptionalString(latest.requesterSessionKey)) === spawnedBy &&
+        ? isCurrentSessionChildOwner({
+            entry,
+            ownerSessionKey: spawnedBy,
+            controllerSessionKey:
+              normalizeOptionalString(latest.controllerSessionKey) ||
+              normalizeOptionalString(latest.requesterSessionKey),
+          }) &&
           shouldKeepSubagentRunChildLink(latest, {
             activeDescendants: filterRowContext
               ? filterRowContext.subagentRuns.countActiveDescendantRuns(key)

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -135,6 +135,21 @@ function runningChildSession(
   };
 }
 
+function runningControlledChildSession(
+  sessionId: string,
+  spawnedBy: string,
+  now: number,
+  parentSessionKey?: string,
+): SessionEntry {
+  return {
+    sessionId,
+    spawnedBy,
+    ...(parentSessionKey ? { parentSessionKey } : {}),
+    updatedAt: now,
+    status: "running",
+  };
+}
+
 async function seedSessionEntries(
   storePath: string,
   store: Record<string, SessionEntry>,
@@ -234,6 +249,13 @@ describe("single gateway session row child-session cache", () => {
       "/tmp/openclaw-single-row-cache-fresh-registry",
       async ({ now, storePath }) => {
         const fixture = createMovingChildFixture(now);
+        // This fixture moves runtime control only; an explicit parent would
+        // instead declare durable navigation lineage that must remain linked.
+        fixture.store[fixture.child] = runningControlledChildSession(
+          "child",
+          fixture.oldParent,
+          now,
+        );
         await seedSessionEntries(storePath, fixture.store);
 
         setSubagentControllerRun(fixture.child, fixture.oldParent, now);
@@ -242,6 +264,36 @@ describe("single gateway session row child-session cache", () => {
         ]);
 
         setSubagentControllerRun(fixture.child, fixture.newParent, now + 25);
+        expectChildMovedToNewParent(fixture, now);
+      },
+    );
+  });
+
+  test("keeps independent navigation lineage while cached runtime control moves", async () => {
+    await withSingleRowCacheStore(
+      "openclaw-single-row-cache-navigation-owner-",
+      "/tmp/openclaw-single-row-cache-navigation-owner",
+      async ({ now, storePath }) => {
+        const fixture = createMovingChildFixture(now);
+        const navigationParent = "agent:main:dashboard:navigation-parent";
+        fixture.store[navigationParent] = parentSession("navigation-parent", now);
+        fixture.store[fixture.child] = runningControlledChildSession(
+          "child",
+          fixture.oldParent,
+          now,
+          navigationParent,
+        );
+        await seedSessionEntries(storePath, fixture.store);
+
+        setSubagentControllerRun(fixture.child, fixture.oldParent, now);
+        expect(loadGatewaySessionRow(navigationParent, { now })?.childSessions).toEqual([
+          fixture.child,
+        ]);
+
+        setSubagentControllerRun(fixture.child, fixture.newParent, now + 25);
+        expect(loadGatewaySessionRow(navigationParent, { now: now + 50 })?.childSessions).toEqual([
+          fixture.child,
+        ]);
         expectChildMovedToNewParent(fixture, now);
       },
     );

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -24,6 +24,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withEnv } from "../test-utils/env.js";
+import { buildSingleRowStoreChildSessionsByKey } from "./session-utils-projection.js";
 import {
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
@@ -172,6 +173,81 @@ describe("listSessionsFromStore subagent metadata", () => {
       entryId: "entry-source",
     });
     expect(row.previousSessionId).toBe("sess-previous");
+  });
+
+  test("discovers controlled children through both navigation and runtime owners", () => {
+    const now = Date.now();
+    const navigationParentKey = "agent:main:dashboard:navigation-parent";
+    const controlParentKey = "agent:main:subagent:runtime-controller";
+    const staleParentKey = "agent:main:subagent:stale-controller";
+    const childSessionKey = "agent:main:subagent:controlled-child";
+    const store: Record<string, SessionEntry> = {
+      [navigationParentKey]: {
+        sessionId: "sess-navigation-parent",
+        updatedAt: now - 2_000,
+      } as SessionEntry,
+      [controlParentKey]: {
+        sessionId: "sess-runtime-controller",
+        updatedAt: now - 1_000,
+      } as SessionEntry,
+      [childSessionKey]: {
+        sessionId: "sess-controlled-child",
+        updatedAt: now,
+        spawnedBy: staleParentKey,
+        parentSessionKey: navigationParentKey,
+      } as SessionEntry,
+    };
+
+    addSubagentRunForTests({
+      runId: "run-controlled-child-dual-owner",
+      childSessionKey,
+      controllerSessionKey: controlParentKey,
+      requesterSessionKey: controlParentKey,
+      requesterDisplayKey: "runtime-controller",
+      task: "controlled child",
+      cleanup: "keep",
+      createdAt: now - 5_000,
+      startedAt: now - 4_000,
+    });
+
+    const listForOwner = (ownerSessionKey: string) =>
+      listSessionsFromStore({
+        cfg,
+        storePath: "/tmp/sessions.json",
+        store,
+        opts: { spawnedBy: ownerSessionKey },
+      });
+
+    const navigationChildren = listForOwner(navigationParentKey).sessions;
+    expect(navigationChildren.map((session) => session.key)).toEqual([childSessionKey]);
+    expect(navigationChildren[0]?.parentSessionKey).toBe(navigationParentKey);
+    expect(navigationChildren[0]?.controlOwnerSessionKey).toBe(controlParentKey);
+    expect(listForOwner(controlParentKey).sessions.map((session) => session.key)).toEqual([
+      childSessionKey,
+    ]);
+    expect(listForOwner(staleParentKey).sessions).toEqual([]);
+
+    const all = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+    expect(
+      all.sessions.find((session) => session.key === navigationParentKey)?.childSessions,
+    ).toEqual([childSessionKey]);
+    expect(all.sessions.find((session) => session.key === controlParentKey)?.childSessions).toEqual(
+      [childSessionKey],
+    );
+
+    expect(
+      buildSingleRowStoreChildSessionsByKey({
+        store,
+        storePath: "/tmp/sessions.json",
+        key: navigationParentKey,
+        now,
+      }).get(navigationParentKey),
+    ).toEqual([childSessionKey]);
   });
 
   test("includes subagent status timing and direct child session keys", () => {

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -1,7 +1,10 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
-import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  resolveUiSessionNavigationParentKey,
+} from "../lib/sessions/session-key.ts";
 export { fetchChildSessionRows } from "../lib/sessions/child-session-data.ts";
 
 const MAX_SESSION_LINEAGE_DEPTH = 16;
@@ -57,7 +60,7 @@ export async function fetchSessionLineage(params: {
         params.knownRows.set(row.key, row);
       }
       topmostRow = row;
-      const parentKey = (row.spawnedBy ?? row.parentSessionKey)?.trim();
+      const parentKey = resolveUiSessionNavigationParentKey(row);
       if (!parentKey) {
         break;
       }

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { GatewaySessionRow } from "../api/types.ts";
+import { fetchSessionLineage } from "./app-sidebar-child-session-data.ts";
 import { buildSidebarSessionNavigationState } from "./app-sidebar-session-navigation-logic.ts";
+import { projectSessionTree } from "./app-sidebar-session-tree.ts";
+import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 
 function projectDraftOwnership(
   row: Pick<GatewaySessionRow, "createdActor" | "sharingRole" | "visibility">,
@@ -77,6 +80,105 @@ describe("sidebar draft ownership presentation", () => {
         "owner",
       ),
     ).toBe(false);
+  });
+});
+
+describe("sidebar navigation lineage ownership", () => {
+  const navigationParent: GatewaySessionRow = {
+    key: "agent:main:dashboard:navigation-parent",
+    kind: "direct",
+    updatedAt: 1,
+    childSessions: ["agent:main:subagent:child"],
+  };
+  const controlParent: GatewaySessionRow = {
+    key: "agent:main:main",
+    kind: "direct",
+    updatedAt: 2,
+    childSessions: ["agent:main:subagent:child"],
+  };
+  const child: GatewaySessionRow = {
+    key: "agent:main:subagent:child",
+    kind: "direct",
+    updatedAt: 3,
+    parentSessionKey: navigationParent.key,
+    spawnedBy: controlParent.key,
+  };
+
+  it("projects a known child exactly once under its explicit navigation parent", () => {
+    const projected = projectSessionTree({
+      roots: [navigationParent, controlParent],
+      agentRows: [navigationParent, controlParent, child],
+      childRowsByParent: {},
+      loadingChildKeys: new Set(),
+      knownSessionAttention: [],
+      toSidebarSession: (row, isChild) =>
+        ({
+          key: row.key,
+          isChild,
+          attention: { kind: "none" },
+          runningChildCount: 0,
+          failedChildCount: 0,
+        }) as SidebarRecentSession,
+    });
+
+    expect(
+      projected.map((row) => ({ key: row.key, children: row.children.map((entry) => entry.key) })),
+    ).toEqual([
+      { key: navigationParent.key, children: [child.key] },
+      { key: controlParent.key, children: [] },
+    ]);
+  });
+
+  it("walks a directly opened child through its navigation parent, not its controller", async () => {
+    const knownRows = new Map(
+      [navigationParent, controlParent, child].map((row) => [row.key, row]),
+    );
+    const lineage = await fetchSessionLineage({
+      client: {} as Parameters<typeof fetchSessionLineage>[0]["client"],
+      sessionKey: child.key,
+      knownRows,
+      isCurrent: () => true,
+    });
+
+    expect(lineage).toMatchObject({
+      rowsByParent: { [navigationParent.key]: [child] },
+      topmostRow: navigationParent,
+      lookupFailed: false,
+    });
+  });
+
+  it("falls back to the control owner when persisted navigation lineage is blank", async () => {
+    const childWithBlankParent = { ...child, parentSessionKey: "  \t  " };
+    const projected = projectSessionTree({
+      roots: [controlParent],
+      agentRows: [controlParent, childWithBlankParent],
+      childRowsByParent: {},
+      loadingChildKeys: new Set(),
+      knownSessionAttention: [],
+      toSidebarSession: (row, isChild) =>
+        ({
+          key: row.key,
+          isChild,
+          attention: { kind: "none" },
+          runningChildCount: 0,
+          failedChildCount: 0,
+        }) as SidebarRecentSession,
+    });
+
+    expect(projected[0]?.children.map((row) => row.key)).toEqual([child.key]);
+
+    const lineage = await fetchSessionLineage({
+      client: {} as Parameters<typeof fetchSessionLineage>[0]["client"],
+      sessionKey: child.key,
+      knownRows: new Map([controlParent, childWithBlankParent].map((row) => [row.key, row])),
+      isCurrent: () => true,
+    });
+
+    expect(lineage).toMatchObject({
+      rowsByParent: { [controlParent.key]: [childWithBlankParent] },
+      topmostRow: controlParent,
+      lookupFailed: false,
+    });
   });
 });
 

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -23,6 +23,7 @@ import {
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
+  resolveUiSessionNavigationParentKey,
 } from "../lib/sessions/session-key.ts";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
 import { AppSidebarBase } from "./app-sidebar-base.ts";
@@ -671,7 +672,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       ...rows,
       ...Object.values(this.sessionData.childSessionRowsByParent).flat(),
     ].filter((row) => {
-      const parentKey = row.spawnedBy ?? row.parentSessionKey;
+      const parentKey = resolveUiSessionNavigationParentKey(row);
       return (
         parentKey != null &&
         mainSessionKeys.has(parentKey) &&

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -1,5 +1,8 @@
 import type { GatewaySessionRow } from "../api/types.ts";
-import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  resolveUiSessionNavigationParentKey,
+} from "../lib/sessions/session-key.ts";
 import {
   SIDEBAR_SESSION_NO_ATTENTION,
   rowDemandsVisibility,
@@ -50,11 +53,17 @@ export function projectSessionTree(params: {
   };
   for (const row of rowsByKey.values()) {
     for (const childKey of row.childSessions ?? []) {
-      appendChild(row.key, childKey);
+      const child = rowsByKey.get(childKey);
+      const navigationParentKey = resolveUiSessionNavigationParentKey(child);
+      // Runtime control and sidebar navigation can have different parents;
+      // known children belong to their explicit navigation parent only.
+      if (!navigationParentKey || areUiSessionKeysEquivalent(navigationParentKey, row.key)) {
+        appendChild(row.key, childKey);
+      }
     }
   }
   for (const row of rowsByKey.values()) {
-    const parentKey = row.spawnedBy ?? row.parentSessionKey;
+    const parentKey = resolveUiSessionNavigationParentKey(row);
     if (parentKey) {
       appendChild(parentKey, row.key);
     }
@@ -141,7 +150,7 @@ export function projectSessionTree(params: {
   const rootKeys = new Set(roots.map((row) => row.key));
   return roots
     .filter((row) => {
-      const parentKey = row.spawnedBy ?? row.parentSessionKey;
+      const parentKey = resolveUiSessionNavigationParentKey(row);
       return !parentKey || !rootKeys.has(parentKey);
     })
     .map((row) => build(row, false, new Set()));

--- a/ui/src/lib/sessions/session-key.test.ts
+++ b/ui/src/lib/sessions/session-key.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { canonicalUiSessionKeyForPersistence, uiSessionEventMatches } from "./session-key.ts";
+import {
+  canonicalUiSessionKeyForPersistence,
+  resolveUiSessionNavigationParentKey,
+  uiSessionEventMatches,
+} from "./session-key.ts";
 
 describe("UI session identity", () => {
   it.each([
@@ -53,5 +57,26 @@ describe("UI session identity", () => {
     expect(uiSessionEventMatches(host, "agent:ops:main")).toBe(true);
     expect(canonicalUiSessionKeyForPersistence(host, "main")).toBe("agent:ops:home");
     expect(canonicalUiSessionKeyForPersistence(host, "agent:ops:main")).toBe("agent:ops:home");
+  });
+
+  it.each([
+    {
+      parentSessionKey: "  agent:main:dashboard:navigation-parent  ",
+      spawnedBy: "agent:main:controller",
+      expected: "agent:main:dashboard:navigation-parent",
+    },
+    {
+      parentSessionKey: "",
+      spawnedBy: "  agent:main:controller  ",
+      expected: "agent:main:controller",
+    },
+    {
+      parentSessionKey: "  \t  ",
+      spawnedBy: "agent:main:controller",
+      expected: "agent:main:controller",
+    },
+    { parentSessionKey: null, spawnedBy: "  ", expected: undefined },
+  ])("resolves the first non-empty navigation parent", ({ expected, ...row }) => {
+    expect(resolveUiSessionNavigationParentKey(row)).toBe(expected);
   });
 });

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -49,6 +49,12 @@ export function parseAgentSessionKey(
   return { agentId, rest };
 }
 
+export function resolveUiSessionNavigationParentKey(
+  row: { parentSessionKey?: string | null; spawnedBy?: string | null } | null | undefined,
+): string | undefined {
+  return normalizeOptionalString(row?.parentSessionKey) ?? normalizeOptionalString(row?.spawnedBy);
+}
+
 function normalizeMainKey(value: string | undefined | null): string {
   return normalizeOptionalLowercaseString(value) ?? DEFAULT_MAIN_KEY;
 }

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -526,4 +526,67 @@ describe("AppSidebar session ownership", () => {
       sidebar.querySelector(`[data-session-key="${childKey}"] [aria-label="Done"]`),
     ).not.toBeNull();
   });
+
+  it("renders a controlled child once under its explicit dashboard parent", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const navigationParentKey = "agent:main:dashboard:navigation-parent";
+    const controlParentKey = "agent:main:main";
+    const childKey = "agent:main:subagent:controlled-child";
+    const child = {
+      key: childKey,
+      kind: "direct" as const,
+      label: "Controlled child",
+      updatedAt: 3,
+      parentSessionKey: navigationParentKey,
+      spawnedBy: controlParentKey,
+    };
+    const harness = createSessionsHarness("main", [navigationParentKey]);
+    harness.list.mockImplementation(async (options) => {
+      const sessions = options?.spawnedBy === navigationParentKey ? [child] : [];
+      return {
+        ts: 3,
+        path: "",
+        count: sessions.length,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions,
+      };
+    });
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    harness.publishList({
+      result: {
+        ts: 3,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: navigationParentKey,
+            kind: "direct",
+            label: "Dashboard parent",
+            updatedAt: 2,
+            childSessions: [childKey],
+          },
+        ],
+      },
+    });
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(`[data-session-key="${childKey}"]`)).toBeNull();
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`[data-child-session-toggle="${navigationParentKey}"]`)
+      ?.click();
+    await waitForFast(() =>
+      expect(harness.list).toHaveBeenCalledWith(
+        expect.objectContaining({ spawnedBy: navigationParentKey }),
+      ),
+    );
+    await waitForFast(() =>
+      expect(sidebar.querySelectorAll(`[data-session-key="${childKey}"]`)).toHaveLength(1),
+    );
+    expect(
+      sidebar
+        .querySelector(`[data-session-key="${childKey}"]`)
+        ?.classList.contains("sidebar-recent-session--child"),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users coordinating repeated child-agent tasks could receive a previous task's answer when the new turn produced no reply, where simultaneously completed child tasks could change order between equivalent parent summaries, and where a controlled dashboard child was undiscoverable, misplaced, or duplicated because live Gateway filtering and sidebar lineage disagreed about its navigation owner.

## Why This Change Was Made

Child completion now recognizes canonical user and projected inter-session turn boundaries, and equal-timestamp results use stable child-session identity. Gateway live-owner filtering plus full-list and single-row child indexes now preserve both the explicit navigation parent and the actual runtime controller while still rejecting stale `spawnedBy` metadata. One canonical sidebar parent resolver consistently prefers a trimmed, non-empty explicit navigation parent and falls back to the controller for blank or whitespace legacy metadata. This follows the existing session-visibility contract, which already authorizes `parentSessionKey`; no session-history cursor, persistent state, SQLite schema, authentication, authorization boundary, or public protocol contracts change.

## User Impact

Parent agents no longer mistake an old answer for a newly failed or silent task, concurrent child findings remain stable, and unloaded controlled child sessions can be discovered and displayed exactly once beneath their actual dashboard conversation.

## Evidence

- Frozen baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact candidate: `33ad986ebe503ccd3f9dc906cf02ff486e534302`.
- `PATH="/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin:$PATH" /Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node scripts/run-vitest.mjs src/agents/subagent-announce-output.test.ts` — **27 passed**.
- From `ui/`, `/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node ../node_modules/vitest/vitest.mjs run --config vitest.config.ts --project unit src/components/app-sidebar-session-navigation-logic.test.ts src/lib/sessions/session-key.test.ts --maxWorkers=1` — **16 passed**, including whitespace/empty parent fallback and direct child ancestry.
- `/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.gateway-core.config.ts src/gateway/session-utils.subagent.test.ts --maxWorkers=1 --testNamePattern 'discovers controlled children|keeps persisted navigation lineage|does not reattach moved children|does not return moved child sessions|returns dashboard child sessions'` — **5 passed**; exercises the real Gateway filtered list, current controller, explicit navigation owner, stale-controller rejection, and both full/single-row child indexes.
- From `ui/`, `/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node ../node_modules/vitest/vitest.mjs run --config vitest.config.ts --project unit src/components/app-sidebar.test.ts --maxWorkers=1 --testNamePattern 'renders a controlled child once under its explicit dashboard parent|keeps owner avatars off child rows'` — **2 passed**, including a genuinely unloaded child, owner-aware Gateway filter, and a real mounted sidebar.
- Focused `oxfmt --check`, `oxlint` on all twelve changed files, and `git diff --check` passed.
- Existing ownership boundary proof: `src/plugin-sdk/session-visibility.ts:359` already treats explicit `parentSessionKey` as an authorized owner.
- Direct Codex contract inspection: `../codex/codex-rs/app-server-protocol/src/protocol/thread_history.rs:474`, `../codex/codex-rs/app-server-protocol/src/protocol/thread_history.rs:1208`, and `../codex/codex-rs/app-server-protocol/src/protocol/thread_history_projection.rs:53`.
- Exact-commit structured Codex `gpt-5.6-sol` autoreview: **clean, confidence 0.96, no accepted/actionable findings**; shared TruffleHog secret scan: **clean**.
