### PR TITLE
fix(cron): reject disabled delivery accounts when scheduling

### DIFF
--- a/src/cron/delivery-channel-validation.ts
+++ b/src/cron/delivery-channel-validation.ts
@@ -5,6 +5,8 @@ import {
   resolveTargetPrefixedChannel,
   validateTargetProviderPrefix,
 } from "../infra/outbound/channel-target-prefix.js";
+import { normalizeAccountId } from "../routing/account-id.js";
+import { resolveNormalizedAccountEntry } from "../routing/account-lookup.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import type { CronDelivery, CronFailureAlert, CronJobCreate } from "./types.js";
 
@@ -55,6 +57,48 @@ async function assertConfiguredAnnounceChannel(params: {
   }
 }
 
+/**
+ * Rejects an announce account the operator has turned off in config, so a job is
+ * not scheduled against a route its owner already disabled - the same late failure
+ * this file prevents for `channel` (see `assertValidCronFailureAlert`).
+ *
+ * Scoped to a matching `accounts.<id>.enabled: false` entry, and nothing else.
+ * Cron delivery ids are not always operator-typed (`delivery-context.ts` copies
+ * the current context account into inferred jobs); channel `isEnabled` adapters
+ * report unlisted or credential-suppressed accounts as not enabled; and a
+ * top-level `channels.<id>.enabled: false` is not uniformly channel-wide - twitch
+ * resolves named accounts from `accounts` alone. Only the account entry itself is
+ * an unambiguous statement about this route.
+ */
+function assertEnabledAnnounceAccount(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+  accountId?: string;
+  field: "delivery.accountId";
+}) {
+  if (!params.accountId || !params.channel || params.channel === "last") {
+    return;
+  }
+  // Aliases are valid delivery channels (`urbit` -> `tlon`) but config lives under
+  // the canonical id, so normalize before reading it.
+  const channel = normalizeMessageChannel(params.channel) ?? params.channel;
+  const channelConfig = (params.cfg.channels as Record<string, unknown> | undefined)?.[channel];
+  if (!channelConfig || typeof channelConfig !== "object" || Array.isArray(channelConfig)) {
+    return;
+  }
+  const accounts = (channelConfig as { accounts?: Record<string, { enabled?: unknown }> }).accounts;
+  // Channels resolve account keys canonically (matrix `"Team Ops"` answers to
+  // `team-ops`), so match the same way or a disabled entry is missed.
+  if (
+    resolveNormalizedAccountEntry(accounts, params.accountId, normalizeAccountId)?.enabled !== false
+  ) {
+    return;
+  }
+  throw new Error(
+    `${params.field}: account "${params.accountId}" is disabled for channel ${channel}`,
+  );
+}
+
 function resolveAnnounceValidationChannel(params: {
   channel?: string;
   to?: string;
@@ -92,6 +136,12 @@ export async function assertValidCronAnnounceDelivery(params: {
       cfg: params.cfg,
       channel: resolveAnnounceValidationChannel(params.delivery),
       field: "delivery.channel",
+    });
+    assertEnabledAnnounceAccount({
+      cfg: params.cfg,
+      channel: resolveAnnounceValidationChannel(params.delivery),
+      accountId: params.delivery.accountId,
+      field: "delivery.accountId",
     });
   }
 

--- a/src/gateway/server-methods/cron-error-classification.ts
+++ b/src/gateway/server-methods/cron-error-classification.ts
@@ -21,6 +21,7 @@ export function isCronInvalidRequestError(err: unknown): boolean {
     message.includes('cron.update payload.kind="agentTurn" requires message') ||
     message.includes("cron webhook delivery requires") ||
     message.includes("delivery.channel") ||
+    message.includes("delivery.accountId") ||
     message.includes("delivery.failureDestination.channel") ||
     message.includes("failureAlert.channel") ||
     message.includes("cron completion destination webhook requires") ||

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -72,6 +72,19 @@ function createPrefixOnlyChannelPlugin(
   };
 }
 
+function createEnablementHostileChannelPlugin(id: string): ChannelPlugin {
+  const base = createPrefixOnlyChannelPlugin(id, [id]);
+  return {
+    ...base,
+    config: {
+      ...base.config,
+      // Mirrors twitch/discord: an unlisted or credential-suppressed account
+      // resolves to a not-enabled account, which must NOT read as operator intent.
+      isEnabled: () => false,
+    },
+  };
+}
+
 function setCronValidationTestRegistry(): void {
   setActivePluginRegistry(
     createTestRegistry([
@@ -84,6 +97,11 @@ function setCronValidationTestRegistry(): void {
         pluginId: "slack",
         plugin: createPrefixOnlyChannelPlugin("slack", ["slack"]),
         source: "test:slack",
+      },
+      {
+        pluginId: "twitch",
+        plugin: createEnablementHostileChannelPlugin("twitch"),
+        source: "test:twitch",
       },
       {
         pluginId: "msteams",
@@ -342,6 +360,20 @@ function telegramSlackConfig(params: { includeMainSession?: boolean } = {}): Ope
       },
     },
     plugins: pluginEntries("telegram", "slack"),
+  } as OpenClawConfig;
+}
+
+function telegramDisabledAccountConfig(): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        accounts: {
+          primary: { botToken: "telegram-token-primary" },
+          retired: { botToken: "telegram-token-retired", enabled: false },
+        },
+      },
+    },
+    plugins: pluginEntries("telegram"),
   } as OpenClawConfig;
 }
 
@@ -2131,6 +2163,247 @@ describe("cron method validation", () => {
 
     expect(context.cron.add).not.toHaveBeenCalled();
     expectResponseError(respond, { messageIncludes: "delivery.channel is not configured" });
+  });
+
+  it("rejects an announce accountId whose account is explicitly disabled", async () => {
+    setRuntimeConfig(telegramDisabledAccountConfig());
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "disabled delivery account",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123456",
+          accountId: "retired",
+        },
+      }),
+    );
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.accountId",
+    });
+  });
+
+  it("accepts an announce accountId whose account is enabled", async () => {
+    setRuntimeConfig(telegramDisabledAccountConfig());
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "enabled delivery account",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123456",
+          accountId: "primary",
+        },
+      }),
+    );
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+  });
+
+  it("accepts an unlisted accountId so binding-derived ids keep working", async () => {
+    // Cron delivery ids are not always operator-typed: delivery-context.ts copies
+    // the current context account into inferred jobs, and a channel may resolve an
+    // unlisted binding id against its sole token. Only disabled accounts are rejected.
+    setRuntimeConfig(telegramConfig());
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "binding-derived delivery account",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123456",
+          accountId: "bot:12345",
+        },
+      }),
+    );
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+  });
+
+  it("accepts an unlisted accountId on a channel whose isEnabled reports it disabled", async () => {
+    // twitch/discord resolve an unlisted or credential-suppressed account to a
+    // not-enabled account. That is not the operator disabling a route, so cron
+    // creation must not be blocked by it - only a config-declared enabled:false is.
+    setRuntimeConfig({
+      channels: { twitch: { accounts: { main: { accessToken: "t" } } } },
+      plugins: pluginEntries("twitch"),
+    } as OpenClawConfig);
+
+    const { respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "enablement-hostile channel account",
+        delivery: {
+          mode: "announce",
+          channel: "twitch",
+          to: "twitch:room",
+          accountId: "unlisted-account",
+        },
+      }),
+    );
+
+    const call = respond.mock.calls.at(0);
+    // The channel itself may be judged unconfigured in this fixture; what must not
+    // happen is a rejection naming delivery.accountId.
+    expect(String(call?.[2] ? (call[2] as { message?: unknown }).message : "")).not.toContain(
+      "delivery.accountId",
+    );
+  });
+
+  it("accepts a named account when only the top-level channel config is disabled", async () => {
+    // A top-level `channels.<id>.enabled: false` is not uniformly channel-wide:
+    // twitch resolves named accounts from `accounts` alone, so a disabled root
+    // block must not make every account on that channel unschedulable.
+    setRuntimeConfig({
+      channels: {
+        twitch: { enabled: false, accounts: { main: { accessToken: "t" } } },
+      },
+      plugins: pluginEntries("twitch"),
+    } as OpenClawConfig);
+
+    const { respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "named account under disabled root",
+        delivery: {
+          mode: "announce",
+          channel: "twitch",
+          to: "twitch:room",
+          accountId: "main",
+        },
+      }),
+    );
+
+    const call = respond.mock.calls.at(0);
+    expect(String(call?.[2] ? (call[2] as { message?: unknown }).message : "")).not.toContain(
+      "delivery.accountId",
+    );
+  });
+
+  it("rejects a disabled account whose config key is not canonical", async () => {
+    // Channels resolve account keys canonically: matrix treats `"Team Ops"` as
+    // `team-ops`. A disabled entry stored under the display form must still match.
+    setRuntimeConfig({
+      channels: {
+        telegram: {
+          accounts: {
+            primary: { botToken: "telegram-token-primary" },
+            "Team Ops": { botToken: "telegram-token-team", enabled: false },
+          },
+        },
+      },
+      plugins: pluginEntries("telegram"),
+    } as OpenClawConfig);
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "noncanonical disabled account key",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123456",
+          accountId: "team-ops",
+        },
+      }),
+    );
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.accountId",
+    });
+  });
+
+  it("rejects a disabled account reached through a channel alias", async () => {
+    // Aliases are valid delivery channels (msteams answers to `teams`) while the
+    // config lives under the canonical id, so the alias must resolve before lookup.
+    setRuntimeConfig({
+      channels: {
+        msteams: {
+          accounts: {
+            work: { botToken: "teams-token-work", enabled: false },
+          },
+        },
+      },
+      plugins: pluginEntries("msteams"),
+    } as OpenClawConfig);
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "disabled account via alias",
+        delivery: {
+          mode: "announce",
+          channel: "teams",
+          to: "msteams:conversation",
+          accountId: "work",
+        },
+      }),
+    );
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.accountId",
+    });
+  });
+
+  it("accepts announce delivery that omits accountId", async () => {
+    setRuntimeConfig(telegramConfig());
+
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "no delivery account",
+        delivery: { mode: "announce", channel: "telegram", to: "telegram:123456" },
+      }),
+    );
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+  });
+
+  it("rejects a delivery patch that introduces a disabled accountId", async () => {
+    setRuntimeConfig(telegramDisabledAccountConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      { id: "cron-1", patch: { delivery: { accountId: "retired" } } },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "telegram:123456" },
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.accountId",
+    });
+  });
+
+  it("keeps a non-routing patch unblocked by a legacy-invalid stored accountId", async () => {
+    // Account validation runs only behind the delivery-patch gate, so edits that do
+    // not touch routing must not be rejected because of an id stored before this
+    // validation existed.
+    setRuntimeConfig(telegramDisabledAccountConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      { id: "cron-1", patch: { enabled: false } },
+      createCronJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123456",
+          accountId: "retired",
+        },
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expectCronSuccess(respond);
   });
 
   it("accepts provider-prefixed announce target without delivery.channel when multiple channels are configured", async () => {


### PR DESCRIPTION
## What Problem This Solves

Scheduling an automation against a channel account the operator has turned off succeeds. The job is stored and scheduled against a route its owner already disabled, and nothing says so until it fires.

```
openclaw automations add "every 1h" "post the daily digest" \
  --channel telegram --to "telegram:123456" --account retired
```

With `channels.telegram.accounts.retired.enabled = false`, that job is created and appears in `automations list` with a next run time. `cron.add` and `cron.update` validated the delivery block's channel and target, but `delivery.accountId` was normalized as a string and persisted verbatim.

## Why This Change Was Made

`src/cron/delivery-channel-validation.ts` already applies this rule to the channel on the same route. The comment on `assertValidCronFailureAlert` explains why an explicit unknown channel is rejected at mutation time rather than at run time: otherwise it is stored and only fails later as `channel_not_found`. The account had no equivalent check.

`assertEnabledAnnounceAccount` now runs beside the existing channel checks in `assertValidCronAnnounceDelivery`. It canonicalizes the resolved announce channel, looks the request's account up in that channel's `accounts` map using canonical account-id matching, and rejects only when that entry carries `enabled: false`.

**The predicate is deliberately that narrow, because every wider signal has a false positive here:**

- Cron delivery ids are not always operator-typed — `src/cron/delivery-context.ts` copies the current delivery context's account into inferred jobs.
- Channel `isEnabled` adapters report unlisted or credential-suppressed accounts as not enabled. `extensions/twitch/src/config.ts` resolves *any* unlisted id to `enabled: false`, and `extensions/discord/src/accounts.ts` treats duplicate-token suppression the same way.
- A top-level `channels.<id>.enabled: false` is not uniformly channel-wide — twitch resolves named accounts from `accounts` alone, so a disabled root block does not make those accounts unschedulable.

Only the account entry itself is an unambiguous statement about this route, so only that blocks a mutation. No channel plugin is resolved on this path, which keeps the gateway mutation off the bundled-plugin loading path that `src/gateway/AGENTS.md` warns about.

Both cron mutation paths share this validator and the update caller is already gated on `"delivery" in patch`, so edits that do not touch routing — toggling `bestEffort`, disabling a job — stay unblocked by an id stored before this validation existed. `cron-error-classification.ts` learns the field name so the precondition recheck inside `updateWithPrecondition` still classifies it as `INVALID_REQUEST` instead of escaping unclassified.

Known limits, stated rather than hidden: this is a create/update-time check and does not revalidate at run time, does not migrate already-stored jobs, and cannot see disablement a channel expresses outside its `accounts` entry. `delivery.failureDestination.accountId` is out of scope because its effective route layers over the global failure-destination config (`src/cron/delivery-plan.ts`), so it needs route resolution before validation rather than a raw check on the partial override.

## User Impact

An operator who points an automation at an account they have disabled finds out when they create or edit the job, instead of discovering a schedule that quietly cannot deliver. Jobs that omit `accountId`, name an enabled account, or carry a binding-derived id are unaffected.

## Evidence

Real-behavior proof below: packaged CLI (`node openclaw.mjs`) against a real Gateway on an isolated state dir and port, with the real bundled telegram plugin.

Focused tests: 10 added to `src/gateway/server-methods/cron.validation.test.ts` (179 passing in that file), covering a disabled delivery account, an enabled account, an omitted account, an unlisted binding-derived id, a channel whose `isEnabled` reports everything disabled, a named account under a disabled top-level channel block, a non-canonical disabled account key, a disabled account reached through a channel alias, a disabled-account update patch, and a non-routing patch over a legacy-invalid stored id. `src/cron` plus `src/gateway/server-methods/cron` = 160 files / 1893 tests green. Neutralising the check fails exactly the rejection tests and nothing else; each normalization test also fails individually when its normalization step is reverted. `tsgo:core`, `oxfmt`, and `oxlint` clean.

## Response on each mutation path

Confirming the intended `INVALID_REQUEST` behaviour on the three paths this touches, each pinned by a focused test in `src/gateway/server-methods/cron.validation.test.ts`:

| Path | Result | Test |
|---|---|---|
| `cron.add` with a configured-disabled account | `INVALID_REQUEST`, no job row created | `rejects an announce accountId whose account is explicitly disabled` |
| `cron.update` whose patch changes delivery routing to a disabled account | `INVALID_REQUEST`, no mutation | `rejects a delivery patch that introduces a disabled accountId` |
| `cron.update` that does not touch routing, over a job whose stored account is already disabled | succeeds unchanged | `keeps a non-routing patch unblocked by a legacy-invalid stored accountId` |

The third row is the upgrade case: a job stored before this validation existed stays editable, because the update caller only reaches this check when the patch contains `delivery`. `cron-error-classification.ts` carries `delivery.accountId` so the precondition recheck inside `updateWithPrecondition` classifies it the same way as the first-pass check rather than escaping unclassified.

Branch state: this head is `MERGEABLE` against current `main`, and no upstream commit since the base touches `src/cron/delivery-channel-validation.ts`, `src/gateway/server-methods/cron.ts`, `cron-error-classification.ts`, or the routing helpers it calls. I have not rebased purely to advance the SHA, because the captured proof above is pinned to this head and a rebase would invalidate it; happy to refresh on request.

## Real behavior proof

Behavior addressed: `cron.add` accepted and persisted a `delivery.accountId` naming an account the operator had disabled in config. The job was stored and scheduled against a route its owner had already turned off, and nothing reported that until it fired.

Real environment tested: Linux (Node 24.18.0), **packaged CLI** (`node openclaw.mjs`, dist-backed — not a source transpile) driving a **real OpenClaw Gateway** started with `openclaw gateway run` on an isolated `OPENCLAW_STATE_DIR` and port 18899, with the **real bundled telegram channel plugin** loaded. `cron.add` was invoked over the gateway websocket RPC by the real `openclaw automations add` command. Config declares two telegram accounts: `primary` and `retired` (`enabled: false`). Nothing on the cron or account-resolution path is mocked; the only placeholder is the bot token value, which is never contacted because validation runs before any delivery.

Exact steps or command run after this patch: captured at head `90b426b23cc` (base `c75e435e30b`). Each of the three accounts below was run as a separate `automations add`, then the stored jobs were listed.

```bash
export OPENCLAW_TOKEN="redacted-local-gateway-token"
export OPENCLAW_STATE_DIR=/tmp/cron-proof/state
export OPENCLAW_CONFIG_PATH=/tmp/cron-proof/openclaw.json
node openclaw.mjs gateway run &
node openclaw.mjs automations add "every 1h" "post the daily digest" \
  --name digest-retired --channel telegram --to "telegram:123456" \
  --account retired --token "$OPENCLAW_TOKEN"
node openclaw.mjs automations list --token "$OPENCLAW_TOKEN"
```

Before evidence:

Identical commands at the same base, with this patch's production change reverted and the dist rebuilt (`grep -c 'is disabled for channel' dist/` = **0**).

```
=== BEFORE [1] disabled account 'retired' ===
  "id": "79905748-a132-494c-ac2d-5a32f8f566d9",
    "accountId": "retired"

=== BEFORE: stored jobs ===
ID                                   Name             Schedule
79905748-a132-494c-ac2d-5a32f8f566d9 digest-retired   every 1h
```

Evidence after fix:

Same commands at head `90b426b23cc`, dist rebuilt with the patch (`grep -c 'is disabled for channel' dist/` = **1**).

```
=== AFTER [1] disabled account 'retired' ===
GatewayClientRequestError: invalid cron.add params: delivery.accountId: account "retired" is disabled for channel telegram

=== AFTER [2] unlisted account 'ghost' (must still be accepted) ===
  "id": "0b8dd690-de9d-4094-8c36-f8d7e0ee72d8",

=== AFTER [3] enabled account 'primary' ===
  "id": "abfb5c93-5a4b-49a8-9422-0386d3053616",

=== AFTER: stored jobs ===
ID                                   Name             Schedule
0b8dd690-de9d-4094-8c36-f8d7e0ee72d8 digest-ghost     every 1h
abfb5c93-5a4b-49a8-9422-0386d3053616 digest-primary   every 1h
```

Observed result after fix: the disabled account is rejected at `cron.add` and **no job row is created** for it — before the patch the identical command returned a job id and left a scheduled job behind. The unlisted `ghost` and the enabled `primary` are both still accepted, which is the intended scope: only a config-declared `enabled: false` blocks a mutation, so binding-derived ids that resolve against a sole channel token keep working.

What was not tested: the runtime delivery path (this is a create/update-time check and does not revalidate at run time); `cron.update` is covered by focused tests rather than the CLI, since both mutation paths call the same validator; non-telegram channels — the check reads config only and is channel-agnostic, and the alias, non-canonical-key, `isEnabled`-hostile, and disabled-root cases are covered by focused tests, but only telegram was driven live.

Proof limitations or environment constraints: the telegram bot tokens in the proof config are placeholders; they are never used because rejection happens during `cron.add`. The gateway ran with an isolated `OPENCLAW_STATE_DIR` and its own port, so no live gateway was touched. The check cannot see disablement a channel expresses outside its `accounts` entry — that is a deliberate scope limit, not an oversight, and the reasoning is in the PR body.
