### PR TITLE
fix(qa): verify requested scenarios and reject silent character runs

### DIFF
--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -523,6 +523,38 @@ describe("runQaCharacterEval", () => {
     expect(result.runs[0]?.error).toBeUndefined();
   });
 
+  it.each([
+    { description: "user-only conversation", transcript: "USER Alice: hello?" },
+    { description: "report-only fallback", transcript: "# Character scenario report" },
+  ])("rejects a passing suite with a $description", async ({ transcript }) => {
+    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
+      makeSuiteResult({
+        outputDir: params.outputDir,
+        model: params.primaryModel,
+        transcript,
+      }),
+    );
+    const runJudge = makeRunJudge([
+      { model: "openai/gpt-5.6-luna", rank: 1, score: 0.5, summary: "no reply" },
+    ]);
+
+    const result = await runQaCharacterEval({
+      repoRoot: tempRoot,
+      outputDir: path.join(tempRoot, "character"),
+      models: ["openai/gpt-5.6-luna"],
+      judgeModels: ["openai/gpt-5.6-luna"],
+      runSuite,
+      runJudge,
+    });
+
+    expectFirstRunFailure(result, {
+      model: "openai/gpt-5.6-luna",
+      error: "candidate transcript did not contain an assistant reply",
+    });
+    expect(result.runs[0]?.stats.assistantTurns).toBe(0);
+    expect(result.runs[0]?.transcript).toBe(transcript);
+  });
+
   it("marks raw tool failure transcripts as failed output", async () => {
     const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
       makeSuiteResult({

--- a/extensions/qa-lab/src/character-eval.ts
+++ b/extensions/qa-lab/src/character-eval.ts
@@ -543,7 +543,14 @@ export async function runQaCharacterEval(params: QaCharacterEvalParams) {
           scenarioIds: [scenarioId],
         });
         const transcript = extractTranscript(result);
-        const transcriptFailure = detectTranscriptFailure(transcript);
+        const stats = collectTranscriptStats(transcript);
+        // Character capture tolerates missed turns, so a passing scenario alone
+        // cannot prove this candidate ever delivered an assistant reply.
+        const transcriptFailure =
+          detectTranscriptFailure(transcript) ??
+          (stats.assistantTurns === 0
+            ? "candidate transcript did not contain an assistant reply"
+            : undefined);
         const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(
           result.summaryPath,
         );
@@ -558,7 +565,7 @@ export async function runQaCharacterEval(params: QaCharacterEvalParams) {
           reportPath: result.reportPath,
           summaryPath: result.summaryPath,
           transcript,
-          stats: collectTranscriptStats(transcript),
+          stats,
           ...(transcriptFailure ? { error: transcriptFailure } : {}),
         } satisfies QaCharacterEvalRun;
         logCharacterEvalProgress(

--- a/extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts
@@ -45,7 +45,18 @@ describe("QA native Vitest scenario routing", () => {
           }
           await fs.writeFile(
             reportArg.slice("--outputFile.json=".length),
-            JSON.stringify({ numFailedTests: 0, numPassedTests: 1, success: true }),
+            JSON.stringify({
+              numFailedTests: 0,
+              numPassedTests: 1,
+              success: true,
+              testResults: [
+                {
+                  name: path.join(repoRoot, testPath),
+                  status: "passed",
+                  assertionResults: [{ fullName: "runs paired node inference", status: "passed" }],
+                },
+              ],
+            }),
             "utf8",
           );
           return { exitCode: 0, stdout: "1 passed\n", stderr: "" };

--- a/extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts
@@ -31,6 +31,9 @@ describe("QA native Vitest scenario routing", () => {
     };
 
     try {
+      const requestedTestFile = path.join(repoRoot, testPath);
+      await fs.mkdir(path.dirname(requestedTestFile), { recursive: true });
+      await fs.writeFile(requestedTestFile, "// native scenario fixture\n", "utf8");
       const result = await runQaTestFileScenarios({
         repoRoot,
         outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", scenario.id),

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -121,13 +121,24 @@ async function makeTempRepo(prefix: string) {
 
 async function writeNativeVitestReport(
   command: QaScenarioCommandExecution,
-  counts: { failed?: number; passed: number; testFilePath?: string; testName?: string },
+  counts: {
+    createRequestedTestFile?: boolean;
+    failed?: number;
+    passed: number;
+    testFilePath?: string;
+    testName?: string;
+  },
 ) {
   const reportArg = command.args.find((arg) => arg.startsWith("--outputFile.json="));
   if (!reportArg) {
     return;
   }
   const requestedTestPath = command.args.find((arg) => arg.endsWith(".test.ts"));
+  if (requestedTestPath && counts.createRequestedTestFile !== false) {
+    const requestedTestFile = path.resolve(command.cwd, requestedTestPath);
+    await fs.mkdir(path.dirname(requestedTestFile), { recursive: true });
+    await fs.writeFile(requestedTestFile, "// native scenario fixture\n", "utf8");
+  }
   const testNamePatternIndex = command.args.indexOf("--testNamePattern");
   const testName =
     counts.testName ??
@@ -491,6 +502,37 @@ describe("qa test file scenario runner", () => {
 
       expect(result.results[0]).toMatchObject({
         failureMessage: expect.stringContaining("requested test file"),
+        status: "fail",
+      });
+      expect(result.evidence.entries[0]?.result.status).toBe("fail");
+    },
+  );
+
+  it.each([{ executionKind: "vitest" as const }, { executionKind: "playwright" as const }])(
+    "rejects a passing $executionKind report when the requested test file does not exist",
+    async ({ executionKind }) => {
+      const repoRoot = await makeTempRepo(`qa-${executionKind}-missing-requested-test-`);
+      const scenarioPath =
+        executionKind === "playwright"
+          ? "ui/src/e2e/chat-flow.e2e.test.ts"
+          : "extensions/qa-lab/src/coverage-report.test.ts";
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", `scenario-${executionKind}`),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        scenarios: [makeTestFileScenario(executionKind, scenarioPath)],
+        runCommand: async (command) => {
+          await writeNativeVitestReport(command, {
+            createRequestedTestFile: false,
+            passed: 1,
+          });
+          return { exitCode: 0, stdout: "missing test reportedly passed\n", stderr: "" };
+        },
+      });
+
+      expect(result.results[0]).toMatchObject({
+        failureMessage: expect.stringContaining("existing requested test file"),
         status: "fail",
       });
       expect(result.evidence.entries[0]?.result.status).toBe("fail");

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -121,18 +121,32 @@ async function makeTempRepo(prefix: string) {
 
 async function writeNativeVitestReport(
   command: QaScenarioCommandExecution,
-  counts: { failed?: number; passed: number },
+  counts: { failed?: number; passed: number; testFilePath?: string; testName?: string },
 ) {
   const reportArg = command.args.find((arg) => arg.startsWith("--outputFile.json="));
   if (!reportArg) {
     return;
   }
+  const requestedTestPath = command.args.find((arg) => arg.endsWith(".test.ts"));
+  const testNamePatternIndex = command.args.indexOf("--testNamePattern");
+  const testName =
+    counts.testName ??
+    (testNamePatternIndex < 0 ? undefined : command.args[testNamePatternIndex + 1]) ??
+    "executes the requested scenario";
   await fs.writeFile(
     reportArg.slice("--outputFile.json=".length),
     JSON.stringify({
       numFailedTests: counts.failed ?? 0,
       numPassedTests: counts.passed,
       success: (counts.failed ?? 0) === 0,
+      testResults: [
+        {
+          name: path.resolve(command.cwd, counts.testFilePath ?? requestedTestPath ?? "unknown"),
+          status: counts.passed > 0 ? "passed" : "skipped",
+          assertionResults:
+            counts.passed > 0 ? [{ fullName: testName, title: testName, status: "passed" }] : [],
+        },
+      ],
     }),
     "utf8",
   );
@@ -447,6 +461,122 @@ describe("qa test file scenario runner", () => {
       }
     },
   );
+
+  it.each([{ executionKind: "vitest" as const }, { executionKind: "playwright" as const }])(
+    "rejects a passing $executionKind report for an unrelated test file",
+    async ({ executionKind }) => {
+      const repoRoot = await makeTempRepo(`qa-${executionKind}-wrong-report-file-`);
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", `scenario-${executionKind}`);
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        scenarios: [
+          makeTestFileScenario(
+            executionKind,
+            executionKind === "playwright"
+              ? "ui/src/e2e/chat-flow.e2e.test.ts"
+              : "extensions/qa-lab/src/coverage-report.test.ts",
+          ),
+        ],
+        runCommand: async (command) => {
+          await writeNativeVitestReport(command, {
+            passed: 1,
+            testFilePath: "extensions/qa-lab/src/unrelated.test.ts",
+          });
+          return { exitCode: 0, stdout: "unrelated test passed\n", stderr: "" };
+        },
+      });
+
+      expect(result.results[0]).toMatchObject({
+        failureMessage: expect.stringContaining("requested test file"),
+        status: "fail",
+      });
+      expect(result.evidence.entries[0]?.result.status).toBe("fail");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "authenticates requested tests when the checkout root is a symlink",
+    async () => {
+      const canonicalRoot = await fs.realpath(await makeTempRepo("qa-vitest-symlinked-checkout-"));
+      const symlinkedRoot = path.join(canonicalRoot, "checkout-alias");
+      await fs.symlink(canonicalRoot, symlinkedRoot, "dir");
+      const scenarioPath = "extensions/qa-lab/src/coverage-report.test.ts";
+      const result = await runQaTestFileScenarios({
+        repoRoot: symlinkedRoot,
+        outputDir: path.join(symlinkedRoot, ".artifacts", "qa-e2e", "scenario-vitest"),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        scenarios: [makeTestFileScenario("vitest", scenarioPath)],
+        runCommand: async (command) => {
+          await writeNativeVitestReport(command, {
+            passed: 1,
+            testFilePath: path.join(canonicalRoot, scenarioPath),
+          });
+          return { exitCode: 0, stdout: "canonical test passed\n", stderr: "" };
+        },
+      });
+
+      expect(result.results[0]).toMatchObject({ status: "pass" });
+      expect(result.evidence.entries[0]?.result.status).toBe("pass");
+    },
+  );
+
+  it("rejects a passing Playwright report that misses the requested test name", async () => {
+    const repoRoot = await makeTempRepo("qa-playwright-wrong-report-test-");
+    const result = await runQaTestFileScenarios({
+      repoRoot,
+      outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-playwright"),
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      scenarios: [
+        makeTestFileScenario(
+          "playwright",
+          "ui/src/e2e/chat-flow.e2e.test.ts",
+          "required visual assertion",
+        ),
+      ],
+      runCommand: async (command) => {
+        await writeNativeVitestReport(command, {
+          passed: 1,
+          testName: "unrelated visual assertion",
+        });
+        return { exitCode: 0, stdout: "unrelated assertion passed\n", stderr: "" };
+      },
+    });
+
+    expect(result.results[0]).toMatchObject({
+      failureMessage: expect.stringContaining("requested test name"),
+      status: "fail",
+    });
+    expect(result.evidence.entries[0]?.result.status).toBe("fail");
+  });
+
+  it("records invalid Playwright test-name patterns as failed scenario evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-playwright-invalid-report-pattern-");
+    const result = await runQaTestFileScenarios({
+      repoRoot,
+      outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-playwright"),
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      scenarios: [makeTestFileScenario("playwright", "ui/src/e2e/chat-flow.e2e.test.ts", "[")],
+      runCommand: async (command) => {
+        await writeNativeVitestReport(command, {
+          passed: 1,
+          testName: "executed visual assertion",
+        });
+        return { exitCode: 0, stdout: "visual assertion passed\n", stderr: "" };
+      },
+    });
+
+    expect(result.results[0]).toMatchObject({
+      failureMessage: expect.stringContaining("invalid requested test name pattern"),
+      status: "fail",
+    });
+    expect(result.evidence.entries[0]?.result.status).toBe("fail");
+  });
 
   it.each([{ executionKind: "vitest" as const }, { executionKind: "playwright" as const }])(
     "does not reuse a prior passing $executionKind report when the next child writes none",

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -241,8 +241,31 @@ function withScenarioCoverage(
   return { ...entry, coverage: coverageForScenario(scenario) };
 }
 
+async function canonicalizeNativeTestFilePath(params: {
+  canonicalRepoRoot: string;
+  repoRoot: string;
+  testPath: string;
+}) {
+  const absoluteTestPath = path.resolve(params.repoRoot, params.testPath);
+  const canonicalTestPath = await fs.realpath(absoluteTestPath).catch(() => undefined);
+  if (canonicalTestPath) {
+    return canonicalTestPath;
+  }
+
+  const repoRelativePath = path.relative(params.repoRoot, absoluteTestPath);
+  if (
+    repoRelativePath !== ".." &&
+    !repoRelativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(repoRelativePath)
+  ) {
+    return path.resolve(params.canonicalRepoRoot, repoRelativePath);
+  }
+  return absoluteTestPath;
+}
+
 async function readNativeVitestExecutionFailure(params: {
   outputDir: string;
+  repoRoot: string;
   scenario: QaTestFileScenario;
 }): Promise<string | undefined> {
   const reportPath = resolveNativeVitestReportPath(params.scenario, params.outputDir);
@@ -250,10 +273,14 @@ async function readNativeVitestExecutionFailure(params: {
   if (!report || typeof report !== "object") {
     return `Vitest exited successfully without writing a valid JSON test report at ${reportPath}.`;
   }
-  const { numFailedTests, numPassedTests, success } = report as {
+  const { numFailedTests, numPassedTests, success, testResults } = report as {
     numFailedTests?: unknown;
     numPassedTests?: unknown;
     success?: unknown;
+    testResults?: Array<{
+      name?: unknown;
+      assertionResults?: Array<{ fullName?: unknown; status?: unknown; title?: unknown }>;
+    }>;
   };
   if (
     success !== true ||
@@ -263,6 +290,55 @@ async function readNativeVitestExecutionFailure(params: {
     numFailedTests !== 0
   ) {
     return "Vitest exited successfully without reporting a successfully executed test.";
+  }
+  const canonicalRepoRoot = await fs.realpath(params.repoRoot);
+  const expectedTestPath = await canonicalizeNativeTestFilePath({
+    canonicalRepoRoot,
+    repoRoot: params.repoRoot,
+    testPath: params.scenario.execution.path,
+  });
+  const matchingTestResult = (
+    await Promise.all(
+      (Array.isArray(testResults) ? testResults : []).map(async (result) => {
+        if (!result || typeof result.name !== "string") {
+          return undefined;
+        }
+        const reportedTestPath = await canonicalizeNativeTestFilePath({
+          canonicalRepoRoot,
+          repoRoot: params.repoRoot,
+          testPath: result.name,
+        });
+        return reportedTestPath === expectedTestPath ? result : undefined;
+      }),
+    )
+  ).find((result) => result !== undefined);
+  const passedAssertions = Array.isArray(matchingTestResult?.assertionResults)
+    ? matchingTestResult.assertionResults.filter((assertion) => assertion.status === "passed")
+    : [];
+  if (passedAssertions.length === 0) {
+    return `Vitest exited successfully without a passed assertion for the requested test file ${params.scenario.execution.path}.`;
+  }
+  const testNamePattern =
+    params.scenario.execution.kind === "playwright"
+      ? params.scenario.execution.testNamePattern
+      : undefined;
+  if (testNamePattern) {
+    let requestedTestName: RegExp;
+    try {
+      // Vitest resolves string --testNamePattern values with the same RegExp constructor.
+      requestedTestName = new RegExp(testNamePattern);
+    } catch {
+      return `Vitest exited successfully with an invalid requested test name pattern ${JSON.stringify(testNamePattern)}.`;
+    }
+    if (
+      !passedAssertions.some((assertion) => {
+        const assertionName =
+          typeof assertion.fullName === "string" ? assertion.fullName : assertion.title;
+        return typeof assertionName === "string" && requestedTestName.test(assertionName);
+      })
+    ) {
+      return `Vitest exited successfully without a passed assertion for the requested test name pattern ${JSON.stringify(testNamePattern)}.`;
+    }
   }
   return undefined;
 }

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -29,10 +29,11 @@ import {
   type QaScenarioCommandResult,
 } from "./test-file-scenario-command-lifecycle.js";
 import { isDockerE2eScenario, runDockerE2eBatch } from "./test-file-scenario-docker-batch.js";
+import { readScriptProducerEvidence } from "./test-file-scenario-script-evidence.js";
 import {
-  readJsonFileIfExists,
-  readScriptProducerEvidence,
-} from "./test-file-scenario-script-evidence.js";
+  readNativeVitestExecutionFailure,
+  resolveNativeVitestReportPath,
+} from "./test-file-scenario-vitest-report.js";
 export type { QaScenarioCommandExecution } from "./test-file-scenario-command-lifecycle.js";
 
 export type QaTestFileScenario = QaSeedScenarioWithSource & {
@@ -99,10 +100,6 @@ export function isQaTestFileScenario(
     scenario.execution.kind === "playwright" ||
     scenario.execution.kind === "script"
   );
-}
-
-function resolveNativeVitestReportPath(scenario: QaTestFileScenario, outputDir: string): string {
-  return path.join(outputDir, `${scenario.id}.vitest-report.json`);
 }
 
 function vitestReporterArgs(
@@ -239,108 +236,6 @@ function withScenarioCoverage(
   scenario: QaTestFileScenario,
 ) {
   return { ...entry, coverage: coverageForScenario(scenario) };
-}
-
-async function canonicalizeNativeTestFilePath(params: {
-  canonicalRepoRoot: string;
-  repoRoot: string;
-  testPath: string;
-}) {
-  const absoluteTestPath = path.resolve(params.repoRoot, params.testPath);
-  const canonicalTestPath = await fs.realpath(absoluteTestPath).catch(() => undefined);
-  if (canonicalTestPath) {
-    return canonicalTestPath;
-  }
-
-  const repoRelativePath = path.relative(params.repoRoot, absoluteTestPath);
-  if (
-    repoRelativePath !== ".." &&
-    !repoRelativePath.startsWith(`..${path.sep}`) &&
-    !path.isAbsolute(repoRelativePath)
-  ) {
-    return path.resolve(params.canonicalRepoRoot, repoRelativePath);
-  }
-  return absoluteTestPath;
-}
-
-async function readNativeVitestExecutionFailure(params: {
-  outputDir: string;
-  repoRoot: string;
-  scenario: QaTestFileScenario;
-}): Promise<string | undefined> {
-  const reportPath = resolveNativeVitestReportPath(params.scenario, params.outputDir);
-  const report = await readJsonFileIfExists(reportPath);
-  if (!report || typeof report !== "object") {
-    return `Vitest exited successfully without writing a valid JSON test report at ${reportPath}.`;
-  }
-  const { numFailedTests, numPassedTests, success, testResults } = report as {
-    numFailedTests?: unknown;
-    numPassedTests?: unknown;
-    success?: unknown;
-    testResults?: Array<{
-      name?: unknown;
-      assertionResults?: Array<{ fullName?: unknown; status?: unknown; title?: unknown }>;
-    }>;
-  };
-  if (
-    success !== true ||
-    typeof numPassedTests !== "number" ||
-    !Number.isSafeInteger(numPassedTests) ||
-    numPassedTests < 1 ||
-    numFailedTests !== 0
-  ) {
-    return "Vitest exited successfully without reporting a successfully executed test.";
-  }
-  const canonicalRepoRoot = await fs.realpath(params.repoRoot);
-  const expectedTestPath = await canonicalizeNativeTestFilePath({
-    canonicalRepoRoot,
-    repoRoot: params.repoRoot,
-    testPath: params.scenario.execution.path,
-  });
-  const matchingTestResult = (
-    await Promise.all(
-      (Array.isArray(testResults) ? testResults : []).map(async (result) => {
-        if (!result || typeof result.name !== "string") {
-          return undefined;
-        }
-        const reportedTestPath = await canonicalizeNativeTestFilePath({
-          canonicalRepoRoot,
-          repoRoot: params.repoRoot,
-          testPath: result.name,
-        });
-        return reportedTestPath === expectedTestPath ? result : undefined;
-      }),
-    )
-  ).find((result) => result !== undefined);
-  const passedAssertions = Array.isArray(matchingTestResult?.assertionResults)
-    ? matchingTestResult.assertionResults.filter((assertion) => assertion.status === "passed")
-    : [];
-  if (passedAssertions.length === 0) {
-    return `Vitest exited successfully without a passed assertion for the requested test file ${params.scenario.execution.path}.`;
-  }
-  const testNamePattern =
-    params.scenario.execution.kind === "playwright"
-      ? params.scenario.execution.testNamePattern
-      : undefined;
-  if (testNamePattern) {
-    let requestedTestName: RegExp;
-    try {
-      // Vitest resolves string --testNamePattern values with the same RegExp constructor.
-      requestedTestName = new RegExp(testNamePattern);
-    } catch {
-      return `Vitest exited successfully with an invalid requested test name pattern ${JSON.stringify(testNamePattern)}.`;
-    }
-    if (
-      !passedAssertions.some((assertion) => {
-        const assertionName =
-          typeof assertion.fullName === "string" ? assertion.fullName : assertion.title;
-        return typeof assertionName === "string" && requestedTestName.test(assertionName);
-      })
-    ) {
-      return `Vitest exited successfully without a passed assertion for the requested test name pattern ${JSON.stringify(testNamePattern)}.`;
-    }
-  }
-  return undefined;
 }
 
 async function runScenarioCommandSteps(params: {

--- a/extensions/qa-lab/src/test-file-scenario-vitest-report.ts
+++ b/extensions/qa-lab/src/test-file-scenario-vitest-report.ts
@@ -67,12 +67,13 @@ export async function readNativeVitestExecutionFailure(params: {
   ) {
     return "Vitest exited successfully without reporting a successfully executed test.";
   }
+  const expectedTestPath = await fs
+    .realpath(path.resolve(params.repoRoot, params.scenario.execution.path))
+    .catch(() => undefined);
+  if (!expectedTestPath) {
+    return `Vitest exited successfully without an existing requested test file ${params.scenario.execution.path}.`;
+  }
   const canonicalRepoRoot = await fs.realpath(params.repoRoot);
-  const expectedTestPath = await canonicalizeNativeTestFilePath({
-    canonicalRepoRoot,
-    repoRoot: params.repoRoot,
-    testPath: params.scenario.execution.path,
-  });
   const matchingTestResult = (
     await Promise.all(
       (Array.isArray(testResults) ? testResults : []).map(async (result) => {

--- a/extensions/qa-lab/src/test-file-scenario-vitest-report.ts
+++ b/extensions/qa-lab/src/test-file-scenario-vitest-report.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
+import { readJsonFileIfExists } from "./test-file-scenario-script-evidence.js";
+
+type NativeTestFileScenario = Pick<QaSeedScenarioWithSource, "id"> & {
+  execution: Extract<
+    QaSeedScenarioWithSource["execution"],
+    { kind: "script" | "vitest" | "playwright" }
+  >;
+};
+
+export function resolveNativeVitestReportPath(
+  scenario: Pick<NativeTestFileScenario, "id">,
+  outputDir: string,
+): string {
+  return path.join(outputDir, `${scenario.id}.vitest-report.json`);
+}
+
+async function canonicalizeNativeTestFilePath(params: {
+  canonicalRepoRoot: string;
+  repoRoot: string;
+  testPath: string;
+}) {
+  const absoluteTestPath = path.resolve(params.repoRoot, params.testPath);
+  const canonicalTestPath = await fs.realpath(absoluteTestPath).catch(() => undefined);
+  if (canonicalTestPath) {
+    return canonicalTestPath;
+  }
+
+  const repoRelativePath = path.relative(params.repoRoot, absoluteTestPath);
+  if (
+    repoRelativePath !== ".." &&
+    !repoRelativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(repoRelativePath)
+  ) {
+    return path.resolve(params.canonicalRepoRoot, repoRelativePath);
+  }
+  return absoluteTestPath;
+}
+
+export async function readNativeVitestExecutionFailure(params: {
+  outputDir: string;
+  repoRoot: string;
+  scenario: NativeTestFileScenario;
+}): Promise<string | undefined> {
+  const reportPath = resolveNativeVitestReportPath(params.scenario, params.outputDir);
+  const report = await readJsonFileIfExists(reportPath);
+  if (!report || typeof report !== "object") {
+    return `Vitest exited successfully without writing a valid JSON test report at ${reportPath}.`;
+  }
+  const { numFailedTests, numPassedTests, success, testResults } = report as {
+    numFailedTests?: unknown;
+    numPassedTests?: unknown;
+    success?: unknown;
+    testResults?: Array<{
+      name?: unknown;
+      assertionResults?: Array<{ fullName?: unknown; status?: unknown; title?: unknown }>;
+    }>;
+  };
+  if (
+    success !== true ||
+    typeof numPassedTests !== "number" ||
+    !Number.isSafeInteger(numPassedTests) ||
+    numPassedTests < 1 ||
+    numFailedTests !== 0
+  ) {
+    return "Vitest exited successfully without reporting a successfully executed test.";
+  }
+  const canonicalRepoRoot = await fs.realpath(params.repoRoot);
+  const expectedTestPath = await canonicalizeNativeTestFilePath({
+    canonicalRepoRoot,
+    repoRoot: params.repoRoot,
+    testPath: params.scenario.execution.path,
+  });
+  const matchingTestResult = (
+    await Promise.all(
+      (Array.isArray(testResults) ? testResults : []).map(async (result) => {
+        if (!result || typeof result.name !== "string") {
+          return undefined;
+        }
+        const reportedTestPath = await canonicalizeNativeTestFilePath({
+          canonicalRepoRoot,
+          repoRoot: params.repoRoot,
+          testPath: result.name,
+        });
+        return reportedTestPath === expectedTestPath ? result : undefined;
+      }),
+    )
+  ).find((result) => result !== undefined);
+  const passedAssertions = Array.isArray(matchingTestResult?.assertionResults)
+    ? matchingTestResult.assertionResults.filter((assertion) => assertion.status === "passed")
+    : [];
+  if (passedAssertions.length === 0) {
+    return `Vitest exited successfully without a passed assertion for the requested test file ${params.scenario.execution.path}.`;
+  }
+  const testNamePattern =
+    params.scenario.execution.kind === "playwright"
+      ? params.scenario.execution.testNamePattern
+      : undefined;
+  if (testNamePattern) {
+    let requestedTestName: RegExp;
+    try {
+      // Vitest resolves string --testNamePattern values with the same RegExp constructor.
+      requestedTestName = new RegExp(testNamePattern);
+    } catch {
+      return `Vitest exited successfully with an invalid requested test name pattern ${JSON.stringify(testNamePattern)}.`;
+    }
+    if (
+      !passedAssertions.some((assertion) => {
+        const assertionName =
+          typeof assertion.fullName === "string" ? assertion.fullName : assertion.title;
+        return typeof assertionName === "string" && requestedTestName.test(assertionName);
+      })
+    ) {
+      return `Vitest exited successfully without a passed assertion for the requested test name pattern ${JSON.stringify(testNamePattern)}.`;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
# fix(qa): authenticate native scenario execution and character replies

## What Problem This Solves

Two independently reproducible QA Lab correctness defects can report successful product evidence when the requested behavior never actually occurred:

1. Native Vitest and Playwright scenarios trust global passing-test counters, so an unrelated test file can satisfy the requested scenario and an unrelated Playwright assertion can satisfy its requested test-name filter.
2. Character-evaluation scenarios intentionally tolerate individual missing replies. If every model turn is unanswered, the suite can still complete successfully and the evaluator incorrectly records that candidate as passing, despite a transcript with zero assistant replies.

These defects belong to different private QA owners and have distinct reproductions and fixes; shared Vitest/Playwright file and assertion symptoms count as one native-scenario root.

## Why This Change Was Made

The native scenario runner now authenticates the actual installed Vitest JSON reporter contract: successful global counters are necessary but insufficient. It additionally requires a passed assertion under the requested test file and, for Playwright scenarios, a passed assertion matching the requested test-name regular expression. Requested and reported paths are normalized against the checkout's real filesystem identity so symlinked checkouts remain valid; malformed requested expressions produce explicit failed scenario evidence.

The character-evaluation owner already computes user/assistant turn statistics from the actual captured conversation. It now reuses that authoritative result to reject a candidate when no assistant turn was delivered, while preserving useful transcripts, existing provider/tool error diagnostics, blocked-producer semantics, and genuinely answered runs.

The installed Vitest reporter implementation and declarations were inspected directly: `testResults[].name` identifies the test file, `assertionResults[]` records `status`, `fullName`, and `title`, and the CLI constructs string name filters with `new RegExp(pattern)`. Both supported character scenarios intentionally catch per-turn response failures; the character evaluator, not the reusable suite schema or public protocol, owns model-candidate success.

## User Impact

- QA evidence cannot pass solely because some other Vitest or Playwright test passed.
- Playwright scenario selection must correspond to an actually passed requested assertion.
- Missing or invalid requested execution identity becomes an explicit, actionable failed scenario result.
- Character-evaluation model candidates with zero delivered assistant replies appear as failures instead of misleading successful judged runs.
- Legitimate symlinked checkouts, valid native assertions, answered character conversations, and existing producer blocked/failed behavior continue to work.

## Exact Scope

- Frozen canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Branch: `codex/auto-qa-scenario-execution-proof`.
- Native scenario owner commit: `2b23cffba89fc18934f981f7ceac1a5460fbbac4`.
- Character-evaluation owner commit and exact reviewed head: `686ec2c4d5c751fe1858a572267aee9b0fb7a013`.
- Independent root causes: **2**.
- No Gateway protocol, SQLite/storage, public configuration, provider authentication, plugin SDK, migrations, or user-visible product contract changes.
- Docker scheduler/watchdog changes are deliberately excluded.

## Reproduction Before

The immutable frozen-baseline native runner was substituted into the isolated test owner without changing canonical main. Three authentic negative-control regressions failed because baseline incorrectly produced `status: "pass"`:

- Passing Vitest report for an unrelated requested test file.
- Passing Playwright report for an unrelated requested test file.
- Passing Playwright report with an assertion that does not match its requested test-name pattern.

The character-evaluation implementation matched frozen main byte-for-byte. Two focused negative-control regressions failed because a passing suite incorrectly produced a passing model candidate for:

- A user-only conversation with no assistant reply.
- A report-only fallback with no assistant reply.

## Verification After

Exact immutable head `686ec2c4d5c751fe1858a572267aee9b0fb7a013`:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree \
  node scripts/run-vitest.mjs \
    extensions/qa-lab/src/character-eval.test.ts \
    extensions/qa-lab/src/test-file-scenario-runner.test.ts \
    extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts \
    extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts

Test Files  4 passed (4)
Tests       64 passed (64)
```

The exact-head suite covers both new character negative controls, requested Vitest and Playwright test-file identity, requested assertion names, invalid regex handling, symlinked checkout identity, stale reports, zero passed assertions, script evidence ownership, producer blocked semantics, process timeout/cleanup, and existing E2E routing.

Additional completed checks:

- `oxfmt --check` passed on every changed production and test file.
- `git diff --check e051a7bb4a6ba69b87391e990b00813114b1d482..HEAD` passed.
- Frozen-baseline ancestry guard passed.
- Exact-head worktree cleanliness guard passed.
- Genuine structured full-stack Codex `gpt-5.6-sol` / `high` autoreview completed on the exact immutable two-commit head: **clean, zero accepted/actionable findings, "patch is correct," confidence 0.91**.
- The bundled official TruffleHog preflight scanned the exact reviewed content and reported **clean (13.0 seconds)**.
- Structured review artifacts: `review-q2qascenario-686ec2c4d5c7.json` and `review-q2qascenario-686ec2c4d5c7.txt`.
- No live Gateway, live provider, browser, remote lease, hosted CI, branch fetch, push, PR creation, or canonical-main mutation is claimed.

## Changed Files

- `extensions/qa-lab/src/test-file-scenario-runner.ts`
- `extensions/qa-lab/src/test-file-scenario-runner.test.ts`
- `extensions/qa-lab/src/test-file-scenario-runner.e2e-routing.test.ts`
- `extensions/qa-lab/src/character-eval.ts`
- `extensions/qa-lab/src/character-eval.test.ts`
