### PR TITLE
fix(openai): preserve video terminal outcomes and valid edit requests

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -234,6 +234,67 @@ describe("openai video generation provider", () => {
     expect(result.metadata?.status).toBe("completed");
   });
 
+  it.each(["vid_failed", undefined])(
+    "surfaces an immediately failed OpenAI submission before polling or validating id (%s)",
+    async (videoId) => {
+      const release = vi.fn(async () => {});
+      postJsonRequestMock.mockResolvedValue({
+        response: streamedJsonResponse({
+          ...(videoId ? { id: videoId } : {}),
+          status: "failed",
+          error: { message: "OpenAI video generation was rejected" },
+        }),
+        release,
+      });
+
+      await expect(
+        buildOpenAIVideoGenerationProvider().generateVideo({
+          provider: "openai",
+          model: "sora-2",
+          prompt: "A scene that cannot be generated",
+          cfg: {},
+        }),
+      ).rejects.toThrow("OpenAI video generation was rejected");
+
+      expect(pollProviderOperationJsonMock).not.toHaveBeenCalled();
+      expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("downloads an immediately completed OpenAI submission without polling it again", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "vid_completed",
+        model: "sora-2",
+        status: "completed",
+        seconds: "4",
+        size: "720x1280",
+      }),
+      release,
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      headers: new Headers({ "content-type": "video/mp4" }),
+      arrayBuffer: async () => Buffer.from("completed-video"),
+    });
+
+    const result = await buildOpenAIVideoGenerationProvider().generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "A scene already generated",
+      cfg: {},
+    });
+
+    expect(pollProviderOperationJsonMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      model: "sora-2",
+      metadata: { seconds: "4", size: "720x1280", status: "completed", videoId: "vid_completed" },
+    });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({
@@ -586,12 +647,61 @@ describe("openai video generation provider", () => {
     expect(createRequest.body).toBeInstanceOf(FormData);
     const form = createRequest.body as FormData;
     expect(form.get("prompt")).toBe("Remix this clip");
-    expect(form.get("model")).toBe("sora-2");
+    expect(form.get("model")).toBeNull();
     expect(form.get("video")).toBeInstanceOf(File);
     expect(form.get("input_reference")).toBeNull();
     expect(createRequest.timeoutMs).toBe(120000);
     expect(createRequest.fetchFn).toBe(fetch);
     expect(createRequest.allowPrivateNetwork).toBe(false);
+  });
+
+  it("surfaces an immediately failed OpenAI video edit without polling it", async () => {
+    const release = vi.fn(async () => {});
+    postMultipartRequestMock.mockResolvedValueOnce({
+      response: streamedJsonResponse({
+        id: "vid_edit_failed",
+        status: "failed",
+        error: { message: "OpenAI video edit was rejected" },
+      }),
+      release,
+    });
+
+    await expect(
+      buildOpenAIVideoGenerationProvider().generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "Remix this clip",
+        cfg: {},
+        inputVideos: [{ buffer: Buffer.from("mp4-bytes"), mimeType: "video/mp4" }],
+      }),
+    ).rejects.toThrow("OpenAI video edit was rejected");
+
+    expect(pollProviderOperationJsonMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("downloads an immediately completed OpenAI video edit without polling it again", async () => {
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({ id: "vid_edit_completed", model: "sora-2", status: "completed" }),
+      )
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("completed-edit"),
+      });
+
+    const result = await buildOpenAIVideoGenerationProvider().generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "Remix this clip",
+      cfg: {},
+      inputVideos: [{ buffer: Buffer.from("mp4-bytes"), mimeType: "video/mp4" }],
+    });
+
+    expect(pollProviderOperationJsonMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(2);
+    expect(result.metadata).toMatchObject({ status: "completed", videoId: "vid_edit_completed" });
   });
 
   it("honors configured request allowPrivateNetwork for multipart video uploads", async () => {

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -64,6 +64,12 @@ type OpenAIVideoResponse = {
   } | null;
 };
 
+function readOpenAIVideoFailureMessage(payload: OpenAIVideoResponse): string | undefined {
+  return payload.status === "failed"
+    ? (normalizeOptionalString(payload.error?.message) ?? "OpenAI video generation failed")
+    : undefined;
+}
+
 function toBlobBytes(buffer: Buffer): ArrayBuffer {
   const arrayBuffer = new ArrayBuffer(buffer.byteLength);
   new Uint8Array(arrayBuffer).set(buffer);
@@ -168,10 +174,7 @@ async function pollOpenAIVideo(
     dispatcherPolicy: params.dispatcherPolicy,
     auditContext: "openai-video-status",
     isComplete: (payload) => payload.status === "completed",
-    getFailureMessage: (payload) =>
-      payload.status === "failed"
-        ? normalizeOptionalString(payload.error?.message) || "OpenAI video generation failed"
-        : undefined,
+    getFailureMessage: readOpenAIVideoFailureMessage,
   });
 }
 
@@ -386,7 +389,6 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
           : await (() => {
               const form = new FormData();
               form.set("prompt", req.prompt);
-              form.set("model", model);
               form.set("video", referenceAsset.file);
               const multipartHeaders = new Headers(headers);
               multipartHeaders.delete("Content-Type");
@@ -432,22 +434,29 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
           response,
           "OpenAI video generation failed",
         );
+        const failureMessage = readOpenAIVideoFailureMessage(submitted);
+        if (failureMessage) {
+          throw new Error(failureMessage);
+        }
         const videoId = normalizeOptionalString(submitted.id);
         if (!videoId) {
           throw new Error("OpenAI video generation response missing video id");
         }
-        const completed = await pollOpenAIVideo({
-          videoId,
-          headers,
-          timeoutMs: resolveProviderOperationTimeoutMs({
-            deadline,
-            defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-          }),
-          baseUrl,
-          fetchFn,
-          allowPrivateNetwork,
-          dispatcherPolicy,
-        });
+        const completed =
+          submitted.status === "completed"
+            ? submitted
+            : await pollOpenAIVideo({
+                videoId,
+                headers,
+                timeoutMs: resolveProviderOperationTimeoutMs({
+                  deadline,
+                  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+                }),
+                baseUrl,
+                fetchFn,
+                allowPrivateNetwork,
+                dispatcherPolicy,
+              });
         const video = await downloadOpenAIVideo({
           videoId,
           headers,


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where OpenAI video creation or editing could hide the provider's actual rejection, misleadingly complain about a missing video ID, or poll a job that was already complete. Also fixes video-edit requests that supplied an unsupported `model` parameter and could therefore be rejected by OpenAI's edit endpoint.

These are two independent private OpenAI provider-owner defects affecting Sora video creation and video-to-video editing.

## Why This Change Was Made

Use the authoritative status and nested error returned by OpenAI's initial video creation/edit response before deciding whether an asynchronous status poll is necessary. Share the same failure interpretation between initial submissions and subsequent polling, preserve existing request cleanup, and send only the official `prompt`/`video` parameters to `/videos/edits`.

The repair stays inside the bundled OpenAI provider owner. Public plugin SDK, authentication, configuration, provider routing, request-network policy, generated-media limits, operation deadlines, and pending-job polling remain unchanged.

## User Impact

- A video generation or edit rejected immediately now reports OpenAI's original actionable error, even when the failed response has no video ID.
- An already-completed video creation or edit downloads immediately without a redundant status request that could fail or consume the remaining operation deadline.
- Video-to-video edits no longer submit the unsupported `model` multipart field and instead follow the provider's documented edit schema.
- Existing pending-job polling, model metadata, configured network rules, media-size protections, and one-time response cleanup continue to work.

## Evidence

- Frozen clean baseline and direct commit parent: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact isolated branch: `codex/qa100-openai-video-terminal-submit`.
- Exact structured-reviewed candidate: `d8b1565ee23f9a591b85e3270870fb158b1211fd`.
- Frozen baseline reproduces both defects: unconditional polling at `extensions/openai/video-generation-provider.ts:439` and an unsupported edit `model` field at `extensions/openai/video-generation-provider.ts:389`.
- Exact-commit focused OpenAI video provider suite: **19/19 tests passed**.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs \
  extensions/openai/video-generation-provider.test.ts
```

- Regression coverage includes immediately failed submissions with and without IDs, preserved provider error messages, immediately completed JSON creation, failed/completed multipart edits, official edit request fields, pending-job polling, request cleanup, configured network policy, and generated-media limits.
- Installed official `openai@6.49.0` source directly confirms creation/edit return the authoritative `Video` status and nested failure message at `node_modules/openai/src/resources/videos.ts:16`, `:87`, `:158`, and `:204`; `VideoEditParams` permits only `prompt` and `video` at `node_modules/openai/src/resources/videos.ts:344`.
- Codex runtime/protocol behavior was inspected directly at `../codex/sdk/python/src/openai_codex/_run.py:60`, `../codex/codex-rs/app-server-protocol/src/protocol/v2/turn.rs:30`, and `../codex/codex-rs/app-server-protocol/src/protocol/thread_history.rs:1187`.
- Genuine exact-commit structured Codex `gpt-5.6-sol` / high review: **clean, zero findings, 0.93 confidence**.
- Official **TruffleHog 3.96.0** exact-commit content preflight: **clean**.
- Targeted formatting, `git diff --check`, clean isolated worktree, frozen-parent ancestry, and unchanged clean canonical `main` all passed.
- No live video-provider request was made.

## Distinct Root Causes

1. Initial video submission terminal status/error ownership incorrectly belonged to asynchronous polling instead of the authoritative submission response.
2. Multipart video edits reused the creation model parameter despite OpenAI's edit endpoint accepting only `prompt` and `video`.

## Explicit Exclusions

Existing held OpenAI/xAI realtime terminal-event work is unrelated and unchanged. No public configuration, authentication, plugin SDK, gateway protocol, dependency, persistence, or canonical-main behavior is modified.
