### PR TITLE
fix(feishu): preserve paginated reaction actors and topic ownership

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -77,8 +77,9 @@ export async function resolveReactionSyntheticEvent(
 
   const emoji = event.reaction_type?.emoji_type;
   const messageId = event.message_id;
-  const senderId = event.user_id?.open_id;
-  const senderUserId = event.user_id?.user_id;
+  const senderOpenId = event.user_id?.open_id?.trim();
+  const senderUserId = event.user_id?.user_id?.trim();
+  const senderId = senderOpenId || senderUserId;
   if (!emoji || !messageId || !senderId) {
     return null;
   }
@@ -135,14 +136,18 @@ export async function resolveReactionSyntheticEvent(
   return {
     sender: {
       sender_id: {
-        open_id: senderId,
+        ...(senderOpenId ? { open_id: senderOpenId } : {}),
         ...(senderUserId ? { user_id: senderUserId } : {}),
       },
       sender_type: "user",
     },
     message: {
       message_id: `${messageId}:reaction:${emoji}:${uuid()}`,
+      // Synthetic IDs are local-only; replies and topic routing must retain the real message facts.
+      reply_target_message_id: messageId,
       typing_target_message_id: messageId,
+      ...(reactedMsg.rootId ? { root_id: reactedMsg.rootId } : {}),
+      ...(reactedMsg.threadId ? { thread_id: reactedMsg.threadId } : {}),
       chat_id: syntheticChatId,
       chat_type: syntheticChatType,
       message_type: "text",

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -380,6 +380,54 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(result?.message.typing_target_message_id).toBe("om_msg1");
   });
 
+  it("preserves reaction actors when Feishu supplies user_id without open_id", async () => {
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event: makeReactionEvent({ user_id: { user_id: "u_actor_only" } }),
+      botOpenId: "ou_bot",
+      fetchMessage: async () => createFetchedReactionMessage("oc_group_from_lookup", "group"),
+      uuid: () => "fixed-uuid",
+    });
+
+    expect(result?.sender.sender_id).toEqual({ user_id: "u_actor_only" });
+    expect(parseFeishuMessageEvent(result!, "ou_bot").senderOpenId).toBe("u_actor_only");
+  });
+
+  it.each(["created", "deleted"] as const)(
+    "preserves the real reply anchor and topic ownership for %s reactions",
+    async (action) => {
+      const result = await resolveReactionSyntheticEvent({
+        cfg,
+        accountId: "default",
+        event: makeReactionEvent(),
+        botOpenId: "ou_bot",
+        action,
+        fetchMessage: async () => ({
+          ...createFetchedReactionMessage("oc_topic_group", "group"),
+          rootId: "om_topic_root",
+          threadId: "omt_topic",
+        }),
+        uuid: () => "fixed-uuid",
+      });
+
+      expect(result?.message).toEqual(
+        expect.objectContaining({
+          reply_target_message_id: "om_msg1",
+          root_id: "om_topic_root",
+          thread_id: "omt_topic",
+        }),
+      );
+      expect(parseFeishuMessageEvent(result!, "ou_bot")).toEqual(
+        expect.objectContaining({
+          replyTargetMessageId: "om_msg1",
+          rootId: "om_topic_root",
+          threadId: "omt_topic",
+        }),
+      );
+    },
+  );
+
   it("drops unverified reactions when sender verification times out", async () => {
     const event = makeReactionEvent();
     const result = await resolveReactionSyntheticEvent({
@@ -412,6 +460,7 @@ describe("resolveReactionSyntheticEvent", () => {
       },
       message: {
         message_id: "om_msg1:reaction:THUMBSUP:fixed-uuid",
+        reply_target_message_id: "om_msg1",
         typing_target_message_id: "om_msg1",
         chat_id: "oc_group_from_event",
         chat_type: "group",

--- a/extensions/feishu/src/reactions.test.ts
+++ b/extensions/feishu/src/reactions.test.ts
@@ -29,6 +29,7 @@ import { listReactionsFeishu } from "./reactions.js";
 describe("listReactionsFeishu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    listMock.mockReset();
   });
 
   it("reads the SDK's nested operator ownership fields", async () => {
@@ -108,5 +109,106 @@ describe("listReactionsFeishu", () => {
         operatorId: "tenant-1",
       },
     ]);
+  });
+
+  it("drains every reaction page while retaining the requested emoji filter", async () => {
+    listMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            {
+              reaction_id: "r-first",
+              reaction_type: { emoji_type: "HEART" },
+              operator: { operator_type: "user", operator_id: "ou_user" },
+            },
+          ],
+          has_more: true,
+          page_token: "page-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            {
+              reaction_id: "r-bot",
+              reaction_type: { emoji_type: "HEART" },
+              operator: { operator_type: "app", operator_id: "cli_main" },
+            },
+          ],
+          has_more: false,
+        },
+      });
+
+    const reactions = await listReactionsFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_message",
+      emojiType: "HEART",
+    });
+
+    expect(reactions.map((reaction) => reaction.reactionId)).toEqual(["r-first", "r-bot"]);
+    expect(listMock).toHaveBeenNthCalledWith(1, {
+      path: { message_id: "om_message" },
+      params: { reaction_type: "HEART" },
+    });
+    expect(listMock).toHaveBeenNthCalledWith(2, {
+      path: { message_id: "om_message" },
+      params: { reaction_type: "HEART", page_token: "page-2" },
+    });
+  });
+
+  it("rejects a continuation response without its required page token", async () => {
+    listMock.mockResolvedValue({
+      code: 0,
+      data: { items: [], has_more: true },
+    });
+
+    await expect(
+      listReactionsFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_message" }),
+    ).rejects.toThrow(/page token/i);
+    expect(listMock).toHaveBeenCalledOnce();
+  });
+
+  it("rejects repeated reaction page tokens", async () => {
+    listMock.mockResolvedValue({
+      code: 0,
+      data: { items: [], has_more: true, page_token: "same-page" },
+    });
+
+    await expect(
+      listReactionsFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_message" }),
+    ).rejects.toThrow(/repeated page token/i);
+    expect(listMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates API failures from continuation pages", async () => {
+    listMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [], has_more: true, page_token: "page-2" },
+      })
+      .mockResolvedValueOnce({ code: 9999, msg: "continuation unavailable" });
+
+    await expect(
+      listReactionsFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_message" }),
+    ).rejects.toThrow("Feishu list reactions failed: continuation unavailable");
+  });
+
+  it("bounds malformed endless reaction pagination", async () => {
+    let nextPage = 0;
+    listMock.mockImplementation(async () => ({
+      code: 0,
+      data: {
+        items: [],
+        has_more: true,
+        page_token: `page-${++nextPage}`,
+      },
+    }));
+
+    await expect(
+      listReactionsFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_message" }),
+    ).rejects.toThrow(/pagination limit/i);
+    expect(listMock).toHaveBeenCalledTimes(100);
   });
 });

--- a/extensions/feishu/src/reactions.test.ts
+++ b/extensions/feishu/src/reactions.test.ts
@@ -195,20 +195,39 @@ describe("listReactionsFeishu", () => {
     ).rejects.toThrow("Feishu list reactions failed: continuation unavailable");
   });
 
-  it("bounds malformed endless reaction pagination", async () => {
+  it("drains valid reaction lists beyond 100 pages", async () => {
     let nextPage = 0;
-    listMock.mockImplementation(async () => ({
-      code: 0,
-      data: {
-        items: [],
-        has_more: true,
-        page_token: `page-${++nextPage}`,
-      },
-    }));
+    listMock.mockImplementation(async () => {
+      nextPage += 1;
+      const hasMore = nextPage < 101;
+      return {
+        code: 0,
+        data: {
+          items: hasMore
+            ? []
+            : [
+                {
+                  reaction_id: "r-last-page",
+                  reaction_type: { emoji_type: "HEART" },
+                  operator: { operator_type: "app", operator_id: "cli_main" },
+                },
+              ],
+          has_more: hasMore,
+          page_token: hasMore ? `page-${nextPage}` : undefined,
+        },
+      };
+    });
 
     await expect(
       listReactionsFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_message" }),
-    ).rejects.toThrow(/pagination limit/i);
-    expect(listMock).toHaveBeenCalledTimes(100);
+    ).resolves.toEqual([
+      {
+        reactionId: "r-last-page",
+        emojiType: "HEART",
+        operatorType: "app",
+        operatorId: "cli_main",
+      },
+    ]);
+    expect(listMock).toHaveBeenCalledTimes(101);
   });
 });

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -10,6 +10,8 @@ type FeishuReaction = {
   operatorId: string;
 };
 
+const MAX_FEISHU_REACTION_PAGES = 100;
+
 function resolveConfiguredFeishuClient(params: { cfg: ClawdbotConfig; accountId?: string }) {
   const account = resolveFeishuRuntimeAccount(params);
   if (!account.configured) {
@@ -94,37 +96,67 @@ export async function listReactionsFeishu(params: {
 }): Promise<FeishuReaction[]> {
   const { cfg, messageId, emojiType, accountId } = params;
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
+  const reactions: FeishuReaction[] = [];
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
 
-  const response = (await client.im.messageReaction.list({
-    path: { message_id: messageId },
-    params: emojiType ? { reaction_type: emojiType } : undefined,
-  })) as {
-    code?: number;
-    msg?: string;
-    data?: {
-      items?: Array<{
-        reaction_id?: string;
-        reaction_type?: { emoji_type?: string };
-        operator?: {
-          operator_type?: string;
-          operator_id?: string;
-        };
-      }>;
+  for (let page = 0; page < MAX_FEISHU_REACTION_PAGES; page += 1) {
+    const response = (await client.im.messageReaction.list({
+      path: { message_id: messageId },
+      params:
+        emojiType || pageToken
+          ? {
+              ...(emojiType ? { reaction_type: emojiType } : {}),
+              ...(pageToken ? { page_token: pageToken } : {}),
+            }
+          : undefined,
+    })) as {
+      code?: number;
+      msg?: string;
+      data?: {
+        items?: Array<{
+          reaction_id?: string;
+          reaction_type?: { emoji_type?: string };
+          operator?: {
+            operator_type?: string;
+            operator_id?: string;
+          };
+        }>;
+        has_more?: boolean;
+        page_token?: string;
+      };
     };
-  };
 
-  assertFeishuReactionApiSuccess(response, "list reactions");
+    assertFeishuReactionApiSuccess(response, "list reactions");
 
-  const items = response.data?.items ?? [];
-  return items.map((item) => ({
-    reactionId: item.reaction_id ?? "",
-    emojiType: item.reaction_type?.emoji_type ?? "",
-    operatorType:
-      item.operator?.operator_type === "app"
-        ? "app"
-        : item.operator?.operator_type === "user"
-          ? "user"
-          : "unknown",
-    operatorId: item.operator?.operator_id ?? "",
-  }));
+    for (const item of response.data?.items ?? []) {
+      reactions.push({
+        reactionId: item.reaction_id ?? "",
+        emojiType: item.reaction_type?.emoji_type ?? "",
+        operatorType:
+          item.operator?.operator_type === "app"
+            ? "app"
+            : item.operator?.operator_type === "user"
+              ? "user"
+              : "unknown",
+        operatorId: item.operator?.operator_id ?? "",
+      });
+    }
+
+    if (response.data?.has_more !== true) {
+      return reactions;
+    }
+
+    const nextPageToken = response.data.page_token?.trim();
+    if (!nextPageToken) {
+      throw new Error("Feishu reaction pagination is missing its next page token");
+    }
+    if (seenPageTokens.has(nextPageToken)) {
+      throw new Error("Feishu reaction pagination returned a repeated page token");
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  throw new Error("Feishu reaction pagination limit exceeded");
 }

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -10,8 +10,6 @@ type FeishuReaction = {
   operatorId: string;
 };
 
-const MAX_FEISHU_REACTION_PAGES = 100;
-
 function resolveConfiguredFeishuClient(params: { cfg: ClawdbotConfig; accountId?: string }) {
   const account = resolveFeishuRuntimeAccount(params);
   if (!account.configured) {
@@ -100,7 +98,7 @@ export async function listReactionsFeishu(params: {
   const seenPageTokens = new Set<string>();
   let pageToken: string | undefined;
 
-  for (let page = 0; page < MAX_FEISHU_REACTION_PAGES; page += 1) {
+  while (true) {
     const response = (await client.im.messageReaction.list({
       path: { message_id: messageId },
       params:
@@ -157,6 +155,4 @@ export async function listReactionsFeishu(params: {
     seenPageTokens.add(nextPageToken);
     pageToken = nextPageToken;
   }
-
-  throw new Error("Feishu reaction pagination limit exceeded");
 }

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -381,6 +381,37 @@ describe("getMessageFeishu", () => {
     });
   });
 
+  it("preserves the canonical root and thread returned by the Feishu message API", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_topic_child",
+            root_id: "om_topic_root",
+            thread_id: "omt_topic",
+            chat_id: "oc_topic_group",
+            msg_type: "text",
+            body: { content: JSON.stringify({ text: "topic reply" }) },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_topic_child",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_topic_child",
+        rootId: "om_topic_root",
+        threadId: "omt_topic",
+      }),
+    );
+  });
+
   it("falls through empty interactive card element arrays and locale variants", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -92,6 +92,7 @@ type FeishuMessageGetItem = {
   message_id?: string;
   chat_id?: string;
   chat_type?: FeishuChatType;
+  root_id?: string;
   thread_id?: string;
   msg_type?: string;
   body?: { content?: string };
@@ -389,6 +390,7 @@ function parseFeishuMessageItem(
     content: parseFeishuMessageContent(rawContent, msgType, item.message_id),
     contentType: msgType,
     createTime: parseStrictNonNegativeInteger(item.create_time),
+    ...(item.root_id ? { rootId: item.root_id } : {}),
     threadId: item.thread_id || undefined,
   };
 }

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -76,6 +76,8 @@ export type FeishuMessageInfo = {
   content: string;
   contentType: string;
   createTime?: number;
+  /** Root message ID for replies inside Feishu topics. */
+  rootId?: string;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */
   threadId?: string;
 };


### PR DESCRIPTION
## What Problem This Solves

Feishu operators encounter three independent reaction-owner failures: reactions on later provider pages are invisible to list/remove/clear actions; valid reaction actors represented only by Feishu user_id are silently discarded; and reaction-driven replies lose the real message anchor and topic thread.

## Why This Change Was Made

- Follow the Feishu SDK's has_more/page_token contract until the actual terminal page, retaining reaction filters and app/user ownership on every page. Reject missing or repeated continuation tokens and propagate provider failures; valid lists beyond 100 pages remain supported.
- Preserve either SDK-supported actor identity (open_id or user_id) without changing notification policy, application self-reaction filtering, or authorization.
- Carry the original message reply target plus the message lookup's canonical root_id/thread_id into both created and deleted synthetic reaction events.

## User Impact

1. Feishu reaction listings and own-reaction removal/clear-all actions include every provider page.
2. Users whose reaction events supply only user_id are delivered to the normal Feishu agent path.
3. Reaction-driven responses stay attached to the correct real message and topic for both additions and removals.

Exactly three bounded plugin-private root-cause fixes; no authentication, public SDK/configuration, protocol, storage, or dependency behavior changes.

## Evidence

- Frozen canonical base: `e051a7bb4a6ba69b87391e990b00813114b1d482`; final clean isolated candidate: `c4537fec7c9cb19ea1c538be872c1654a87e990b`.
- Exact final single-worker Feishu owner/channel command:

```text
PATH=/Users/steipete/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_FS_SAFE_NATIVE_MODE=off FS_SAFE_NATIVE_MODE=off /Users/steipete/.local/bin/node scripts/run-vitest.mjs extensions/feishu/src/reactions.test.ts extensions/feishu/src/monitor.reaction.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/channel.test.ts --reporter=dot
```

- **4 focused owner files, 164/164 tests passed** at the final committed SHA.
- The pagination owner independently passes all **7 regressions**, including a legitimate **101-page** reaction listing, emoji-filter preservation, missing/repeated cursor rejection, continuation-page API failure, and app/user operator identity.
- Actual production-module probes verify frozen-main red -> final-candidate green for all three roots, including both created and deleted reaction events.
- Official installed SDK contract proof: `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:262805`, `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:262822`, `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:262830`, `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:310323`, `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:310354`, `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:261874`, and `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:261876`.
- Existing sibling cursor owner: `extensions/feishu/src/chat.ts:175`; reaction action callers: `extensions/feishu/src/channel.ts:1509`, `extensions/feishu/src/channel.ts:1545`, and `extensions/feishu/src/channel.ts:1596`.
- Initial whole-branch reviewer identified and we fixed an unsupported 100-page ceiling; final exact-head structured review: **clean, zero findings, 0.91 confidence**, and genuine shared TruffleHog: **clean**.
- Seven changed paths pass targeted oxfmt and `git diff --check`; frozen parent, isolated candidate, and untouched canonical main are clean.

## Explicit Exclusions

No live Feishu credentials or provider calls; no configuration, authentication/security policy, public plugin SDK, gateway protocol, migration, SQLite, dependency, canonical-main, or other plugin changes.
