### PR TITLE
fix(gateway): preserve authoritative owner event outcomes

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -17,6 +17,7 @@ import {
   releaseAgentRunContext,
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
+import { subscribePluginSessionsChanged } from "../plugins/gateway-events.js";
 
 const persistGatewaySessionLifecycleEventMock = vi.fn();
 const logErrorMock = vi.fn();
@@ -64,6 +65,7 @@ vi.mock("./session-utils.js", () => {
 
 import { getRuntimeConfig } from "../config/io.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   emitAgentEvent,
   emitAgentEvents,
@@ -1960,6 +1962,38 @@ describe("agent event handler", () => {
     const persistEvent = requireRecord(persistParams.event, "persist lifecycle event");
     expect(persistEvent.runId).toBe("run-finished");
     expect(requireRecord(persistEvent.data, "persist lifecycle event data").phase).toBe("end");
+  });
+
+  it("publishes run lifecycle changes to plugins without websocket subscribers", async () => {
+    const sessionKey = "agent:main:headless-run";
+    const received = vi.fn();
+    const unsubscribe = subscribePluginSessionsChanged(received);
+    const publisher = createGatewayBroadcaster({ clients: new Set() });
+    const { broadcastToConnIds, handler } = createHarness({
+      resolveSessionKeyForRun: () => sessionKey,
+    });
+    broadcastToConnIds.mockImplementation(publisher.broadcastToConnIds);
+    registerAgentRunContext("run-headless", { sessionKey, verboseLevel: "off" });
+
+    try {
+      emitAgentEvent(handler, "run-headless", "lifecycle", { phase: "start", startedAt: 900 });
+      await waitForFast(() => {
+        expect(received).toHaveBeenCalledWith({ sessionKey, phase: "start" });
+      });
+
+      emitAgentEvent(
+        handler,
+        "run-headless",
+        "lifecycle",
+        { phase: "end", startedAt: 900, endedAt: 1_700 },
+        { seq: 2, ts: 1_800 },
+      );
+      await waitForFast(() => {
+        expect(received.mock.calls.map(([event]) => event.phase)).toEqual(["start", "end"]);
+      });
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("does not project stale pre-reset lifecycle events into session subscriber snapshots", async () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -52,6 +52,7 @@ import type {
 } from "./server-chat-state.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
+import { hasSessionChangeReceivers } from "./session-change-receivers.js";
 import {
   deriveGatewaySessionLifecycleProjectionPatch,
   isRestartRecoveryLifecycleEvent,
@@ -819,7 +820,7 @@ export function createAgentEventHandler({
             return;
           }
           const sessionEventConnIds = sessionEventSubscribers.getAll();
-          if (sessionEventConnIds.size === 0) {
+          if (!hasSessionChangeReceivers(sessionEventConnIds)) {
             return;
           }
           broadcastToConnIds(
@@ -1665,7 +1666,7 @@ export function createAgentEventHandler({
         );
       });
       const sessionEventConnIds = sessionEventSubscribers.getAll();
-      if (sessionEventConnIds.size > 0) {
+      if (hasSessionChangeReceivers(sessionEventConnIds)) {
         broadcastToConnIds(
           "sessions.changed",
           {

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -1,5 +1,6 @@
 // Shared sessions.changed broadcaster for gateway RPC and chat-command mutations.
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { hasSessionChangeReceivers } from "../session-change-receivers.js";
 import { buildGatewaySessionEventFields } from "../session-event-payload.js";
 import { invalidateSessionSharingSnapshot } from "../session-sharing.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
@@ -25,7 +26,7 @@ export function emitSessionsChanged(
 ) {
   invalidateSessionSharingSnapshot(payload.sessionKey);
   const connIds = context.getSessionEventSubscriberConnIds();
-  if (connIds.size === 0) {
+  if (!hasSessionChangeReceivers(connIds)) {
     return;
   }
   const sessionRow = payload.sessionKey

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -11,7 +11,6 @@ import {
   loadSessionEntryReadOnly as loadAccessorSessionEntryReadOnly,
   resolveTranscriptSessionKeyBySessionId,
 } from "../config/sessions/session-accessor.js";
-import { hasPluginSessionsChangedSubscribers } from "../plugins/gateway-events.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -23,6 +22,7 @@ import type {
   SessionMessageSubscriberRegistry,
 } from "./server-chat.js";
 import { resolveVisibleActiveSessionRunState } from "./server-methods/session-active-runs.js";
+import { hasSessionChangeReceivers } from "./session-change-receivers.js";
 import {
   buildGatewaySessionEventFields,
   buildGatewaySessionEventRow,
@@ -39,10 +39,6 @@ import {
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
-
-function hasSessionsChangedReceiver(connIds: ReadonlySet<string>): boolean {
-  return connIds.size > 0 || hasPluginSessionsChangedSubscribers();
-}
 
 function readMessageIdempotencyKey(message: unknown): string | undefined {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
@@ -271,7 +267,7 @@ async function handleTranscriptUpdateBroadcast(
   }
   if (connIds.size === 0) {
     if (
-      !hasPluginSessionsChangedSubscribers() ||
+      !hasSessionChangeReceivers(connIds) ||
       (update.message !== undefined && projectChatDisplayMessage(update.message))
     ) {
       return;
@@ -388,7 +384,7 @@ async function handleTranscriptUpdateBroadcast(
   // Messages suppressed from display can still change transcript state, so
   // notify broad session listeners even when no session.message is emitted.
   const sessionEventConnIds = params.sessionEventSubscribers.getAll();
-  if (!hasSessionsChangedReceiver(sessionEventConnIds)) {
+  if (!hasSessionChangeReceivers(sessionEventConnIds)) {
     return;
   }
   params.broadcastToConnIds(
@@ -420,7 +416,7 @@ export function createLifecycleEventBroadcastHandler(params: {
       text?: string;
     };
     const connIds = params.sessionEventSubscribers.getAll();
-    if (!hasSessionsChangedReceiver(connIds)) {
+    if (!hasSessionChangeReceivers(connIds)) {
       return;
     }
     const sessionRow = loadGatewaySessionRow(event.sessionKey);

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-contracts";
 import { afterEach, expect, test, vi } from "vitest";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { subscribePluginSessionsChanged } from "../plugins/gateway-events.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   pinActivePluginSessionExtensionRegistry,
@@ -20,6 +21,7 @@ import {
   normalizeSessionDeliveryState,
   projectSessionDeliveryFields,
 } from "../utils/delivery-context.shared.js";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
 import { buildGatewaySessionRow } from "./session-utils.js";
 import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
@@ -694,6 +696,34 @@ test("sessions.changed mutation events refresh effective fast metadata", async (
     effectiveFastModeSource: "session",
     fastAutoOnSeconds: 30,
   });
+});
+
+test("sessions.changed mutations reach plugin subscribers without websocket clients", async () => {
+  await writeMainSessionStore({ label: "Original title" });
+  const received = vi.fn();
+  const unsubscribe = subscribePluginSessionsChanged(received);
+  const { broadcastToConnIds } = createGatewayBroadcaster({ clients: new Set() });
+
+  try {
+    await invokeSessionMutation({
+      method: "sessions.patch",
+      params: { key: "main", label: "Renamed title" },
+      subscribedConnIds: new Set(),
+      context: { broadcastToConnIds },
+    });
+
+    await vi.waitFor(() => {
+      expect(received).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+          label: "Renamed title",
+          reason: "patch",
+        }),
+      );
+    });
+  } finally {
+    unsubscribe();
+  }
 });
 
 test("sessions.list marks sessions with active abortable runs", async () => {

--- a/src/gateway/session-change-receivers.ts
+++ b/src/gateway/session-change-receivers.ts
@@ -1,0 +1,6 @@
+import { hasPluginSessionsChangedSubscribers } from "../plugins/gateway-events.js";
+
+/** Native plugin listeners remain session-change receivers without a websocket client. */
+export function hasSessionChangeReceivers(connIds: ReadonlySet<string>): boolean {
+  return connIds.size > 0 || hasPluginSessionsChangedSubscribers();
+}


### PR DESCRIPTION
## Summary

- Count existing native plugin session-change listeners as Gateway event receivers even when no WebSocket client is subscribed.
- Reuse one private receiver-ownership predicate across RPC session mutations, agent run start/end, transcript changes, and session lifecycle events.
- Keep event publication in the existing broadcaster; preserve subscriber cleanup, no-receiver fast paths, and existing WebSocket behavior.

## Root cause

Exactly **one** owner-boundary defect: Gateway session-change publishers inferred "no listeners" solely from an empty WebSocket subscriber set. The existing broadcaster already publishes `sessions.changed` to native plugins before inspecting connected sockets, but RPC mutation and agent lifecycle owners returned before reaching that broadcaster.

The defect is directly observable on current `origin/main` in `src/gateway/server-methods/session-change-event.ts:27`, `src/gateway/server-chat.ts:821`, and `src/gateway/server-chat.ts:1667`; broadcaster-owned plugin delivery already exists in `src/gateway/server-broadcast.ts:211`.

## Verification

- Frozen baseline: `e051a7bb4a6ba69b87391e990b00813114b1d482`.
- Exact immutable candidate: `5e126d5110cb60cac8535b2bdfef3186ee2e3112` on `codex/auto-qa-gateway-event-owner`.
- Current `origin/main`: `500fed6d4a91efc2ee3beb1b2d437cb58e5691cb`; candidate is not merged, none of its six changed paths diverged from the frozen baseline, and `git merge-tree origin/main HEAD` succeeds.
- **206/206 focused tests passed:** 188 Gateway session-event/mutation/agent-event tests plus 18 native plugin service lifecycle and subscription tests.
- Exact proof command: `OPENCLAW_VITEST_MAX_WORKERS=1 /Users/steipete/.local/bin/node scripts/run-vitest.mjs src/gateway/server-session-events.test.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server.sessions.list-changed.test.ts src/plugins/services.test.ts`.
- Production zero-client broadcaster plus actual native plugin subscriptions prove both `sessions.patch` delivery and ordered agent `start`/`end` delivery.
- Existing siblings verify transcript/lifecycle notifications, subscription revocation and disconnect-independent cleanup, duplicate subscriber isolation, stable snapshots, and throwing/rejecting handler containment.
- All six changed paths pass `oxlint --type-aware --deny-warnings --threads=1` with zero warnings; exact-commit `git diff --check` passes and the worktree is clean.
- Independent strict complete-owner review: **clean**. Genuine structured exact-commit Codex `gpt-5.6-sol` / `high` autoreview: **clean**, patch correct, **0.94** confidence, zero accepted/actionable findings. Official shared TruffleHog pre-scan: **clean**. Both exact-commit review artifacts are recorded in the companion landing manifest.

## Compatibility

Private Gateway implementation and focused tests only. No public protocol, authentication, configuration, SDK, security, persistent-state, plugin API, or user-visible setup changes.
