### PR TITLE
fix(tui): preserve authoritative agent terminal outcomes and queued turns

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1844,6 +1844,826 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it.each([
+    {
+      label: "provider timeout",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "agent provider timeout",
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "provider timeout during an error lifecycle",
+      phase: "error",
+      terminal: {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "agent provider timeout",
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "provider timeout during an error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: {
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "agent provider timeout",
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "mechanically aborted provider timeout without an explicit stop reason",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "agent provider timeout",
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "provider-timeout error lifecycle without an abort or stop reason",
+      phase: "error",
+      terminal: {
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "agent provider timeout",
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "operator cancellation before provider startup",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: false,
+      },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "operator cancellation after provider startup",
+      phase: "end",
+      terminal: { aborted: true, stopReason: "rpc", providerStarted: true },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "operator cancellation after a queue timeout and provider startup",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: true,
+      },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "RPC cancellation error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: { stopReason: "rpc" },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "abort cancellation error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: { stopReason: "aborted" },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "restart cancellation error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: { stopReason: "restart" },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "stop cancellation error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: { stopReason: "stop" },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "blocked run despite its mechanical abort",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        stopReason: "aborted",
+        livenessState: "blocked",
+        error: "All fallback candidates ended incomplete",
+      },
+      expected: {
+        state: "error",
+        errorMessage: "All fallback candidates ended incomplete",
+      },
+      result: {
+        payloads: [{ text: "All fallback candidates ended incomplete", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          error: { kind: "incomplete_turn", message: "Internal fallback details" },
+        },
+      },
+    },
+    {
+      label: "mechanically aborted incomplete run without a cancellation reason",
+      phase: "end",
+      terminal: {
+        aborted: true,
+        livenessState: "abandoned",
+        error: "The agent stopped before finishing its tool call",
+      },
+      expected: {
+        state: "error",
+        errorMessage: "The agent stopped before finishing its tool call",
+      },
+      result: {
+        payloads: [{ text: "The agent stopped before finishing its tool call", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "abandoned",
+          error: { kind: "incomplete_turn", message: "Internal incomplete-turn details" },
+        },
+      },
+    },
+    {
+      label: "blocked error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: {
+        livenessState: "blocked",
+        error: "All fallback candidates ended incomplete",
+      },
+      expected: {
+        state: "error",
+        errorMessage: "All fallback candidates ended incomplete",
+      },
+      result: {
+        payloads: [{ text: "All fallback candidates ended incomplete", isError: true }],
+        meta: { livenessState: "blocked" },
+      },
+    },
+    {
+      label: "abandoned error lifecycle without a mechanical abort",
+      phase: "error",
+      terminal: {
+        livenessState: "abandoned",
+        error: "The agent stopped before finishing its tool call",
+      },
+      expected: {
+        state: "error",
+        errorMessage: "The agent stopped before finishing its tool call",
+      },
+      result: {
+        payloads: [{ text: "The agent stopped before finishing its tool call", isError: true }],
+        meta: { livenessState: "abandoned" },
+      },
+    },
+  ] as const)("preserves the terminal distinction for $label", async (testCase) => {
+    const { phase, terminal, expected } = testCase;
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string; isError?: boolean }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockImplementationOnce(() => pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "check the terminal outcome",
+      runId: "run-terminal-outcome",
+    });
+
+    registeredListener?.({
+      runId: "run-terminal-outcome",
+      stream: "lifecycle",
+      data: { phase, ...terminal },
+    });
+    if ("result" in testCase) {
+      pending.resolve(testCase.result);
+    }
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-terminal-outcome",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        ...expected,
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: "provider timeout",
+      meta: {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: { kind: "retry_limit", message: "agent provider timeout" },
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "operator cancellation after provider startup",
+      meta: { aborted: true, stopReason: "rpc", providerStarted: true },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "operator cancellation after a queue timeout and provider startup",
+      meta: {
+        aborted: true,
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: true,
+      },
+      expected: { state: "aborted" },
+    },
+    {
+      label: "blocked run despite its mechanical abort",
+      meta: {
+        aborted: true,
+        livenessState: "blocked",
+        error: {
+          kind: "context_overflow",
+          message: "Internal provider error with private diagnostics",
+        },
+      },
+      payloads: [
+        {
+          isError: true,
+          text: "Context overflow: prompt too large for the model. Try /reset or /new.",
+        },
+      ],
+      expected: {
+        state: "error",
+        errorMessage: "Context overflow: prompt too large for the model. Try /reset or /new.",
+      },
+    },
+    {
+      label: "abandoned run without an abort signal",
+      meta: {
+        livenessState: "abandoned",
+        error: {
+          kind: "incomplete_turn",
+          message: "Agent run ended before producing a complete result.",
+        },
+      },
+      expected: {
+        state: "error",
+        errorMessage: "Agent run ended before producing a complete result.",
+      },
+    },
+    {
+      label: "blocked liveness without an abort or error payload",
+      meta: { livenessState: "blocked" },
+      expected: {
+        state: "error",
+        errorMessage: "Agent run blocked before producing a usable result.",
+      },
+    },
+    {
+      label: "abandoned liveness without an abort or error payload",
+      meta: { livenessState: "abandoned" },
+      expected: {
+        state: "error",
+        errorMessage: "Agent run ended before producing a complete result.",
+      },
+    },
+    {
+      label: "mechanically aborted incomplete run without a cancellation reason",
+      meta: {
+        aborted: true,
+        livenessState: "abandoned",
+        error: {
+          kind: "incomplete_turn",
+          message: "Internal incomplete-turn details",
+        },
+      },
+      payloads: [
+        {
+          isError: true,
+          text: "Search finished successfully. The final response was interrupted.",
+        },
+      ],
+      expected: {
+        state: "error",
+        errorMessage: "Search finished successfully. The final response was interrupted.",
+      },
+    },
+    {
+      label: "provider timeout without a mechanical abort",
+      meta: {
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: { kind: "retry_limit", message: "agent provider timeout" },
+      },
+      expected: { state: "error", errorMessage: "agent provider timeout" },
+    },
+    {
+      label: "mechanically aborted provider timeout without an explicit stop reason",
+      meta: {
+        aborted: true,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      payloads: [
+        {
+          isError: true,
+          text: "Provider timed out. Increase its timeout and try again.",
+        },
+      ],
+      expected: {
+        state: "error",
+        errorMessage: "Provider timed out. Increase its timeout and try again.",
+      },
+    },
+    {
+      label: "provider timeout with an actionable error payload but no metadata error",
+      meta: {
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      payloads: [
+        {
+          isError: true,
+          text: "Request timed out. Please try again or increase the provider timeout.",
+        },
+      ],
+      expected: {
+        state: "error",
+        errorMessage: "Request timed out. Please try again or increase the provider timeout.",
+      },
+    },
+    {
+      label: "structured agent failure without liveness attribution",
+      meta: {
+        error: {
+          kind: "image_size",
+          message: "Provider rejected a 42 MiB image",
+        },
+      },
+      payloads: [
+        {
+          isError: true,
+          text: "Image too large for the model. Please compress or resize the image and try again.",
+        },
+      ],
+      expected: {
+        state: "error",
+        errorMessage:
+          "Image too large for the model. Please compress or resize the image and try again.",
+      },
+    },
+  ] as const)("preserves the result metadata terminal distinction for $label", async (testCase) => {
+    const { meta, expected } = testCase;
+    const payloads = "payloads" in testCase ? testCase.payloads : [];
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    agentCommandFromIngressMock.mockResolvedValueOnce({ payloads, meta });
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "check the result outcome",
+      runId: "run-result-outcome",
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-result-outcome",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        ...expected,
+      },
+    });
+  });
+
+  it("waits for the actionable provider-timeout result after its metadata-free lifecycle end", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string; isError?: boolean }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "wait for timeout guidance",
+      runId: "run-timeout-lifecycle-first",
+    });
+
+    registeredListener?.({
+      runId: "run-timeout-lifecycle-first",
+      stream: "lifecycle",
+      data: { phase: "end", aborted: true, stopReason: "timeout" },
+    });
+    await flushMicrotasks();
+
+    expect(
+      events.some(
+        ({ event, payload }) =>
+          event === "chat" && (payload as { state?: string }).state === "error",
+      ),
+    ).toBe(false);
+
+    const timeoutMessage =
+      "Request timed out before a response was generated. Please try again, " +
+      "or increase `agents.defaults.timeoutSeconds` in your config.";
+    pending.resolve({
+      payloads: [{ text: timeoutMessage, isError: true }],
+      meta: {
+        aborted: true,
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-timeout-lifecycle-first",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "error",
+        errorMessage: timeoutMessage,
+      },
+    });
+    expect(
+      events.filter(
+        ({ event, payload }) =>
+          event === "chat" && (payload as { state?: string }).state === "error",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      label: "metadata-free provider timeout",
+      lifecycle: { aborted: true, stopReason: "timeout" },
+      result: {
+        payloads: [
+          { text: "Provider timed out; increase its timeout and try again.", isError: true },
+        ],
+        meta: { aborted: true, timeoutPhase: "provider", providerStarted: true },
+      },
+    },
+    {
+      label: "mechanically aborted provider timeout without an explicit stop reason",
+      lifecycle: { aborted: true, timeoutPhase: "provider", providerStarted: true },
+      result: {
+        payloads: [
+          { text: "Provider timed out; increase its timeout and try again.", isError: true },
+        ],
+        meta: { aborted: true, timeoutPhase: "provider", providerStarted: true },
+      },
+    },
+    {
+      label: "provider timeout without a mechanical abort",
+      lifecycle: { stopReason: "timeout" },
+      result: {
+        payloads: [
+          { text: "Provider timed out; increase its timeout and try again.", isError: true },
+        ],
+        meta: { stopReason: "timeout", timeoutPhase: "provider", providerStarted: true },
+      },
+    },
+    {
+      label: "provider timeout status without a mechanical abort",
+      lifecycle: { status: "timeout" },
+      result: {
+        payloads: [
+          { text: "Provider timed out; increase its timeout and try again.", isError: true },
+        ],
+        meta: { status: "timeout", timeoutPhase: "provider", providerStarted: true },
+      },
+    },
+    {
+      label: "mechanically aborted blocked turn",
+      lifecycle: {
+        aborted: true,
+        stopReason: "aborted",
+        livenessState: "blocked",
+        error: "All provider candidates ended incomplete",
+      },
+      result: {
+        payloads: [{ text: "No provider completed the response. Try again.", isError: true }],
+        meta: { aborted: true, livenessState: "blocked" },
+      },
+    },
+    {
+      label: "blocked turn without a mechanical abort",
+      lifecycle: {
+        livenessState: "blocked",
+        error: "All provider candidates ended incomplete",
+      },
+      result: {
+        payloads: [{ text: "No provider completed the response. Try again.", isError: true }],
+        meta: { livenessState: "blocked" },
+      },
+    },
+    {
+      label: "mechanically aborted abandoned turn",
+      lifecycle: {
+        aborted: true,
+        livenessState: "abandoned",
+        error: "The agent stopped before finishing its tool call",
+      },
+      result: {
+        payloads: [{ text: "The response ended before its tool call completed.", isError: true }],
+        meta: { aborted: true, livenessState: "abandoned" },
+      },
+    },
+    {
+      label: "abandoned turn without a mechanical abort",
+      lifecycle: {
+        livenessState: "abandoned",
+        error: "The agent stopped before finishing its tool call",
+      },
+      result: {
+        payloads: [{ text: "The response ended before its tool call completed.", isError: true }],
+        meta: { livenessState: "abandoned" },
+      },
+    },
+  ] as const)(
+    "keeps a deferred $label ahead of queued followups",
+    async ({ lifecycle, result }) => {
+      await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
+        const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+        const pending = deferred<{
+          payloads: Array<{ text: string; isError?: boolean }>;
+          meta: Record<string, unknown>;
+        }>();
+        agentCommandFromIngressMock
+          .mockReturnValueOnce(pending.promise)
+          .mockResolvedValueOnce({ payloads: [{ text: "queued response" }], meta: {} });
+        loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+          cfg: { messages: { queue: { mode: "followup" } } },
+          canonicalKey: sessionKey,
+          storePath: "/tmp/openclaw-sessions.json",
+          store: {},
+          entry: { queueDebounceMs: 0 },
+        }));
+
+        const backend = new EmbeddedTuiBackend();
+        const events: Array<{ event: string; payload: unknown }> = [];
+        backend.onEvent = (evt) => {
+          events.push({ event: evt.event, payload: evt.payload });
+        };
+        backend.start();
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "first response",
+          runId: "run-deferred-lifecycle-owner",
+        });
+
+        registeredListener?.({
+          runId: "run-deferred-lifecycle-owner",
+          stream: "assistant",
+          data: { text: "partial response", delta: "partial response" },
+        });
+        registeredListener?.({
+          runId: "run-deferred-lifecycle-owner",
+          stream: "lifecycle",
+          data: { phase: "end", ...lifecycle },
+        });
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "queued followup",
+          runId: "run-deferred-lifecycle-followup",
+        });
+        await flushMicrotasks();
+        vi.advanceTimersByTime(6);
+        await flushMicrotasks();
+
+        expect(events).not.toContainEqual({
+          event: "chat",
+          payload: expect.objectContaining({
+            runId: "run-deferred-lifecycle-followup",
+            state: "error",
+          }),
+        });
+        expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+        pending.resolve(result);
+        await vi.waitFor(() => {
+          expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+        });
+        expect(events).toContainEqual({
+          event: "chat",
+          payload: expect.objectContaining({
+            runId: "run-deferred-lifecycle-owner",
+            state: "error",
+            errorMessage: result.payloads[0].text,
+          }),
+        });
+      });
+    },
+  );
+
+  it.each([
+    { label: "mechanically aborted", lifecycle: { aborted: true, stopReason: "timeout" } },
+    { label: "not mechanically aborted", lifecycle: { stopReason: "timeout" } },
+  ] as const)(
+    "bounds a $label provider timeout when its authoritative result never settles",
+    async ({ lifecycle }) => {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      const pending = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+      const backend = new EmbeddedTuiBackend();
+      const events: Array<{ event: string; payload: unknown }> = [];
+      backend.onEvent = (evt) => {
+        events.push({ event: evt.event, payload: evt.payload });
+      };
+      backend.start();
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "bound the terminal timeout",
+        runId: "run-timeout-result-missing",
+      });
+
+      registeredListener?.({
+        runId: "run-timeout-result-missing",
+        stream: "lifecycle",
+        data: { phase: "end", ...lifecycle },
+      });
+      await flushMicrotasks();
+      vi.advanceTimersByTime(15_001);
+
+      expect(events).toContainEqual({
+        event: "chat",
+        payload: {
+          runId: "run-timeout-result-missing",
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          state: "error",
+          errorMessage: "Request timed out before a response was generated. Please try again.",
+        },
+      });
+    },
+  );
+
+  it.each([
+    {
+      label: "blocked",
+      lifecycle: {
+        aborted: true,
+        stopReason: "aborted",
+        livenessState: "blocked",
+        error: "Private provider candidate details",
+      },
+    },
+    {
+      label: "blocked without a mechanical abort",
+      lifecycle: {
+        livenessState: "blocked",
+        error: "Private provider candidate details",
+      },
+    },
+    {
+      label: "abandoned",
+      lifecycle: {
+        aborted: true,
+        livenessState: "abandoned",
+        error: "Private incomplete-tool details",
+      },
+    },
+    {
+      label: "abandoned without a mechanical abort",
+      lifecycle: {
+        livenessState: "abandoned",
+        error: "Private incomplete-tool details",
+      },
+    },
+  ] as const)(
+    "bounds a $label turn when its authoritative result never settles",
+    async ({ lifecycle }) => {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      agentCommandFromIngressMock.mockReturnValueOnce(new Promise(() => {}));
+
+      const backend = new EmbeddedTuiBackend();
+      const events: Array<{ event: string; payload: unknown }> = [];
+      backend.onEvent = (evt) => {
+        events.push({ event: evt.event, payload: evt.payload });
+      };
+      backend.start();
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "bound the incomplete terminal",
+        runId: "run-incomplete-result-missing",
+      });
+
+      registeredListener?.({
+        runId: "run-incomplete-result-missing",
+        stream: "lifecycle",
+        data: { phase: "end", ...lifecycle },
+      });
+      await flushMicrotasks();
+      vi.advanceTimersByTime(15_001);
+
+      expect(events).toContainEqual({
+        event: "chat",
+        payload: {
+          runId: "run-incomplete-result-missing",
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          state: "error",
+          errorMessage: "The agent stopped before finishing its response. Please try again.",
+        },
+      });
+    },
+  );
+
+  it("preserves a thrown provider timeout when its abort signal is also raised", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const { AgentRunTerminalOutcomeError, buildAgentRunTerminalOutcome } =
+      await import("../agents/agent-run-terminal-outcome.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+      opts.abortSignal?.addEventListener("abort", () => {
+        pending.reject(
+          new AgentRunTerminalOutcomeError(
+            new Error("agent provider timeout"),
+            buildAgentRunTerminalOutcome({
+              status: "timeout",
+              stopReason: "timeout",
+              timeoutPhase: "provider",
+              providerStarted: true,
+            }),
+          ),
+        );
+      });
+      return pending.promise;
+    });
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "check the thrown timeout",
+      runId: "run-thrown-timeout",
+    });
+    await backend.abortChat({
+      sessionKey: "agent:main:main",
+      runId: "run-thrown-timeout",
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-thrown-timeout",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "error",
+        errorMessage: "agent provider timeout",
+      },
+    });
+  });
+
   it("retains the latest tool validation summary for an aborted chat event", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -2,6 +2,10 @@
 import { randomUUID } from "node:crypto";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
+import {
+  buildAgentRunTerminalOutcome,
+  findAgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import {
   resolveAgentDir,
@@ -1214,7 +1218,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.clearPendingLifecycleError(runId);
     const timer = setTimeout(() => {
       this.pendingLifecycleErrors.delete(runId);
-      this.emitChatError(runId, run, errorMessage);
+      this.emitChatTerminal(runId, run, "error", errorMessage);
     }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
     timer.unref?.();
     this.pendingLifecycleErrors.set(runId, timer);
@@ -1285,7 +1289,12 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
   }
 
-  private emitChatAborted(runId: string, run: LocalRunState, errorMessage?: string) {
+  private emitChatTerminal(
+    runId: string,
+    run: LocalRunState,
+    state: "aborted" | "error",
+    errorMessage?: string,
+  ) {
     this.clearPendingLifecycleError(runId);
     run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
@@ -1297,35 +1306,98 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     run.registered = true;
     run.lastBroadcastText = undefined;
-    const diagnostic = errorMessage ?? run.toolErrorSummary;
+    const diagnostic = state === "aborted" ? (errorMessage ?? run.toolErrorSummary) : errorMessage;
     this.emit("chat", {
       runId,
       sessionKey: run.sessionKey,
       agentId: run.agentId,
-      state: "aborted",
+      state,
       ...(diagnostic ? { errorMessage: diagnostic } : {}),
     });
   }
 
-  private emitChatError(runId: string, run: LocalRunState, errorMessage?: string) {
-    this.clearPendingLifecycleError(runId);
-    run.markQueuedRunReady();
-    const alreadyFinal = run.finalSent;
-    run.finishing = false;
-    run.lifecycleEnded = true;
-    run.finalSent = true;
-    if (alreadyFinal) {
-      return;
-    }
-    run.registered = true;
-    run.lastBroadcastText = undefined;
-    this.emit("chat", {
-      runId,
-      sessionKey: run.sessionKey,
-      agentId: run.agentId,
-      state: "error",
-      ...(errorMessage ? { errorMessage } : {}),
+  private emitRunTerminalOutcome(
+    runId: string,
+    run: LocalRunState,
+    metadata: {
+      status?: unknown;
+      stopReason?: unknown;
+      timeoutPhase?: unknown;
+      providerStarted?: unknown;
+      livenessState?: unknown;
+      error?: unknown;
+    },
+    aborted: boolean,
+    abortErrorMessage?: string,
+    deferIncompleteResult = false,
+  ): boolean {
+    const timedOut =
+      metadata.status === "timeout" ||
+      metadata.timeoutPhase === "preflight" ||
+      metadata.timeoutPhase === "provider" ||
+      metadata.timeoutPhase === "post_turn";
+    const stopReason =
+      typeof metadata.stopReason === "string"
+        ? metadata.stopReason
+        : timedOut
+          ? "timeout"
+          : aborted && (run.controller.signal.aborted || metadata.livenessState !== "abandoned")
+            ? "aborted"
+            : undefined;
+    const cancellationStopReason =
+      stopReason === "rpc" || stopReason === "aborted" || stopReason === "restart";
+    // Mechanical aborts and incomplete turns must preserve the canonical owner
+    // outcome instead of becoming operator cancellations or successful finals.
+    const outcome = buildAgentRunTerminalOutcome({
+      status:
+        stopReason === "timeout" || metadata.status === "timeout"
+          ? "timeout"
+          : aborted ||
+              cancellationStopReason ||
+              metadata.status === "error" ||
+              stopReason === "error" ||
+              typeof metadata.error === "string"
+            ? "error"
+            : "ok",
+      error: typeof metadata.error === "string" ? metadata.error : undefined,
+      stopReason,
+      livenessState: metadata.livenessState,
+      timeoutPhase: metadata.timeoutPhase,
+      providerStarted: metadata.providerStarted,
     });
+    if (deferIncompleteResult && outcome.status === "timeout" && !outcome.error) {
+      // Lifecycle end precedes its actionable timeout payload; bound the wait
+      // so a stalled command still produces an operator-visible terminal.
+      this.scheduleChatError(
+        runId,
+        run,
+        "Request timed out before a response was generated. Please try again.",
+      );
+      return true;
+    }
+    if (
+      deferIncompleteResult &&
+      !run.controller.signal.aborted &&
+      (outcome.reason === "blocked" || outcome.reason === "abandoned")
+    ) {
+      // An incomplete lifecycle cannot release queued work before its command
+      // result supplies the public diagnostic; bound stalled producers too.
+      this.scheduleChatError(
+        runId,
+        run,
+        "The agent stopped before finishing its response. Please try again.",
+      );
+      return true;
+    }
+    if (outcome.reason === "cancelled" || outcome.reason === "aborted") {
+      this.emitChatTerminal(runId, run, "aborted", abortErrorMessage);
+      return true;
+    }
+    if (outcome.status !== "ok") {
+      this.emitChatTerminal(runId, run, "error", outcome.error);
+      return true;
+    }
+    return false;
   }
 
   private ensureRunRegistered(runId: string, run: LocalRunState) {
@@ -1410,8 +1482,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     if (phase === "end") {
       run.finishing = false;
-      if (aborted) {
-        this.emitChatAborted(evt.runId, run, toolErrorSummary);
+      if (this.emitRunTerminalOutcome(evt.runId, run, evt.data, aborted, toolErrorSummary, true)) {
         return;
       }
       run.lifecycleEnded = true;
@@ -1423,8 +1494,30 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     if (phase === "error") {
       run.finishing = false;
-      if (aborted) {
-        this.emitChatAborted(evt.runId, run, toolErrorSummary);
+      const lifecycleCancellation =
+        evt.data?.stopReason === "rpc" ||
+        evt.data?.stopReason === "aborted" ||
+        evt.data?.stopReason === "restart" ||
+        evt.data?.stopReason === "stop";
+      if (
+        (aborted ||
+          lifecycleCancellation ||
+          evt.data?.stopReason === "timeout" ||
+          evt.data?.status === "timeout" ||
+          evt.data?.timeoutPhase === "preflight" ||
+          evt.data?.timeoutPhase === "provider" ||
+          evt.data?.timeoutPhase === "post_turn" ||
+          evt.data?.livenessState === "blocked" ||
+          evt.data?.livenessState === "abandoned") &&
+        this.emitRunTerminalOutcome(
+          evt.runId,
+          run,
+          evt.data,
+          aborted || lifecycleCancellation,
+          toolErrorSummary,
+          true,
+        )
+      ) {
         return;
       }
       const errorMessage = typeof evt.data?.error === "string" ? evt.data.error : undefined;
@@ -1452,9 +1545,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
           const run = this.runs.get(params.runId);
           if (run) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            this.emitChatError(
+            this.emitChatTerminal(
               params.runId,
               run,
+              "error",
               `previous run did not finish cleanly: ${errorMessage}`,
             );
           }
@@ -1463,7 +1557,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         if (params.controller.signal.aborted) {
           const run = this.runs.get(params.runId);
           if (run) {
-            this.emitChatAborted(params.runId, run);
+            this.emitChatTerminal(params.runId, run, "aborted");
           }
           return;
         }
@@ -1473,7 +1567,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (activeRun?.pendingQueue) {
         await waitForQueueDebounce(activeRun.pendingQueue, params.controller.signal);
         if (params.controller.signal.aborted) {
-          this.emitChatAborted(params.runId, activeRun);
+          this.emitChatTerminal(params.runId, activeRun, "aborted");
           return;
         }
         message = buildLocalQueuedPrompt(activeRun.pendingQueue);
@@ -1493,7 +1587,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           return;
         }
         if (params.controller.signal.aborted) {
-          this.emitChatAborted(params.runId, run);
+          this.emitChatTerminal(params.runId, run, "aborted");
           return;
         }
         this.emit("chat.side_result", {
@@ -1538,8 +1632,17 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
-      if (params.controller.signal.aborted || result?.meta?.aborted === true) {
-        this.emitChatAborted(params.runId, run);
+      const terminalError =
+        result?.payloads?.find((payload) => payload.isError === true)?.text?.trim() ||
+        result?.meta?.error?.message;
+      if (
+        this.emitRunTerminalOutcome(
+          params.runId,
+          run,
+          { ...result?.meta, error: terminalError },
+          params.controller.signal.aborted || result?.meta?.aborted === true,
+        )
+      ) {
         return;
       }
 
@@ -1575,12 +1678,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
-      if (params.controller.signal.aborted) {
-        this.emitChatAborted(params.runId, run);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const terminalOutcome = findAgentRunTerminalOutcome(error);
+      if (
+        terminalOutcome &&
+        this.emitRunTerminalOutcome(
+          params.runId,
+          run,
+          { ...terminalOutcome, error: terminalOutcome.error ?? errorMessage },
+          params.controller.signal.aborted,
+        )
+      ) {
         return;
       }
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.emitChatError(params.runId, run, errorMessage);
+      if (params.controller.signal.aborted) {
+        this.emitChatTerminal(params.runId, run, "aborted");
+        return;
+      }
+      this.emitChatTerminal(params.runId, run, "error", errorMessage);
     } finally {
       this.runs.get(params.runId)?.markQueuedRunReady();
       this.runs.delete(params.runId);


### PR DESCRIPTION
## Summary

- Route embedded terminal lifecycle events, completed results, and thrown failures through the existing canonical agent-run terminal owner.
- Preserve hard provider timeout outcomes, distinguish operator cancellation from mechanically aborted blocked or abandoned work, and reject structured agent failures instead of presenting them as successful replies.
- Keep authoritative user-facing error payloads and remediation visible, retain thrown timeout diagnostics, and consolidate duplicate terminal-emission paths.
- Keep buffered incomplete turns ahead of queued followups, classify lifecycle outcomes even without mechanical-abort metadata, and bound every deferred timeout/blocked/abandoned terminal with one sanitized 15-second owner fallback.

## Root-cause fixes

1. Provider timeouts became ordinary cancellations or false successful chat finals across lifecycle, returned-metadata, and thrown-error paths.
2. Mechanically aborted blocked agent runs appeared as operator cancellations instead of visible actionable failures.
3. Abandoned/incomplete agent turns appeared as successful replies or user cancellations, including after incomplete tool execution.
4. Structured agent failures without separate liveness attribution appeared as successful terminal replies.

## Verification

- Frozen current-main baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact candidate: `7c7efe29abe98ee12d901ac123d73eb36d9d9aa9`.
- Independently reproduced four current-main terminal misclassifications and the existing thrown-timeout failure before implementing the owner refactor.
- Full earlier owner pass: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_FS_SAFE_NATIVE_MODE=off FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/embedded-backend.test.ts`: **83 passed** before subsequent producer-shaped regressions were added.
- Exact final candidate: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_FS_SAFE_NATIVE_MODE=off FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/embedded-backend.test.ts -t 'terminal distinction|metadata-free lifecycle end|keeps a deferred|bounds a .*timeout|bounds a .*turn|thrown provider timeout'`: **44 passed**, with **110 total owner cases available**.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_FS_SAFE_NATIVE_MODE=off FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/agent-run-terminal-outcome.test.ts`: **27 passed**.
- Targeted type-aware `oxlint`, `oxfmt --check`, `git diff --check`, and clean exact-head worktree passed.
- Exact producer-shaped RED→GREEN proof covered metadata-free lifecycle end before actionable timeout result; buffered timeout/blocked/abandoned turns with and without mechanical-abort flags; five-millisecond queued-followup failure caused by premature lifecycle completion; sanitized bounded 15-second fallback when the authoritative result never settles; and RPC/abort/restart/stop lifecycle cancellation without a mechanical abort.
- Independent whole-owner review examined canonical terminal precedence, actual blocked/abandoned/timeout producers, Gateway siblings, TUI consumers, recovery timing, cancellation, and remediation payloads. The relevant Codex protocol/runtime contracts were personally inspected at `../codex/codex-rs/protocol/src/protocol.rs:4201`, `../codex/codex-rs/core/src/tasks/mod.rs:223`, `../codex/codex-rs/core/src/tasks/mod.rs:900`, and `../codex/codex-rs/core/src/guardian/review_session.rs:1085`.
- Final genuine structured TruffleHog-backed commit-mode autoreview: **clean**, `gpt-5.6-sol`, high reasoning, exact commit, zero actionable findings, overall correctness **0.87**.

## Risk

Bounded internal embedded-TUI owner refactor only. No gateway protocol, public configuration, authentication, persistent state, SQLite schema, dependency, or plugin SDK changes.
