### PR TITLE
fix(media): preserve orientation, container types, and safe filenames

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -41,6 +41,7 @@ describe("mime detection", () => {
   }
 
   it.each([
+    { format: "avif", expected: "image/avif" },
     { format: "jpg", expected: "image/jpeg" },
     { format: "jpeg", expected: "image/jpeg" },
     { format: "png", expected: "image/png" },
@@ -275,6 +276,22 @@ describe("mime detection", () => {
     });
   });
 
+  it.each([
+    { brand: "avif", expected: "image/avif" },
+    { brand: "avis", expected: "image/avif" },
+    { brand: "M4B ", expected: "audio/mp4" },
+    { brand: "M4V ", expected: "video/x-m4v" },
+    { brand: "hevc", expected: "image/heic-sequence" },
+    { brand: "msf1", expected: "image/heif-sequence" },
+  ] as const)("preserves the file-type MIME for ISO-BMFF $brand media", async (testCase) => {
+    const buffer = Buffer.alloc(24);
+    buffer.writeUInt32BE(buffer.length, 0);
+    buffer.write("ftyp", 4, "ascii");
+    buffer.write(testCase.brand, 8, "ascii");
+
+    await expectDetectedMime({ input: { buffer }, expected: testCase.expected });
+  });
+
   it("does not let conflicting audio metadata override MPEG video bytes", async () => {
     const mpegProgramStream = Buffer.from([0x00, 0x00, 0x01, 0xba, 0x00, 0x00, 0x00, 0x00]);
 
@@ -369,15 +386,20 @@ describe("getFileExtension", () => {
 
 describe("mimeTypeFromFilePath", () => {
   it.each([
+    { filePath: "photo.avif", expected: "image/avif" },
     { filePath: "image.bmp", expected: "image/bmp" },
+    { filePath: "photo.heic", expected: "image/heic" },
+    { filePath: "photo.heif", expected: "image/heif" },
     { filePath: "photo.jpg", expected: "image/jpeg" },
     { filePath: "photo.JPG", expected: "image/jpeg" },
     { filePath: "voice.mp3", expected: "audio/mpeg" },
     { filePath: "voice.m2a", expected: "audio/mpeg" },
+    { filePath: "audiobook.m4b", expected: "audio/mp4" },
     { filePath: "voice.oga", expected: "audio/ogg" },
     { filePath: "voice.amr", expected: "audio/amr" },
     { filePath: "voice.wav", expected: "audio/wav" },
     { filePath: "clip.avi", expected: "video/x-msvideo" },
+    { filePath: "clip.m4v", expected: "video/x-m4v" },
     { filePath: "clip.mkv", expected: "video/x-matroska" },
     { filePath: "clip.webm", expected: "video/webm" },
     {
@@ -415,6 +437,7 @@ describe("extensionForMime", () => {
   }
 
   it.each([
+    { mime: "image/avif", expected: ".avif" },
     { mime: "image/jpeg", expected: ".jpg" },
     { mime: "image/jpg", expected: ".jpg" },
     { mime: "image/bmp", expected: ".bmp" },
@@ -423,6 +446,9 @@ describe("extensionForMime", () => {
     { mime: "image/webp", expected: ".webp" },
     { mime: "image/gif", expected: ".gif" },
     { mime: "image/heic", expected: ".heic" },
+    { mime: "image/heic-sequence", expected: ".heic" },
+    { mime: "image/heif", expected: ".heif" },
+    { mime: "image/heif-sequence", expected: ".heif" },
     { mime: "audio/mpeg", expected: ".mp3" },
     { mime: "audio/mp3", expected: ".mp3" },
     { mime: "audio/ogg", expected: ".ogg" },
@@ -433,6 +459,7 @@ describe("extensionForMime", () => {
     { mime: "audio/m4a", expected: ".m4a" },
     { mime: "audio/mp4", expected: ".m4a" },
     { mime: "video/x-msvideo", expected: ".avi" },
+    { mime: "video/x-m4v", expected: ".m4v" },
     { mime: "video/mp4", expected: ".mp4" },
     { mime: "video/x-matroska", expected: ".mkv" },
     { mime: "video/webm", expected: ".webm" },
@@ -465,6 +492,7 @@ describe("isAudioFileName", () => {
   }
 
   it.each([
+    { fileName: "audiobook.M4B", expected: true },
     { fileName: "voice.mp3", expected: true },
     { fileName: "voice.caf", expected: true },
     { fileName: "voice.M2A", expected: true },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -8,8 +8,11 @@ export const FILE_TYPE_SNIFF_MAX_BYTES = 1024 * 1024;
 
 // Map common mimes to preferred file extensions.
 const EXT_BY_MIME: Record<string, string> = {
+  "image/avif": ".avif",
   "image/heic": ".heic",
+  "image/heic-sequence": ".heic",
   "image/heif": ".heif",
+  "image/heif-sequence": ".heif",
   "image/bmp": ".bmp",
   "image/jpg": ".jpg",
   "image/jpeg": ".jpg",
@@ -33,6 +36,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "audio/mp4": ".m4a",
   "audio/x-caf": ".caf",
   "video/x-msvideo": ".avi",
+  "video/x-m4v": ".m4v",
   "video/mp4": ".mp4",
   "video/x-matroska": ".mkv",
   "video/webm": ".webm",
@@ -75,6 +79,7 @@ const MIME_BY_EXT: Record<string, string> = {
   // Canonical extension mappings for common MIME aliases
   ".jpg": "image/jpeg",
   ".m2a": "audio/mpeg",
+  ".m4b": "audio/mp4",
   ".mp3": "audio/mpeg",
   ".oga": "audio/ogg",
   ".wav": "audio/wav",
@@ -283,6 +288,8 @@ export function imageMimeFromFormat(format?: string | null): string | undefined 
     return undefined;
   }
   switch (format.toLowerCase()) {
+    case "avif":
+      return "image/avif";
     case "jpg":
     case "jpeg":
       return "image/jpeg";

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -58,6 +58,31 @@ describe("resolveCurrentTurnImages", () => {
     });
   });
 
+  it("hydrates AVIF attachments when transport metadata only declares generic bytes", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-avif-" }, async (base) => {
+      const imagePath = path.join(base, "photo.avif");
+      const imageBytes = Buffer.from("avif-image");
+      await fs.writeFile(imagePath, imageBytes);
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          media: [{ path: imagePath, contentType: "application/octet-stream", workspaceDir: base }],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result.images).toEqual([
+        {
+          type: "image",
+          data: imageBytes.toString("base64"),
+          mimeType: "image/avif",
+        },
+      ]);
+      expect(result.imageOrder).toEqual(["inline"]);
+    });
+  });
+
   it("does not duplicate a prepared host-staged image during runner hydration", async () => {
     await withTempDir({ prefix: "openclaw-current-turn-staged-image-" }, async (base) => {
       const stagingRoot = path.join(base, "media", "inbound", "staged");

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1195,6 +1195,143 @@ describe("readRemoteMediaBuffer", () => {
   );
 
   it.each([
+    {
+      name: "quoted filename containing a semicolon",
+      header: 'attachment; filename="quarter;final.csv"',
+      fileName: "quarter;final.csv",
+    },
+    {
+      name: "quoted filename containing an escaped quotation mark",
+      header: String.raw`attachment; filename="quarter\"final.csv"`,
+      fileName: 'quarter"final.csv',
+    },
+    {
+      name: "quoted filename containing an escaped semicolon",
+      header: String.raw`attachment; filename="quarter\;final.csv"`,
+      fileName: "quarter;final.csv",
+    },
+    {
+      name: "quoted filename containing an escaped comma",
+      header: String.raw`attachment; filename="quarter\,final.csv"`,
+      fileName: "quarter,final.csv",
+    },
+    {
+      name: "quoted filename containing an escaped space",
+      header: String.raw`attachment; filename="quarter\ final.csv"`,
+      fileName: "quarter final.csv",
+    },
+    {
+      name: "quoted filename containing an escaped hyphen",
+      header: String.raw`attachment; filename="quarter\-final.csv"`,
+      fileName: "quarter-final.csv",
+    },
+    {
+      name: "quoted filename containing multiple escaped punctuation characters",
+      header: String.raw`attachment; filename="quarter\ final\,v2.csv"`,
+      fileName: "quarter final,v2.csv",
+    },
+    {
+      name: "filename text inside an unrelated quoted parameter is ignored",
+      header: 'attachment; note="x; filename=spoof.csv; y"; filename=safe.csv',
+      fileName: "safe.csv",
+    },
+    {
+      name: "Windows drive paths still decode escaped punctuation",
+      header: String.raw`attachment; filename="C:/tmp/quarter\;final.csv"`,
+      fileName: "quarter;final.csv",
+    },
+    {
+      name: "mixed Windows path separators preserve the final basename",
+      header: String.raw`attachment; filename="C:/tmp/reports\Q1.csv"`,
+      fileName: "Q1.csv",
+    },
+    {
+      name: "mixed relative Windows path separators preserve the final basename",
+      header: String.raw`attachment; filename="reports/2026\Q1.csv"`,
+      fileName: "Q1.csv",
+    },
+    {
+      name: "legacy UNC Windows path is reduced to its basename",
+      header: String.raw`attachment; filename="\\server\share\photo.csv"`,
+      fileName: "photo.csv",
+    },
+    {
+      name: "legacy UNC Windows path preserves a Unicode-leading basename",
+      header: String.raw`attachment; filename="\\server\share\é.csv"`,
+      fileName: "é.csv",
+    },
+    {
+      name: "legacy UNC Windows path preserves a punctuation-leading basename",
+      header: String.raw`attachment; filename="\\server\share\;photo.csv"`,
+      fileName: ";photo.csv",
+    },
+    {
+      name: "legacy UNC Windows path preserves a space-leading basename",
+      header: String.raw`attachment; filename="\\server\share\ photo.csv"`,
+      fileName: " photo.csv",
+    },
+    {
+      name: "legacy relative Windows path is reduced to its basename",
+      header: String.raw`attachment; filename="reports\Q1.csv"`,
+      fileName: "Q1.csv",
+    },
+    {
+      name: "nested legacy relative Windows path is reduced to its basename",
+      header: String.raw`attachment; filename="reports\2026\Q1.csv"`,
+      fileName: "Q1.csv",
+    },
+    {
+      name: "UTF-8 filename with a language tag",
+      header: "attachment; filename*=UTF-8'en'%E2%82%ACrates.csv",
+      fileName: "€rates.csv",
+    },
+    {
+      name: "ISO-8859-1 extended filename",
+      header: "attachment; filename*=ISO-8859-1''caf%E9.csv",
+      fileName: "café.csv",
+    },
+    {
+      name: "valid extended filename preferred over plain fallback",
+      header: "attachment; filename=legacy.csv; filename*=UTF-8'en'%E2%82%ACrates.csv",
+      fileName: "€rates.csv",
+    },
+    {
+      name: "malformed extended filename falls back to plain filename",
+      header: "attachment; filename=fallback.csv; filename*=UTF-8''%ZZbad.csv",
+      fileName: "fallback.csv",
+    },
+    {
+      name: "unsupported extended charset falls back to plain filename",
+      header: "attachment; filename*=UTF-16''bad.csv; filename=fallback.csv",
+      fileName: "fallback.csv",
+    },
+  ] as const)("parses $name for buffered and stored remote media", async (testCase) => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+          status: 200,
+          headers: {
+            "content-disposition": testCase.header,
+            "content-type": "text/csv",
+          },
+        }),
+    );
+    const request = {
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 8,
+    };
+
+    const buffered = await readRemoteMediaBuffer(request);
+    const stored = await saveRemoteMedia(request);
+
+    expect(buffered.fileName).toBe(testCase.fileName);
+    expect(stored.fileName).toBe(testCase.fileName);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
     [`attachment; filename*=UTF-8''reports%2FQ1.pdf`, "reports_Q1.pdf"],
     [`attachment; filename*=UTF-8''reports%5CQ1.pdf`, "reports_Q1.pdf"],
     [`attachment; filename*=UTF-8''reports%2F%2FQ1.pdf`, "reports__Q1.pdf"],

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -141,21 +141,113 @@ function decodeRemoteFileNameComponent(value: string): string {
   }
 }
 
+function decodeExtendedRemoteFileName(value: string): string | undefined {
+  const match = /^([^']*)'[^']*'(.*)$/u.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const charset = match[1]?.toLowerCase();
+  const encoded = match[2] ?? "";
+  try {
+    if (charset === "utf-8") {
+      return decodeURIComponent(encoded).replace(/[\\/]/g, "_");
+    }
+    if (charset === "iso-8859-1") {
+      if (/%(?![\da-f]{2})/iu.test(encoded)) {
+        return undefined;
+      }
+      return encoded
+        .replace(/%([\da-f]{2})/giu, (_match, hex: string) =>
+          String.fromCharCode(Number.parseInt(hex, 16)),
+        )
+        .replace(/[\\/]/g, "_");
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function* parseContentDispositionParameters(header: string): Generator<{
+  name: string;
+  value: string;
+}> {
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index <= header.length; index += 1) {
+    const character = header[index];
+    if (escaped || (quoted && character === "\\")) {
+      escaped = !escaped;
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (index !== header.length && (quoted || character !== ";")) {
+      continue;
+    }
+    const parameter = header.slice(start, index).trim();
+    start = index + 1;
+    const separator = parameter.indexOf("=");
+    if (separator > 0) {
+      yield {
+        name: parameter.slice(0, separator).trim().toLowerCase(),
+        value: stripQuotes(parameter.slice(separator + 1).trim()),
+      };
+    }
+  }
+}
+
+function decodeQuotedRemoteFileName(value: string): string {
+  const windowsDrivePath = /^[a-z]:[\\/]/iu.test(value);
+  const windowsNetworkPath = value.startsWith("\\\\");
+  const mixedWindowsPath = value.includes("/") && value.includes("\\");
+  const relativeWindowsPath =
+    /\\[\p{L}\p{N}]/u.test(value) && /^[^\\/:]+(?:\\[^\\]+)+$/u.test(value);
+  if (!windowsDrivePath && !windowsNetworkPath && !mixedWindowsPath && !relativeWindowsPath) {
+    return value.replace(/\\(.)/gu, "$1");
+  }
+  const lastForwardSeparator = value.lastIndexOf("/");
+  if (lastForwardSeparator >= 0) {
+    const prefix = value.slice(0, lastForwardSeparator + 1);
+    const fileName = value.slice(lastForwardSeparator + 1).replace(/\\([^\p{L}\p{N}])/gu, "$1");
+    return `${prefix}${fileName}`;
+  }
+  const firstBackslash = value.indexOf("\\");
+  if (
+    !windowsDrivePath &&
+    !windowsNetworkPath &&
+    firstBackslash === value.lastIndexOf("\\") &&
+    /\\[^\p{L}\p{N}]/u.test(value)
+  ) {
+    return value.replace(/\\(.)/gu, "$1");
+  }
+  // Backslash-only legacy paths need every separator, including before Unicode or spaces.
+  return value.replace(/\\"/gu, '"');
+}
+
 function parseContentDispositionFileName(header?: string | null): string | undefined {
   if (!header) {
     return undefined;
   }
-  const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
-  if (starMatch?.[1]) {
-    const cleaned = stripQuotes(starMatch[1].trim());
-    const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
-    return basenameFromAnyPath(decodeRemoteFileNameComponent(encoded));
+  let fallbackFileName: string | undefined;
+  for (const parameter of parseContentDispositionParameters(header)) {
+    if (parameter.name === "filename") {
+      fallbackFileName ??=
+        basenameFromAnyPath(decodeQuotedRemoteFileName(parameter.value)) || undefined;
+      continue;
+    }
+    if (parameter.name !== "filename*") {
+      continue;
+    }
+    const decoded = decodeExtendedRemoteFileName(parameter.value);
+    if (decoded) {
+      return basenameFromAnyPath(decoded) || undefined;
+    }
   }
-  const match = /filename\s*=\s*([^;]+)/i.exec(header);
-  if (match?.[1]) {
-    return basenameFromAnyPath(stripQuotes(match[1].trim()));
-  }
-  return undefined;
+  return fallbackFileName;
 }
 
 function basenameFromUrlPathname(pathname: string): string {

--- a/src/media/image-ops.rastermill-adapter.test.ts
+++ b/src/media/image-ops.rastermill-adapter.test.ts
@@ -78,6 +78,38 @@ describe("image ops Rastermill adapter", () => {
     expect(resolveSystemBin).toHaveBeenLastCalledWith("powershell", { trust: "strict" });
   });
 
+  it.each([
+    { orientation: null, expected: { width: 640, height: 480 } },
+    { orientation: 1, expected: { width: 640, height: 480 } },
+    { orientation: 4, expected: { width: 640, height: 480 } },
+    { orientation: 5, expected: { width: 480, height: 640 } },
+    { orientation: 6, expected: { width: 480, height: 640 } },
+    { orientation: 7, expected: { width: 480, height: 640 } },
+    { orientation: 8, expected: { width: 480, height: 640 } },
+  ] as const)("reports display dimensions for EXIF orientation $orientation", async (testCase) => {
+    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+    const probe = {
+      width: 640,
+      height: 480,
+      format: "jpeg" as const,
+      hasAlpha: false,
+      orientation: testCase.orientation,
+      bytes: 24,
+    };
+    vi.doMock("rastermill", () => ({
+      ...actualRastermill,
+      createRastermill: vi.fn(() => ({ probe: vi.fn(async () => probe) })),
+      readImageProbeFromHeader: vi.fn(() => probe),
+    }));
+    const { getImageMetadata, readImageMetadataFromHeader, readImageProbeFromHeader } =
+      await import("./image-ops.js");
+    const image = Buffer.from("image");
+
+    expect(readImageMetadataFromHeader(image)).toEqual(testCase.expected);
+    await expect(getImageMetadata(image)).resolves.toEqual(testCase.expected);
+    expect(readImageProbeFromHeader(image)).toEqual(probe);
+  });
+
   it("exposes Rastermill unavailable errors through the SDK alias", async () => {
     const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
     const unavailableError = new actualRastermill.RastermillUnavailableError(

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -4,7 +4,6 @@ import {
   isRastermillUnavailableError,
   RastermillUnavailableError,
   readImageProbeFromHeader as readRastermillImageProbeFromHeader,
-  readImageMetadataFromHeader as readRastermillImageMetadataFromHeader,
   type ImageProbe,
   type ImageMetadata,
 } from "rastermill";
@@ -75,9 +74,20 @@ export function buildImageResizeSideGrid(maxSide: number, sideStart: number): nu
     .toSorted((a, b) => b - a);
 }
 
-/** Reads dimensions from image header bytes without invoking a full image decode. */
+function resolveDisplayImageMetadata(probe: ImageProbe | null): ImageMetadata | null {
+  if (!probe) {
+    return null;
+  }
+  // Rastermill reports encoded axes; orientations 5-8 swap the displayed axes.
+  if (probe.orientation && probe.orientation >= 5 && probe.orientation <= 8) {
+    return { width: probe.height, height: probe.width };
+  }
+  return { width: probe.width, height: probe.height };
+}
+
+/** Reads display dimensions from image header bytes without invoking a full image decode. */
 export function readImageMetadataFromHeader(buffer: Buffer): ImageMetadata | null {
-  return readRastermillImageMetadataFromHeader(buffer);
+  return resolveDisplayImageMetadata(readRastermillImageProbeFromHeader(buffer));
 }
 
 /** Reads image probe data from header bytes without invoking a full image decode. */
@@ -92,10 +102,9 @@ function wrapRastermillUnavailable(operation: string, error: unknown): never {
   throw error;
 }
 
-/** Fully probes image dimensions through Rastermill when header-only metadata is insufficient. */
+/** Fully probes display dimensions through Rastermill when header-only metadata is insufficient. */
 export async function getImageMetadata(buffer: Buffer): Promise<ImageMetadata | null> {
-  const info = await createImageProcessor().probe(buffer);
-  return info ? { width: info.width, height: info.height } : null;
+  return resolveDisplayImageMetadata(await createImageProcessor().probe(buffer));
 }
 
 /** Resizes or encodes image bytes as JPEG through the shared image processor. */

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -490,6 +490,35 @@ describe("loadWebMedia", () => {
     ).rejects.toThrow(/dimensions exceed model image limits/i);
   });
 
+  it("renames opaque PNGs converted to JPEG across direct and local image owners", async () => {
+    const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
+    const sourcePng = createLargeColorBlockPng(64);
+    const imageCompression = { models: [{ maxSidePx: 32, preferredSidePx: 32 }] };
+
+    const direct = await optimizeImageBufferForWebMedia({
+      buffer: sourcePng,
+      contentType: "image/png",
+      fileName: "portrait.png",
+      maxBytes: 1024 * 1024,
+      imageCompression,
+    });
+    const convertedPath = path.join(fixtureRoot, "portrait.png");
+    await fs.writeFile(convertedPath, sourcePng);
+    const loaded = await loadWebMedia(convertedPath, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+      imageCompression,
+    });
+
+    for (const result of [direct, loaded]) {
+      expect(result.kind).toBe("image");
+      expect(result.contentType).toBe("image/jpeg");
+      expect(result.fileName).toBe("portrait.jpg");
+      expect(result.buffer.subarray(0, 3)).toEqual(Buffer.from([0xff, 0xd8, 0xff]));
+      expect(readJpegDimensions(result.buffer)).toEqual({ width: 32, height: 32 });
+    }
+  });
+
   it("applies model image maxBytes to the effective image cap", async () => {
     await expect(
       loadWebMediaRaw(tinyPngFile, {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -1000,10 +1000,7 @@ export async function optimizeImageBufferForWebMedia(params: {
     buffer: optimized.buffer,
     contentType: optimized.mimeType,
     kind: "image",
-    fileName:
-      optimized.format === "jpeg" && isHeicSource(params)
-        ? toJpegFileName(params.fileName)
-        : params.fileName,
+    fileName: optimized.format === "jpeg" ? toJpegFileName(params.fileName) : params.fileName,
   };
 }
 
@@ -1063,10 +1060,7 @@ async function loadWebMediaInternal(
       throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
     }
 
-    const fileName =
-      optimized.format === "jpeg" && meta && isHeicSource(meta)
-        ? toJpegFileName(meta.fileName)
-        : meta?.fileName;
+    const fileName = optimized.format === "jpeg" ? toJpegFileName(meta?.fileName) : meta?.fileName;
 
     return {
       buffer: optimized.buffer,


### PR DESCRIPTION
## What Problem This Solves

Four generic media boundaries currently lose facts that users and models need: oriented JPEGs report encoded instead of displayed dimensions, common AVIF/M4V/M4B/HEIC containers lack complete canonical MIME mappings, quoted/extended attachment filenames are truncated or mishandled, and PNG-to-JPEG conversion retains a misleading source extension.

## Why This Change Was Made

- Normalize EXIF orientation at the two existing metadata owners while preserving the raw probe contract.
- Extend the canonical media MIME owner using actual installed `file-type` brand contracts, including AVIF image hydration and M4B audio classification.
- Replace fragile Content-Disposition matching with a dependency-free quote/escape-aware top-level parameter parser, validated UTF-8/Latin-1 extended decoding, safe plain fallback, and legacy Windows basename preservation.
- Route both direct and loaded JPEG conversion results through the existing JPEG filename normalizer.
- Preserve MIME sniffing, SSRF, traversal, existing `audio/mp4 -> .m4a` preference, public SDK surfaces, and plugin ownership. Matrix-specific video work is intentionally excluded.

## User Impact

- Photos taken in portrait orientation now display their actual dimensions to model, channel, and preview consumers.
- AVIF images, M4V videos, M4B audiobooks, and HEIC/HEIF sequences keep correct type and extension metadata.
- Downloaded attachment names survive quoted semicolons, escaped punctuation/spaces, international extended values, malformed fallback, and Windows drive/UNC/relative/mixed paths without weakening filename sanitization.
- Opaque images converted to JPEG are consistently returned as `*.jpg` from both optimization entry points.

## Evidence

- Frozen base: `e051a7bb4a6ba69b87391e990b00813114b1d482`; isolated candidate: `9eb53c2fcd7bbb2fef94c281a1d31cf4e75a012e`.
- Exact-head focused owner suites: **262 passing tests** across MIME, EXIF, full fetch/security, and current-turn image owners.
- Exact-head web-media/security cases: **5 passing tests**; 81 unrelated cases intentionally skipped.
- Final complete fetch/security suite: **77 passing tests**, including spoofed quoted parameters; escaped quote, semicolon, comma, space, hyphen, and multiple punctuation; malformed/unsupported extended fallbacks; and drive, UNC, nested, mixed, Unicode, punctuation, and space-prefixed Windows basenames.
- Actual installed `file-type` recognizes six exercised ISO-BMFF brands; actual installed Rastermill reports a real EXIF-orientation-6 JPEG as raw **568×269**, with both metadata owners and real JPEG output reporting **269×568**.
- All nine changed paths pass `oxfmt --check`, targeted `oxlint`, and `git diff --check`; sparse checkout remains clean and 16 MB.
- Genuine official TruffleHog exact-commit preflight: **clean**. Independent Codex `gpt-5.6-sol` / high structured exact-commit review: **zero findings**, **patch is correct**, confidence **0.99** (`review-q2mediatransforms-9eb53c2fcd7.json`).
