### PR TITLE
fix(google): preserve stream terminals and provider tool-call identities

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2450,7 +2450,11 @@ describe("google transport stream", () => {
     expect(getFirstModelTurn(params.contents).parts[0]?.functionCall).toMatchObject({
       id: "provider_call_42",
     });
-    expect(params.contents[1]?.parts?.[0]?.functionResponse).toMatchObject({
+    const responseTurn = expectDefined(
+      params.contents[1],
+      "matching Google tool response turn",
+    ) as GoogleTestContentTurn;
+    expect(responseTurn.parts[0]?.functionResponse).toMatchObject({
       id: "provider_call_42",
     });
   });

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1,5 +1,6 @@
 // Google tests cover transport stream plugin behavior.
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
@@ -1342,6 +1343,99 @@ describe("google transport stream", () => {
     });
   });
 
+  it.each(["google-generative-ai", "google-vertex"] as const)(
+    "preserves an undelimited terminal provider error from %s",
+    async (api) => {
+      if (api === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        await useGoogleAuthLibraryCredentials("unterminated-error", "ya29.vertex-token");
+      }
+      guardedFetchMock.mockResolvedValueOnce(
+        buildRawSseResponse(
+          'data: {"candidates":[{"finishReason":"STOP"}]}\n\n' +
+            'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exhausted"}}',
+        ),
+      );
+      const result =
+        api === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "RESOURCE_EXHAUSTED",
+        errorMessage: expect.stringContaining("quota exhausted"),
+      });
+    },
+  );
+
+  it("preserves an undelimited provider error over a real Google HTTP/SSE stream", async () => {
+    const server = createServer((request, response) => {
+      request.resume();
+      request.on("end", () => {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.write('data: {"candidates":[{"finishReason":"STOP"}]}\n\n');
+        response.end(
+          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"live quota exhausted"}}',
+        );
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing Google loopback server address");
+      }
+      guardedFetchMock.mockImplementation((_url, init) =>
+        fetch(`http://127.0.0.1:${address.port}/stream`, init),
+      );
+      const result = await runGeminiStreamResult({ options: { apiKey: "test-google-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "RESOURCE_EXHAUSTED",
+        errorMessage: expect.stringContaining("live quota exhausted"),
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it.each(["google-generative-ai", "google-vertex"] as const)(
+    "keeps an unspecified %s finish reason nonterminal",
+    async (api) => {
+      if (api === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        await useGoogleAuthLibraryCredentials("unspecified-finish", "ya29.vertex-token");
+      }
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: "partial" }] },
+                finishReason: "FINISH_REASON_UNSPECIFIED",
+              },
+            ],
+          },
+        ]),
+      );
+      const result =
+        api === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({ stopReason: "error", errorCode: "STREAM_INCOMPLETE" });
+    },
+  );
+
   it.each([
     { label: "carriage-return-only", delimiter: "\r\r" },
     { label: "line-feed then carriage-return", delimiter: "\n\r" },
@@ -2331,9 +2425,33 @@ describe("google transport stream", () => {
       parts: [
         {
           thoughtSignature: signature,
-          functionCall: { name: "lookup", args: { q: "hello" } },
+          functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
         },
       ],
+    });
+  });
+
+  it("preserves matching provider call identities on same-route Gemini replay", () => {
+    const model = buildGeminiModel({ id: "gemini-3.1-pro-preview" });
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ id: "provider_call_42" }),
+        {
+          role: "toolResult",
+          toolCallId: "provider_call_42",
+          toolName: "lookup",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: 1,
+        },
+      ],
+    } as never);
+
+    expect(getFirstModelTurn(params.contents).parts[0]?.functionCall).toMatchObject({
+      id: "provider_call_42",
+    });
+    expect(params.contents[1]?.parts?.[0]?.functionResponse).toMatchObject({
+      id: "provider_call_42",
     });
   });
 
@@ -3101,6 +3219,9 @@ describe("google transport stream", () => {
         role: "user",
         parts: ["screenshot", "weather"].map((name) => ({
           functionResponse: {
+            ...(modelId === "gemini-2.5-flash"
+              ? { id: name === "screenshot" ? "call_1" : "call_2" }
+              : {}),
             name,
             response:
               name === "screenshot" ? { output: "(see attached image)" } : { output: "Sunny, 21C" },

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1343,9 +1343,14 @@ describe("google transport stream", () => {
     });
   });
 
-  it.each(["google-generative-ai", "google-vertex"] as const)(
-    "preserves an undelimited terminal provider error from %s",
-    async (api) => {
+  it.each([
+    { api: "google-generative-ai", prefix: "data: ", framing: "framed" },
+    { api: "google-generative-ai", prefix: "", framing: "bare" },
+    { api: "google-vertex", prefix: "data: ", framing: "framed" },
+    { api: "google-vertex", prefix: "", framing: "bare" },
+  ] as const)(
+    "preserves an undelimited $framing terminal provider error from $api",
+    async ({ api, prefix }) => {
       if (api === "google-vertex") {
         vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
         vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
@@ -1354,7 +1359,7 @@ describe("google transport stream", () => {
       guardedFetchMock.mockResolvedValueOnce(
         buildRawSseResponse(
           'data: {"candidates":[{"finishReason":"STOP"}]}\n\n' +
-            'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exhausted"}}',
+            `${prefix}{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exhausted"}}`,
         ),
       );
       const result =
@@ -1370,42 +1375,48 @@ describe("google transport stream", () => {
     },
   );
 
-  it("preserves an undelimited provider error over a real Google HTTP/SSE stream", async () => {
-    const server = createServer((request, response) => {
-      request.resume();
-      request.on("end", () => {
-        response.writeHead(200, { "content-type": "text/event-stream" });
-        response.write('data: {"candidates":[{"finishReason":"STOP"}]}\n\n');
-        response.end(
-          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"live quota exhausted"}}',
+  it.each([
+    { prefix: "data: ", framing: "framed" },
+    { prefix: "", framing: "bare" },
+  ])(
+    "preserves an undelimited $framing error over a real Google HTTP/SSE stream",
+    async ({ prefix }) => {
+      const server = createServer((request, response) => {
+        request.resume();
+        request.on("end", () => {
+          response.writeHead(200, { "content-type": "text/event-stream" });
+          response.write('data: {"candidates":[{"finishReason":"STOP"}]}\n\n');
+          response.end(
+            `${prefix}{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"live quota exhausted"}}`,
+          );
+        });
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Missing Google loopback server address");
+        }
+        guardedFetchMock.mockImplementation((_url, init) =>
+          fetch(`http://127.0.0.1:${address.port}/stream`, init),
         );
-      });
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
+        const result = await runGeminiStreamResult({ options: { apiKey: "test-google-key" } });
 
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("Missing Google loopback server address");
+        expect(result).toMatchObject({
+          stopReason: "error",
+          errorCode: "RESOURCE_EXHAUSTED",
+          errorMessage: expect.stringContaining("live quota exhausted"),
+        });
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
       }
-      guardedFetchMock.mockImplementation((_url, init) =>
-        fetch(`http://127.0.0.1:${address.port}/stream`, init),
-      );
-      const result = await runGeminiStreamResult({ options: { apiKey: "test-google-key" } });
-
-      expect(result).toMatchObject({
-        stopReason: "error",
-        errorCode: "RESOURCE_EXHAUSTED",
-        errorMessage: expect.stringContaining("live quota exhausted"),
-      });
-    } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
+    },
+  );
 
   it.each(["google-generative-ai", "google-vertex"] as const)(
     "keeps an unspecified %s finish reason nonterminal",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -495,7 +495,9 @@ describe("google transport stream", () => {
     );
     const result = await stream.result();
 
-    expect(buildGuardedModelFetchMock).toHaveBeenCalledWith(model);
+    expect(buildGuardedModelFetchMock).toHaveBeenCalledWith(model, undefined, {
+      sanitizeSse: false,
+    });
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
     expect(guardedCall[0]).toBe(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
@@ -587,6 +589,92 @@ describe("google transport stream", () => {
     });
   });
 
+  it.each(["google", "google-vertex"] as const)(
+    "preserves previously reported %s usage categories across sparse stream updates",
+    async (provider) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "draft" }] } }],
+            usageMetadata: {
+              promptTokenCount: 100,
+              cachedContentTokenCount: 40,
+              toolUsePromptTokenCount: 6,
+              candidatesTokenCount: 1,
+              totalTokenCount: 107,
+            },
+          },
+          {
+            candidates: [{ content: { parts: [{ text: " final" }] }, finishReason: "STOP" }],
+            usageMetadata: {
+              candidatesTokenCount: 12,
+              thoughtsTokenCount: 3,
+              totalTokenCount: 121,
+            },
+          },
+        ]),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result.usage).toMatchObject({
+        input: 66,
+        output: 15,
+        cacheRead: 40,
+        totalTokens: 121,
+      });
+    },
+  );
+
+  it.each(["google", "google-vertex"] as const)(
+    "recomputes a stale %s usage aggregate when a sparse update omits the total",
+    async (provider) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "draft" }] } }],
+            usageMetadata: {
+              promptTokenCount: 100,
+              cachedContentTokenCount: 40,
+              toolUsePromptTokenCount: 6,
+              candidatesTokenCount: 1,
+              totalTokenCount: 107,
+            },
+          },
+          {
+            candidates: [{ content: { parts: [{ text: " final" }] }, finishReason: "STOP" }],
+            usageMetadata: { candidatesTokenCount: 12, thoughtsTokenCount: 3 },
+          },
+        ]),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result.usage).toMatchObject({
+        input: 66,
+        output: 15,
+        cacheRead: 40,
+        totalTokens: 121,
+      });
+    },
+  );
+
   it.each([
     {
       provider: "google",
@@ -668,6 +756,139 @@ describe("google transport stream", () => {
     },
   );
 
+  it.each(["google", "google-vertex"] as const)(
+    "ignores an unspecified %s finish reason before the authoritative terminal reason",
+    async (provider) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: "partial" }] },
+                finishReason: "FINISH_REASON_UNSPECIFIED",
+              },
+            ],
+          },
+          {
+            candidates: [{ content: { parts: [{ text: " final" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "stop",
+        content: [{ type: "text", text: "partial final" }],
+      });
+    },
+  );
+
+  it.each(["google", "google-vertex"] as const)(
+    "rejects a truncated %s SSE tail after an otherwise successful terminal chunk",
+    async (provider) => {
+      const terminalChunk = {
+        candidates: [{ content: { parts: [{ text: "answer" }] }, finishReason: "STOP" }],
+      };
+      guardedFetchMock.mockResolvedValueOnce(
+        buildRawSseResponse(
+          `data: ${JSON.stringify(terminalChunk)}\n\ndata: {"candidates":[{"content":`,
+        ),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "STREAM_INCOMPLETE",
+        errorType: "google_incomplete_stream",
+      });
+    },
+  );
+
+  it.each(["google", "google-vertex"] as const)(
+    "accepts trailing %s SSE heartbeat comments and metadata",
+    async (provider) => {
+      const terminalChunk = {
+        candidates: [{ content: { parts: [{ text: "answer" }] }, finishReason: "STOP" }],
+      };
+      guardedFetchMock.mockResolvedValueOnce(
+        buildRawSseResponse(
+          `data: ${JSON.stringify(terminalChunk)}\n\n: keep-alive\nevent: heartbeat\nid: last`,
+        ),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "stop",
+        content: [{ type: "text", text: "answer" }],
+      });
+    },
+  );
+
+  it.each(["google", "google-vertex"] as const)(
+    "surfaces a streamed %s provider error after a successful candidate chunk",
+    async (provider) => {
+      const terminalChunk = {
+        candidates: [{ content: { parts: [{ text: "answer" }] }, finishReason: "STOP" }],
+      };
+      const providerError = {
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: "Provider quota exhausted",
+        },
+      };
+      guardedFetchMock.mockResolvedValueOnce(
+        buildRawSseResponse(
+          `data: ${JSON.stringify(terminalChunk)}\n\n${JSON.stringify(providerError)}`,
+        ),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "RESOURCE_EXHAUSTED",
+        errorType: "google_stream_failed",
+        errorMessage: "Google stream error (RESOURCE_EXHAUSTED): Provider quota exhausted",
+      });
+    },
+  );
+
   it.each(["SAFETY", "MALFORMED_FUNCTION_CALL"] as const)(
     "preserves the actionable %s candidate finish message",
     async (finishReason) => {
@@ -691,6 +912,30 @@ describe("google transport stream", () => {
         errorCode: finishReason,
         errorType: "google_generation_failed",
         errorMessage: `Google generation stopped (${finishReason}): Provider rejected the generated response`,
+      });
+    },
+  );
+
+  it.each(["SAFETY", "MALFORMED_FUNCTION_CALL"] as const)(
+    "keeps an actionable %s terminal failure after a later STOP",
+    async (finishReason) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              { finishReason, finishMessage: "Provider rejected the generated response" },
+            ],
+          },
+          { candidates: [{ finishReason: "STOP" }] },
+        ]),
+      );
+
+      const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: finishReason,
+        errorType: "google_generation_failed",
       });
     },
   );
@@ -931,7 +1176,7 @@ describe("google transport stream", () => {
     ]);
   });
 
-  it("keeps duplicate tool-call ids distinct while retaining the first signature", async () => {
+  it("keeps duplicate tool-call ids distinct without sharing their thought signatures", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([
         {
@@ -982,9 +1227,581 @@ describe("google transport stream", () => {
     expect(toolCalls[1]).toMatchObject({
       name: "second",
       arguments: { value: 2 },
-      thoughtSignature: "first_signature",
     });
+    expect(toolCalls[1]).not.toHaveProperty("thoughtSignature", "first_signature");
     expect(toolCalls[1]?.id).not.toBe("call_1");
+  });
+
+  it("finalizes a streamed Vertex function call once after its partial arguments are complete", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "vertex_call_1",
+                      name: "lookup",
+                      partialArgs: [
+                        { jsonPath: "$.query", stringValue: "Par", willContinue: true },
+                        { jsonPath: "$.filters[0].enabled", boolValue: true },
+                      ],
+                      willContinue: true,
+                    },
+                    thoughtSignature: "dmVydGV4X3NpZw==",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "vertex_call_1",
+                      name: "lookup",
+                      partialArgs: [{ jsonPath: "$.query", stringValue: "is" }],
+                      willContinue: false,
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+        { apiKey: "gcp-vertex-credentials", fetch: guardedFetchMock } as never,
+      ),
+    );
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect((await stream.result()).content).toEqual([
+      {
+        type: "toolCall",
+        id: "vertex_call_1",
+        name: "lookup",
+        arguments: { query: "Paris", filters: [{ enabled: true }] },
+        thoughtSignature: "dmVydGV4X3NpZw==",
+      },
+    ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+  });
+
+  it("rejects a Vertex function call that is still continuing at the terminal chunk", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "vertex_call_1",
+                      name: "lookup",
+                      partialArgs: [
+                        { jsonPath: "$.query", stringValue: "Par", willContinue: true },
+                      ],
+                      willContinue: true,
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorCode: "INCOMPLETE_FUNCTION_CALL",
+      errorType: "google_incomplete_tool_call",
+    });
+  });
+
+  it("assembles official id-less Vertex function-call fragments through an unnamed final marker", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { name: "lookup", willContinue: true },
+                    thoughtSignature: "dmVydGV4X2Fub255bW91c19zaWc=",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      partialArgs: [
+                        { jsonPath: "$.query", stringValue: "Par", willContinue: true },
+                      ],
+                      willContinue: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      partialArgs: [{ jsonPath: "$.query", stringValue: "is" }],
+                      willContinue: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          candidates: [{ content: { parts: [{ functionCall: {} }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+        { apiKey: "gcp-vertex-credentials", fetch: guardedFetchMock } as never,
+      ),
+    );
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const result = await stream.result();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toMatchObject({
+      type: "toolCall",
+      name: "lookup",
+      arguments: { query: "Paris" },
+      thoughtSignature: "dmVydGV4X2Fub255bW91c19zaWc=",
+    });
+    expect(result.content[0]?.id).toMatch(/^lookup_/);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+  });
+
+  it.each(["STOP", "MAX_TOKENS"] as const)(
+    "rejects an id-less Vertex function call that is still continuing at %s",
+    async (finishReason) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        name: "lookup",
+                        partialArgs: [
+                          { jsonPath: "$.query", stringValue: "Par", willContinue: true },
+                        ],
+                        willContinue: true,
+                      },
+                    },
+                  ],
+                },
+                finishReason,
+              },
+            ],
+          },
+        ]),
+      );
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+      googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+      const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "INCOMPLETE_FUNCTION_CALL",
+        errorType: "google_incomplete_tool_call",
+      });
+    },
+  );
+
+  it("keeps separately named id-less Vertex function calls distinct", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { name: "lookup", args: { city: "Paris" } } },
+                  { functionCall: { name: "weather", args: { city: "London" } } },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result.content).toMatchObject([
+      { type: "toolCall", name: "lookup", arguments: { city: "Paris" } },
+      { type: "toolCall", name: "weather", arguments: { city: "London" } },
+    ]);
+    expect(result.content[0]?.id).not.toBe(result.content[1]?.id);
+  });
+
+  it.each([
+    { names: ["lookup", "lookup"], label: "same-name" },
+    { names: ["lookup", "weather"], label: "different-name" },
+  ])(
+    "keeps parallel $label id-less Vertex partial calls on their own part positions",
+    async ({ names }) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              {
+                content: {
+                  parts: names.map((name, index) => ({
+                    functionCall: { name, willContinue: true },
+                    thoughtSignature: `signature_${index}`,
+                  })),
+                },
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  parts: ["Paris", "London"].map((city) => ({
+                    functionCall: {
+                      partialArgs: [{ jsonPath: "$.city", stringValue: city }],
+                      willContinue: false,
+                    },
+                  })),
+                },
+                finishReason: "STOP",
+              },
+            ],
+          },
+        ]),
+      );
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+      googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+      const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+      expect(result.stopReason).toBe("toolUse");
+      expect(result.content).toMatchObject([
+        { type: "toolCall", name: names[0], arguments: { city: "Paris" } },
+        { type: "toolCall", name: names[1], arguments: { city: "London" } },
+      ]);
+      expect(result.content[0]?.thoughtSignature).toBe("signature_0");
+      expect(result.content[1]?.thoughtSignature).toBe("signature_1");
+      expect(result.content[0]?.id).not.toBe(result.content[1]?.id);
+    },
+  );
+
+  it("keeps parallel Vertex partial calls with duplicate provider ids and names distinct", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [0, 1].map((index) => ({
+                  functionCall: { id: "call_shared", name: "lookup", willContinue: true },
+                  thoughtSignature: `signature_${index}`,
+                })),
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: ["Paris", "London"].map((city) => ({
+                  functionCall: {
+                    id: "call_shared",
+                    name: "lookup",
+                    partialArgs: [{ jsonPath: "$.city", stringValue: city }],
+                    willContinue: false,
+                  },
+                })),
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.content).toMatchObject([
+      { id: "call_shared", name: "lookup", arguments: { city: "Paris" } },
+      { name: "lookup", arguments: { city: "London" } },
+    ]);
+    expect(result.content[0]?.thoughtSignature).toBe("signature_0");
+    expect(result.content[1]?.thoughtSignature).toBe("signature_1");
+    expect(result.content[1]?.id).not.toBe("call_shared");
+  });
+
+  it("lets only one parallel id-less Vertex call adopt a late provider id", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [0, 1].map(() => ({
+                  functionCall: { name: "lookup", willContinue: true },
+                })),
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: ["Paris", "London"].map((city) => ({
+                  functionCall: {
+                    id: "late_shared",
+                    name: "lookup",
+                    partialArgs: [{ jsonPath: "$.city", stringValue: city }],
+                    willContinue: false,
+                  },
+                })),
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.content).toMatchObject([
+      { id: "late_shared", arguments: { city: "Paris" } },
+      { arguments: { city: "London" } },
+    ]);
+    expect(result.content[1]?.id).not.toBe("late_shared");
+  });
+
+  it("preserves ProtoJSON nulls and RFC 9535 bracket-name partial argument paths", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "vertex_call_1",
+                      name: "lookup",
+                      partialArgs: [
+                        { jsonPath: "$['postal.code']", stringValue: "94107" },
+                        { jsonPath: '$["display name"]', stringValue: "Ada" },
+                        { jsonPath: "$['']", stringValue: "empty member" },
+                        { jsonPath: "$[ 'spaced name' ]", stringValue: "spaced" },
+                        { jsonPath: "$['say\\\"what']", stringValue: "escaped" },
+                        { jsonPath: "$['user\\'s.city']", stringValue: "Paris" },
+                        { jsonPath: "$.café", stringValue: "Marais" },
+                        { jsonPath: "$.🌡️", numberValue: 21 },
+                        { jsonPath: "$['nested.key'][0]['quoted value']", numberValue: 7 },
+                        { jsonPath: "$.optional", nullValue: null },
+                        { jsonPath: "$.sdkNull", nullValue: "NULL_VALUE" },
+                      ],
+                      willContinue: false,
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result.content[0]).toMatchObject({
+      type: "toolCall",
+      arguments: {
+        "postal.code": "94107",
+        "display name": "Ada",
+        "": "empty member",
+        "spaced name": "spaced",
+        'say"what': "escaped",
+        "user's.city": "Paris",
+        café: "Marais",
+        "🌡️": 21,
+        "nested.key": [{ "quoted value": 7 }],
+        optional: null,
+        sdkNull: null,
+      },
+    });
+  });
+
+  it.each([
+    { label: "unsafe sparse indices", path: "$.items[100000000]" },
+    { label: "malformed selectors", path: "$.filters[" },
+    { label: "prototype selectors", path: "$['__proto__'].polluted" },
+  ])("rejects $label before materializing streamed tool arguments", async ({ path }) => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      name: "lookup",
+                      partialArgs: [{ jsonPath: path, stringValue: "unsafe" }],
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorCode: "INVALID_FUNCTION_CALL",
+      errorType: "google_invalid_tool_call",
+    });
+  });
+
+  it("keeps complete model-provided tool arguments from changing their object prototype", async () => {
+    const untrustedArguments = JSON.parse(
+      '{"__proto__":{"isAdmin":true},"city":"Paris"}',
+    ) as Record<string, unknown>;
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "vertex_call_1",
+                      name: "lookup",
+                      args: untrustedArguments,
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+
+    const result = await runGoogleVertexStreamResult({ fetch: guardedFetchMock });
+    const toolCall = result.content[0];
+
+    expect(toolCall).toMatchObject({ type: "toolCall", arguments: { city: "Paris" } });
+    expect(Object.getPrototypeOf(toolCall?.arguments)).toBe(Object.prototype);
+    expect(toolCall?.arguments).not.toHaveProperty("isAdmin");
+    expect(Object.hasOwn(toolCall?.arguments ?? {}, "__proto__")).toBe(true);
   });
 
   it("keeps explicit thinking signatures after tool-call SSE parts", async () => {
@@ -1726,6 +2543,61 @@ describe("google transport stream", () => {
   });
 
   it.each([
+    { provider: "google", model: buildGeminiModel({ id: "gemini-3.1-pro-preview" }) },
+    { provider: "google-vertex", model: buildGoogleVertexModel() },
+  ])(
+    "preserves provider-issued $provider call and result identities for parallel tools",
+    ({ provider, model }) => {
+      const params = buildGoogleGenerativeAiParams(model, {
+        messages: [
+          { role: "user", content: "Look up both cities.", timestamp: 0 },
+          {
+            role: "assistant",
+            provider,
+            api: model.api,
+            model: model.id,
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              { type: "toolCall", id: "call_alpha", name: "lookup", arguments: { city: "Paris" } },
+              { type: "toolCall", id: "call_beta", name: "lookup", arguments: { city: "London" } },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_alpha",
+            toolName: "lookup",
+            content: [{ type: "text", text: "Paris is sunny" }],
+            isError: false,
+            timestamp: 2,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_beta",
+            toolName: "lookup",
+            content: [{ type: "text", text: "London is rainy" }],
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      } as never);
+
+      expect(params.contents[1]).toMatchObject({
+        parts: [
+          { functionCall: { id: "call_alpha", name: "lookup", args: { city: "Paris" } } },
+          { functionCall: { id: "call_beta", name: "lookup", args: { city: "London" } } },
+        ],
+      });
+      expect(params.contents[2]).toMatchObject({
+        parts: [
+          { functionResponse: { id: "call_alpha", name: "lookup" } },
+          { functionResponse: { id: "call_beta", name: "lookup" } },
+        ],
+      });
+    },
+  );
+
+  it.each([
     {
       name: "replays Gemini tool call thought signatures for same-model history",
       modelId: "gemini-3-flash-preview",
@@ -1786,7 +2658,7 @@ describe("google transport stream", () => {
       parts: [
         {
           thoughtSignature: signature,
-          functionCall: { name: "lookup", args: { q: "hello" } },
+          functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
         },
       ],
     });
@@ -2768,6 +3640,9 @@ describe("google transport stream", () => {
             name,
             response:
               name === "screenshot" ? { output: "(see attached image)" } : { output: "Sunny, 21C" },
+            ...(modelId === "gemini-2.5-flash"
+              ? { id: name === "screenshot" ? "call_1" : "call_2" }
+              : {}),
           },
         })),
       });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1338,21 +1338,22 @@ async function* parseGoogleSseChunks(
           .filter((line) => line.startsWith("data:"))
           .map((line) => line.slice(5).trim())
           .join("\n");
-        if (!trailingData) {
+        const trailingPayload = trailingData || buffer.trim();
+        if (!trailingPayload || (!trailingData && !trailingPayload.startsWith("{"))) {
           completed = true;
           break;
         }
         let trailingChunk: unknown;
         try {
-          trailingChunk = JSON.parse(trailingData);
+          trailingChunk = JSON.parse(trailingPayload);
         } catch {
           throw new Error("Google SSE stream ended with an incomplete frame");
         }
         if (!isRecord(trailingChunk) || !isRecord(trailingChunk.error)) {
           throw new Error("Google SSE stream ended with an incomplete frame");
         }
-        // A complete provider-error payload owns its typed failure even when EOF omits the delimiter.
-        buffer += "\n\n";
+        // Provider errors can arrive as bare JSON or data frames without their final delimiter.
+        buffer = `data: ${JSON.stringify(trailingChunk)}\n\n`;
       } else {
         buffer += decoder.decode(value, { stream: true });
       }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -563,6 +563,7 @@ function convertGoogleMessages(
 ) {
   const contents: Array<Record<string, unknown>> = [];
   const replayToolCallThoughtSignatures = new Map<string, string>();
+  const sameRouteToolCallIds = new Set<string>();
   const shouldReplayToolCallThoughtSignature = requiresToolCallThoughtSignature(model.id);
   const routeModel = normalizeGoogleTransportModelRoute(model);
   const transformedMessages = transformTransportMessages(
@@ -654,6 +655,9 @@ function convertGoogleMessages(
           continue;
         }
         if (block.type === "toolCall") {
+          if (isSameRoute) {
+            sameRouteToolCallIds.add(block.id);
+          }
           const replayKey = toolCallThoughtSignatureReplayKey(block);
           const replayedThoughtSignature =
             shouldReplayToolCallThoughtSignature && isSameRoute
@@ -679,7 +683,7 @@ function convertGoogleMessages(
             functionCall: {
               name: block.name,
               args: coerceTransportToolCallArguments(block.arguments),
-              ...(requiresToolCallId(model.id) ? { id: block.id } : {}),
+              ...(isSameRoute || requiresToolCallId(model.id) ? { id: block.id } : {}),
             },
             ...(thoughtSignature ? { thoughtSignature } : {}),
           });
@@ -720,7 +724,9 @@ function convertGoogleMessages(
           ...(modelSupportsMultimodalFunctionResponse && imageParts.length > 0
             ? { parts: imageParts }
             : {}),
-          ...(requiresToolCallId(model.id) ? { id: msg.toolCallId } : {}),
+          ...(sameRouteToolCallIds.has(msg.toolCallId) || requiresToolCallId(model.id)
+            ? { id: msg.toolCallId }
+            : {}),
         },
       };
       if (activeToolResultParts) {
@@ -1327,17 +1333,29 @@ async function* parseGoogleSseChunks(
       signal?.throwIfAborted();
       if (done) {
         buffer += decoder.decode();
-        if (
-          buffer
-            .split(/\r\n|\n|\r/u)
-            .some((line) => line.startsWith("data:") && line.slice(5).trim().length > 0)
-        ) {
+        const trailingData = buffer
+          .split(/\r\n|\n|\r/u)
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trim())
+          .join("\n");
+        if (!trailingData) {
+          completed = true;
+          break;
+        }
+        let trailingChunk: unknown;
+        try {
+          trailingChunk = JSON.parse(trailingData);
+        } catch {
           throw new Error("Google SSE stream ended with an incomplete frame");
         }
-        completed = true;
-        break;
+        if (!isRecord(trailingChunk) || !isRecord(trailingChunk.error)) {
+          throw new Error("Google SSE stream ended with an incomplete frame");
+        }
+        // A complete provider-error payload owns its typed failure even when EOF omits the delimiter.
+        buffer += "\n\n";
+      } else {
+        buffer += decoder.decode(value, { stream: true });
       }
-      buffer += decoder.decode(value, { stream: true });
       let boundary = GOOGLE_SSE_EVENT_BOUNDARY_RE.exec(buffer);
       while (boundary) {
         const rawEvent = buffer.slice(0, boundary.index);
@@ -1662,7 +1680,10 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
               }
             }
           }
-          if (typeof candidate?.finishReason === "string") {
+          if (
+            typeof candidate?.finishReason === "string" &&
+            candidate.finishReason !== "FINISH_REASON_UNSPECIFIED"
+          ) {
             sawTerminalReason = true;
             output.stopReason = mapStopReasonString(candidate.finishReason);
             if (output.stopReason === "error") {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -35,6 +35,7 @@ import {
   type WritableTransportStream,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import {
+  isRecord,
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -140,11 +141,7 @@ type GoogleSseChunk = {
         text?: string;
         thought?: boolean;
         thoughtSignature?: string;
-        functionCall?: {
-          id?: string;
-          name?: string;
-          args?: Record<string, unknown>;
-        };
+        functionCall?: GoogleFunctionCall;
       }>;
     };
     finishReason?: string;
@@ -160,8 +157,36 @@ type GoogleSseChunk = {
   };
 };
 
+type GooglePartialFunctionArgument = {
+  jsonPath?: string;
+  boolValue?: boolean;
+  nullValue?: "NULL_VALUE" | null;
+  numberValue?: number;
+  stringValue?: string;
+  willContinue?: boolean;
+};
+
+type GoogleFunctionCall = {
+  id?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+  partialArgs?: GooglePartialFunctionArgument[];
+  willContinue?: boolean;
+};
+
+type GooglePendingToolCall = {
+  block: Extract<GoogleTransportContentBlock, { type: "toolCall" }>;
+  contentIndex: number;
+  fragmentsByPath: Map<string, unknown>;
+  pending: boolean;
+  providerId?: string;
+};
+
+type GoogleUsageMetadata = NonNullable<GoogleSseChunk["usageMetadata"]>;
+
 let toolCallCounter = 0;
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+const MAX_GOOGLE_PARTIAL_ARGUMENT_ARRAY_INDEX = 1024;
 
 function requiresToolCallId(modelId: string): boolean {
   return modelId.startsWith("claude-") || modelId.startsWith("gpt-oss-");
@@ -184,6 +209,133 @@ function retainThoughtSignature(existing: string | undefined, incoming: string |
     return incoming;
   }
   return existing;
+}
+
+function googlePartialArgumentPath(jsonPath: string | undefined): Array<string | number> {
+  if (!jsonPath?.startsWith("$")) {
+    return [];
+  }
+  const segments: Array<string | number> = [];
+  const segmentPattern =
+    /\.([A-Za-z_$\u0080-\u{10ffff}][\w$\u0080-\u{10ffff}-]*)|\[\s*(\d+)\s*\]|\[\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*\]/gu;
+  let offset = 1;
+  for (const match of jsonPath.matchAll(segmentPattern)) {
+    if (match.index !== offset) {
+      return [];
+    }
+    const bracketName = match[3];
+    let key = match[1] ?? match[2];
+    if (bracketName) {
+      try {
+        let jsonName = '"';
+        for (let index = 1; index < bracketName.length - 1; index += 1) {
+          const character = bracketName[index];
+          if (character === "\\") {
+            const escaped = bracketName[++index];
+            if (!escaped) {
+              return [];
+            }
+            jsonName += escaped === "'" ? "'" : escaped === '"' ? '\\"' : `\\${escaped}`;
+          } else {
+            jsonName += character === '"' ? '\\"' : character;
+          }
+        }
+        const decodedName: unknown = JSON.parse(`${jsonName}"`);
+        if (typeof decodedName !== "string") {
+          return [];
+        }
+        key = decodedName;
+      } catch {
+        return [];
+      }
+    }
+    if (key === undefined || key === "__proto__" || key === "constructor" || key === "prototype") {
+      return [];
+    }
+    if (match[2]) {
+      const index = Number(key);
+      // A model-controlled sparse index can expand into millions of JSON nulls
+      // when completed arguments are emitted to the agent/tool consumer.
+      if (!Number.isSafeInteger(index) || index > MAX_GOOGLE_PARTIAL_ARGUMENT_ARRAY_INDEX) {
+        throw invalidGoogleFunctionCall("an unsafe array index");
+      }
+      segments.push(index);
+    } else {
+      segments.push(key);
+    }
+    offset += match[0].length;
+  }
+  return offset === jsonPath.length ? segments : [];
+}
+
+function invalidGoogleFunctionCall(reason: string): Error {
+  return Object.assign(new Error(`Google function call contains ${reason}`), {
+    code: "INVALID_FUNCTION_CALL",
+    type: "google_invalid_tool_call",
+  });
+}
+
+function assignGooglePartialArgument(
+  argumentsObject: Record<string, unknown>,
+  path: Array<string | number>,
+  value: unknown,
+): void {
+  if (path.length === 0) {
+    return;
+  }
+  let current: Record<string, unknown> | unknown[] = argumentsObject;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const key = path[index];
+    if (key === undefined) {
+      return;
+    }
+    const existing = current[key as keyof typeof current];
+    if (!isRecord(existing) && !Array.isArray(existing)) {
+      current[key as keyof typeof current] = (
+        typeof path[index + 1] === "number" ? [] : {}
+      ) as never;
+    }
+    current = current[key as keyof typeof current] as Record<string, unknown> | unknown[];
+  }
+  const finalKey = path[path.length - 1];
+  if (finalKey !== undefined) {
+    current[finalKey as keyof typeof current] = value as never;
+  }
+}
+
+function mergeGoogleFunctionCallArguments(
+  pendingCall: GooglePendingToolCall,
+  functionCall: GoogleFunctionCall,
+): void {
+  if (functionCall.args) {
+    // Object spread defines own properties, including a literal __proto__ key;
+    // Object.assign would invoke its legacy setter on model-controlled JSON.
+    pendingCall.block.arguments = { ...pendingCall.block.arguments, ...functionCall.args };
+  }
+  for (const partialArg of functionCall.partialArgs ?? []) {
+    const path = googlePartialArgumentPath(partialArg.jsonPath);
+    if (path.length === 0 || !partialArg.jsonPath) {
+      throw invalidGoogleFunctionCall("an invalid or unsafe partial argument path");
+    }
+    let value: unknown;
+    if (typeof partialArg.stringValue === "string") {
+      const previous = pendingCall.fragmentsByPath.get(partialArg.jsonPath);
+      value =
+        typeof previous === "string"
+          ? `${previous}${partialArg.stringValue}`
+          : partialArg.stringValue;
+    } else if (typeof partialArg.boolValue === "boolean") {
+      value = partialArg.boolValue;
+    } else if (typeof partialArg.numberValue === "number") {
+      value = partialArg.numberValue;
+    } else if (partialArg.nullValue === null || partialArg.nullValue === "NULL_VALUE") {
+      value = null;
+    } else {
+      continue;
+    }
+    pendingCall.fragmentsByPath.set(partialArg.jsonPath, value);
+    assignGooglePartialArgument(pendingCall.block.arguments, path, value);
+  }
 }
 
 function stableStringifyGoogleToolCallValue(value: unknown): string {
@@ -530,6 +682,7 @@ function normalizeGoogleThinkingConfig(
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
   const replayToolCallThoughtSignatures = new Map<string, string>();
+  const forwardedToolCallIds = new Set<string>();
   const shouldReplayToolCallThoughtSignature = requiresToolCallThoughtSignature(model.id);
   const routeModel = normalizeGoogleTransportModelRoute(model);
   const transformedMessages = transformTransportMessages(
@@ -555,6 +708,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
       flushToolResultRun();
     }
     if (msg.role === "user") {
+      forwardedToolCallIds.clear();
       if (typeof msg.content === "string") {
         contents.push({
           role: "user",
@@ -582,6 +736,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     }
 
     if (msg.role === "assistant") {
+      forwardedToolCallIds.clear();
       const isSameRoute = isSameGoogleTransportRoute(msg, model);
       const parts: Array<Record<string, unknown>> = [];
       const nextReplayToolCallThoughtSignatures = new Map<string, string>();
@@ -620,6 +775,10 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           continue;
         }
         if (block.type === "toolCall") {
+          const shouldForwardToolCallId = requiresToolCallId(model.id) || isSameRoute;
+          if (shouldForwardToolCallId) {
+            forwardedToolCallIds.add(block.id);
+          }
           const replayKey = toolCallThoughtSignatureReplayKey(block);
           const replayedThoughtSignature =
             shouldReplayToolCallThoughtSignature && isSameRoute
@@ -645,7 +804,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             functionCall: {
               name: block.name,
               args: coerceTransportToolCallArguments(block.arguments),
-              ...(requiresToolCallId(model.id) ? { id: block.id } : {}),
+              ...(shouldForwardToolCallId ? { id: block.id } : {}),
             },
             ...(thoughtSignature ? { thoughtSignature } : {}),
           });
@@ -686,7 +845,9 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           ...(modelSupportsMultimodalFunctionResponse && imageParts.length > 0
             ? { parts: imageParts }
             : {}),
-          ...(requiresToolCallId(model.id) ? { id: msg.toolCallId } : {}),
+          ...(requiresToolCallId(model.id) || forwardedToolCallIds.has(msg.toolCallId)
+            ? { id: msg.toolCallId }
+            : {}),
         },
       };
       if (activeToolResultParts) {
@@ -1168,6 +1329,31 @@ async function buildGoogleTransportHeaders(params: {
     : buildGoogleHeaders(params.model, params.apiKey, params.optionHeaders);
 }
 
+function parseGoogleSseChunk(data: string): GoogleSseChunk {
+  let chunk: unknown;
+  try {
+    chunk = JSON.parse(data);
+  } catch {
+    throw new Error("Google SSE stream returned malformed JSON");
+  }
+  if (!isRecord(chunk)) {
+    throw new Error("Google SSE stream returned malformed JSON");
+  }
+  if (isRecord(chunk.error)) {
+    const errorCode =
+      normalizeOptionalString(chunk.error.status) ??
+      (typeof chunk.error.code === "number" ? String(chunk.error.code) : undefined) ??
+      "GOOGLE_STREAM_ERROR";
+    const errorMessage =
+      normalizeOptionalString(chunk.error.message) ?? "Provider returned a streamed error";
+    throw Object.assign(new Error(`Google stream error (${errorCode}): ${errorMessage}`), {
+      code: errorCode,
+      type: "google_stream_failed",
+    });
+  }
+  return chunk as GoogleSseChunk;
+}
+
 async function* parseGoogleSseChunks(
   response: Response,
   signal?: AbortSignal,
@@ -1190,6 +1376,26 @@ async function* parseGoogleSseChunks(
       }
       const { done, value } = await reader.read();
       if (done) {
+        buffer += decoder.decode().replace(/\r/g, "");
+        const trailing = buffer.trim();
+        if (trailing) {
+          const onlySseMetadata = trailing
+            .split("\n")
+            .every((line) => /^\s*(?::|(?:event|id|retry)(?::|$))/u.test(line));
+          if (onlySseMetadata) {
+            completed = true;
+            break;
+          }
+          // The SDK accepts only complete SSE frames; bare provider errors still
+          // carry the actionable status when a stream fails after a valid chunk.
+          if (trailing.startsWith("{")) {
+            parseGoogleSseChunk(trailing);
+          }
+          throw Object.assign(new Error("Google SSE stream ended with an incomplete event"), {
+            code: "STREAM_INCOMPLETE",
+            type: "google_incomplete_stream",
+          });
+        }
         completed = true;
         break;
       }
@@ -1207,11 +1413,7 @@ async function* parseGoogleSseChunks(
         if (!data || data === "[DONE]") {
           continue;
         }
-        try {
-          yield JSON.parse(data) as GoogleSseChunk;
-        } catch {
-          throw new Error("Google SSE stream returned malformed JSON");
-        }
+        yield parseGoogleSseChunk(data);
       }
     }
   } finally {
@@ -1227,21 +1429,29 @@ function updateUsage(
   output: MutableAssistantOutput,
   model: GoogleTransportModel,
   chunk: GoogleSseChunk,
+  knownUsage: GoogleUsageMetadata,
 ) {
-  const usage = chunk.usageMetadata;
-  if (!usage) {
+  if (!chunk.usageMetadata) {
     return;
   }
-  const promptTokens = usage.promptTokenCount || 0;
-  const cacheRead = usage.cachedContentTokenCount || 0;
-  const toolUsePromptTokens = usage.toolUsePromptTokenCount || 0;
-  const outputTokens = (usage.candidatesTokenCount || 0) + (usage.thoughtsTokenCount || 0);
+  Object.assign(knownUsage, chunk.usageMetadata);
+  const promptTokens = knownUsage.promptTokenCount ?? 0;
+  const cacheRead = knownUsage.cachedContentTokenCount ?? 0;
+  const toolUsePromptTokens = knownUsage.toolUsePromptTokenCount ?? 0;
+  const outputTokens =
+    (knownUsage.candidatesTokenCount ?? 0) + (knownUsage.thoughtsTokenCount ?? 0);
+  const totalTokens =
+    chunk.usageMetadata.totalTokenCount ??
+    (Object.keys(chunk.usageMetadata).some((field) => field !== "totalTokenCount")
+      ? promptTokens + outputTokens + toolUsePromptTokens
+      : (knownUsage.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens));
+  knownUsage.totalTokenCount = totalTokens;
   output.usage = {
     input: Math.max(0, promptTokens - cacheRead) + toolUsePromptTokens,
     output: outputTokens,
     cacheRead,
     cacheWrite: 0,
-    totalTokens: usage.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
+    totalTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };
   calculateCost(model, output.usage);
@@ -1293,7 +1503,9 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
       };
       try {
         const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? undefined;
-        const guardedFetch = buildGuardedModelFetch(model);
+        // Google owns SSE parsing; OpenAI-oriented sanitizing drops unframed
+        // provider errors before this transport can expose their real status.
+        const guardedFetch = buildGuardedModelFetch(model, undefined, { sanitizeSse: false });
         let params = buildGoogleGenerativeAiParams(model, context, options);
         const nextParams = await options?.onPayload?.(params, model);
         if (nextParams !== undefined) {
@@ -1338,10 +1550,10 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
         let currentBlockIndex = -1;
         let sawTerminalReason = false;
         let terminalGenerationError: Error | undefined;
-        const toolCallBlocksById = new Map<
-          string,
-          Extract<GoogleTransportContentBlock, { type: "toolCall" }>
-        >();
+        const knownUsage: GoogleUsageMetadata = {};
+        const toolCallsByProviderId = new Map<string, GooglePendingToolCall>();
+        const pendingToolCallsByPartIndex = new Map<number, GooglePendingToolCall>();
+        const pendingToolCalls = new Set<GooglePendingToolCall>();
         const chunks =
           sse.firstChunk === undefined
             ? sse.chunks
@@ -1351,7 +1563,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
               })(sse.firstChunk);
         for await (const chunk of chunks) {
           output.responseId ||= chunk.responseId;
-          updateUsage(output, model, chunk);
+          updateUsage(output, model, chunk, knownUsage);
           const candidate = chunk.candidates?.[0];
           const promptFeedback = chunk.promptFeedback;
           if (!candidate && promptFeedback) {
@@ -1365,7 +1577,8 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
             });
           }
           if (candidate?.content?.parts) {
-            for (const part of candidate.content.parts) {
+            const providerIdsInCandidate = new Set<string>();
+            for (const [partIndex, part] of candidate.content.parts.entries()) {
               const hasThoughtSignature =
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
               const hasText = typeof part.text === "string";
@@ -1442,50 +1655,116 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                   pushTextBlockEnd(stream, output, currentBlockIndex);
                   currentBlockIndex = -1;
                 }
-                const providedId = part.functionCall.id;
-                const existingToolCall =
-                  typeof providedId === "string" ? toolCallBlocksById.get(providedId) : undefined;
-                const isDuplicate = existingToolCall !== undefined;
-                const toolCallId =
-                  providedId && !isDuplicate
-                    ? providedId
-                    : `${part.functionCall.name || "tool"}_${Date.now()}_${++toolCallCounter}`;
-                const toolCall: GoogleTransportContentBlock = {
-                  type: "toolCall",
-                  id: toolCallId,
-                  name: part.functionCall.name || "",
-                  arguments: part.functionCall.args ?? {},
-                  thoughtSignature: retainThoughtSignature(
-                    existingToolCall?.thoughtSignature,
-                    part.thoughtSignature,
-                  ),
-                };
-                output.content.push(toolCall);
-                if (!toolCallBlocksById.has(toolCall.id)) {
-                  toolCallBlocksById.set(toolCall.id, toolCall);
+                const functionCall = part.functionCall;
+                const providedId = functionCall.id;
+                const repeatedProviderId =
+                  typeof providedId === "string" && providerIdsInCandidate.has(providedId);
+                if (typeof providedId === "string") {
+                  providerIdsInCandidate.add(providedId);
                 }
-                const blockIndex = output.content.length - 1;
-                stream.push({
-                  type: "toolcall_start",
-                  contentIndex: blockIndex,
-                  partial: output as never,
-                });
-                stream.push({
-                  type: "toolcall_delta",
-                  contentIndex: blockIndex,
-                  delta: JSON.stringify(toolCall.arguments),
-                  partial: output as never,
-                });
-                stream.push({
-                  type: "toolcall_end",
-                  contentIndex: blockIndex,
-                  toolCall,
-                  partial: output as never,
-                });
+                const identifiedToolCall =
+                  typeof providedId === "string"
+                    ? toolCallsByProviderId.get(providedId)
+                    : undefined;
+                // Vertex can omit id and name on all fragments, including
+                // final `{}` markers. Part position distinguishes parallel
+                // anonymous calls that invoke the same function.
+                const positionedToolCall = pendingToolCallsByPartIndex.get(partIndex);
+                const positionedCallMatches =
+                  positionedToolCall?.pending === true &&
+                  (!functionCall.name || positionedToolCall.block.name === functionCall.name) &&
+                  (!providedId ||
+                    !positionedToolCall.providerId ||
+                    positionedToolCall.providerId === providedId);
+                const existingToolCall = positionedCallMatches
+                  ? positionedToolCall
+                  : repeatedProviderId
+                    ? undefined
+                    : identifiedToolCall;
+                // Only an unfinished call with matching identity owns its continuation;
+                // duplicate provider ids must never inherit another call's signature.
+                const isContinuation =
+                  existingToolCall?.pending === true &&
+                  (!functionCall.name || existingToolCall.block.name === functionCall.name);
+                let pendingToolCall: GooglePendingToolCall;
+                if (isContinuation && existingToolCall) {
+                  pendingToolCall = existingToolCall;
+                  pendingToolCall.block.thoughtSignature = retainThoughtSignature(
+                    pendingToolCall.block.thoughtSignature,
+                    part.thoughtSignature,
+                  );
+                  if (
+                    providedId &&
+                    !pendingToolCall.providerId &&
+                    !repeatedProviderId &&
+                    !toolCallsByProviderId.has(providedId)
+                  ) {
+                    pendingToolCall.providerId = providedId;
+                    pendingToolCall.block.id = providedId;
+                    toolCallsByProviderId.set(providedId, pendingToolCall);
+                  }
+                } else {
+                  const toolCallId =
+                    providedId && !identifiedToolCall
+                      ? providedId
+                      : `${functionCall.name || "tool"}_${Date.now()}_${++toolCallCounter}`;
+                  const toolCall: Extract<GoogleTransportContentBlock, { type: "toolCall" }> = {
+                    type: "toolCall",
+                    id: toolCallId,
+                    name: functionCall.name || "",
+                    arguments: {},
+                    ...(part.thoughtSignature ? { thoughtSignature: part.thoughtSignature } : {}),
+                  };
+                  output.content.push(toolCall);
+                  pendingToolCall = {
+                    block: toolCall,
+                    contentIndex: output.content.length - 1,
+                    fragmentsByPath: new Map<string, unknown>(),
+                    pending: false,
+                    ...(providedId ? { providerId: providedId } : {}),
+                  };
+                  if (providedId && !identifiedToolCall) {
+                    toolCallsByProviderId.set(providedId, pendingToolCall);
+                  }
+                  stream.push({
+                    type: "toolcall_start",
+                    contentIndex: pendingToolCall.contentIndex,
+                    partial: output as never,
+                  });
+                }
+                mergeGoogleFunctionCallArguments(pendingToolCall, functionCall);
+                pendingToolCall.pending =
+                  functionCall.willContinue === true ||
+                  (functionCall.willContinue !== false &&
+                    (functionCall.partialArgs ?? []).some((argument) => argument.willContinue));
+                if (pendingToolCall.pending) {
+                  pendingToolCalls.add(pendingToolCall);
+                  pendingToolCallsByPartIndex.set(partIndex, pendingToolCall);
+                } else {
+                  pendingToolCalls.delete(pendingToolCall);
+                  if (pendingToolCallsByPartIndex.get(partIndex) === pendingToolCall) {
+                    pendingToolCallsByPartIndex.delete(partIndex);
+                  }
+                  stream.push({
+                    type: "toolcall_delta",
+                    contentIndex: pendingToolCall.contentIndex,
+                    delta: JSON.stringify(pendingToolCall.block.arguments),
+                    partial: output as never,
+                  });
+                  stream.push({
+                    type: "toolcall_end",
+                    contentIndex: pendingToolCall.contentIndex,
+                    toolCall: pendingToolCall.block,
+                    partial: output as never,
+                  });
+                }
               }
             }
           }
-          if (typeof candidate?.finishReason === "string") {
+          if (
+            typeof candidate?.finishReason === "string" &&
+            candidate.finishReason !== "FINISH_REASON_UNSPECIFIED"
+          ) {
             sawTerminalReason = true;
             output.stopReason = mapStopReasonString(candidate.finishReason);
             if (output.stopReason === "error") {
@@ -1512,6 +1791,12 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
         }
         if (terminalGenerationError && !options?.signal?.aborted) {
           throw terminalGenerationError;
+        }
+        if (sawTerminalReason && pendingToolCalls.size > 0 && !options?.signal?.aborted) {
+          throw Object.assign(new Error("Google stream ended with an incomplete function call"), {
+            code: "INCOMPLETE_FUNCTION_CALL",
+            type: "google_incomplete_tool_call",
+          });
         }
         if (!sawTerminalReason && !options?.signal?.aborted) {
           throw Object.assign(new Error("Google stream ended before a terminal finish reason"), {

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -253,8 +253,8 @@ describe("google-shared convertMessages", () => {
     } as Context);
 
     expect(contents[0]?.parts).toEqual([
-      { functionCall: { name: "signed", args: {} }, thoughtSignature: "c2lnbmVk" },
-      { functionCall: { name: "unsigned", args: {} } },
+      { functionCall: { id: "call_1", name: "signed", args: {} }, thoughtSignature: "c2lnbmVk" },
+      { functionCall: { id: "call_2", name: "unsigned", args: {} } },
     ]);
   });
 
@@ -634,6 +634,28 @@ describe("google-shared convertMessages", () => {
 
     expect(assertRecord(toolCall.functionCall).id).toBeUndefined();
     expect(assertRecord(toolResponse.functionResponse).id).toBeUndefined();
+  });
+
+  it("preserves matching provider call identities on same-route Gemini replay", () => {
+    const model = makeModel("gemini-3-flash");
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "provider_call_42", name: "lookup", arguments: {} },
+        ]),
+        {
+          role: "toolResult",
+          toolCallId: "provider_call_42",
+          toolName: "lookup",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as Context);
+
+    expect(contents[0]?.parts?.[0]?.functionCall?.id).toBe("provider_call_42");
+    expect(contents[1]?.parts?.[0]?.functionResponse?.id).toBe("provider_call_42");
   });
 
   it("serializes structured tool results into function responses", () => {

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -671,6 +671,17 @@ describe("runGoogleGenerateContentLifecycle", () => {
     },
   );
 
+  it("keeps an unspecified Google finish reason nonterminal", async () => {
+    const { result } = await runGoogleFixture([
+      googleResponse({
+        parts: [{ text: "partial output" }],
+        finishReason: FinishReason.FINISH_REASON_UNSPECIFIED,
+      }),
+    ]);
+
+    expect(result).toMatchObject({ stopReason: "error", errorCode: "STREAM_INCOMPLETE" });
+  });
+
   it("closes partial text before reporting a failed candidate", async () => {
     const { events, result } = await runGoogleFixture(
       [

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -184,6 +184,7 @@ export function convertMessages<T extends GoogleApiType>(
   // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
   // live inside functionResponse, so hold them until the consecutive result run ends.
   const pendingToolResultImageTurns: Content[] = [];
+  const sameRouteToolCallIds = new Set<string>();
   let activeToolResultParts: Part[] | undefined;
   const flushToolResultRun = (): void => {
     contents.push(...pendingToolResultImageTurns);
@@ -263,6 +264,9 @@ export function convertMessages<T extends GoogleApiType>(
             });
           }
         } else if (block.type === "toolCall") {
+          if (isSameProviderAndModel && model.provider !== "google-gemini-cli") {
+            sameRouteToolCallIds.add(block.id);
+          }
           const args = coerceTransportToolCallArguments(block.arguments);
           const ownSignature = resolveThoughtSignature(
             isSameProviderAndModel,
@@ -278,7 +282,9 @@ export function convertMessages<T extends GoogleApiType>(
             functionCall: {
               name: block.name,
               args,
-              ...(requiresToolCallId(model.id) ? { id: block.id } : {}),
+              ...(sameRouteToolCallIds.has(block.id) || requiresToolCallId(model.id)
+                ? { id: block.id }
+                : {}),
             },
             ...(thoughtSignature && { thoughtSignature }),
           };
@@ -319,7 +325,7 @@ export function convertMessages<T extends GoogleApiType>(
         },
       }));
 
-      const includeId = requiresToolCallId(model.id);
+      const includeId = sameRouteToolCallIds.has(msg.toolCallId) || requiresToolCallId(model.id);
       const functionResponsePart: Part = {
         functionResponse: {
           name: msg.toolName,
@@ -972,7 +978,10 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
       }
     }
 
-    if (candidate?.finishReason) {
+    if (
+      candidate?.finishReason &&
+      candidate.finishReason !== FinishReason.FINISH_REASON_UNSPECIFIED
+    ) {
       sawTerminalReason = true;
       params.output.stopReason = mapStopReason(candidate.finishReason);
       if (params.output.stopReason === "error") {


### PR DESCRIPTION
## Problem
Google and Vertex streams replaced a complete trailing quota error with generic truncation, treated FINISH_REASON_UNSPECIFIED as a terminal failure, and discarded provider function-call IDs needed to match tool responses. The published Google adapter shared the terminal and identity bugs.

## Fix
Repair the existing provider-owned SSE parser and both canonical plugin/published consumers. Preserve typed complete trailing errors, keep unspecified finish states nonterminal, and replay same-route call/response IDs together while retaining foreign-route and Gemini CLI contracts. Remove the stale unsupported Vertex partial-argument machinery.

## Proof
Direct installed official Google SDK types document unspecified finish-state behavior, matching call/response IDs, and unsupported Gemini partial arguments. A real localhost HTTP/SSE server reproduces a terminal 429 and proves RESOURCE_EXHAUSTED survives the missing final delimiter. All 238 focused Google, Vertex, plugin, and published-adapter tests pass; independent review and targeted lint are clean. Full local wrapper/type gates are blocked only by preexisting stale linked dependencies; hosted CI installs pinned versions. Production growth: 30 lines.