### PR TITLE
fix(cli): keep config file output raw under JSON logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **CLI config file output:** keep `openclaw config file` on raw stdout under JSON logging so scripts receive the config path instead of a structured log envelope.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **CLI config file output:** keep `openclaw config file` on raw stdout under JSON logging so scripts receive the config path instead of a structured log envelope.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -242,6 +242,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       bypassConfigGuard: true,
       ensureCliPath: false,
       loadPlugins: "never",
+      ownsProtocolStdout: true,
       networkProxy: "bypass",
     },
   },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -220,6 +220,7 @@ describe("command-path-policy", () => {
       bypassConfigGuard: true,
       ensureCliPath: false,
       loadPlugins: "never",
+      ownsProtocolStdout: true,
       networkProxy: "bypass",
     });
     expectResolvedPolicy(["config", "set"], {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4212,6 +4212,7 @@ describe("config cli", () => {
       try {
         await runConfigCommand(["config", "file"]);
         const output = String(lastMockArg(mockLog));
+        expect(mockWriteStdout).toHaveBeenCalledWith(configPath);
         expect(output).toBe(configPath);
         expect(path.isAbsolute(output)).toBe(true);
         expect(output).not.toContain("$OPENCLAW_HOME");

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4212,9 +4212,9 @@ describe("config cli", () => {
       try {
         await runConfigCommand(["config", "file"]);
         const output = String(lastMockArg(mockWriteStdout));
-        expect(mockWriteStdout).toHaveBeenCalledWith(configPath);
-        expect(output).toBe(configPath);
-        expect(path.isAbsolute(output)).toBe(true);
+        expect(mockWriteStdout).toHaveBeenCalledWith(`${configPath}\n`);
+        expect(output).toBe(`${configPath}\n`);
+        expect(path.isAbsolute(output.trimEnd())).toBe(true);
         expect(output).not.toContain("$OPENCLAW_HOME");
         expect(output).not.toContain("~");
         expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4211,7 +4211,7 @@ describe("config cli", () => {
 
       try {
         await runConfigCommand(["config", "file"]);
-        const output = String(lastMockArg(mockLog));
+        const output = String(lastMockArg(mockWriteStdout));
         expect(mockWriteStdout).toHaveBeenCalledWith(configPath);
         expect(output).toBe(configPath);
         expect(path.isAbsolute(output)).toBe(true);

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -281,7 +281,7 @@ export async function runConfigUnset(opts: {
 async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
-    runtime.log(resolveConfigPath());
+    writeRuntimeStdout(runtime, resolveConfigPath());
   } catch (err) {
     runtime.error(danger(String(err)));
     runtime.exit(1);

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -281,7 +281,7 @@ export async function runConfigUnset(opts: {
 async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
-    writeRuntimeStdout(runtime, resolveConfigPath());
+    writeRuntimeStdout(runtime, `${resolveConfigPath()}\n`);
   } catch (err) {
     runtime.error(danger(String(err)));
     runtime.exit(1);

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -361,6 +361,13 @@ describe("JSON console style process output", () => {
     expect(output).not.toHaveProperty("message");
   });
 
+  it("keeps config file output as one raw path", async () => {
+    const result = await runCliProcess({ args: ["config", "file"], config: loggingConfig });
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(`${result.fixture.configPath}\n`);
+  });
+
   it("keeps typed recommendation machine output as a raw array", async () => {
     const result = await runCliProcess({
       args: ["onboard", "recommendations", "--json"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scripts using `openclaw config file` would receive a JSON log record instead of the configuration path when JSON console logging was enabled.

## Why This Change Was Made

The command now owns protocol stdout and writes the resolved path through the raw stdout boundary, matching scalar configuration commands and keeping startup diagnostics on stderr.

## User Impact

`CONFIG="$(openclaw config file)"` reliably returns the absolute configuration path plus one newline, regardless of console log formatting.

## Evidence

- Exact reviewed head: `fc9a21d00d24309d0145c87443cf83e1aa239061` (product and test files are unchanged from `1668232fe536aab5dca91bb02a45dcc5ee225d5a`; the final commit only removes release-owned changelog text).
- Blacksmith Testbox focused proof after the explicit newline correction: https://github.com/openclaw/openclaw/actions/runs/30659137388
  - 169/169 config CLI tests passed.
  - 53/53 real CLI process tests passed, including JSON-console raw-path output.
- The complete scoped changed gate passed before the explicit newline correction: https://github.com/openclaw/openclaw/actions/runs/30656739109; the exact correction is covered by the focused and process proof above and refreshed hosted exact-head CI.
- Exact-head Blacksmith Testbox real CLI probe: https://github.com/openclaw/openclaw/actions/runs/30659604807

```text
exit=0
stdout_lines=1
stdout_matches_config_path=true
stdout=<redacted-config-path>
stderr_bytes=0
```

- Final whole-branch autoreview: clean, patch-correct confidence 0.99.
- `git diff --check`: passed.

Release-note context: `openclaw config file` remains raw, script-safe stdout when JSON console logging is configured.
