### PR TITLE
fix(imessage): recover the oldest missed messages during catchup

### DIFF
--- a/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
@@ -4,6 +4,7 @@ import { getIMessageRuntime } from "../runtime.js";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
 import {
+  advanceIMessageCatchupCursor,
   IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES,
   IMESSAGE_CATCHUP_CURSOR_NAMESPACE,
   resolveCatchupConfig,
@@ -446,5 +447,287 @@ describe("runIMessageCatchup", () => {
 
     expect(summary.replayed).toBe(1);
     expect(dispatched).toEqual(["g-600"]);
+  });
+
+  it("recovers the oldest rows when one chat's backlog exceeds perRunLimit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-05-08T11:30:00Z"),
+      lastSeenRowid: 0,
+    });
+    const backlogStartMs = Date.parse("2026-05-08T11:31:00Z");
+    const backlog = Array.from({ length: 100 }, (_, index) =>
+      makeRow({
+        id: index + 1,
+        guid: `g-${index + 1}`,
+        chat_id: 1,
+        created_at: new Date(backlogStartMs + (index + 1) * 1_000).toISOString(),
+      }),
+    );
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 1, last_message_at: "2026-05-08T11:59:00.000Z" }] };
+      }
+      if (method === "messages.history") {
+        const p = params as { limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        return {
+          messages: backlog
+            .filter((row) => Date.parse(String(row.created_at)) >= startMs)
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const runCatchup = async () =>
+      await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config: resolveCatchupConfig({ enabled: true, perRunLimit: 50, maxAgeMinutes: 60 }),
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+      });
+
+    const first = await runCatchup();
+    expect(first.fullyCaughtUp).toBe(false);
+    expect(first.cursorAfter.lastSeenRowid).toBe(50);
+    expect(dispatched).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+
+    const second = await runCatchup();
+    expect(second.fullyCaughtUp).toBe(true);
+    expect(second.cursorAfter.lastSeenRowid).toBe(100);
+    expect(dispatched).toEqual(Array.from({ length: 100 }, (_, index) => index + 1));
+  });
+
+  it("keeps live cursor eligibility when a chat backlog exceeds the per-chat history budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    const warnings: string[] = [];
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-05-08T11:30:00Z"),
+      lastSeenRowid: 0,
+    });
+    const backlogStartMs = Date.parse("2026-05-08T11:31:00Z");
+    const backlog = Array.from({ length: 520 }, (_, index) =>
+      makeRow({
+        id: index + 1,
+        guid: `g-${index + 1}`,
+        chat_id: 1,
+        created_at: new Date(backlogStartMs + (index + 1) * 1_000).toISOString(),
+      }),
+    );
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 1, last_message_at: "2026-05-08T11:59:00.000Z" }] };
+      }
+      if (method === "messages.history") {
+        const p = params as { limit: number };
+        return {
+          messages: backlog
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const summary = await runIMessageCatchup({
+      client: client as never,
+      accountId: "default",
+      config: resolveCatchupConfig({ enabled: true, perRunLimit: 500, maxAgeMinutes: 60 }),
+      includeAttachments: false,
+      dispatchPayload: async () => {},
+      runtime: { log: (msg) => warnings.push(msg) },
+    });
+
+    expect(summary.querySucceeded).toBe(true);
+    expect(summary.fullyCaughtUp).toBe(true);
+    expect(warnings.filter((msg) => /cannot be recovered|unrecoverable/.test(msg))).toEqual([]);
+  });
+
+  it("delivers interleaved chats without claiming loss when one chat fills the history budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    const warnings: string[] = [];
+    const config = resolveCatchupConfig({ enabled: true, perRunLimit: 50, maxAgeMinutes: 60 });
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-05-08T11:00:00Z"),
+      lastSeenRowid: 0,
+    });
+    const epochMs = Date.parse("2026-05-08T11:01:00Z");
+    const rowMs = (rowid: number) => epochMs + rowid * 1_000;
+    const db = [
+      ...Array.from({ length: 100 }, (_, index) => index + 1).map((rowid) =>
+        makeRow({
+          id: rowid,
+          guid: `g-${rowid}`,
+          chat_id: 2,
+          created_at: new Date(rowMs(rowid)).toISOString(),
+        }),
+      ),
+      ...Array.from({ length: 500 }, (_, index) => index + 101).map((rowid) =>
+        makeRow({
+          id: rowid,
+          guid: `g-${rowid}`,
+          chat_id: 1,
+          created_at: new Date(rowMs(rowid)).toISOString(),
+        }),
+      ),
+    ];
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return {
+          chats: [
+            { id: 1, last_message_at: new Date(rowMs(600)).toISOString() },
+            { id: 2, last_message_at: new Date(rowMs(100)).toISOString() },
+          ],
+        };
+      }
+      if (method === "messages.history") {
+        const p = params as { chat_id: number; limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        return {
+          messages: db
+            .filter(
+              (row) => row.chat_id === p.chat_id && Date.parse(String(row.created_at)) >= startMs,
+            )
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const runCatchup = async () =>
+      await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config,
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+        runtime: { log: (msg) => warnings.push(msg) },
+      });
+
+    const first = await runCatchup();
+    expect(dispatched).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+    expect(first.cursorAfter.lastSeenRowid).toBe(50);
+
+    let last = first;
+    for (let pass = 0; pass < 20 && !last.fullyCaughtUp; pass++) {
+      last = await runCatchup();
+    }
+    expect(last.fullyCaughtUp).toBe(true);
+    expect(dispatched).toEqual(Array.from({ length: 600 }, (_, index) => index + 1));
+    expect(last.cursorAfter.lastSeenRowid).toBe(600);
+    expect(warnings.filter((msg) => /cannot be recovered|unrecoverable/.test(msg))).toEqual([]);
+  });
+
+  it("delivers the downtime backlog on the next startup after a full page and live traffic", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    const warnings: string[] = [];
+    const config = resolveCatchupConfig({ enabled: true, perRunLimit: 500, maxAgeMinutes: 60 });
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-05-08T11:00:00Z"),
+      lastSeenRowid: 0,
+    });
+    const epochMs = Date.parse("2026-05-08T11:01:00Z");
+    const rowMs = (rowid: number) => epochMs + rowid * 1_000;
+    const db: Array<Record<string, unknown>> = [];
+    const addRows = (from: number, to: number, chatId: number) => {
+      for (let rowid = from; rowid <= to; rowid++) {
+        db.push(
+          makeRow({
+            id: rowid,
+            guid: `g-${rowid}`,
+            chat_id: chatId,
+            created_at: new Date(rowMs(rowid)).toISOString(),
+          }),
+        );
+      }
+    };
+    addRows(1, 500, 1);
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        const latest = new Map<number, number>();
+        for (const row of db) {
+          const chatId = row.chat_id as number;
+          const at = Date.parse(String(row.created_at));
+          latest.set(chatId, Math.max(latest.get(chatId) ?? at, at));
+        }
+        return {
+          chats: [...latest].map(([id, at]) => ({
+            id,
+            last_message_at: new Date(at).toISOString(),
+          })),
+        };
+      }
+      if (method === "messages.history") {
+        const p = params as { chat_id: number; limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        return {
+          messages: db
+            .filter(
+              (row) => row.chat_id === p.chat_id && Date.parse(String(row.created_at)) >= startMs,
+            )
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const runStartupCatchup = async () => {
+      const summary = await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config,
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+        runtime: { log: (msg) => warnings.push(msg) },
+      });
+      return { summary, liveCursorEnabled: summary.querySucceeded && summary.fullyCaughtUp };
+    };
+
+    const startup = await runStartupCatchup();
+    expect(dispatched).toEqual(Array.from({ length: 500 }, (_, index) => index + 1));
+    expect(warnings.filter((msg) => /cannot be recovered|unrecoverable/.test(msg))).toEqual([]);
+    expect(startup.liveCursorEnabled).toBe(true);
+
+    addRows(501, 1_200, 1);
+    for (let rowid = 501; rowid <= 1_200; rowid++) {
+      if (startup.liveCursorEnabled) {
+        await advanceIMessageCatchupCursor(
+          "default",
+          { lastSeenMs: rowMs(rowid), lastSeenRowid: rowid },
+          config,
+        );
+      }
+    }
+
+    addRows(1_201, 1_260, 2);
+    dispatched.length = 0;
+    const restart = await runStartupCatchup();
+    expect(dispatched).toEqual(Array.from({ length: 60 }, (_, index) => index + 1_201));
+    expect(restart.summary.cursorAfter.lastSeenRowid).toBe(1_260);
+    expect(restart.summary.fullyCaughtUp).toBe(true);
   });
 });

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -13,11 +13,11 @@ import {
 import { parseIMessageNotification } from "./parse-notification.js";
 import type { IMessagePayload } from "./types.js";
 
-// Per-chat history fetch budget. messages.history is per-chat; we cap each
-// chat's fetch to the global perRunLimit so a single noisy group cannot
-// dominate the cursor advance — the cross-chat sort + final slice still
-// caps the global pass at perRunLimit.
-const PER_CHAT_HISTORY_LIMIT_CAP = 500;
+// Per-chat history fetch budget. Upstream `messages.history` orders
+// `date DESC LIMIT ?`, so a smaller limit drops the OLDEST rows. Always ask
+// for the full budget: the cross-chat sort + perRunLimit slice below can only
+// pick the true oldest rows if the per-chat page reached them.
+const PER_CHAT_HISTORY_LIMIT = 500;
 
 // chats.list page size used during catchup. 200 covers far more than any
 // realistic offline window worth of distinct chats while staying well under
@@ -113,7 +113,6 @@ export async function runIMessageCatchup(
     }
     const chats = chatsResult?.chats ?? [];
     const collected: IMessageCatchupRow[] = [];
-    const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
     let historyFetchFailed = false;
     // Track the highest rowid / date the imsg bridge actually returned across
     // all chats, regardless of whether each row passed the parser. The catchup
@@ -143,7 +142,7 @@ export async function runIMessageCatchup(
           "messages.history",
           {
             chat_id: chatId,
-            limit: perChatLimit,
+            limit: PER_CHAT_HISTORY_LIMIT,
             start: sinceISO,
             attachments: includeAttachments,
           },


### PR DESCRIPTION
## What Problem This Solves

With `catchup.enabled: true`, messages that arrive while the gateway is down are supposed to be replayed on the next startup. They are not. After downtime longer than `perRunLimit` messages, the OLDEST missed messages are dropped permanently and catchup reports itself fully caught up.

`messages.history` is a per-chat descending query. `catchup-bridge.ts` asked each chat for only `perRunLimit` rows, so with the default `perRunLimit: 50` a 100-message backlog came back as rowids 51 to 100 and rowids 1 to 50 were never fetched. The cross-chat sort, the `perRunLimit` slice, and the watermark clamp downstream are all designed to hand out the oldest rows first across startups, but they can only pick from rows the per-chat page actually reached. The cursor then advanced past the rows that were never fetched, so no later startup could reach them either.

## Why This Change Was Made

Root cause, `extensions/imessage/src/monitor/catchup-bridge.ts:113` and `:145` on main:

```ts
const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
...
{ chat_id: chatId, limit: perChatLimit, start: sinceISO, attachments: includeAttachments }
```

`limit` here is `perRunLimit`, the global replay cap. Upstream `imsg` runs `... ORDER BY date DESC LIMIT ?`, so shrinking the limit does not trim the newest rows, it trims the oldest ones, server side, before OpenClaw sees them. The comment on `PER_CHAT_HISTORY_LIMIT_CAP` described the intent correctly (stop one noisy group from dominating a pass) but the mechanism it chose deletes the exact rows catchup exists to recover.

The fix is to always request the full per-chat budget:

```ts
{ chat_id: chatId, limit: PER_CHAT_HISTORY_LIMIT, start: sinceISO, attachments: includeAttachments }
```

Fairness across chats was never the fetch limit's job. The cross-chat sort plus the `perRunLimit` slice already caps each pass globally and already hands out the true oldest rows first, and the watermark clamp already holds the cursor at the last dispatched rowid so the next startup resumes exactly where this one stopped. Production delta is 6 added and 7 removed lines.

Sibling surfaces: the three other `messages.history` callers are unaffected because they all want the most recent rows, which is what a descending limited query returns. `approval-reaction-poller.ts:109` and `conversation-repair.ts:196` pass no lower time bound at all, and `dm-history.ts:123` already compensates by requesting `limit + 1` and taking `slice(-maxMessages)`.

## User Impact

Any operator running the iMessage plugin with catchup enabled silently loses the start of every downtime backlog longer than `perRunLimit` messages. It is the worst failure class in this repo: the messages never reach the agent, and catchup reports success. With this change the same backlog is delivered complete, oldest first, across as many startups as the global `perRunLimit` requires.

## Changes since the last review

ClawSweeper's open finding was `[P2] Do not call a global ROWID gap unrecoverable` at `catchup-bridge.ts:209-214`, and the matching P1 merge risk. The finding is correct. The previous head compared this chat's oldest fetched rowid against `sinceRowid`, which is the global cursor, so rowids that simply belong to a different conversation read as a gap and the operator was told they could not be recovered.

That diagnostic is now removed rather than reworded. There is no sound per-chat completeness signal available from a single descending page: a full page means the budget was reached, never that older rows exist. Making the line tentative would keep an operator-facing claim that cannot be checked, and `main` ships no such warning today, so removing it is not a regression against `main`. This also drops the PR back to a single-purpose recovery fix. A truthful version needs a per-chat continuation contract from upstream `imsg` (a cursor or a has-more flag on `messages.history`); that is a separate change against the dependency and is not started here.

The interleaved-chat regression the review asked for is added: two conversations sharing one global rowid space, one of them filling the entire 500-row budget, driven to completion across startups. It fails against `main` and passes here, and it also fails against the previous head's diagnostic if that code is restored.

Explicit maintainer decision left open: a single conversation with more than 500 messages inside the catchup window still has its oldest rows dropped, and after this change nothing in the log names that. The alternative is to strand the durable cursor behind the live stream, which the previous review already rejected as a P1. Accepting the silent case is the deliberate tradeoff on this PR.

## Evidence

Local gates, from a deps-enabled worktree at head `71eaa9b954016dc3f7d1b2d058973c4398a026d1`:

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/cache-lifecycle.test.ts` - 46 passed. Against pristine main's `catchup-bridge.ts` the same suite fails 2 cases: `recovers the oldest rows when one chat's backlog exceeds perRunLimit` and `delivers interleaved chats without claiming loss when one chat fills the history budget`.
- `node scripts/run-oxlint.mjs extensions/imessage/src/monitor/catchup-bridge.ts extensions/imessage/src/monitor/catchup-bridge.test-support.ts` - clean.
- `./node_modules/.bin/oxfmt --check` on both changed files - clean.
- `git diff --check` - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` - no diagnostics in any changed file. Both lanes report two errors that reproduce on pristine main in this checkout and are unrelated to this change: `packages/terminal-core/src/ansi.ts(194,38) TS2554` and `@openclaw/session-url-contract/parse` unresolved.
- Full build not run; this change touches no dynamic imports, module boundaries, or published surfaces.

## Real behavior proof

Behavior addressed: with `catchup.enabled: true` and the default `perRunLimit: 50`, messages that arrived during gateway downtime are dropped permanently instead of replayed, starting from the oldest, while catchup reports itself fully caught up.
Real environment tested: the native `imsg` binary 0.13.4 from steipete/tap, running on macOS 26.3 as `imsg rpc --json --db <path>` and executing its own Swift `ChatMessagesQuery` SQL against a real SQLite `chat.db` built on the Apple Messages schema with Apple-epoch nanosecond dates. On the OpenClaw side the real `IMessageRpcClient` spawned that binary as a child process and spoke newline-delimited JSON-RPC over stdio, the real `runIMessageCatchup` entry point drove every gateway startup, and the catchup cursor was the real SQLite-backed plugin-state keyed store on disk, carried across startups. Nothing in the RPC or cursor path is substituted. Runs were done on pristine main `e31a6e29fff724e07e108d7c5cef3ed104dc2354`, on the previous head of this branch `b2ad08b2498966ee94ac49b2111b085228727b5e`, and on this head `71eaa9b954016dc3f7d1b2d058973c4398a026d1`, with identical inputs. All identifiers in the database are synthetic: handles `+15550000001` and `+15550000002` from the reserved 555 range, message GUIDs are literal `PROOF-GUID-NNN` values. No personal conversation data and no real `chat.db` was read.
Exact steps or command run after this patch: build a `chat.db` on the Messages schema holding one downtime backlog of 600 messages interleaved across two conversations in a single global rowid space, conversation 2 owning rowids 1 to 100 and conversation 1 owning rowids 101 to 600 so conversation 1 fills the entire per-chat budget; spawn `imsg rpc --json --db <path>` through the real client; seed the persisted cursor at rowid 0; then drive repeated gateway startups with `perRunLimit: 50` until catchup reports nothing left to replay, recording every rowid handed to the inbound dispatch path and every operator log line.
Evidence after fix:
```
# BEFORE (pristine main e31a6e29fff7)
native imsg binary: 0.13.4
messages.history(chat_id=1, limit=50) returned rowids 551..600 (50 rows, newest first)
startups run: 3
messages delivered to the gateway: 100 of 600
oldest delivered rowid: 51
permanently missed rowids: 500 (1..550)
final persisted cursor rowid: 600
operator lines claiming permanent loss: 0
first permanent-loss line: none

# PREVIOUS HEAD OF THIS BRANCH (b2ad08b24989, identical inputs)
native imsg binary: 0.13.4
messages.history(chat_id=1, limit=50) returned rowids 551..600 (50 rows, newest first)
startups run: 13
messages delivered to the gateway: 600 of 600
oldest delivered rowid: 1
permanently missed rowids: none
final persisted cursor rowid: 600
operator lines claiming permanent loss: 2
first permanent-loss line: imessage catchup: chat_id=1 returned a full 500-row page whose oldest rowid is 101; any rows between cursor 0 and 101 are outside the per-chat history budget and cannot be recovered

# AFTER (this patch 71eaa9b95401, identical inputs)
native imsg binary: 0.13.4
messages.history(chat_id=1, limit=50) returned rowids 551..600 (50 rows, newest first)
startups run: 13
messages delivered to the gateway: 600 of 600
oldest delivered rowid: 1
permanently missed rowids: none
final persisted cursor rowid: 600
operator lines claiming permanent loss: 0
first permanent-loss line: none
```
Observed result after fix: the second line is the upstream contract shown from the binary itself, a request for 50 rows over a 500-row conversation returns the NEWEST 50 and omits rowids 101 to 550; on pristine main that is what catchup asks for, so the gateway receives 100 of the 600 downtime messages, the oldest one it ever sees is rowid 51, and rowids 1 to 550 are gone for good even though the cursor still moves to 600; with this patch the identical backlog arrives complete, 600 of 600, starting at rowid 1, and no operator line asserts permanent loss, whereas the previous head recovered the same 600 messages but printed two loss claims about rowids 1 to 100 that had in fact just been delivered from the other conversation.
What was not tested: no run against a real macOS `~/Library/Messages/chat.db`, since that needs Full Disk Access to the operator's own Messages database; the native binary was pointed at a synthetic database on the same schema, and its read-only `chats.list` and `messages.history` paths are the ones catchup uses. The IMCore and AppleScript send paths are untouched. Live `watch.subscribe` delivery was not driven; catchup is a startup-time path and does not overlap it. A single conversation whose backlog exceeds the 500-row per-chat budget is still not drained, and after this change nothing warns about it; that needs a per-chat continuation contract from upstream `imsg`. Full build not run.
