### PR TITLE
fix(media): recognize AIFF variants consistently across input pipelines

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -336,6 +336,21 @@ describe("mime detection", () => {
     expect(mime).toBe("audio/aac");
   });
 
+  it.each([
+    { form: "AIFF", fileName: "voice.aiff" },
+    { form: "AIFC", fileName: "voice.aifc" },
+  ])("detects $form audio from its authentic container signature", async ({ form, fileName }) => {
+    const buffer = Buffer.alloc(64);
+    buffer.write("FORM", 0, "ascii");
+    buffer.writeUInt32BE(buffer.length - 8, 4);
+    buffer.write(form, 8, "ascii");
+
+    await expectDetectedMime({
+      input: { buffer, filePath: fileName },
+      expected: "audio/aiff",
+    });
+  });
+
   it("detects Apple CAF audio by magic bytes when file-type does not recognize the container", async () => {
     // CAF files start with the four-byte ASCII tag "caff". `file-type` v22 has
     // no native CAF detector, so without the manual magic-byte fallback the
@@ -393,6 +408,12 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "photo.jpg", expected: "image/jpeg" },
     { filePath: "photo.JPG", expected: "image/jpeg" },
     { filePath: "voice.mp3", expected: "audio/mpeg" },
+    { filePath: "voice.aiff", expected: "audio/aiff" },
+    { filePath: "voice.AIFF", expected: "audio/aiff" },
+    { filePath: "voice.aif", expected: "audio/aiff" },
+    { filePath: "voice.AIF", expected: "audio/aiff" },
+    { filePath: "voice.aifc", expected: "audio/aiff" },
+    { filePath: "voice.AIFC", expected: "audio/aiff" },
     { filePath: "voice.m2a", expected: "audio/mpeg" },
     { filePath: "audiobook.m4b", expected: "audio/mp4" },
     { filePath: "voice.oga", expected: "audio/ogg" },
@@ -449,6 +470,10 @@ describe("extensionForMime", () => {
     { mime: "image/heic-sequence", expected: ".heic" },
     { mime: "image/heif", expected: ".heif" },
     { mime: "image/heif-sequence", expected: ".heif" },
+    { mime: "audio/aiff", expected: ".aiff" },
+    { mime: "audio/x-aiff", expected: ".aiff" },
+    { mime: "Audio/AIFF", expected: ".aiff" },
+    { mime: "AUDIO/X-AIFF; codecs=pcm", expected: ".aiff" },
     { mime: "audio/mpeg", expected: ".mp3" },
     { mime: "audio/mp3", expected: ".mp3" },
     { mime: "audio/ogg", expected: ".ogg" },
@@ -494,6 +519,12 @@ describe("isAudioFileName", () => {
   it.each([
     { fileName: "audiobook.M4B", expected: true },
     { fileName: "voice.mp3", expected: true },
+    { fileName: "voice.aiff", expected: true },
+    { fileName: "voice.AIFF", expected: true },
+    { fileName: "voice.aif", expected: true },
+    { fileName: "voice.AIF", expected: true },
+    { fileName: "voice.aifc", expected: true },
+    { fileName: "voice.AIFC", expected: true },
     { fileName: "voice.caf", expected: true },
     { fileName: "voice.M2A", expected: true },
     { fileName: "voice.oga", expected: true },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -20,6 +20,8 @@ const EXT_BY_MIME: Record<string, string> = {
   "image/svg+xml": ".svg",
   "image/webp": ".webp",
   "image/gif": ".gif",
+  "audio/aiff": ".aiff",
+  "audio/x-aiff": ".aiff",
   "audio/ogg": ".ogg",
   "audio/mpeg": ".mp3",
   "audio/mp3": ".mp3",
@@ -85,6 +87,8 @@ const MIME_BY_EXT: Record<string, string> = {
   ".wav": "audio/wav",
   ".webm": "video/webm",
   // Additional extension aliases
+  ".aif": "audio/aiff",
+  ".aifc": "audio/aiff",
   ".jpeg": "image/jpeg",
   ".js": "text/javascript",
   ".log": "text/plain",

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -369,6 +369,25 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe("[media attached: /tmp/document.pdf]");
   });
 
+  it.each([".aiff", ".aif", ".aifc", ".webm", ".wma", ".alac"])(
+    "strips transcribed %s audio without an explicit MIME type",
+    (extension) => {
+      const note = buildInboundMediaNote({
+        MediaPaths: [`/tmp/voice${extension}`, "/tmp/document.pdf"],
+        MediaUnderstanding: [
+          {
+            kind: "audio.transcription",
+            attachmentIndex: 0,
+            text: "Transcribed audio content",
+            provider: "whisper",
+          },
+        ],
+      });
+
+      expect(note).toBe("[media attached: /tmp/document.pdf]");
+    },
+  );
+
   it("strips a transcribed kind-only audio fact without relying on its filename", () => {
     const projection = buildInboundMediaNoteProjection({
       media: [

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -1,5 +1,6 @@
 /** Builds compact prompt notes for inbound media attachments. */
 import path from "node:path";
+import { isAudioFileName } from "@openclaw/media-core/mime";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeMediaFacts, type MediaFact } from "../media/media-facts.js";
 import { getMediaDir } from "../media/store.js";
@@ -61,34 +62,18 @@ function formatMediaAttachedLine(params: {
   return `${prefix}${pathValue}${typePart}${urlPart}]`;
 }
 
-// Common audio file extensions for transcription detection
-const AUDIO_EXTENSIONS = new Set([
-  ".ogg",
-  ".opus",
-  ".mp3",
-  ".m4a",
-  ".m2a",
-  ".wav",
-  ".webm",
-  ".flac",
-  ".aac",
-  ".wma",
-  ".aiff",
-  ".alac",
-  ".oga",
-]);
+// WebM is ambiguous, while WMA and ALAC do not have canonical extension mappings.
+const AUDIO_EXTENSIONS_WITHOUT_CANONICAL_MIME = [".webm", ".wma", ".alac"] as const;
 
 function isAudioPath(pathLocal: string | undefined): boolean {
   if (!pathLocal) {
     return false;
   }
-  const lower = normalizeLowercaseStringOrEmpty(pathLocal);
-  for (const ext of AUDIO_EXTENSIONS) {
-    if (lower.endsWith(ext)) {
-      return true;
-    }
+  if (isAudioFileName(pathLocal)) {
+    return true;
   }
-  return false;
+  const lower = normalizeLowercaseStringOrEmpty(pathLocal);
+  return AUDIO_EXTENSIONS_WITHOUT_CANONICAL_MIME.some((extension) => lower.endsWith(extension));
 }
 
 function isValidAttachmentIndex(index: number, attachmentCount: number): boolean {

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -63,6 +63,29 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     });
   });
 
+  it.each([
+    { extension: ".aiff", form: "AIFF" },
+    { extension: ".aif", form: "AIFF" },
+    { extension: ".aifc", form: "AIFC" },
+  ])(
+    "exposes $extension audio files with their canonical MIME type",
+    async ({ extension, form }) => {
+      const { audioPath, localRoot } = writeAudioFixture(
+        [...Buffer.from("FORM", "ascii"), 0, 0, 0, 4, ...Buffer.from(form, "ascii")],
+        extension,
+      );
+
+      const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+        [{ mediaUrl: audioPath, trustedLocalMedia: true }],
+        { localRoots: [localRoot] },
+      );
+
+      expect(blocks[0]).toMatchObject({
+        attachment: { label: `clip${extension}`, kind: "audio", mimeType: "audio/aiff" },
+      });
+    },
+  );
+
   it("preserves voice-note metadata on local audio attachments", async () => {
     const { audioPath, localRoot } = writeAudioFixture();
 

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1282,6 +1282,54 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Transcript).toBe("fallback transcript");
   });
 
+  it.each([
+    { extension: ".aiff", form: "AIFF" },
+    { extension: ".aif", form: "AIFF" },
+    { extension: ".aifc", form: "AIFC" },
+  ])(
+    "transcribes $extension attachments without an explicit content type",
+    async ({ extension, form }) => {
+      const audioBuffer = createSafeAudioFixtureBuffer(2048, 0);
+      audioBuffer.write("FORM", 0, "ascii");
+      audioBuffer.writeUInt32BE(audioBuffer.length - 8, 4);
+      audioBuffer.write(form, 8, "ascii");
+      const audioPath = await createTempMediaFile({
+        fileName: `speech${extension}`,
+        content: audioBuffer,
+      });
+      const transcribeAudio = vi.fn(async () => ({ text: "AIFF transcript" }));
+      const ctx: MsgContext = {
+        Body: "",
+        media: [{ path: audioPath }],
+      };
+      const cfg: OpenClawConfig = {
+        tools: {
+          media: {
+            models: [{ provider: "google", capabilities: ["audio"] }],
+            audio: { enabled: true, maxBytes: 1024 * 1024 },
+          },
+        },
+      };
+
+      const result = await applyMediaUnderstanding({
+        ctx,
+        cfg,
+        providers: {
+          google: {
+            id: "google",
+            transcribeAudio,
+          },
+        },
+      });
+
+      expect(result.appliedAudio).toBe(true);
+      expect(transcribeAudio).toHaveBeenCalledWith(
+        expect.objectContaining({ fileName: `speech${extension}`, mime: "audio/aiff" }),
+      );
+      expect(ctx.Transcript).toBe("AIFF transcript");
+    },
+  );
+
   it("skips audio STT for attachments marked transcribed by channel preflight", async () => {
     const dir = await createTempMediaDir();
     const audioPath = path.join(dir, "voice.ogg");

--- a/src/media-understanding/audio-preflight.test.ts
+++ b/src/media-understanding/audio-preflight.test.ts
@@ -44,6 +44,27 @@ describe("transcribeFirstAudio", () => {
     expect(ctx.media?.[1]?.transcribed).toBe(true);
   });
 
+  it.each([".aiff", ".aif", ".aifc"])(
+    "transcribes %s voice notes without an explicit content type",
+    async (extension) => {
+      runAudioTranscriptionMock.mockResolvedValueOnce({
+        transcript: "AIFF voice note transcript",
+        attachments: [],
+      });
+
+      const ctx: MsgContext = {
+        Body: "<media:audio>",
+        media: [{ path: `/tmp/voice${extension}` }],
+      };
+
+      await expect(transcribeFirstAudio({ ctx, cfg: {} })).resolves.toBe(
+        "AIFF voice note transcript",
+      );
+      expect(runAudioTranscriptionMock).toHaveBeenCalledOnce();
+      expect(ctx.media?.[0]?.transcribed).toBe(true);
+    },
+  );
+
   it("skips audio preflight when audio config is explicitly disabled", async () => {
     const transcript = await transcribeFirstAudio({
       ctx: {

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -195,6 +195,13 @@ describe("playback transcode policy", () => {
       expected: "native",
     },
     {
+      name: "compressed AIFF-C audio",
+      fileName: "compressed.aifc",
+      mimeType: "audio/aiff",
+      audioCodec: "adpcm_ima_qt",
+      expected: "transcode",
+    },
+    {
       name: "float PCM WAV",
       fileName: "float.wav",
       mimeType: "audio/x-wav",


### PR DESCRIPTION
## What Problem This Solves

Real Apple AIFF attachments were silently discarded by filename-based audio consumers even though OpenClaw's installed `file-type` dependency already identifies their `FORM` container as `audio/aiff`. The older candidate fixed `.aiff` and `.aif`, but still lost genuine compressed `.aifc` attachments. A separate duplicated audio-extension registry also left already-transcribed `.aif` and `.aifc` attachments visible in model prompts.

## Why This Change Was Made

The canonical media MIME owner lacked round-trip mappings for `audio/aiff` and `audio/x-aiff`, and lacked `.aif`/`.aifc` filename aliases. WebChat, media understanding, audio preflight, and playback already consume that shared owner, so restoring all three filename forms there repairs their common root. Prompt-note projection now reuses the same canonical audio classifier instead of maintaining a stale duplicate extension list; only ambiguous WebM and currently unmapped WMA/ALAC retain their existing explicit exceptions.

Installed upstream contracts were inspected directly: `file-type` recognizes `FORM` as `audio/aiff`; `music-metadata` supports both `AIFF` and `AIFC`; and `mime-db` associates `audio/x-aiff` with `.aif`, `.aiff`, and `.aifc`. No dependency, vendor, configuration, storage, plugin-boundary, or public protocol changes are included.

## User Impact

- AIFF, `.aif`, and compressed AIFF-C attachments are recognized as audio, transcribed, displayed in WebChat, and routed through the existing playback transcode policy.
- Audio already transcribed no longer remains in prompt-visible attachment context merely because its filename ends in `.aif` or `.aifc`.
- Existing WAV playback and legacy WebM, WMA, and ALAC prompt suppression remain unchanged.
- Production source shrinks by 11 lines relative to the frozen baseline.

## Evidence

- Frozen canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact isolated branch: `codex/auto-qa-aiff-media`.
- Exact candidate commit: `47ddc133ddb2aaca2600c0404305ee518b8d9a7a`; its direct parent is the frozen canonical baseline.
- Baseline genuine WebChat reproduction: `/System/Library/Sounds/Glass.aiff` and an Apple `afconvert`-generated `FORM/AIFC` attachment each produced **zero** assistant audio blocks; converted `RIFF/WAVE` continued producing one.
- Candidate genuine WebChat proof: all three authentic AIFF, AIFF-C, and WAV attachments each produced **one** correctly labeled assistant audio block.
- Direct exact-head runtime integration: **40 assertions passed**, covering installed byte sniffers, both AIFF forms, lowercase/uppercase extension aliases, MIME round trips, attachment classification, actual WebChat blocks, AIFF/AIFF-C playback transcode routing, WAV native playback, transcribed prompt suppression, and unchanged WebM/WMA/ALAC exceptions.
- Eight-file targeted `oxfmt --check`: passed. Exact-commit `git diff --check`: passed.
- Focused Vitest is intentionally delegated to coordinator-managed remote capacity because the authorized campaign coordinator prohibited local execution while host load exceeded 50–70 on 10 CPUs.
- The separately observed Matrix compressed-AIFF duration parser defect is excluded from this PR and routed to its plugin owner.
- Strict shared root-cause count: **1**; affected consumers are sibling manifestations, not separately countable defects.
- Exact-commit structured Codex gpt-5.6-sol/high autoreview: **clean, zero findings, 0.96 confidence**; official TruffleHog exact-content preflight clean (7.0 seconds).
