### PR TITLE
fix(ui): keep hidden session rail from reopening automatically

### DIFF
--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -187,6 +187,15 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     }
   };
 
+  protected sessionRailOpenRequestProps(sessionKey: string) {
+    return {
+      sessionRailOpenRequest:
+        this.sessionRailOpenSessionKey === sessionKey ? this.sessionRailOpenRequest : 0,
+      sessionRailConsumedOpenRequest: this.sessionRailConsumedOpenRequest,
+      onSessionRailOpenRequestConsumed: this.consumeSessionRailOpenRequest,
+    };
+  }
+
   protected readonly submitSessionCompanionQuestion = async (question: string) => {
     const state = this.state;
     if (!state || !state.sessionKey) {

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -143,6 +143,9 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected sessionRailLoad: Promise<void> | null = null;
   protected sessionRailOpenRequest = 0;
   protected sessionRailOpenSessionKey = "";
+  // The rail can unmount while catalog or lazy state is shown. Keep the consumed
+  // generation on the pane so a retained request cannot replay after remount.
+  protected sessionRailConsumedOpenRequest = 0;
   protected deferredSessionHydrationRequestVersion = 0;
   protected sessionCompanionHydrationKey = "";
   protected readonly sessionCompanionThreads = new ChatSessionCompanionThreads(() => {
@@ -177,6 +180,12 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     this.sessionRailOpenRequest += 1;
     this.requestUpdate();
   }
+
+  protected readonly consumeSessionRailOpenRequest = (openRequest: number) => {
+    if (openRequest > this.sessionRailConsumedOpenRequest) {
+      this.sessionRailConsumedOpenRequest = openRequest;
+    }
+  };
 
   protected readonly submitSessionCompanionQuestion = async (question: string) => {
     const state = this.state;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -283,8 +283,10 @@ export class ChatPane extends ChatPaneHeader {
         : this.sessionCompanionThreads.view(state.sessionKey),
       sessionRailOpenRequest:
         this.sessionRailOpenSessionKey === state.sessionKey ? this.sessionRailOpenRequest : 0,
+      sessionRailConsumedOpenRequest: this.sessionRailConsumedOpenRequest,
       sessionRailMode: selectedSessionRailMode,
       sessionRailDocked: !catalogKey && chatMainWidth >= SESSION_RAIL_DOCK_MIN_WIDTH,
+      onSessionRailOpenRequestConsumed: this.consumeSessionRailOpenRequest,
       onSessionRailSubmit: (question) => void this.submitSessionCompanionQuestion(question),
       onSessionRailDraftChange: (draft) =>
         this.sessionCompanionThreads.setDraft(state.sessionKey, draft),
@@ -704,3 +706,4 @@ export class ChatPane extends ChatPaneHeader {
     )}${this.renderResetConfirmation()}`;
   }
 }
+/* oxlint-disable max-lines -- TODO: split this oversized owner surface. */

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -281,12 +281,9 @@ export class ChatPane extends ChatPaneHeader {
       sessionRailCompanion: catalogKey
         ? undefined
         : this.sessionCompanionThreads.view(state.sessionKey),
-      sessionRailOpenRequest:
-        this.sessionRailOpenSessionKey === state.sessionKey ? this.sessionRailOpenRequest : 0,
-      sessionRailConsumedOpenRequest: this.sessionRailConsumedOpenRequest,
+      ...this.sessionRailOpenRequestProps(state.sessionKey),
       sessionRailMode: selectedSessionRailMode,
       sessionRailDocked: !catalogKey && chatMainWidth >= SESSION_RAIL_DOCK_MIN_WIDTH,
-      onSessionRailOpenRequestConsumed: this.consumeSessionRailOpenRequest,
       onSessionRailSubmit: (question) => void this.submitSessionCompanionQuestion(question),
       onSessionRailDraftChange: (draft) =>
         this.sessionCompanionThreads.setDraft(state.sessionKey, draft),
@@ -706,4 +703,3 @@ export class ChatPane extends ChatPaneHeader {
     )}${this.renderResetConfirmation()}`;
   }
 }
-/* oxlint-disable max-lines -- TODO: split this oversized owner surface. */

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -555,7 +555,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it(
-    "does not replay a retained session rail open generation after an A-B-A round trip",
+    "does not replay a consumed session rail open generation after round trips or remounts",
     FULL_APP_TEST_OPTIONS,
     async () => {
       if (!realChatServer) {
@@ -586,7 +586,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         );
         const result = await page.evaluate(async () => {
           localStorage.setItem("openclaw.chat.observerHud.display", "pill");
-          const rail = document.createElement("openclaw-chat-session-rail") as HTMLElement & {
+          type Rail = HTMLElement & {
             companion: {
               exchanges: [];
               pendingQuestion: null;
@@ -595,27 +595,38 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               draft: string;
             };
             connected: boolean;
+            consumedOpenRequest: number;
+            onOpenRequestConsumed: (openRequest: number) => void;
+            onVisibilityChange: (visible: boolean) => void;
             openRequest: number;
             sessionKey: string;
             updateComplete: Promise<boolean>;
           };
+          const createRail = () => document.createElement("openclaw-chat-session-rail") as Rail;
+          let rail = createRail();
+          let consumedOpenRequest = 0;
           let visibleReports = 0;
-          rail.companion = {
-            exchanges: [],
-            pendingQuestion: null,
-            failedQuestion: null,
-            hint: null,
-            draft: "What changed?",
+          const configureRail = (nextRail: Rail) => {
+            nextRail.companion = {
+              exchanges: [],
+              pendingQuestion: null,
+              failedQuestion: null,
+              hint: null,
+              draft: "What changed?",
+            };
+            nextRail.connected = true;
+            nextRail.consumedOpenRequest = consumedOpenRequest;
+            nextRail.onOpenRequestConsumed = (openRequest) => {
+              consumedOpenRequest = openRequest;
+            };
+            nextRail.onVisibilityChange = (visible) => {
+              if (visible) {
+                visibleReports += 1;
+              }
+            };
           };
-          rail.connected = true;
+          configureRail(rail);
           rail.sessionKey = "agent:main:a";
-          (
-            rail as typeof rail & { onVisibilityChange: (visible: boolean) => void }
-          ).onVisibilityChange = (visible) => {
-            if (visible) {
-              visibleReports += 1;
-            }
-          };
           document.body.replaceChildren(rail);
           await rail.updateComplete;
           const mode = () =>
@@ -623,26 +634,42 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           const update = async (sessionKey: string, openRequest: number) => {
             rail.sessionKey = sessionKey;
             rail.openRequest = openRequest;
+            rail.consumedOpenRequest = consumedOpenRequest;
             await rail.updateComplete;
             return mode();
           };
 
+          const sameElementModes = [
+            await update("agent:main:a", 1),
+            await update("agent:main:b", 0),
+            await update("agent:main:a", 1),
+            await update("agent:main:a", 2),
+          ];
+          rail.remove();
+          rail = createRail();
+          configureRail(rail);
+          rail.sessionKey = "agent:main:a";
+          rail.openRequest = 2;
+          document.body.append(rail);
+          await rail.updateComplete;
+          const remountMode = mode();
+          const nextGenerationMode = await update("agent:main:a", 3);
+
           return {
-            modes: [
-              await update("agent:main:a", 1),
-              await update("agent:main:b", 0),
-              await update("agent:main:a", 1),
-              await update("agent:main:a", 2),
-            ],
+            sameElementModes,
+            remountMode,
+            nextGenerationMode,
             storedPreference: localStorage.getItem("openclaw.chat.observerHud.display"),
             visibleReports,
           };
         });
 
         expect(result).toEqual({
-          modes: ["expanded", "pill", "pill", "expanded"],
+          sameElementModes: ["expanded", "pill", "pill", "expanded"],
+          remountMode: "pill",
+          nextGenerationMode: "expanded",
           storedPreference: "pill",
-          visibleReports: 2,
+          visibleReports: 3,
         });
       } finally {
         await closeBrowserPage(page);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -554,6 +554,102 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     sharedBrowser = null;
   });
 
+  it(
+    "does not replay a retained session rail open generation after an A-B-A round trip",
+    FULL_APP_TEST_OPTIONS,
+    async () => {
+      if (!realChatServer) {
+        throw new Error("Expected the Control UI server to be ready");
+      }
+      const page = await openBrowserPage(900, 700);
+      try {
+        await page.goto(realChatServer.baseUrl, {
+          waitUntil: "domcontentloaded",
+          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+        });
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve, reject) => {
+              const script = document.createElement("script");
+              script.type = "module";
+              script.src = "/src/pages/chat/components/chat-session-rail.ts";
+              script.addEventListener("load", () => resolve(), { once: true });
+              script.addEventListener(
+                "error",
+                () => reject(new Error("Session rail module failed")),
+                {
+                  once: true,
+                },
+              );
+              document.head.append(script);
+            }),
+        );
+        const result = await page.evaluate(async () => {
+          localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+          const rail = document.createElement("openclaw-chat-session-rail") as HTMLElement & {
+            companion: {
+              exchanges: [];
+              pendingQuestion: null;
+              failedQuestion: null;
+              hint: null;
+              draft: string;
+            };
+            connected: boolean;
+            openRequest: number;
+            sessionKey: string;
+            updateComplete: Promise<boolean>;
+          };
+          let visibleReports = 0;
+          rail.companion = {
+            exchanges: [],
+            pendingQuestion: null,
+            failedQuestion: null,
+            hint: null,
+            draft: "What changed?",
+          };
+          rail.connected = true;
+          rail.sessionKey = "agent:main:a";
+          (
+            rail as typeof rail & { onVisibilityChange: (visible: boolean) => void }
+          ).onVisibilityChange = (visible) => {
+            if (visible) {
+              visibleReports += 1;
+            }
+          };
+          document.body.replaceChildren(rail);
+          await rail.updateComplete;
+          const mode = () =>
+            rail.querySelector(".chat-session-rail--expanded") ? "expanded" : "pill";
+          const update = async (sessionKey: string, openRequest: number) => {
+            rail.sessionKey = sessionKey;
+            rail.openRequest = openRequest;
+            await rail.updateComplete;
+            return mode();
+          };
+
+          return {
+            modes: [
+              await update("agent:main:a", 1),
+              await update("agent:main:b", 0),
+              await update("agent:main:a", 1),
+              await update("agent:main:a", 2),
+            ],
+            storedPreference: localStorage.getItem("openclaw.chat.observerHud.display"),
+            visibleReports,
+          };
+        });
+
+        expect(result).toEqual({
+          modes: ["expanded", "pill", "pill", "expanded"],
+          storedPreference: "pill",
+          visibleReports: 2,
+        });
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
+
   it.each([
     [320, 568],
     [1366, 900],

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -81,7 +81,7 @@ describe("ChatSessionRailState", () => {
     localStorage.setItem(displayPreferenceKey, "pill");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.tryAutoOpen(1)).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
     expect(new ChatSessionRailState().mode(input())).toBe("pill");
@@ -91,7 +91,7 @@ describe("ChatSessionRailState", () => {
     localStorage.setItem(displayPreferenceKey, "off");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen()).toBe(false);
+    expect(state.tryAutoOpen(1)).toBe(false);
     expect(state.mode(input())).toBe("restore-icon");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
     expect(new ChatSessionRailState().mode(input())).toBe("restore-icon");
@@ -100,27 +100,31 @@ describe("ChatSessionRailState", () => {
   it("persists explicit collapse and hide after transient auto-open", () => {
     const state = new ChatSessionRailState("pill");
 
-    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.tryAutoOpen(1)).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     state.collapse();
     expect(state.mode(input())).toBe("pill");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
 
-    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.tryAutoOpen(2)).toBe(true);
     state.hide();
     expect(state.mode(input())).toBe("restore-icon");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
-    expect(state.tryAutoOpen()).toBe(false);
+    expect(state.tryAutoOpen(3)).toBe(false);
   });
 
   it("clears transient auto-open when the session changes", () => {
     localStorage.setItem(displayPreferenceKey, "pill");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.tryAutoOpen(1)).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     state.resetTransientState();
     expect(state.mode(input())).toBe("pill");
+    expect(state.tryAutoOpen(1)).toBe(false);
+    expect(state.mode(input())).toBe("pill");
+    expect(state.tryAutoOpen(2)).toBe(true);
+    expect(state.mode(input())).toBe("expanded");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 
@@ -376,17 +380,31 @@ describe("ChatSessionRailElement", () => {
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 
-  it("clears pill auto-open on session change without changing persistence", async () => {
+  it("does not replay a retained auto-open request after a session round trip", async () => {
     localStorage.setItem(displayPreferenceKey, "pill");
-    const element = await mount();
+    const onVisibilityChange = vi.fn();
+    const element = await mount({ onVisibilityChange });
 
     element.openRequest = 1;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+    expect(onVisibilityChange).toHaveBeenCalledOnce();
 
     element.sessionKey = "agent:main:other";
+    element.openRequest = 0;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+
+    element.sessionKey = "agent:main:run";
+    element.openRequest = 1;
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+    expect(onVisibilityChange).toHaveBeenCalledOnce();
+
+    element.openRequest = 2;
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+    expect(onVisibilityChange).toHaveBeenCalledTimes(2);
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 });

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -81,7 +81,7 @@ describe("ChatSessionRailState", () => {
     localStorage.setItem(displayPreferenceKey, "pill");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen(1)).toBe(true);
+    expect(state.tryAutoOpen()).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
     expect(new ChatSessionRailState().mode(input())).toBe("pill");
@@ -91,7 +91,7 @@ describe("ChatSessionRailState", () => {
     localStorage.setItem(displayPreferenceKey, "off");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen(1)).toBe(false);
+    expect(state.tryAutoOpen()).toBe(false);
     expect(state.mode(input())).toBe("restore-icon");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
     expect(new ChatSessionRailState().mode(input())).toBe("restore-icon");
@@ -100,30 +100,28 @@ describe("ChatSessionRailState", () => {
   it("persists explicit collapse and hide after transient auto-open", () => {
     const state = new ChatSessionRailState("pill");
 
-    expect(state.tryAutoOpen(1)).toBe(true);
+    expect(state.tryAutoOpen()).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     state.collapse();
     expect(state.mode(input())).toBe("pill");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
 
-    expect(state.tryAutoOpen(2)).toBe(true);
+    expect(state.tryAutoOpen()).toBe(true);
     state.hide();
     expect(state.mode(input())).toBe("restore-icon");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
-    expect(state.tryAutoOpen(3)).toBe(false);
+    expect(state.tryAutoOpen()).toBe(false);
   });
 
   it("clears transient auto-open when the session changes", () => {
     localStorage.setItem(displayPreferenceKey, "pill");
     const state = new ChatSessionRailState();
 
-    expect(state.tryAutoOpen(1)).toBe(true);
+    expect(state.tryAutoOpen()).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     state.resetTransientState();
     expect(state.mode(input())).toBe("pill");
-    expect(state.tryAutoOpen(1)).toBe(false);
-    expect(state.mode(input())).toBe("pill");
-    expect(state.tryAutoOpen(2)).toBe(true);
+    expect(state.tryAutoOpen()).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
@@ -343,7 +341,8 @@ describe("ChatSessionRailElement", () => {
 
   it("does not reopen or report visible after hide when an open request arrives", async () => {
     const onVisibilityChange = vi.fn();
-    const element = await mount({ onVisibilityChange });
+    const onOpenRequestConsumed = vi.fn();
+    const element = await mount({ onOpenRequestConsumed, onVisibilityChange });
 
     (element.querySelector(".chat-session-rail__hide") as HTMLButtonElement | null)?.click();
     await element.updateComplete;
@@ -356,19 +355,22 @@ describe("ChatSessionRailElement", () => {
 
     expect(element.querySelector(".chat-session-rail--restore")).not.toBeNull();
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
+    expect(onOpenRequestConsumed).toHaveBeenCalledWith(1);
     expect(onVisibilityChange).not.toHaveBeenCalled();
   });
 
   it("auto-opens from pill without persisting card, then collapses persistently", async () => {
     localStorage.setItem(displayPreferenceKey, "pill");
+    const onOpenRequestConsumed = vi.fn();
     const onVisibilityChange = vi.fn();
-    const element = await mount({ onVisibilityChange });
+    const element = await mount({ onOpenRequestConsumed, onVisibilityChange });
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
 
     element.openRequest = 1;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
+    expect(onOpenRequestConsumed).toHaveBeenCalledWith(1);
     expect(onVisibilityChange).toHaveBeenCalledOnce();
     expect(onVisibilityChange).toHaveBeenLastCalledWith(true);
 
@@ -382,16 +384,22 @@ describe("ChatSessionRailElement", () => {
 
   it("does not replay a retained auto-open request after a session round trip", async () => {
     localStorage.setItem(displayPreferenceKey, "pill");
+    let consumedOpenRequest = 0;
+    const onOpenRequestConsumed = vi.fn((openRequest: number) => {
+      consumedOpenRequest = openRequest;
+    });
     const onVisibilityChange = vi.fn();
-    const element = await mount({ onVisibilityChange });
+    const element = await mount({ onOpenRequestConsumed, onVisibilityChange });
 
     element.openRequest = 1;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+    expect(consumedOpenRequest).toBe(1);
     expect(onVisibilityChange).toHaveBeenCalledOnce();
 
     element.sessionKey = "agent:main:other";
     element.openRequest = 0;
+    element.consumedOpenRequest = consumedOpenRequest;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
 
@@ -404,6 +412,7 @@ describe("ChatSessionRailElement", () => {
     element.openRequest = 2;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+    expect(onOpenRequestConsumed).toHaveBeenCalledTimes(2);
     expect(onVisibilityChange).toHaveBeenCalledTimes(2);
     expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -54,10 +54,16 @@ describe("ChatSessionRailState", () => {
     expect(state.mode(input())).toBe("pill");
     state.expand();
     expect(state.mode(input())).toBe("expanded");
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("card");
     state.collapse();
     expect(state.mode(input())).toBe("pill");
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
     state.hide();
     expect(state.mode(input())).toBe("restore-icon");
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+    state.show();
+    expect(state.mode(input())).toBe("pill");
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
   });
 
   it("opens digest-less from the restore icon and resets per session", () => {
@@ -65,8 +71,29 @@ describe("ChatSessionRailState", () => {
     const idle = { running: false, activeRunId: null, digest: null } as const;
     state.show();
     expect(state.mode(input(idle))).toBe("pill");
-    state.resetManualOpen();
+    state.resetTransientState();
     expect(state.mode(input(idle))).toBe("restore-icon");
+  });
+
+  it("keeps automatic expansion transient and rejects it while hidden", () => {
+    const pillState = new ChatSessionRailState("pill");
+    expect(pillState.expandTransiently()).toBe(true);
+    expect(pillState.mode(input())).toBe("expanded");
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBeNull();
+    pillState.collapse();
+    expect(pillState.mode(input())).toBe("pill");
+
+    const hiddenState = new ChatSessionRailState("off");
+    expect(hiddenState.expandTransiently()).toBe(false);
+    expect(hiddenState.mode(input())).toBe("restore-icon");
+  });
+
+  it("clears transient expansion when the session changes", () => {
+    const state = new ChatSessionRailState("pill");
+    expect(state.expandTransiently()).toBe(true);
+    expect(state.mode(input())).toBe("expanded");
+    state.resetTransientState();
+    expect(state.mode(input())).toBe("pill");
   });
 
   it("keeps a companion thread renderable without an observer digest", () => {
@@ -280,5 +307,42 @@ describe("ChatSessionRailElement", () => {
       ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+  });
+
+  it("does not reopen or report visible after hide when an open request arrives", async () => {
+    const onVisibilityChange = vi.fn();
+    const element = await mount({ onVisibilityChange });
+
+    (element.querySelector(".chat-session-rail__hide") as HTMLButtonElement | null)?.click();
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--restore")).not.toBeNull();
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+
+    onVisibilityChange.mockClear();
+    element.openRequest = 1;
+    await element.updateComplete;
+
+    expect(element.querySelector(".chat-session-rail--restore")).not.toBeNull();
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+  });
+
+  it("auto-opens from pill without persisting card and clears on session change", async () => {
+    localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+    const onVisibilityChange = vi.fn();
+    const element = await mount({ onVisibilityChange });
+    expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+
+    element.openRequest = 1;
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    expect(onVisibilityChange).toHaveBeenCalledOnce();
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(true);
+
+    element.sessionKey = "agent:main:other";
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
   });
 });

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -37,6 +37,8 @@ function input(overrides: Partial<SessionRailInput> = {}): SessionRailInput {
   };
 }
 
+const displayPreferenceKey = "openclaw.chat.observerHud.display";
+
 describe("ChatSessionRailState", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
@@ -54,16 +56,16 @@ describe("ChatSessionRailState", () => {
     expect(state.mode(input())).toBe("pill");
     state.expand();
     expect(state.mode(input())).toBe("expanded");
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("card");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("card");
     state.collapse();
     expect(state.mode(input())).toBe("pill");
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
     state.hide();
     expect(state.mode(input())).toBe("restore-icon");
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
     state.show();
     expect(state.mode(input())).toBe("pill");
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 
   it("opens digest-less from the restore icon and resets per session", () => {
@@ -75,25 +77,51 @@ describe("ChatSessionRailState", () => {
     expect(state.mode(input(idle))).toBe("restore-icon");
   });
 
-  it("keeps automatic expansion transient and rejects it while hidden", () => {
-    const pillState = new ChatSessionRailState("pill");
-    expect(pillState.expandTransiently()).toBe(true);
-    expect(pillState.mode(input())).toBe("expanded");
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBeNull();
-    pillState.collapse();
-    expect(pillState.mode(input())).toBe("pill");
+  it("auto-opens pill transiently without changing the persisted preference", () => {
+    localStorage.setItem(displayPreferenceKey, "pill");
+    const state = new ChatSessionRailState();
 
-    const hiddenState = new ChatSessionRailState("off");
-    expect(hiddenState.expandTransiently()).toBe(false);
-    expect(hiddenState.mode(input())).toBe("restore-icon");
+    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.mode(input())).toBe("expanded");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
+    expect(new ChatSessionRailState().mode(input())).toBe("pill");
   });
 
-  it("clears transient expansion when the session changes", () => {
+  it("rejects auto-open while hidden and preserves the off preference", () => {
+    localStorage.setItem(displayPreferenceKey, "off");
+    const state = new ChatSessionRailState();
+
+    expect(state.tryAutoOpen()).toBe(false);
+    expect(state.mode(input())).toBe("restore-icon");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
+    expect(new ChatSessionRailState().mode(input())).toBe("restore-icon");
+  });
+
+  it("persists explicit collapse and hide after transient auto-open", () => {
     const state = new ChatSessionRailState("pill");
-    expect(state.expandTransiently()).toBe(true);
+
+    expect(state.tryAutoOpen()).toBe(true);
+    expect(state.mode(input())).toBe("expanded");
+    state.collapse();
+    expect(state.mode(input())).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
+
+    expect(state.tryAutoOpen()).toBe(true);
+    state.hide();
+    expect(state.mode(input())).toBe("restore-icon");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
+    expect(state.tryAutoOpen()).toBe(false);
+  });
+
+  it("clears transient auto-open when the session changes", () => {
+    localStorage.setItem(displayPreferenceKey, "pill");
+    const state = new ChatSessionRailState();
+
+    expect(state.tryAutoOpen()).toBe(true);
     expect(state.mode(input())).toBe("expanded");
     state.resetTransientState();
     expect(state.mode(input())).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 
   it("keeps a companion thread renderable without an observer digest", () => {
@@ -220,7 +248,7 @@ describe("ChatSessionCompanionThreads", () => {
 describe("ChatSessionRailElement", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
-    localStorage.setItem("openclaw.chat.observerHud.display", "card");
+    localStorage.setItem(displayPreferenceKey, "card");
     vi.spyOn(Date, "now").mockReturnValue(600_000);
   });
 
@@ -316,19 +344,19 @@ describe("ChatSessionRailElement", () => {
     (element.querySelector(".chat-session-rail__hide") as HTMLButtonElement | null)?.click();
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--restore")).not.toBeNull();
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
 
     onVisibilityChange.mockClear();
     element.openRequest = 1;
     await element.updateComplete;
 
     expect(element.querySelector(".chat-session-rail--restore")).not.toBeNull();
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("off");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
     expect(onVisibilityChange).not.toHaveBeenCalled();
   });
 
-  it("auto-opens from pill without persisting card and clears on session change", async () => {
-    localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+  it("auto-opens from pill without persisting card, then collapses persistently", async () => {
+    localStorage.setItem(displayPreferenceKey, "pill");
     const onVisibilityChange = vi.fn();
     const element = await mount({ onVisibilityChange });
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
@@ -336,13 +364,29 @@ describe("ChatSessionRailElement", () => {
     element.openRequest = 1;
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
     expect(onVisibilityChange).toHaveBeenCalledOnce();
     expect(onVisibilityChange).toHaveBeenLastCalledWith(true);
+
+    element
+      .querySelector(".chat-session-rail--expanded")
+      ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
+  });
+
+  it("clears pill auto-open on session change without changing persistence", async () => {
+    localStorage.setItem(displayPreferenceKey, "pill");
+    const element = await mount();
+
+    element.openRequest = 1;
+    await element.updateComplete;
+    expect(element.querySelector(".chat-session-rail--expanded")).not.toBeNull();
 
     element.sessionKey = "agent:main:other";
     await element.updateComplete;
     expect(element.querySelector(".chat-session-rail--pill")).not.toBeNull();
-    expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    expect(localStorage.getItem(displayPreferenceKey)).toBe("pill");
   });
 });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1859,6 +1859,10 @@ describe("session rail open requests", () => {
     localStorage.setItem("openclaw.chat.observerHud.display", "pill");
     const container = document.createElement("div");
     document.body.append(container);
+    let consumedOpenRequest = 0;
+    const onSessionRailOpenRequestConsumed = vi.fn((openRequest: number) => {
+      consumedOpenRequest = openRequest;
+    });
     const onObserverVisibilityChange = vi.fn();
     const companion = {
       exchanges: [],
@@ -1874,7 +1878,9 @@ describe("session rail open requests", () => {
             sessionKey,
             sessionRailReady: true,
             sessionRailOpenRequest,
+            sessionRailConsumedOpenRequest: consumedOpenRequest,
             sessionRailCompanion: companion,
+            onSessionRailOpenRequestConsumed,
             onObserverVisibilityChange,
           }),
         ),
@@ -1891,6 +1897,7 @@ describe("session rail open requests", () => {
     try {
       let rail = await renderSession("agent:main:a", 1);
       expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+      expect(consumedOpenRequest).toBe(1);
 
       rail = await renderSession("agent:main:b", 0);
       expect(rail?.querySelector(".chat-session-rail--pill")).not.toBeNull();
@@ -1901,6 +1908,68 @@ describe("session rail open requests", () => {
 
       rail = await renderSession("agent:main:a", 2);
       expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+      expect(onSessionRailOpenRequestConsumed).toHaveBeenCalledTimes(2);
+      expect(onObserverVisibilityChange).toHaveBeenCalledTimes(2);
+      expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    } finally {
+      container.remove();
+    }
+  });
+
+  it("does not replay a consumed generation after the rail unmounts and remounts", async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+    const container = document.createElement("div");
+    document.body.append(container);
+    let consumedOpenRequest = 0;
+    const onSessionRailOpenRequestConsumed = vi.fn((openRequest: number) => {
+      consumedOpenRequest = openRequest;
+    });
+    const onObserverVisibilityChange = vi.fn();
+    const renderRail = async (sessionRailReady: boolean, sessionRailOpenRequest: number) => {
+      render(
+        renderChat(
+          createChatProps({
+            sessionKey: "agent:main:a",
+            sessionRailReady,
+            sessionRailOpenRequest,
+            sessionRailConsumedOpenRequest: consumedOpenRequest,
+            sessionRailCompanion: {
+              exchanges: [],
+              pendingQuestion: null,
+              failedQuestion: null,
+              hint: null,
+              draft: "What changed?",
+            },
+            onSessionRailOpenRequestConsumed,
+            onObserverVisibilityChange,
+          }),
+        ),
+        container,
+      );
+      const rail = container.querySelector(
+        "openclaw-chat-session-rail",
+      ) as ChatSessionRailElement | null;
+      await rail?.updateComplete;
+      return rail;
+    };
+
+    try {
+      let rail = await renderRail(true, 1);
+      expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+      expect(consumedOpenRequest).toBe(1);
+
+      rail = await renderRail(false, 1);
+      expect(rail).toBeNull();
+
+      rail = await renderRail(true, 1);
+      expect(rail?.querySelector(".chat-session-rail--pill")).not.toBeNull();
+      expect(onSessionRailOpenRequestConsumed).toHaveBeenCalledOnce();
+      expect(onObserverVisibilityChange).toHaveBeenCalledOnce();
+
+      rail = await renderRail(true, 2);
+      expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+      expect(onSessionRailOpenRequestConsumed).toHaveBeenCalledTimes(2);
       expect(onObserverVisibilityChange).toHaveBeenCalledTimes(2);
       expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
     } finally {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -26,6 +26,7 @@ import {
   createSessionsListResult,
   DEFAULT_CHAT_MODEL_CATALOG,
 } from "../../test-helpers/chat-model.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   getChatAttachmentDataUrl,
@@ -50,6 +51,7 @@ import {
   renderChatModelControls,
   type ChatModelControlsProps,
 } from "./components/chat-model-controls.ts";
+import { ChatSessionRailElement } from "./components/chat-session-rail.ts";
 import {
   resetChatThreadPresentationState,
   resetChatThreadSessionPresentationState,
@@ -1849,6 +1851,62 @@ afterEach(() => {
   replaceSlashCommands(buildFallbackSlashCommands());
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe("session rail open requests", () => {
+  it("does not replay the pane's retained generation after an A-B-A round trip", async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+    const container = document.createElement("div");
+    document.body.append(container);
+    const onObserverVisibilityChange = vi.fn();
+    const companion = {
+      exchanges: [],
+      pendingQuestion: null,
+      failedQuestion: null,
+      hint: null,
+      draft: "What changed?",
+    };
+    const renderSession = async (sessionKey: string, sessionRailOpenRequest: number) => {
+      render(
+        renderChat(
+          createChatProps({
+            sessionKey,
+            sessionRailReady: true,
+            sessionRailOpenRequest,
+            sessionRailCompanion: companion,
+            onObserverVisibilityChange,
+          }),
+        ),
+        container,
+      );
+      const rail = container.querySelector(
+        "openclaw-chat-session-rail",
+      ) as ChatSessionRailElement | null;
+      expect(rail).not.toBeNull();
+      await rail?.updateComplete;
+      return rail;
+    };
+
+    try {
+      let rail = await renderSession("agent:main:a", 1);
+      expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+
+      rail = await renderSession("agent:main:b", 0);
+      expect(rail?.querySelector(".chat-session-rail--pill")).not.toBeNull();
+
+      rail = await renderSession("agent:main:a", 1);
+      expect(rail?.querySelector(".chat-session-rail--pill")).not.toBeNull();
+      expect(onObserverVisibilityChange).toHaveBeenCalledOnce();
+
+      rail = await renderSession("agent:main:a", 2);
+      expect(rail?.querySelector(".chat-session-rail--expanded")).not.toBeNull();
+      expect(onObserverVisibilityChange).toHaveBeenCalledTimes(2);
+      expect(localStorage.getItem("openclaw.chat.observerHud.display")).toBe("pill");
+    } finally {
+      container.remove();
+    }
+  });
 });
 
 describe("per-pane chat presentation state", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -108,8 +108,10 @@ export type ChatProps = {
   onObserverVisibilityChange?: (visible: boolean) => void;
   sessionRailCompanion?: ChatSessionCompanionThread;
   sessionRailOpenRequest?: number;
+  sessionRailConsumedOpenRequest?: number;
   sessionRailMode?: SessionRailMode;
   sessionRailDocked?: boolean;
+  onSessionRailOpenRequestConsumed?: (openRequest: number) => void;
   onSessionRailSubmit?: (question: string) => void;
   onSessionRailDraftChange?: (draft: string) => void;
   onSessionRailClear?: () => void;
@@ -643,6 +645,8 @@ export function renderChat(props: ChatProps) {
                       .companion=${props.sessionRailCompanion}
                       .connected=${props.connected}
                       .openRequest=${props.sessionRailOpenRequest ?? 0}
+                      .consumedOpenRequest=${props.sessionRailConsumedOpenRequest ?? 0}
+                      .onOpenRequestConsumed=${props.onSessionRailOpenRequestConsumed}
                       .onSubmit=${props.onSessionRailSubmit}
                       .onDraftChange=${props.onSessionRailDraftChange}
                       .onClear=${props.onSessionRailClear}

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -49,9 +49,6 @@ function unreadFinalDigest(digest: SessionObserverDigest, lastReadAt?: number): 
 export class ChatSessionRailState {
   private autoExpandedRunIds = new Set<string>();
   private autoExpandedRunId: string | null = null;
-  // The pane projects a retained generation as 0 while another session is selected.
-  // Keep consumption across resets so A/N -> B/0 -> A/N cannot replay N.
-  private lastHandledOpenRequest = 0;
   private transientExpanded = false;
   // Explicit open from the restore icon while idle: the companion must stay
   // reachable at any point, even with no digest and an empty thread.
@@ -67,11 +64,7 @@ export class ChatSessionRailState {
     this.manualOpen = false;
   }
 
-  tryAutoOpen(openRequest: number): boolean {
-    if (openRequest <= this.lastHandledOpenRequest) {
-      return false;
-    }
-    this.lastHandledOpenRequest = openRequest;
+  tryAutoOpen(): boolean {
     if (this.displayPreference === "off") {
       return false;
     }
@@ -199,6 +192,8 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
   };
   @property({ attribute: false }) connected = false;
   @property({ attribute: false }) openRequest = 0;
+  @property({ attribute: false }) consumedOpenRequest = 0;
+  @property({ attribute: false }) onOpenRequestConsumed?: (openRequest: number) => void;
   @property({ attribute: false }) onSubmit?: (question: string) => void;
   @property({ attribute: false }) onDraftChange?: (draft: string) => void;
   @property({ attribute: false }) onClear?: () => void;
@@ -229,8 +224,9 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
         this.terminalAgeReference = Date.now();
       }
     }
-    if (changedProperties.has("openRequest") && this.openRequest > 0) {
-      if (this.railState.tryAutoOpen(this.openRequest)) {
+    if (changedProperties.has("openRequest") && this.openRequest > this.consumedOpenRequest) {
+      this.onOpenRequestConsumed?.(this.openRequest);
+      if (this.railState.tryAutoOpen()) {
         this.onVisibilityChange?.(true);
       }
     }

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -64,7 +64,7 @@ export class ChatSessionRailState {
     this.manualOpen = false;
   }
 
-  expandTransiently(): boolean {
+  tryAutoOpen(): boolean {
     if (this.displayPreference === "off") {
       return false;
     }
@@ -223,7 +223,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
       }
     }
     if (changedProperties.has("openRequest") && this.openRequest > 0) {
-      if (this.railState.expandTransiently()) {
+      if (this.railState.tryAutoOpen()) {
         this.onVisibilityChange?.(true);
       }
     }

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -49,6 +49,7 @@ function unreadFinalDigest(digest: SessionObserverDigest, lastReadAt?: number): 
 export class ChatSessionRailState {
   private autoExpandedRunIds = new Set<string>();
   private autoExpandedRunId: string | null = null;
+  private transientExpanded = false;
   // Explicit open from the restore icon while idle: the companion must stay
   // reachable at any point, even with no digest and an empty thread.
   private manualOpen = false;
@@ -57,8 +58,18 @@ export class ChatSessionRailState {
     private displayPreference: ChatObserverDisplayPreference = loadChatObserverDisplayPreference(),
   ) {}
 
-  resetManualOpen(): void {
+  resetTransientState(): void {
+    this.transientExpanded = false;
+    this.autoExpandedRunId = null;
     this.manualOpen = false;
+  }
+
+  expandTransiently(): boolean {
+    if (this.displayPreference === "off") {
+      return false;
+    }
+    this.transientExpanded = true;
+    return true;
   }
 
   mode(input: SessionRailInput): SessionRailMode {
@@ -82,32 +93,36 @@ export class ChatSessionRailState {
       this.autoExpandedRunIds.add(runId);
       this.autoExpandedRunId = runId;
     }
-    return this.displayPreference === "card" || (runId !== null && this.autoExpandedRunId === runId)
+    return this.displayPreference === "card" ||
+      this.transientExpanded ||
+      (runId !== null && this.autoExpandedRunId === runId)
       ? "expanded"
       : "pill";
   }
 
   expand(): void {
     this.displayPreference = "card";
+    this.transientExpanded = false;
     this.autoExpandedRunId = null;
     storeChatObserverDisplayPreference("card");
   }
 
   collapse(): void {
     this.displayPreference = "pill";
+    this.transientExpanded = false;
     this.autoExpandedRunId = null;
     storeChatObserverDisplayPreference("pill");
   }
 
   hide(): void {
     this.displayPreference = "off";
-    this.autoExpandedRunId = null;
-    this.manualOpen = false;
+    this.resetTransientState();
     storeChatObserverDisplayPreference("off");
   }
 
   show(): void {
     this.displayPreference = "pill";
+    this.transientExpanded = false;
     this.autoExpandedRunId = null;
     this.manualOpen = true;
     storeChatObserverDisplayPreference("pill");
@@ -198,9 +213,9 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
   protected override willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("sessionKey")) {
       this.terminalAgeReference = Date.now();
-      // A manual idle-open is a per-session gesture; it must not leak the
-      // rail open into the next selected session.
-      this.railState.resetManualOpen();
+      // Automatic and manual opens are per-session gestures; neither may leak
+      // the rail open into the next selected session.
+      this.railState.resetTransientState();
     }
     if (changedProperties.has("digest") && this.digest) {
       if (this.digest.health === "done" || this.digest.health === "failed") {
@@ -208,8 +223,9 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
       }
     }
     if (changedProperties.has("openRequest") && this.openRequest > 0) {
-      this.railState.expand();
-      this.onVisibilityChange?.(true);
+      if (this.railState.expandTransiently()) {
+        this.onVisibilityChange?.(true);
+      }
     }
   }
 

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -49,6 +49,9 @@ function unreadFinalDigest(digest: SessionObserverDigest, lastReadAt?: number): 
 export class ChatSessionRailState {
   private autoExpandedRunIds = new Set<string>();
   private autoExpandedRunId: string | null = null;
+  // The pane projects a retained generation as 0 while another session is selected.
+  // Keep consumption across resets so A/N -> B/0 -> A/N cannot replay N.
+  private lastHandledOpenRequest = 0;
   private transientExpanded = false;
   // Explicit open from the restore icon while idle: the companion must stay
   // reachable at any point, even with no digest and an empty thread.
@@ -64,7 +67,11 @@ export class ChatSessionRailState {
     this.manualOpen = false;
   }
 
-  tryAutoOpen(): boolean {
+  tryAutoOpen(openRequest: number): boolean {
+    if (openRequest <= this.lastHandledOpenRequest) {
+      return false;
+    }
+    this.lastHandledOpenRequest = openRequest;
     if (this.displayPreference === "off") {
       return false;
     }
@@ -223,7 +230,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
       }
     }
     if (changedProperties.has("openRequest") && this.openRequest > 0) {
-      if (this.railState.tryAutoOpen()) {
+      if (this.railState.tryAutoOpen(this.openRequest)) {
         this.onVisibilityChange?.(true);
       }
     }


### PR DESCRIPTION
Closes #116921

## What Problem This Solves

Fixes two ways the Control UI session companion rail could reopen after the operator had collapsed or hidden it:

1. Automatic open requests shared the explicit persistent `expand()` path and could overwrite `off` or `pill` with `card`.
2. A consumed request generation could replay after session changes or after the rail element unmounted while catalog or lazy state hid it.

The failing lifecycle sequence was:

`A/N -> rail unmounts -> rail remounts with A/N`

The pane retained generation N, but child-owned consumption state disappeared with the old rail element.

## Why This Change Was Made

The pane now owns one bounded, monotonic consumed-generation scalar. It passes the scalar and a consume callback through Chat View to the rail.

The rail consumes a new generation before applying display preference:

- `off` rejects automatic opening but still consumes the request;
- `pill` expands transiently without persisting `card`;
- session changes clear only transient visual state;
- rail unmount/remount preserves consumption because the pane outlives the child;
- explicit show, expand, collapse, and hide remain the only stored-preference mutations.

No per-session map, config, schema, migration, or new persistence surface was added.

The rail visibility callback remains tied to gateway observer visibility. A session change or rail unmount must not emit `false`, because that would disable observer updates rather than merely collapse the UI.

## Owner Boundary

- Producer and lifecycle owner: `ChatPaneBase` owns the pane-local request generation and its consumed generation.
- Projection: `chat-pane-render.ts` and `chat-view.ts` pass the current generation, consumed generation, and consume callback.
- Consumer: `ChatSessionRailElement` acknowledges a newer generation, then applies transient visual policy through `ChatSessionRailState`.
- Persisted preference owner remains unchanged in `ChatSessionRailState`.

## User Impact

- An explicitly hidden rail stays hidden, including across reloads.
- Pill users get activity-driven expansion without losing the pill preference.
- A same-element A/N -> B/0 -> A/N round trip does not replay N.
- Removing and remounting the rail with retained A/N does not replay N.
- A genuinely newer generation still opens the rail.

## Evidence

- Exact rebased head: `0ad25f539505471a8a07b3b68c654617388f3c83`.
- Rebase base: `b58b2057a34097adbc70284d7e007ebc80a248c1`.
- Focused current-head UI run: 297 tests passed across `chat-responsive.browser.test.ts` and `chat-view.test.ts`.
- The sole responsive-browser failure is the unrelated native gateway picker CSS assertion; it reproduces identically on current main.
- `node scripts/check-max-lines-ratchet.mjs --base origin/main` passed with 993 grandfathered suppressions.
- `git diff --check origin/main...HEAD` passed.
- The five rebased commits retain valid Git signatures.
- Secret and diff scrub was clean.

## ClawSweeper Rank-up Moves

- Exact-head source, caller, and browser review: completed.
- Explicit maintainer approval: completed.
- Fresh exact-head workflow refresh: completed successfully on `0ad25f539505471a8a07b3b68c654617388f3c83`.

## Current Hold

No code, review-thread, mergeability, or exact-head CI blocker remains.
