### PR TITLE
fix(test): configure kitchen-sink conformance personality

### DIFF
--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -269,11 +269,20 @@ function readConfig() {
 
 function configureRuntime() {
   const pluginId = process.env.KITCHEN_SINK_ID;
+  const personality = process.env.KITCHEN_SINK_PERSONALITY?.trim();
   const { configPath, config } = readConfig();
   config.plugins = config.plugins || {};
   config.plugins.entries = config.plugins.entries || {};
   config.plugins.entries[pluginId] = {
     ...config.plugins.entries[pluginId],
+    ...(personality
+      ? {
+          config: {
+            ...config.plugins.entries[pluginId]?.config,
+            personality,
+          },
+        }
+      : {}),
     hooks: {
       ...config.plugins.entries[pluginId]?.hooks,
       allowConversationAccess: true,

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -327,6 +327,32 @@ describe("kitchen-sink plugin assertions", () => {
     );
   });
 
+  it("persists the scenario personality in plugin config", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "openclaw-kitchen-sink-config-"));
+    try {
+      const result = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "configure-runtime"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          KITCHEN_SINK_ID: "openclaw-kitchen-sink-fixture",
+          KITCHEN_SINK_PERSONALITY: "conformance",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      const config = JSON.parse(
+        readFileSync(path.join(home, ".openclaw", "openclaw.json"), "utf8"),
+      );
+      expect(config.plugins.entries["openclaw-kitchen-sink-fixture"]).toMatchObject({
+        config: { personality: "conformance" },
+        hooks: { allowConversationAccess: true },
+      });
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
   it("requires kitchen-sink plugins to appear in inspect-all output", () => {
     const result = runAssertInstalled({
       allInspectPayload: [fullSurfaceInspectPayload("other-plugin")],


### PR DESCRIPTION
## Summary

- persist the kitchen-sink scenario personality through the plugin's public config entry
- keep the existing environment hint, but stop relying on ambient env propagation for conformance
- add a focused config-shape regression test

## Failure evidence

The frozen full-release validation's plugin prerelease Docker lane failed `npm-latest-conformance` because the installed plugin still registered the invalid full-surface probes:

- https://github.com/openclaw/openclaw/actions/runs/30642986531/job/91198370173

An isolated conformance-only Testbox run reproduced the same failure, proving this was not cross-scenario contamination.

## Validation

Blacksmith Testbox `tbx_01kywf4f86r0gk9b7z636afvhf`:

- before patch: isolated `npm-latest-conformance` Docker scenario failed with unexpected invalid diagnostics
- `node scripts/run-vitest.mjs test/scripts/kitchen-sink-plugin-assertions.test.ts` — 30 tests passed
- after patch: isolated `npm-latest-conformance` Docker scenario passed
- `./node_modules/.bin/oxfmt --check scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs test/scripts/kitchen-sink-plugin-assertions.test.ts` passed
- `git diff --check` passed
