### PR TITLE
fix(telegram): preserve native polls and inbound formatting entities

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -12,7 +12,7 @@ import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import type { TelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
-import { getTelegramTextParts } from "./bot/helpers.js";
+import { getTelegramTextParts, joinTelegramTextParts } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
@@ -123,10 +123,11 @@ export function createTelegramInboundDebounceRuntime(
             settleSpooledReplayParticipants(participants, result);
             return;
           }
-          const combinedText = entries
-            .map((entry) => getTelegramTextParts(entry.msg).text)
-            .filter(Boolean)
-            .join("\n");
+          const combinedTextParts = joinTelegramTextParts(
+            entries.map((entry) => entry.msg),
+            "\n",
+          );
+          const combinedText = combinedTextParts.text;
           const combinedMedia = entries.flatMap((entry) => entry.allMedia);
           if (!combinedText.trim() && combinedMedia.length === 0) {
             releaseDispatchDedupeClaims(
@@ -141,6 +142,7 @@ export function createTelegramInboundDebounceRuntime(
             ...buildSyntheticTextMessage({
               base: first.msg,
               text: combinedText,
+              entities: combinedTextParts.entities,
               date: last.msg.date ?? first.msg.date,
             }),
             forward_origin: undefined,

--- a/extensions/telegram/src/bot-handlers.inbound-text.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-text.runtime.ts
@@ -6,6 +6,7 @@ import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runti
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import type { TelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
+import { joinTelegramTextParts } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
@@ -71,7 +72,11 @@ export function createTelegramInboundTextRuntime(
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
-      const combinedText = entry.messages.map((message) => message.msg.text ?? "").join("");
+      const combinedTextParts = joinTelegramTextParts(
+        entry.messages.map((message) => message.msg),
+        "",
+      );
+      const combinedText = combinedTextParts.text;
       if (!combinedText.trim()) {
         releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
@@ -80,6 +85,7 @@ export function createTelegramInboundTextRuntime(
       const syntheticMessage = buildSyntheticTextMessage({
         base: first.msg,
         text: combinedText,
+        entities: combinedTextParts.entities,
         date: last.msg.date ?? first.msg.date,
       });
       const result = await processMessageWithReplyChain({

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -148,6 +148,7 @@ export function createTelegramMessageLifecycleRuntime({
   const buildSyntheticTextMessage = (params: {
     base: Message;
     text: string;
+    entities?: Message["entities"];
     date?: number;
     from?: Message["from"];
   }): Message => ({
@@ -156,7 +157,7 @@ export function createTelegramMessageLifecycleRuntime({
     text: params.text,
     caption: undefined,
     caption_entities: undefined,
-    entities: undefined,
+    entities: params.entities?.length ? params.entities : undefined,
     ...(params.date != null ? { date: params.date } : {}),
   });
   const buildSyntheticContext = (

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
@@ -42,4 +42,18 @@ describe("Telegram ambient transcript media text", () => {
 
     expect(body).toBe("#9 Ada: <media:attachment>");
   });
+
+  it("preserves combined formatting entities when building synthetic text messages", () => {
+    const entities = [{ type: "bold" as const, offset: 3, length: 4 }];
+    const synthetic = runtime.buildSyntheticTextMessage({
+      base: message({ caption: "old caption", caption_entities: entities }),
+      text: "😀 bold",
+      entities,
+    });
+
+    expect(synthetic.text).toBe("😀 bold");
+    expect(synthetic.entities).toEqual(entities);
+    expect(synthetic.caption).toBeUndefined();
+    expect(synthetic.caption_entities).toBeUndefined();
+  });
 });

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -83,6 +83,38 @@ function transcribeCallContext(index = 0): Record<string, unknown> {
 }
 
 describe("resolveTelegramInboundBody", () => {
+  it("delivers native poll questions, options, voter totals, and state", async () => {
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 12,
+        date: 1_700_000_012,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        poll: {
+          id: "poll-12",
+          question: "Approve deploy?",
+          options: [
+            { persistent_id: "approve", text: "Approve", voter_count: 4 },
+            { persistent_id: "hold", text: "Hold", voter_count: 0 },
+          ],
+          total_voter_count: 4,
+          is_closed: true,
+          is_anonymous: true,
+          type: "regular",
+          allows_multiple_answers: true,
+        },
+      } as never,
+    });
+
+    expect(result?.rawBody).toContain("[Poll] Approve deploy?");
+    expect(result?.bodyText).toContain("1. Approve — 4 votes");
+    expect(result?.bodyText).toContain("2. Hold — 0 votes");
+    expect(result?.bodyText).toContain("Total voters: 4");
+    expect(result?.bodyText).toContain("Visibility: anonymous");
+    expect(result?.bodyText).toContain("Selection: multiple answers");
+    expect(result?.bodyText).toContain("Status: closed");
+  });
+
   it("delivers rich-message-only updates as a sanitized placeholder", async () => {
     const result = await resolveTelegramBody({
       msg: {

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, it } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 
 describe("buildTelegramMessageContext forwarded debounce batches", () => {
+  it("preserves each buffered message's formatting entities in model-visible order", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "😀 bold\nread docs",
+        entities: [
+          { type: "bold", offset: 3, length: 4 },
+          { type: "text_link", offset: 13, length: 4, url: "https://docs.example" },
+        ],
+      },
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            text: "😀 bold",
+            entities: [{ type: "bold", offset: 3, length: 4 }],
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            text: "read docs",
+            entities: [{ type: "text_link", offset: 5, length: 4, url: "https://docs.example" }],
+          },
+        ],
+      },
+    });
+
+    expect(context?.ctxPayload.RawBody).toBe("😀 **bold**\nread [docs](https://docs.example)");
+    expect(context?.ctxPayload.BodyForAgent).toBe("😀 **bold**\nread [docs](https://docs.example)");
+    expect(context?.ctxPayload.CommandBody).toBe("😀 **bold**\nread [docs](https://docs.example)");
+  });
+
   it("keeps ordinary text plain while attributing only the forwarded segment", async () => {
     const chat = { id: 999, type: "private" as const, first_name: "Alice" };
     const sender = { id: 42, first_name: "Alice", is_bot: false };

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -33,6 +33,7 @@ import type {
   TelegramMessageContextSessionRuntimeOverrides,
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
+import { renderTelegramTextEntities } from "./bot/body-helpers.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 
 type TelegramMentionFacts = NonNullable<
@@ -397,8 +398,9 @@ export async function buildTelegramInboundContextPayload(params: {
   const inboundDebounceBodySegments = hasMultiMessageDebounceBatch
     ? options?.inboundDebounceMessages?.flatMap((debouncedMessage) => {
         const debouncedMedia = resolveTelegramPrimaryMedia(debouncedMessage);
+        const textParts = getTelegramTextParts(debouncedMessage);
         const segmentBody =
-          getTelegramTextParts(debouncedMessage).text ||
+          renderTelegramTextEntities(textParts.text, textParts.entities) ||
           formatMediaPlaceholderText(debouncedMedia ? [{ kind: debouncedMedia.kind }] : []);
         if (!segmentBody) {
           return [];

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1346,6 +1346,93 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("dispatches native poll messages through the ordinary inbound handler", async () => {
+    configureOpenDm();
+    replySpy.mockClear();
+    createTelegramBot({ token: "tok" });
+
+    await getMessageHandler()(
+      makePrivateTextContext({
+        text: "",
+        messageId: 551,
+        message: {
+          text: undefined,
+          poll: {
+            id: "poll-551",
+            question: "Approve deployment?",
+            options: [
+              { persistent_id: "yes", text: "Yes", voter_count: 3 },
+              { persistent_id: "no", text: "No", voter_count: 0 },
+            ],
+            total_voter_count: 3,
+            is_closed: false,
+            is_anonymous: false,
+            type: "regular",
+            allows_multiple_answers: false,
+          },
+        },
+      }),
+    );
+
+    expect(replySpy).toHaveBeenCalledOnce();
+    const payload = requireValue(replySpy.mock.calls[0]?.[0], "inbound poll payload");
+    expect(payload.BodyForAgent).toContain("[Poll] Approve deployment?");
+    expect(payload.BodyForAgent).toContain("1. Yes — 3 votes");
+    expect(payload.BodyForAgent).toContain("2. No — 0 votes");
+    expect(payload.BodyForAgent).toContain("Total voters: 3");
+  });
+
+  it("preserves formatting entities through the forwarded-message debounce boundary", async () => {
+    configureOpenDm({ timezone: "envelopeTimezone" });
+    replySpy.mockClear();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      for (const [messageId, text, entities, origin] of [
+        [561, "😀 bold", [{ type: "bold", offset: 3, length: 4 }], "Original A"],
+        [
+          562,
+          "read docs",
+          [{ type: "text_link", offset: 5, length: 4, url: "https://docs.example" }],
+          "Original B",
+        ],
+      ] as const) {
+        await messageHandler(
+          makePrivateTextContext({
+            text,
+            messageId,
+            date: 1736380800 + messageId,
+            message: {
+              entities,
+              forward_origin: {
+                type: "hidden_user",
+                date: 500 + messageId,
+                sender_user_name: origin,
+              },
+            },
+          }),
+        );
+      }
+
+      takeLatestTimerCallback(80)();
+      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledOnce());
+      const payload = requireValue(
+        replySpy.mock.calls[0]?.[0],
+        "formatted forwarded batch payload",
+      );
+      expect(payload.RawBody).toBe("😀 **bold**\nread [docs](https://docs.example)");
+      expect(payload.BodyForAgent).toContain("😀 **bold**");
+      expect(payload.BodyForAgent).toContain("read [docs](https://docs.example)");
+      expect(payload.BodyForAgent).toContain("[Forwarded from Original A");
+      expect(payload.BodyForAgent).toContain("[Forwarded from Original B");
+      expect(payload.CommandBody).toBe("😀 **bold**\nread [docs](https://docs.example)");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("preserves structured origin for a single forwarded debounce entry", async () => {
     configureOpenDm({ timezone: "envelopeTimezone" });
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/telegram/src/bot/body-helpers.inbound.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.inbound.test.ts
@@ -1,0 +1,103 @@
+import type { Message } from "grammy/types";
+import { describe, expect, it } from "vitest";
+import {
+  getTelegramTextParts,
+  joinTelegramTextParts,
+  renderTelegramTextEntities,
+} from "./body-helpers.js";
+
+function asTelegramMessage(message: unknown): Message {
+  return message as Message;
+}
+
+describe("getTelegramTextParts", () => {
+  it("projects native Telegram polls into bounded, accurate inbound text", () => {
+    const result = getTelegramTextParts(
+      asTelegramMessage({
+        poll: {
+          id: "poll-1",
+          question: "Ship the release?",
+          options: [
+            { persistent_id: "yes", text: "Yes", voter_count: 2 },
+            { persistent_id: "no", text: "No", voter_count: 1 },
+          ],
+          total_voter_count: 3,
+          is_closed: false,
+          is_anonymous: false,
+          type: "quiz",
+          allows_multiple_answers: false,
+          correct_option_ids: [0],
+          description: "Read docs",
+          description_entities: [
+            { type: "text_link", offset: 5, length: 4, url: "https://docs.example" },
+          ],
+          explanation: "All checks passed.",
+          explanation_entities: [{ type: "bold", offset: 0, length: 3 }],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      text: [
+        "[Poll] Ship the release?",
+        "Read [docs](https://docs.example)",
+        "1. Yes — 2 votes (correct)",
+        "2. No — 1 vote",
+        "Total voters: 3",
+        "Type: quiz",
+        "Visibility: public",
+        "Selection: single answer",
+        "Status: open",
+        "Explanation: **All** checks passed.",
+      ].join("\n"),
+      entities: [],
+    });
+  });
+});
+
+describe("joinTelegramTextParts", () => {
+  it("rebases text and caption entities using Telegram UTF-16 offsets", () => {
+    const result = joinTelegramTextParts(
+      [
+        asTelegramMessage({
+          text: "😀 bold",
+          entities: [{ type: "bold", offset: 3, length: 4 }],
+        }),
+        asTelegramMessage({
+          caption: "read docs",
+          caption_entities: [
+            { type: "text_link", offset: 5, length: 4, url: "https://docs.example" },
+          ],
+        }),
+      ],
+      "\n",
+    );
+
+    expect(result.text).toBe("😀 bold\nread docs");
+    expect(result.entities).toEqual([
+      { type: "bold", offset: 3, length: 4 },
+      { type: "text_link", offset: 13, length: 4, url: "https://docs.example" },
+    ]);
+    expect(renderTelegramTextEntities(result.text, result.entities)).toBe(
+      "😀 **bold**\nread [docs](https://docs.example)",
+    );
+  });
+
+  it("skips empty segments without shifting later entity offsets", () => {
+    const result = joinTelegramTextParts(
+      [
+        asTelegramMessage({ text: "" }),
+        asTelegramMessage({
+          text: "bold",
+          entities: [{ type: "bold", offset: 0, length: 4 }],
+        }),
+      ],
+      "\n",
+    );
+
+    expect(result).toEqual({
+      text: "bold",
+      entities: [{ type: "bold", offset: 0, length: 4 }],
+    });
+  });
+});

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -96,9 +96,10 @@ export type TelegramTextEntity = NonNullable<Message["entities"]>[number];
 
 const TELEGRAM_RICH_MESSAGE_PLACEHOLDER = "[unsupported Telegram rich_message received]";
 
-type TelegramTextMessage = Pick<Message, "text" | "caption" | "entities" | "caption_entities"> & {
-  rich_message?: unknown;
-};
+type TelegramTextMessage = Pick<
+  Message,
+  "text" | "caption" | "entities" | "caption_entities" | "poll"
+> & { rich_message?: unknown };
 
 function hasTelegramRichMessage(value: unknown): boolean {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -215,13 +216,67 @@ export function resolveTelegramTextContent(text: unknown, caption?: unknown): st
   return isBinaryContent(raw) ? "" : raw;
 }
 
+function formatTelegramPollText(poll: NonNullable<Message["poll"]>): string {
+  const correctOptionIds = new Set(poll.correct_option_ids ?? []);
+  const optionLines = poll.options.map((option, index) => {
+    const optionText = renderTelegramTextEntities(option.text, option.text_entities);
+    const voteLabel = option.voter_count === 1 ? "vote" : "votes";
+    const correctLabel = correctOptionIds.has(index) ? " (correct)" : "";
+    return `${index + 1}. ${optionText} — ${option.voter_count} ${voteLabel}${correctLabel}`;
+  });
+
+  return [
+    `[Poll] ${renderTelegramTextEntities(poll.question, poll.question_entities)}`,
+    ...(poll.description
+      ? [renderTelegramTextEntities(poll.description, poll.description_entities)]
+      : []),
+    ...optionLines,
+    `Total voters: ${poll.total_voter_count}`,
+    `Type: ${poll.type}`,
+    `Visibility: ${poll.is_anonymous ? "anonymous" : "public"}`,
+    `Selection: ${poll.allows_multiple_answers ? "multiple answers" : "single answer"}`,
+    `Status: ${poll.is_closed ? "closed" : "open"}`,
+    ...(poll.explanation
+      ? [`Explanation: ${renderTelegramTextEntities(poll.explanation, poll.explanation_entities)}`]
+      : []),
+  ].join("\n");
+}
+
 export function getTelegramTextParts(msg: TelegramTextMessage): {
   text: string;
   entities: TelegramTextEntity[];
 } {
   const text = resolveTelegramTextContent(msg.text, msg.caption);
-  const entities = text ? (msg.entities ?? msg.caption_entities ?? []) : [];
-  return { text, entities };
+  if (text) {
+    return { text, entities: msg.entities ?? msg.caption_entities ?? [] };
+  }
+  return { text: msg.poll ? formatTelegramPollText(msg.poll) : "", entities: [] };
+}
+
+export function joinTelegramTextParts(
+  messages: readonly Message[],
+  separator: string,
+): { text: string; entities: TelegramTextEntity[] } {
+  const textParts: string[] = [];
+  const entities: TelegramTextEntity[] = [];
+  let offset = 0;
+
+  for (const message of messages) {
+    const textPart = getTelegramTextParts(message);
+    if (!textPart.text) {
+      continue;
+    }
+    if (textParts.length > 0) {
+      offset += separator.length;
+    }
+    entities.push(
+      ...textPart.entities.map((entity) => ({ ...entity, offset: entity.offset + offset })),
+    );
+    textParts.push(textPart.text);
+    offset += textPart.text.length;
+  }
+
+  return { text: textParts.join(separator), entities };
 }
 
 function isTelegramMentionWordChar(char: string | undefined): boolean {

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -36,6 +36,7 @@ import {
   getTelegramTextParts,
   hasBotMention,
   isBinaryContent,
+  joinTelegramTextParts,
   normalizeForwardedContext,
   resolveTelegramPrimaryMedia,
   resolveTelegramRichMessageBody,
@@ -58,6 +59,7 @@ export {
   getTelegramTextParts,
   hasBotMention,
   isBinaryContent,
+  joinTelegramTextParts,
   normalizeForwardedContext,
   resolveTelegramPrimaryMedia,
 };


### PR DESCRIPTION
## What Problem This Solves

Telegram users could send native polls that were accepted and then silently discarded because the inbound owner classified a poll as neither text nor downloadable media. Separately, coalesced Telegram text and captions discarded their formatting entities, removing model-visible bold/code/link information and misaligning entity offsets after multi-message or long-text buffering.

## Why This Change Was Made

The canonical Telegram text owner now projects Bot API poll questions, options, correct quiz answers, voter counts, visibility, selection mode, open/closed state, description, and explanation into bounded model-visible text. Each poll field retains its own Bot API formatting entities, and `total_voter_count` is correctly labeled as voters rather than selected votes.

The same owner joins text and caption segments with correctly rebased UTF-16 entity offsets. Both the ordinary debounce owner and long-text fragment owner preserve those entities in their synthetic messages, while forwarded-batch projection renders every original segment without changing existing forwarding or context-visibility rules.

## User Impact

- Native Telegram poll messages reach the agent with their actual question, options, vote counts, quiz answer, voter total, visibility, state, description links, and explanation formatting.
- Emoji-prefixed text, formatted captions, inline links, and forwarded message batches retain their original Telegram formatting in `RawBody`, `BodyForAgent`, and `CommandBody`.
- Authorization, pairing, allowlists, private context, storage, transport acknowledgement, plugin boundaries, and external dependencies remain unchanged.
- Channel direct-message-topic authorization/classification is explicitly excluded and held for maintainer/security review; the separately audited `text_mention` defect remains in its existing owner lane.

## Evidence

- Frozen canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Isolated candidate branch: `codex/qa200-telegram-inbound-poll-entities`.
- Exact candidate commit: `d33275ade658f07f1f37d4d960b3ead177e31cff`; its direct parent is the frozen baseline.
- Installed dependency contracts inspected directly: `node_modules/@grammyjs/types/message.d.ts` defines native `Message.poll`, poll option vote counts, quiz correctness, field entities, and `total_voter_count`; `node_modules/@grammyjs/types/update.d.ts` distinguishes ordinary poll-containing messages from standalone poll-state/vote updates.
- Frozen-source reproduction proved native poll messages returned `null` and a formatted two-message batch produced `bold\nitalic` instead of `**bold**\n_italic_`.
- Candidate direct real-owner/context proof passed **12 assertions**, including `resolveTelegramInboundBody`, UTF-16 offset rebasing, and actual `buildTelegramMessageContext` model/body/command projections.
- Final amended-owner proof passed **6 additional assertions**, including entity-carried description URLs, formatted explanations, correct total-voter labeling, emoji-sensitive offsets, and rendered caption links.
- Targeted `oxfmt --check` passed for all **11 changed files**; exact-commit `git diff --check`, frozen direct parent, and clean isolated worktree passed.
- Focused Vitest regressions are committed at the canonical helper, inbound-body, forwarded-context, synthetic-message, and full inbound-handler boundaries; execution is intentionally delegated to coordinator-managed remote proof because the coordinator prohibited local suites during critical disk pressure.
- Exact-commit structured Codex `gpt-5.6-sol`/high autoreview: **clean, zero actionable findings, 0.93 confidence**; the shared real TruffleHog exact-content preflight was clean (**4.1 seconds**).
- Distinct verified root-cause count: **2** — silently dropped inbound native polls; lost/coalesced Telegram text and caption entities.
