### PR TITLE
fix(ui): coordinate settings mutations and visible refresh outcomes

### DIFF
--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -147,6 +147,9 @@ suite.define(() => {
   it("completes device-code sign-in and re-detects the configured model", async () => {
     await suite.withPage(
       {
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
@@ -175,6 +178,14 @@ suite.define(() => {
             "wizard.next",
           ],
           methodResponses: {
+            "config.get": {
+              config: {},
+              sourceConfig: {},
+              raw: "{}",
+              hash: "config-hash-1",
+              valid: true,
+              issues: [],
+            },
             "openclaw.setup.detect": initialDetection,
             "openclaw.setup.auth.start": {
               sessionId: "device-code-session",
@@ -202,12 +213,39 @@ suite.define(() => {
 
         const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
         expect(response?.status()).toBe(200);
+        const configReadsBeforeStart = (await gateway.getRequests("config.get")).length;
+        await gateway.deferNext("config.get");
         await page.getByRole("button", { name: "Pair" }).click();
 
         const start = await gateway.waitForRequest("openclaw.setup.auth.start");
         expect(start.params).toMatchObject({ authChoice: "provider-device-code" });
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBe(configReadsBeforeStart + 1);
         await page.getByText("ABCD-1234").waitFor();
+        await page.getByText("Working…").waitFor();
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            path: path.join(artifactDir, "model-setup-refresh-pending.png"),
+          });
+        }
+        await gateway.rejectDeferred("config.get", {
+          code: "UNAVAILABLE",
+          message: "authoritative snapshot unavailable",
+        });
+        await expect.poll(() => page.getByText("Working…").count()).toBe(0);
         await page.getByText("Expires in 14 minutes").waitFor();
+        await page
+          .locator("openclaw-modal-dialog")
+          .getByRole("alert")
+          .filter({ hasText: "authoritative snapshot unavailable" })
+          .waitFor();
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "model-setup-refresh-warning.png"),
+          });
+        }
         const signInLink = page.getByRole("link", { name: "Open sign-in page" });
         await expect.poll(() => signInLink.getAttribute("href")).toBe("https://example.com/device");
 

--- a/ui/src/pages/model-setup/model-setup-icon-loader.ts
+++ b/ui/src/pages/model-setup/model-setup-icon-loader.ts
@@ -1,0 +1,136 @@
+import type { ApplicationContext } from "../../app/context.ts";
+import { fetchCatalogIconBlobUrl } from "../plugins/icon-loader.ts";
+
+type IconRequest = {
+  controller: AbortController;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export class ModelSetupIconLoader {
+  private urls: Record<string, string> = {};
+  private readonly misses = new Set<string>();
+  private readonly requests = new Map<string, IconRequest>();
+
+  constructor(
+    private readonly getContext: () => ApplicationContext,
+    private readonly isEligible: (iconUrl: string) => boolean,
+    private readonly onChange: (urls: Record<string, string>) => void,
+  ) {}
+
+  reconcile(eligible: ReadonlySet<string>): void {
+    const nextUrls = { ...this.urls };
+    let changed = false;
+    for (const [iconUrl, blobUrl] of Object.entries(nextUrls)) {
+      if (!eligible.has(iconUrl)) {
+        URL.revokeObjectURL(blobUrl);
+        delete nextUrls[iconUrl];
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.publish(nextUrls);
+    }
+    for (const [iconUrl, request] of this.requests) {
+      if (!eligible.has(iconUrl)) {
+        clearTimeout(request.timeout);
+        request.controller.abort();
+        this.requests.delete(iconUrl);
+      }
+    }
+    for (const iconUrl of this.misses) {
+      if (!eligible.has(iconUrl)) {
+        this.misses.delete(iconUrl);
+      }
+    }
+    for (const iconUrl of eligible) {
+      if (!this.urls[iconUrl] && !this.misses.has(iconUrl) && !this.requests.has(iconUrl)) {
+        this.fetch(iconUrl);
+      }
+    }
+  }
+
+  invalidate(iconUrl: string): void {
+    const request = this.requests.get(iconUrl);
+    if (request) {
+      clearTimeout(request.timeout);
+      request.controller.abort();
+      this.requests.delete(iconUrl);
+    }
+    const blobUrl = this.urls[iconUrl];
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+    }
+    const nextUrls = { ...this.urls };
+    delete nextUrls[iconUrl];
+    this.publish(nextUrls);
+    this.misses.add(iconUrl);
+  }
+
+  reset(): void {
+    for (const request of this.requests.values()) {
+      clearTimeout(request.timeout);
+      request.controller.abort();
+    }
+    for (const blobUrl of Object.values(this.urls)) {
+      URL.revokeObjectURL(blobUrl);
+    }
+    this.requests.clear();
+    this.misses.clear();
+    this.publish({});
+  }
+
+  private fetch(iconUrl: string): void {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new DOMException("catalog icon fetch timed out", "TimeoutError")),
+      10_000,
+    );
+    const request = { controller, timeout };
+    this.requests.set(iconUrl, request);
+    const context = this.getContext();
+    void fetchCatalogIconBlobUrl({
+      iconUrl,
+      basePath: context.basePath,
+      gatewayUrl: context.gateway.connection.gatewayUrl,
+      auth: {
+        hello: context.gateway.snapshot.hello,
+        settings: { token: context.gateway.connection.token },
+        password: context.gateway.connection.password,
+      },
+      signal: controller.signal,
+    })
+      .then((blobUrl) => {
+        if (
+          this.requests.get(iconUrl) !== request ||
+          this.getContext().gateway.snapshot.phase !== "connected" ||
+          !this.isEligible(iconUrl)
+        ) {
+          if (blobUrl) {
+            URL.revokeObjectURL(blobUrl);
+          }
+          return;
+        }
+        if (blobUrl) {
+          this.publish({ ...this.urls, [iconUrl]: blobUrl });
+        } else {
+          this.misses.add(iconUrl);
+        }
+      })
+      .catch(() => {
+        if (this.requests.get(iconUrl) === request) {
+          this.misses.add(iconUrl);
+        }
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        if (this.requests.get(iconUrl) === request) {
+          this.requests.delete(iconUrl);
+        }
+      });
+  }
+
+  private publish(urls: Record<string, string>): void {
+    this.urls = urls;
+    this.onChange(urls);
+  }
+}

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -107,6 +107,7 @@ function createContext() {
     client,
     request,
     runtimeConfig,
+    snapshot,
     context: {
       gateway,
       basePath: "/openclaw",
@@ -571,6 +572,55 @@ describe("ModelSetupPage catalog icons", () => {
       expect(page.textContent).toContain("Connection verified");
     });
     expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    runtimeConfig.dispose();
+  });
+
+  it("drops a queued wizard action when setup access changes before dispatch", async () => {
+    const { context, client, request, runtimeConfig, snapshot } = createContext();
+    let releaseConfigSet: ((value: { hash: string }) => void) | undefined;
+    request.mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return {
+          config: {},
+          sourceConfig: {},
+          raw: "{}",
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.set") {
+        return await new Promise<{ hash: string }>((resolve) => {
+          releaseConfigSet = resolve;
+        });
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["pending"], true);
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          authOptions: [{ id: "provider-auth", label: "Provider", kind: "oauth", featured: true }],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+    await vi.waitFor(() => expect(releaseConfigSet).toBeTypeOf("function"));
+    snapshot.hello.auth.scopes = ["operator.read"];
+    releaseConfigSet?.({ hash: "hash-2" });
+
+    await vi.waitFor(() => expect(page.textContent).toContain("Model setup request failed."));
+    expect(request).not.toHaveBeenCalledWith(
+      "openclaw.setup.auth.start",
+      expect.anything(),
+      expect.anything(),
+    );
     runtimeConfig.dispose();
   });
 

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -504,6 +504,150 @@ describe("ModelSetupPage catalog icons", () => {
     runtimeConfig.dispose();
   });
 
+  it("owns the complete wizard action between draft flush and authoritative refresh", async () => {
+    const { context, client, request, runtimeConfig } = createContext();
+    const order: string[] = [];
+    let config: Record<string, unknown> = { pending: false };
+    let hash = "hash-1";
+    request.mockImplementation(async (method: string, params?: unknown) => {
+      order.push(method);
+      if (method === "config.get") {
+        return {
+          config,
+          sourceConfig: config,
+          raw: JSON.stringify(config),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.set") {
+        config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
+        hash = "hash-2";
+        return { hash };
+      }
+      if (method === "openclaw.setup.auth.start") {
+        return { sessionId: "wizard-session", done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        config = { ...config, configuredModel: "provider/model" };
+        hash = "hash-3";
+        return { done: true, status: "done" };
+      }
+      if (method === "openclaw.setup.detect") {
+        return {
+          ...detection,
+          configuredModel: "provider/model",
+          setupComplete: true,
+        };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    await runtimeConfig.ensureLoaded();
+    order.length = 0;
+    runtimeConfig.patchForm(["pending"], true);
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          authOptions: [{ id: "provider-auth", label: "Provider", kind: "oauth", featured: true }],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(order).toEqual([
+        "config.set",
+        "openclaw.setup.auth.start",
+        "wizard.next",
+        "config.get",
+        "openclaw.setup.detect",
+      ]);
+      expect(page.textContent).toContain("Connection verified");
+    });
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    runtimeConfig.dispose();
+  });
+
+  it("keeps autonomous gateway progress inside the wizard mutation lane", async () => {
+    const { context, client, request, runtimeConfig } = createContext();
+    const order: string[] = [];
+    let nextCount = 0;
+    let releaseProgress: ((value: unknown) => void) | undefined;
+    request.mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        order.push("config.get");
+        return {
+          config: {},
+          sourceConfig: {},
+          raw: "{}",
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      order.push(method);
+      if (method === "openclaw.setup.auth.start") {
+        return { sessionId: "wizard-session", done: false, status: "running" };
+      }
+      if (method === "wizard.next" && nextCount++ === 0) {
+        return {
+          done: false,
+          status: "running",
+          step: { id: "download", type: "progress", message: "Downloading", executor: "gateway" },
+        };
+      }
+      if (method === "wizard.next") {
+        return await new Promise((resolve) => {
+          releaseProgress = resolve;
+        });
+      }
+      if (method === "wizard.cancel") {
+        return {};
+      }
+      if (method === "openclaw.setup.detect") {
+        return { ...detection, configuredModel: "provider/model", setupComplete: true };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    await runtimeConfig.ensureLoaded();
+    order.length = 0;
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          authOptions: [{ id: "provider-auth", label: "Provider", kind: "oauth", featured: true }],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+    await vi.waitFor(() => expect(releaseProgress).toBeTypeOf("function"));
+
+    const competingMutation = runtimeConfig.runExternalMutation(async () => {
+      order.push("competing-mutation");
+    });
+    await Promise.resolve();
+    expect(order).not.toContain("competing-mutation");
+
+    page.querySelector<HTMLButtonElement>("openclaw-modal-dialog .btn")?.click();
+    await page.updateComplete;
+    await Promise.resolve();
+    expect(order).not.toContain("competing-mutation");
+
+    releaseProgress?.({ done: true, status: "done" });
+    await competingMutation;
+    expect(order.indexOf("competing-mutation")).toBeGreaterThan(order.indexOf("config.get"));
+    runtimeConfig.dispose();
+  });
+
   it("does not activate a stale candidate through a replacement connection", async () => {
     const { context: baseContext, client } = createContext();
     const replacementRequest = vi.fn();
@@ -596,5 +740,58 @@ describe("ModelSetupPage catalog icons", () => {
       expect(page.textContent).toContain("Connection verified");
       expect(page.textContent).toContain("config.get failed after model commit");
     });
+  });
+
+  it("coordinates wizard requests and keeps an authoritative refresh warning visible", async () => {
+    const { context: baseContext, client, request } = createContext();
+    const runExternalMutation = vi.fn(
+      async (task: (client: GatewayBrowserClient) => Promise<unknown>) => ({
+        ok: true as const,
+        value: await task(client),
+        refresh: { ok: false as const, error: "config.get failed after wizard commit" },
+      }),
+    );
+    const context = {
+      ...baseContext,
+      runtimeConfig: {
+        ...baseContext.runtimeConfig,
+        runExternalMutation,
+      },
+    } as ApplicationContext;
+    request.mockImplementation(async (method: string) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { sessionId: "wizard-session", done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        return {
+          done: false,
+          status: "running",
+          step: { id: "token", type: "text", message: "Paste token" },
+        };
+      }
+      return {};
+    });
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          authOptions: [{ id: "provider-auth", label: "Provider", kind: "oauth", featured: true }],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(runExternalMutation).toHaveBeenCalledTimes(1);
+      expect(page.textContent).toContain("config.get failed after wizard commit");
+      expect(page.textContent).toContain("Paste token");
+    });
+    page.querySelector<HTMLButtonElement>("openclaw-modal-dialog .btn")?.click();
+    await page.updateComplete;
+    expect(page.textContent).toContain("config.get failed after wizard commit");
   });
 });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -17,8 +17,8 @@ import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { fetchCatalogIconBlobUrl } from "../plugins/icon-loader.ts";
 import type { ModelSetupDetectionConnection } from "./detect-cache.ts";
+import { ModelSetupIconLoader } from "./model-setup-icon-loader.ts";
 import {
   findPreparedModelCandidate,
   type ModelSetupPrepareOption,
@@ -102,11 +102,11 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   private pendingPrepareOption: ModelSetupPrepareOption | null = null;
   private wizardMutationGeneration = 0;
   private wizardMutationActive = false;
-  private readonly iconMisses = new Set<string>();
-  private readonly iconRequests = new Map<
-    string,
-    { controller: AbortController; timeout: ReturnType<typeof setTimeout> }
-  >();
+  private readonly iconLoader = new ModelSetupIconLoader(
+    () => this.context,
+    (iconUrl) => this.currentIconUrls().has(iconUrl),
+    (urls) => (this.iconUrls = urls),
+  );
   private readonly subscriptions = new SubscriptionsController(this).watch(
     () => this.context?.gateway,
     (gateway, notify) => gateway.subscribe(notify),
@@ -240,7 +240,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     void this.detectTask.run([null, null]);
     void this.activationTask.run([null, null]);
     void this.verifyTask.run([null]);
-    this.resetIcons();
+    this.iconLoader.reset();
     void this.wizard.cancel();
     this.subscriptions.clear();
     super.disconnectedCallback();
@@ -264,7 +264,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
 
   override updated() {
     this.synchronizeGateway(this.context.gateway.snapshot);
-    this.reconcileIcons();
+    this.iconLoader.reconcile(this.currentIconUrls());
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]): void {
@@ -300,7 +300,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     void this.activationTask.run([null, null]);
     this.verifyState = { phase: "idle" };
     void this.verifyTask.run([null]);
-    this.resetIcons();
+    this.iconLoader.reset();
     this.pendingPrepareOption = null;
     void this.wizard.cancel();
     this.pageState = { phase: "loading" };
@@ -349,122 +349,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         ...(result.recommendedInstalls ?? []),
       ].flatMap((entry) => (entry.icon && !resolveSetupBrandIcon(entry) ? [entry.icon] : [])),
     );
-  }
-
-  private reconcileIcons(): void {
-    const eligible = this.currentIconUrls();
-    const nextUrls = { ...this.iconUrls };
-    let changed = false;
-    for (const [iconUrl, blobUrl] of Object.entries(nextUrls)) {
-      if (!eligible.has(iconUrl)) {
-        URL.revokeObjectURL(blobUrl);
-        delete nextUrls[iconUrl];
-        changed = true;
-      }
-    }
-    if (changed) {
-      this.iconUrls = nextUrls;
-    }
-    for (const [iconUrl, request] of this.iconRequests) {
-      if (!eligible.has(iconUrl)) {
-        clearTimeout(request.timeout);
-        request.controller.abort();
-        this.iconRequests.delete(iconUrl);
-      }
-    }
-    for (const iconUrl of this.iconMisses) {
-      if (!eligible.has(iconUrl)) {
-        this.iconMisses.delete(iconUrl);
-      }
-    }
-    for (const iconUrl of eligible) {
-      if (
-        !this.iconUrls[iconUrl] &&
-        !this.iconMisses.has(iconUrl) &&
-        !this.iconRequests.has(iconUrl)
-      ) {
-        this.fetchIcon(iconUrl);
-      }
-    }
-  }
-
-  private fetchIcon(iconUrl: string): void {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(new DOMException("catalog icon fetch timed out", "TimeoutError")),
-      10_000,
-    );
-    const request = { controller, timeout };
-    this.iconRequests.set(iconUrl, request);
-    void fetchCatalogIconBlobUrl({
-      iconUrl,
-      basePath: this.context.basePath,
-      gatewayUrl: this.context.gateway.connection.gatewayUrl,
-      auth: {
-        hello: this.context.gateway.snapshot.hello,
-        settings: { token: this.context.gateway.connection.token },
-        password: this.context.gateway.connection.password,
-      },
-      signal: controller.signal,
-    })
-      .then((blobUrl) => {
-        if (
-          this.iconRequests.get(iconUrl) !== request ||
-          this.context.gateway.snapshot.phase !== "connected" ||
-          !this.currentIconUrls().has(iconUrl)
-        ) {
-          if (blobUrl) {
-            URL.revokeObjectURL(blobUrl);
-          }
-          return;
-        }
-        if (blobUrl) {
-          this.iconUrls = { ...this.iconUrls, [iconUrl]: blobUrl };
-        } else {
-          this.iconMisses.add(iconUrl);
-        }
-      })
-      .catch(() => {
-        if (this.iconRequests.get(iconUrl) === request) {
-          this.iconMisses.add(iconUrl);
-        }
-      })
-      .finally(() => {
-        clearTimeout(timeout);
-        if (this.iconRequests.get(iconUrl) === request) {
-          this.iconRequests.delete(iconUrl);
-        }
-      });
-  }
-
-  private invalidateIcon(iconUrl: string): void {
-    const request = this.iconRequests.get(iconUrl);
-    if (request) {
-      clearTimeout(request.timeout);
-      request.controller.abort();
-      this.iconRequests.delete(iconUrl);
-    }
-    const blobUrl = this.iconUrls[iconUrl];
-    if (blobUrl) {
-      URL.revokeObjectURL(blobUrl);
-    }
-    const next = { ...this.iconUrls };
-    delete next[iconUrl];
-    this.iconUrls = next;
-    this.iconMisses.add(iconUrl);
-  }
-
-  private resetIcons(): void {
-    for (const request of this.iconRequests.values()) {
-      clearTimeout(request.timeout);
-      request.controller.abort();
-    }
-    for (const blobUrl of Object.values(this.iconUrls)) {
-      URL.revokeObjectURL(blobUrl);
-    }
-    this.iconRequests.clear();
-    this.iconMisses.clear();
-    this.iconUrls = {};
   }
 
   private async detect(): Promise<SystemAgentSetupDetectResult | null> {
@@ -744,7 +628,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       },
       onManualConnect: () => this.connectManual(),
       onMoreSignInToggle: (open) => (this.moreSignInOpen = open),
-      onIconError: (iconUrl) => this.invalidateIcon(iconUrl),
+      onIconError: (iconUrl) => this.iconLoader.invalidate(iconUrl),
       onOpenChat: () => {
         if (this.routeData?.firstRun) {
           this.context.navigate("custodian", { search: "?onboarding=1" });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -38,7 +38,7 @@ import {
 } from "./state.ts";
 import { renderModelSetup, resolveSetupBrandIcon } from "./view.ts";
 import { ModelSetupWizardRunner } from "./wizard-runner.ts";
-import type { ModelSetupWizardStartMethod } from "./wizard-runner.ts";
+import type { ModelSetupWizardCompletion, ModelSetupWizardStartMethod } from "./wizard-runner.ts";
 
 const MODEL_SETUP_DOCS_URL = "https://docs.openclaw.ai/concepts/model-providers";
 
@@ -102,10 +102,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   private pendingPrepareOption: ModelSetupPrepareOption | null = null;
   private wizardMutationGeneration = 0;
   private wizardMutationActive = false;
-  private pendingWizardCompletion: {
-    startMethod: ModelSetupWizardStartMethod;
-    preparedModelRef?: string;
-  } | null = null;
   private readonly iconMisses = new Set<string>();
   private readonly iconRequests = new Map<
     string,
@@ -125,12 +121,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       if (next.phase === "step" && next.step.id !== previousStep) {
         this.wizardValue = initialWizardValue(next.step);
       }
-    },
-    onDone: (startMethod, preparedModelRef) => {
-      this.pendingWizardCompletion = {
-        startMethod,
-        ...(preparedModelRef ? { preparedModelRef } : {}),
-      };
     },
     requestFailedMessage: () => t("modelSetup.errors.requestFailed"),
     cancelledMessage: () => t("modelSetup.wizard.cancelled"),
@@ -247,7 +237,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   override disconnectedCallback() {
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    this.pendingWizardCompletion = null;
     void this.detectTask.run([null, null]);
     void this.activationTask.run([null, null]);
     void this.verifyTask.run([null]);
@@ -306,7 +295,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.observedConnection = connection;
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    this.pendingWizardCompletion = null;
     void this.detectTask.run([null, null]);
     this.activationState = { phase: "idle" };
     void this.activationTask.run([null, null]);
@@ -623,19 +611,19 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   private closeWizard(): void {
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    this.pendingWizardCompletion = null;
     this.pendingPrepareOption = null;
     this.wizard.close();
   }
 
-  private async runWizardMutation(task: () => Promise<void>): Promise<void> {
+  private async runWizardMutation(
+    task: () => Promise<ModelSetupWizardCompletion | null>,
+  ): Promise<void> {
     const client = this.context.gateway.snapshot.client;
     if (this.wizardMutationActive || !this.canUseSetup(client)) {
       return;
     }
     const generation = ++this.wizardMutationGeneration;
     this.wizardMutationActive = true;
-    this.pendingWizardCompletion = null;
     this.requestUpdate();
     try {
       const mutation = await this.context.runtimeConfig.runExternalMutation(
@@ -643,7 +631,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
           if (mutationClient !== client) {
             throw new Error("Connection changed before model setup continued.");
           }
-          await task();
+          return await task();
         },
       );
       if (generation !== this.wizardMutationGeneration) {
@@ -660,8 +648,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         return;
       }
       this.setupRefreshWarning = mutation.refresh.ok ? null : mutation.refresh.error;
-      const completion = this.pendingWizardCompletion;
-      this.pendingWizardCompletion = null;
+      const completion = mutation.value;
       if (completion) {
         // The coordinated wizard action has settled; follow-up activation owns
         // its own mutation lane and must not be blocked by the prior busy flag.
@@ -685,7 +672,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   private cancelWizard(): void {
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    this.pendingWizardCompletion = null;
     this.pendingPrepareOption = null;
     // A Gateway-owned step can commit while cancellation is being handled.
     // Hide this generation now, but let its mutation lane settle and refresh.

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -95,10 +95,17 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   @state() private manualError: string | null = null;
   @state() private moreSignInOpen = false;
   @state() private iconUrls: Record<string, string> = {};
+  @state() private setupRefreshWarning: string | null = null;
 
   private observedConnection: (ModelSetupRouteData["connection"] & { connected: boolean }) | null =
     null;
   private pendingPrepareOption: ModelSetupPrepareOption | null = null;
+  private wizardMutationGeneration = 0;
+  private wizardMutationActive = false;
+  private pendingWizardCompletion: {
+    startMethod: ModelSetupWizardStartMethod;
+    preparedModelRef?: string;
+  } | null = null;
   private readonly iconMisses = new Set<string>();
   private readonly iconRequests = new Map<
     string,
@@ -113,13 +120,18 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     getClient: () => this.context?.gateway.snapshot.client ?? null,
     onChange: (next) => {
       const previousStep = this.wizardState.phase === "step" ? this.wizardState.step.id : null;
-      this.wizardState = next;
+      this.wizardState =
+        next.phase === "step" && this.wizardMutationActive ? { ...next, busy: true } : next;
       if (next.phase === "step" && next.step.id !== previousStep) {
         this.wizardValue = initialWizardValue(next.step);
       }
     },
-    onDone: (startMethod, preparedModelRef) =>
-      void this.handleWizardDone(startMethod, preparedModelRef),
+    onDone: (startMethod, preparedModelRef) => {
+      this.pendingWizardCompletion = {
+        startMethod,
+        ...(preparedModelRef ? { preparedModelRef } : {}),
+      };
+    },
     requestFailedMessage: () => t("modelSetup.errors.requestFailed"),
     cancelledMessage: () => t("modelSetup.wizard.cancelled"),
     sessionExpiredMessage: () => t("modelSetup.wizard.sessionExpired"),
@@ -233,6 +245,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   });
 
   override disconnectedCallback() {
+    this.wizardMutationGeneration += 1;
+    this.wizardMutationActive = false;
+    this.pendingWizardCompletion = null;
     void this.detectTask.run([null, null]);
     void this.activationTask.run([null, null]);
     void this.verifyTask.run([null]);
@@ -289,6 +304,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       return;
     }
     this.observedConnection = connection;
+    this.wizardMutationGeneration += 1;
+    this.wizardMutationActive = false;
+    this.pendingWizardCompletion = null;
     void this.detectTask.run([null, null]);
     this.activationState = { phase: "idle" };
     void this.activationTask.run([null, null]);
@@ -602,20 +620,83 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.wizard.close();
   }
 
-  private cancelWizard(): void {
-    this.pendingPrepareOption = null;
-    void this.wizard.cancel();
-  }
-
   private closeWizard(): void {
+    this.wizardMutationGeneration += 1;
+    this.wizardMutationActive = false;
+    this.pendingWizardCompletion = null;
     this.pendingPrepareOption = null;
     this.wizard.close();
+  }
+
+  private async runWizardMutation(task: () => Promise<void>): Promise<void> {
+    const client = this.context.gateway.snapshot.client;
+    if (this.wizardMutationActive || !this.canUseSetup(client)) {
+      return;
+    }
+    const generation = ++this.wizardMutationGeneration;
+    this.wizardMutationActive = true;
+    this.pendingWizardCompletion = null;
+    this.requestUpdate();
+    try {
+      const mutation = await this.context.runtimeConfig.runExternalMutation(
+        async (mutationClient) => {
+          if (mutationClient !== client) {
+            throw new Error("Connection changed before model setup continued.");
+          }
+          await task();
+        },
+      );
+      if (generation !== this.wizardMutationGeneration) {
+        if (mutation.ok && !mutation.refresh.ok && this.isConnected) {
+          this.setupRefreshWarning = mutation.refresh.error;
+        }
+        if (this.isConnected && this.canUseSetup(this.context.gateway.snapshot.client)) {
+          void this.detect();
+        }
+        return;
+      }
+      if (!mutation.ok) {
+        this.wizard.fail(mutation.error);
+        return;
+      }
+      this.setupRefreshWarning = mutation.refresh.ok ? null : mutation.refresh.error;
+      const completion = this.pendingWizardCompletion;
+      this.pendingWizardCompletion = null;
+      if (completion) {
+        // The coordinated wizard action has settled; follow-up activation owns
+        // its own mutation lane and must not be blocked by the prior busy flag.
+        this.wizardMutationActive = false;
+        await this.handleWizardDone(completion.startMethod, completion.preparedModelRef);
+      } else if (this.wizardState.phase === "step" && this.wizardState.busy) {
+        this.wizardState = { ...this.wizardState, busy: false };
+      }
+    } catch (error) {
+      if (generation === this.wizardMutationGeneration) {
+        this.wizard.fail(errorMessage(error));
+      }
+    } finally {
+      if (generation === this.wizardMutationGeneration) {
+        this.wizardMutationActive = false;
+        this.requestUpdate();
+      }
+    }
+  }
+
+  private cancelWizard(): void {
+    this.wizardMutationGeneration += 1;
+    this.wizardMutationActive = false;
+    this.pendingWizardCompletion = null;
+    this.pendingPrepareOption = null;
+    // A Gateway-owned step can commit while cancellation is being handled.
+    // Hide this generation now, but let its mutation lane settle and refresh.
+    void this.wizard.cancel({ settleActiveRequest: true });
   }
 
   private actionsDisabled(): boolean {
     return (
       this.activationState.phase === "testing" ||
       this.verifyState.phase === "checking" ||
+      this.wizardMutationActive ||
       (this.wizardState.phase !== "idle" &&
         this.wizardState.phase !== "error" &&
         this.wizardState.phase !== "cancelled")
@@ -646,6 +727,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         !gatewayTooOld &&
         isGatewayMethodAdvertised(snapshot, "openclaw.setup.prepare.start") === true,
       gatewayTooOld,
+      refreshWarning: this.setupRefreshWarning,
       actionsDisabled: this.actionsDisabled(),
       manualProviderId: this.manualProviderId,
       manualApiKey: this.manualApiKey,
@@ -659,12 +741,14 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       onStartAuth: (option: AuthOption) => {
         this.pendingPrepareOption = null;
         this.wizardMode = "auth";
-        void this.wizard.start(option.id);
+        void this.runWizardMutation(() => this.wizard.start(option.id));
       },
       onStartPrepare: (option: ModelSetupPrepareOption) => {
         this.pendingPrepareOption = option;
         this.wizardMode = "prepare";
-        void this.wizard.start(option.id, "openclaw.setup.prepare.start");
+        void this.runWizardMutation(() =>
+          this.wizard.start(option.id, "openclaw.setup.prepare.start"),
+        );
       },
       onManualProviderChange: (providerId) => this.selectManualProvider(providerId),
       onUseManualProvider: (providerId) => void this.useManualProvider(providerId),
@@ -687,7 +771,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         void this.detect();
       },
       onWizardValueChange: (value) => (this.wizardValue = value),
-      onWizardAnswer: (value, includeValue) => void this.wizard.answer(value, includeValue),
+      onWizardAnswer: (value, includeValue) =>
+        void this.runWizardMutation(() => this.wizard.answer(value, includeValue)),
       onWizardCancel: () => this.cancelWizard(),
       onWizardClose: () => this.closeWizard(),
     });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -517,6 +517,13 @@ export class ModelSetupPage extends OpenClawLightDomElement {
           }
           return await task();
         },
+        {
+          canDispatch: () =>
+            generation === this.wizardMutationGeneration &&
+            this.context.gateway.snapshot.client === client &&
+            this.canUseSetup(client),
+          dispatchError: t("modelSetup.errors.requestFailed"),
+        },
       );
       if (generation !== this.wizardMutationGeneration) {
         if (mutation.ok && !mutation.refresh.ok && this.isConnected) {

--- a/ui/src/pages/model-setup/model-setup-reconnect.test.ts
+++ b/ui/src/pages/model-setup/model-setup-reconnect.test.ts
@@ -240,6 +240,58 @@ describe("ModelSetupPage Gateway reconnect ownership", () => {
     runtimeConfig.dispose();
   });
 
+  it("suppresses a late wizard completion but retains its reconnect refresh warning", async () => {
+    const { client, context, request, runtimeConfig, setGatewayPhase } = createFixture();
+    let releaseWizard: ((value: unknown) => void) | undefined;
+    request.mockImplementation(async (method) => {
+      if (method === "config.get") {
+        return {
+          config: {},
+          sourceConfig: {},
+          raw: "{}",
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "openclaw.setup.auth.start") {
+        return { sessionId: "wizard-before-reconnect", done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        return await new Promise((resolve) => {
+          // The server can finish a cancellation-locked commit after the local
+          // request was invalidated, so deliberately ignore the abort signal.
+          releaseWizard = resolve;
+        });
+      }
+      if (method === "openclaw.setup.detect") {
+        return {
+          ...detection,
+          configuredModel: "provider/current-model",
+          setupComplete: true,
+        };
+      }
+      return {};
+    });
+    await runtimeConfig.ensureLoaded();
+    const page = await mountPage(context, client);
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+    await vi.waitFor(() => expect(releaseWizard).toBeTypeOf("function"));
+
+    setGatewayPhase("reconnecting");
+    setGatewayPhase("connected");
+    releaseWizard?.({ done: true, status: "done" });
+
+    await vi.waitFor(() => {
+      expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+      expect(page.textContent).toContain(
+        "Connection changed before the configuration update was refreshed.",
+      );
+      expect(selectedModelDetail(page)).toBe("current-model");
+    });
+    runtimeConfig.dispose();
+  });
+
   it("rejects a route completion produced before a same-client reconnect", async () => {
     const { client, context, request, runtimeConfig, setGatewayPhase } = createFixture();
     request.mockImplementation(async (method) =>

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -1040,7 +1040,6 @@ describe("renderModelSetup", () => {
       "prepare",
     );
     expect(text(prepareConfirm)).toContain("Continue");
-    expect(text(prepareConfirm)).toContain("No");
     expect(text(prepareConfirm)).not.toContain("Yes");
   });
 

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -116,6 +116,7 @@ function props(overrides: Partial<ModelSetupViewProps> = {}): ModelSetupViewProp
     canVerify: true,
     canPrepare: true,
     gatewayTooOld: false,
+    refreshWarning: null,
     actionsDisabled: false,
     manualProviderId: "openai",
     manualApiKey: "",

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -85,6 +85,7 @@ type ModelSetupViewProps = {
   canVerify: boolean;
   canPrepare: boolean;
   gatewayTooOld: boolean;
+  refreshWarning: string | null;
   actionsDisabled: boolean;
   manualProviderId: string;
   manualApiKey: string;
@@ -612,11 +613,15 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
             </button>`
           : nothing}
       </div>
+      ${props.refreshWarning
+        ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+        : nothing}
       ${body}
     </div>
     ${renderModelSetupWizard({
       mode: props.wizardMode,
       state: props.wizard,
+      refreshWarning: props.refreshWarning,
       value: props.wizardValue,
       onValueChange: props.onWizardValueChange,
       onAnswer: props.onWizardAnswer,

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -228,5 +228,12 @@ describe("ModelSetupWizardRunner", () => {
     });
 
     expect(seen).toEqual(messages);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.setup.prepare.start",
+      "wizard.next",
+      "wizard.next",
+      "wizard.next",
+      "wizard.next",
+    ]);
   });
 });

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -25,11 +25,9 @@ describe("ModelSetupWizardRunner", () => {
       return Promise.resolve({});
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const onDone = vi.fn();
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
       onChange: () => undefined,
-      onDone,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
       sessionExpiredMessage: () => "expired",
@@ -49,8 +47,7 @@ describe("ModelSetupWizardRunner", () => {
       expect.objectContaining({ timeoutMs: null, signal: expect.any(AbortSignal) }),
     );
     resolveDone!({ done: true, status: "done" });
-    await answer;
-    expect(onDone).toHaveBeenCalledOnce();
+    await expect(answer).resolves.toEqual({ startMethod: "openclaw.setup.auth.start" });
     expect(runner.state).toEqual({ phase: "done", authChoice: "openai-oauth" });
   });
 
@@ -68,7 +65,6 @@ describe("ModelSetupWizardRunner", () => {
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
       onChange: () => undefined,
-      onDone: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
       sessionExpiredMessage: () => "expired",
@@ -100,7 +96,6 @@ describe("ModelSetupWizardRunner", () => {
     const runner = new ModelSetupWizardRunner({
       getClient: () => ({ request }) as unknown as GatewayBrowserClient,
       onChange: () => undefined,
-      onDone: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
       sessionExpiredMessage: () => "expired",
@@ -153,7 +148,6 @@ describe("ModelSetupWizardRunner", () => {
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
       onChange: () => undefined,
-      onDone: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
       sessionExpiredMessage: () => "Setup expired. Close and restart setup.",
@@ -205,7 +199,6 @@ describe("ModelSetupWizardRunner", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const seen: string[] = [];
-    const onDone = vi.fn();
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
       onChange: (state) => {
@@ -213,18 +206,14 @@ describe("ModelSetupWizardRunner", () => {
           seen.push(state.step.message ?? "");
         }
       },
-      onDone,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
       sessionExpiredMessage: () => "expired",
     });
 
-    await runner.start("llama-cpp", "openclaw.setup.prepare.start");
-    await vi.waitFor(() => {
-      expect(onDone).toHaveBeenCalledWith(
-        "openclaw.setup.prepare.start",
-        "llama-cpp/gemma-4-e4b-it-q4_k_m",
-      );
+    await expect(runner.start("llama-cpp", "openclaw.setup.prepare.start")).resolves.toEqual({
+      startMethod: "openclaw.setup.prepare.start",
+      preparedModelRef: "llama-cpp/gemma-4-e4b-it-q4_k_m",
     });
 
     expect(seen).toEqual(messages);

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -12,10 +12,14 @@ export type ModelSetupWizardStartMethod =
   | "openclaw.setup.auth.start"
   | "openclaw.setup.prepare.start";
 
+export type ModelSetupWizardCompletion = {
+  startMethod: ModelSetupWizardStartMethod;
+  preparedModelRef?: string;
+};
+
 type WizardRunnerOptions = {
   getClient: () => GatewayBrowserClient | null;
   onChange: (state: ModelSetupWizardState) => void;
-  onDone: (startMethod: ModelSetupWizardStartMethod, preparedModelRef?: string) => void;
   requestFailedMessage: () => string;
   cancelledMessage: () => string;
   sessionExpiredMessage: () => string;
@@ -37,10 +41,10 @@ export class ModelSetupWizardRunner {
   async start(
     authChoice: string,
     startMethod: ModelSetupWizardStartMethod = "openclaw.setup.auth.start",
-  ): Promise<void> {
+  ): Promise<ModelSetupWizardCompletion | null> {
     const client = this.options.getClient();
     if (!client || this.currentState.phase !== "idle") {
-      return;
+      return null;
     }
     const generation = ++this.generation;
     const sessionId = crypto.randomUUID();
@@ -56,30 +60,31 @@ export class ModelSetupWizardRunner {
         { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS, signal: abortController.signal },
       );
       if (generation !== this.generation) {
-        return;
+        return null;
       }
       if (started.done) {
-        this.applyResult(authChoice, started);
-        return;
+        return this.applyResult(authChoice, started);
       }
-      await this.requestNext(authChoice, undefined, generation);
+      return await this.requestNext(authChoice, undefined, generation);
     } catch (error) {
       this.handleError(error, generation);
+      return null;
     }
   }
 
-  async answer(value: unknown, includeValue = true): Promise<void> {
+  async answer(value: unknown, includeValue = true): Promise<ModelSetupWizardCompletion | null> {
     const state = this.currentState;
     if (state.phase !== "step" || state.busy || !this.sessionId) {
-      return;
+      return null;
     }
     const generation = this.generation;
     this.setState({ ...state, busy: true, validationError: null });
     const answer = includeValue ? { stepId: state.step.id, value } : { stepId: state.step.id };
     try {
-      await this.requestNext(state.authChoice, answer, generation);
+      return await this.requestNext(state.authChoice, answer, generation);
     } catch (error) {
       this.handleError(error, generation);
+      return null;
     }
   }
 
@@ -125,12 +130,12 @@ export class ModelSetupWizardRunner {
     authChoice: string,
     answer: { stepId: string; value?: unknown } | undefined,
     generation: number,
-  ): Promise<void> {
+  ): Promise<ModelSetupWizardCompletion | null> {
     const client = this.options.getClient();
     const sessionId = this.sessionId;
     const signal = this.abortController?.signal;
     if (!client || !sessionId || !signal) {
-      return;
+      return null;
     }
     let nextAnswer = answer;
     while (true) {
@@ -140,11 +145,15 @@ export class ModelSetupWizardRunner {
         { timeoutMs: MODEL_SETUP_WIZARD_NEXT_TIMEOUT_MS, signal },
       );
       if (generation !== this.generation) {
-        return;
+        return null;
       }
-      const next = this.applyResult(authChoice, result);
+      const completion = this.applyResult(authChoice, result);
+      if (completion) {
+        return completion;
+      }
+      const next = this.currentState;
       if (next.phase !== "step" || next.step.executor !== "gateway") {
-        return;
+        return null;
       }
       // Gateway-owned progress has no user control to trigger the next poll.
       // Keep it in this request chain so its mutation owner settles with it.
@@ -152,7 +161,10 @@ export class ModelSetupWizardRunner {
     }
   }
 
-  private applyResult(authChoice: string, result: WizardNextResult): ModelSetupWizardState {
+  private applyResult(
+    authChoice: string,
+    result: WizardNextResult,
+  ): ModelSetupWizardCompletion | null {
     const next = wizardStateFromResult(
       authChoice,
       result,
@@ -161,12 +173,15 @@ export class ModelSetupWizardRunner {
         : this.options.requestFailedMessage(),
     );
     this.setState(next);
-    if (next.phase === "done") {
-      this.sessionId = null;
-      this.abortController = null;
-      this.options.onDone(this.startMethod, next.preparedModelRef);
+    if (next.phase !== "done") {
+      return null;
     }
-    return next;
+    this.sessionId = null;
+    this.abortController = null;
+    return {
+      startMethod: this.startMethod,
+      ...(next.preparedModelRef ? { preparedModelRef: next.preparedModelRef } : {}),
+    };
   }
 
   private handleError(error: unknown, generation: number): void {

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -83,12 +83,14 @@ export class ModelSetupWizardRunner {
     }
   }
 
-  async cancel(): Promise<void> {
+  async cancel(options: { settleActiveRequest?: boolean } = {}): Promise<void> {
     const client = this.options.getClient();
     const sessionId = this.sessionId;
     this.generation += 1;
     this.sessionId = null;
-    this.abortController?.abort();
+    if (!options.settleActiveRequest) {
+      this.abortController?.abort();
+    }
     this.abortController = null;
     this.setState({ phase: "idle" });
     if (!client || !sessionId) {
@@ -130,18 +132,27 @@ export class ModelSetupWizardRunner {
     if (!client || !sessionId || !signal) {
       return;
     }
-    const result = await client.request<WizardNextResult>(
-      "wizard.next",
-      { sessionId, ...(answer ? { answer } : {}) },
-      { timeoutMs: MODEL_SETUP_WIZARD_NEXT_TIMEOUT_MS, signal },
-    );
-    if (generation !== this.generation) {
-      return;
+    let nextAnswer = answer;
+    while (true) {
+      const result = await client.request<WizardNextResult>(
+        "wizard.next",
+        { sessionId, ...(nextAnswer ? { answer: nextAnswer } : {}) },
+        { timeoutMs: MODEL_SETUP_WIZARD_NEXT_TIMEOUT_MS, signal },
+      );
+      if (generation !== this.generation) {
+        return;
+      }
+      const next = this.applyResult(authChoice, result);
+      if (next.phase !== "step" || next.step.executor !== "gateway") {
+        return;
+      }
+      // Gateway-owned progress has no user control to trigger the next poll.
+      // Keep it in this request chain so its mutation owner settles with it.
+      nextAnswer = undefined;
     }
-    this.applyResult(authChoice, result);
   }
 
-  private applyResult(authChoice: string, result: WizardNextResult): void {
+  private applyResult(authChoice: string, result: WizardNextResult): ModelSetupWizardState {
     const next = wizardStateFromResult(
       authChoice,
       result,
@@ -154,18 +165,8 @@ export class ModelSetupWizardRunner {
       this.sessionId = null;
       this.abortController = null;
       this.options.onDone(this.startMethod, next.preparedModelRef);
-      return;
     }
-    // Gateway-executed steps (download/pull progress) carry no input controls,
-    // so nothing would ever ask for the next one. Keep polling: the session
-    // long-polls until the next update or the terminal result, so this renders
-    // live progress instead of freezing on the first frame.
-    if (next.phase === "step" && next.step.executor === "gateway") {
-      const generation = this.generation;
-      void this.requestNext(authChoice, undefined, generation).catch((error: unknown) => {
-        this.handleError(error, generation);
-      });
-    }
+    return next;
   }
 
   private handleError(error: unknown, generation: number): void {

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -9,6 +9,7 @@ const WIZARD_TEXT_INPUT_ID = "model-setup-wizard-text-input";
 type WizardViewProps = {
   mode: "auth" | "prepare";
   state: ModelSetupWizardState;
+  refreshWarning: string | null;
   value: unknown;
   onValueChange: (value: unknown) => void;
   onAnswer: (value: unknown, includeValue?: boolean) => void;
@@ -46,6 +47,9 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
           </h2>
         </div>
         <div class="model-setup-wizard__body">
+          ${props.refreshWarning
+            ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+            : nothing}
           ${props.state.phase === "starting"
             ? html`<div role="status">
                 ${t(


### PR DESCRIPTION
## What Problem This Solves

Current main already coordinates one-shot model activation and Memory/plugin mutations, but model-setup wizard start, prepare, and answer actions bypassed the shared RuntimeConfig mutation owner. Those Gateway sessions can persist `openclaw.json`, so a pending Settings draft could race the wizard commit and the Control UI could keep a stale config hash when authoritative refresh failed.

## Why This Change Was Made

One logical wizard segment now owns one `runExternalMutation` flight: start through the first human prompt, or answer through the next prompt/terminal result. Gateway-executed progress is awaited inside that segment so sibling writes cannot interleave. Terminal completion returns from the runner through `mutation.value`, and the owner's final `canDispatch` check drops queued work if generation, connection, capability, or access changes before dispatch. Refresh failures remain page-owned and visible across wizard steps, cancel/close, and reconnect.

The page was also returned below its line budget by extracting its existing catalog icon request/miss/blob lifecycle into `ModelSetupIconLoader`; no baseline or suppression changed.

The production growth is required by two explicit ownership boundaries: RuntimeConfig owns the complete wizard mutation/refresh segment, while `ModelSetupIconLoader` owns icon request cancellation, eligibility, publication, misses, and blob revocation outside the page.

## User Impact

Pending Settings edits flush before model setup writes, stale queued setup actions do not revive after access or generation changes, wizard commits refresh the authoritative config snapshot and hash, autonomous progress cannot interleave with another write, and refresh failures remain visibly actionable. No config, default, protocol, auth, or public API changes.

## Evidence

- Current-main bug: wizard start/prepare/answer invoked committing setup RPCs outside `runExternalMutation`.
- Red proof: restoring direct callbacks produced 5 failed / 7 passed tests and the wrong ordering `setup start -> wizard.next -> config.set`.
- Green focused proof: page/reconnect/runner/view tests passed 65/65, including delayed-write access revocation with no wizard RPC.
- Browser proof: the focused device-code Chromium E2E passed and retained the authoritative refresh warning inside the modal.
- `node scripts/check-changed.mjs -- <ten changed paths>` passed formatting, dependency, dead-export, i18n, core/UI tsgo, max-lines, and lint on Testbox `tbx_01kzmh69de0zav1yd5vn5nk3xs`; Actions run https://github.com/openclaw/openclaw/actions/runs/31344594179.
- Fresh Codex autoreview: clean, no accepted/actionable findings, confidence 0.98.
- Production/test delta: production +298/-175 (net +123); tests +349/-16 (net +333).
- ClawSweeper finding and rank-up move addressed: queued wizard dispatch now uses the mutation owner's final generation/access/capability guard with a delayed-flush regression. Exact-head CI remains required before merge.
