### PR TITLE
feat(plugins): externalize Mistral provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Mistral plugin distribution:** ship the Mistral provider as an installable official plugin instead of bundling it in core, while preserving configured Mistral models through update repair.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Mistral plugin distribution:** ship the Mistral provider as an installable official plugin instead of bundling it in core, while preserving configured Mistral models through update repair.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-59 plugins
+58 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -121,8 +121,6 @@ Each entry lists the package, distribution route, and description.
 
 - **[minimax](/plugins/reference/minimax)** (`@openclaw/minimax-provider`) - included in OpenClaw. Adds MiniMax, MiniMax Portal model provider support to OpenClaw.
 
-- **[mistral](/plugins/reference/mistral)** (`@openclaw/mistral-provider`) - included in OpenClaw. Adds Mistral model provider support to OpenClaw.
-
 - **[novita](/plugins/reference/novita)** (`@openclaw/novita-provider`) - included in OpenClaw. Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
 
 - **[nvidia](/plugins/reference/nvidia)** (`@openclaw/nvidia-provider`) - included in OpenClaw. Adds NVIDIA model provider support to OpenClaw.
@@ -173,7 +171,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-86 plugins
+87 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -270,6 +268,8 @@ Each entry lists the package, distribution route, and description.
 - **[memory-lancedb](/plugins/reference/memory-lancedb)** (`@openclaw/memory-lancedb`) - npm; ClawHub. OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.
 
 - **[meta](/plugins/reference/meta)** (`@openclaw/meta-provider`) - npm; ClawHub: `clawhub:@openclaw/meta-provider`. Adds Meta model provider support to OpenClaw.
+
+- **[mistral](/plugins/reference/mistral)** (`@openclaw/mistral-provider`) - npm; ClawHub: `clawhub:@openclaw/mistral-provider`. Adds Mistral model provider support to OpenClaw.
 
 - **[moonshot](/plugins/reference/moonshot)** (`@openclaw/moonshot-provider`) - npm; ClawHub: `clawhub:@openclaw/moonshot-provider`. Adds Moonshot model provider support to OpenClaw.
 

--- a/docs/plugins/reference/mistral.md
+++ b/docs/plugins/reference/mistral.md
@@ -12,7 +12,7 @@ Adds Mistral model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/mistral-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/mistral-provider`
 
 ## Surface
 

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -7,12 +7,14 @@ read_when:
 title: "Mistral"
 ---
 
-The bundled `mistral` plugin registers four contracts: chat completions, media understanding (Voxtral batch transcription), realtime STT for Voice Call (Voxtral Realtime), and memory embeddings (`mistral-embed`).
+The official external `mistral` plugin registers four contracts: chat completions,
+media understanding (Voxtral batch transcription), realtime STT for Voice Call
+(Voxtral Realtime), and memory embeddings (`mistral-embed`).
 
 | Property         | Value                                       |
 | ---------------- | ------------------------------------------- |
 | Provider id      | `mistral`                                   |
-| Plugin           | bundled, enabled by default                 |
+| Plugin           | `@openclaw/mistral-provider`                |
 | Auth env var     | `MISTRAL_API_KEY`                           |
 | Onboarding flag  | `--auth-choice mistral-api-key`             |
 | Direct CLI flag  | `--mistral-api-key <key>`                   |
@@ -26,6 +28,12 @@ The bundled `mistral` plugin registers four contracts: chat completions, media u
 ## Getting started
 
 <Steps>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install @openclaw/mistral-provider
+    openclaw gateway restart
+    ```
+  </Step>
   <Step title="Get your API key">
     Create an API key in the [Mistral Console](https://console.mistral.ai/).
   </Step>
@@ -68,7 +76,7 @@ The bundled `mistral` plugin registers four contracts: chat completions, media u
 | `mistral/mistral-medium-2508`    | text, image | 128,000 | 8,192      | Deprecated; hidden; use Mistral Medium 3.5            |
 | `mistral/devstral-medium-latest` | text        | 262,144 | 32,768     | Deprecated; hidden; use Mistral Medium 3.5            |
 
-Browse the bundled catalog row before changing config:
+Browse the plugin catalog row before changing config:
 
 ```bash
 openclaw models list --all --provider mistral --plain
@@ -106,7 +114,7 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
 
 ## Voice Call streaming STT
 
-The bundled `mistral` plugin registers Voxtral Realtime as a Voice Call streaming STT provider.
+The `mistral` plugin registers Voxtral Realtime as a Voice Call streaming STT provider.
 
 | Setting      | Config path                                                            | Default                                 |
 | ------------ | ---------------------------------------------------------------------- | --------------------------------------- |
@@ -178,7 +186,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
     ```
 
     <Note>
-    Other bundled Mistral catalog models do not use this parameter. Mistral's native Magistral models are deprecated; use adjustable reasoning on Mistral Small 4 or Mistral Medium 3.5 for current API models.
+    Other Mistral catalog models do not use this parameter. Mistral's native Magistral models are deprecated; use adjustable reasoning on Mistral Small 4 or Mistral Medium 3.5 for current API models.
     </Note>
 
   </Accordion>

--- a/extensions/mistral/README.md
+++ b/extensions/mistral/README.md
@@ -1,0 +1,16 @@
+# OpenClaw Mistral Provider
+
+Official OpenClaw provider plugin for Mistral models, Voxtral transcription, and
+Mistral memory embeddings.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/mistral-provider
+openclaw gateway restart
+```
+
+Set `MISTRAL_API_KEY`, then select a `mistral/*` model or configure Mistral for
+media transcription, realtime transcription, or memory embeddings.
+
+See <https://docs.openclaw.ai/providers/mistral> for setup and configuration.

--- a/extensions/mistral/index.ts
+++ b/extensions/mistral/index.ts
@@ -22,7 +22,7 @@ function buildMistralReplayPolicy() {
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Mistral Provider",
-  description: "Bundled Mistral provider plugin",
+  description: "Official Mistral provider plugin",
   manifest,
   provider: {
     label: "Mistral",

--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -17,7 +17,7 @@ function catalogModelById(models: ReturnType<typeof buildCatalogModels>, id: str
 }
 
 describe("mistral model definitions", () => {
-  it("uses current OpenClaw pricing for the bundled default model", () => {
+  it("uses current OpenClaw pricing for the default model", () => {
     const model = buildMistralModelDefinition();
     expect(model.id).toBe(MISTRAL_DEFAULT_MODEL_ID);
     expect(model.contextWindow).toBe(262144);

--- a/extensions/mistral/onboard.test.ts
+++ b/extensions/mistral/onboard.test.ts
@@ -4,7 +4,7 @@ import {
   expectProviderOnboardPrimaryAndFallbacks,
 } from "openclaw/plugin-sdk/provider-test-contracts";
 import { describe, expect, it } from "vitest";
-import { buildMistralModelDefinition as buildBundledMistralModelDefinition } from "./model-definitions.js";
+import { buildMistralModelDefinition } from "./model-definitions.js";
 import { MISTRAL_DEFAULT_MODEL_REF } from "./model-definitions.js";
 import { applyMistralConfig, applyMistralProviderConfig } from "./onboard.js";
 
@@ -35,14 +35,14 @@ describe("mistral onboard", () => {
     expect(mistralDefault?.maxTokens).toBe(16384);
   });
 
-  it("uses the bundled mistral default model definition", () => {
-    const bundled = buildBundledMistralModelDefinition();
+  it("uses the Mistral default model definition", () => {
+    const defaultDefinition = buildMistralModelDefinition();
     const cfg = applyMistralProviderConfig({});
     const defaultModel = cfg.models?.providers?.mistral?.models.find(
-      (model) => model.id === bundled.id,
+      (model) => model.id === defaultDefinition.id,
     );
 
-    expect(defaultModel).toEqual(bundled);
+    expect(defaultModel).toEqual(defaultDefinition);
   });
 
   it("adds the expected alias for the default model", () => {

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/mistral-provider",
   "version": "2026.7.2",
-  "private": true,
   "description": "OpenClaw Mistral provider plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/mistral-provider",
+      "npmSpec": "@openclaw/mistral-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "!dist/extensions/memory-lancedb/**",
     "!dist/extensions/meta/**",
     "!dist/extensions/matrix/**",
+    "!dist/extensions/mistral/**",
     "!dist/extensions/moonshot/**",
     "!dist/extensions/msteams/**",
     "!dist/extensions/mxc/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -860,6 +860,59 @@
       }
     },
     {
+      "name": "@openclaw/mistral-provider",
+      "description": "OpenClaw Mistral provider plugin",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "mistral",
+          "label": "Mistral"
+        },
+        "providerEndpoints": [
+          {
+            "endpointClass": "mistral-public",
+            "hosts": ["api.mistral.ai"]
+          }
+        ],
+        "providers": [
+          {
+            "id": "mistral",
+            "name": "Mistral",
+            "docs": "/providers/mistral",
+            "categories": ["cloud", "llm"],
+            "envVars": ["MISTRAL_API_KEY"],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "mistral-api-key",
+                "choiceLabel": "Mistral API key",
+                "groupId": "mistral",
+                "groupLabel": "Mistral AI",
+                "groupHint": "API key",
+                "optionKey": "mistralApiKey",
+                "cliFlag": "--mistral-api-key",
+                "cliOption": "--mistral-api-key <key>",
+                "cliDescription": "Mistral API key",
+                "onboardingScopes": ["text-inference"]
+              }
+            ]
+          }
+        ],
+        "contracts": {
+          "memoryEmbeddingProviders": ["mistral"],
+          "mediaUnderstandingProviders": ["mistral"],
+          "realtimeTranscriptionProviders": ["mistral"]
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/mistral-provider",
+          "npmSpec": "@openclaw/mistral-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/groq-provider",
       "description": "OpenClaw Groq media-understanding provider.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -167,6 +167,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
   it.each([
     ["byteplus", "@openclaw/byteplus-provider", true],
     ["duckduckgo", "@openclaw/duckduckgo-plugin", false],
+    ["mistral", "@openclaw/mistral-provider", true],
     ["synthetic", "@openclaw/synthetic-provider", true],
     ["teams-meetings", "@openclaw/teams-meetings", true],
     ["volcengine", "@openclaw/volcengine-provider", true],

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -341,14 +341,16 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
   });
 
-  const { repairStaleAgentModelRefs } =
-    await import("./doctor/shared/stale-agent-model-ref-repair.js");
-  const staleAgentModelRepair = repairStaleAgentModelRefs(state.candidate, { env: process.env });
-  applyConfigMutation(staleAgentModelRepair, {
-    fixHint: `Run "${doctorFixCommand}" to remove stale agent model references.`,
-    sanitize: true,
-    emitWarnings: true,
-  });
+  if (!shouldRepair) {
+    const { repairStaleAgentModelRefs } =
+      await import("./doctor/shared/stale-agent-model-ref-repair.js");
+    const staleAgentModelRepair = repairStaleAgentModelRefs(state.candidate, { env: process.env });
+    applyConfigMutation(staleAgentModelRepair, {
+      fixHint: `Run "${doctorFixCommand}" to remove stale agent model references.`,
+      sanitize: true,
+      emitWarnings: true,
+    });
+  }
 
   const { collectPluginToolAllowlistWarnings } =
     await import("./doctor/shared/plugin-tool-allowlist-warnings.js");

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -972,6 +972,31 @@ describe("normalizeCompatibilityConfigValues", () => {
     expect(result.config.agents?.list?.[1]?.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
+  it("preserves model refs backed by a configured installable provider", () => {
+    const result = repairStaleAgentModelRefs(
+      {
+        plugins: {
+          allow: ["mistral"],
+          entries: { mistral: { enabled: true } },
+        },
+        agents: {
+          defaults: {
+            model: { primary: "mistral/mistral-large-latest" },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        pluginProviderIds: new Set(),
+        persistedProviderIdsByAgentId: new Map(),
+      },
+    );
+
+    expect(result.changes).toEqual([]);
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: "mistral/mistral-large-latest",
+    });
+  });
+
   it("does not treat one agent-local provider as globally available", () => {
     const result = repairStaleAgentModelRefs(
       {

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   maybeRepairStalePluginConfig: vi.fn(),
   repairStaleOAuthProfileShadows: vi.fn(),
   repairMissingConfiguredPluginInstalls: vi.fn(),
+  repairStaleAgentModelRefs: vi.fn(),
   resolveAuthProfileOrder: vi.fn(),
   resolveProfileUnusableUntilForDisplay: vi.fn(),
 }));
@@ -56,6 +57,10 @@ vi.mock("../doctor-auth-flat-profiles.js", () => ({
 
 vi.mock("./shared/missing-configured-plugin-install.js", () => ({
   repairMissingConfiguredPluginInstalls: mocks.repairMissingConfiguredPluginInstalls,
+}));
+
+vi.mock("./shared/stale-agent-model-ref-repair.js", () => ({
+  repairStaleAgentModelRefs: mocks.repairStaleAgentModelRefs,
 }));
 
 vi.mock("../../agents/auth-profiles.js", () => ({
@@ -279,6 +284,11 @@ describe("doctor repair sequencing", () => {
       changes: [],
       warnings: [],
     });
+    mocks.repairStaleAgentModelRefs.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+      warnings: [],
+    }));
     mocks.repairStaleOAuthProfileShadows.mockResolvedValue({
       changes: [],
       warnings: [],
@@ -651,6 +661,102 @@ describe("doctor repair sequencing", () => {
       'Installed missing configured plugin "brave" from @openclaw/brave-plugin.',
       "brave web search provider selected, enabled automatically.",
     ]);
+  });
+
+  it("installs an external provider before validating configured model references", async () => {
+    let mistralInstalled = false;
+    mocks.repairMissingConfiguredPluginInstalls.mockImplementationOnce(async () => {
+      mistralInstalled = true;
+      return {
+        changes: ['Installed missing configured plugin "mistral" from @openclaw/mistral-provider.'],
+        warnings: [],
+        repairedPluginIds: ["mistral"],
+      };
+    });
+    mocks.repairStaleAgentModelRefs.mockImplementationOnce((cfg: OpenClawConfig) => ({
+      config: mistralInstalled
+        ? cfg
+        : {
+            ...cfg,
+            agents: {
+              ...cfg.agents,
+              defaults: {
+                ...cfg.agents?.defaults,
+                model: { primary: "openai/gpt-5.6-sol" },
+              },
+            },
+          },
+      changes: mistralInstalled ? [] : ["replaced Mistral model before plugin repair"],
+      warnings: [],
+    }));
+    const config = {
+      plugins: {
+        allow: ["mistral"],
+        entries: { mistral: { enabled: true } },
+      },
+      agents: {
+        defaults: { model: { primary: "mistral/mistral-large-latest" } },
+      },
+      memory: { search: { provider: "mistral" } },
+    } as OpenClawConfig;
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: config,
+        candidate: config,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(mocks.repairMissingConfiguredPluginInstalls.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.repairStaleAgentModelRefs.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(result.state.candidate.plugins?.allow).toEqual(["mistral"]);
+    expect(result.state.candidate.plugins?.entries?.mistral?.enabled).toBe(true);
+    expect(result.state.candidate.agents?.defaults?.model).toEqual({
+      primary: "mistral/mistral-large-latest",
+    });
+    expect(result.state.candidate.memory?.search?.provider).toBe("mistral");
+  });
+
+  it("preserves external provider model references when plugin install repair fails", async () => {
+    mocks.repairMissingConfiguredPluginInstalls.mockResolvedValueOnce({
+      changes: [],
+      warnings: [
+        'Failed to install missing configured plugin "mistral" from @openclaw/mistral-provider: package install failed',
+      ],
+      failedPluginIds: ["mistral"],
+    });
+    const config = {
+      plugins: {
+        allow: ["mistral"],
+        entries: { mistral: { enabled: true } },
+      },
+      agents: {
+        defaults: { model: { primary: "mistral/mistral-large-latest" } },
+      },
+      memory: { search: { provider: "mistral" } },
+    } as OpenClawConfig;
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: config,
+        candidate: config,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(mocks.repairStaleAgentModelRefs).not.toHaveBeenCalled();
+    expect(result.state.candidate.plugins?.allow).toEqual(["mistral"]);
+    expect(result.state.candidate.plugins?.entries?.mistral?.enabled).toBe(true);
+    expect(result.state.candidate.agents?.defaults?.model).toEqual({
+      primary: "mistral/mistral-large-latest",
+    });
+    expect(result.state.candidate.memory?.search?.provider).toBe("mistral");
   });
 
   it("applies doctor contracts exposed by newly installed plugins", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -40,6 +40,7 @@ import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sen
 import { repairMissingConfiguredPluginInstalls } from "./shared/missing-configured-plugin-install.js";
 import { maybeRepairOpenPolicyAllowFrom } from "./shared/open-policy-allowfrom.js";
 import { cleanupLegacyPluginDependencyState } from "./shared/plugin-dependency-cleanup.js";
+import { repairStaleAgentModelRefs } from "./shared/stale-agent-model-ref-repair.js";
 import { maybeRepairStaleConfiguredAuthOrders } from "./shared/stale-auth-order.js";
 import { repairStaleOAuthProfileShadows } from "./shared/stale-oauth-profile-shadows.js";
 import { maybeRepairStalePluginConfig } from "./shared/stale-plugin-config.js";
@@ -195,7 +196,15 @@ export async function runDoctorRepairSequence(params: {
   const failedPluginIds = missingConfiguredPluginInstallRepair.failedPluginIds ?? [];
   const hasUnscopedInstallRepairWarnings =
     missingConfiguredPluginInstallRepair.warnings.length > 0 && failedPluginIds.length === 0;
-  if (!isUpdatePackageSwapInProgress(env) && !hasUnscopedInstallRepairWarnings) {
+  const packageSwapInProgress = isUpdatePackageSwapInProgress(env);
+  const pluginInstallRepairConverged =
+    !packageSwapInProgress && failedPluginIds.length === 0 && !hasUnscopedInstallRepairWarnings;
+  if (pluginInstallRepairConverged) {
+    // Provider availability is authoritative only after configured plugin repair
+    // converges. Preserve model refs while package installation still needs a retry.
+    applyMutation(repairStaleAgentModelRefs(state.candidate, { env }));
+  }
+  if (!packageSwapInProgress && !hasUnscopedInstallRepairWarnings) {
     applyMutation(
       maybeRepairStalePluginConfig(state.candidate, env, {
         preservePluginIds: failedPluginIds,

--- a/src/commands/doctor/shared/stale-agent-model-ref-repair.ts
+++ b/src/commands/doctor/shared/stale-agent-model-ref-repair.ts
@@ -13,7 +13,9 @@ import { normalizeProviderId } from "../../../agents/model-selection.js";
 import type { AgentModelConfig } from "../../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolvePluginMetadataSnapshot } from "../../../plugins/plugin-metadata-snapshot.js";
+import { resolveProviderInstallCatalogEntries } from "../../../plugins/provider-install-catalog.js";
 import { listMutableCodexRouteAgentEntries } from "./codex-route-agent-entries.js";
+import { collectConfiguredProviderSelectionIds } from "./configured-provider-selection-ids.js";
 
 type StaleAgentModelRefRepair = {
   config: OpenClawConfig;
@@ -45,37 +47,52 @@ function collectPluginProviderIds(
   cfg: OpenClawConfig,
   options: RepairOptions,
 ): { providerIds?: Set<string>; warnings: string[] } {
+  let providerIds: Set<string>;
   if (options.pluginProviderIds) {
-    return {
-      providerIds: new Set([...options.pluginProviderIds].map(normalizeProviderId).filter(Boolean)),
-      warnings: [],
-    };
-  }
+    providerIds = new Set([...options.pluginProviderIds].map(normalizeProviderId).filter(Boolean));
+  } else {
+    const defaultAgentId = tryResolveDefaultAgentId(cfg);
+    const workspaceDir = defaultAgentId ? resolveAgentWorkspaceDir(cfg, defaultAgentId) : undefined;
+    const snapshot = resolvePluginMetadataSnapshot({
+      config: cfg,
+      workspaceDir: workspaceDir ?? undefined,
+      env: options.env ?? process.env,
+      allowWorkspaceScopedCurrent: true,
+    });
+    if (snapshot.diagnostics.some((diagnostic) => diagnostic.level === "error")) {
+      return {
+        warnings: [
+          "Skipped stale agent model reference repair because plugin discovery reported errors.",
+        ],
+      };
+    }
 
-  const defaultAgentId = tryResolveDefaultAgentId(cfg);
-  const workspaceDir = defaultAgentId ? resolveAgentWorkspaceDir(cfg, defaultAgentId) : undefined;
-  const snapshot = resolvePluginMetadataSnapshot({
+    providerIds = new Set<string>();
+    for (const owners of [
+      snapshot.owners.providers,
+      snapshot.owners.modelCatalogProviders,
+      snapshot.owners.setupProviders,
+      snapshot.owners.cliBackends,
+    ]) {
+      for (const providerId of owners.keys()) {
+        const normalized = normalizeProviderId(providerId);
+        if (normalized) {
+          providerIds.add(normalized);
+        }
+      }
+    }
+  }
+  const selectedProviderIds = collectConfiguredProviderSelectionIds(cfg);
+  for (const entry of resolveProviderInstallCatalogEntries({
     config: cfg,
-    workspaceDir: workspaceDir ?? undefined,
     env: options.env ?? process.env,
-    allowWorkspaceScopedCurrent: true,
-  });
-  if (snapshot.diagnostics.some((diagnostic) => diagnostic.level === "error")) {
-    return {
-      warnings: [
-        "Skipped stale agent model reference repair because plugin discovery reported errors.",
-      ],
-    };
-  }
-
-  const providerIds = new Set<string>();
-  for (const owners of [
-    snapshot.owners.providers,
-    snapshot.owners.modelCatalogProviders,
-    snapshot.owners.setupProviders,
-    snapshot.owners.cliBackends,
-  ]) {
-    for (const providerId of owners.keys()) {
+    includeUntrustedWorkspacePlugins: false,
+  })) {
+    const entryProviderIds = [entry.providerId, ...(entry.providerAliases ?? [])];
+    if (!entryProviderIds.some((providerId) => selectedProviderIds.has(providerId.toLowerCase()))) {
+      continue;
+    }
+    for (const providerId of entryProviderIds) {
       const normalized = normalizeProviderId(providerId);
       if (normalized) {
         providerIds.add(normalized);

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2147,6 +2147,30 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("lists Mistral with its model and capability provider contracts", () => {
+    const mistral = expectCatalogEntry("mistral");
+    const manifest = getOfficialExternalPluginCatalogManifest(mistral);
+
+    expect(resolveOfficialExternalPluginId(mistral)).toBe("mistral");
+    expect(resolveOfficialExternalPluginInstall(mistral)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/mistral-provider",
+      npmSpec: "@openclaw/mistral-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+    expect(manifest?.providers).toEqual([
+      expect.objectContaining({
+        id: "mistral",
+        envVars: ["MISTRAL_API_KEY"],
+      }),
+    ]);
+    expect(manifest?.contracts).toMatchObject({
+      memoryEmbeddingProviders: ["mistral"],
+      mediaUnderstandingProviders: ["mistral"],
+      realtimeTranscriptionProviders: ["mistral"],
+    });
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -342,7 +342,7 @@ describe("bundled plugin build entries", () => {
   it("excludes externalized model providers from bundled artifacts", () => {
     const artifacts = listBundledPluginPackArtifacts();
 
-    for (const pluginId of ["byteplus", "cohere", "meta", "xiaomi"]) {
+    for (const pluginId of ["byteplus", "cohere", "meta", "mistral", "xiaomi"]) {
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/index.js`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/openclaw.plugin.json`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/package.json`);


### PR DESCRIPTION
## What Problem This Solves

Mistral still ships inside the core OpenClaw npm package even though its provider,
Voxtral transcription, and memory embedding surfaces already fit the official
external plugin contract. This keeps provider-specific code in every core install
and prevents Mistral from using the normal independent plugin release path.

## Why This Change Was Made

Externalize Mistral as the official `@openclaw/mistral-provider` package. The
change adds npm and ClawHub install/release metadata, excludes Mistral from the
core distribution, publishes its model and capability contracts through the
official external catalog, and preserves upgrades from previously bundled
installations through the generic persisted-location bridge.

The shared `@mistralai/mistralai` dependency remains owned by `packages/ai`,
which still contains the core Mistral transport implementation.

Upgrade repair now installs configured external providers before validating
model references. Failed or in-progress package repair preserves those
references for retry, and preview mode recognizes configured providers that the
official catalog can install.

## User Impact

Operators install Mistral once with:

```bash
openclaw plugins install @openclaw/mistral-provider
openclaw gateway restart
```

Existing installations that previously used the bundled Mistral plugin are
relocated to the trusted official package during core update. Plugin allow and
enabled state, the selected Mistral model, and the Mistral memory provider remain
unchanged.

## Evidence

- Final head: `6723cb54fa89351f181d063ddcda913b927dab16`; code-bearing proof head: `c177680370e50e07207ca09e939af80dc0520e14`; exact base: `a1026663aed621e70b2e811713d5e29ceade823f`. The final commit only removes the release-owned `CHANGELOG.md` entry; release-note context remains in this PR body.
- 169 focused externalization tests passed across the tooling, CLI bridge, external catalog, and Mistral extension lanes.
- 152 focused repair tests passed: sequencing 20/20, stale-model migrations 76/76, config flow 56/56.
- Plugin SDK and extension import-boundary checks passed.
- Plugin inventory generation and verification passed.
- Exact six-file changed gate passed on Blacksmith Testbox `tbx_01kywmp7061xvzsp78rm5ph80k` ([run 30652644668](https://github.com/openclaw/openclaw/actions/runs/30652644668)).
- Final-head autoreview completed with no actionable findings.
- Release-like proof for code-bearing head `c177680370e50e07207ca09e939af80dc0520e14` passed on Blacksmith Testbox `tbx_01kywn7c9ww8wk6ttv5eyns5hh` ([run 30653285875](https://github.com/openclaw/openclaw/actions/runs/30653285875)):
  - exact base package contains bundled Mistral; exact head package does not;
  - standalone `@openclaw/mistral-provider@2026.7.2` contains its runtime and manifest;
  - fresh install and two gateway boots load Mistral from the external package root;
  - bundled-to-external `openclaw update repair` installs the trusted official package;
  - allow, enabled, primary model, and memory-provider config survive immediately after repair;
  - upgraded install and two gateway boots discover Mistral models from the external package root.
- Artifact SHA-256:
  - base core: `df938ee8f4019d75c1b00453ef48bed407c64fde2bb4eb0a2760a1031f427b6d`
  - head core: `460c4b1d715cae313f4089e74a8a9976c17a167de92869bb8f40963e0f3d1fd3`
  - plugin: `13770fa907d57152d0eb5f1882eea07c7fbd30d0c6ee964d8a1d7571ad979198`
- Selected npm release planning identifies `@openclaw/mistral-provider` as the only publish candidate.
- Selected ClawHub planning identifies the package as a valid bootstrap candidate.

- [x] AI-assisted
- [x] I understand the implementation and validation evidence.
