### PR TITLE
fix(together): preserve immediate video outcomes and image references

### DIFF
--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -180,6 +180,53 @@ describe("together video generation provider", () => {
     },
   );
 
+  it("uses an actionable fallback when an immediately failed submission omits its error", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ status: "failed", error: null }),
+      release,
+    });
+
+    await expect(
+      buildTogetherVideoGenerationProvider().generateVideo({
+        provider: "together",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        prompt: "A scene that cannot be generated",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Together video generation failed");
+
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces provider errors from a failed poll and releases the submission", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "video_failed_later", status: "in_progress" }),
+      release,
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      json: async () => ({
+        id: "video_failed_later",
+        status: "failed",
+        error: { message: "Together video content policy blocked this prompt" },
+      }),
+    });
+
+    await expect(
+      buildTogetherVideoGenerationProvider().generateVideo({
+        provider: "together",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        prompt: "A scene that fails after submission",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Together video content policy blocked this prompt");
+
+    expect(fetchWithTimeoutMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("downloads an immediately completed Together submission without polling it again", async () => {
     const release = vi.fn(async () => {});
     postJsonRequestMock.mockResolvedValue({
@@ -208,6 +255,26 @@ describe("together video generation provider", () => {
       model: "Wan-AI/Wan2.2-T2V-A14B",
       metadata: { status: "completed", videoId: "video_completed" },
     });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an immediately completed submission without a generated video URL", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "video_missing_output", status: "completed" }),
+      release,
+    });
+
+    await expect(
+      buildTogetherVideoGenerationProvider().generateVideo({
+        provider: "together",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        prompt: "A completed scene without media",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Together video generation completed without an output URL");
+
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
   });
 
@@ -406,7 +473,9 @@ describe("together video generation provider", () => {
 
     const request = requireFirstPostJsonRequest("Together request");
     const body = requireRecord(request.body, "Together request body");
+    const media = requireRecord(body.media, "Together video media payload");
     expect(body.model).toBe("Wan-AI/Wan2.2-I2V-A14B");
-    expect(body.reference_images).toHaveLength(1);
+    expect(media.reference_images).toHaveLength(1);
+    expect(body).not.toHaveProperty("reference_images");
   });
 });

--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -153,6 +153,64 @@ describe("together video generation provider", () => {
     });
   });
 
+  it.each(["video_failed", undefined])(
+    "surfaces an immediately failed Together submission before polling or validating id (%s)",
+    async (videoId) => {
+      const release = vi.fn(async () => {});
+      postJsonRequestMock.mockResolvedValue({
+        response: streamedJsonResponse({
+          ...(videoId ? { id: videoId } : {}),
+          status: "failed",
+          error: { message: "Together video quota exhausted" },
+        }),
+        release,
+      });
+
+      await expect(
+        buildTogetherVideoGenerationProvider().generateVideo({
+          provider: "together",
+          model: "Wan-AI/Wan2.2-T2V-A14B",
+          prompt: "A scene that cannot be generated",
+          cfg: {},
+        }),
+      ).rejects.toThrow("Together video quota exhausted");
+
+      expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("downloads an immediately completed Together submission without polling it again", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "video_completed",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        status: "completed",
+        outputs: { video_url: "https://example.com/completed.mp4" },
+      }),
+      release,
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      headers: new Headers({ "content-type": "video/mp4" }),
+      arrayBuffer: async () => Buffer.from("completed-video"),
+    });
+
+    const result = await buildTogetherVideoGenerationProvider().generateVideo({
+      provider: "together",
+      model: "Wan-AI/Wan2.2-T2V-A14B",
+      prompt: "A scene already generated",
+      cfg: {},
+    });
+
+    expect(fetchWithTimeoutMock).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      model: "Wan-AI/Wan2.2-T2V-A14B",
+      metadata: { status: "completed", videoId: "video_completed" },
+    });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("bounds an unbounded successful Together create JSON body and cancels the stream", async () => {
     const oversized = oversizedJsonResponse();
     postJsonRequestMock.mockResolvedValue({

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -87,6 +87,12 @@ function extractTogetherVideoUrl(payload: TogetherVideoResponse): string | undef
   );
 }
 
+function readTogetherVideoFailureMessage(payload: TogetherVideoResponse): string | undefined {
+  return payload.status === "failed"
+    ? (normalizeOptionalString(payload.error?.message) ?? "Together video generation failed")
+    : undefined;
+}
+
 function resolveTogetherDurationSeconds(value: unknown): string | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
@@ -120,10 +126,7 @@ async function pollTogetherVideo(params: {
     requestFailedMessage: "Together video status request failed",
     timeoutMessage: `Together video generation task ${params.videoId} did not finish in time`,
     isComplete: (payload) => payload.status === "completed",
-    getFailureMessage: (payload) =>
-      payload.status === "failed"
-        ? (normalizeOptionalString(payload.error?.message) ?? "Together video generation failed")
-        : undefined,
+    getFailureMessage: readTogetherVideoFailureMessage,
   });
 }
 
@@ -284,20 +287,27 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
           response,
           "Together video generation failed",
         );
+        const failureMessage = readTogetherVideoFailureMessage(submitted);
+        if (failureMessage) {
+          throw new Error(failureMessage);
+        }
         const videoId = normalizeOptionalString(submitted.id);
         if (!videoId) {
           throw new Error("Together video generation response missing id");
         }
-        const completed = await pollTogetherVideo({
-          videoId,
-          headers,
-          timeoutMs: resolveProviderOperationTimeoutMs({
-            deadline,
-            defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-          }),
-          baseUrl,
-          fetchFn,
-        });
+        const completed =
+          submitted.status === "completed"
+            ? submitted
+            : await pollTogetherVideo({
+                videoId,
+                headers,
+                timeoutMs: resolveProviderOperationTimeoutMs({
+                  deadline,
+                  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+                }),
+                baseUrl,
+                fetchFn,
+              });
         const videoUrl = extractTogetherVideoUrl(completed);
         if (!videoUrl) {
           throw new Error("Together video generation completed without an output URL");

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -267,7 +267,7 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
         if (!value) {
           throw new Error("Together reference image is missing image data.");
         }
-        body.reference_images = [value];
+        body.media = { reference_images: [value] };
       }
       const { response, release } = await postJsonRequest({
         url: `${baseUrl}/videos`,


### PR DESCRIPTION
## What Problem This Solves

Together video creation currently mishandles two independently scoped provider-owner contracts:

1. `POST /videos` returns a complete `VideoJob`, but immediately failed or completed submissions were treated as pending jobs. Failures could lose the actual provider message to missing-ID validation or status polling, while already completed jobs performed an unnecessary status request.
2. Image-to-video requests serialized `reference_images` at the deprecated top level instead of Together's canonical `media.reference_images` request shape.

## Why This Change Was Made

Together's official generated SDK declares that both video creation and retrieval return the same `VideoJob`, including terminal `failed`/`completed` statuses, `error.message`, and `outputs.video_url`. Its current request contract explicitly deprecates top-level image references and defines the supported nested media shape. The existing Together provider is the correct owner for both response lifecycle handling and provider-specific serialization.

The change reuses one owner-local failure reader for submission and polling, honors immediately completed submissions without polling, preserves exactly-once response release, and serializes image inputs as `media.reference_images`. The temporarily accepted deprecated field is removed from requests without changing any public provider contract.

## User Impact

- Immediately rejected generations show the provider's actionable quota, policy, or other failure message even when the failed response has no video ID.
- Immediately completed generations download directly without an unnecessary status request.
- Pending jobs retain their existing polling and provider error behavior; malformed completed responses still fail visibly.
- Image-to-video requests use Together's current canonical media format, avoiding reliance on its deprecated legacy request field.
- Existing public video models, default model, capabilities, authentication, configuration, and SDK surfaces remain unchanged.

## Evidence

- Frozen source: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact candidate: `602cc88c4770ff91b3d3a72eb74d5db47daf388b` on `codex/qa100-together-video-terminal-submit`; **two plugin-private provider-owner roots**.
- Baseline RED: provider errors were swallowed or replaced by missing-ID validation, already completed jobs triggered redundant status polling, and canonical nested image media was absent.
- Exact-commit focused Together owner proof: **15/15 tests passed**, covering immediate failures with and without IDs, missing provider-error fallback, later polling failures, immediately completed downloads, missing completed output, once-only response release, existing bounded responses, and canonical nested image media.
- Immutable official Together generated SDK: [create returns `VideoJob`](https://github.com/togethercomputer/together-typescript/blob/a3fdab476c9d6549934c9a0ed2a0c03361444714/src/resources/videos.ts#L19-L20); [terminal status, provider error, and completed output](https://github.com/togethercomputer/together-typescript/blob/a3fdab476c9d6549934c9a0ed2a0c03361444714/src/resources/videos.ts#L68-L118); [top-level image references are explicitly deprecated](https://github.com/togethercomputer/together-typescript/blob/a3fdab476c9d6549934c9a0ed2a0c03361444714/src/resources/videos.ts#L183-L191); [canonical nested media references](https://github.com/togethercomputer/together-typescript/blob/a3fdab476c9d6549934c9a0ed2a0c03361444714/src/resources/videos.ts#L238-L262).
- Official API and provider documentation: [Together create-video API](https://docs.together.ai/reference/create-videos) and [video-generation media parameters](https://docs.together.ai/docs/inference/videos/parameters).
- Genuine TruffleHog 3.96.0-backed, full-frozen-branch structured Codex autoreview: **CLEAN**, zero findings, **0.99 confidence**; targeted `oxfmt --check`, `git diff --check`, frozen ancestry, and clean committed worktree all passed.
- No live provider request, main-worktree modification, push, or public configuration/default/model/catalog/auth/capability change.

The current official Together model catalog no longer lists the existing Wan2.2 defaults. That pre-existing public model/default and documentation migration requires separate owner review and is intentionally outside this provider-private fix.
