### PR TITLE
fix(memory): suggest reindex, not --fix, for a missing qmd index

### DIFF
--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -552,7 +552,15 @@ export async function runMemoryStatus(
         lines.push(`  ${issue.severity === "error" ? warn(issue.message) : muted(issue.message)}`);
       }
       if (!opts.fix) {
-        lines.push(`  ${muted(`Fix: openclaw memory status --fix --agent ${agentId}`)}`);
+        // Only a subset of audit issues are repaired by `--fix`; a missing qmd
+        // index needs a reindex instead, so each hint is gated on the matching
+        // issue actually being present.
+        if (audit.issues.some((issue) => issue.fixable)) {
+          lines.push(`  ${muted(`Fix: openclaw memory status --fix --agent ${agentId}`)}`);
+        }
+        if (audit.issues.some((issue) => issue.code === "qmd-index-missing")) {
+          lines.push(`  ${muted(`Fix: openclaw memory index --agent ${agentId}`)}`);
+        }
       }
     }
     if (dreamingAudit?.issues.length) {
@@ -562,7 +570,7 @@ export async function runMemoryStatus(
       for (const issue of dreamingAudit.issues) {
         lines.push(`  ${issue.severity === "error" ? warn(issue.message) : muted(issue.message)}`);
       }
-      if (!opts.fix) {
+      if (!opts.fix && dreamingAudit.issues.some((issue) => issue.fixable)) {
         lines.push(`  ${muted(`Fix: openclaw memory status --fix --agent ${agentId}`)}`);
       }
     }

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1450,6 +1450,34 @@ describe("memory cli", () => {
     });
   });
 
+  it("suggests reindexing instead of --fix when the qmd index is missing", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const close = vi.fn(async () => {});
+      const missingDbPath = path.join(qmdFixtureRoot, `missing-${qmdCaseId++}.sqlite`);
+      mockManager({
+        probeVectorAvailability: vi.fn(async () => true),
+        status: () =>
+          makeMemoryStatus({
+            backend: "qmd",
+            provider: "qmd",
+            model: "qmd",
+            requestedProvider: "qmd",
+            workspaceDir,
+            dbPath: missingDbPath,
+          }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expectLogged(log, "QMD index file is missing.");
+      expectLogged(log, "Fix: openclaw memory index --agent main");
+      expectNotLogged(log, "Fix: openclaw memory status --fix --agent main");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   it("fails index when qmd db file is empty", async () => {
     const close = vi.fn(async () => {});
     const sync = vi.fn(async () => {});


### PR DESCRIPTION
## What Problem This Solves

Fixes #116937.

When an agent has no qmd store at all (0 files, no index — not a stale
one), `openclaw memory status --agent <id>` reports the audit issue
"QMD index file is missing." followed by a blanket hint:

```
Fix: openclaw memory status --fix --agent <id>
```

Running that suggested `--fix` returns `Repair: no changes` and leaves
the problem unresolved. Per `--help`, `--fix` only repairs stale recall
locks and normalizes promotion metadata — it has no code path that
creates a missing qmd index. The audit issue for a missing qmd index
(`qmd-index-missing`) is already marked `fixable: false` in
`short-term-promotion-artifacts.ts`, but `cli-status.runtime.ts` always
printed the `--fix` hint whenever *any* audit issue existed, regardless
of whether that issue was actually repairable by `--fix`.

## Why This Change Was Made

`extensions/memory-core/src/cli-status.runtime.ts` builds the "Issues"
section of `memory status` from `audit.issues` /
`dreamingAudit.issues`, each of which already carries a `fixable`
boolean. The fix hint should reflect that flag instead of firing
unconditionally:

- Only print `Fix: openclaw memory status --fix --agent <id>` when at
  least one present issue is actually `fixable: true` (applies to both
  the short-term promotion audit and the dreaming-artifacts audit).
- When the qmd index file is missing (`qmd-index-missing`), print
  `Fix: openclaw memory index --agent <id>` instead — `memory index`
  runs the manager's `sync`/reindex path, which creates the missing
  index from scratch (confirmed by reading
  `extensions/memory-core/src/cli-index-search.runtime.ts`, where
  `runMemoryIndex` calls `syncFn` and only stats the resulting db file
  afterward).

This is the minimal fix described as option 2 in the issue: change the
suggested remediation message rather than teaching `--fix` a new,
unrelated repair path.

## User Impact

Operators debugging an agent with a missing memory index now get a
command that actually resolves the problem, instead of being sent down
a dead-end (`--fix` reporting "no changes"). No behavior changes for
any issue that `--fix` can actually repair.

## Evidence

Added a test in `extensions/memory-core/src/cli.test.ts`:
`"suggests reindexing instead of --fix when the qmd index is missing"`.
It sets a qmd-backend status pointing at a nonexistent db path and
asserts the output contains `Fix: openclaw memory index --agent main`
and does **not** contain `Fix: openclaw memory status --fix --agent main`.

Confirmed the test fails without the fix (reverted only
`cli-status.runtime.ts` via `git checkout HEAD~1 --
extensions/memory-core/src/cli-status.runtime.ts`, ran the test, saw
the old blanket `Fix: openclaw memory status --fix --agent main` hint
printed instead), then restored the fix and re-ran:

```
$ node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts
 Test Files  1 passed (1)
      Tests  79 passed (79)
```

Also ran, both clean:
```
$ ./node_modules/.bin/oxfmt --check extensions/memory-core/src/cli-status.runtime.ts extensions/memory-core/src/cli.test.ts
$ node scripts/check-changed.mjs -- extensions/memory-core/src/cli-status.runtime.ts extensions/memory-core/src/cli.test.ts
# typecheck extensions / typecheck extension tests / lint extension changed files / guards all passed
```

AI-assistance disclosure: this change was authored with the assistance
of an AI coding agent (Claude), reviewed and validated as described
above before being pushed.


## Real QMD Behavior Proof

Requested by ClawSweeper review: a redacted terminal transcript from a
real QMD-backed agent showing the missing-index status, `openclaw
memory index --agent <id>` running, and the follow-up status no longer
reporting the missing-index condition.

Ran against a real `qmd` binary (`npm install -g @tobilu/qmd`, v2.5.3)
in an isolated `HOME`/state dir (no mocks, no CLI-internal test
harness):

```
$ node openclaw.mjs config patch --stdin <<< '{ "memory": { "backend": "qmd" } }'
Applied 1 config update(s). Restart the gateway to apply.

$ mkdir -p ~/.openclaw/workspace/memory
$ echo '# Test note' > ~/.openclaw/workspace/memory/notes.md

$ node openclaw.mjs memory status --agent main
Memory Search (main)
Provider: qmd (requested: qmd)
...
Store: ~/.openclaw/agents/main/qmd/xdg-cache/qmd/index.sqlite
...
Issues:
  sessions directory missing (~/.openclaw/agents/main/sessions)
  QMD index file is missing.
  Fix: openclaw memory index --agent main

$ node openclaw.mjs memory index --agent main
[memory] qmd manager initialized for agent "main" mode=cli collections=3 durationMs=933
[memory] qmd sync completed for agent "main" reason=cli durationMs=196
QMD index: ~/.openclaw/agents/main/qmd/xdg-cache/qmd/index.sqlite (114688 bytes)
Memory index updated (main).

$ node openclaw.mjs memory status --agent main
Memory Search (main)
Provider: qmd (requested: qmd)
...
Indexed: 1/1 files · 1 chunks
Store: ~/.openclaw/agents/main/qmd/xdg-cache/qmd/index.sqlite
...
Issues:
  sessions directory missing (~/.openclaw/agents/main/sessions)
```

Before the fix (missing index, `main` had the unconditional hint), the
last line of the first status run would instead have been `Fix:
openclaw memory status --fix --agent main`, which repairs nothing for
this issue. With the fix, the hint is `openclaw memory index --agent
main`, and running it creates the real QMD `index.sqlite` from
scratch, after which the "QMD index file is missing." issue and its
hint no longer appear in status output — confirming `memory index`
resolves the exact reported condition end-to-end against a real QMD
sidecar.
