### PR TITLE
fix(ai): Codex stream shows internal parser text on a malformed frame

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.sse-parse-error.test.ts
@@ -1,0 +1,111 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
+import type { Context, Model } from "../types.js";
+import { streamOpenAICodexResponses } from "./openai-chatgpt-responses.js";
+
+// Stands in for the payload class this path exposes: text that reached the SSE
+// frame as ordinary stream content rather than as a provider error envelope.
+const SENTINEL = "MODEL_EMITTED_SENTINEL_a1b2c3";
+
+// V8 quotes the first ten characters of an unparseable document back in the
+// SyntaxError message, so this prefix is what leaks when the raw parser text is
+// forwarded instead of the shared marker.
+const LEAKED_PREFIX = SENTINEL.slice(0, 10);
+
+// A frame body that is not JSON from its first token. This is the malformed
+// shape a proxy or gateway produces when it injects plain text into the event
+// stream, and the only class whose SyntaxError message quotes frame content.
+const MALFORMED_FRAME = `${SENTINEL} partial frame`;
+
+const COMPLETED_FRAME = JSON.stringify({
+  type: "response.completed",
+  response: {
+    id: "resp_control",
+    status: "completed",
+    output: [],
+    usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+  },
+});
+
+function createJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature`;
+}
+
+const context = {
+  messages: [{ role: "user", content: "hi", timestamp: 1 }],
+} satisfies Context;
+
+function makeModel(baseUrl: string): Model<"openai-chatgpt-responses"> {
+  return {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    api: "openai-chatgpt-responses",
+    provider: "openai",
+    baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+  } satisfies Model<"openai-chatgpt-responses">;
+}
+
+// Real loopback socket speaking the Codex event stream. Only the far end of the
+// socket is ours; the SSE reader and the provider stream are production code.
+async function streamCodexSseFrames(
+  frames: readonly string[],
+): Promise<{ stopReason: string; errorMessage?: string }> {
+  const server = createServer((request, response) => {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+    });
+    for (const data of frames) {
+      response.write(`data: ${data}\n\n`);
+    }
+    response.end();
+    void request.resume();
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  try {
+    const result = await streamOpenAICodexResponses(
+      makeModel(`http://127.0.0.1:${address.port}`),
+      context,
+      {
+        apiKey: createJwt({
+          "https://api.openai.com/auth": { chatgpt_account_id: "acct-sse-parse" },
+        }),
+        transport: "sse",
+      },
+    ).result();
+    return { stopReason: result.stopReason, errorMessage: result.errorMessage };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe("Codex malformed SSE frames", () => {
+  it("reports the shared malformed-fragment error without echoing parser text", async () => {
+    const result = await streamCodexSseFrames([MALFORMED_FRAME]);
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
+    expect(result.errorMessage).not.toContain(LEAKED_PREFIX);
+  });
+
+  it("still completes a well-formed stream", async () => {
+    const result = await streamCodexSseFrames([COMPLETED_FRAME]);
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.errorMessage).toBeUndefined();
+  });
+});

--- a/packages/ai/src/providers/openai-chatgpt-responses.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.sse-parse-error.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
-import { streamOpenAICodexResponses } from "./openai-chatgpt-responses.js";
+import { parseSSEForTest, streamOpenAICodexResponses } from "./openai-chatgpt-responses.js";
 
 // Stands in for the payload class this path exposes: text that reached the SSE
 // frame as ordinary stream content rather than as a provider error envelope.
@@ -94,6 +94,50 @@ async function streamCodexSseFrames(
 }
 
 describe("Codex malformed SSE frames", () => {
+  it("classifies only parser-owned SyntaxErrors as malformed frames", async () => {
+    const iterator = parseSSEForTest(
+      new Response(`data: ${MALFORMED_FRAME}\n\n`, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await iterator.next();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      name: "CodexProtocolError",
+      message: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+      cause: expect.any(SyntaxError),
+    });
+  });
+
+  it("preserves a consumer-thrown SyntaxError unchanged", async () => {
+    const iterator = parseSSEForTest(
+      new Response(`data: ${COMPLETED_FRAME}\n\n`, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const first = await iterator.next();
+    expect(first).toMatchObject({
+      done: false,
+      value: { type: "response.completed" },
+    });
+
+    const consumerError = new SyntaxError("consumer failed after receiving an event");
+    let caught: unknown;
+    try {
+      await iterator.throw(consumerError);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(consumerError);
+  });
+
   it("reports the shared malformed-fragment error without echoing parser text", async () => {
     const result = await streamCodexSseFrames([MALFORMED_FRAME]);
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -841,8 +841,9 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
         if (dataLines.length > 0) {
           const data = dataLines.join("\n").trim();
           if (data && data !== "[DONE]") {
+            let event: Record<string, unknown>;
             try {
-              yield JSON.parse(data) as Record<string, unknown>;
+              event = JSON.parse(data) as Record<string, unknown>;
             } catch (cause) {
               if (!(cause instanceof SyntaxError)) {
                 throw cause;
@@ -851,6 +852,9 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
               // assistant error formatting maps to the malformed-fragment retry copy.
               throw new CodexProtocolError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, { cause });
             }
+            // Keep suspension outside the parse catch so iterator.throw() cannot relabel a
+            // consumer failure as malformed provider input.
+            yield event;
           }
         }
         idx = buffer.indexOf("\n\n");

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -38,6 +38,7 @@ import { sleepWithAbort } from "../internal/retry-sleep.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type {
   Api,
   AssistantMessage,
@@ -843,10 +844,12 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
             try {
               yield JSON.parse(data) as Record<string, unknown>;
             } catch (cause) {
-              throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
-                cause,
-                payload: data,
-              });
+              if (!(cause instanceof SyntaxError)) {
+                throw cause;
+              }
+              // Align with the canonical transport contract: the shared marker is what
+              // assistant error formatting maps to the malformed-fragment retry copy.
+              throw new CodexProtocolError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, { cause });
             }
           }
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using a ChatGPT-login (Codex) model would see raw
internal parser text in the chat error surface — instead of the standard
"malformed fragment, please try again" message — when a streamed response frame
arrives that is not valid JSON.

Every other streaming provider path in the repo reports this same failure through
one shared marker, and assistant error formatting turns that marker into a clean
operator message. The Codex SSE path builds its own string, so the substitution
never fires and the internal text is surfaced verbatim.

## Why This Change Was Made

`packages/ai/src/providers/openai-chatgpt-responses.ts` caught the `JSON.parse`
failure and rethrew it as `` `Invalid Codex SSE JSON: ${formatThrownValue(cause)}` ``.
That string is what reaches the user, and **three separate consumers key off the
shared marker by exact string equality**, so none of them can recognise it:

| consumer | what it does with the marker |
|---|---|
| `src/shared/assistant-error-format.ts:229` | maps it to the malformed-fragment retry copy |
| `src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts:260,504` | same copy on the sanitize path |
| `src/agents/embedded-agent-helpers/errors.ts:1509` | same copy; the block below it is the "never return raw unhandled errors" fallback, which returns `raw` |

The canonical shape already exists in this repo for exactly this boundary —
`packages/ai/src/transports/anthropic-transport-stream.ts:795` converts only a
`SyntaxError` into `MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE` and preserves the
original error as `cause`. This change mirrors that contract in the Codex SSE parse boundary. The parser
stores the parsed event in a local, catches only `JSON.parse`'s `SyntaxError`, and
yields after the catch. Parser-owned malformed frames become the shared marker,
while consumer-injected failures — including a `SyntaxError` sent through
`iterator.throw()` — propagate untouched.

**Deliberately out of scope — the WebSocket twin.** The same file has a second
ad-hoc message at the WebSocket decode site (`Invalid Codex WebSocket JSON`).
It is left alone because two open PRs own that block today:
https://github.com/openclaw/openclaw/pull/111138 asserts on that exact message
text, and https://github.com/openclaw/openclaw/pull/109581 restructures the
surrounding `failed = new CodexProtocolError(...)` assignment. Aligning it here
would conflict with both. It should follow once those land.

The now-unused `payload: data` field is dropped with the ad-hoc message: it is
declared `payload?: unknown` on a module-private class and is never read anywhere
in the repo, and it is the field that carried the raw frame. Error classification
uses `instanceof CodexProtocolError` (`:713`), so the message change does not
affect any retry or transport decision.

## User Impact

Operators on ChatGPT-login models now get the same actionable message as every
other provider when a stream frame is malformed — "LLM streaming response
contained a malformed fragment. Please try again." — instead of internal parser
wording. As a bounded secondary effect, the ten-character prefix of the offending
frame that V8 quotes back inside its `SyntaxError` message no longer reaches the
error surface.

## Evidence

Regression coverage added in
`packages/ai/src/providers/openai-chatgpt-responses.sse-parse-error.test.ts`.
It runs a **real loopback `node:http` server** emitting `text/event-stream` and
drives the production `streamOpenAICodexResponses` path. Focused generator tests
also prove that parser-owned malformed frames retain the original `SyntaxError`
as `cause`, while an exact consumer-injected `SyntaxError` escapes unchanged.

Terminal output, this branch:

```
 Test Files  7 passed (7)
      Tests  188 passed (188)
```
(the Codex response parser/provider family plus the sibling Anthropic SSE
parser and transport suites)

**Before/after, measured — mutation run = the base behaviour.** Reverting only the
provider hunk and rerunning the committed test produces the current-main column:

| | `result.errorMessage` seen by the caller |
|---|---|
| base behaviour (mutation run) | `Invalid Codex SSE JSON: Unexpected token 'M', "MODEL_EMIT"... is not valid JSON` |
| this branch | `OpenClaw transport error: malformed_streaming_fragment` |

```
mutation run: 1 failed | 1 passed
this branch:  2 passed
```
Only the new test fails under mutation, so it is load-bearing. The second test in
the file is a **control case**: a well-formed `response.completed` stream over the
same loopback server still reaches `stopReason: "stop"` — it passed on the very
first run, before the fix existed, so the harness is not simply failing everything.

**Operator-visible column**, measured by calling the shared formatter directly on
both strings:

| | bytes | `formatRawAssistantErrorForUi(raw)` | recognised by `isStreamingJsonParseError` |
|---|---|---|---|
| base behaviour | 79 | *(returned verbatim, unchanged)* | `false` |
| this branch | 54 | `LLM streaming response contained a malformed fragment. Please try again.` | `true` |

Direct dependency-contract proof was checked against OpenAI Codex at
`a850875a8eb603d18cb14cb2c5e80c930de9bd48`: response setup in
`codex-rs/codex-api/src/endpoint/responses.rs:70-98,128-163`, parser ownership in
`codex-rs/codex-api/src/sse/responses.rs:468-575`, channel-backed stream types in
`codex-rs/codex-api/src/common.rs:73-115,333-344`, and consumers in
`codex-rs/core/src/client.rs:1289-1345,1803-1975`.

Exact-head validation: 188 focused tests passed; `oxfmt --check`, targeted
`oxlint`, production/test `tsgo`, dead-code, boundaries, import cycles, and
storage guards passed in the delegated changed gate:
https://github.com/openclaw/openclaw/actions/runs/30676785123. Fresh branch
`autoreview` found no actionable issues (0.99 correct).

---
AI-assisted: authored with Claude Code, reviewed and measured locally by me.