### PR TITLE
fix(ui): preserve accessible and authoritative chat stream state

### DIFF
--- a/ui/src/components/markdown-file-links.ts
+++ b/ui/src/components/markdown-file-links.ts
@@ -89,6 +89,19 @@ export function markdownFileLinkFromEvent(
   return { path, line: line ? Number.parseInt(line, 10) : null };
 }
 
+export function markdownFileLinkFromKeyboardEvent(
+  event: KeyboardEvent,
+): { path: string; line: number | null } | null {
+  if (event.key !== "Enter" && event.key !== " ") {
+    return null;
+  }
+  const target = markdownFileLinkFromEvent(event);
+  if (target) {
+    event.preventDefault();
+  }
+  return target;
+}
+
 export function splitMarkdownFileLineSuffix(raw: string): { path: string; line: number | null } {
   const match = FILE_LINE_SUFFIX_RE.exec(raw);
   const line = match?.[1];

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -270,6 +270,8 @@ export function createMarkdownParser(): MarkdownIt {
               if (target) {
                 token.attrs = token.attrs?.filter(([name]) => name !== "href") ?? null;
                 token.attrJoin("class", "markdown-file-link");
+                token.attrSet("role", "button");
+                token.attrSet("tabindex", "0");
                 token.attrSet("data-file-path", target.path);
                 if (target.line !== null) {
                   token.attrSet("data-file-line", String(target.line));
@@ -313,6 +315,8 @@ export function createMarkdownParser(): MarkdownIt {
           const open = new state.Token("link_open", "a", 1);
           open.markup = "file-link";
           open.attrSet("class", "markdown-file-link");
+          open.attrSet("role", "button");
+          open.attrSet("tabindex", "0");
           open.attrSet("data-file-path", target.path);
           if (target.line !== null) {
             open.attrSet("data-file-line", String(target.line));
@@ -386,7 +390,7 @@ export function createMarkdownParser(): MarkdownIt {
     }
     const lineAttribute =
       target.line === null ? "" : ` data-file-line="${escapeMarkdownHtml(String(target.line))}"`;
-    return `<a class="markdown-file-link" data-file-path="${escapeMarkdownHtml(target.path)}"${lineAttribute}>${rendered}</a>`;
+    return `<a class="markdown-file-link" role="button" tabindex="0" data-file-path="${escapeMarkdownHtml(target.path)}"${lineAttribute}>${rendered}</a>`;
   };
 
   // Override image to only allow base64 data URIs (#15437).

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -8,6 +8,8 @@ import {
 
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
+const LIST_ITEM_OPEN_RE = /^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/u;
+const LINK_REFERENCE_CANDIDATE_RE = /^[ \t]*\[/u;
 
 type DetailsFrame = { hasSummary: boolean };
 type FenceMarker = { length: number; marker: "`" | "~" };
@@ -111,6 +113,8 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
   const detailsStack: DetailsFrame[] = [];
   const codeSpans = findMarkdownCodeSpans(markdownLocal);
   let lastFenceOffset = 0;
+  let firstListOffset: number | null = null;
+  let hasLinkReferenceDefinition = false;
 
   while (index < markdownLocal.length) {
     const nextLineBreak = markdownLocal.indexOf("\n", index);
@@ -129,6 +133,10 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
       continue;
     }
 
+    if (firstListOffset === null && LIST_ITEM_OPEN_RE.test(line)) {
+      firstListOffset = index;
+    }
+
     const openingFence = getFenceMarker(line);
     if (openingFence) {
       openFence = openingFence;
@@ -138,10 +146,25 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
     }
 
     updateDetailsStack(line, detailsStack, false, codeSpans, index);
-    if (line.trim() === "" && detailsStack.length === 0) {
-      boundary = lineEnd;
+    if (detailsStack.length === 0) {
+      if (LINK_REFERENCE_CANDIDATE_RE.test(stripMarkdownContainerPrefixes(line).content)) {
+        hasLinkReferenceDefinition = true;
+      }
+      if (line.trim() === "") {
+        boundary = lineEnd;
+      }
     }
     index = lineEnd;
+  }
+
+  // A bracket-leading line can start a multiline or escaped reference label.
+  // Keep its complete document together rather than guessing label boundaries.
+  if (hasLinkReferenceDefinition) {
+    boundary = 0;
+  } else if (firstListOffset !== null) {
+    // Blank lines cannot prove a list has ended: loose items, continuation
+    // indentation, and nested blocks all share the original list container.
+    boundary = Math.min(boundary, firstListOffset);
   }
 
   return {

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -768,6 +768,26 @@ PY
       expect(disabled.querySelector("a[data-file-path]")).toBeNull();
     });
 
+    it.each([
+      ["plain text", "see src/lib/foo.ts:42"],
+      ["inline code", "`src/lib/foo.ts:42`"],
+      ["explicit Markdown", "[source](src/lib/foo.ts:42)"],
+    ])(
+      "makes %s workspace file links keyboard-focusable without adding an href",
+      (_kind, input) => {
+        const fragment = htmlFragment(toSanitizedMarkdownHtml(input, { fileLinks: true }));
+        const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-file-link");
+
+        expect(link?.getAttribute("role")).toBe("button");
+        expect(link?.getAttribute("tabindex")).toBe("0");
+        expect(link?.hasAttribute("href")).toBe(false);
+        document.body.append(fragment);
+        link?.focus();
+        expect(document.activeElement).toBe(link);
+        fragment.remove();
+      },
+    );
+
     it("links prefixed single-segment paths but not bare prose filenames", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml("~/notes.md ./x.ts ../y.ts foo.ts", { fileLinks: true }),
@@ -1075,6 +1095,20 @@ describe("toStreamingMarkdownHtml", () => {
     const html = toStreamingMarkdownHtml("## Done\n\nworking **tail");
 
     expect(html).toBe("<h2>Done</h2>\n<p>working <strong>tail</strong></p>\n");
+  });
+
+  it.each([
+    ["loose sibling list items", "- one\n\n- two"],
+    ["list-item paragraph continuation", "- one\n\n  continuation"],
+    ["nested loose list items", "- one\n\n  - nested"],
+    ["a reference link and its later definition", "[Docs][doc]\n\n[doc]: https://example.com"],
+    ["escaped bracket labels", "[Docs][ref\\]]\n\n[ref\\]]: https://example.com"],
+    ["multiline reference labels", "[Docs][foo bar]\n\n[foo\n bar]: https://example.com"],
+    ["list-nested reference definitions", "See [x]\n\n- item\n\n    [x]: /url"],
+    ["tab-indented list continuation", "Intro\n\n  - one\n\n\tcontinuation"],
+    ["list continuation before a root heading", "- one\n\n  continuation\n# Heading"],
+  ])("preserves whole-document Markdown semantics for %s", (_kind, input) => {
+    expect(toStreamingMarkdownHtml(input)).toBe(toSanitizedMarkdownHtml(input));
   });
 
   it("uses Unicode separators as stable markdown boundaries", () => {

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -66,6 +66,7 @@ const allowedAttrs = [
   "open",
   "rel",
   "target",
+  "tabindex",
   "title",
   "start",
   "src",
@@ -76,6 +77,7 @@ const allowedAttrs = [
   "data-file-path",
   "type",
   "aria-label",
+  "role",
 ];
 const sanitizeOptions = {
   ALLOWED_TAGS: allowedTags,

--- a/ui/src/lib/chat/tool-call-view.test.ts
+++ b/ui/src/lib/chat/tool-call-view.test.ts
@@ -617,4 +617,23 @@ describe("resolveToolCallView", () => {
 
     expect(resolveToolCallView(source)).toBe(resolveToolCallView(source));
   });
+
+  it("keeps tool-name presentation authoritative when different calls share args", () => {
+    const args = { path: "/repo/a.ts", oldText: "before", newText: "after" };
+
+    expect(resolveToolCallView({ name: "read", args })).toMatchObject({
+      kind: "read",
+      target: "a.ts",
+    });
+    expect(resolveToolCallView({ name: "edit", args })).toMatchObject({
+      kind: "edit",
+      target: "a.ts",
+      stat: { added: 1, removed: 1 },
+    });
+    expect(resolveToolCallView({ name: "write", args })).toMatchObject({
+      kind: "write",
+      target: "a.ts",
+    });
+    expect(resolveToolCallView({ name: "READ", args }).kind).toBe("read");
+  });
 });

--- a/ui/src/lib/chat/tool-call-view.ts
+++ b/ui/src/lib/chat/tool-call-view.ts
@@ -323,20 +323,24 @@ export function resolveToolCallKind(name: string, args?: unknown): ToolCallKind 
 // Cache entries remember which details object they were built from: live tool
 // rows first render with args only and gain result `details` (e.g. the edit
 // diff) later on the same args identity, which must invalidate the cache.
-const toolCallViewCache = new WeakMap<object, { details: unknown; view: ToolCallView }>();
+const toolCallViewCache = new WeakMap<
+  object,
+  { details: unknown; name: string; view: ToolCallView }
+>();
 
 export function resolveToolCallView(source: ToolCallViewSource): ToolCallView {
   const args = asRecord(source.args);
   const cacheKey = args ?? asRecord(source.details);
+  const name = normalizeKey(source.name);
   if (cacheKey) {
     const cached = toolCallViewCache.get(cacheKey);
-    if (cached && cached.details === source.details) {
+    if (cached && cached.details === source.details && cached.name === name) {
       return cached.view;
     }
   }
   const view = buildToolCallView(source, args);
   if (cacheKey) {
-    toolCallViewCache.set(cacheKey, { details: source.details, view });
+    toolCallViewCache.set(cacheKey, { details: source.details, name, view });
   }
   return view;
 }

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -83,6 +83,33 @@ describe("markdown sidebar", () => {
     panel.remove();
   });
 
+  it.each(["Enter", " "])("opens focused markdown preview file links with %j", async (key) => {
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
+      updateComplete?: Promise<unknown>;
+    };
+    const onOpenWorkspaceFile = vi.fn();
+    panel.content = { kind: "markdown", content: "See `ui/src/pages/chat/chat-view.ts:362`" };
+    panel.onOpenWorkspaceFile = onOpenWorkspaceFile;
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    const link = panel.querySelector<HTMLAnchorElement>("a.markdown-file-link");
+    link?.focus();
+    expect(document.activeElement).toBe(link);
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    link?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenWorkspaceFile).toHaveBeenCalledOnce();
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith({
+      path: "ui/src/pages/chat/chat-view.ts",
+      line: 362,
+    });
+    panel.remove();
+  });
+
   it("activates Markdown images only when a chat owner opts in", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -5,7 +5,10 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
-import { markdownFileLinkFromEvent } from "../../../components/markdown-file-links.ts";
+import {
+  markdownFileLinkFromEvent,
+  markdownFileLinkFromKeyboardEvent,
+} from "../../../components/markdown-file-links.ts";
 import "../../../components/web-awesome.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
@@ -1281,6 +1284,13 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     }
   };
 
+  private readonly handlePanelKeyDown = (event: KeyboardEvent) => {
+    const target = markdownFileLinkFromKeyboardEvent(event);
+    if (target) {
+      this.onOpenWorkspaceFile?.(target);
+    }
+  };
+
   override render() {
     const matches = this.fileSearchMatches();
     const currentMatchIndex = matches.length
@@ -1291,7 +1301,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const fillHost =
       this.visibleContent?.kind === "file" || this.visibleContent?.kind === "markdown";
     return html`
-      <div class=${fillHost ? "sidebar-panel-host--fill" : ""} @click=${this.handlePanelClick}>
+      <div
+        class=${fillHost ? "sidebar-panel-host--fill" : ""}
+        @click=${this.handlePanelClick}
+        @keydown=${this.handlePanelKeyDown}
+      >
         ${renderMarkdownSidebar({
           content: this.visibleContent,
           error: this.error,

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -165,6 +165,35 @@ describe("chat transcript row measurement", () => {
     }
   });
 
+  it.each(["Enter", " "])("opens focused transcript file links with %j", async (key) => {
+    const transcript = createTestTranscript();
+    const onOpenWorkspaceFile = vi.fn();
+    const onHistoryIntent = vi.fn();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = {
+      ...threadProps("pane-file-link", "agent:main:main", [
+        { role: "assistant", content: "Inspect `src/chat.ts:17`", timestamp: 1_000 },
+      ]),
+      onOpenWorkspaceFile,
+      onHistoryIntent,
+    };
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const link = container.querySelector<HTMLAnchorElement>("a.markdown-file-link");
+    link?.focus();
+    expect(document.activeElement).toBe(link);
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    link?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith({ path: "src/chat.ts", line: 17 });
+    expect(onHistoryIntent).not.toHaveBeenCalled();
+    transcript.hostDisconnected();
+  });
+
   it("keeps built row identities across an A to B to A presentation reset", () => {
     const paneId = "pane-session-items";
     const messagesA = [{ role: "assistant", content: "session A", timestamp: 1_000 }];

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -21,7 +21,10 @@ import { copyMarkdownLabel } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
-import { markdownFileLinkFromEvent } from "../../../components/markdown-file-links.ts";
+import {
+  markdownFileLinkFromEvent,
+  markdownFileLinkFromKeyboardEvent,
+} from "../../../components/markdown-file-links.ts";
 import "../../../components/tooltip.ts";
 import { McpAppUnmountGate } from "../../../components/mcp-app-unmount.ts";
 import { i18n, t } from "../../../i18n/index.ts";
@@ -1796,7 +1799,14 @@ function renderChatThreadContents(
       @focusout=${(event: FocusEvent) => transcript.handleFocusOut(event)}
       @scroll=${props.onChatScroll}
       @wheel=${props.onHistoryIntent ? { handleEvent: props.onHistoryIntent, passive: true } : null}
-      @keydown=${props.onHistoryIntent}
+      @keydown=${(event: KeyboardEvent) => {
+        const target = markdownFileLinkFromKeyboardEvent(event);
+        if (target) {
+          props.onOpenWorkspaceFile?.(target);
+          return;
+        }
+        props.onHistoryIntent?.(event);
+      }}
       @touchstart=${props.onHistoryIntent
         ? { handleEvent: props.onHistoryIntent, passive: true }
         : null}

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -91,10 +91,13 @@ type SessionReferenceSearch = { agentId: string } & (
   | { kind: "slug"; value: string }
 );
 
-const resolutionCache = new WeakMap<
-  GatewayBrowserClient,
-  Map<string, Promise<SessionReferenceResolution | null>>
->();
+type PendingSessionReference = {
+  controller: AbortController;
+  promise: Promise<SessionReferenceResolution | null>;
+  subscribers: Set<AbortSignal>;
+};
+
+const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSessionReference>>();
 
 function uniqueShortIdPrefix(
   value: string,
@@ -205,21 +208,47 @@ async function querySessionReference(
   signal: AbortSignal,
 ): Promise<SessionReferenceResolution | null> {
   const client = await waitForGatewayClient(context.gateway, signal);
-  let cache = resolutionCache.get(client);
-  if (!cache) {
-    cache = new Map();
-    resolutionCache.set(client, cache);
-  }
+  signal.throwIfAborted();
+  const cache = resolutionCache.get(client) ?? new Map<string, PendingSessionReference>();
+  resolutionCache.set(client, cache);
   const cacheKey = `${normalizeAgentId(search.agentId)}:${search.kind}:${search.value}`;
   let pending = cache.get(cacheKey);
-  if (!pending) {
-    pending = querySessionReferencePages(context, search);
+  if (!pending || pending.controller.signal.aborted) {
+    const controller = new AbortController();
+    pending = {
+      controller,
+      promise: Promise.resolve().then(() =>
+        querySessionReferencePages(context, search, controller.signal),
+      ),
+      subscribers: new Set(),
+    };
     cache.set(cacheKey, pending);
   }
+  pending.subscribers.add(signal);
+  const shared = pending;
+  let rejectAbort: (reason: unknown) => void = () => undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const onAbort = () => {
+    shared.subscribers.delete(signal);
+    // The producer is shared: one cancelled navigation must not cancel another
+    // active route's lookup, but the final subscriber must stop later pages.
+    if (shared.subscribers.size === 0) {
+      shared.controller.abort(signal.reason);
+    }
+    rejectAbort(signal.reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
   try {
-    return await pending;
+    return await Promise.race([shared.promise, aborted]);
   } finally {
-    if (cache.get(cacheKey) === pending) {
+    signal.removeEventListener("abort", onAbort);
+    shared.subscribers.delete(signal);
+    if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
       cache.delete(cacheKey);
     }
   }
@@ -228,10 +257,12 @@ async function querySessionReference(
 async function querySessionReferencePages(
   context: ApplicationContext,
   search: SessionReferenceSearch,
+  signal: AbortSignal,
 ): Promise<SessionReferenceResolution | null> {
   const matches = new Map<string, GatewaySessionRow>();
   let offset = 0;
   for (let page = 0; ; page += 1) {
+    signal.throwIfAborted();
     const result = await context.sessions.list({
       agentId: search.agentId,
       archivedFilter: "all",
@@ -240,6 +271,7 @@ async function querySessionReferencePages(
       search: sessionReferenceSearchText(context, search),
       ...(offset > 0 ? { offset } : {}),
     });
+    signal.throwIfAborted();
     if (!result) {
       return null;
     }

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -215,6 +215,60 @@ describe("loadChatRoute", () => {
     expect(list).toHaveBeenCalledTimes(5);
   });
 
+  it("stops paginating once the route navigation is aborted", async () => {
+    const { context, list } = contextFor(result([]));
+    const navigation = new AbortController();
+    list.mockImplementation(async (options) => {
+      navigation.abort();
+      return result([], {
+        hasMore: true,
+        nextOffset: (options?.offset ?? 0) + 20,
+      });
+    });
+
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname: "/chat/main/deadbeef", search: "", hash: "" },
+        "chat",
+        navigation.signal,
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a shared session lookup alive while another navigation still owns it", async () => {
+    const matching = row({
+      key: "agent:main:dashboard:deadbeef-0000-4000-8000-000000000001",
+      displayName: "Shared lookup",
+    });
+    const { context, list } = contextFor(result([]));
+    let releaseLookup: ((value: SessionsListResult) => void) | undefined;
+    list.mockImplementation(
+      () =>
+        new Promise<SessionsListResult>((resolve) => {
+          releaseLookup = resolve;
+        }),
+    );
+    const staleNavigation = new AbortController();
+    const activeNavigation = new AbortController();
+    const location = { pathname: "/chat/main/deadbeef", search: "", hash: "" };
+    const stale = loadChatRoute(context, location, "chat", staleNavigation.signal);
+    const active = loadChatRoute(context, location, "chat", activeNavigation.signal);
+    await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+
+    staleNavigation.abort();
+    releaseLookup?.(result([matching]));
+
+    await expect(stale).rejects.toMatchObject({ name: "AbortError" });
+    await expect(active).resolves.toMatchObject({
+      kind: "session",
+      sessionKey: matching.key,
+      face: "chat",
+    });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
   it("stops after one unavailable session-list result", async () => {
     const { context, list } = contextFor(null);
     await expect(

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -325,6 +325,101 @@ describe("app-tool-stream result blocks", () => {
     expect(content.some((block) => block.type === "toolresult" && block.text === "")).toBe(true);
   });
 
+  it.each([
+    ["omitted name", undefined],
+    ["empty name", ""],
+    ["blank name", "   "],
+    ["generic placeholder", "tool"],
+    ["conflicting name", "write"],
+  ])("preserves an established tool identity when the result has an %s", (_label, name) => {
+    const host = createHost();
+    const toolCallId = "call-preserve-name";
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        name: "read",
+        toolCallId,
+        args: { path: "/workspace/report.txt" },
+      }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "tool", {
+        phase: "result",
+        ...(name === undefined ? {} : { name }),
+        toolCallId,
+        result: "file contents",
+      }),
+    );
+
+    const entry = host.toolStreamById.get(buildToolStreamIdentity("run-1", toolCallId));
+    expect(entry?.name).toBe("read");
+    expect(entry?.message.content).toEqual([
+      { type: "toolcall", name: "read", arguments: { path: "/workspace/report.txt" } },
+      { type: "toolresult", name: "read", text: "file contents" },
+    ]);
+  });
+
+  it.each([undefined, "tool"])(
+    "applies session-status result effects when its known tool name is reported as %j",
+    (name) => {
+      const host = createHost();
+      const toolCallId = "status-preserve-name";
+      handleAgentEvent(
+        host,
+        agentEvent("run-1", 1, "tool", {
+          phase: "start",
+          name: "session_status",
+          toolCallId,
+        }),
+      );
+      handleAgentEvent(
+        host,
+        agentEvent("run-1", 2, "tool", {
+          phase: "result",
+          ...(name === undefined ? {} : { name }),
+          toolCallId,
+          result: {
+            details: {
+              changedModel: true,
+              sessionKey: "main",
+              modelOverride: "openai/gpt-5.6-luna",
+            },
+          },
+        }),
+      );
+
+      expect(host.sessions.state.modelOverrides.main).toBe("openai/gpt-5.6-luna");
+    },
+  );
+
+  it("upgrades a placeholder start name when a later event supplies the concrete name", () => {
+    const host = createHost();
+    const toolCallId = "call-upgrade-name";
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        toolCallId,
+        args: { path: "/workspace/report.txt" },
+      }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "tool", {
+        phase: "result",
+        name: "read",
+        toolCallId,
+        result: "file contents",
+      }),
+    );
+
+    expect(host.toolStreamById.get(buildToolStreamIdentity("run-1", toolCallId))?.name).toBe(
+      "read",
+    );
+  });
+
   it("keeps interleaved sibling-run calls and results under independent identities", () => {
     const host = createHost({ chatRunId: "run-foreground" });
     const toolCallId = "call-shared";

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -986,8 +986,15 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   if (!toolCallId) {
     return;
   }
-  const name = typeof data.name === "string" ? data.name : "tool";
+  const toolStreamIdentity = buildToolStreamIdentity(payload.runId, toolCallId);
+  let entry = host.toolStreamById.get(toolStreamIdentity);
   const phase = typeof data.phase === "string" ? data.phase : "";
+  // A started call owns its concrete identity even when later events omit or
+  // contradict it; an unnamed placeholder can still adopt its first real name.
+  const name =
+    phase !== "start" && entry?.name && entry.name !== "tool"
+      ? entry.name
+      : (toTrimmedString(data.name) ?? entry?.name ?? "tool");
   if (phase === "start" && payload.runId === host.chatRunId) {
     host.chatRunStartup = { state: "activity", runId: payload.runId };
   }
@@ -1006,8 +1013,6 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   const now = Date.now();
-  const toolStreamIdentity = buildToolStreamIdentity(payload.runId, toolCallId);
-  let entry = host.toolStreamById.get(toolStreamIdentity);
   if (!entry) {
     // Commit any in-progress streaming text as a segment so it renders
     // above the tool card instead of below it.


### PR DESCRIPTION
## What Problem This Solves

Five independently reproduced Control UI chat defects silently damage ordinary operator workflows:

1. Streaming Markdown splits loose lists, indented continuations, and reference links into unrelated fragments, so live replies briefly display different content and links from completed replies.
2. Workspace file references look clickable but cannot receive keyboard focus or open from Enter/Space in either the transcript or Markdown detail sidebar.
3. Cancelled session navigation continues requesting up to five Gateway session pages after the operator has already moved elsewhere.
4. Tool-card caching reuses a `read` presentation for an `edit` or `write` when calls share an arguments object.
5. Tool completion events without a repeated name overwrite an authoritative started name with generic `tool`, corrupting transcript labels and skipping named result effects.

## Why This Change Was Made

Repair each canonical owner directly. Cache only the independent prefix before the first Markdown list, keep every subsequent list/container fragment intact, and render reference definitions with the complete document that owns them. Generate sanitized, href-less file anchors with explicit button semantics, tab focus, and shared Enter/Space activation used by both chat surfaces. Make the existing session-resolution cache subscriber-aware: cancel a paginated producer only when its last route navigation aborts, while preserving live shared callers. Include normalized tool identity in the presentation cache. Resolve result identity from the authoritative existing tool-call entry before applying result effects or rebuilding its transcript.

The change preserves the Markdown sanitizer, external-link policy, href-less local-file security boundary, session lookup limits, Gateway/public protocol, configuration, authentication, and persistent-state contracts.

## User Impact

- Live replies preserve whole-document list structure, indented Markdown, and reference-style hyperlinks.
- Keyboard and assistive-technology users can focus workspace references and open them with Enter or Space from both the transcript and detail preview.
- Rapid session navigation stops obsolete Gateway pagination without interrupting another navigation sharing the same lookup.
- Read, edit, and write tool cards retain the correct file presentation, diff, and action affordances.
- Completed tools keep their started names; nameless `session_status` results continue updating the visible model override.

## Evidence

- Frozen source: `e051a7bb4a6ba69b87391e990b00813114b1d482`; isolated sparse branch: `codex/qa200-ui-chat-stream-ownership`; exact candidate: `a7f00d9918ea0c513635d31b3d3b3d950539ba4f`; 15 MB worktree; frozen canonical checkout unchanged.
- Actual owner-level red proof: **27 newly added regressions failed before the fixes** across Markdown structure, escaped/multiline/list-nested reference labels, tab-expanded and stale-boundary list continuation, all three file-link generation forms, real focused transcript/sidebar keyboard activation, aborted/shared Gateway lookup, shared-arguments tool presentation, omitted/empty/blank/conflicting result names, placeholder upgrades, and nameless/conflicting `session_status` effects.
- Actual exact-source green proof: all **27 focused regressions passed** after the canonical-owner fixes.
- Eight complete affected owner and sibling suites: **328/328 tests passed** in `ui/src/components/markdown.test.ts`, `ui/src/components/markdown-details.test.ts`, `ui/src/lib/chat/tool-call-view.test.ts`, `ui/src/pages/chat/route.test.ts`, `ui/src/pages/chat/tool-stream.node.test.ts`, `ui/src/pages/chat/tool-stream-fallback.node.test.ts`, `ui/src/pages/chat/components/chat-sidebar.test.ts`, and `ui/src/pages/chat/components/chat-thread.measure.test.ts`.
- Actual sanitizer/XSS assertions remain green in the complete Markdown owner suite; href-less file-link invariants and external HTTP-link behavior are preserved.
- All 15 changed files pass targeted `oxfmt --check`, single-thread `oxlint`, existing max-lines enforcement, and `git diff --check`.
- Exact-commit TruffleHog 3.96.0 secret scan: **clean**.
- Independent review found genuine escaped/multiline/container-indented reference-label, Markdown-tab-column, stale list-boundary, and conflicting terminal-name gaps. Every finding failed with an exact red regression; direct inspection of markdown-it's reference, list, and tab-expanded block-state owners confirmed the dependency contract. The final streaming owner deletes the brittle list-indent/boundary state machine and preserves every case with green behavior proof.
- Exact-commit structured independent Codex `gpt-5.6-sol` high-reasoning autoreview: **CLEAN**, zero accepted/actionable findings, **patch is correct**, confidence **0.87**.

No public API, Gateway protocol, configuration, authentication, migration, SQLite, dependency, generated locale, live Gateway, or publishing changes.
