### PR TITLE
fix(qa): preserve account readiness, receipt threads, and failure evidence

### DIFF
--- a/extensions/qa-channel/src/channel.test.ts
+++ b/extensions/qa-channel/src/channel.test.ts
@@ -291,7 +291,6 @@ describe("qa-channel plugin", () => {
           text: "hello",
           accountId: "default",
           replyToId: "parent-1",
-          threadId: "thread-1",
         });
         const receiptPart = result.receipt.parts[0];
         expect(receiptPart?.kind).toBe("text");
@@ -312,7 +311,6 @@ describe("qa-channel plugin", () => {
           },
           accountId: "default",
           replyToId: "parent-1",
-          threadId: "thread-1",
         };
         const result =
           kind === "payload"

--- a/extensions/qa-channel/src/channel.ts
+++ b/extensions/qa-channel/src/channel.ts
@@ -39,6 +39,20 @@ type QaChannelPayloadSendContext = Pick<
   | "mediaReadFile"
 >;
 
+function createQaChannelMessageReceipt(
+  ctx: Pick<QaChannelPayloadSendContext, "replyToId" | "threadId" | "to">,
+  messageId: string,
+  kind: "media" | "text",
+) {
+  const { threadId } = resolveQaTargetThread({ target: ctx.to, threadId: ctx.threadId });
+  return createMessageReceiptFromOutboundResults({
+    results: [{ channel: QA_CHANNEL_ID, messageId }],
+    threadId,
+    replyToId: ctx.replyToId ?? undefined,
+    kind,
+  });
+}
+
 async function sendQaChannelMessagePayload(ctx: QaChannelPayloadSendContext) {
   const text = ctx.payload.text ?? ctx.text;
   const mediaUrls = Array.from(
@@ -69,12 +83,11 @@ async function sendQaChannelMessagePayload(ctx: QaChannelPayloadSendContext) {
         });
   return {
     messageId: result.messageId,
-    receipt: createMessageReceiptFromOutboundResults({
-      results: [{ channel: QA_CHANNEL_ID, messageId: result.messageId }],
-      threadId: ctx.threadId == null ? undefined : String(ctx.threadId),
-      replyToId: ctx.replyToId ?? undefined,
-      kind: mediaUrls.length > 0 ? "media" : "text",
-    }),
+    receipt: createQaChannelMessageReceipt(
+      ctx,
+      result.messageId,
+      mediaUrls.length > 0 ? "media" : "text",
+    ),
   };
 }
 
@@ -102,16 +115,9 @@ const qaChannelMessageAdapter = defineChannelMessageAdapter({
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
       });
-      const threadId = ctx.threadId == null ? undefined : String(ctx.threadId);
-      const replyToId = ctx.replyToId ?? undefined;
       return {
         messageId: result.messageId,
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: QA_CHANNEL_ID, messageId: result.messageId }],
-          threadId,
-          replyToId,
-          kind: "text",
-        }),
+        receipt: createQaChannelMessageReceipt(ctx, result.messageId, "text"),
       };
     },
     media: async (ctx) => {
@@ -129,12 +135,7 @@ const qaChannelMessageAdapter = defineChannelMessageAdapter({
       });
       return {
         messageId: result.messageId,
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: QA_CHANNEL_ID, messageId: result.messageId }],
-          threadId: ctx.threadId == null ? undefined : String(ctx.threadId),
-          replyToId: ctx.replyToId ?? undefined,
-          kind: "media",
-        }),
+        receipt: createQaChannelMessageReceipt(ctx, result.messageId, "media"),
       };
     },
   },

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
@@ -134,6 +134,43 @@ describe("Matrix QA fault proxy", () => {
     ]);
   });
 
+  it.each(["forwarded", "faulted"] as const)(
+    "finishes the %s response when its exchange observer rejects",
+    async (mode) => {
+      const target = await startTargetServer();
+      let observations = 0;
+      proxy = await startMatrixQaFaultProxy({
+        targetBaseUrl: target.baseUrl,
+        rules:
+          mode === "faulted"
+            ? [
+                {
+                  id: "synthetic-fault",
+                  match: () => true,
+                  response: () => ({ body: { errcode: "M_QA_FAULT" }, status: 503 }),
+                },
+              ]
+            : [],
+        onExchange: async () => {
+          observations += 1;
+          throw new Error("capture observer failed");
+        },
+      });
+
+      const response = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toMatchObject({
+        errcode: "MATRIX_QA_FAULT_PROXY_ERROR",
+        error: "capture observer failed",
+      });
+      expect(observations).toBe(1);
+      expect(target.requests).toHaveLength(mode === "forwarded" ? 1 : 0);
+    },
+  );
+
   it("rejects request targets that resolve outside the configured origin", async () => {
     const target = await startTargetServer();
     proxy = await startMatrixQaFaultProxy({ targetBaseUrl: target.baseUrl, rules: [] });

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.ts
@@ -366,6 +366,22 @@ export async function startMatrixQaFaultProxy(
     void (async () => {
       let observedRequest: MatrixQaFaultProxyRequest | undefined;
       let observedContext: unknown;
+      let observerNotified = false;
+      const observeExchange = async (
+        request: MatrixQaFaultProxyRequest,
+        response: MatrixQaFaultProxyForwardedResponse,
+        context?: unknown,
+      ) => {
+        if (!params.onExchange) {
+          return;
+        }
+        observerNotified = true;
+        await params.onExchange({
+          ...(context !== undefined ? { context } : {}),
+          request,
+          response,
+        });
+      };
       try {
         const requestTarget = req.url ?? "/";
         if (!requestTarget.startsWith("/") || requestTarget.startsWith("//")) {
@@ -408,11 +424,7 @@ export async function startMatrixQaFaultProxy(
           });
           if (rule.response) {
             const response = normalizeJsonResponse(rule.response(request));
-            await params.onExchange?.({
-              ...(context !== undefined ? { context } : {}),
-              request,
-              response,
-            });
+            await observeExchange(request, response, context);
             writeForwardedResponse(res, response);
             return;
           }
@@ -431,11 +443,7 @@ export async function startMatrixQaFaultProxy(
                 response: forwarded,
               })
             : forwarded;
-        await params.onExchange?.({
-          ...(context !== undefined ? { context } : {}),
-          request,
-          response,
-        });
+        await observeExchange(request, response, context);
         writeForwardedResponse(res, response);
       } catch (error) {
         const failure =
@@ -456,12 +464,12 @@ export async function startMatrixQaFaultProxy(
                 status: 502,
               };
         const response = normalizeJsonResponse(failure);
-        if (observedRequest) {
-          await params.onExchange?.({
-            ...(observedContext !== undefined ? { context: observedContext } : {}),
-            request: observedRequest,
-            response,
-          });
+        if (observedRequest && !observerNotified) {
+          try {
+            await observeExchange(observedRequest, response, observedContext);
+          } catch {
+            // Capture is diagnostic; its failure must not strand the original HTTP response.
+          }
         }
         if (!res.destroyed) {
           writeForwardedResponse(res, response, {

--- a/extensions/qa-lab/src/qa-channel-transport.test.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.test.ts
@@ -84,6 +84,19 @@ describe("qa channel transport", () => {
     expect(call).toHaveBeenCalledTimes(2);
   });
 
+  it("does not report another running account as the default account", async () => {
+    const transport = createQaChannelTransport(createQaBusState());
+    const call = vi.fn().mockResolvedValue({
+      channelAccounts: {
+        "qa-channel": [{ accountId: "other", running: true, restartPending: false }],
+      },
+    });
+
+    await expect(
+      transport.waitReady({ gateway: { call }, timeoutMs: 5, pollIntervalMs: 1 }),
+    ).rejects.toThrow('qa-channel account "default" not reported; available accounts: other');
+  });
+
   it("surfaces the last reported qa-channel account status on timeout", async () => {
     const transport = createQaChannelTransport(createQaBusState());
     const call = vi.fn().mockResolvedValue({

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -52,8 +52,7 @@ async function waitForQaChannelReady(params: {
         >;
       };
       const accounts = payload.channelAccounts?.[QA_CHANNEL_ID] ?? [];
-      const account =
-        accounts.find((entry) => entry.accountId === QA_CHANNEL_ACCOUNT_ID) ?? accounts[0];
+      const account = accounts.find((entry) => entry.accountId === QA_CHANNEL_ACCOUNT_ID);
       lastProbeError = null;
       lastAccountStatus = account
         ? JSON.stringify({
@@ -61,7 +60,11 @@ async function waitForQaChannelReady(params: {
             running: account.running ?? null,
             restartPending: account.restartPending ?? null,
           })
-        : "no qa-channel accounts reported";
+        : accounts.length > 0
+          ? `qa-channel account "${QA_CHANNEL_ACCOUNT_ID}" not reported; available accounts: ${accounts
+              .map((entry) => entry.accountId ?? "unknown")
+              .join(", ")}`
+          : "no qa-channel accounts reported";
       if (account?.running && account.restartPending !== true) {
         return;
       }

--- a/extensions/qa-lab/src/report.test.ts
+++ b/extensions/qa-lab/src/report.test.ts
@@ -24,8 +24,39 @@ describe("renderQaMarkdownReport", () => {
     expect(report).toContain("- Duration ms: 2000");
     expect(report).toContain("- Passed: 1");
     expect(report).toContain("- Failed: 1");
+    expect(report).toContain("- Skipped: 0");
     expect(report).toContain("```text\nline one\nline two\n```");
     expect(report).toContain("- [x] send");
     expect(report).toContain("## Timeline");
+  });
+
+  it("counts skipped coverage and distinguishes skipped checks from failures", () => {
+    const report = renderQaMarkdownReport({
+      title: "QA Report",
+      startedAt: new Date("2026-01-01T00:00:00.000Z"),
+      finishedAt: new Date("2026-01-01T00:00:01.000Z"),
+      checks: [
+        { name: "unavailable check", status: "skip" },
+        { name: "broken check", status: "fail" },
+      ],
+      scenarios: [
+        {
+          name: "unavailable scenario",
+          status: "skip",
+          steps: [
+            { name: "unavailable step", status: "skip" },
+            { name: "broken step", status: "fail" },
+          ],
+        },
+      ],
+    });
+
+    expect(report).toContain("- Passed: 0");
+    expect(report).toContain("- Failed: 1");
+    expect(report).toContain("- Skipped: 2");
+    expect(report).toContain("- [ ] unavailable check (skip)");
+    expect(report).toContain("- [ ] broken check (fail)");
+    expect(report).toContain("  - [ ] unavailable step (skip)");
+    expect(report).toContain("  - [ ] broken step (fail)");
   });
 });

--- a/extensions/qa-lab/src/report.ts
+++ b/extensions/qa-lab/src/report.ts
@@ -20,6 +20,12 @@ function pushQaReportDetailsBlock(lines: string[], label: string, details: strin
   lines.push("", "```text", details, "```");
 }
 
+function formatQaReportCheck(check: QaReportCheck, indent = "") {
+  const marker = check.status === "pass" ? "x" : " ";
+  const outcome = check.status === "pass" ? "" : ` (${check.status})`;
+  return `${indent}- [${marker}] ${check.name}${outcome}`;
+}
+
 export function renderQaMarkdownReport(params: {
   title: string;
   startedAt: Date;
@@ -37,6 +43,9 @@ export function renderQaMarkdownReport(params: {
   const failCount =
     checks.filter((check) => check.status === "fail").length +
     scenarios.filter((scenario) => scenario.status === "fail").length;
+  const skipCount =
+    checks.filter((check) => check.status === "skip").length +
+    scenarios.filter((scenario) => scenario.status === "skip").length;
 
   const lines = [
     `# ${params.title}`,
@@ -46,13 +55,14 @@ export function renderQaMarkdownReport(params: {
     `- Duration ms: ${params.finishedAt.getTime() - params.startedAt.getTime()}`,
     `- Passed: ${passCount}`,
     `- Failed: ${failCount}`,
+    `- Skipped: ${skipCount}`,
     "",
   ];
 
   if (checks.length > 0) {
     lines.push("## Checks", "");
     for (const check of checks) {
-      lines.push(`- [${check.status === "pass" ? "x" : " "}] ${check.name}`);
+      lines.push(formatQaReportCheck(check));
       if (check.details) {
         pushQaReportDetailsBlock(lines, "Details", check.details, "  ");
       }
@@ -71,7 +81,7 @@ export function renderQaMarkdownReport(params: {
       if (scenario.steps?.length) {
         lines.push("- Steps:");
         for (const step of scenario.steps) {
-          lines.push(`  - [${step.status === "pass" ? "x" : " "}] ${step.name}`);
+          lines.push(formatQaReportCheck(step, "  "));
           if (step.details) {
             pushQaReportDetailsBlock(lines, "Details", step.details, "    ");
           }


### PR DESCRIPTION
## What Problem This Solves

The private QA subsystem had four independent ownership and reporting failures: a running unrelated account could falsely satisfy synthetic-channel readiness; deliveries addressed with an encoded thread target lost that thread in their receipts; a rejecting Matrix fault-proxy observer was invoked twice, escaped as an unhandled rejection, and stranded the HTTP response; and QA Markdown reports omitted skipped totals while presenting skipped checks identically to failures.

## Why This Change Was Made

- Require the exact QA transport account and report the actual available accounts when it is absent.
- Resolve one canonical synthetic-channel thread from the target and explicit metadata for every text, media, and payload receipt.
- Notify Matrix fault-proxy observers at most once and always finish the owning HTTP response, including forwarded and injected-fault paths.
- Count skipped checks and scenarios and visibly distinguish skipped and failed checks and scenario steps.

## User Impact

1. QA scenarios cannot start against the wrong synthetic account and fail later without an actionable readiness diagnosis.
2. Thread-aware text, generated-media, and combined payload deliveries retain accurate thread ownership in both receipt levels.
3. Fault-injection and recording observer failures return a completed, visible HTTP error instead of hanging the runner or raising an unhandled rejection.
4. Operators can see unavailable coverage and distinguish skipped checks from genuine failures in the normal QA report.

All four changes remain inside the private `qa-channel` / `qa-lab` owners. Public protocol, configuration, authentication, persistent state, SQLite, provider contracts, and the canonical `main` checkout are unchanged.

## Evidence

- Frozen clean canonical parent: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact isolated candidate: `1089a898b17e5f1a350377dfb1a290d890fd8df9`.
- Focused single-worker owner suites: **27 tests passed across three files**, covering exact-account readiness, forwarded and injected-fault observer rejection, and truthful skipped report rendering.
- A real disposable localhost QA bus independently exercised **all three synthetic delivery modes**; text, media, and payload each returned `topic-1` at both receipt levels, and the payload preserved one deduplicated physical media attachment.
- A real disposable localhost fault proxy returned HTTP **502**, exposed the original observer error, and notified the rejecting observer exactly once.
- The real default-account readiness probe rejected a running `foreign-account` and included the unavailable `default` account plus the reported account in its diagnostic.
- Report rendering includes `Skipped: 2` and distinct `(skip)` / `(fail)` statuses for both checks and scenario steps.
- All eight changed files passed targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check`.
- Exact-commit structured autoreview (`codex`, `gpt-5.6-sol`, reasoning `high`): **clean, zero findings, confidence 0.94**. Genuine campaign-shared TruffleHog secret scan: **clean**.
- The full synthetic-channel owner test file was deliberately stopped during its expensive repository-graph transform on the overloaded host; its changed invariant is instead proved through the real three-mode localhost transport boundary above.
