### PR TITLE
fix(cron): preserve failure alert route context

### DIFF
--- a/src/cron/service/failure-alerts.account-routing.test.ts
+++ b/src/cron/service/failure-alerts.account-routing.test.ts
@@ -9,25 +9,64 @@ import { resolveFailureAlert } from "./failure-alerts.js";
 import { createCronServiceState, type DeferredCronNotifications } from "./state.js";
 import { applyJobResult } from "./timer.js";
 
+function stripTestTargetPrefix(raw: string, prefixes: readonly string[]): string | undefined {
+  const target = raw
+    .trim()
+    .replace(new RegExp(`^(?:${prefixes.join("|")}):`, "i"), "")
+    .trim();
+  return target || undefined;
+}
+
+function normalizeDiscordTestTarget(raw: string): string | undefined {
+  const target = raw.trim().toLowerCase();
+  if (!target) {
+    return undefined;
+  }
+  if (target.startsWith("discord:channel:")) {
+    return target.slice("discord:".length);
+  }
+  if (target.startsWith("discord:")) {
+    return `user:${target.slice("discord:".length)}`;
+  }
+  return /^(channel|user):/.test(target) ? target : `channel:${target}`;
+}
+
 describe("cron failure alert account routing", () => {
   beforeEach(() => {
+    const pluginSpecs = [
+      {
+        id: "telegram",
+        aliases: [],
+        targetPrefixes: ["telegram", "tg"],
+        normalizeTarget: (raw: string) => {
+          const target = stripTestTargetPrefix(raw, ["telegram", "tg"]);
+          return target ? `telegram:${target}` : undefined;
+        },
+      },
+      {
+        id: "googlechat",
+        aliases: ["gchat", "google-chat"],
+        targetPrefixes: ["googlechat", "google-chat", "gchat"],
+        normalizeTarget: (raw: string) =>
+          stripTestTargetPrefix(raw, ["googlechat", "google-chat", "gchat"]),
+      },
+      {
+        id: "discord",
+        aliases: [],
+        targetPrefixes: ["discord"],
+        normalizeTarget: normalizeDiscordTestTarget,
+      },
+    ];
     setActivePluginRegistry(
       createTestRegistry(
-        [
-          { id: "telegram", aliases: [], targetPrefixes: ["telegram", "tg"] },
-          {
-            id: "googlechat",
-            aliases: ["gchat", "google-chat"],
-            targetPrefixes: ["googlechat", "google-chat", "gchat"],
-          },
-        ].map(({ id, aliases, targetPrefixes }) => {
+        pluginSpecs.map(({ id, aliases, targetPrefixes, normalizeTarget }) => {
           const plugin = createChannelTestPluginBase({ id });
           return {
             pluginId: id,
             plugin: {
               ...plugin,
               meta: { ...plugin.meta, aliases },
-              messaging: { targetPrefixes },
+              messaging: { targetPrefixes, normalizeTarget },
             },
             source: `test:${id}`,
           };
@@ -200,6 +239,19 @@ describe("cron failure alert account routing", () => {
       expected: { channel: "slack", to: undefined, accountId: undefined },
     },
     {
+      name: "does not equate Discord user and channel targets with the same id",
+      globalAlert: { enabled: true, after: 1 },
+      deliveryChannel: "discord",
+      deliveryTo: "1234567890",
+      jobAlert: { channel: "discord", to: "discord:1234567890" },
+      expected: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: undefined,
+        threadId: undefined,
+      },
+    },
+    {
       name: "does not inherit the primary account for a webhook",
       globalAlert: {
         enabled: true,
@@ -308,6 +360,13 @@ describe("cron failure alert account routing", () => {
       deliveryTo: "gchat:RoomA",
       failureAlert: { channel: "googlechat", to: "googlechat:RoomA" },
       expectedChannel: "googlechat",
+    },
+    {
+      name: "plugin-normalized equivalent",
+      deliveryChannel: "discord",
+      deliveryTo: "1234567890",
+      failureAlert: { channel: "discord", to: "discord:channel:1234567890" },
+      expectedChannel: "discord",
     },
   ])("keeps the primary account and topic on $name failure alerts", (testCase) => {
     const { failureAlert } = testCase;

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -3,10 +3,8 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { FailoverReason } from "../../agents/embedded-agent-helpers/types.js";
 import { normalizeAnyChannelId } from "../../channels/registry-normalize.js";
-import {
-  resolveTargetPrefixedChannel,
-  stripTargetProviderPrefix,
-} from "../../infra/outbound/channel-target-prefix.js";
+import { resolveTargetPrefixedChannel } from "../../infra/outbound/channel-target-prefix.js";
+import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 
@@ -53,11 +51,12 @@ function resolveFailureAlertChannel(channel: unknown, to?: string): CronMessageC
 }
 
 function normalizeFailureAlertRecipient(channel: CronMessageChannel, to: string): string {
-  if (resolveTargetPrefixedChannel(to) !== channel) {
+  try {
+    return normalizeTargetForProvider(channel, to) ?? to;
+  } catch {
+    // Invalid loaded targets are distinct routes; they must not block run finalization.
     return to;
   }
-  // Canonicalize loaded-provider aliases only; recipient/topic ids can be case-sensitive.
-  return stripTargetProviderPrefix(to, to.slice(0, to.indexOf(":")));
 }
 
 function normalizeTo(input: unknown): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Cron failure alerts could lose the primary delivery account and thread even when an explicitly configured alert target named the same channel destination. Current main compared only raw strings plus provider prefixes, so Discord `1234567890` and `discord:channel:1234567890` were treated as different routes. The same heuristic could also falsely equate a Discord user target with a channel target that had the same numeric id.

## Why This Change Was Made

`resolveFailureAlert` owns the effective alert route. It now uses the active channel plugin's canonical `messaging.normalizeTarget` contract for route identity, and its existing single `inheritsDeliveryRoute` fact continues to govern both account and thread inheritance. A malformed or throwing plugin target fails closed to a distinct route so it cannot abort cron outcome finalization.

The stale branch's display-name helper and completion-message wording were removed because they are unrelated user-visible copy changes. The separate `delivery.failureDestination` dedupe path remains a named follow-up: it intentionally suppresses thread inheritance and needs its own route-equivalence decision rather than being folded into this repair.

## User Impact

Failure alerts using equivalent Discord, Slack, or other plugin-canonical target forms retain the intended account and thread/topic. Targets that only look similar after stripping a provider prefix no longer inherit another route's account or thread.

## Evidence

- Regression before the production fix:
  - `node scripts/run-vitest.mjs src/cron/service/failure-alerts.account-routing.test.ts`
  - 2 failed, 20 passed. The equivalent Discord channel case returned `accountId: undefined` and `threadId: undefined`; the distinct Discord user target incorrectly inherited both.
- Regression after the fix and after the final rebase:
  - `node scripts/run-vitest.mjs src/cron/service/failure-alerts.account-routing.test.ts`
  - 22 passed.
- Downstream forwarding proof:
  - `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts`
  - 29 passed.
- Changed-file gate:
  - `node scripts/check-changed.mjs`
  - Passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31317111974
- Autoreview: clean after one round; no accepted/actionable findings.
- Production delta: +6/-7. Tests: +68/-9.

Rank-up moves applied: rebased onto current main; one canonical route fact now governs account and thread inheritance; regression coverage omits the alert account so inherited ownership is proved. Telegram Desktop proof was intentionally skipped because #117765 already fixed the Telegram provider-alias case; this branch repairs the remaining plugin-canonical Slack/Discord identity bug and makes no live Telegram claim.

Release-note context: cron failure alerts now preserve account and thread context across channel-canonical target aliases without conflating user and channel routes.
