### PR TITLE
fix(auto-reply): avoid false overload attribution on stalled replies

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -453,7 +453,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
         operation.staleExpiryReason === "stuck_recovery");
     const queuedFinal = droppedBeforeOutput
       ? dispatcher.sendFinalReply({
-          text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
+          text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
           isError: true,
         })
       : false;

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -140,31 +140,34 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("sends overload feedback when stuck recovery expires the active reply", async () => {
-    let resolverStarted: () => void = () => {};
-    const resolverStartedPromise = new Promise<void>((resolve) => {
-      resolverStarted = resolve;
-    });
-    const dispatchParams = createVisibleDispatchParams(async (_ctx, options) => {
-      resolverStarted();
-      await new Promise<void>((resolve) => {
-        options?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+  it.each(["no_activity", "stuck_recovery"] as const)(
+    "sends truthful stalled feedback when %s expires the active reply",
+    async (reason) => {
+      let resolverStarted: () => void = () => {};
+      const resolverStartedPromise = new Promise<void>((resolve) => {
+        resolverStarted = resolve;
       });
-      const error = new Error("reply expired");
-      error.name = "AbortError";
-      throw error;
-    });
+      const dispatchParams = createVisibleDispatchParams(async (_ctx, options) => {
+        resolverStarted();
+        await new Promise<void>((resolve) => {
+          options?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        const error = new Error("reply expired");
+        error.name = "AbortError";
+        throw error;
+      });
 
-    const dispatchPromise = dispatchReplyFromConfig(dispatchParams);
-    await resolverStartedPromise;
-    const operation = replyRunRegistry.get(sessionKey);
-    expect(operation).toBeDefined();
-    expect(expireStaleReplyOperation(operation!, "stuck_recovery")).toBe(true);
+      const dispatchPromise = dispatchReplyFromConfig(dispatchParams);
+      await resolverStartedPromise;
+      const operation = replyRunRegistry.get(sessionKey);
+      expect(operation).toBeDefined();
+      expect(expireStaleReplyOperation(operation!, reason)).toBe(true);
 
-    await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: true });
-    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
-      text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
-      isError: true,
-    });
-  });
+      await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: true });
+      expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
+        text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+        isError: true,
+      });
+    },
+  );
 });


### PR DESCRIPTION
Closes #116949.

## What Problem This Solves

Fixes an issue where users whose visible reply stalled during recovery were told that the Gateway was overloaded even when no overload evidence existed.

## Why This Change Was Made

The stale-reply dispatch boundary now reports only the known fact: the turn stopped making progress and was interrupted. Provider overload copy remains owned by the existing typed provider-error paths.

The regression covers both stale reasons that reach this notice: `no_activity` and `stuck_recovery`. This is intentionally separate from https://github.com/openclaw/openclaw/pull/111092, which repairs broader silent terminal projection and remains proof-blocked.

## User Impact

Users still receive a visible retry notice after a pre-output stalled reply is cleared, but the notice no longer directs them toward an unsupported Gateway-overload diagnosis.

## Evidence

Frozen base: `5332641ed3bab552d23fb16c67bc697a373ea9d7`

Exact head: `83b60b9a7a5e067303edd5fe6856598695d9b4ae`

Production LOC delta: `+1 / -1` (net zero).

- Baseline focused suite: 3 passed while asserting the incorrect overload copy.
- Regression-first run: both `no_activity` and `stuck_recovery` cases failed with the old overload text.
- After fix: `dispatch-from-config.stale-recovery.test.ts` plus `reply-run-registry.test.ts`: 2 files, 55 tests passed.
- Targeted `oxfmt --check`: passed.
- Targeted `oxlint`: passed.
- `git diff --check`: passed.
- Final-diff automated review: clean, no actionable findings.
- Secret/private-data preflight: clean.

`check:changed` could not acquire a remote backend: Blacksmith Testbox was unauthenticated, and the configured brokered providers require a newer Crabbox/login. No live provider or channel credentials were used; the deterministic failure and fix are exercised at the production reply-dispatch boundary immediately before outbound delivery.

Agent transcript omitted.


## Real Behavior Proof
Artifact: `.artifacts/issue-116949-pr116959-83b60b9/verdict.json`
Blacksmith Testbox was unauthenticated, so this trusted maintainer head used the policy-approved focused local fallback.
```json
{
  "schemaVersion": 1,
  "generatedAt": "2026-07-31T17:17:40.489Z",
  "pr": {
    "number": 116959,
    "head": "83b60b9a7a5e067303edd5fe6856598695d9b4ae"
  },
  "issue": 116949,
  "execution": {
    "mode": "trusted-focused-local-fallback",
    "gateway": "ephemeral real Gateway child",
    "provider": "repo mock-openai HTTP/SSE server",
    "channel": "repo qa-channel bus transport",
    "staleTrigger": "Gateway-only clock advanced 600001ms after pre-output model call began",
    "remoteFallbackReason": "Blacksmith Testbox client not authenticated"
  },
  "realBehavior": {
    "result": "PASS",
    "assertions": {
      "exactHead": true,
      "delayedRequestReachedMockProvider": true,
      "activeRunObservedBeforeTakeover": true,
      "neutralFinalDelivered": true,
      "neutralFinalRepliesToInterruptedTurn": true,
      "noFalseGatewayOverloadAttribution": true,
      "replacementTurnCompleted": true
    },
    "observed": {
      "neutralText": "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
      "recoveryText": "QA-STALE-RECOVERY-NEXT-TURN-OK",
      "outboundCount": 2
    }
  },
  "focusedTests": [
    {
      "command": "node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts",
      "result": "PASS",
      "tests": {
        "passed": 4,
        "total": 4
      },
      "contract": "Both no_activity and stuck_recovery pre-output expiries emit the neutral final."
    },
    {
      "command": "node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts",
      "result": "PASS",
      "tests": {
        "passed": 74,
        "total": 74
      },
      "contracts": [
        "Typed periodic rate limits retain weekly-limit and reset-time attribution.",
        "Typed overload failures retain overload attribution without rate-limit cooldown copy."
      ]
    }
  ],
  "verdict": "PASS"
}
```
