### PR TITLE
fix(nodes): validate photo payloads before publishing captures

### DIFF
--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -420,16 +420,55 @@ describe("nodes photos_latest", () => {
       photo: { ...PHOTOS_LATEST_PAYLOAD.photos[0], format: "webp" },
       expectedError: /unsupported photos\.latest format/i,
     },
+    {
+      name: "malformed base64",
+      photo: { format: "jpeg", base64: "not-base64!", width: 1, height: 1 },
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "insecure URL",
+      photo: { format: "jpeg", url: "http://198.51.100.42/photo.jpg", width: 1, height: 1 },
+      remoteIp: "198.51.100.42",
+      expectedError: /only https/i,
+    },
+    {
+      name: "mismatched URL host",
+      photo: { format: "jpeg", url: "https://198.51.100.43/photo.jpg", width: 1, height: 1 },
+      remoteIp: "198.51.100.42",
+      expectedError: /must match node host/i,
+    },
+    {
+      name: "missing URL node host",
+      photo: { format: "jpeg", url: "https://198.51.100.42/photo.jpg", width: 1, height: 1 },
+      expectedError: /node remoteip/i,
+    },
+    {
+      name: "valid URL with malformed base64",
+      photo: {
+        format: "jpeg",
+        url: "https://198.51.100.42/photo.jpg",
+        base64: "not-base64!",
+        width: 1,
+        height: 1,
+      },
+      remoteIp: "198.51.100.42",
+      expectedError: /invalid base64/i,
+    },
   ])("rejects a second photo with $name before writing the first", async (testCase) => {
+    stubFetchTextResponse("url-image");
     setupNodeInvokeMock({
+      ...(testCase.remoteIp ? { remoteIp: testCase.remoteIp } : {}),
       invokePayload: { photos: [PHOTOS_LATEST_PAYLOAD.photos[0], testCase.photo] },
     });
     const firstPhotoId = "00000000-0000-4000-8000-000000000022";
+    const secondPhotoId = "00000000-0000-4000-8000-000000000033";
     const firstPhotoPath = cameraTempPath({ kind: "snap", ext: "jpg", id: firstPhotoId });
+    const secondPhotoPath = cameraTempPath({ kind: "snap", ext: "jpg", id: secondPhotoId });
     const randomUUID = vi
       .spyOn(crypto, "randomUUID")
       .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
-      .mockReturnValueOnce(firstPhotoId);
+      .mockReturnValueOnce(firstPhotoId)
+      .mockReturnValueOnce(secondPhotoId);
 
     try {
       await expect(
@@ -446,6 +485,7 @@ describe("nodes photos_latest", () => {
     } finally {
       randomUUID.mockRestore();
       await fs.unlink(firstPhotoPath).catch(() => undefined);
+      await fs.unlink(secondPhotoPath).catch(() => undefined);
     }
   });
 

--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -380,7 +380,7 @@ describe("nodes camera_clip", () => {
 });
 
 describe("nodes photos_latest", () => {
-  it("returns empty content/details when no photos are available", async () => {
+  it("returns an explicit model-facing result when no photos are available", async () => {
     setupNodeInvokeMock({
       onInvoke: (invokeParams) => {
         expectInvokeParams(invokeParams, {
@@ -407,7 +407,7 @@ describe("nodes photos_latest", () => {
       { modelHasVision: false },
     );
 
-    expect(result.content ?? []).toStrictEqual([]);
+    expect(result.content).toStrictEqual([{ type: "text", text: "No photos found." }]);
     expect(result.details).toStrictEqual([]);
   });
 

--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -1,5 +1,8 @@
 // Verifies node camera/photo tool payloads, media URLs, and vision gating.
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cameraTempPath } from "../cli/nodes-camera.js";
 import {
   readFileUtf8AndCleanup,
   stubFetchTextResponse,
@@ -257,8 +260,11 @@ describe("nodes camera_snap", () => {
     );
 
     expectNoImages(result);
-    expect(result.content ?? []).toStrictEqual([]);
-    expect(expectFirstMediaUrl(result)).toMatch(/openclaw-camera-snap-front-.*\.jpg$/);
+    const mediaUrl = expectFirstMediaUrl(result);
+    expect(mediaUrl).toMatch(/openclaw-camera-snap-front-.*\.jpg$/);
+    expect(result.content).toStrictEqual([
+      { type: "text", text: `Camera photo saved to ${mediaUrl}.` },
+    ]);
   });
 
   it("passes deviceId when provided", async () => {
@@ -309,8 +315,11 @@ describe("nodes camera_snap", () => {
       facing: "front",
     });
 
-    expect(result.content ?? []).toStrictEqual([]);
-    await expect(readFileUtf8AndCleanup(expectFirstMediaUrl(result))).resolves.toBe("url-image");
+    const mediaUrl = expectFirstMediaUrl(result);
+    expect(result.content).toStrictEqual([
+      { type: "text", text: `Camera photo saved to ${mediaUrl}.` },
+    ]);
+    await expect(readFileUtf8AndCleanup(mediaUrl)).resolves.toBe("url-image");
   });
 
   it("rejects camera_snap url payloads when node remoteIp is missing", async () => {
@@ -380,6 +389,115 @@ describe("nodes camera_clip", () => {
 });
 
 describe("nodes photos_latest", () => {
+  it.each([
+    ["missing gateway response", null],
+    ["missing payload", {}],
+    ["missing photos collection", { payload: {} }],
+    ["null photos collection", { payload: { photos: null } }],
+    ["non-array photos collection", { payload: { photos: {} } }],
+  ])("rejects a %s instead of reporting an empty photo library", async (_label, response) => {
+    setupNodeInvokeMock({ onInvoke: () => response });
+
+    await expect(executePhotosLatest({ modelHasVision: false })).rejects.toThrow(
+      "invalid photos.latest payload",
+    );
+  });
+
+  it("rejects more photos than the node was asked to return", async () => {
+    setupNodeInvokeMock({
+      invokePayload: { photos: [PHOTOS_LATEST_PAYLOAD.photos[0], PHOTOS_LATEST_PAYLOAD.photos[0]] },
+    });
+
+    await expect(executePhotosLatest({ modelHasVision: false })).rejects.toThrow(
+      "photos.latest returned 2 photos; requested at most 1",
+    );
+  });
+
+  it.each([
+    {
+      name: "missing image data",
+      photo: { format: "jpeg", width: 1, height: 1 },
+      expectedError: /invalid camera\.snap payload/i,
+    },
+    {
+      name: "malformed base64",
+      photo: { format: "jpeg", base64: "not-base64!", width: 1, height: 1 },
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "insecure URL",
+      photo: {
+        format: "jpeg",
+        url: "http://198.51.100.42/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      remoteIp: "198.51.100.42",
+      expectedError: /only https/i,
+    },
+    {
+      name: "valid URL with malformed base64",
+      photo: {
+        format: "jpeg",
+        url: "https://198.51.100.42/photo.jpg",
+        base64: "not-base64!",
+        width: 1,
+        height: 1,
+      },
+      remoteIp: "198.51.100.42",
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "mismatched URL host",
+      photo: {
+        format: "jpeg",
+        url: "https://198.51.100.43/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      remoteIp: "198.51.100.42",
+      expectedError: /must match node host/i,
+    },
+    {
+      name: "URL without node remote host",
+      photo: {
+        format: "jpeg",
+        url: "https://198.51.100.42/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      expectedError: /node remoteip/i,
+    },
+  ])("rejects a second photo with $name before writing the first", async (testCase) => {
+    setupNodeInvokeMock({
+      ...(testCase.remoteIp ? { remoteIp: testCase.remoteIp } : {}),
+      invokePayload: { photos: [PHOTOS_LATEST_PAYLOAD.photos[0], testCase.photo] },
+    });
+    const firstPhotoId = "00000000-0000-4000-8000-000000000022";
+    const firstPhotoPath = cameraTempPath({ kind: "snap", ext: "jpg", id: firstPhotoId });
+    const randomUUID = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce(firstPhotoId);
+
+    try {
+      await expect(
+        executeNodes(
+          {
+            action: "photos_latest",
+            node: NODE_ID,
+            limit: 2,
+          },
+          { modelHasVision: false },
+        ),
+      ).rejects.toThrow(testCase.expectedError);
+      await expect(fs.stat(firstPhotoPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      randomUUID.mockRestore();
+      await fs.unlink(firstPhotoPath).catch(() => undefined);
+    }
+  });
+
   it("returns an explicit model-facing result when no photos are available", async () => {
     setupNodeInvokeMock({
       onInvoke: (invokeParams) => {
@@ -417,13 +535,16 @@ describe("nodes photos_latest", () => {
     const result = await executePhotosLatest({ modelHasVision: false });
 
     expectNoImages(result);
-    expect(result.content ?? []).toStrictEqual([]);
     const details =
       (result.details as { photos?: Array<Record<string, unknown>> } | undefined)?.photos ?? [];
     expect(details[0]?.width).toBe(1);
     expect(details[0]?.height).toBe(1);
     expect(details[0]?.createdAt).toBe("2026-03-04T00:00:00Z");
-    expect(expectFirstMediaUrl(result)).toMatch(/openclaw-camera-snap-.*\.jpg$/);
+    const mediaUrl = expectFirstMediaUrl(result);
+    expect(mediaUrl).toMatch(/openclaw-camera-snap-.*\.jpg$/);
+    expect(result.content).toStrictEqual([
+      { type: "text", text: `Library photo saved to ${mediaUrl}.` },
+    ]);
   });
 
   it("includes inline image blocks when model has vision", async () => {

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -198,7 +198,7 @@ async function executeCameraSnap({
       },
       idempotencyKey: crypto.randomUUID(),
     });
-    const payload = parseCameraSnapPayload(raw?.payload);
+    const payload = parseCameraSnapPayload(raw?.payload, { expectedHost: resolvedNode.remoteIp });
     const normalizedFormat = normalizeLowercaseStringOrEmpty(payload.format);
     if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
       throw new Error(`unsupported camera.snap format: ${payload.format}`);
@@ -281,7 +281,7 @@ async function executePhotosLatest({
 
   // Reject every malformed batch member before creating any capture artifact.
   const photos = payload.photos.map((photoRaw) => {
-    const photo = parseCameraSnapPayload(photoRaw);
+    const photo = parseCameraSnapPayload(photoRaw, { expectedHost: resolvedNode.remoteIp });
     const normalizedFormat = normalizeLowercaseStringOrEmpty(photo.format);
     if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
       throw new Error(`unsupported photos.latest format: ${photo.format}`);

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -175,7 +175,7 @@ async function executeCameraSnap({
       },
       idempotencyKey: crypto.randomUUID(),
     });
-    const payload = parseCameraSnapPayload(raw?.payload);
+    const payload = parseCameraSnapPayload(raw?.payload, { expectedHost: resolvedNode.remoteIp });
     const normalizedFormat = normalizeLowercaseStringOrEmpty(payload.format);
     if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
       throw new Error(`unsupported camera.snap format: ${payload.format}`);
@@ -199,6 +199,8 @@ async function executeCameraSnap({
         data: payload.base64,
         mimeType: imageMimeFromFormat(payload.format) ?? (isJpeg ? "image/jpeg" : "image/png"),
       });
+    } else {
+      content.push({ type: "text", text: `Camera photo saved to ${filePath}.` });
     }
     details.push({
       facing: target.artifactFacing,
@@ -255,11 +257,19 @@ async function executePhotosLatest({
     },
     idempotencyKey: crypto.randomUUID(),
   });
-  const payload =
-    raw?.payload && typeof raw.payload === "object" && !Array.isArray(raw.payload)
-      ? (raw.payload as Record<string, unknown>)
-      : {};
-  const photos = Array.isArray(payload.photos) ? payload.photos : [];
+  const payload = raw?.payload;
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
+    !Array.isArray((payload as Record<string, unknown>).photos)
+  ) {
+    throw new Error("invalid photos.latest payload");
+  }
+  const photos = (payload as { photos: unknown[] }).photos;
+  if (photos.length > limit) {
+    throw new Error(`photos.latest returned ${photos.length} photos; requested at most ${limit}`);
+  }
 
   if (photos.length === 0) {
     return await sanitizeToolResultImages(
@@ -272,12 +282,26 @@ async function executePhotosLatest({
   const content: AgentToolResult<unknown>["content"] = [];
   const details: Array<Record<string, unknown>> = [];
 
-  for (const [index, photoRaw] of photos.entries()) {
-    const photo = parseCameraSnapPayload(photoRaw);
+  // Validate the complete bounded batch before writing artifacts so malformed
+  // later entries cannot leave an unreported, partially successful capture.
+  const parsedPhotos = photos.map((photoRaw, index) => {
+    let photo: ReturnType<typeof parseCameraSnapPayload>;
+    try {
+      photo = parseCameraSnapPayload(photoRaw, { expectedHost: resolvedNode.remoteIp });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`invalid photos.latest payload at photo ${index + 1}: ${reason}`, {
+        cause: error,
+      });
+    }
     const normalizedFormat = normalizeLowercaseStringOrEmpty(photo.format);
     if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
       throw new Error(`unsupported photos.latest format: ${photo.format}`);
     }
+    return { photoRaw, photo, normalizedFormat };
+  });
+
+  for (const [index, { photoRaw, photo, normalizedFormat }] of parsedPhotos.entries()) {
     const isJpeg = normalizedFormat === "jpg" || normalizedFormat === "jpeg";
     const filePath = cameraTempPath({
       kind: "snap",
@@ -297,6 +321,8 @@ async function executePhotosLatest({
         data: photo.base64,
         mimeType: imageMimeFromFormat(photo.format) ?? (isJpeg ? "image/jpeg" : "image/png"),
       });
+    } else {
+      content.push({ type: "text", text: `Library photo saved to ${filePath}.` });
     }
 
     const createdAt =

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -37,6 +37,7 @@ import {
   readFiniteNumberParam,
   readNonNegativeIntegerParam,
   readPositiveIntegerParam,
+  textResult,
 } from "./common.js";
 import type { GatewayCallOptions } from "./gateway.js";
 import { callGatewayTool } from "./gateway.js";
@@ -262,10 +263,7 @@ async function executePhotosLatest({
 
   if (photos.length === 0) {
     return await sanitizeToolResultImages(
-      {
-        content: [],
-        details: [],
-      },
+      textResult("No photos found.", []),
       "nodes:photos_latest",
       imageSanitization,
     );

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -739,6 +739,7 @@ describe("createNodesTool screen_record duration guardrails", () => {
     const result = await tool.execute("call-1", {
       action: "photos_latest",
       node: "macbook",
+      limit: 2,
     });
 
     expect(result?.details).toEqual({

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -156,6 +156,47 @@ describe("nodes camera helpers", () => {
     );
   });
 
+  it.each([
+    {
+      name: "malformed base64",
+      payload: { format: "jpg", base64: "not-base64!", width: 1, height: 1 },
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "insecure URL",
+      payload: { format: "jpg", url: "http://198.51.100.42/photo.jpg", width: 1, height: 1 },
+      expectedHost: "198.51.100.42",
+      expectedError: /only https/i,
+    },
+    {
+      name: "mismatched URL host",
+      payload: { format: "jpg", url: "https://198.51.100.43/photo.jpg", width: 1, height: 1 },
+      expectedHost: "198.51.100.42",
+      expectedError: /must match node host/i,
+    },
+    {
+      name: "missing URL node host",
+      payload: { format: "jpg", url: "https://198.51.100.42/photo.jpg", width: 1, height: 1 },
+      expectedError: /node remoteip/i,
+    },
+    {
+      name: "valid URL with malformed base64",
+      payload: {
+        format: "jpg",
+        url: "https://198.51.100.42/photo.jpg",
+        base64: "not-base64!",
+        width: 1,
+        height: 1,
+      },
+      expectedHost: "198.51.100.42",
+      expectedError: /invalid base64/i,
+    },
+  ])("rejects $name while parsing a camera.snap payload", (testCase) => {
+    expect(() =>
+      parseCameraSnapPayload(testCase.payload, { expectedHost: testCase.expectedHost }),
+    ).toThrow(testCase.expectedError);
+  });
+
   it.each([undefined, "front", "back", "both"] as const)(
     "collapses Linux facing=%s into one unknown-position capture",
     (facing) => {

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -117,6 +117,62 @@ describe("nodes camera helpers", () => {
     );
   });
 
+  it.each([
+    {
+      name: "malformed base64",
+      payload: { format: "jpg", base64: "not-base64!", width: 1, height: 1 },
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "non-HTTPS URL",
+      payload: {
+        format: "jpg",
+        url: "http://198.51.100.42/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      expectedHost: "198.51.100.42",
+      expectedError: /only https/i,
+    },
+    {
+      name: "malformed base64 with a valid URL",
+      payload: {
+        format: "jpg",
+        url: "https://198.51.100.42/photo.jpg",
+        base64: "not-base64!",
+        width: 1,
+        height: 1,
+      },
+      expectedHost: "198.51.100.42",
+      expectedError: /invalid base64/i,
+    },
+    {
+      name: "different URL host",
+      payload: {
+        format: "jpg",
+        url: "https://198.51.100.43/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      expectedHost: "198.51.100.42",
+      expectedError: /must match node host/i,
+    },
+    {
+      name: "missing node host for URL",
+      payload: {
+        format: "jpg",
+        url: "https://198.51.100.42/photo.jpg",
+        width: 1,
+        height: 1,
+      },
+      expectedError: /node remoteip/i,
+    },
+  ])("rejects a camera.snap payload with $name before writing", (testCase) => {
+    expect(() =>
+      parseCameraSnapPayload(testCase.payload, { expectedHost: testCase.expectedHost }),
+    ).toThrow(testCase.expectedError);
+  });
+
   it("collapses Linux facing requests into one unknown-position capture", () => {
     expect(resolveCameraSnapTargets({ facing: "both", platform: "linux" })).toEqual([
       { artifactFacing: "unknown" },

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -82,8 +82,11 @@ type CameraClipPayload = {
   hasAudio: boolean;
 };
 
-/** Validate and normalize an unknown camera still-image payload. */
-export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
+/** Validate a complete still-image payload before any capture can be published. */
+export function parseCameraSnapPayload(
+  value: unknown,
+  opts: { expectedHost?: string } = {},
+): CameraSnapPayload {
   const obj = asRecord(value);
   const format = readStringValue(obj.format);
   const base64 = readStringValue(obj.base64);
@@ -92,6 +95,12 @@ export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
   const height = asNumber(obj.height);
   if (!format || (!base64 && !url) || width === undefined || height === undefined) {
     throw new Error("invalid camera.snap payload");
+  }
+  if (url) {
+    validateCameraPayloadUrl(url, requireNodeRemoteIp(opts.expectedHost));
+  }
+  if (base64) {
+    validateCameraPayloadBase64(base64, MAX_CAMERA_BASE64_BYTES);
   }
   return { format, ...(base64 ? { base64 } : {}), ...(url ? { url } : {}), width, height };
 }
@@ -128,21 +137,26 @@ export function cameraTempPath(opts: {
   return path.join(tmpDir, `${cliName}-camera-${opts.kind}${facingPart}-${id}${ext}`);
 }
 
-/** Download a node-hosted media URL to disk after HTTPS, host, redirect, and size checks. */
-async function writeUrlToFile(filePath: string, url: string, opts: { expectedHost: string }) {
+function validateCameraPayloadUrl(url: string, expectedNodeHost: string): string {
   const parsed = new URL(url);
   if (parsed.protocol !== "https:") {
     throw new Error(`writeUrlToFile: only https URLs are allowed, got ${parsed.protocol}`);
   }
-  const expectedHost = normalizeHostname(opts.expectedHost);
+  const expectedHost = normalizeHostname(expectedNodeHost);
   if (!expectedHost) {
     throw new Error("writeUrlToFile: expectedHost is required");
   }
   if (normalizeHostname(parsed.hostname) !== expectedHost) {
     throw new Error(
-      `writeUrlToFile: url host ${parsed.hostname} must match node host ${opts.expectedHost}`,
+      `writeUrlToFile: url host ${parsed.hostname} must match node host ${expectedNodeHost}`,
     );
   }
+  return expectedHost;
+}
+
+/** Download a node-hosted media URL to disk after HTTPS, host, redirect, and size checks. */
+async function writeUrlToFile(filePath: string, url: string, opts: { expectedHost: string }) {
+  const expectedHost = validateCameraPayloadUrl(url, opts.expectedHost);
 
   // The node host is allowed even when private because the RPC response supplied its remote IP.
   const policy = {
@@ -234,13 +248,7 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
   return { path: filePath, bytes };
 }
 
-/** Decode a base64 media payload to disk with preflight and post-decode size checks. */
-export async function writeBase64ToFile(
-  filePath: string,
-  base64: string,
-  opts: { maxBytes?: number } = {},
-) {
-  const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
+function validateCameraPayloadBase64(base64: string, maxBytes: number): string {
   if (estimateBase64DecodedBytes(base64) > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
   }
@@ -248,6 +256,17 @@ export async function writeBase64ToFile(
   if (!canonicalBase64) {
     throw new Error("writeBase64ToFile: invalid base64 payload");
   }
+  return canonicalBase64;
+}
+
+/** Decode a base64 media payload to disk with preflight and post-decode size checks. */
+export async function writeBase64ToFile(
+  filePath: string,
+  base64: string,
+  opts: { maxBytes?: number } = {},
+) {
+  const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
+  const canonicalBase64 = validateCameraPayloadBase64(base64, maxBytes);
   const buf = Buffer.from(canonicalBase64, "base64");
   if (buf.length > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded ${buf.length} bytes, exceeds max ${maxBytes}`);

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -83,8 +83,11 @@ async function cancelIgnoredResponseBody(response: Response | undefined): Promis
   }
 }
 
-/** Validate and normalize an unknown camera still-image payload. */
-export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
+/** Validate and normalize a camera still before any artifact can be created. */
+export function parseCameraSnapPayload(
+  value: unknown,
+  opts: { expectedHost?: string } = {},
+): CameraSnapPayload {
   const obj = asRecord(value);
   const format = asString(obj.format);
   const base64 = asString(obj.base64);
@@ -93,6 +96,12 @@ export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
   const height = asNumber(obj.height);
   if (!format || (!base64 && !url) || width === undefined || height === undefined) {
     throw new Error("invalid camera.snap payload");
+  }
+  if (url) {
+    validateCameraPayloadUrl(url, requireNodeRemoteIp(opts.expectedHost));
+  }
+  if (base64) {
+    validateCameraPayloadBase64(base64, MAX_CAMERA_BASE64_BYTES);
   }
   return { format, ...(base64 ? { base64 } : {}), ...(url ? { url } : {}), width, height };
 }
@@ -129,21 +138,26 @@ export function cameraTempPath(opts: {
   return path.join(tmpDir, `${cliName}-camera-${opts.kind}${facingPart}-${id}${ext}`);
 }
 
-/** Download a node-hosted media URL to disk after HTTPS, host, redirect, and size checks. */
-async function writeUrlToFile(filePath: string, url: string, opts: { expectedHost: string }) {
+function validateCameraPayloadUrl(url: string, expectedNodeHost: string): string {
   const parsed = new URL(url);
   if (parsed.protocol !== "https:") {
     throw new Error(`writeUrlToFile: only https URLs are allowed, got ${parsed.protocol}`);
   }
-  const expectedHost = normalizeHostname(opts.expectedHost);
+  const expectedHost = normalizeHostname(expectedNodeHost);
   if (!expectedHost) {
     throw new Error("writeUrlToFile: expectedHost is required");
   }
   if (normalizeHostname(parsed.hostname) !== expectedHost) {
     throw new Error(
-      `writeUrlToFile: url host ${parsed.hostname} must match node host ${opts.expectedHost}`,
+      `writeUrlToFile: url host ${parsed.hostname} must match node host ${expectedNodeHost}`,
     );
   }
+  return expectedHost;
+}
+
+/** Download a node-hosted media URL to disk after HTTPS, host, redirect, and size checks. */
+async function writeUrlToFile(filePath: string, url: string, opts: { expectedHost: string }) {
+  const expectedHost = validateCameraPayloadUrl(url, opts.expectedHost);
 
   // The node host is allowed even when private because the RPC response supplied its remote IP.
   const policy = {
@@ -236,13 +250,7 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
   return { path: filePath, bytes };
 }
 
-/** Decode a base64 media payload to disk with preflight and post-decode size checks. */
-export async function writeBase64ToFile(
-  filePath: string,
-  base64: string,
-  opts: { maxBytes?: number } = {},
-) {
-  const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
+function validateCameraPayloadBase64(base64: string, maxBytes: number): string {
   if (estimateBase64DecodedBytes(base64) > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
   }
@@ -250,6 +258,17 @@ export async function writeBase64ToFile(
   if (!canonicalBase64) {
     throw new Error("writeBase64ToFile: invalid base64 payload");
   }
+  return canonicalBase64;
+}
+
+/** Decode a base64 media payload to disk with preflight and post-decode size checks. */
+export async function writeBase64ToFile(
+  filePath: string,
+  base64: string,
+  opts: { maxBytes?: number } = {},
+) {
+  const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
+  const canonicalBase64 = validateCameraPayloadBase64(base64, maxBytes);
   const buf = Buffer.from(canonicalBase64, "base64");
   if (buf.length > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded ${buf.length} bytes, exceeds max ${maxBytes}`);

--- a/src/cli/nodes-cli/register.camera.test.ts
+++ b/src/cli/nodes-cli/register.camera.test.ts
@@ -46,7 +46,7 @@ vi.mock("./rpc.js", async () => {
       return {
         payload: {
           format: "jpg",
-          base64: "redacted-base64",
+          base64: "cmVkYWN0ZWQtYmFzZTY0",
           width: 1600,
           height: 1200,
         },

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -187,7 +187,9 @@ export function registerNodesCameraCommands(nodes: Command) {
             });
 
             const raw = await callNodesGatewayCli("node.invoke", opts, invokeParams);
-            const payload = parseCameraSnapPayload(getGatewayInvokePayload(raw));
+            const payload = parseCameraSnapPayload(getGatewayInvokePayload(raw), {
+              expectedHost: node.remoteIp,
+            });
             const filePath = cameraTempPath({
               kind: "snap",
               facing: target.artifactFacing,

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -185,7 +185,9 @@ export function registerNodesCameraCommands(nodes: Command) {
             });
 
             const raw = await callGatewayCli("node.invoke", opts, invokeParams);
-            const payload = parseCameraSnapPayload(getGatewayInvokePayload(raw));
+            const payload = parseCameraSnapPayload(getGatewayInvokePayload(raw), {
+              expectedHost: node.remoteIp,
+            });
             const filePath = cameraTempPath({
               kind: "snap",
               facing: target.artifactFacing,


### PR DESCRIPTION
## Problem
Photo batches validated structure before processing but postponed base64 and URL checks until each image was written. A valid first private image remained on disk if the second was malformed or unsafe, while dual URL plus invalid base64 could incorrectly succeed.

## Fix
Validate every representation through the shared camera owner before publishing: bounded canonical base64, HTTPS, trusted resolved node host, and required host identity. Preserve the current atomic publisher and valid iOS, Android, and macOS behavior. Superseded outcome/writer changes from the original branch were removed.

## Proof
Five actual node-tool/filesystem regressions first reproduced leaked images or false success; five parser regressions independently failed before the fix. The repaired CLI, parser, real artifact lifecycle, and node owner now pass 158 tests. Repository guards, formatting, dead-export scan, and independent review are clean. Full local typechecking is blocked only by preexisting linked dependency versions older than the lockfile; hosted CI installs pinned dependencies. Production growth: 21 lines.