### PR TITLE
fix(realtime): prevent queued transcription slowdown under backlog

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -102,6 +102,12 @@ function requireFirstMockArg<T>(mock: { mock: { calls: T[][] } }, label: string)
   return expectDefined(arg, "arg test invariant");
 }
 
+function encodeSequence(value: number): Buffer {
+  const frame = Buffer.allocUnsafe(2);
+  frame.writeUInt16BE(value);
+  return frame;
+}
+
 describe("createRealtimeTranscriptionWebSocketSession", () => {
   it("flushes queued binary audio after an open-ready connection", async () => {
     const frames: Buffer[] = [];
@@ -130,6 +136,128 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     await framesReady.promise;
     expect(Buffer.concat(frames).toString()).toBe("queuedafter");
     expect(session.isConnected()).toBe(true);
+    session.close();
+  });
+
+  it("drops the oldest queued audio by bytes and flushes the retained tail in order", async () => {
+    const frames: Buffer[] = [];
+    const framesReady = createSignal();
+    const server = await createRealtimeServer({
+      onBinary: (payload) => {
+        frames.push(payload);
+        if (frames.length === 3) {
+          framesReady.resolve();
+        }
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: {},
+      url: server.url,
+      maxQueuedBytes: 7,
+      readyOnOpen: true,
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    for (let index = 0; index < 13_000; index += 1) {
+      session.sendAudio(encodeSequence(index));
+    }
+    session.sendAudio(Buffer.from([0xaa, 0xbb, 0xcc]));
+
+    await session.connect();
+    await framesReady.promise;
+    expect(frames).toEqual([
+      encodeSequence(12_998),
+      encodeSequence(12_999),
+      Buffer.from([0xaa, 0xbb, 0xcc]),
+    ]);
+    session.close();
+  });
+
+  it("flushes a large retained audio tail in order after reconnect", async () => {
+    const connections: WebSocket[] = [];
+    const frames: Buffer[] = [];
+    const framesReady = createSignal();
+    const server = await createRealtimeServer({
+      onConnection: (ws) => connections.push(ws),
+      onBinary: (payload) => {
+        frames.push(payload);
+        if (frames.length === 4) {
+          framesReady.resolve();
+        }
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession<{ type?: string }>({
+      providerId: "test",
+      callbacks: {},
+      url: server.url,
+      maxQueuedBytes: 8,
+      maxReconnectAttempts: 1,
+      reconnectDelayMs: 1,
+      onMessage: (event, transport) => {
+        if (event.type === "session.created") {
+          transport.markReady();
+        }
+      },
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    const connecting = session.connect();
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    connections[0]?.send(JSON.stringify({ type: "session.created" }));
+    await connecting;
+
+    connections[0]?.close(1011, "reconnect");
+    await vi.waitFor(() => expect(session.isConnected()).toBe(false));
+    await vi.waitFor(() => expect(connections).toHaveLength(2));
+    for (let index = 0; index < 13_000; index += 1) {
+      session.sendAudio(encodeSequence(index));
+    }
+    connections[1]?.send(JSON.stringify({ type: "session.created" }));
+
+    await framesReady.promise;
+    expect(frames).toEqual([
+      encodeSequence(12_996),
+      encodeSequence(12_997),
+      encodeSequence(12_998),
+      encodeSequence(12_999),
+    ]);
+    session.close();
+  });
+
+  it("discards a large queued audio tail when closed before connecting", async () => {
+    const frames: Buffer[] = [];
+    const framesReady = createSignal();
+    const server = await createRealtimeServer({
+      onBinary: (payload) => {
+        frames.push(payload);
+        framesReady.resolve();
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: {},
+      url: server.url,
+      maxQueuedBytes: 8,
+      readyOnOpen: true,
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    for (let index = 0; index < 13_000; index += 1) {
+      session.sendAudio(encodeSequence(index));
+    }
+    session.close();
+
+    await session.connect();
+    session.sendAudio(Buffer.from("live"));
+    await framesReady.promise;
+    expect(frames).toEqual([Buffer.from("live")]);
     session.close();
   });
 

--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -161,10 +161,18 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       },
     });
 
-    for (let index = 0; index < 13_000; index += 1) {
-      session.sendAudio(encodeSequence(index));
+    const shiftSpy = vi.spyOn(Array.prototype, "shift");
+    let shiftCalls = 0;
+    try {
+      for (let index = 0; index < 13_000; index += 1) {
+        session.sendAudio(encodeSequence(index));
+      }
+      session.sendAudio(Buffer.from([0xaa, 0xbb, 0xcc]));
+      shiftCalls = shiftSpy.mock.calls.length;
+    } finally {
+      shiftSpy.mockRestore();
     }
-    session.sendAudio(Buffer.from([0xaa, 0xbb, 0xcc]));
+    expect(shiftCalls).toBe(0);
 
     await session.connect();
     await framesReady.promise;

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -72,7 +72,8 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
   private closed = false;
   private connected = false;
   private currentUrl = "";
-  private queuedAudio: Buffer[] = [];
+  private queuedAudio: Array<Buffer | undefined> = [];
+  private queuedAudioHead = 0;
   private queuedBytes = 0;
   private ready = false;
   private readySinceMs: number | undefined;
@@ -140,8 +141,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     this.ready = false;
     this.readySinceMs = undefined;
     this.reconnectSupervisor.cancel();
-    this.queuedAudio = [];
-    this.queuedBytes = 0;
+    this.clearQueuedAudio();
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       this.forceClose();
       return;
@@ -380,21 +380,45 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
   }
 
   private queueAudio(audio: Buffer): void {
-    this.queuedAudio.push(Buffer.from(audio));
-    this.queuedBytes += audio.byteLength;
-    while (this.queuedBytes > this.maxQueuedBytes && this.queuedAudio.length > 0) {
+    const queued = Buffer.from(audio);
+    this.queuedAudio.push(queued);
+    this.queuedBytes += queued.byteLength;
+    while (
+      this.queuedBytes > this.maxQueuedBytes &&
+      this.queuedAudioHead < this.queuedAudio.length
+    ) {
       // Keep the most recent audio when reconnects stall; old buffered audio is
-      // less useful than avoiding unbounded memory growth.
-      const dropped = this.queuedAudio.shift();
+      // less useful than avoiding unbounded memory growth. Advancing a head
+      // index keeps sustained overflow amortized O(1) instead of shifting the queue.
+      const dropped = this.queuedAudio[this.queuedAudioHead];
+      this.queuedAudio[this.queuedAudioHead] = undefined;
+      this.queuedAudioHead += 1;
       this.queuedBytes -= dropped?.byteLength ?? 0;
     }
+    this.compactQueuedAudio();
   }
 
   private flushQueuedAudio(): void {
-    for (const audio of this.queuedAudio) {
-      this.options.sendAudio(audio, this.transport);
+    for (let index = this.queuedAudioHead; index < this.queuedAudio.length; index += 1) {
+      const audio = this.queuedAudio[index];
+      if (audio) {
+        this.options.sendAudio(audio, this.transport);
+      }
     }
+    this.clearQueuedAudio();
+  }
+
+  private compactQueuedAudio(): void {
+    if (this.queuedAudioHead === 0 || this.queuedAudioHead * 2 < this.queuedAudio.length) {
+      return;
+    }
+    this.queuedAudio = this.queuedAudio.slice(this.queuedAudioHead);
+    this.queuedAudioHead = 0;
+  }
+
+  private clearQueuedAudio(): void {
     this.queuedAudio = [];
+    this.queuedAudioHead = 0;
     this.queuedBytes = 0;
   }
 


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where realtime transcription sessions could spend quadratic time evicting queued microphone frames during a prolonged provider connect or reconnect stall.

## Why This Change Was Made

The shared websocket session now advances a queue head and periodically compacts retained storage instead of shifting the full array for every dropped frame. This keeps eviction amortized constant-time while preserving the existing byte cap, newest-audio policy, reconnect behavior, and provider adapter contracts.

The fix stays in the canonical shared owner used by OpenAI, Deepgram, ElevenLabs, Mistral, and xAI. It adds no provider, config, environment-variable, or public API surface.

## User Impact

Realtime transcription remains responsive under large pre-ready or reconnect backlogs without increasing retained audio or changing which frames are sent.

## Evidence

- Exact signed head: `7820683b625b80f7aec4a3721a425961d2016324`
- Focused websocket lifecycle suite: 17/17 passed
- Real loopback HTTP upgrade + `ws` server queues 13,000 frames, proves the bounded retained tail flushes in order, asserts the hot path performs zero `Array.shift()` calls, and repeats the lifecycle invariant across reconnect
- Close-before-connect regression proves queued frames are discarded
- Formatting and `git diff --check`: passed
- Exact-head autoreview: clean, 0.97 confidence
- Independent exact-head review: clean; the zero-shift assertion closes the original performance-proof gap
- Live provider proof is blocked because no compatible OpenAI Platform, Deepgram, ElevenLabs, Mistral, or xAI credential is configured; the stored OpenAI profiles are OAuth-only, while realtime transcription resolves `api_key` profiles, and the current live helper connects before sending so it cannot exercise this pre-ready queue
- Blacksmith Testbox did not execute the changed gate because two fresh leases stalled during repository sync; no test command ran
- ClawSweeper and hosted exact-head CI: pending on this draft

## Provenance

The queue path was introduced by `0e7bcf7588d279e68e866664551d5a2da7c58864` on April 23, 2026 while realtime transcription websocket sessions were consolidated into the shared owner.
