### PR TITLE
fix(cron): preserve schedule ownership and truthful delivery outcomes

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -7,6 +7,7 @@ import {
   markCronJobActive,
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
+  noteActiveCronJobTriggerMutation,
   resetCronActiveJobs,
 } from "./active-jobs.js";
 
@@ -80,6 +81,30 @@ describe("active cron schedule ownership", () => {
     noteActiveCronJobScheduleMutation("rescheduled-job");
 
     expect(marker?.scheduleMutated).toBe(true);
+  });
+
+  it("records trigger mutations without retiring schedule ownership", () => {
+    const marker = markCronJobActive("trigger-edited-job");
+
+    noteActiveCronJobTriggerMutation("trigger-edited-job");
+
+    expect(marker?.triggerMutated).toBe(true);
+    expect(marker?.scheduleMutated).toBeUndefined();
+  });
+
+  it("keeps trigger mutation ownership after the script is edited back", () => {
+    const marker = markCronJobActive("trigger-restored-job");
+
+    noteActiveCronJobTriggerMutation("trigger-restored-job");
+    noteActiveCronJobTriggerMutation("trigger-restored-job");
+
+    expect(marker?.triggerMutated).toBe(true);
+  });
+
+  it("does not create trigger markers for an idle job", () => {
+    noteActiveCronJobTriggerMutation("idle-trigger-job");
+
+    expect(hasActiveCronJobs()).toBe(false);
   });
 
   it("keeps a mutation after the schedule is edited back to its original value", () => {

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -15,6 +15,7 @@ export type CronActiveJobMarker = {
   generation: number;
   token: number;
   scheduleMutated?: true;
+  triggerMutated?: true;
   jobRemoved?: true;
   preserveAcrossGenerationAdvance?: boolean;
 };
@@ -107,6 +108,20 @@ export function noteActiveCronJobScheduleMutation(jobId: string): void {
     // Keep mutation history on the admitted run: A→B→A has the original
     // schedule value but still belongs to the operator's newer edit.
     marker.scheduleMutated = true;
+  }
+}
+
+/** Records a durable trigger edit against the exact run that evaluated it. */
+export function noteActiveCronJobTriggerMutation(jobId: string): void {
+  if (!jobId) {
+    return;
+  }
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
+    // A→B→A restores the script but cannot return ownership of the new
+    // trigger state to an evaluation admitted before either durable edit.
+    marker.triggerMutated = true;
   }
 }
 

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -90,6 +90,58 @@ describe("resolveCronExecutionRetryHint", () => {
     }
   });
 
+  it("does not classify incidental 429 numbers or provider names as rate limits", () => {
+    for (const message of [
+      "context limit 1429 exceeded",
+      "process exited with 429 lines of output",
+      "assertion failed: expected 429 got 0",
+      "error 429 got 0",
+      "process exited with code 429",
+      "API error: 4291",
+      "APIError: 4291",
+      "HTTP/2 4291",
+      "requested URL returned error: 4291",
+      "ENOENT: no such file '/etc/cloudflare.toml'",
+      "Cloudflare API token is invalid",
+    ]) {
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["rate_limit"] })).toEqual({
+        retryable: false,
+      });
+    }
+  });
+
+  it("classifies genuine HTTP and provider API rate limits", () => {
+    for (const message of [
+      "HTTP 429 Too Many Requests",
+      "HTTP/2 429",
+      "HTTP/1.1 429",
+      "received status 429 from upstream",
+      "response code: 429",
+      "statusCode: 429",
+      "status_code=429",
+      "responseCode: 429",
+      "API error: 429",
+      "APIError: 429",
+      "api_error: 429",
+      "curl: (22) The requested URL returned error: 429",
+      "URL returned error: 429",
+      "Provider API error (429): Quota exceeded [code=quota_exceeded]",
+      "429 rate limit exceeded",
+      "429: quota exceeded",
+      "429: quota exhausted",
+      '{"error":{"type":"rate_limit_error"}}',
+      "rate_limit_exceeded",
+      "rate_limit_reached",
+      "resource has been exhausted",
+      "429",
+    ]) {
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["rate_limit"] })).toEqual({
+        retryable: true,
+        category: "rate_limit",
+      });
+    }
+  });
+
   it("classifies session lifecycle claim conflicts as transient regardless of retryOn (#106875)", () => {
     for (const message of [
       'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -25,14 +25,18 @@ type CronRetryHintInput = {
 const SERVER_ERROR_PATTERN =
   /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
 
+// Numeric ids, process exit codes, and Cloudflare provider names are not HTTP
+// throttling signals; require status/API-error context or actual limit wording.
+const RATE_LIMIT_PATTERN =
+  /\b(?:https?(?:\/\d(?:\.\d)?)?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?)\b[\s:=#"'(]{0,6}429\b|\b(?:provider\s+)?api[ _-]?error\b[\s:=#"'(]{0,6}429\b|\b(?:requested\s+)?url\s+returned\s+error\b[\s:=#"'(]{0,6}429\b|\b429\b[\s:)\].,-]*(?:rate[_ -]?limit(?:ed|ing)?(?:[_ -](?:error|exceeded|reached))?|too many requests|resource has been exhausted|quota(?:\s+(?:exceeded|exhausted|depleted|reached))?)\b|\brate[_ -]?limit(?:ed|ing)?(?:[_ -](?:error|exceeded|reached))?\b|\btoo many requests\b|\bresource has been exhausted\b|\btokens per day\b|^\s*429\s*$/i;
+
 // Lifecycle claims can lose a race before provider execution. Retry only before
 // execution starts; afterward, tools may have produced non-idempotent effects.
 const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
   /^(?:(?:CronSessionLifecycleClaimError|Error): )?Session "[^"\n]+" (?:changed|was deleted) while starting work\. Retry\.$/;
 
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
-  rate_limit:
-    /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
+  rate_limit: RATE_LIMIT_PATTERN,
   overloaded:
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -1021,7 +1021,7 @@ describe("cron stagger defaults", () => {
     expectCronStaggerMs(job, 0);
   });
 
-  it("preserves existing stagger when editing cron expression without stagger", () => {
+  it("derives a fresh top-of-hour stagger when replacing the cron expression", () => {
     const now = Date.now();
     const job: CronJob = {
       id: "job-keep-stagger",
@@ -1043,8 +1043,57 @@ describe("cron stagger defaults", () => {
     expect(job.schedule.kind).toBe("cron");
     if (job.schedule.kind === "cron") {
       expect(job.schedule.expr).toBe("0 */2 * * *");
-      expect(job.schedule.staggerMs).toBe(120_000);
+      expect(job.schedule.staggerMs).toBe(DEFAULT_TOP_OF_HOUR_STAGGER_MS);
     }
+  });
+
+  it("drops an old stagger when the replacement expression has no stagger default", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-drop-stagger",
+      name: "job-drop-stagger",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 120_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+
+    applyJobPatch(job, {
+      schedule: { kind: "cron", expr: "30 9 * * *", tz: "UTC" },
+    });
+
+    expect(job.schedule).toEqual({ kind: "cron", expr: "30 9 * * *", tz: "UTC" });
+  });
+
+  it("preserves explicit staggering for a metadata-only cron schedule edit", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-keep-stagger",
+      name: "job-keep-stagger",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 120_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+
+    applyJobPatch(job, {
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "America/Los_Angeles" },
+    });
+
+    expect(job.schedule).toEqual({
+      kind: "cron",
+      expr: "0 * * * *",
+      tz: "America/Los_Angeles",
+      staggerMs: 120_000,
+    });
   });
 
   it("applies default stagger when switching from every to top-of-hour cron", () => {

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -34,6 +34,13 @@ function buildAnnounceIsolatedAgentTurnJob(name: string): CronAddInput {
   };
 }
 
+function buildWebhookIsolatedAgentTurnJob(name: string): CronAddInput {
+  return {
+    ...buildIsolatedAgentTurnJob(name),
+    delivery: { mode: "webhook", to: "https://example.invalid/cron-completion" },
+  };
+}
+
 function buildAnnounceWithFailureDestinationJob(name: string): CronAddInput {
   return {
     ...buildAnnounceIsolatedAgentTurnJob(name),
@@ -242,6 +249,22 @@ async function runIsolatedJobAndReadState(params: {
 }
 
 describe("CronService persists delivered status", () => {
+  it("records requested webhook delivery as unknown until its detached send is observed", async () => {
+    let finishedDeliveryStatus: string | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildWebhookIsolatedAgentTurnJob("webhook-pending"),
+      onFinished: (event) => {
+        finishedDeliveryStatus = event.deliveryStatus;
+      },
+    });
+
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBeUndefined();
+    expect(updated?.state.lastDeliveryStatus).toBe("unknown");
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
+    expect(finishedDeliveryStatus).toBe("unknown");
+  });
+
   it("persists lastDelivered=true when isolated job reports delivered", async () => {
     const updated = await runIsolatedJobAndReadState({
       job: buildAnnounceIsolatedAgentTurnJob("delivered-true"),

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CronEvent } from "./service.js";
 import { CronService } from "./service.js";
-import { setupCronServiceSuite } from "./service.test-harness.js";
+import { createDeferred, setupCronServiceSuite } from "./service.test-harness.js";
 import { computeJobNextRunAtMs } from "./service/jobs.js";
 import type { CronServiceDeps } from "./service/state.js";
 import { loadCronStore } from "./store.js";
@@ -13,6 +13,7 @@ const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-trigger-
 
 type Evaluator = NonNullable<CronServiceDeps["evaluateCronTrigger"]>;
 type IsolatedRunner = CronServiceDeps["runIsolatedAgentJob"];
+type ScriptRunner = NonNullable<CronServiceDeps["runScriptJob"]>;
 
 function watcher(overrides: Partial<CronJobCreate> = {}): CronJobCreate {
   return {
@@ -30,6 +31,7 @@ function watcher(overrides: Partial<CronJobCreate> = {}): CronJobCreate {
 async function createHarness(params: {
   evaluateCronTrigger?: Evaluator;
   runIsolatedAgentJob?: IsolatedRunner;
+  runScriptJob?: ScriptRunner;
 }) {
   const { storePath } = await makeStorePath();
   const events: CronEvent[] = [];
@@ -45,6 +47,7 @@ async function createHarness(params: {
     requestHeartbeat: vi.fn(),
     runIsolatedAgentJob,
     ...(params.evaluateCronTrigger ? { evaluateCronTrigger: params.evaluateCronTrigger } : {}),
+    ...(params.runScriptJob ? { runScriptJob: params.runScriptJob } : {}),
     onEvent: (event) => events.push(structuredClone(event)),
   });
   await cron.start();
@@ -266,6 +269,195 @@ describe("cron trigger evaluation", () => {
       expect(failed.cron.getJob(job.id)?.state.nextRunAtMs).toEqual(expect.any(Number));
     } finally {
       failed.cron.stop();
+    }
+  });
+
+  it.each([
+    ["replaced", false],
+    ["restored after replacement", true],
+  ] as const)("preserves a %s trigger edited during a manual fired run", async (_, restore) => {
+    const started = createDeferred<void>();
+    const completion = createDeferred<{ status: "ok"; summary: string }>();
+    const evaluateCronTrigger = vi.fn(async () => ({
+      kind: "evaluated" as const,
+      fire: true,
+      state: { owner: "obsolete" },
+    }));
+    const harness = await createHarness({
+      evaluateCronTrigger,
+      runIsolatedAgentJob: vi.fn(async () => {
+        started.resolve();
+        return completion.promise;
+      }),
+    });
+    try {
+      const originalTrigger = { script: "original trigger", once: true };
+      const job = await harness.cron.add(watcher({ trigger: originalTrigger }));
+      const run = runWhenDue(harness.cron, job.id);
+      await started.promise;
+
+      await harness.cron.update(job.id, {
+        trigger: { script: "replacement trigger", once: true },
+        state: { triggerState: { owner: "latest edit" } },
+      });
+      if (restore) {
+        await harness.cron.update(job.id, { trigger: originalTrigger });
+      }
+      completion.resolve({ status: "ok", summary: "done" });
+      expect(await run).toEqual({ ok: true, ran: true });
+
+      const stored = harness.cron.getJob(job.id);
+      expect(stored?.enabled).toBe(true);
+      expect(stored?.trigger).toEqual(
+        restore ? originalTrigger : { script: "replacement trigger", once: true },
+      );
+      expect(stored?.state.triggerState).toEqual({ owner: "latest edit" });
+      expect(stored?.state.lastTriggerEvalAtMs).toBeUndefined();
+      expect(stored?.state.nextRunAtMs).toEqual(expect.any(Number));
+    } finally {
+      completion.resolve({ status: "ok", summary: "cleanup" });
+      harness.cron.stop();
+    }
+  });
+
+  it.each([
+    ["edited", false],
+    ["restored after an edit", true],
+  ] as const)("preserves trigger state %s during a manual fired run", async (_, restore) => {
+    const started = createDeferred<void>();
+    const completion = createDeferred<{ status: "ok"; summary: string }>();
+    const harness = await createHarness({
+      evaluateCronTrigger: vi.fn(async () => ({
+        kind: "evaluated" as const,
+        fire: true,
+        state: { owner: "obsolete evaluation" },
+      })),
+      runIsolatedAgentJob: vi.fn(async () => {
+        started.resolve();
+        return completion.promise;
+      }),
+    });
+    try {
+      const originalState = { owner: "original" };
+      const job = await harness.cron.add(
+        watcher({
+          trigger: { script: "unchanged trigger", once: true },
+          state: { triggerState: originalState },
+        }),
+      );
+      const run = runWhenDue(harness.cron, job.id);
+      await started.promise;
+
+      await harness.cron.update(job.id, { state: { triggerState: { owner: "latest edit" } } });
+      if (restore) {
+        await harness.cron.update(job.id, { state: { triggerState: originalState } });
+      }
+      completion.resolve({ status: "ok", summary: "done" });
+      expect(await run).toEqual({ ok: true, ran: true });
+
+      const stored = harness.cron.getJob(job.id);
+      expect(stored?.enabled).toBe(true);
+      expect(stored?.trigger).toEqual({ script: "unchanged trigger", once: true });
+      expect(stored?.state.triggerState).toEqual(
+        restore ? originalState : { owner: "latest edit" },
+      );
+      expect(stored?.state.lastTriggerEvalAtMs).toBeUndefined();
+    } finally {
+      completion.resolve({ status: "ok", summary: "cleanup" });
+      harness.cron.stop();
+    }
+  });
+
+  it.each([
+    ["replaced", false],
+    ["restored after replacement", true],
+  ] as const)(
+    "does not let a %s active payload script overwrite shared state",
+    async (_, restore) => {
+      const started = createDeferred<void>();
+      const completion = createDeferred<{
+        status: "ok";
+        stateChanged: true;
+        state: { owner: string };
+      }>();
+      const harness = await createHarness({
+        runScriptJob: vi.fn(async () => {
+          started.resolve();
+          return completion.promise;
+        }),
+      });
+      try {
+        const originalPayload = { kind: "script" as const, script: "return original" };
+        const job = await harness.cron.add(
+          watcher({
+            trigger: undefined,
+            payload: originalPayload,
+            state: { triggerState: { owner: "current" } },
+          }),
+        );
+        const run = runWhenDue(harness.cron, job.id);
+        await started.promise;
+
+        await harness.cron.update(job.id, {
+          payload: { kind: "script", script: "return replacement" },
+        });
+        if (restore) {
+          await harness.cron.update(job.id, { payload: originalPayload });
+        }
+        completion.resolve({
+          status: "ok",
+          stateChanged: true,
+          state: { owner: "obsolete payload" },
+        });
+        expect(await run).toEqual({ ok: true, ran: true });
+
+        const stored = harness.cron.getJob(job.id);
+        expect(stored?.payload).toMatchObject(
+          restore ? originalPayload : { kind: "script", script: "return replacement" },
+        );
+        expect(stored?.state.triggerState).toEqual({ owner: "current" });
+      } finally {
+        completion.resolve({ status: "ok", stateChanged: true, state: { owner: "cleanup" } });
+        harness.cron.stop();
+      }
+    },
+  );
+
+  it.each([
+    ["trigger definition", true],
+    ["trigger state only", false],
+  ] as const)("preserves %s edited during its suspended quiet evaluation", async (_, replace) => {
+    const started = createDeferred<void>();
+    const evaluation = createDeferred<{
+      kind: "evaluated";
+      fire: false;
+      state: { owner: string };
+    }>();
+    const evaluateCronTrigger = vi.fn(async () => {
+      started.resolve();
+      return evaluation.promise;
+    });
+    const harness = await createHarness({ evaluateCronTrigger });
+    try {
+      const job = await harness.cron.add(watcher({ trigger: { script: "old trigger" } }));
+      const run = runWhenDue(harness.cron, job.id);
+      await started.promise;
+
+      await harness.cron.update(job.id, {
+        ...(replace ? { trigger: { script: "replacement trigger" } } : {}),
+        state: { triggerState: { owner: "latest edit" } },
+      });
+      evaluation.resolve({ kind: "evaluated", fire: false, state: { owner: "obsolete" } });
+      expect(await run).toEqual({ ok: true, ran: true });
+
+      const stored = harness.cron.getJob(job.id);
+      expect(stored?.trigger).toEqual({ script: replace ? "replacement trigger" : "old trigger" });
+      expect(stored?.state.triggerState).toEqual({ owner: "latest edit" });
+      expect(stored?.state.lastTriggerEvalAtMs).toBeUndefined();
+      expect(stored?.state.nextRunAtMs).toEqual(expect.any(Number));
+    } finally {
+      evaluation.resolve({ kind: "evaluated", fire: false, state: { owner: "cleanup" } });
+      harness.cron.stop();
     }
   });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -302,9 +302,9 @@ export function applyJobPatch(
       const explicitStaggerMs = normalizeCronStaggerMs(patch.schedule.staggerMs);
       if (explicitStaggerMs !== undefined) {
         job.schedule = { ...patch.schedule, staggerMs: explicitStaggerMs };
-      } else if (job.schedule.kind === "cron") {
-        // Preserve an existing explicit stagger when editing only the cron
-        // expression; otherwise a patch could silently change fire timing.
+      } else if (job.schedule.kind === "cron" && job.schedule.expr === patch.schedule.expr) {
+        // Metadata-only resaves keep the existing stagger, but a replacement
+        // expression owns a fresh default and must not inherit stale timing.
         job.schedule = { ...patch.schedule, staggerMs: job.schedule.staggerMs };
       } else {
         const defaultStaggerMs = resolveDefaultCronStaggerMs(patch.schedule.expr);

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -8,6 +8,7 @@ import {
   isCronJobActive,
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
+  noteActiveCronJobTriggerMutation,
 } from "../active-jobs.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { deleteCronJobScratch } from "../scratch-store.js";
@@ -161,6 +162,16 @@ async function persistUpdatedJob(params: {
     // Mark only committed edits; a failed SQLite write cannot retire the run's
     // schedule ownership, and idempotent re-saves must not create a new claim.
     noteActiveCronJobScheduleMutation(nextJob.id);
+  }
+  if (
+    !isDeepStrictEqual(previousJob.trigger, nextJob.trigger) ||
+    !isDeepStrictEqual(previousJob.state.triggerState, nextJob.state.triggerState) ||
+    ((previousJob.payload.kind === "script" || nextJob.payload.kind === "script") &&
+      !isDeepStrictEqual(previousJob.payload, nextJob.payload))
+  ) {
+    // Trigger/script definitions and shared-state edits retire the admitted
+    // state writer; otherwise an obsolete evaluation or script wins later.
+    noteActiveCronJobTriggerMutation(nextJob.id);
   }
   armTimer(state);
   emit(state, {

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -24,7 +24,10 @@ import type { CronServiceState, CronWakeMode } from "./state.js";
 import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
-import { resolveCronRunScheduleOwnership } from "./timer-outcomes.js";
+import {
+  resolveCronRunScheduleOwnership,
+  resolveCronRunTriggerOwnership,
+} from "./timer-outcomes.js";
 import {
   applyJobResult,
   applyScriptRunResult,
@@ -160,6 +163,11 @@ async function finishPreparedManualRun(
         currentJob: job,
         activeJobMarker: prepared.activeJobMarker,
       });
+      const triggerOwnership = resolveCronRunTriggerOwnership({
+        admittedJob: prepared.admittedJob,
+        currentJob: job,
+        activeJobMarker: prepared.activeJobMarker,
+      });
       const scheduleMode =
         scheduleOwnership === "stale"
           ? "stale-preserve"
@@ -179,7 +187,7 @@ async function finishPreparedManualRun(
             endedAt,
             triggerEval: coreResult.triggerEval,
           },
-          { scheduleMode },
+          { scheduleMode, triggerOwnership },
         );
       } else {
         shouldDelete = applyJobResult(
@@ -205,9 +213,9 @@ async function finishPreparedManualRun(
             endedAt,
             triggerEval: coreResult.triggerEval,
           },
-          { scheduleOwnership },
+          { scheduleOwnership, triggerOwnership },
         );
-        applyScriptRunResult(job, coreResult);
+        applyScriptRunResult(job, coreResult, { triggerOwnership });
 
         // Stream payloads are event-owned by their batch. Generic recurring
         // error backoff must not synthesize a later run without that batch.

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -36,6 +36,7 @@ import {
 } from "./timer-trigger.js";
 
 type CronScheduleOwnership = "current" | "stale";
+type CronTriggerOwnership = "current" | "stale";
 
 /** Checks both the admitted schedule and edits that may have returned to its original value. */
 export function resolveCronRunScheduleOwnership(params: {
@@ -45,6 +46,19 @@ export function resolveCronRunScheduleOwnership(params: {
 }): CronScheduleOwnership {
   return params.activeJobMarker?.scheduleMutated === true ||
     !cronSchedulingInputsEqual(params.admittedJob, params.currentJob)
+    ? "stale"
+    : "current";
+}
+
+/** Keeps trigger state owned by the exact script/once definition that evaluated it. */
+export function resolveCronRunTriggerOwnership(params: {
+  admittedJob: CronJob;
+  currentJob: CronJob;
+  activeJobMarker?: CronActiveJobMarker;
+}): CronTriggerOwnership {
+  return params.activeJobMarker?.triggerMutated === true ||
+    params.admittedJob.trigger?.script !== params.currentJob.trigger?.script ||
+    params.admittedJob.trigger?.once !== params.currentJob.trigger?.once
     ? "stale"
     : "current";
 }
@@ -447,9 +461,9 @@ function applyTriggerEvaluationState(
 export function applyTriggerRunResult(
   job: CronJob,
   result: { status: CronRunStatus; endedAt: number; triggerEval?: CronTriggerEvalOutcome },
-  opts?: { scheduleOwnership?: CronScheduleOwnership },
+  opts?: { scheduleOwnership?: CronScheduleOwnership; triggerOwnership?: CronTriggerOwnership },
 ): void {
-  if (!result.triggerEval) {
+  if (!result.triggerEval || opts?.triggerOwnership === "stale") {
     return;
   }
   // Fired-run trigger state persists only on payload success: a failed or
@@ -482,8 +496,13 @@ export function applyTriggerRunResult(
 export function applyScriptRunResult(
   job: CronJob,
   result: { status: CronRunStatus; scriptStateChanged?: boolean; scriptState?: unknown },
+  opts?: { triggerOwnership?: CronTriggerOwnership },
 ): void {
-  if (result.status === "ok" && result.scriptStateChanged === true) {
+  if (
+    opts?.triggerOwnership !== "stale" &&
+    result.status === "ok" &&
+    result.scriptStateChanged === true
+  ) {
     // Trigger and payload scripts share frozen trigger.state. The payload's
     // final state wins only after trigger evaluation and payload execution succeed.
     job.state.triggerState = result.scriptState;
@@ -495,7 +514,10 @@ export function applyTriggerNoFireResult(
   state: CronServiceState,
   job: CronJob,
   result: { startedAt: number; endedAt: number; triggerEval: CronTriggerEvalOutcome },
-  opts?: { scheduleMode?: "advance" | "force-preserve" | "stale-preserve" },
+  opts?: {
+    scheduleMode?: "advance" | "force-preserve" | "stale-preserve";
+    triggerOwnership?: CronTriggerOwnership;
+  },
 ): void {
   const previousNextRunAtMs = job.state.nextRunAtMs;
   const previousPacedNextRunAtMs = job.state.pacedNextRunAtMs;
@@ -503,7 +525,7 @@ export function applyTriggerNoFireResult(
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
   job.updatedAtMs = result.endedAt;
-  if (!result.triggerEval.busy) {
+  if (!result.triggerEval.busy && opts?.triggerOwnership !== "stale") {
     // A non-firing evaluation is successful scheduler work, not a payload run;
     // reset error machinery while leaving lastRun/delivery history untouched.
     job.state.consecutiveErrors = 0;
@@ -578,6 +600,11 @@ export function applyOutcomeToStoredJob(
     currentJob: job,
     activeJobMarker: result.activeJobMarker,
   });
+  const triggerOwnership = resolveCronRunTriggerOwnership({
+    admittedJob: result.job,
+    currentJob: job,
+    activeJobMarker: result.activeJobMarker,
+  });
 
   if (result.status === "ok" && result.triggerEval && !result.triggerEval.fired) {
     // Quiet trigger ticks intentionally emit no finished event: run history,
@@ -590,7 +617,10 @@ export function applyOutcomeToStoredJob(
         endedAt: result.endedAt,
         triggerEval: result.triggerEval,
       },
-      { scheduleMode: scheduleOwnership === "stale" ? "stale-preserve" : "advance" },
+      {
+        scheduleMode: scheduleOwnership === "stale" ? "stale-preserve" : "advance",
+        triggerOwnership,
+      },
     );
     job.state.startupCatchupAtMs = undefined;
     if (scheduleOwnership === "current") {
@@ -602,8 +632,8 @@ export function applyOutcomeToStoredJob(
   }
 
   const shouldDelete = applyJobResult(state, job, result, { scheduleOwnership });
-  applyTriggerRunResult(job, result, { scheduleOwnership });
-  applyScriptRunResult(job, result);
+  applyTriggerRunResult(job, result, { scheduleOwnership, triggerOwnership });
+  applyScriptRunResult(job, result, { triggerOwnership });
   job.state.startupCatchupAtMs = undefined;
 
   emitJobFinished(state, job, result, result.startedAt);

--- a/src/cron/service/timer-trigger.ts
+++ b/src/cron/service/timer-trigger.ts
@@ -215,7 +215,8 @@ export function resolveDeliveryState(params: {
   error?: string;
   failureNotification: CronFailureNotificationDelivery;
 } {
-  const primaryDeliveryRequested = resolveCronDeliveryPlan(params.job).requested;
+  const primaryDeliveryPlan = resolveCronDeliveryPlan(params.job);
+  const primaryDeliveryRequested = primaryDeliveryPlan.requested;
   // Failure destinations can receive alerts even when the primary delivery
   // path was disabled or failed before direct delivery produced an ack.
   const alternateFailureNotificationRequested =
@@ -224,7 +225,9 @@ export function resolveDeliveryState(params: {
     resolveFailureDestination(params.job, params.globalFailureDestination) !== null;
   if (!primaryDeliveryRequested) {
     return {
-      status: "not-requested",
+      // Webhooks run outside the announce runner. Their completion is not yet
+      // known here, but an explicitly requested webhook is never "not-requested".
+      status: primaryDeliveryPlan.mode === "webhook" ? "unknown" : "not-requested",
       failureNotification: {
         status: alternateFailureNotificationRequested ? "unknown" : "not-requested",
       },

--- a/src/cron/service/timer.pacing.test.ts
+++ b/src/cron/service/timer.pacing.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  clearCronJobActive,
+  markCronJobActive,
+  noteActiveCronJobTriggerMutation,
+} from "../active-jobs.js";
 import { makeCronJob } from "../delivery.test-helpers.js";
 import { createNoopLogger } from "../service.test-harness.js";
 import type { CronJob, CronPacing } from "../types.js";
@@ -29,6 +34,90 @@ function makePacedJob(pacing: CronPacing, everyMs = 60 * 60_000): CronJob {
     state: { nextRunAtMs: STARTED_AT },
   });
 }
+
+describe("cron trigger evaluation ownership", () => {
+  it("keeps a replacement once trigger armed after an obsolete fired payload", () => {
+    const state = makeState();
+    const job = makePacedJob({ min: "15m" });
+    job.trigger = { script: "old trigger", once: true };
+    const admittedJob = structuredClone(job);
+    job.trigger = { script: "replacement trigger", once: true };
+    job.state.triggerState = { owner: "replacement" };
+    state.store = { version: 1, jobs: [job] };
+
+    applyOutcomeToStoredJob(state, {
+      jobId: job.id,
+      job: admittedJob,
+      status: "ok",
+      startedAt: STARTED_AT,
+      endedAt: ENDED_AT,
+      triggerEval: { fired: true, stateChanged: true, state: { owner: "obsolete trigger" } },
+      scriptStateChanged: true,
+      scriptState: { owner: "obsolete payload" },
+    });
+
+    expect(job.enabled).toBe(true);
+    expect(job.state.triggerState).toEqual({ owner: "replacement" });
+    expect(job.state.lastTriggerEvalAtMs).toBeUndefined();
+    expect(job.state.nextRunAtMs).toBeGreaterThan(ENDED_AT);
+  });
+
+  it("does not let an obsolete quiet evaluation replace current trigger state", () => {
+    const state = makeState();
+    const job = makePacedJob({ min: "15m" });
+    job.trigger = { script: "old trigger" };
+    const admittedJob = structuredClone(job);
+    job.trigger = { script: "replacement trigger" };
+    job.state.triggerState = { owner: "replacement" };
+    job.state.consecutiveErrors = 3;
+    job.state.scheduleErrorCount = 2;
+    state.store = { version: 1, jobs: [job] };
+
+    applyOutcomeToStoredJob(state, {
+      jobId: job.id,
+      job: admittedJob,
+      status: "ok",
+      startedAt: STARTED_AT,
+      endedAt: ENDED_AT,
+      triggerEval: { fired: false, stateChanged: true, state: { owner: "obsolete" } },
+    });
+
+    expect(job.state.triggerState).toEqual({ owner: "replacement" });
+    expect(job.state.triggerEvalCount).toBeUndefined();
+    expect(job.state.consecutiveErrors).toBe(3);
+    expect(job.state.scheduleErrorCount).toBe(2);
+    expect(job.state.nextRunAtMs).toBeGreaterThan(ENDED_AT);
+  });
+
+  it("retains trigger ownership when an edited script is restored during its active run", () => {
+    const state = makeState();
+    const job = makePacedJob({ min: "15m" });
+    job.trigger = { script: "original trigger", once: true };
+    const admittedJob = structuredClone(job);
+    job.state.triggerState = { owner: "latest edit" };
+    state.store = { version: 1, jobs: [job] };
+    const activeJobMarker = markCronJobActive(job.id);
+    noteActiveCronJobTriggerMutation(job.id);
+
+    try {
+      applyOutcomeToStoredJob(state, {
+        jobId: job.id,
+        job: admittedJob,
+        activeJobMarker,
+        status: "ok",
+        startedAt: STARTED_AT,
+        endedAt: ENDED_AT,
+        triggerEval: { fired: true, stateChanged: true, state: { owner: "obsolete" } },
+      });
+
+      expect(job.enabled).toBe(true);
+      expect(job.state.triggerState).toEqual({ owner: "latest edit" });
+      expect(job.state.lastTriggerFireAtMs).toBeUndefined();
+    } finally {
+      clearCronJobActive(job.id, activeJobMarker);
+    }
+  });
+});
 
 describe("applyJobResult dynamic cadence", () => {
   it.each([


### PR DESCRIPTION
# fix(cron): preserve scheduler truth across edits and delivery

## What Problem This Solves

Four independent cron-owner defects currently make scheduler behavior or execution evidence misleading:

1. Replacing a cron expression without an explicit stagger silently inherits the previous expression's staggering, even when the replacement should be exact or should receive its own top-of-hour default.
2. An obsolete active trigger evaluation can overwrite newer trigger or payload-script state and disarm a newly edited `once` trigger. The existing schedule identity correctly ignores script identity, but finalization incorrectly treated cadence ownership as trigger ownership.
3. Explicit webhook completion delivery is projected as `not-requested` even though delivery was requested; its detached send is simply not observed when the scheduler records the run.
4. Unrelated numbers containing `429`, process exit codes, and the bare Cloudflare provider name are treated as retryable HTTP rate limits.

## Why This Change Was Made

Each fix stays at its existing owner boundary:

- Cron schedule patching preserves the prior stagger only when the expression itself is unchanged. Replacement expressions derive their own existing default or remain unstaggered.
- Active cron execution receives a separate process-local trigger mutation marker after a trigger-definition or trigger-state edit becomes durable. Scheduled and manual finalization independently compare trigger ownership, preserve replacement trigger state and payload-script state, and keep replacement `once` triggers armed. The marker also protects edits that restore the original script or original state during the same active run.
- Delivery projection distinguishes a requested but unobserved webhook (`unknown`) from delivery that was actually disabled (`not-requested`), without changing announce-runner delivery planning.
- Rate-limit retry classification requires HTTP/status/provider-API context or explicit throttling wording, including `statusCode: 429`, `API error: 429`, and `429: quota exceeded`. Structured provider classifications continue to take precedence.

## User Impact

- Edited cron expressions run on their intended cadence instead of inheriting stale per-job offsets.
- Operators can safely edit active trigger scripts or trigger state, including A→B→A edits, without losing replacement state or accidentally disabling the replacement trigger.
- Cron execution history and finished events correctly acknowledge that requested webhook delivery is still unknown.
- Permanent or unrelated failures stop entering rate-limit retry loops merely because their text contains a `429`-like number or a Cloudflare product name.

## Exact Scope

- Frozen baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Branch: `codex/qa200-cron-scheduler-truth`.
- Exact reviewed commit: `b2b1f2abf0c96305febdeb8c8f0cfe24eba2d300`.
- Independent fixed roots: **4**.
- Owner scope: `src/cron/**` only.
- No SQLite schema/version, persisted data contract, public configuration, provider authentication, Gateway protocol, or plugin SDK changes.
- Failure-alert cooldown and durable delivery facts are intentionally excluded because they require persistent-state and asynchronous delivery-owner review.

## Verification

Exact committed owner suites:

```text
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.cron.config.ts \
  src/cron/retry-hint.test.ts \
  src/cron/active-jobs.test.ts \
  src/cron/service.jobs.test.ts \
  src/cron/service/timer.pacing.test.ts \
  src/cron/service.persists-delivered-status.test.ts \
  src/cron/service.trigger-eval.test.ts

Test Files  6 passed (6)
Tests       174 passed (174)
```

Additional completed proof:

- Direct owner probes cover old-stagger removal, a fresh top-of-hour default, unchanged-expression stagger preservation, webhook/announce/none projection, active trigger-definition/state A→B→A ownership, replacement `once` enablement, and protection from both stale evaluator and payload-script state.
- Contextual HTTP 429 owner regressions accepted 13 authentic HTTP/provider/quota shapes and rejected eight incidental numeric/provider-name shapes.
- Integration regressions exercise actual manual fired runs and quiet evaluations while the operator edits their trigger definition or trigger state, including A→B→A restorations.
- `oxfmt --check` passed on all 13 changed files; `git diff HEAD^ HEAD --check`, exact frozen-parent verification, and clean sparse worktree checks passed.
- Genuine full-stack structured Codex `gpt-5.6-sol` / `high` autoreview completed on the exact committed head: **clean, zero findings, “patch is correct,” confidence 0.86**. Its bundled official TruffleHog preflight also passed.
- Structured review artifacts: `review-q2cronscheduler-b2b1f2abf0c.json` and `review-q2cronscheduler-b2b1f2abf0c.txt`.
- Official TruffleHog 3.96.0 separately scanned the exact committed changed content through the shared autoreview commit-snapshot owner with structured JSON output and `verified,unknown` result policy: **64 chunks, 19,108 bytes, zero findings**.
- No full-suite, hosted-CI, remote lease, live provider, live Gateway, branch fetch, push, PR creation, or main mutation is claimed.

## Changed Files

- `src/cron/active-jobs.ts`
- `src/cron/active-jobs.test.ts`
- `src/cron/retry-hint.ts`
- `src/cron/retry-hint.test.ts`
- `src/cron/service/jobs.ts`
- `src/cron/service.jobs.test.ts`
- `src/cron/service/ops-mutations.ts`
- `src/cron/service/ops-run.ts`
- `src/cron/service/timer-outcomes.ts`
- `src/cron/service/timer-trigger.ts`
- `src/cron/service/timer.pacing.test.ts`
- `src/cron/service.persists-delivered-status.test.ts`
- `src/cron/service.trigger-eval.test.ts`
