### PR TITLE
fix(ci): use corrected Kova release evaluator

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -70,7 +70,7 @@ env:
   OCM_VERSION: v0.2.29
   OCM_LINUX_X64_SHA256: d966098d6ba2bc10891be3c76e162a37b07f28c4f51da75d2eb509886eb7e1cf
   KOVA_REPOSITORY: openclaw/Kova
-  KOVA_CANONICAL_CONFIG_REF: 517952b835640a368c4af6dfe6dc8365ae841b57
+  KOVA_CANONICAL_CONFIG_REF: e2ff1b66e5597a0df2ddb50276257e36069513dd
   KOVA_LEGACY_LIST_CONFIG_REF: f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c
   PERFORMANCE_MODEL_ID: gpt-5.6-luna
   # Release matrices cold-build the candidate runtime before measurement.

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -84,7 +84,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const canonicalKovaRef = "517952b835640a368c4af6dfe6dc8365ae841b57";
+    const canonicalKovaRef = "e2ff1b66e5597a0df2ddb50276257e36069513dd";
     const legacyKovaRef = "f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation would reject current OpenClaw builds for duplicate and misattributed RSS threshold failures when the canonical Kova evaluator still used the pre-fix process-role contract.

## Why This Change Was Made

The canonical Kova pin now includes the merged process-role attribution repair and the matching retirement of obsolete runtime-dependency diagnostics. The legacy config pin remains unchanged for historical target schemas.

Kova ownership fixes:
- https://github.com/openclaw/Kova/pull/80
- https://github.com/openclaw/Kova/pull/81

## User Impact

Maintainers can run the full release gate against current `main` and receive attributable agent/gateway RSS evidence instead of duplicate wrapper-role failures. No performance budget is raised or bypassed.

## Evidence

- Failing exact-main release run: https://github.com/openclaw/openclaw/actions/runs/30641688176
- Failing performance child: https://github.com/openclaw/openclaw/actions/runs/30641937629
- Old evaluator (`517952b8`) repeated the same product RSS under `agent-cli`, `agent-process`, and `command-tree`; all three agent samples and all three bundled-plugin samples failed.
- Corrected Kova release-shaped proof: https://github.com/openclaw/openclaw/actions/runs/30620388830
  - agent primary role: `agent-process`
  - agent RSS: 849.6 MB
  - mock provider RSS: 72.4 MB
  - 5/5 selected scenarios passed with zero violations
- Current post-merge Kova proof: https://github.com/openclaw/openclaw/actions/runs/30623132812
  - corrected `primary-role-product-scope-v3` attribution
  - successful retry: agent 859.7 MB, gateway 955.0 MB, bundled-plugin startup 971.8 MB
- `git diff --check`: passed
- AI-assisted: yes; maintainer reviewed the two-line pin/test update and understands the change.