### PR TITLE
fix(signal): report real account health and preserve reaction ownership

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -579,10 +579,12 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             lastProbeAt: snapshot.lastProbeAt ?? null,
           }),
         probeAccount: async ({ account, timeoutMs }) => {
-          const baseUrl = account.baseUrl;
-          const { probeSignal } = await loadSignalProbeModule();
-          return await probeSignal(baseUrl, timeoutMs, {
+          const { probeSignalAccount } = await loadSignalProbeModule();
+          return await probeSignalAccount({
+            baseUrl: account.baseUrl,
+            timeoutMs,
             transportKind: account.transport.kind,
+            account: account.config.account,
           });
         },
         formatCapabilitiesProbe: ({ probe }) =>

--- a/extensions/signal/src/client-adapter.test.ts
+++ b/extensions/signal/src/client-adapter.test.ts
@@ -83,7 +83,28 @@ describe("signalCheck", () => {
     await expect(
       signalCheck("http://container:8080", 5_000, { transportKind: "container" }),
     ).resolves.toEqual({ ok: true, status: 200 });
-    expect(containerCheck).toHaveBeenCalledWith("http://container:8080", 5_000);
+    expect(containerCheck).toHaveBeenCalledWith("http://container:8080", 5_000, undefined);
+    expect(nativeCheck).not.toHaveBeenCalled();
+  });
+
+  it("validates the configured container account's receive WebSocket", async () => {
+    containerCheck.mockResolvedValue({
+      ok: false,
+      status: 200,
+      error: "Signal container receive endpoint did not upgrade to WebSocket (HTTP 200)",
+    });
+
+    await expect(
+      signalCheck("http://container:8080", 5_000, {
+        transportKind: "container",
+        account: "+15550001111",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: 200,
+      error: "Signal container receive endpoint did not upgrade to WebSocket (HTTP 200)",
+    });
+    expect(containerCheck).toHaveBeenCalledWith("http://container:8080", 5_000, "+15550001111");
     expect(nativeCheck).not.toHaveBeenCalled();
   });
 });

--- a/extensions/signal/src/client-adapter.ts
+++ b/extensions/signal/src/client-adapter.ts
@@ -56,11 +56,11 @@ export async function signalRpcRequest<T = unknown>(
 export async function signalCheck(
   baseUrl: string,
   timeoutMs = DEFAULT_TIMEOUT_MS,
-  options: { transportKind?: SignalTransportKind } = {},
+  options: { transportKind?: SignalTransportKind; account?: string } = {},
 ): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
   try {
     return usesContainer(options.transportKind)
-      ? await containerCheck(baseUrl, timeoutMs)
+      ? await containerCheck(baseUrl, timeoutMs, options.account)
       : await nativeCheck(baseUrl, timeoutMs);
   } catch (error) {
     return { ok: false, status: null, error: formatErrorMessage(error) };

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -180,6 +180,7 @@ describe("probeSignal", () => {
         enabled: true,
         configured: true,
         baseUrl: "http://127.0.0.1:8080",
+        config: {},
         transport: {
           kind: "managed-native",
           baseUrl: "http://127.0.0.1:8080",
@@ -215,6 +216,59 @@ describe("probeSignal", () => {
     expect(res.ok).toBe(true);
     expect(res.version).toBe("0.13.22");
     expect(res.status).toBe(200);
+  });
+
+  it("preserves every version reported by a Signal REST container", async () => {
+    vi.spyOn(clientModule, "signalCheck").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      error: null,
+    });
+    vi.spyOn(clientModule, "signalRpcRequest").mockResolvedValueOnce({
+      versions: ["v1", "v2"],
+      build: 42,
+    });
+
+    const result = await probeSignal("http://127.0.0.1:8080", 1000, {
+      transportKind: "container",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("v1, v2");
+  });
+
+  it("reports container accounts unhealthy when their receive WebSocket cannot upgrade", async () => {
+    const signalCheck = vi.spyOn(clientModule, "signalCheck").mockResolvedValueOnce({
+      ok: false,
+      status: 200,
+      error: "Signal container receive endpoint did not upgrade to WebSocket (HTTP 200)",
+    });
+    const signalRpcRequest = vi.spyOn(clientModule, "signalRpcRequest");
+
+    const result = await signalPlugin.status!.probeAccount!({
+      cfg: {} as never,
+      account: {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        baseUrl: "http://127.0.0.1:8080",
+        config: { account: "+15550001111" },
+        transport: { kind: "container", url: "http://127.0.0.1:8080" },
+      } as never,
+      timeoutMs: 1000,
+    });
+
+    expect(signalCheck).toHaveBeenCalledWith("http://127.0.0.1:8080", 1000, {
+      transportKind: "container",
+      account: "+15550001111",
+    });
+    expect(signalRpcRequest).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: false,
+      status: 200,
+      error: "Signal container receive endpoint did not upgrade to WebSocket (HTTP 200)",
+      version: null,
+    });
   });
 
   it("returns ok=false when /check fails", async () => {

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -924,6 +924,43 @@ describe("monitorSignalProvider tool results", () => {
     expect(hasQueuedReactionEventFor("+15550001111")).toBe(true);
   });
 
+  it("notifies on own UUID-only reactions using the configured account UUID", async () => {
+    const accountUuid = "123e4567-e89b-12d3-a456-426614174000";
+    setReactionNotificationConfig("own", {
+      account: "+15550002222",
+      accountUuid,
+    });
+
+    await receiveSingleEnvelope({
+      ...makeBaseEnvelope(),
+      reactionMessage: {
+        emoji: "✅",
+        targetAuthorUuid: accountUuid,
+        targetSentTimestamp: 2,
+      },
+    });
+
+    expect(hasQueuedReactionEventFor("+15550001111")).toBe(true);
+  });
+
+  it("does not classify a different account UUID as an own reaction", async () => {
+    setReactionNotificationConfig("own", {
+      account: "+15550002222",
+      accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    await receiveSingleEnvelope({
+      ...makeBaseEnvelope(),
+      reactionMessage: {
+        emoji: "✅",
+        targetAuthorUuid: "00000000-0000-4000-8000-000000000001",
+        targetSentTimestamp: 2,
+      },
+    });
+
+    expect(hasQueuedReactionEventFor("+15550001111")).toBe(false);
+  });
+
   it("processes messages when reaction metadata is present", async () => {
     replyMock.mockResolvedValue({ text: "pong" });
 

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -183,26 +183,31 @@ function isSignalReactionMessage(
 function shouldEmitSignalReactionNotification(params: {
   mode?: SignalReactionNotificationMode;
   account?: string | null;
+  accountUuid?: string | null;
   targets?: SignalReactionTarget[];
   sender?: ReturnType<typeof resolveSignalSender> | null;
   allowlist?: string[];
 }) {
-  const { mode, account, targets, sender, allowlist } = params;
+  const { mode, account, accountUuid, targets, sender, allowlist } = params;
   const effectiveMode = mode ?? "own";
   if (effectiveMode === "off") {
     return false;
   }
   if (effectiveMode === "own") {
-    const accountId = account?.trim();
-    if (!accountId || !targets || targets.length === 0) {
+    const accountId = normalizeOptionalString(account);
+    const normalizedAccountUuid = normalizeOptionalString(accountUuid);
+    if ((!accountId && !normalizedAccountUuid) || !targets || targets.length === 0) {
       return false;
     }
-    const normalizedAccount = normalizeE164(accountId);
+    const normalizedAccount = accountId ? normalizeE164(accountId) : undefined;
     return targets.some((target) => {
       if (target.kind === "uuid") {
-        return accountId === target.id || accountId === `uuid:${target.id}`;
+        // UUID-only reaction payloads omit the phone identity carried by account.
+        return [accountId, normalizedAccountUuid].some(
+          (candidate) => candidate === target.id || candidate === `uuid:${target.id}`,
+        );
       }
-      return normalizedAccount === target.id;
+      return Boolean(normalizedAccount) && normalizedAccount === target.id;
     });
   }
   if (effectiveMode === "allowlist") {

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -24,7 +24,13 @@ function getCapturedCtx() {
 function getGroupHistoryEntries(
   groupHistories: Map<
     string,
-    Array<{ sender?: string; body?: string; media?: HistoryMediaEntry[] }>
+    Array<{
+      sender?: string;
+      body?: string;
+      media?: HistoryMediaEntry[];
+      timestamp?: number;
+      messageId?: string;
+    }>
   >,
   groupId = "g1",
 ) {
@@ -249,6 +255,27 @@ describe("signal mention gating", () => {
     const entry = expectDefined(entries[0], "Signal group history entry");
     expect(entry.sender).toBe("Alice");
     expect(entry.body).toBe("hello from alice");
+  });
+
+  it("keeps the canonical data-message timestamp in skipped group history", async () => {
+    const { handler, groupHistories } = createMentionGatedHistoryHandler();
+    const timestamp = 1700000000123;
+
+    await handler(
+      createSignalReceiveEvent({
+        timestamp: undefined,
+        dataMessage: {
+          timestamp,
+          message: "history without a mention",
+          attachments: [],
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+
+    const entry = expectDefined(getGroupHistoryEntries(groupHistories)[0], "Signal history entry");
+    expect(entry.timestamp).toBe(timestamp);
+    expect(entry.messageId).toBe(String(timestamp));
   });
 
   it("records edited target reply authors for skipped group messages", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -811,6 +811,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const shouldNotify = deps.shouldEmitSignalReactionNotification({
       mode: deps.reactionMode,
       account: deps.account,
+      accountUuid: deps.accountUuid,
       targets,
       sender: params.sender,
       allowlist: deps.reactionAllowlist,
@@ -1101,9 +1102,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           sender: envelope.sourceName ?? senderDisplay,
           body: messageText || visibleQuoteText,
           media: toHistoryMediaEntries(pendingMedia),
-          timestamp: envelope.timestamp ?? undefined,
-          messageId:
-            typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined,
+          timestamp: inboundTimestamp,
+          messageId,
         },
       });
       await registerSignalReplyContext({

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -143,6 +143,7 @@ export type SignalEventHandlerDeps = {
   shouldEmitSignalReactionNotification: (params: {
     mode?: SignalReactionNotificationMode;
     account?: string | null;
+    accountUuid?: string | null;
     targets?: SignalReactionTarget[];
     sender?: SignalSender | null;
     allowlist?: string[];

--- a/extensions/signal/src/probe.ts
+++ b/extensions/signal/src/probe.ts
@@ -16,22 +16,34 @@ function parseSignalVersion(value: unknown): string | null {
     return value.trim();
   }
   if (typeof value === "object" && value !== null) {
-    const version = (value as { version?: unknown }).version;
+    const { version, versions } = value as { version?: unknown; versions?: unknown };
     if (typeof version === "string" && version.trim()) {
       return version.trim();
+    }
+    if (Array.isArray(versions)) {
+      const normalizedVersions = versions
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (normalizedVersions.length > 0) {
+        return normalizedVersions.join(", ");
+      }
     }
   }
   return null;
 }
 
-export async function probeSignal(
+type SignalProbeOptions = {
+  transportKind?: SignalTransportKind;
+  /** @deprecated Pass transportKind after resolving the account transport. */
+  apiMode?: "auto" | "native" | "container";
+};
+
+async function probeSignalTransport(
   baseUrl: string,
   timeoutMs: number,
-  options: {
-    transportKind?: SignalTransportKind;
-    /** @deprecated Pass transportKind after resolving the account transport. */
-    apiMode?: "auto" | "native" | "container";
-  } = {},
+  options: SignalProbeOptions,
+  account?: string,
 ): Promise<SignalProbe> {
   return await runChannelProbe(undefined, async () => {
     const result: Omit<SignalProbe, "elapsedMs"> = {
@@ -46,7 +58,10 @@ export async function probeSignal(
     } catch (error) {
       return { ...result, error: formatErrorMessage(error) };
     }
-    const check = await signalCheck(baseUrl, timeoutMs, { transportKind });
+    const check = await signalCheck(baseUrl, timeoutMs, {
+      transportKind,
+      ...(account && transportKind === "container" ? { account } : {}),
+    });
     if (!check.ok) {
       return {
         ...result,
@@ -68,13 +83,33 @@ export async function probeSignal(
   });
 }
 
+export async function probeSignal(
+  baseUrl: string,
+  timeoutMs: number,
+  options: SignalProbeOptions = {},
+): Promise<SignalProbe> {
+  return await probeSignalTransport(baseUrl, timeoutMs, options);
+}
+
+export async function probeSignalAccount(params: {
+  baseUrl: string;
+  timeoutMs: number;
+  transportKind: SignalTransportKind;
+  account?: string;
+}): Promise<SignalProbe> {
+  // Container /about can succeed while this account's receive WebSocket cannot upgrade.
+  return await probeSignalTransport(
+    params.baseUrl,
+    params.timeoutMs,
+    { transportKind: params.transportKind },
+    params.account,
+  );
+}
+
 async function resolveProbeTransportKind(
   baseUrl: string,
   timeoutMs: number,
-  options: {
-    transportKind?: SignalTransportKind;
-    apiMode?: "auto" | "native" | "container";
-  },
+  options: SignalProbeOptions,
 ): Promise<SignalTransportKind> {
   if (options.transportKind) {
     return options.transportKind;


### PR DESCRIPTION
## What Problem This Solves

Signal operators currently encounter four separate private-owner failures: container account health reports green even when its receive WebSocket cannot upgrade; REST container versions disappear from account status; own reactions with UUID-only targets are silently ignored; and mention-skipped group messages lose their authoritative timestamp and message identity when only the data-message timestamp is present.

## Why This Change Was Made

- Pass the configured Signal account through the private account-probe and transport-adapter owners so existing container receive-WebSocket validation checks the actual `/v1/receive/{account}` endpoint.
- Preserve every version from the REST container's documented `{ versions: [...] }` response while retaining existing native string and `{ version: ... }` behavior.
- Match UUID-only own-reaction targets against the already-configured Signal account UUID, retain phone/UUID-prefix behavior, and reject unrelated account UUIDs.
- Carry the event handler's already-resolved canonical inbound timestamp and message ID into mention-skipped group history.

## User Impact

1. A REST container with a healthy `/v1/about` response but broken account receive-WebSocket upgrade now reports a visible, actionable unhealthy account state.
2. Container-backed Signal account status displays all advertised REST versions.
3. UUID-only reactions to the bot's messages produce the expected own-reaction notification without accepting reactions intended for another account.
4. Mention-skipped Signal group history preserves chronology and message identity when upstream timestamps appear on the data message.

These are exactly four bounded Signal-plugin owner fixes; native SSE's intentionally unlimited initial receive timeout, authentication, public SDK exports, public configuration, gateway protocol, persistent state, and other plugins remain unchanged.

## Evidence

- Frozen canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact isolated candidate: `8603a48357241b8cb0692aa5bea16434491776e0`.
- Genuine red owner proof: the configured-account transport regression initially failed because `containerCheck` received only `[url, timeout]`, omitting the configured account and its receive-WebSocket probe.
- Exact-candidate focused owner Vitest proof: **4 Signal test files, 134/134 tests passed**, using the repository's globally locked focused-test wrapper and a single worker.
- Exact-commit real-localhost production-owner proof: a real HTTP server returns `{ versions: ["v1", "v2"] }`, the direct container probe preserves `version: "v1, v2"`, and the account-aware probe attempts exactly one real receive upgrade and returns `ok: false`, HTTP `200`, and the actionable failed-WebSocket-upgrade error.
- Exact production own-reaction owner proof: configured matching UUID returns `true`; a different UUID returns `false`.
- Existing focused owner tests also preserve native `timeoutMs: 0` streaming semantics and cover canonical mention-skipped history timestamp/message ID, container account health, native health, and REST version parsing.
- All **10 touched files** pass targeted existing-binary `oxfmt --check` and `oxlint`; staged/final `git diff --check`, immutable frozen parent, clean isolated worktree, and the 6.6 MiB sparse-checkout bound all pass.
- The upstream REST response contract is exercised by `extensions/signal/src/client-container.real-server.test.ts:85`; the existing receive-WebSocket owner contract is covered by `extensions/signal/src/client-container.test.ts:384`; the existing documented `/v1/about` false-health failure is described in `docs/channels/signal.md:243`.
- Genuine exact-commit structured `$autoreview` (`codex`, `gpt-5.6-sol`, reasoning `high`): **clean, zero findings, confidence 0.93**; the shared genuine TruffleHog secret scan also passed cleanly.

## Explicit Exclusions

No public Signal account/config/auth/schema change, plugin SDK/export change, gateway protocol change, SQLite/schema/state change, dependency change, broad/full-suite run, canonical-main mutation, branch push, PR creation, or native SSE handshake-timeout change is included.
