### PR TITLE
fix(slack): preserve thread reads, edit formatting, and complete replies

### DIFF
--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { createSlackEditTestClient, createSlackSendTestClient } from "./blocks.test-helpers.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
 
-const { editSlackMessage, sendSlackMessage } = await import("./actions.js");
+const { editSlackMessage, editSlackRenderedMessage, sendSlackMessage } =
+  await import("./actions.js");
 const SLACK_TEXT_LIMIT = 8000;
 const SLACK_EDIT_TEXT_MAX_BYTES = 4000;
 
@@ -68,6 +69,36 @@ describe("sendSlackMessage blocks", () => {
 });
 
 describe("editSlackMessage blocks", () => {
+  it("renders authored Markdown using the same mrkdwn dialect as sends", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackMessage("C123", "171234.567", "**bold** and [OpenClaw](https://example.com)", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith({
+      channel: "C123",
+      ts: "171234.567",
+      text: "*bold* and <https://example.com|OpenClaw>",
+    });
+  });
+
+  it("preserves already-rendered Slack mrkdwn when finalizing a preview", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackRenderedMessage("C123", "171234.567", "*bold*", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith({
+      channel: "C123",
+      ts: "171234.567",
+      text: "*bold*",
+    });
+  });
+
   it("caps long plain-text edits at the live UTF-8 byte limit", async () => {
     const client = createSlackEditTestClient();
     const text = `${"x".repeat(3_999)}…${"a".repeat(SLACK_TEXT_LIMIT)}`;

--- a/extensions/slack/src/actions.read.test.ts
+++ b/extensions/slack/src/actions.read.test.ts
@@ -63,10 +63,40 @@ describe("Slack read actions", () => {
       ts: "171234.567",
       limit: undefined,
       latest: undefined,
-      oldest: undefined,
+      oldest: "171234.567",
     });
     expect(client.conversations.history).not.toHaveBeenCalled();
     expect(result.messages.map((message) => message.ts)).toEqual(["171234.890", "171235.000"]);
+  });
+
+  it("excludes the parent before applying the thread page limit", async () => {
+    const client = createClient();
+    const threadMessages = [
+      { ts: "171234.567", text: "parent" },
+      { ts: "171234.890", text: "first reply" },
+      { ts: "171235.000", text: "second reply" },
+    ];
+    client.conversations.replies.mockImplementationOnce(
+      ({ oldest, limit }: { oldest?: string; limit?: number }) => {
+        const eligible = threadMessages.filter((message) => !oldest || message.ts > oldest);
+        return {
+          messages: eligible.slice(0, limit),
+          has_more: limit !== undefined && eligible.length > limit,
+        };
+      },
+    );
+
+    await expect(
+      readSlackMessages("C1", {
+        client,
+        threadId: "171234.567",
+        limit: 1,
+        token: "xoxb-test",
+      }),
+    ).resolves.toEqual({
+      messages: [{ ts: "171234.890", text: "first reply" }],
+      hasMore: true,
+    });
   });
 
   it("filters a specific thread reply by messageId", async () => {
@@ -90,10 +120,51 @@ describe("Slack read actions", () => {
       limit: 1,
       inclusive: true,
       latest: "171234.890",
-      oldest: undefined,
+      oldest: "171234.890",
     });
     expect(result).toEqual({
       messages: [{ ts: "171234.890", text: "reply" }],
+      hasMore: false,
+    });
+  });
+
+  it("reads an exact reply directly after more than a full thread page", async () => {
+    const client = createClient();
+    const threadMessages = Array.from({ length: 102 }, (_, index) => ({
+      ts: `171234.${String(index).padStart(6, "0")}`,
+      text: index === 101 ? "requested reply" : `message ${String(index)}`,
+    }));
+    const messageId = "171234.000101";
+    client.conversations.replies.mockImplementationOnce(
+      ({
+        oldest,
+        latest,
+        inclusive,
+        limit,
+      }: {
+        oldest?: string;
+        latest?: string;
+        inclusive?: boolean;
+        limit?: number;
+      }) => {
+        const eligible = threadMessages.filter(
+          (message) =>
+            (!oldest || message.ts > oldest || (inclusive && message.ts === oldest)) &&
+            (!latest || message.ts < latest || (inclusive && message.ts === latest)),
+        );
+        return { messages: eligible.slice(0, limit), has_more: eligible.length > (limit ?? 0) };
+      },
+    );
+
+    await expect(
+      readSlackMessages("C1", {
+        client,
+        threadId: "171234.000000",
+        messageId,
+        token: "xoxb-test",
+      }),
+    ).resolves.toEqual({
+      messages: [{ ts: messageId, text: "requested reply" }],
       hasMore: false,
     });
   });
@@ -206,7 +277,7 @@ describe("Slack read actions", () => {
       limit: 1,
       inclusive: true,
       latest: "171234.890",
-      oldest: undefined,
+      oldest: "171234.890",
     });
     expect(result).toEqual({
       messages: [{ ts: "171234.890", text: "exact" }],
@@ -302,9 +373,28 @@ describe("Slack read actions", () => {
       ts: "1712345678.000001",
       limit: undefined,
       latest: "1712320496",
-      oldest: "1712340000.000001",
+      oldest: "1712345678.000001",
     });
     expect(client.conversations.history).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit thread lower bound after the parent timestamp", async () => {
+    const client = createClient();
+
+    await readSlackMessages("C1", {
+      client,
+      threadId: "1712345678.000001",
+      after: "1712345678.000002",
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.replies).toHaveBeenCalledWith({
+      channel: "C1",
+      ts: "1712345678.000001",
+      limit: undefined,
+      latest: undefined,
+      oldest: "1712345678.000002",
+    });
   });
 
   it("routes read-mode actions through the bounded lookup client", async () => {

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -10,6 +10,7 @@ import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackLookupClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
+import { normalizeSlackOutboundText } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { hasSlackMessageTableBlock, resolveSlackMessageText } from "./monitor/block-text.js";
 import { resolveSlackMedia } from "./monitor/media.js";
@@ -366,6 +367,16 @@ export async function editSlackMessage(
   content: string,
   opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
 ) {
+  await editSlackRenderedMessage(channelId, messageId, normalizeSlackOutboundText(content), opts);
+}
+
+// Finalized previews already contain Slack mrkdwn; a second Markdown render changes its meaning.
+export async function editSlackRenderedMessage(
+  channelId: string,
+  messageId: string,
+  content: string,
+  opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
+) {
   const client = await getClient(opts, "write");
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   const editText = buildSlackEditTextPayload(content, blocks);
@@ -476,7 +487,7 @@ export async function readSlackMessages(
     ? {
         inclusive: true,
         latest: exactMessageId,
-        oldest: undefined,
+        oldest: exactMessageId,
       }
     : {
         latest: normalizeSlackReadTimestamp(opts.before, "before"),
@@ -486,11 +497,18 @@ export async function readSlackMessages(
 
   // Use conversations.replies for thread messages, conversations.history for channel messages.
   if (opts.threadId) {
+    // Slack pages thread roots before replies; exclude the root before its limit consumes the page.
+    const oldest = exactMessageId
+      ? exactMessageId
+      : exactBounds.oldest && Number(exactBounds.oldest) > Number(opts.threadId)
+        ? exactBounds.oldest
+        : opts.threadId;
     const result = await client.conversations.replies({
       channel: channelId,
       ts: opts.threadId,
       limit: readLimit,
       ...exactBounds,
+      oldest,
     });
     const messages = ((result.messages ?? []) as SlackMessageSummary[])
       .filter((message) => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -876,6 +876,7 @@ vi.mock("../../format.js", () => ({
 
 vi.mock("../../limits.js", () => ({
   SLACK_TEXT_LIMIT: 4000,
+  SLACK_EDIT_TEXT_MAX_BYTES: 4000,
 }));
 
 vi.mock("../../sent-thread-cache.js", () => ({
@@ -1228,6 +1229,23 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
+
+  it.each([
+    { name: "ASCII", text: "x".repeat(4_001) },
+    { name: "UTF-8", text: "界".repeat(1_334) },
+  ])(
+    "delivers the complete $name final when it exceeds Slack's edit byte limit",
+    async ({ text }) => {
+      finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+      mockedDispatchSequence = [{ kind: "final", payload: { text } }];
+
+      await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+      expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+      expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+      expectDeliverReplyCall(0, text);
+    },
+  );
 
   it("uses a disposable portable preview before custom-identity final delivery", async () => {
     const relayIdentity = { username: "Nik Team Claw", iconEmoji: ":robot_face:" };
@@ -4255,6 +4273,40 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
         audioAsVoice: true,
         spokenText: "Spoken answer",
         ttsSupplement: { spokenText: "Spoken answer" },
+      },
+    ]);
+  });
+
+  it("delivers complete oversized TTS text together with its media", async () => {
+    const spokenText = "x".repeat(4_001);
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: {
+          mediaUrl: "https://example.com/tts.mp3",
+          audioAsVoice: true,
+          spokenText,
+          ttsSupplement: { spokenText },
+        },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    const delivered = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expect(delivered.replies).toEqual([
+      {
+        text: spokenText,
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText,
+        ttsSupplement: { spokenText },
       },
     ]);
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -24,6 +24,7 @@ import type { ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../../errors.js";
 import { normalizeSlackOutboundText } from "../../format.js";
+import { SLACK_EDIT_TEXT_MAX_BYTES } from "../../limits.js";
 import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
 import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
@@ -32,6 +33,7 @@ import {
   stopSlackStream,
   type SlackStreamSession,
 } from "../../streaming.js";
+import { countSlackTextUtf8Bytes } from "../../truncate.js";
 import { resolveSlackBotLoopProtection } from "./dispatch-helpers.js";
 import { createSlackProgressRuntime } from "./dispatch-progress.js";
 import { createSlackDispatchSetup } from "./dispatch-setup.js";
@@ -183,6 +185,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyRenderPlan.mode === "single" && replyRenderPlan.textIsSlackMrkdwn
         ? trimmedFinalText
         : normalizeSlackOutboundText((replySourceText ?? "").trim());
+    const previewFinalTextFitsEdit =
+      countSlackTextUtf8Bytes(previewFinalText) <= SLACK_EDIT_TEXT_MAX_BYTES;
     const shouldRestoreTtsSupplementTextForPreviewFallback =
       Boolean(ttsSupplement) &&
       ttsSupplement?.visibleTextAlreadyDelivered !== true &&
@@ -202,6 +206,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       previewStreamingEnabled &&
       !payload.isError &&
       !requiresSeparateFallbackDelivery &&
+      previewFinalTextFitsEdit &&
       trimmedFinalText.length > 0
     ) {
       const channelId = draftStream.channelId();
@@ -287,6 +292,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             (reply.hasMedia && !ttsSupplement) ||
             payload.isError ||
             requiresSeparateFallbackDelivery ||
+            !previewFinalTextFitsEdit ||
             (trimmedFinalText.length === 0 && !slackBlocks?.length)
           ) {
             return undefined;

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
@@ -7,6 +7,8 @@ const editSlackMessageMock = vi.fn();
 vi.mock("../../actions.js", () => ({
   editSlackMessage: (...args: unknown[]) =>
     editSlackMessageMock(...(args as Parameters<typeof editSlackMessageMock>)),
+  editSlackRenderedMessage: (...args: unknown[]) =>
+    editSlackMessageMock(...(args as Parameters<typeof editSlackMessageMock>)),
 }));
 
 let finalizeSlackPreviewEdit: typeof import("./preview-finalize.js").finalizeSlackPreviewEdit;
@@ -75,9 +77,52 @@ describe("finalizeSlackPreviewEdit", () => {
       channel: "C123",
       ts: "170000.111",
       latest: "171234.567",
+      oldest: "171234.567",
       inclusive: true,
-      limit: 100,
+      limit: 1,
     });
+  });
+
+  it("recovers an applied edit beyond the first busy-thread readback page", async () => {
+    editSlackMessageMock.mockRejectedValueOnce(new Error("socket closed after commit"));
+    const messageId = "171234.000101";
+    const threadMessages = Array.from({ length: 102 }, (_, index) => ({
+      ts: `171234.${String(index).padStart(6, "0")}`,
+      text: index === 101 ? "final answer" : `message ${String(index)}`,
+    }));
+    const client = createClient();
+    (client.conversations.replies as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      ({
+        oldest,
+        latest,
+        inclusive,
+        limit,
+      }: {
+        oldest?: string;
+        latest?: string;
+        inclusive?: boolean;
+        limit?: number;
+      }) => ({
+        messages: threadMessages
+          .filter(
+            (message) =>
+              (!oldest || message.ts > oldest || (inclusive && message.ts === oldest)) &&
+              (!latest || message.ts < latest || (inclusive && message.ts === latest)),
+          )
+          .slice(0, limit),
+      }),
+    );
+
+    await expect(
+      finalizeSlackPreviewEdit({
+        client,
+        token: "xoxb-test",
+        channelId: "C123",
+        messageId,
+        threadTs: "171234.000000",
+        text: "final answer",
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("rethrows when readback does not match the expected final text", async () => {

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.ts
@@ -1,7 +1,7 @@
 // Slack plugin module implements preview finalize behavior.
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { editSlackMessage } from "../../actions.js";
+import { editSlackRenderedMessage } from "../../actions.js";
 import { buildSlackBlocksFallbackText } from "../../blocks-fallback.js";
 import { buildSlackEditTextPayload } from "../../edit-text.js";
 import { normalizeSlackOutboundText } from "../../format.js";
@@ -103,8 +103,9 @@ async function readSlackMessageAfterEditError(params: {
       channel: params.channelId,
       ts: params.threadTs,
       latest: params.messageId,
+      oldest: params.messageId,
       inclusive: true,
-      limit: 100,
+      limit: 1,
     });
     const reply = (replyResult.messages ?? []).find(
       (message) => (message as SlackReadbackMessage | undefined)?.ts === params.messageId,
@@ -166,7 +167,7 @@ export async function finalizeSlackPreviewEdit(params: {
   threadTs?: string;
 }): Promise<void> {
   try {
-    await editSlackMessage(params.channelId, params.messageId, params.text, {
+    await editSlackRenderedMessage(params.channelId, params.messageId, params.text, {
       token: params.token,
       accountId: params.accountId,
       client: params.client,


### PR DESCRIPTION
## What Problem This Solves

Slack operators can currently receive empty thread reads, duplicate final replies after an ambiguous edit response, visibly unrendered bold/link Markdown, and silently truncated final answers even though delivery reports success. These are four distinct failures in the Slack plugin's private transport owners.

## Why This Change Was Made

- Exclude the thread parent inside `conversations.replies` before Slack applies its requested page limit; constrain exact reads to `oldest=latest=messageId` with `inclusive: true`.
- Recover ambiguous committed thread edits with the same exact-message request instead of scanning only the first 100 oldest replies.
- Normalize authored Markdown at the existing public edit boundary, while keeping a Slack-plugin-private path for finalized text that is already valid Slack mrkdwn.
- Skip preview finalization when the complete rendered final exceeds Slack's 4,000 UTF-8 byte edit ceiling; send the original final, including visible TTS text and media, through normal complete delivery instead.

## User Impact

1. Reading one thread reply returns a reply instead of silently consuming the page with its parent; exact reply reads also work on busy threads.
2. A committed preview edit remains recognized even after 100 earlier messages, preventing duplicate fallback answers.
3. Edited `**bold**` and Markdown links render correctly without turning already-rendered Slack `*bold*` into italic text.
4. Long ASCII, multibyte, and TTS final responses reach Slack intact instead of being silently clipped at the edit limit.

## Evidence

- Frozen, clean canonical baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`; exact isolated candidate: `d562ed4f5880c50f7d62e6fa9e102568887f48ac`.
- Four exact-candidate Slack owner Vitest files: **172 tests passed**.
- Direct fake-WebClient regressions implement Slack's actual oldest-first ordering, page limits, exclusive/inclusive timeline bounds, and a 102-message busy thread.
- Formatting regressions separately prove CommonMark bold/link rendering and preservation of already-rendered Slack mrkdwn.
- Final-delivery regressions cover a 4,001-byte ASCII reply, a 4,002-byte multibyte reply, and oversized visible TTS text delivered together with its audio.
- Installed dependency contracts: `node_modules/@slack/web-api/dist/types/request/conversations.d.ts:124`, `node_modules/@slack/web-api/dist/types/request/common.d.ts:1`, and `node_modules/@slack/web-api/dist/types/request/common.d.ts:15`.
- Seven-file targeted `oxfmt --check`, `oxlint`, staged/final `git diff --check`, exact frozen parent, and clean isolated/canonical worktrees passed.
- Exact-tree structured `$autoreview` (`codex`, `gpt-5.6-sol`, reasoning `high`): **clean, zero findings, confidence 0.93**; genuine shared TruffleHog credential scan: **clean**.

## Explicit Exclusions

No Slack authentication or modal-policy changes. No public SDK export/signature, configuration, dependency, gateway-protocol, persistence, live-credential, canonical-main, fetch, push, or pull-request changes.
