### PR TITLE
fix(messages): reply actions leak citation markers and draw the no-reply fallback

### DIFF
--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -367,6 +367,34 @@ describe("isDeliveredMessageToolOnlySourceReplyResult", () => {
     ).toBe(false);
   });
 
+  it("accepts a confirmed current-source poll delivery", () => {
+    expect(
+      isDeliveredMessageToolOnlySourceReplyResult({
+        sourceReplyDeliveryMode: "message_tool_only",
+        toolName: "message",
+        args: { action: "poll", pollQuestion: "Preferred default?", pollOption: ["a", "b"] },
+        result: {
+          details: {
+            ok: true,
+            pollId: "poll-1",
+            sourceReplyRoute: "current-source",
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects an unconfirmed poll delivery", () => {
+    expect(
+      isDeliveredMessageToolOnlySourceReplyResult({
+        sourceReplyDeliveryMode: "message_tool_only",
+        toolName: "message",
+        args: { action: "poll", pollQuestion: "Preferred default?", pollOption: ["a", "b"] },
+        result: { details: { ok: true, pollId: "poll-1" } },
+      }),
+    ).toBe(false);
+  });
+
   it("accepts only confirmed implicit message sends", () => {
     expect(
       isDeliveredMessageToolOnlySourceReplyResult({

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -63,8 +63,11 @@ function isMessageToolSourceReplyActionName(action: unknown): boolean {
   if (typeof action !== "string") {
     return false;
   }
+  // Polls and reply-type actions deliver the visible source answer too; they
+  // qualify only when the runner confirmed the current-source route (or the
+  // caller allows explicit routes), enforced by the caller below.
   const normalized = action.trim().toLowerCase();
-  return normalized === "reply" || normalized === "thread-reply";
+  return normalized === "reply" || normalized === "thread-reply" || normalized === "poll";
 }
 
 function normalizeStatus(value: unknown): string | undefined {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -105,7 +105,9 @@ const mocks = vi.hoisted(() => ({
   prepareOutboundMirrorRoute: vi.fn(),
   beginTerminalSourceReplyDelivery: vi.fn(),
   cancelTerminalSourceReplyDelivery: vi.fn(),
+  isCurrentSourceReplyActionName: vi.fn(() => false),
   isDeliveredCurrentSourceReply: vi.fn(() => false),
+  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
   reconcileTerminalSourceReplyDelivery: vi.fn(),
 }));
 
@@ -131,7 +133,9 @@ vi.mock("./message.gateway.runtime.js", () => ({
 vi.mock("./source-reply-mirror.js", () => ({
   beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
+  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
   isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
+  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
   reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
 }));
 

--- a/src/infra/outbound/message-action-runner.reply-action.test.ts
+++ b/src/infra/outbound/message-action-runner.reply-action.test.ts
@@ -1,0 +1,176 @@
+// Covers reply-type plugin actions: outbound text hygiene (citation control
+// markers) and current-source delivery marking for implicit reply routes.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { runMessageAction } from "./message-action-runner.js";
+
+type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+
+const testchatConfig = {
+  channels: {
+    testchat: {
+      enabled: true,
+    },
+  },
+} as OpenClawConfig;
+
+const CITATION_MARKED_MESSAGE = "Ayutthaya Thai is my pick. citeturn2search9turn2search6";
+
+function createReplyActionPlugin(handleAction: ChannelActionHandler): ChannelPlugin {
+  return {
+    id: "testchat",
+    meta: {
+      id: "testchat",
+      label: "Test Chat",
+      selectionLabel: "Test Chat",
+      docsPath: "/channels/testchat",
+      blurb: "Reply action test plugin.",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isConfigured: () => true,
+    },
+    outbound: {
+      deliveryMode: "direct",
+      sendText: async () => ({ channel: "testchat", messageId: "m-send-1" }),
+    },
+    messaging: {
+      targetResolver: {
+        looksLikeId: () => true,
+      },
+    },
+    actions: {
+      describeMessageTool: () => ({ actions: ["reply"] }),
+      supportsAction: ({ action }) => action === "reply",
+      handleAction,
+    },
+  };
+}
+
+function registerReplyPlugin() {
+  const payload = { ok: true, messageId: "m-reply-1", repliedTo: "platform-guid-1" };
+  const handleAction = vi.fn(async () => ({
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    details: payload,
+  }));
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "testchat", source: "test", plugin: createReplyActionPlugin(handleAction) },
+    ]),
+  );
+  return handleAction;
+}
+
+function readHandledParams(handleAction: {
+  mock: { calls: readonly unknown[][] };
+}): Record<string, unknown> {
+  const [call] = handleAction.mock.calls;
+  const arg = call?.[0];
+  if (typeof arg !== "object" || arg === null || Array.isArray(arg)) {
+    throw new Error("expected plugin handleAction call");
+  }
+  const params = (arg as Record<string, unknown>).params;
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new Error("expected plugin handleAction params");
+  }
+  return params as Record<string, unknown>;
+}
+
+async function runReplyAction(params: {
+  actionParams: Record<string, unknown>;
+  currentMessageId?: string | number;
+}) {
+  const toolContext = {
+    currentChannelProvider: "testchat" as const,
+    currentChannelId: "direct:user-1",
+    ...(params.currentMessageId !== undefined ? { currentMessageId: params.currentMessageId } : {}),
+  };
+  return await runMessageAction({
+    cfg: testchatConfig,
+    action: "reply",
+    params: { channel: "testchat", ...params.actionParams },
+    toolContext,
+    messageActionAuthorization: {
+      requesterAccountId: "default",
+      toolContext,
+    },
+    sessionKey: "agent:main:testchat:direct:user-1",
+    defaultAccountId: "default",
+    sourceReplyDeliveryMode: "message_tool_only",
+    dryRun: false,
+  });
+}
+
+describe("runMessageAction reply-type plugin actions", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("strips citation control markers from reply text before plugin dispatch", async () => {
+    const handleAction = registerReplyPlugin();
+
+    await runReplyAction({
+      actionParams: { message: CITATION_MARKED_MESSAGE, messageId: "1783" },
+      currentMessageId: "1783",
+    });
+
+    const handledParams = readHandledParams(handleAction);
+    expect(handledParams.message).toBe("Ayutthaya Thai is my pick.");
+  });
+
+  it("marks replies to the run's inbound message as current-source deliveries", async () => {
+    registerReplyPlugin();
+
+    const result = await runReplyAction({
+      actionParams: { message: "visible reply", messageId: "1783" },
+      currentMessageId: "1783",
+    });
+
+    expect(result.kind).toBe("action");
+    expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+    const details = "toolResult" in result ? result.toolResult?.details : undefined;
+    expect(details).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it("matches numeric replied-to message ids against string tool-context ids", async () => {
+    registerReplyPlugin();
+
+    const result = await runReplyAction({
+      actionParams: { message: "visible reply", messageId: 1783 },
+      currentMessageId: "1783",
+    });
+
+    expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it("leaves replies to other messages unmarked", async () => {
+    registerReplyPlugin();
+
+    const result = await runReplyAction({
+      actionParams: { message: "visible reply", messageId: "999" },
+      currentMessageId: "1783",
+    });
+
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
+  });
+
+  it("leaves explicitly targeted replies unmarked", async () => {
+    registerReplyPlugin();
+
+    const result = await runReplyAction({
+      actionParams: {
+        message: "visible reply",
+        messageId: "1783",
+        to: "direct:someone-else",
+      },
+      currentMessageId: "1783",
+    });
+
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
+  });
+});

--- a/src/infra/outbound/message-action-runner.reply-action.test.ts
+++ b/src/infra/outbound/message-action-runner.reply-action.test.ts
@@ -45,8 +45,8 @@ function createReplyActionPlugin(handleAction: ChannelActionHandler): ChannelPlu
       },
     },
     actions: {
-      describeMessageTool: () => ({ actions: ["reply"] }),
-      supportsAction: ({ action }) => action === "reply",
+      describeMessageTool: () => ({ actions: ["reply", "poll"] }),
+      supportsAction: ({ action }) => action === "reply" || action === "poll",
       handleAction,
     },
   };
@@ -94,6 +94,33 @@ async function runReplyAction(params: {
     cfg: testchatConfig,
     action: "reply",
     params: { channel: "testchat", ...params.actionParams },
+    toolContext,
+    messageActionAuthorization: {
+      requesterAccountId: "default",
+      toolContext,
+    },
+    sessionKey: "agent:main:testchat:direct:user-1",
+    defaultAccountId: "default",
+    sourceReplyDeliveryMode: "message_tool_only",
+    dryRun: false,
+  });
+}
+
+async function runPollAction(params: { to: string }) {
+  const toolContext = {
+    currentChannelProvider: "testchat" as const,
+    currentChannelId: "direct:user-1",
+    currentMessageId: "1783",
+  };
+  return await runMessageAction({
+    cfg: testchatConfig,
+    action: "poll",
+    params: {
+      channel: "testchat",
+      to: params.to,
+      pollQuestion: "Preferred default?",
+      pollOption: ["Tell me right away", "Only important"],
+    },
     toolContext,
     messageActionAuthorization: {
       requesterAccountId: "default",
@@ -170,6 +197,23 @@ describe("runMessageAction reply-type plugin actions", () => {
       },
       currentMessageId: "1783",
     });
+
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
+  });
+
+  it("marks polls sent to the current conversation as current-source deliveries", async () => {
+    registerReplyPlugin();
+
+    const result = await runPollAction({ to: "direct:user-1" });
+
+    expect(result.kind).toBe("poll");
+    expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it("leaves polls sent to other conversations unmarked", async () => {
+    registerReplyPlugin();
+
+    const result = await runPollAction({ to: "direct:someone-else" });
 
     expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
   });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -295,11 +295,12 @@ function markDeliveredCurrentSourceReply<T extends MessageActionRunResult>(
 ): T {
   // Current-source identity comes from the authorized route and delivery receipt,
   // not the reply mode; automatic runs also use this marker to avoid false fallbacks.
-  // Reply-type actions are visible source replies too: leaving them unmarked made
-  // dispatch send the no-visible-reply fallback after a delivered reply.
+  // Reply-type actions and polls are visible source replies too: leaving them
+  // unmarked made dispatch send the no-visible-reply fallback after a delivered
+  // reply or poll.
   const isReplyActionResult =
     result.kind === "action" && isCurrentSourceReplyActionName(result.action);
-  if (result.kind !== "send" && !isReplyActionResult) {
+  if (result.kind !== "send" && result.kind !== "poll" && !isReplyActionResult) {
     return result;
   }
   const authorization = params.input.messageActionAuthorization;
@@ -307,7 +308,7 @@ function markDeliveredCurrentSourceReply<T extends MessageActionRunResult>(
     return result;
   }
   const mirrorParams = {
-    action: isReplyActionResult ? result.action : "send",
+    action: isReplyActionResult ? result.action : result.kind === "poll" ? "poll" : "send",
     channel: params.channel,
     actionParams: params.actionParams,
     cfg: params.cfg,
@@ -1739,8 +1740,17 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
       dryRun,
     }),
   });
+  const pollReplyToIsExplicit = Boolean(readStringParam(params, "replyTo"));
   if (gatewayPluginAction) {
-    return gatewayPluginAction;
+    return markDeliveredCurrentSourceReply(gatewayPluginAction, {
+      cfg,
+      actionParams: params,
+      channel,
+      accountId,
+      input,
+      agentId,
+      replyToIsExplicit: pollReplyToIsExplicit,
+    });
   }
 
   const poll = await executePollAction({
@@ -1787,17 +1797,28 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     },
   });
 
-  return {
-    kind: "poll",
-    channel,
-    action,
-    to,
-    handledBy: poll.handledBy,
-    payload: poll.payload,
-    toolResult: poll.toolResult,
-    pollResult: poll.pollResult,
-    dryRun,
-  };
+  return markDeliveredCurrentSourceReply(
+    {
+      kind: "poll",
+      channel,
+      action,
+      to,
+      handledBy: poll.handledBy,
+      payload: poll.payload,
+      toolResult: poll.toolResult,
+      pollResult: poll.pollResult,
+      dryRun,
+    },
+    {
+      cfg,
+      actionParams: params,
+      channel,
+      accountId,
+      input,
+      agentId,
+      replyToIsExplicit: pollReplyToIsExplicit,
+    },
+  );
 }
 
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -125,7 +125,9 @@ import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbo
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
+  isCurrentSourceReplyActionName,
   isDeliveredCurrentSourceReply,
+  isDeliveredCurrentSourceReplyAction,
   reconcileTerminalSourceReplyDelivery,
 } from "./source-reply-mirror.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
@@ -293,26 +295,35 @@ function markDeliveredCurrentSourceReply<T extends MessageActionRunResult>(
 ): T {
   // Current-source identity comes from the authorized route and delivery receipt,
   // not the reply mode; automatic runs also use this marker to avoid false fallbacks.
-  if (result.kind !== "send") {
+  // Reply-type actions are visible source replies too: leaving them unmarked made
+  // dispatch send the no-visible-reply fallback after a delivered reply.
+  const isReplyActionResult =
+    result.kind === "action" && isCurrentSourceReplyActionName(result.action);
+  if (result.kind !== "send" && !isReplyActionResult) {
     return result;
   }
   const authorization = params.input.messageActionAuthorization;
+  if (!authorization?.toolContext) {
+    return result;
+  }
+  const mirrorParams = {
+    action: isReplyActionResult ? result.action : "send",
+    channel: params.channel,
+    actionParams: params.actionParams,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    currentAccountId: authorization.requesterAccountId ?? params.input.defaultAccountId,
+    sessionKey: params.input.sessionKey,
+    sessionId: params.input.sessionId,
+    agentId: params.agentId,
+    toolContext: authorization.toolContext,
+    deliveredPayload: result.payload,
+    replyToIsExplicit: params.replyToIsExplicit,
+  };
   if (
-    !authorization?.toolContext ||
-    !isDeliveredCurrentSourceReply({
-      action: "send",
-      channel: params.channel,
-      actionParams: params.actionParams,
-      cfg: params.cfg,
-      accountId: params.accountId,
-      currentAccountId: authorization.requesterAccountId ?? params.input.defaultAccountId,
-      sessionKey: params.input.sessionKey,
-      sessionId: params.input.sessionId,
-      agentId: params.agentId,
-      toolContext: authorization.toolContext,
-      deliveredPayload: result.payload,
-      replyToIsExplicit: params.replyToIsExplicit,
-    })
+    isReplyActionResult
+      ? !isDeliveredCurrentSourceReplyAction(mirrorParams)
+      : !isDeliveredCurrentSourceReply(mirrorParams)
   ) {
     return result;
   }
@@ -1820,6 +1831,16 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     throw new Error(`Channel ${channel} is unavailable for message actions (plugin not loaded).`);
   }
 
+  // Plugin actions bypass buildSendPayloadParts, so model-authored text here
+  // never crossed the outbound text hygiene sends get: reply/edit deliveries
+  // leaked raw citation control markers to end users.
+  const rawActionMessage = params.message;
+  if (typeof rawActionMessage === "string" && rawActionMessage) {
+    params.message = stripPlainTextToolCallBlocks(
+      stripUnsupportedCitationControlMarkers(rawActionMessage),
+    );
+  }
+
   // Plugin actions bypass send/poll, so inherit thread metadata before either
   // gateway or local dispatch to keep both execution modes on the same topic.
   const targetForThreading =
@@ -1856,9 +1877,18 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
       dryRun,
     }),
   });
+  const replyToIsExplicit = Boolean(readStringParam(params, "replyTo"));
   if (gatewayPluginAction) {
     // Gateway-owned actions must execute where the live channel runtime exists.
-    return gatewayPluginAction;
+    return markDeliveredCurrentSourceReply(gatewayPluginAction, {
+      cfg,
+      actionParams: params,
+      channel,
+      accountId,
+      input,
+      agentId,
+      replyToIsExplicit,
+    });
   }
 
   const authorization = input.messageActionAuthorization;
@@ -1892,15 +1922,26 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
   if (!handled) {
     throw new Error(`Message action ${action} not supported for channel ${channel}.`);
   }
-  return {
-    kind: "action",
-    channel,
-    action,
-    handledBy: "plugin",
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-    dryRun,
-  };
+  return markDeliveredCurrentSourceReply(
+    {
+      kind: "action",
+      channel,
+      action,
+      handledBy: "plugin",
+      payload: extractToolPayload(handled),
+      toolResult: handled,
+      dryRun,
+    },
+    {
+      cfg,
+      actionParams: params,
+      channel,
+      accountId,
+      input,
+      agentId,
+      replyToIsExplicit,
+    },
+  );
 }
 
 export async function runMessageAction(

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -372,6 +372,84 @@ export function isDeliveredCurrentSourceReply(params: SourceReplyTranscriptMirro
   );
 }
 
+// `thread-reply` addresses a thread target and only optionally carries a
+// replied-to message id, so the message-id contract below cannot verify it;
+// its current-source marking needs thread-placement validation as follow-up.
+const CURRENT_SOURCE_REPLY_ACTION_NAMES = new Set(["reply"]);
+
+/** Reply-type message actions address a message id rather than a conversation target. */
+export function isCurrentSourceReplyActionName(action: string): boolean {
+  return CURRENT_SOURCE_REPLY_ACTION_NAMES.has(action.trim().toLowerCase());
+}
+
+function normalizeMessageIdValue(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return normalizeOptionalString(value);
+}
+
+/**
+ * Confirms a successful reply-type action addressed the message that triggered the
+ * current run. Reply actions resolve their conversation from the replied-to message,
+ * so target matching cannot apply; replying to the run's own inbound message is the
+ * one implicit route that provably lands in the current source conversation.
+ */
+export function isDeliveredCurrentSourceReplyAction(
+  params: SourceReplyTranscriptMirrorParams,
+): boolean {
+  if (!isCurrentSourceReplyActionName(params.action)) {
+    return false;
+  }
+  if (hasExplicitDeliveryFailure(params.deliveredPayload)) {
+    return false;
+  }
+  if (!params.sessionKey?.trim()) {
+    return false;
+  }
+  const toolContext = params.toolContext;
+  if (!toolContext) {
+    return false;
+  }
+  const accountId = normalizeOptionalString(params.accountId);
+  if (accountId) {
+    const currentAccountId = normalizeOptionalString(params.currentAccountId);
+    if (
+      !currentAccountId ||
+      normalizeAccountId(accountId) !== normalizeAccountId(currentAccountId)
+    ) {
+      return false;
+    }
+  }
+  const currentChannel = normalizeOptionalLowercaseString(toolContext.currentChannelProvider);
+  if (!currentChannel || currentChannel !== normalizeOptionalLowercaseString(params.channel)) {
+    return false;
+  }
+  // Target params on reply actions are either agent-explicit or runner-resolved
+  // from the tool context; both must still address the current conversation.
+  // Delegate equivalence to the channel plugin first so provider-normalized
+  // forms (for example `C123` vs `channel:C123`) are recognized like sends.
+  const requestedTarget = resolveSourceReplyTarget(params.actionParams);
+  if (requestedTarget) {
+    const matchesToolContextTarget = getChannelPlugin(params.channel as ChannelId)?.threading
+      ?.matchesToolContextTarget;
+    if (!matchesToolContextTarget?.({ target: requestedTarget, toolContext })) {
+      const currentTargets = [
+        normalizeOptionalString(toolContext.currentMessagingTarget),
+        normalizeOptionalString(toolContext.currentChannelId),
+      ].filter((target): target is string => Boolean(target));
+      if (!currentTargets.some((target) => target === requestedTarget)) {
+        return false;
+      }
+    }
+  }
+  const repliedToMessageId = normalizeMessageIdValue(
+    params.actionParams.messageId ?? params.actionParams.replyTo,
+  );
+  const currentMessageId = normalizeMessageIdValue(toolContext.currentMessageId);
+  return Boolean(repliedToMessageId && currentMessageId && repliedToMessageId === currentMessageId);
+}
+
 /** Mirrors successful outbound source replies into the owning session transcript. */
 export async function mirrorDeliveredSourceReplyToTranscript(
   params: SourceReplyTranscriptMirrorParams,

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -295,7 +295,10 @@ function isCurrentSourceConversation(
     resolveChannelThreadAddressing(params.channel),
   ),
 ): params is MirrorableSourceReplyTranscriptParams {
-  if (params.action !== "send") {
+  // Polls share the send target contract: `to` addresses a conversation, so the
+  // same current-source matching applies. Transcript mirroring stays send-only
+  // because poll params carry no message text to mirror.
+  if (params.action !== "send" && params.action !== "poll") {
     return false;
   }
   if (!params.sessionKey?.trim()) {


### PR DESCRIPTION
Related: #85193, #116560

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users receiving an agent answer sent via `message(action=reply)` would see raw model citation control markers (the `citeturn2search…` private-use span rendered as garbage glyphs) inside the delivered message, immediately followed by a spurious "No reply was generated for this message. This is usually a temporary model failure - please try again." bubble in the same conversation.

Observed in production on 2026-07-30 (gateway 2026.7.2-beta.5, Codex harness, iMessage DM): the model answered with `message(action=reply, messageId=<inbound id>)` and finished the turn with `NO_REPLY`. The delivered platform message body contained the raw U+E200/U+E202/U+E201 citation span, and the no-visible-reply fallback fired anyway.

The same false fallback reproduced the next morning (2026-07-31 09:00 PT) with `message(action=poll)`: the user received and voted on the poll, then got the same "No reply was generated" bubble. Poll results (`kind: "poll"`) were never marked as current-source deliveries either, and the embedded delivery check rejects `poll` at its action-name gate even though it already knows how to read `pollId` receipts.

## Why This Change Was Made

`action=reply` routes through the generic plugin-action path (`handlePluginAction`), which never crossed the outbound text hygiene that sends get in `buildSendPayloadParts` — so the citation-marker strip added by #85204 for #85193 did not cover replies. The same path also never marks a successful delivery as a current-source reply: `markDeliveredCurrentSourceReply` required `result.kind === "send"` (still true after #116560), so `isDeliveredMessageToolOnlySourceReplyResult` rejected the reply and the dispatcher injected the fallback after the `NO_REPLY` final.

The change (1) strips citation control markers and plaintext tool-call blocks from plugin-action `message` text before either gateway RPC or local dispatch, (2) marks a successful `reply` that addresses the run's own inbound message (`messageId`/`replyTo` equal to `toolContext.currentMessageId`, same account and channel, any target param still matching the current conversation — with channel-plugin `matchesToolContextTarget` equivalence like sends) as `sourceReplyRoute: "current-source"`, and (3) marks authorized same-conversation poll deliveries current-source (polls share the send `to` target contract) and accepts runner-confirmed polls in the embedded source-reply check. Transcript mirroring stays send-only; polls sent to other conversations stay unmarked.

Non-goal: `thread-reply` keeps its previous behavior. It addresses a thread target and only optionally carries a replied-to id, so the message-id contract here cannot verify it; its current-source marking needs thread-placement validation as follow-up.

## User Impact

Replies sent through the message tool no longer leak citation-marker garbage into chat text on any channel, and answering via `reply` or a `poll` followed by `NO_REPLY` no longer produces the false "No reply was generated" error bubble after a successfully delivered answer.

## Evidence

**After-fix exact-path runtime proof** (2026-07-31, gateway built from this branch at `f26b451`, macOS, live iMessage DM; private values redacted):

- The inbound message instructed the agent to (1) `message(action="reply")` with text containing the real citation control span U+E200 `cite` U+E202 `turn0search1` U+E201, (2) `message(action="poll")` with two options, (3) end the turn with `NO_REPLY`.
- Session transcript (agent SQLite store): tool call `{"action":"reply","message":"Proof reply \ue200cite\ue202turn0search1\ue201 ok"}` — verified the arguments contain the actual private-use characters — returned `{"ok":true,"messageId":"A2C7BEE8-…","repliedTo":"B62B4299-…"}`; then `{"action":"poll","pollQuestion":"Proof poll?","pollOption":["Alpha","Beta"]}` returned `{"ok":true,"messageId":"DE127B1F-…"}`; final assistant text `NO_REPLY`.
- Delivered platform bytes (Messages store `attributedBody`, outbound row 14:22:28): text is `Proof reply  ok` — **zero private-use-area characters survive**; the poll (`Proof poll?`, Alpha/Beta) delivered at 14:22:34 and renders/votes normally.
- **No "No reply was generated" fallback was sent after the turn.** The most recent fallback row in the same store remains the pre-fix poll incident from earlier the same morning (09:11), giving an in-sequence before/after on identical hardware and channel.

**Unplanned same-day control run:** after the proof, the production gateway (unpatched 2026.7.2-beta.5) came back online and its channel catch-up re-answered the *same* proof instruction four minutes later: its reply leaked the raw citation span into the delivered text and it followed the duplicate poll with the "No reply was generated" fallback. Same instruction, same device, same channel — patched build clean at 14:22, unpatched build reproducing both defects at 14:26.

Pre-fix incident (root-cause evidence): production session transcript shows the tool call `{action: "reply", messageId: "<inbound id>", message: "…citeturn2search9turn2search6"}` with an `ok: true` delivery result, and the platform message store contains the delivered body with the raw markers, followed by the fallback text as the next outbound message.

Deterministic regression tests (`src/infra/outbound/message-action-runner.reply-action.test.ts`, real runner + registered channel plugin, real `source-reply-mirror` logic):

- strips citation control markers from reply text before plugin dispatch (fails on old behavior)
- marks replies to the run's inbound message as current-source deliveries (fails on old behavior)
- matches numeric replied-to message ids against string tool-context ids
- leaves replies to other messages unmarked
- leaves explicitly targeted replies unmarked
- marks polls sent to the current conversation as current-source deliveries (fails on old behavior)
- leaves polls sent to other conversations unmarked
- embedded detection: accepts confirmed current-source poll deliveries, rejects unconfirmed ones

Validation: focused suites pass (`message-action-runner.reply-action`, `message-action-runner.plugin-dispatch`, `message-action-runner.core-send`, `source-reply-mirror`, `embedded-agent-message-tool-source-reply` — 150 tests), `pnpm check:changed` core lanes green, `oxfmt` clean, Codex autoreview (gpt-5.6-sol, high) clean after addressing two findings (thread-reply exclusion, provider-normalized target equivalence).
