### PR TITLE
fix(agents): preserve truthful tool outcomes and cancellation

### DIFF
--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -27,6 +27,7 @@ vi.mock("../subagent-registry-state.js", () => ({
   },
 }));
 
+import { isToolResultError } from "../tool-result-error.js";
 import { createAgentsWaitTool, waitForCollectorCompletion } from "./agents-wait-tool.js";
 import { testing } from "./agents-wait-tool.test-support.js";
 
@@ -193,6 +194,7 @@ describe("agents_wait", () => {
         { runId: "missing", error: "not_found" },
       ],
     });
+    expect(isToolResultError(first)).toBe(false);
   });
 
   it("authorizes a snapshotted ancestor after the ordinary spawner row is archived", async () => {
@@ -293,8 +295,77 @@ describe("agents_wait", () => {
       completed: [],
       pending: [],
       errors: [{ runId: "routed", error: "not_owner" }],
+      success: false,
     });
+    expect(isToolResultError(denied)).toBe(true);
   });
+
+  it("marks entirely missing collector batches as failures without losing per-id errors", async () => {
+    const tool = createAgentsWaitTool({
+      agentSessionKey: "agent:main:main",
+      agentId: "main",
+      config: { tools: { swarm: true } },
+    });
+
+    const result = await tool.execute("call", { ids: ["missing"], timeoutSeconds: 0 });
+
+    expect(result.details).toEqual({
+      completed: [],
+      pending: [],
+      errors: [{ runId: "missing", error: "not_found" }],
+      success: false,
+    });
+    expect(isToolResultError(result)).toBe(true);
+  });
+
+  it("rejects collector batches containing only blank run ids", async () => {
+    const tool = createAgentsWaitTool({
+      agentSessionKey: "agent:main:main",
+      agentId: "main",
+      config: { tools: { swarm: true } },
+    });
+
+    await expect(tool.execute("call", { ids: [" ", "\t"], timeoutSeconds: 0 })).rejects.toThrow(
+      "at least one non-empty run id",
+    );
+  });
+
+  it.each(["before", "during", "registration"] as const)(
+    "rejects when the wait is aborted %s collector polling",
+    async (abortTiming) => {
+      records.set("pending", collectorRun("pending", "agent:main:main"));
+      const tool = createAgentsWaitTool({
+        agentSessionKey: "agent:main:main",
+        agentId: "main",
+        config: { tools: { swarm: true } },
+      });
+      const controller = new AbortController();
+      if (abortTiming === "before") {
+        controller.abort();
+      }
+      if (abortTiming === "registration") {
+        const addEventListener = controller.signal.addEventListener.bind(controller.signal);
+        vi.spyOn(controller.signal, "addEventListener").mockImplementation((...args) => {
+          controller.abort();
+          addEventListener(...args);
+        });
+      }
+
+      const result = tool.execute(
+        "call",
+        { ids: ["pending"], timeoutSeconds: 1 },
+        controller.signal,
+      );
+      if (abortTiming === "during") {
+        controller.abort();
+      }
+
+      await expect(result).rejects.toMatchObject({
+        name: "AbortError",
+        message: "agents_wait aborted.",
+      });
+    },
+  );
 
   it("rejects oversized wait batches before polling", async () => {
     const tool = createAgentsWaitTool({

--- a/src/agents/tools/agents-wait-tool.ts
+++ b/src/agents/tools/agents-wait-tool.ts
@@ -1,5 +1,6 @@
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createAbortError } from "../../infra/abort-signal.js";
 import { onSubagentRegistryPersisted } from "../subagent-registry-state.js";
 import { getSubagentRunsByRunIds } from "../subagent-registry.js";
 import type { SubagentRunRecord } from "../subagent-registry.types.js";
@@ -165,24 +166,33 @@ async function waitForCollector(params: {
 }) {
   const deadline = Date.now() + params.timeoutMs;
   for (;;) {
+    if (params.signal?.aborted) {
+      throw createAbortError("agents_wait aborted.");
+    }
     // Recovery can replace a registry row while preserving its stable swarm id.
     // Re-resolve ownership and completion on every poll instead of retaining old objects.
     const state = readWaitState(params.ids, params.currentSessionKeys);
     if (state.completed.length > 0 || state.pending.length === 0 || Date.now() >= deadline) {
       return state;
     }
-    await new Promise<void>((resolve) => {
-      const finish = () => {
+    await new Promise<void>((resolve, reject) => {
+      const finish = (error?: Error) => {
         clearTimeout(timer);
-        params.signal?.removeEventListener("abort", finish);
+        params.signal?.removeEventListener("abort", onAbort);
+        if (error) {
+          reject(error);
+          return;
+        }
         resolve();
       };
+      const onAbort = () => finish(createAbortError("agents_wait aborted."));
       const timer = setTimeout(finish, Math.min(25, Math.max(0, deadline - Date.now())));
-      params.signal?.addEventListener("abort", finish, { once: true });
+      params.signal?.addEventListener("abort", onAbort, { once: true });
+      // Abort can race listener registration; never turn that cancellation into a successful poll.
+      if (params.signal?.aborted) {
+        onAbort();
+      }
     });
-    if (params.signal?.aborted) {
-      return readWaitState(params.ids, params.currentSessionKeys);
-    }
   }
 }
 
@@ -206,6 +216,9 @@ export function createAgentsWaitTool(opts: {
         throw new ToolInputError(`agents_wait supports at most ${MAX_WAIT_IDS} ids.`);
       }
       const ids = [...new Set(params.ids.map((id) => id.trim()).filter(Boolean))];
+      if (ids.length === 0) {
+        throw new ToolInputError("agents_wait requires at least one non-empty run id.");
+      }
       const currentSessionKeys = new Set(
         [opts.runSessionKey, opts.agentSessionKey].filter((key): key is string =>
           Boolean(key?.trim()),
@@ -222,7 +235,11 @@ export function createAgentsWaitTool(opts: {
         timeoutMs: timeoutSeconds * 1_000,
         signal,
       });
-      return jsonResult(result);
+      const noAuthorizedTargets =
+        result.completed.length === 0 &&
+        result.pending.length === 0 &&
+        Boolean(result.errors?.length);
+      return jsonResult(noAuthorizedTargets ? { ...result, success: false } : result);
     },
   };
 }

--- a/src/agents/tools/structured-output-tool.test.ts
+++ b/src/agents/tools/structured-output-tool.test.ts
@@ -1,6 +1,7 @@
 import { Value } from "typebox/value";
 import { beforeEach, describe, expect, it } from "vitest";
 import { validateStructuredOutputSchema } from "../swarm-output-schema.js";
+import { isToolResultError } from "../tool-result-error.js";
 import { createStructuredOutputTool } from "./structured-output-tool.js";
 import { testing } from "./structured-output-tool.test-support.js";
 
@@ -17,7 +18,8 @@ describe("structured_output", () => {
         additionalProperties: false,
       },
     });
-    await expect(tool.execute("call-1", { result: { answer: "yes" } })).resolves.toBeDefined();
+    const result = await tool.execute("call-1", { result: { answer: "yes" } });
+    expect(isToolResultError(result)).toBe(false);
     expect(testing.readSwarmStructuredOutput("run-1")?.structured).toEqual({ answer: "yes" });
   });
 
@@ -56,8 +58,12 @@ describe("structured_output", () => {
     await expect(tool.execute("call-1", { result: { count: "bad" } })).rejects.toThrow(
       "Retry once",
     );
-    await expect(tool.execute("call-2", { result: { count: "still bad" } })).resolves.toBeDefined();
-    await expect(tool.execute("call-3", { result: { count: 3 } })).resolves.toBeDefined();
+    const rejectedRetry = await tool.execute("call-2", { result: { count: "still bad" } });
+    const rejectedLaterCall = await tool.execute("call-3", { result: { count: 3 } });
+    expect(rejectedRetry.details).toMatchObject({ status: "rejected", success: false });
+    expect(rejectedLaterCall.details).toMatchObject({ status: "rejected", success: false });
+    expect(isToolResultError(rejectedRetry)).toBe(true);
+    expect(isToolResultError(rejectedLaterCall)).toBe(true);
     expect(testing.readSwarmStructuredOutput("run-2")).toMatchObject({
       structured: undefined,
       invalidAttempts: 2,
@@ -101,9 +107,9 @@ describe("structured_output", () => {
       schema,
       initialState: durableState,
     });
-    await expect(
-      restored.execute("call-2", { result: { count: "still bad" } }),
-    ).resolves.toBeDefined();
+    const rejected = await restored.execute("call-2", { result: { count: "still bad" } });
+    expect(rejected.details).toMatchObject({ status: "rejected", success: false });
+    expect(isToolResultError(rejected)).toBe(true);
     expect(testing.readSwarmStructuredOutput("run-restart")?.invalidAttempts).toBe(2);
   });
 });

--- a/src/agents/tools/structured-output-tool.ts
+++ b/src/agents/tools/structured-output-tool.ts
@@ -78,7 +78,7 @@ export function createStructuredOutputTool(params: {
         throw new ToolInputError("structured_output already recorded for this run");
       }
       if (prior && prior.invalidAttempts >= 2) {
-        return jsonResult({ status: "rejected", schemaError: prior.schemaError });
+        return jsonResult({ status: "rejected", success: false, schemaError: prior.schemaError });
       }
       let validation: ReturnType<typeof validateJsonSchemaValue>;
       try {
@@ -104,7 +104,7 @@ export function createStructuredOutputTool(params: {
           `structured_output validation failed: ${schemaError}. Retry once with a corrected final result.`,
         );
       }
-      return jsonResult({ status: "rejected", schemaError });
+      return jsonResult({ status: "rejected", success: false, schemaError });
     },
   };
 }

--- a/src/agents/tools/update-plan-tool.test.ts
+++ b/src/agents/tools/update-plan-tool.test.ts
@@ -14,7 +14,7 @@ describe("update_plan tool", () => {
       ],
     });
 
-    expect(result.content).toStrictEqual([]);
+    expect(result.content).toEqual([{ type: "text", text: "Plan updated" }]);
     expect(result.details).toEqual({
       status: "updated",
       explanation: "Started work",
@@ -50,7 +50,7 @@ describe("update_plan tool", () => {
       ],
     });
 
-    expect(result.content).toStrictEqual([]);
+    expect(result.content).toEqual([{ type: "text", text: "Plan updated" }]);
     expect(result.details).toEqual({
       status: "updated",
       plan: [

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -9,7 +9,7 @@ import {
   describeUpdatePlanTool,
   UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
-import { type AnyAgentTool, ToolInputError, readStringParam } from "./common.js";
+import { type AnyAgentTool, ToolInputError, readStringParam, textResult } from "./common.js";
 
 const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed"] as const;
 
@@ -91,14 +91,11 @@ export function createUpdatePlanTool(): AnyAgentTool {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
       const plan = readPlanSteps(params);
-      return {
-        content: [],
-        details: {
-          status: "updated" as const,
-          ...(explanation ? { explanation } : {}),
-          plan,
-        },
-      };
+      return textResult("Plan updated", {
+        status: "updated" as const,
+        ...(explanation ? { explanation } : {}),
+        plan,
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

- Return Codex-compatible visible `Plan updated` content from the existing private `update_plan` owner while preserving all structured plan details.
- Mark exhausted and restored `structured_output` schema rejection as unsuccessful through the existing owner result contract, without changing shared rejected-status behavior or retry semantics.
- Preserve `agents_wait` cancellation as `AbortError` before polling, during polling, and across listener-registration races.
- Reject blank-only collector batches and expose entirely unknown or unauthorized batches as failures while preserving per-run diagnostics, authorization checks, and mixed valid/invalid batch behavior.

## Verification

- Frozen base: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Immutable reviewed head: `79979ff4f1ca52f693721614ae4236988f491799` on `codex/qa200-agent-tool-visible-contracts`.
- Strict root-cause count: **4**; commit count: **1**; changed private owner files: **6**.
- `node scripts/run-vitest.mjs src/agents/tools/agents-wait-tool.test.ts src/agents/tools/structured-output-tool.test.ts src/agents/tools/update-plan-tool.test.ts`: **24/24 tests passed** across three owner files and two focused Vitest shards (**8** unit-fast; **16** `agents_wait`).
- Existing dependencies were reused through temporary links against the actual sparse candidate checkout; all links were cleaned up, no installation ran, and frozen main remained clean.
- Focused direct owner probes independently exercised **18 runtime assertions**, including native plan acknowledgment, tool-error classification, missing/unauthorized/mixed wait targets, and all three cancellation races.
- `git diff --check` and existing single-thread `oxfmt` validation passed for all six files.
- Genuine pre-commit structured Codex autoreview: **clean**, no findings, confidence **0.93**.
- Genuine exact-commit structured Codex autoreview: **clean**, no findings, confidence **0.95**.
- Both reviews performed clean scans with verified **TruffleHog 3.96.0**.

## Direct Codex dependency contract proof

- `codex-rs/core/src/tools/handlers/plan.rs:22` defines native `Plan updated` model-visible success output.
- `codex-rs/core/src/tools/handlers/dynamic.rs:150` forwards both dynamic-tool content and the explicit success bit.
- `codex-rs/protocol/src/dynamic_tools.rs:60` declares the dynamic response's `content_items` and `success` fields.
- `codex-rs/core/src/tools/parallel.rs:181` reserves cancellation as the terminal tool outcome.
- `extensions/codex/src/app-server/dynamic-tools.ts:648` computes tool-result error identity and `extensions/codex/src/app-server/dynamic-tools.ts:732` forwards visible content and `success` to Codex.
- `src/agents/tool-result-error.ts:77` already recognizes `details.success === false`; no shared classifier or public schema change is necessary.

## Strict root causes fixed

1. Successful plan updates had no model-visible content.
2. Terminal structured-output rejection was mislabeled successful.
3. Canceled waits became successful collector polls.
4. Blank-only, wholly unknown, or wholly unauthorized wait batches produced misleading success.

## Compatibility

No public tool schema, configuration, plugin SDK, gateway protocol, persistence, provider routing, or authorization-scope changes. Existing structured-output retry budget, rejection status, individual authorization errors, mixed authorized batches, and native abort identity are preserved.
