### PR TITLE
fix(gateway): sessions.steer retry no longer interrupts an active run when replaying a cached idempotency key

### DIFF
--- a/src/gateway/server-methods/chat-abort-authorization.ts
+++ b/src/gateway/server-methods/chat-abort-authorization.ts
@@ -294,6 +294,7 @@ export function resolveAuthorizedPreRegisteredRunsForSessionKeys(params: {
   requester: ChatAbortRequester;
   keyPrefix: string;
   preserveSideRuns?: boolean;
+  excludeRunIds?: ReadonlySet<string>;
 }) {
   const sessionKeys = new Set(
     Array.from(params.sessionKeys, (sessionKey) => normalizeOptionalText(sessionKey)).filter(
@@ -312,6 +313,9 @@ export function resolveAuthorizedPreRegisteredRunsForSessionKeys(params: {
       includeHidden: true,
     });
     if (!run) {
+      continue;
+    }
+    if (params.excludeRunIds?.has(run.runId)) {
       continue;
     }
     const runSessionKeys = [
@@ -374,6 +378,7 @@ export function resolveAuthorizedRunsForSessionKeys(params: {
   defaultAgentId: string;
   requester: ChatAbortRequester;
   preserveSideRuns?: boolean;
+  excludeRunIds?: ReadonlySet<string>;
 }) {
   const sessionKeys = new Set(
     Array.from(params.sessionKeys, (sessionKey) => normalizeOptionalText(sessionKey)).filter(
@@ -392,6 +397,9 @@ export function resolveAuthorizedRunsForSessionKeys(params: {
   let hasUnauthorizedProtectedRuns = false;
   let hasProtectedRuns = false;
   for (const [runId, active] of params.chatAbortControllers) {
+    if (params.excludeRunIds?.has(runId)) {
+      continue;
+    }
     if (!sessionKeys.has(active.sessionKey) && !sessionIds.has(active.sessionId)) {
       continue;
     }

--- a/src/gateway/server-methods/chat-abort-handler.ts
+++ b/src/gateway/server-methods/chat-abort-handler.ts
@@ -40,6 +40,7 @@ import { assertValidParams } from "./validation.js";
 
 type ChatAbortLifecycle = {
   onAuthorizedAfterQueuedAbort?: () => boolean;
+  excludeRunIds?: ReadonlySet<string>;
 };
 
 export async function handleChatAbortRequestWithLifecycle(
@@ -118,6 +119,7 @@ export async function handleChatAbortRequestWithLifecycle(
       stopReason: "rpc",
       requester,
       preserveSideRuns,
+      excludeRunIds: lifecycle.excludeRunIds,
       onAuthorizedAfterQueuedAbort: lifecycle.onAuthorizedAfterQueuedAbort,
     });
     if (res.unauthorized) {

--- a/src/gateway/server-methods/chat-abort-runtime.ts
+++ b/src/gateway/server-methods/chat-abort-runtime.ts
@@ -176,6 +176,7 @@ export async function abortChatRunsForSessionKeyWithPartials(params: {
   stopReason?: string;
   requester: ChatAbortRequester;
   preserveSideRuns?: boolean;
+  excludeRunIds?: ReadonlySet<string>;
   /** Internal session-wide cleanup after exact resolution and all matching owner checks. */
   onAuthorizedAfterQueuedAbort?: () => boolean;
 }): Promise<{ aborted: boolean; runIds: string[]; unauthorized: boolean }> {
@@ -202,6 +203,7 @@ export async function abortChatRunsForSessionKeyWithPartials(params: {
     defaultAgentId: params.defaultAgentId,
     requester: params.requester,
     preserveSideRuns: params.preserveSideRuns,
+    excludeRunIds: params.excludeRunIds,
   });
   const {
     authorizedRuns: authorizedPendingAgentRuns,
@@ -216,6 +218,7 @@ export async function abortChatRunsForSessionKeyWithPartials(params: {
     requester: params.requester,
     keyPrefix: "agent:",
     preserveSideRuns: params.preserveSideRuns,
+    excludeRunIds: params.excludeRunIds,
   });
   const {
     authorizedRuns: authorizedPendingChatRuns,
@@ -230,6 +233,7 @@ export async function abortChatRunsForSessionKeyWithPartials(params: {
     requester: params.requester,
     keyPrefix: PENDING_CHAT_SEND_DEDUPE_PREFIX,
     preserveSideRuns: params.preserveSideRuns,
+    excludeRunIds: params.excludeRunIds,
   });
   const hasAuthorizedGatewayRuns =
     authorizedRuns.length > 0 ||

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -381,28 +381,13 @@ export async function admitChatSend(params: {
     return { ok: false as const };
   }
   if (params.onAdmissionOwned) {
-    const activeEntry = activeRunAbort.entry;
-    const previousVisibility = activeEntry?.controlUiVisible;
-    if (activeEntry) {
-      // Keep the winning replacement visible to idempotency checks but outside
-      // the session-wide abort that clears the run it is replacing.
-      activeEntry.controlUiVisible = false;
-    }
-    let proceed = false;
+    let proceed: boolean;
     try {
       proceed = await params.onAdmissionOwned();
     } catch (error) {
       activeRunAbort.cleanup({ force: true });
       gatewayWorkAdmission.release();
       throw error;
-    } finally {
-      if (activeEntry) {
-        if (previousVisibility === undefined) {
-          delete activeEntry.controlUiVisible;
-        } else {
-          activeEntry.controlUiVisible = previousVisibility;
-        }
-      }
     }
     if (!proceed) {
       activeRunAbort.cleanup({ force: true });

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -48,6 +48,7 @@ export async function admitChatSend(params: {
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
   client: GatewayRequestHandlerOptions["client"];
+  onAdmissionOwned?: () => Promise<boolean>;
 }) {
   const { request, session, respond, context, client } = params;
   const { p, explicitOrigin, normalizedAttachments, turnKind } = request;
@@ -378,6 +379,36 @@ export async function admitChatSend(params: {
       runId: clientRunId,
     });
     return { ok: false as const };
+  }
+  if (params.onAdmissionOwned) {
+    const activeEntry = activeRunAbort.entry;
+    const previousVisibility = activeEntry?.controlUiVisible;
+    if (activeEntry) {
+      // Keep the winning replacement visible to idempotency checks but outside
+      // the session-wide abort that clears the run it is replacing.
+      activeEntry.controlUiVisible = false;
+    }
+    let proceed = false;
+    try {
+      proceed = await params.onAdmissionOwned();
+    } catch (error) {
+      activeRunAbort.cleanup({ force: true });
+      gatewayWorkAdmission.release();
+      throw error;
+    } finally {
+      if (activeEntry) {
+        if (previousVisibility === undefined) {
+          delete activeEntry.controlUiVisible;
+        } else {
+          activeEntry.controlUiVisible = previousVisibility;
+        }
+      }
+    }
+    if (!proceed) {
+      activeRunAbort.cleanup({ force: true });
+      gatewayWorkAdmission.release();
+      return { ok: false as const };
+    }
   }
 
   let releaseGatewayRootContinuation: (() => void) | undefined;

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -32,7 +32,6 @@ import { ensureChatQueuedTurns } from "./chat-abort-runtime.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
-import { admitChatSend } from "./chat-send-admission.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
   resolveWebchatPromptCacheKey,
@@ -40,17 +39,13 @@ import {
 } from "./chat-send-background.js";
 import { createChatSendDispatchErrorLifecycle } from "./chat-send-dispatch-errors.js";
 import { finalizeChatSendNonAgentReplies } from "./chat-send-nonagent-finalization.js";
-import {
-  respondChatSessionRoutingChanged,
-  runChatSendPreAdmission,
-} from "./chat-send-pre-admission.js";
+import { respondChatSessionRoutingChanged } from "./chat-send-pre-admission.js";
 import {
   applyChatSendReplyContextFields,
   resolveChatSendReplyContext,
 } from "./chat-send-reply-context.js";
 import { createChatSendReplyDispatch } from "./chat-send-reply-dispatch.js";
-import { normalizeChatSendRequest } from "./chat-send-request.js";
-import { prepareChatSendSession } from "./chat-send-session.js";
+import { prepareAndAdmitChatSend } from "./chat-send-setup.js";
 import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
 import { applyChatSendManagedMedia, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 import {
@@ -64,19 +59,20 @@ import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-
 import { createGatewayChatUserTurnController } from "./chat-user-turn-recorder.js";
 import { gatewayClientSenderFields } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
 
-export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
-  params,
-  respond,
-  context,
-  client,
-}) => {
-  const normalizedRequest = normalizeChatSendRequest({ params, client });
-  if (!normalizedRequest.ok) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, normalizedRequest.error));
+export async function handleChatSend(
+  { params, respond, context, client }: GatewayRequestHandlerOptions,
+  onAdmissionOwned?: () => Promise<boolean>,
+): Promise<void> {
+  const setup = await prepareAndAdmitChatSend(
+    { params, respond, context, client },
+    onAdmissionOwned,
+  );
+  if (!setup) {
     return;
   }
+  const { normalizedRequest, preparedSession, admitted } = setup;
   const {
     chatSendReceivedAtMs,
     clientInfo,
@@ -86,15 +82,6 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
     rawMessage,
     reconnectResumeRequested,
   } = normalizedRequest.value;
-  const preparedSession = prepareChatSendSession({
-    request: normalizedRequest.value,
-    context,
-    client,
-  });
-  if (!preparedSession.ok) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, preparedSession.error));
-    return;
-  }
   const {
     clientRunId,
     sessionLoadOptions,
@@ -112,26 +99,6 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
     resolvedSessionModel,
     now,
   } = preparedSession.value;
-  const shouldAdmit = await runChatSendPreAdmission({
-    request: normalizedRequest.value,
-    session: preparedSession.value,
-    respond,
-    context,
-    client,
-  });
-  if (!shouldAdmit) {
-    return;
-  }
-  const admitted = await admitChatSend({
-    request: normalizedRequest.value,
-    session: preparedSession.value,
-    respond,
-    context,
-    client,
-  });
-  if (!admitted.ok) {
-    return;
-  }
   const {
     activeRunAbort,
     admittedSessionId,
@@ -726,4 +693,4 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
       errorMessage: String(err),
     });
   }
-};
+}

--- a/src/gateway/server-methods/chat-send-pre-admission.ts
+++ b/src/gateway/server-methods/chat-send-pre-admission.ts
@@ -5,7 +5,7 @@ import { SESSION_ROUTING_CHANGED_ERROR_REASON } from "../../config/sessions/main
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { chatAbortMarkerTimestampMs } from "../server-chat-state.js";
-import { PENDING_CHAT_SEND_DEDUPE_PREFIX, pendingChatSendDedupeKey } from "../server-shared.js";
+import { PENDING_CHAT_SEND_DEDUPE_PREFIX } from "../server-shared.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { setGatewayDedupeEntry } from "./agent-job.js";
 import {
@@ -41,26 +41,6 @@ export function respondChatActiveLeafChanged(respond: GatewayRequestHandlerOptio
     errorShape(ErrorCodes.INVALID_REQUEST, "active branch changed; review and resend", {
       details: { reason: ACTIVE_LEAF_CHANGED_ERROR_REASON },
     }),
-  );
-}
-
-/**
- * True when runChatSendPreAdmission would replay an existing chat.send for this
- * client run id instead of admitting a new turn. Callers that take destructive
- * action before dispatch must consult this first, so an idempotent retry cannot
- * destroy a run it only meant to replay. Keep the checks below in step with the
- * replay branches of runChatSendPreAdmission.
- */
-export function hasReplayableChatSend(
-  context: GatewayRequestHandlerOptions["context"],
-  clientRunId: string,
-): boolean {
-  return (
-    context.dedupe.has(`chat:${clientRunId}`) ||
-    context.chatRunState.runs.get(clientRunId)?.abortMarker !== undefined ||
-    context.dedupe.has(pendingChatSendDedupeKey(clientRunId)) ||
-    context.chatAbortControllers.has(clientRunId) ||
-    context.chatQueuedTurns.has(clientRunId)
   );
 }
 

--- a/src/gateway/server-methods/chat-send-pre-admission.ts
+++ b/src/gateway/server-methods/chat-send-pre-admission.ts
@@ -5,7 +5,7 @@ import { SESSION_ROUTING_CHANGED_ERROR_REASON } from "../../config/sessions/main
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { chatAbortMarkerTimestampMs } from "../server-chat-state.js";
-import { PENDING_CHAT_SEND_DEDUPE_PREFIX } from "../server-shared.js";
+import { PENDING_CHAT_SEND_DEDUPE_PREFIX, pendingChatSendDedupeKey } from "../server-shared.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { setGatewayDedupeEntry } from "./agent-job.js";
 import {
@@ -41,6 +41,26 @@ export function respondChatActiveLeafChanged(respond: GatewayRequestHandlerOptio
     errorShape(ErrorCodes.INVALID_REQUEST, "active branch changed; review and resend", {
       details: { reason: ACTIVE_LEAF_CHANGED_ERROR_REASON },
     }),
+  );
+}
+
+/**
+ * True when runChatSendPreAdmission would replay an existing chat.send for this
+ * client run id instead of admitting a new turn. Callers that take destructive
+ * action before dispatch must consult this first, so an idempotent retry cannot
+ * destroy a run it only meant to replay. Keep the checks below in step with the
+ * replay branches of runChatSendPreAdmission.
+ */
+export function hasReplayableChatSend(
+  context: GatewayRequestHandlerOptions["context"],
+  clientRunId: string,
+): boolean {
+  return (
+    context.dedupe.has(`chat:${clientRunId}`) ||
+    context.chatRunState.runs.get(clientRunId)?.abortMarker !== undefined ||
+    context.dedupe.has(pendingChatSendDedupeKey(clientRunId)) ||
+    context.chatAbortControllers.has(clientRunId) ||
+    context.chatQueuedTurns.has(clientRunId)
   );
 }
 

--- a/src/gateway/server-methods/chat-send-setup.ts
+++ b/src/gateway/server-methods/chat-send-setup.ts
@@ -1,0 +1,54 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { admitChatSend } from "./chat-send-admission.js";
+import { runChatSendPreAdmission } from "./chat-send-pre-admission.js";
+import { normalizeChatSendRequest } from "./chat-send-request.js";
+import { prepareChatSendSession } from "./chat-send-session.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+/** Normalize, prepare, and exclusively admit one new chat.send request. */
+export async function prepareAndAdmitChatSend(
+  {
+    params,
+    respond,
+    context,
+    client,
+  }: Pick<GatewayRequestHandlerOptions, "params" | "respond" | "context" | "client">,
+  onAdmissionOwned?: () => Promise<boolean>,
+) {
+  const normalizedRequest = normalizeChatSendRequest({ params, client });
+  if (!normalizedRequest.ok) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, normalizedRequest.error));
+    return undefined;
+  }
+  const preparedSession = prepareChatSendSession({
+    request: normalizedRequest.value,
+    context,
+    client,
+  });
+  if (!preparedSession.ok) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, preparedSession.error));
+    return undefined;
+  }
+  const shouldAdmit = await runChatSendPreAdmission({
+    request: normalizedRequest.value,
+    session: preparedSession.value,
+    respond,
+    context,
+    client,
+  });
+  if (!shouldAdmit) {
+    return undefined;
+  }
+  const admitted = await admitChatSend({
+    request: normalizedRequest.value,
+    session: preparedSession.value,
+    respond,
+    context,
+    client,
+    onAdmissionOwned,
+  });
+  if (!admitted.ok) {
+    return undefined;
+  }
+  return { normalizedRequest, preparedSession, admitted };
+}

--- a/src/gateway/server-methods/chat.abort-authorization.test.ts
+++ b/src/gateway/server-methods/chat.abort-authorization.test.ts
@@ -34,6 +34,7 @@ async function invokeAbort({
   preserveSideRuns,
   scopes = ["operator.write"],
   onAuthorizedAfterQueuedAbort,
+  excludeRunIds,
 }: {
   context: ReturnType<typeof createChatAbortContext>;
   sessionKey?: string;
@@ -43,11 +44,17 @@ async function invokeAbort({
   preserveSideRuns?: boolean;
   scopes?: string[];
   onAuthorizedAfterQueuedAbort?: () => boolean;
+  excludeRunIds?: ReadonlySet<string>;
 }) {
   return await invokeChatAbortHandler({
-    handler: onAuthorizedAfterQueuedAbort
-      ? (options) => handleChatAbortRequestWithLifecycle(options, { onAuthorizedAfterQueuedAbort })
-      : expectDefined(chatHandlers["chat.abort"], 'chatHandlers["chat.abort"] test invariant'),
+    handler:
+      onAuthorizedAfterQueuedAbort || excludeRunIds
+        ? (options) =>
+            handleChatAbortRequestWithLifecycle(options, {
+              onAuthorizedAfterQueuedAbort,
+              excludeRunIds,
+            })
+        : expectDefined(chatHandlers["chat.abort"], 'chatHandlers["chat.abort"] test invariant'),
     context,
     request: {
       sessionKey,
@@ -373,6 +380,37 @@ describe("chat.abort authorization", () => {
 });
 
 describe("chat.abort queued-turn contract", () => {
+  it("excludes only the replacement run from internal session cleanup", async () => {
+    const oldRun = createActiveRun("main", {
+      owner: { connId: "conn-owner", deviceId: "dev-owner" },
+    });
+    const replacementRun = createActiveRun("main", {
+      owner: { connId: "conn-owner", deviceId: "dev-owner" },
+    });
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([
+        ["run-old", oldRun],
+        ["run-replacement", replacementRun],
+      ]),
+    });
+
+    const respond = await invokeAbort({
+      context,
+      connId: "conn-owner",
+      deviceId: "dev-owner",
+      excludeRunIds: new Set(["run-replacement"]),
+    });
+
+    expect(requireLastRespondCall(respond)[0]).toBe(true);
+    expectAbortPayload(requireLastRespondCall(respond)[1], {
+      aborted: true,
+      runIds: ["run-old"],
+    });
+    expect(oldRun.controller.signal.aborted).toBe(true);
+    expect(replacementRun.controller.signal.aborted).toBe(false);
+    expect(context.chatAbortControllers.has("run-replacement")).toBe(true);
+  });
+
   it("cancels queued turns before session cleanup and the active run", async () => {
     const order: string[] = [];
     const queuedController = new AbortController();

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../infra/agent-events.js";
 import {
   collectTrackedActiveSessionRuns,
+  hasTrackedActiveSessionRun,
   hasVisibleActiveSessionRun,
   resolveVisibleActiveSessionRunState,
 } from "./session-active-runs.js";
@@ -90,6 +91,38 @@ it("matches session-id-only gateway runs during archive admission", () => {
       requestedKey: "agent:main:child",
       canonicalKey: "agent:main:child",
       sessionId: "session-1",
+    }),
+  ).toBe(true);
+});
+
+it("excludes the replacement run from an internal active-session check", () => {
+  const sessionKey = "agent:main:main";
+  const context = {
+    chatAbortControllers: new Map([
+      [
+        "replacement-run",
+        {
+          sessionKey,
+          controlUiVisible: true,
+          projectSessionActive: true,
+        },
+      ],
+    ]),
+  } as never;
+
+  expect(
+    hasTrackedActiveSessionRun({
+      context,
+      requestedKey: sessionKey,
+      canonicalKey: sessionKey,
+      excludeRunIds: new Set(["replacement-run"]),
+    }),
+  ).toBe(false);
+  expect(
+    hasTrackedActiveSessionRun({
+      context,
+      requestedKey: sessionKey,
+      canonicalKey: sessionKey,
     }),
   ).toBe(true);
 });

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -68,22 +68,24 @@ export function hasTrackedActiveSessionRun(params: {
   canonicalKey: string;
   agentId?: string;
   defaultAgentId?: string;
+  excludeRunIds?: ReadonlySet<string>;
 }): boolean {
   const activeRuns = collectTrackedActiveSessionRuns(params.context);
   return activeRuns.some(
     (active) =>
-      isTrackedActiveSessionRunForKey(
+      !params.excludeRunIds?.has(active.runId) &&
+      (isTrackedActiveSessionRunForKey(
         active,
         params.canonicalKey,
         params.agentId,
         params.defaultAgentId,
       ) ||
-      isTrackedActiveSessionRunForKey(
-        active,
-        params.requestedKey,
-        params.agentId,
-        params.defaultAgentId,
-      ),
+        isTrackedActiveSessionRunForKey(
+          active,
+          params.requestedKey,
+          params.agentId,
+          params.defaultAgentId,
+        )),
   );
 }
 

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -26,6 +26,7 @@ import {
   resolveDeletedAgentIdFromSessionKey,
 } from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
+import { hasReplayableChatSend } from "./chat-send-pre-admission.js";
 import { chatHandlers } from "./chat.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
@@ -353,7 +354,14 @@ async function handleSessionSend(params: {
   }
 
   let interruptedActiveRun = false;
-  if (params.interruptIfActive) {
+  // An explicit retry may already own a chat.send that the handler will replay.
+  // Interrupting first aborts whatever is running now - an unrelated turn, or the
+  // very run this retry is replaying - and clears its queued follow-ups, so let
+  // the owning handler replay before steering, as the archive guard does above.
+  const replaysExistingChatSend =
+    explicitIdempotencyKey !== undefined &&
+    hasReplayableChatSend(params.context, explicitIdempotencyKey);
+  if (params.interruptIfActive && !replaysExistingChatSend) {
     const interruptResult = await interruptSessionRunIfActive({
       req: params.req,
       context: params.context,

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -26,8 +26,11 @@ import {
   resolveDeletedAgentIdFromSessionKey,
 } from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
+import { formatForLog } from "../ws-log.js";
+import { handleChatAbortRequestWithLifecycle } from "./chat-abort-handler.js";
 import { handleChatSend } from "./chat-send-handler.js";
 import { chatHandlers } from "./chat.js";
+import { resolveGatewayInflightRequest, type GatewayInflightResult } from "./inflight.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { shouldAttachPendingMessageSeq } from "./session-create-initial-turn.js";
@@ -42,6 +45,92 @@ import type {
   RespondFn,
 } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+type SessionSteerInflightOwner = {
+  respond: RespondFn;
+  fail: (error: unknown) => void;
+  finish: () => void;
+};
+
+function beginSessionSteerInflight(params: {
+  context: GatewayRequestContext;
+  idempotencyKey: string;
+  request: { respond: RespondFn };
+}): { kind: "handled"; done: Promise<void> } | { kind: "owner"; owner: SessionSteerInflightOwner } {
+  const originalRespond = params.request.respond;
+  const dedupeKey = `sessions.steer:${params.idempotencyKey}`;
+  const inflight = resolveGatewayInflightRequest({
+    context: params.context,
+    dedupeKey,
+    idempotencyKey: params.idempotencyKey,
+    respond: originalRespond,
+  });
+  if (inflight.kind === "handled") {
+    return inflight;
+  }
+
+  let resolveResult: (result: GatewayInflightResult) => void = () => {};
+  const work = new Promise<GatewayInflightResult>((resolve) => {
+    resolveResult = resolve;
+  });
+  let settled = false;
+  const settle = (result: GatewayInflightResult): boolean => {
+    if (settled) {
+      return false;
+    }
+    settled = true;
+    resolveResult(result);
+    return true;
+  };
+  inflight.inflightMap.set(dedupeKey, work);
+  const respond: RespondFn = (ok, payload, error, meta) => {
+    settle({
+      ok,
+      ...(payload !== undefined ? { payload } : {}),
+      ...(error ? { error } : {}),
+      ...(meta ? { meta } : {}),
+    });
+    if (meta === undefined) {
+      originalRespond(ok, payload, error);
+      return;
+    }
+    originalRespond(ok, payload, error, meta);
+  };
+
+  return {
+    kind: "owner",
+    owner: {
+      respond,
+      fail: (error) => {
+        const responseError = errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error), {
+          retryable: true,
+        });
+        if (
+          settle({
+            ok: false,
+            error: responseError,
+          })
+        ) {
+          originalRespond(false, undefined, responseError);
+        }
+      },
+      finish: () => {
+        if (!settled) {
+          const error = errorShape(
+            ErrorCodes.UNAVAILABLE,
+            "sessions.steer ended before producing a response",
+            { retryable: true },
+          );
+          settle({ ok: false, error });
+          originalRespond(false, undefined, error);
+        }
+        if (inflight.inflightMap.get(dedupeKey) === work) {
+          inflight.inflightMap.delete(dedupeKey);
+        }
+      },
+    },
+  };
+}
 
 async function createAgentMainSessionForSend(params: {
   req: GatewayRequestHandlerOptions["req"];
@@ -128,6 +217,7 @@ export async function interruptSessionRunIfActive(params: {
   canonicalKey: string;
   agentId?: string;
   sessionId?: string;
+  excludeRunIds?: ReadonlySet<string>;
 }): Promise<{ interrupted: boolean; error?: ReturnType<typeof errorShape> }> {
   const cfg = params.context.getRuntimeConfig();
   const hasTrackedRun = hasTrackedActiveSessionRun({
@@ -136,6 +226,7 @@ export async function interruptSessionRunIfActive(params: {
     canonicalKey: params.canonicalKey,
     agentId: params.agentId,
     defaultAgentId: resolveDefaultAgentId(cfg),
+    excludeRunIds: params.excludeRunIds,
   });
   const hasEmbeddedRun =
     typeof params.sessionId === "string" && params.sessionId
@@ -161,23 +252,25 @@ export async function interruptSessionRunIfActive(params: {
       canonicalKey: params.canonicalKey,
     });
 
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      "chat.abort handler",
-    )({
-      req: params.req,
-      params: {
-        sessionKey: abortSessionKey,
-        ...(params.canonicalKey === "global" && params.agentId ? { agentId: params.agentId } : {}),
+    await handleChatAbortRequestWithLifecycle(
+      {
+        req: params.req,
+        params: {
+          sessionKey: abortSessionKey,
+          ...(params.canonicalKey === "global" && params.agentId
+            ? { agentId: params.agentId }
+            : {}),
+        },
+        respond: (ok, _payload, error) => {
+          abortOk = ok;
+          abortError = error;
+        },
+        context: params.context,
+        client: params.client,
+        isWebchatConnect: params.isWebchatConnect,
       },
-      respond: (ok, _payload, error) => {
-        abortOk = ok;
-        abortError = error;
-      },
-      context: params.context,
-      client: params.client,
-      isWebchatConnect: params.isWebchatConnect,
-    });
+      params.excludeRunIds ? { excludeRunIds: params.excludeRunIds } : {},
+    );
 
     if (!abortOk) {
       return {
@@ -266,184 +359,216 @@ async function handleSessionSend(params: {
       ? rawIdempotencyKey.trim()
       : undefined;
   const idempotencyKey = explicitIdempotencyKey ?? randomUUID();
-  const dispatchChatSend = async (
-    respond: RespondFn,
-    onAdmissionOwned?: () => Promise<boolean>,
-  ) => {
-    const options: GatewayRequestHandlerOptions = {
-      req: params.req,
-      params: {
-        sessionKey: canonicalKey,
-        ...(canonicalKey === "global" && requestedAgentId ? { agentId: requestedAgentId } : {}),
-        message: (p as { message: string }).message,
-        thinking: (p as { thinking?: string }).thinking,
-        attachments: (p as { attachments?: unknown[] }).attachments,
-        timeoutMs: (p as { timeoutMs?: number }).timeoutMs,
-        idempotencyKey,
-      },
-      respond,
-      context: params.context,
-      client: params.client,
-      isWebchatConnect: params.isWebchatConnect,
-    };
-    if (onAdmissionOwned) {
-      await handleChatSend(options, onAdmissionOwned);
-      return;
-    }
-    await expectDefined(chatHandlers["chat.send"], "chat.send handler")(options);
-  };
-  const archivedSessionError = resolveSessionWorkStartError(canonicalKey, entry);
-  if (archivedSessionError) {
-    // An explicit retry may already have a terminal chat.send result. Let the
-    // owning handler replay that result before it applies the archive guard.
-    if (explicitIdempotencyKey) {
-      await dispatchChatSend(params.respond);
-      return;
-    }
-    params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, archivedSessionError));
-    return;
-  }
-  if (!entry?.sessionId && !params.interruptIfActive && isAgentMainSessionKey(cfg, canonicalKey)) {
-    // Sending to an empty agent main session should create it; steering still requires an active row.
-    const created = await createAgentMainSessionForSend({
-      req: params.req,
-      canonicalKey,
-      context: params.context,
-      client: params.client,
-      isWebchatConnect: params.isWebchatConnect,
-    });
-    if (!created.ok) {
-      params.respond(false, undefined, created.error);
-      return;
-    }
-    entry = created.entry;
-    canonicalKey = created.canonicalKey;
-    storePath = created.storePath;
-  }
-  if (!entry?.sessionId) {
-    params.respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-    );
-    return;
-  }
-
-  const readNextMessageSeq = async () =>
-    (await readSessionMessageCountAsync({
-      agentId: requestedAgentId,
-      sessionEntry: entry,
-      sessionId: entry.sessionId,
-      sessionKey: canonicalKey,
-      storePath,
-    })) + 1;
-  let messageSeq: number | undefined;
-  try {
-    messageSeq = await readNextMessageSeq();
-  } catch (error) {
-    if (!isSessionTranscriptProjectionUnavailableError(error)) {
-      throw error;
-    }
-    // Projection rebuilds are transient and happen before dispatch, so callers
-    // can safely retry the same idempotency key without duplicating a turn.
-    params.respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.UNAVAILABLE, "session transcript is rebuilding; retry shortly", {
-        details: { method: params.method },
-        retryable: true,
-        retryAfterMs: 250,
-      }),
-    );
-    return;
-  }
-
-  let interruptedActiveRun = false;
-  const onAdmissionOwned = params.interruptIfActive
-    ? async (): Promise<boolean> => {
-        const interruptResult = await interruptSessionRunIfActive({
-          req: params.req,
+  const steerInflight =
+    params.interruptIfActive && explicitIdempotencyKey
+      ? beginSessionSteerInflight({
           context: params.context,
-          client: params.client,
-          isWebchatConnect: params.isWebchatConnect,
-          requestedKey: key,
-          canonicalKey,
-          agentId: requestedAgentId,
-          sessionId: entry.sessionId,
-        });
-        if (interruptResult.error) {
-          params.respond(false, undefined, interruptResult.error);
-          return false;
-        }
-        interruptedActiveRun = interruptResult.interrupted;
-        try {
-          // A run can finish before the active check or while an interruption
-          // drains. Refresh only for new sends; replays retain their original result.
-          messageSeq = await readNextMessageSeq();
-        } catch (error) {
-          if (!isSessionTranscriptProjectionUnavailableError(error)) {
-            throw error;
-          }
-          // Interruption may already have committed side effects. The sequence is
-          // optional, so preserve delivery and let transcript events reconcile it.
-          messageSeq = undefined;
-        }
-        return true;
-      }
-    : undefined;
+          idempotencyKey,
+          request: params,
+        })
+      : undefined;
+  if (steerInflight?.kind === "handled") {
+    await steerInflight.done;
+    return;
+  }
+  const steerInflightOwner = steerInflight?.owner;
+  const respond = steerInflightOwner?.respond ?? params.respond;
 
-  let sendAcked = false;
-  let sendPayload: unknown;
-  let sendCached = false;
-  let startedRunId: string | undefined;
-  await dispatchChatSend((ok, payload, error, meta) => {
-    sendAcked = ok;
-    sendPayload = payload;
-    sendCached = meta?.cached === true;
-    startedRunId =
-      payload &&
-      typeof payload === "object" &&
-      typeof (payload as { runId?: unknown }).runId === "string"
-        ? (payload as { runId: string }).runId
-        : undefined;
-    if (ok && shouldAttachPendingMessageSeq({ payload, cached: meta?.cached === true })) {
-      params.respond(
-        true,
-        {
-          ...(payload && typeof payload === "object" ? payload : {}),
-          ...(messageSeq !== undefined ? { messageSeq } : {}),
-          ...(interruptedActiveRun ? { interruptedActiveRun: true } : {}),
+  try {
+    const dispatchChatSend = async (
+      dispatchRespond: RespondFn,
+      onAdmissionOwned?: () => Promise<boolean>,
+    ) => {
+      const options: GatewayRequestHandlerOptions = {
+        req: params.req,
+        params: {
+          sessionKey: canonicalKey,
+          ...(canonicalKey === "global" && requestedAgentId ? { agentId: requestedAgentId } : {}),
+          message: (p as { message: string }).message,
+          thinking: (p as { thinking?: string }).thinking,
+          attachments: (p as { attachments?: unknown[] }).attachments,
+          timeoutMs: (p as { timeoutMs?: number }).timeoutMs,
+          idempotencyKey,
         },
+        respond: dispatchRespond,
+        context: params.context,
+        client: params.client,
+        isWebchatConnect: params.isWebchatConnect,
+      };
+      if (onAdmissionOwned) {
+        await handleChatSend(options, onAdmissionOwned);
+        return;
+      }
+      await expectDefined(chatHandlers["chat.send"], "chat.send handler")(options);
+    };
+    const archivedSessionError = resolveSessionWorkStartError(canonicalKey, entry);
+    if (archivedSessionError) {
+      // An explicit retry may already have a terminal chat.send result. Let the
+      // owning handler replay that result before it applies the archive guard.
+      if (explicitIdempotencyKey) {
+        await dispatchChatSend(respond);
+        return;
+      }
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, archivedSessionError));
+      return;
+    }
+    if (
+      !entry?.sessionId &&
+      !params.interruptIfActive &&
+      isAgentMainSessionKey(cfg, canonicalKey)
+    ) {
+      // Sending to an empty agent main session should create it; steering still requires an active row.
+      const created = await createAgentMainSessionForSend({
+        req: params.req,
+        canonicalKey,
+        context: params.context,
+        client: params.client,
+        isWebchatConnect: params.isWebchatConnect,
+      });
+      if (!created.ok) {
+        respond(false, undefined, created.error);
+        return;
+      }
+      entry = created.entry;
+      canonicalKey = created.canonicalKey;
+      storePath = created.storePath;
+    }
+    if (!entry?.sessionId) {
+      respond(
+        false,
         undefined,
-        meta,
+        errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
       );
       return;
     }
-    params.respond(
-      ok,
-      ok && payload && typeof payload === "object"
-        ? {
-            ...payload,
-            ...(interruptedActiveRun ? { interruptedActiveRun: true } : {}),
-          }
-        : payload,
-      error,
-      meta,
-    );
-  }, onAdmissionOwned);
-  if (sendAcked) {
-    if (shouldAttachPendingMessageSeq({ payload: sendPayload, cached: sendCached })) {
-      await reactivateCompletedSubagentSession({
+    const admittedEntry = entry;
+    const admittedSessionId = entry.sessionId;
+
+    const readNextMessageSeq = async () =>
+      (await readSessionMessageCountAsync({
+        agentId: requestedAgentId,
+        sessionEntry: admittedEntry,
+        sessionId: admittedSessionId,
         sessionKey: canonicalKey,
-        runId: startedRunId,
-        task: (p as { message: string }).message,
+        storePath,
+      })) + 1;
+    let messageSeq: number | undefined;
+    try {
+      messageSeq = await readNextMessageSeq();
+    } catch (error) {
+      if (!isSessionTranscriptProjectionUnavailableError(error)) {
+        throw error;
+      }
+      // Projection rebuilds are transient and happen before dispatch, so callers
+      // can safely retry the same idempotency key without duplicating a turn.
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "session transcript is rebuilding; retry shortly", {
+          details: { method: params.method },
+          retryable: true,
+          retryAfterMs: 250,
+        }),
+      );
+      return;
+    }
+
+    let interruptedActiveRun = false;
+    const onAdmissionOwned = params.interruptIfActive
+      ? async (): Promise<boolean> => {
+          const interruptResult = await interruptSessionRunIfActive({
+            req: params.req,
+            context: params.context,
+            client: params.client,
+            isWebchatConnect: params.isWebchatConnect,
+            requestedKey: key,
+            canonicalKey,
+            agentId: requestedAgentId,
+            sessionId: admittedSessionId,
+            excludeRunIds: new Set([idempotencyKey]),
+          });
+          if (interruptResult.error) {
+            respond(false, undefined, interruptResult.error);
+            return false;
+          }
+          interruptedActiveRun = interruptResult.interrupted;
+          try {
+            // A run can finish before the active check or while an interruption
+            // drains. Refresh only for new sends; replays retain their original result.
+            messageSeq = await readNextMessageSeq();
+          } catch (error) {
+            if (!isSessionTranscriptProjectionUnavailableError(error)) {
+              throw error;
+            }
+            // Interruption may already have committed side effects. The sequence is
+            // optional, so preserve delivery and let transcript events reconcile it.
+            messageSeq = undefined;
+          }
+          return true;
+        }
+      : undefined;
+
+    let sendAcked = false;
+    let sendPayload: unknown;
+    let sendCached = false;
+    let startedRunId: string | undefined;
+    await dispatchChatSend((ok, payload, error, meta) => {
+      sendAcked = ok;
+      sendPayload = payload;
+      sendCached = meta?.cached === true;
+      startedRunId =
+        payload &&
+        typeof payload === "object" &&
+        typeof (payload as { runId?: unknown }).runId === "string"
+          ? (payload as { runId: string }).runId
+          : undefined;
+      if (ok && shouldAttachPendingMessageSeq({ payload, cached: meta?.cached === true })) {
+        respond(
+          true,
+          {
+            ...(payload && typeof payload === "object" ? payload : {}),
+            ...(messageSeq !== undefined ? { messageSeq } : {}),
+            ...(interruptedActiveRun ? { interruptedActiveRun: true } : {}),
+          },
+          undefined,
+          meta,
+        );
+        return;
+      }
+      respond(
+        ok,
+        ok && payload && typeof payload === "object"
+          ? {
+              ...payload,
+              ...(interruptedActiveRun ? { interruptedActiveRun: true } : {}),
+            }
+          : payload,
+        error,
+        meta,
+      );
+    }, onAdmissionOwned);
+    if (sendAcked) {
+      if (shouldAttachPendingMessageSeq({ payload: sendPayload, cached: sendCached })) {
+        await reactivateCompletedSubagentSession({
+          sessionKey: canonicalKey,
+          runId: startedRunId,
+          task: (p as { message: string }).message,
+        });
+      }
+      emitSessionsChanged(params.context, {
+        sessionKey: canonicalKey,
+        ...(canonicalKey === "global" && requestedAgentId ? { agentId: requestedAgentId } : {}),
+        reason: interruptedActiveRun ? "steer" : "send",
       });
     }
-    emitSessionsChanged(params.context, {
-      sessionKey: canonicalKey,
-      ...(canonicalKey === "global" && requestedAgentId ? { agentId: requestedAgentId } : {}),
-      reason: interruptedActiveRun ? "steer" : "send",
-    });
+  } catch (error) {
+    if (steerInflightOwner) {
+      steerInflightOwner.fail(error);
+      return;
+    }
+    throw error;
+  } finally {
+    steerInflightOwner?.finish();
   }
 }
 

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -26,7 +26,7 @@ import {
   resolveDeletedAgentIdFromSessionKey,
 } from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
-import { hasReplayableChatSend } from "./chat-send-pre-admission.js";
+import { handleChatSend } from "./chat-send-handler.js";
 import { chatHandlers } from "./chat.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
@@ -266,11 +266,11 @@ async function handleSessionSend(params: {
       ? rawIdempotencyKey.trim()
       : undefined;
   const idempotencyKey = explicitIdempotencyKey ?? randomUUID();
-  const dispatchChatSend = async (respond: RespondFn) => {
-    await expectDefined(
-      chatHandlers["chat.send"],
-      "chat.send handler",
-    )({
+  const dispatchChatSend = async (
+    respond: RespondFn,
+    onAdmissionOwned?: () => Promise<boolean>,
+  ) => {
+    const options: GatewayRequestHandlerOptions = {
       req: params.req,
       params: {
         sessionKey: canonicalKey,
@@ -285,7 +285,12 @@ async function handleSessionSend(params: {
       context: params.context,
       client: params.client,
       isWebchatConnect: params.isWebchatConnect,
-    });
+    };
+    if (onAdmissionOwned) {
+      await handleChatSend(options, onAdmissionOwned);
+      return;
+    }
+    await expectDefined(chatHandlers["chat.send"], "chat.send handler")(options);
   };
   const archivedSessionError = resolveSessionWorkStartError(canonicalKey, entry);
   if (archivedSessionError) {
@@ -354,44 +359,38 @@ async function handleSessionSend(params: {
   }
 
   let interruptedActiveRun = false;
-  // An explicit retry may already own a chat.send that the handler will replay.
-  // Interrupting first aborts whatever is running now - an unrelated turn, or the
-  // very run this retry is replaying - and clears its queued follow-ups, so let
-  // the owning handler replay before steering, as the archive guard does above.
-  const replaysExistingChatSend =
-    explicitIdempotencyKey !== undefined &&
-    hasReplayableChatSend(params.context, explicitIdempotencyKey);
-  if (params.interruptIfActive && !replaysExistingChatSend) {
-    const interruptResult = await interruptSessionRunIfActive({
-      req: params.req,
-      context: params.context,
-      client: params.client,
-      isWebchatConnect: params.isWebchatConnect,
-      requestedKey: key,
-      canonicalKey,
-      agentId: requestedAgentId,
-      sessionId: entry.sessionId,
-    });
-    if (interruptResult.error) {
-      params.respond(false, undefined, interruptResult.error);
-      return;
-    }
-    interruptedActiveRun = interruptResult.interrupted;
-  }
-  if (params.interruptIfActive) {
-    try {
-      // A run can finish before the active check or while an interruption
-      // drains. Refresh after every steer attempt so the pending seq is current.
-      messageSeq = await readNextMessageSeq();
-    } catch (error) {
-      if (!isSessionTranscriptProjectionUnavailableError(error)) {
-        throw error;
+  const onAdmissionOwned = params.interruptIfActive
+    ? async (): Promise<boolean> => {
+        const interruptResult = await interruptSessionRunIfActive({
+          req: params.req,
+          context: params.context,
+          client: params.client,
+          isWebchatConnect: params.isWebchatConnect,
+          requestedKey: key,
+          canonicalKey,
+          agentId: requestedAgentId,
+          sessionId: entry.sessionId,
+        });
+        if (interruptResult.error) {
+          params.respond(false, undefined, interruptResult.error);
+          return false;
+        }
+        interruptedActiveRun = interruptResult.interrupted;
+        try {
+          // A run can finish before the active check or while an interruption
+          // drains. Refresh only for new sends; replays retain their original result.
+          messageSeq = await readNextMessageSeq();
+        } catch (error) {
+          if (!isSessionTranscriptProjectionUnavailableError(error)) {
+            throw error;
+          }
+          // Interruption may already have committed side effects. The sequence is
+          // optional, so preserve delivery and let transcript events reconcile it.
+          messageSeq = undefined;
+        }
+        return true;
       }
-      // Interruption may already have committed side effects. The sequence is
-      // optional, so preserve delivery and let transcript events reconcile it.
-      messageSeq = undefined;
-    }
-  }
+    : undefined;
 
   let sendAcked = false;
   let sendPayload: unknown;
@@ -431,7 +430,7 @@ async function handleSessionSend(params: {
       error,
       meta,
     );
-  });
+  }, onAdmissionOwned);
   if (sendAcked) {
     if (shouldAttachPendingMessageSeq({ payload: sendPayload, cached: sendCached })) {
       await reactivateCompletedSubagentSession({

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -4,7 +4,9 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorShape, ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { SessionTranscriptProjectionUnavailableError } from "../../config/sessions/session-accessor.js";
+import { createDeferred } from "../../test-utils/deferred.js";
 import { expectSubagentFollowupReactivation } from "./subagent-followup.test-helpers.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -19,6 +21,7 @@ const abortEmbeddedAgentRunMock = vi.fn();
 const waitForEmbeddedAgentRunEndMock = vi.fn();
 const clearSessionQueuesMock = vi.fn();
 const chatSendWithAdmissionOwnedMock = vi.fn();
+const handleChatAbortRequestWithLifecycleMock = vi.fn();
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
   const actual = await vi.importActual<typeof import("../../agents/embedded-agent-runner/runs.js")>(
@@ -86,6 +89,11 @@ vi.mock("./chat-send-handler.js", () => ({
   handleChatSend: (...args: unknown[]) => chatSendWithAdmissionOwnedMock(...args),
 }));
 
+vi.mock("./chat-abort-handler.js", () => ({
+  handleChatAbortRequestWithLifecycle: (...args: unknown[]) =>
+    handleChatAbortRequestWithLifecycleMock(...args),
+}));
+
 import { sessionsHandlers } from "./sessions.js";
 
 function createRequestContext(overrides: Record<string, unknown> = {}): GatewayRequestContext {
@@ -113,6 +121,11 @@ describe("sessions.send completed subagent follow-up status", () => {
     abortEmbeddedAgentRunMock.mockReset();
     waitForEmbeddedAgentRunEndMock.mockReset().mockResolvedValue(true);
     clearSessionQueuesMock.mockReset();
+    handleChatAbortRequestWithLifecycleMock
+      .mockReset()
+      .mockImplementation(async (options: { respond: RespondFn }) => {
+        options.respond(true, { ok: true, aborted: true, runIds: ["run-old"] });
+      });
     chatSendWithAdmissionOwnedMock
       .mockReset()
       .mockImplementation(
@@ -501,6 +514,163 @@ describe("sessions.send completed subagent follow-up status", () => {
     expect(clearSessionQueuesMock).not.toHaveBeenCalled();
     expect(readSessionMessageCountAsyncMock).toHaveBeenCalledTimes(1);
     expect(respondMock.mock.calls.at(0)?.[3]).toMatchObject({ cached: true });
+  });
+
+  it("sessions.steer makes a concurrent retry wait for successful interruption", async () => {
+    const sessionKey = "agent:main:main";
+    const idempotencyKey = "steer-concurrent-success";
+    const abortEntered = createDeferred();
+    const releaseAbort = createDeferred();
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-concurrent-success" },
+    });
+    handleChatAbortRequestWithLifecycleMock.mockImplementationOnce(
+      async (options: { respond: RespondFn }, lifecycle: { excludeRunIds?: Set<string> }) => {
+        expect(lifecycle.excludeRunIds).toEqual(new Set([idempotencyKey]));
+        abortEntered.resolve(undefined);
+        await releaseAbort.promise;
+        options.respond(true, { ok: true, aborted: true, runIds: ["run-old"] });
+      },
+    );
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: idempotencyKey, status: "started" });
+    });
+    const context = createRequestContext({
+      chatAbortControllers: new Map([
+        [
+          "run-old",
+          {
+            sessionKey,
+            sessionId: "sess-concurrent-success",
+            controlUiVisible: true,
+            projectSessionActive: true,
+          },
+        ],
+      ]),
+    });
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const invoke = (reqId: string, respond: ReturnType<typeof vi.fn>) =>
+      expectDefined(
+        sessionsHandlers["sessions.steer"],
+        'sessionsHandlers["sessions.steer"] test invariant',
+      )({
+        req: { id: reqId } as never,
+        params: {
+          key: sessionKey,
+          message: "replacement turn",
+          idempotencyKey,
+        },
+        respond: respond as unknown as RespondFn,
+        context,
+        client: null,
+        isWebchatConnect: () => false,
+      });
+
+    const first = invoke("req-concurrent-success-1", firstRespond);
+    await abortEntered.promise;
+    const second = invoke("req-concurrent-success-2", secondRespond);
+    await Promise.resolve();
+
+    expect(secondRespond).not.toHaveBeenCalled();
+    expect(handleChatAbortRequestWithLifecycleMock).toHaveBeenCalledTimes(1);
+    expect(chatSendMock).not.toHaveBeenCalled();
+
+    releaseAbort.resolve(undefined);
+    await Promise.all([first, second]);
+
+    expect(firstRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: idempotencyKey,
+        status: "started",
+        interruptedActiveRun: true,
+      }),
+      undefined,
+    );
+    expect(secondRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: idempotencyKey,
+        status: "started",
+        interruptedActiveRun: true,
+      }),
+      undefined,
+      { cached: true },
+    );
+    expect(chatSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sessions.steer replays interruption failure to a concurrent retry", async () => {
+    const sessionKey = "agent:main:main";
+    const idempotencyKey = "steer-concurrent-failure";
+    const abortEntered = createDeferred();
+    const releaseAbort = createDeferred();
+    const interruptError = errorShape(ErrorCodes.UNAVAILABLE, "interrupt failed");
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-concurrent-failure" },
+    });
+    handleChatAbortRequestWithLifecycleMock.mockImplementationOnce(
+      async (options: { respond: RespondFn }) => {
+        abortEntered.resolve(undefined);
+        await releaseAbort.promise;
+        options.respond(false, undefined, interruptError);
+      },
+    );
+    const context = createRequestContext({
+      chatAbortControllers: new Map([
+        [
+          "run-old",
+          {
+            sessionKey,
+            sessionId: "sess-concurrent-failure",
+            controlUiVisible: true,
+            projectSessionActive: true,
+          },
+        ],
+      ]),
+    });
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const invoke = (reqId: string, respond: ReturnType<typeof vi.fn>) =>
+      expectDefined(
+        sessionsHandlers["sessions.steer"],
+        'sessionsHandlers["sessions.steer"] test invariant',
+      )({
+        req: { id: reqId } as never,
+        params: {
+          key: sessionKey,
+          message: "replacement turn",
+          idempotencyKey,
+        },
+        respond: respond as unknown as RespondFn,
+        context,
+        client: null,
+        isWebchatConnect: () => false,
+      });
+
+    const first = invoke("req-concurrent-failure-1", firstRespond);
+    await abortEntered.promise;
+    const second = invoke("req-concurrent-failure-2", secondRespond);
+    await Promise.resolve();
+
+    expect(secondRespond).not.toHaveBeenCalled();
+    expect(handleChatAbortRequestWithLifecycleMock).toHaveBeenCalledTimes(1);
+
+    releaseAbort.resolve(undefined);
+    await Promise.all([first, second]);
+
+    expect(firstRespond).toHaveBeenCalledWith(false, undefined, interruptError);
+    expect(secondRespond).toHaveBeenCalledWith(false, undefined, interruptError, {
+      cached: true,
+    });
+    expect(chatSendMock).not.toHaveBeenCalled();
   });
 
   for (const method of ["sessions.send", "sessions.steer"] as const) {

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -17,6 +17,7 @@ const chatSendMock = vi.fn();
 const isEmbeddedAgentRunActiveMock = vi.fn();
 const abortEmbeddedAgentRunMock = vi.fn();
 const waitForEmbeddedAgentRunEndMock = vi.fn();
+const clearSessionQueuesMock = vi.fn();
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
   const actual = await vi.importActual<typeof import("../../agents/embedded-agent-runner/runs.js")>(
@@ -27,6 +28,16 @@ vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
     abortEmbeddedAgentRun: (...args: unknown[]) => abortEmbeddedAgentRunMock(...args),
     isEmbeddedAgentRunActive: (...args: unknown[]) => isEmbeddedAgentRunActiveMock(...args),
     waitForEmbeddedAgentRunEnd: (...args: unknown[]) => waitForEmbeddedAgentRunEndMock(...args),
+  };
+});
+
+vi.mock("../../auto-reply/reply/queue/cleanup.js", async () => {
+  const actual = await vi.importActual<typeof import("../../auto-reply/reply/queue/cleanup.js")>(
+    "../../auto-reply/reply/queue/cleanup.js",
+  );
+  return {
+    ...actual,
+    clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
   };
 });
 
@@ -72,6 +83,19 @@ vi.mock("./chat.js", () => ({
 
 import { sessionsHandlers } from "./sessions.js";
 
+function createRequestContext(overrides: Record<string, unknown> = {}): GatewayRequestContext {
+  return {
+    chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
+    chatRunState: { runs: new Map() },
+    dedupe: new Map(),
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set<string>(),
+    getRuntimeConfig: () => ({}),
+    ...overrides,
+  } as unknown as GatewayRequestContext;
+}
+
 describe("sessions.send completed subagent follow-up status", () => {
   beforeEach(() => {
     loadSessionEntryMock.mockReset();
@@ -83,6 +107,7 @@ describe("sessions.send completed subagent follow-up status", () => {
     isEmbeddedAgentRunActiveMock.mockReset().mockReturnValue(false);
     abortEmbeddedAgentRunMock.mockReset();
     waitForEmbeddedAgentRunEndMock.mockReset().mockResolvedValue(true);
+    clearSessionQueuesMock.mockReset();
   });
 
   it("reactivates completed subagent sessions before broadcasting sessions.changed", async () => {
@@ -122,12 +147,10 @@ describe("sessions.send completed subagent follow-up status", () => {
     const broadcastToConnIds = vi.fn();
     const respondMock = vi.fn();
     const respond = respondMock as unknown as RespondFn;
-    const context = {
-      chatAbortControllers: new Map(),
+    const context = createRequestContext({
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
-      getRuntimeConfig: () => ({}),
-    } as unknown as GatewayRequestContext;
+    });
 
     await expectDefined(
       sessionsHandlers["sessions.send"],
@@ -188,10 +211,7 @@ describe("sessions.send completed subagent follow-up status", () => {
           idempotencyKey: "retry-safe-send",
         },
         respond: respondMock as unknown as RespondFn,
-        context: {
-          chatAbortControllers: new Map(),
-          getRuntimeConfig: () => ({}),
-        } as unknown as GatewayRequestContext,
+        context: createRequestContext(),
         client: null,
         isWebchatConnect: () => false,
       });
@@ -237,12 +257,7 @@ describe("sessions.send completed subagent follow-up status", () => {
         idempotencyKey: "steer-after-drain",
       },
       respond: respondMock as unknown as RespondFn,
-      context: {
-        chatAbortControllers: new Map(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set<string>(),
-        getRuntimeConfig: () => ({}),
-      } as unknown as GatewayRequestContext,
+      context: createRequestContext(),
       client: null,
       isWebchatConnect: () => false,
     });
@@ -283,12 +298,7 @@ describe("sessions.send completed subagent follow-up status", () => {
         idempotencyKey: "steer-after-race",
       },
       respond: respondMock as unknown as RespondFn,
-      context: {
-        chatAbortControllers: new Map(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set<string>(),
-        getRuntimeConfig: () => ({}),
-      } as unknown as GatewayRequestContext,
+      context: createRequestContext(),
       client: null,
       isWebchatConnect: () => false,
     });
@@ -331,12 +341,7 @@ describe("sessions.send completed subagent follow-up status", () => {
         idempotencyKey: "steer-after-rebuild",
       },
       respond: respondMock as unknown as RespondFn,
-      context: {
-        chatAbortControllers: new Map(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set<string>(),
-        getRuntimeConfig: () => ({}),
-      } as unknown as GatewayRequestContext,
+      context: createRequestContext(),
       client: null,
       isWebchatConnect: () => false,
     });
@@ -348,6 +353,128 @@ describe("sessions.send completed subagent follow-up status", () => {
       interruptedActiveRun: true,
     });
     expect(respondMock.mock.calls.at(0)?.[1]).not.toHaveProperty("messageSeq");
+  });
+
+  it("sessions.steer replaying a cached idempotency key leaves the active run alone", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-unrelated-run" },
+    });
+    readSessionMessageCountAsyncMock.mockResolvedValue(6);
+    // An unrelated run started after the original steer completed.
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "steer-retry", status: "completed" }, undefined, { cached: true });
+    });
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
+    )({
+      req: { id: "req-steer-replay" } as never,
+      params: {
+        key: sessionKey,
+        message: "replacement turn",
+        idempotencyKey: "steer-retry",
+      },
+      respond: respondMock as unknown as RespondFn,
+      context: createRequestContext({
+        dedupe: new Map([
+          ["chat:steer-retry", { ts: 1, ok: true, payload: { runId: "steer-retry" } }],
+        ]),
+      }),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortEmbeddedAgentRunMock).not.toHaveBeenCalled();
+    expect(clearSessionQueuesMock).not.toHaveBeenCalled();
+    expect(respondMock.mock.calls.at(0)?.[1]).not.toHaveProperty("interruptedActiveRun");
+    expect(respondMock.mock.calls.at(0)?.[3]).toMatchObject({ cached: true });
+  });
+
+  it("sessions.steer still interrupts the active run for a fresh idempotency key", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-active" },
+    });
+    readSessionMessageCountAsyncMock.mockResolvedValue(6);
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "steer-fresh", status: "started" }, undefined, undefined);
+    });
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
+    )({
+      req: { id: "req-steer-fresh" } as never,
+      params: {
+        key: sessionKey,
+        message: "replacement turn",
+        idempotencyKey: "steer-fresh",
+      },
+      respond: respondMock as unknown as RespondFn,
+      context: createRequestContext(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("sess-active");
+    expect(clearSessionQueuesMock).toHaveBeenCalledWith([sessionKey, sessionKey, "sess-active"]);
+    expect(respondMock.mock.calls.at(0)?.[1]).toMatchObject({ interruptedActiveRun: true });
+  });
+
+  it("sessions.steer replaying an in-flight idempotency key leaves its own run alone", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-in-flight" },
+    });
+    readSessionMessageCountAsyncMock.mockResolvedValue(6);
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "steer-inflight", status: "in_flight" }, undefined, {
+        cached: true,
+        runId: "steer-inflight",
+      });
+    });
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
+    )({
+      req: { id: "req-steer-inflight" } as never,
+      params: {
+        key: sessionKey,
+        message: "replacement turn",
+        idempotencyKey: "steer-inflight",
+      },
+      respond: respondMock as unknown as RespondFn,
+      // The run the first attempt started is still registered under its own id.
+      context: createRequestContext({
+        chatAbortControllers: new Map([
+          ["steer-inflight", { sessionKey, sessionId: "sess-in-flight" }],
+        ]),
+      }),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortEmbeddedAgentRunMock).not.toHaveBeenCalled();
+    expect(clearSessionQueuesMock).not.toHaveBeenCalled();
+    expect(respondMock.mock.calls.at(0)?.[3]).toMatchObject({ cached: true });
   });
 
   for (const method of ["sessions.send", "sessions.steer"] as const) {
@@ -366,12 +493,7 @@ describe("sessions.send completed subagent follow-up status", () => {
 
       const respondMock = vi.fn();
       const respond = respondMock as unknown as RespondFn;
-      const context = {
-        chatAbortControllers: new Map(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set<string>(),
-        getRuntimeConfig: () => cfg,
-      } as unknown as GatewayRequestContext;
+      const context = createRequestContext({ getRuntimeConfig: () => cfg });
 
       await expectDefined(
         sessionsHandlers[method],

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -18,6 +18,7 @@ const isEmbeddedAgentRunActiveMock = vi.fn();
 const abortEmbeddedAgentRunMock = vi.fn();
 const waitForEmbeddedAgentRunEndMock = vi.fn();
 const clearSessionQueuesMock = vi.fn();
+const chatSendWithAdmissionOwnedMock = vi.fn();
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
   const actual = await vi.importActual<typeof import("../../agents/embedded-agent-runner/runs.js")>(
@@ -81,6 +82,10 @@ vi.mock("./chat.js", () => ({
   },
 }));
 
+vi.mock("./chat-send-handler.js", () => ({
+  handleChatSend: (...args: unknown[]) => chatSendWithAdmissionOwnedMock(...args),
+}));
+
 import { sessionsHandlers } from "./sessions.js";
 
 function createRequestContext(overrides: Record<string, unknown> = {}): GatewayRequestContext {
@@ -108,6 +113,15 @@ describe("sessions.send completed subagent follow-up status", () => {
     abortEmbeddedAgentRunMock.mockReset();
     waitForEmbeddedAgentRunEndMock.mockReset().mockResolvedValue(true);
     clearSessionQueuesMock.mockReset();
+    chatSendWithAdmissionOwnedMock
+      .mockReset()
+      .mockImplementation(
+        async (options: { respond: RespondFn }, onAdmissionOwned: () => Promise<boolean>) => {
+          if (await onAdmissionOwned()) {
+            await chatSendMock(options);
+          }
+        },
+      );
   });
 
   it("reactivates completed subagent sessions before broadcasting sessions.changed", async () => {
@@ -369,6 +383,11 @@ describe("sessions.send completed subagent follow-up status", () => {
     chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
       respond(true, { runId: "steer-retry", status: "completed" }, undefined, { cached: true });
     });
+    chatSendWithAdmissionOwnedMock.mockImplementationOnce(
+      async (options: { respond: RespondFn }) => {
+        await chatSendMock(options);
+      },
+    );
 
     const respondMock = vi.fn();
     await expectDefined(
@@ -393,6 +412,7 @@ describe("sessions.send completed subagent follow-up status", () => {
 
     expect(abortEmbeddedAgentRunMock).not.toHaveBeenCalled();
     expect(clearSessionQueuesMock).not.toHaveBeenCalled();
+    expect(readSessionMessageCountAsyncMock).toHaveBeenCalledTimes(1);
     expect(respondMock.mock.calls.at(0)?.[1]).not.toHaveProperty("interruptedActiveRun");
     expect(respondMock.mock.calls.at(0)?.[3]).toMatchObject({ cached: true });
   });
@@ -449,6 +469,11 @@ describe("sessions.send completed subagent follow-up status", () => {
         runId: "steer-inflight",
       });
     });
+    chatSendWithAdmissionOwnedMock.mockImplementationOnce(
+      async (options: { respond: RespondFn }) => {
+        await chatSendMock(options);
+      },
+    );
 
     const respondMock = vi.fn();
     await expectDefined(
@@ -474,6 +499,7 @@ describe("sessions.send completed subagent follow-up status", () => {
 
     expect(abortEmbeddedAgentRunMock).not.toHaveBeenCalled();
     expect(clearSessionQueuesMock).not.toHaveBeenCalled();
+    expect(readSessionMessageCountAsyncMock).toHaveBeenCalledTimes(1);
     expect(respondMock.mock.calls.at(0)?.[3]).toMatchObject({ cached: true });
   });
 

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -36,7 +36,11 @@ import {
   createTextTranscriptEvent,
 } from "./server-chat.agent-events.test-helpers.js";
 import { getMaxChatHistoryMessagesBytes } from "./server-constants.js";
-import type { GatewayRequestContext, RespondFn } from "./server-methods/shared-types.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+  RespondFn,
+} from "./server-methods/shared-types.js";
 import { pendingChatSendDedupeKey } from "./server-shared.js";
 import {
   connectOk,
@@ -246,6 +250,7 @@ async function sendControlUiChat(params: {
   idempotencyKey: string;
   message: string;
   respond: RespondFn;
+  onAdmissionOwned?: () => Promise<boolean>;
 }): Promise<void> {
   const requestParams = {
     sessionKey: "main",
@@ -255,11 +260,7 @@ async function sendControlUiChat(params: {
       ? { expectedSessionRoutingContract: params.expectedSessionRoutingContract }
       : {}),
   };
-  const { chatHandlers } = await import("./server-methods/chat.js");
-  await expectDefined(
-    chatHandlers["chat.send"],
-    'chatHandlers["chat.send"] test invariant',
-  )({
+  const options: GatewayRequestHandlerOptions = {
     req: {
       type: "req",
       id: params.idempotencyKey,
@@ -283,7 +284,17 @@ async function sendControlUiChat(params: {
     isWebchatConnect: () => true,
     respond: params.respond,
     context: params.context,
-  });
+  };
+  if (params.onAdmissionOwned) {
+    const { handleChatSend } = await import("./server-methods/chat-send-handler.js");
+    await handleChatSend(options, params.onAdmissionOwned);
+    return;
+  }
+  const { chatHandlers } = await import("./server-methods/chat.js");
+  await expectDefined(
+    chatHandlers["chat.send"],
+    'chatHandlers["chat.send"] test invariant',
+  )(options);
 }
 
 test("chat.send replays a cached result after the session is archived", async () => {
@@ -2829,11 +2840,16 @@ describe("gateway server chat", () => {
       const context = createDirectChatContext();
       dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
       let snapshotAtAck: ReturnType<typeof loadSessionEntry>;
+      const freshAdmission = vi.fn(async () => {
+        expect(context.chatAbortControllers.get(nextRunId)?.controlUiVisible).toBe(false);
+        return true;
+      });
 
       await sendControlUiChat({
         context,
         idempotencyKey: nextRunId,
         message: "admit after terminal claim",
+        onAdmissionOwned: freshAdmission,
         respond: ((ok, payload) => {
           if (ok && (payload as { status?: unknown } | undefined)?.status === "started") {
             snapshotAtAck = loadSessionEntry({
@@ -2844,6 +2860,8 @@ describe("gateway server chat", () => {
         }) as RespondFn,
       });
 
+      expect(freshAdmission).toHaveBeenCalledTimes(1);
+      expect(context.chatAbortControllers.get(nextRunId)?.controlUiVisible).toBeUndefined();
       expect(snapshotAtAck).toMatchObject({
         restartRecoveryDeliveryRunId: nextRunId,
         restartRecoveryDeliverySourceRunId: nextRunId,
@@ -2852,13 +2870,16 @@ describe("gateway server chat", () => {
       });
 
       const retryResponses: Array<{ ok: boolean; payload?: unknown; meta?: unknown }> = [];
+      const replayAdmission = vi.fn(async () => true);
       await sendControlUiChat({
         context,
         idempotencyKey: priorRunId,
         message: "must not execute again",
+        onAdmissionOwned: replayAdmission,
         respond: ((ok, payload, _error, meta) =>
           retryResponses.push({ ok, payload, meta })) as RespondFn,
       });
+      expect(replayAdmission).not.toHaveBeenCalled();
       expect(retryResponses).toEqual([
         {
           ok: true,
@@ -2867,6 +2888,62 @@ describe("gateway server chat", () => {
         },
       ]);
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      dispatchRelease.resolve(undefined);
+      await waitForFast(
+        () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
+        FAST_WAIT_OPTS,
+      );
+    } finally {
+      dispatchRelease.resolve(undefined);
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+    }
+  });
+
+  test("chat.send runs an admission-owned callback for only one concurrent retry", async () => {
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
+    const dispatchRelease = createDeferred();
+    const runId = "idem-concurrent-admission-owner";
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            status: "done",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const context = createDirectChatContext();
+      dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
+      const firstAdmission = vi.fn(async () => true);
+      const secondAdmission = vi.fn(async () => true);
+      const responses: Array<{ ok: boolean; payload?: unknown; meta?: unknown }> = [];
+      const send = (onAdmissionOwned: () => Promise<boolean>) =>
+        sendControlUiChat({
+          context,
+          idempotencyKey: runId,
+          message: "admit exactly once",
+          onAdmissionOwned,
+          respond: ((ok, payload, _error, meta) =>
+            responses.push({ ok, payload, meta })) as RespondFn,
+        });
+
+      await Promise.all([send(firstAdmission), send(secondAdmission)]);
+
+      expect(firstAdmission.mock.calls.length + secondAdmission.mock.calls.length).toBe(1);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(responses).toHaveLength(2);
+      expect(responses.every((response) => response.ok)).toBe(true);
+      expect(
+        responses.filter(
+          (response) =>
+            (response.payload as { status?: unknown } | undefined)?.status === "started",
+        ),
+      ).toHaveLength(1);
 
       dispatchRelease.resolve(undefined);
       await waitForFast(

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2841,7 +2841,7 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
       let snapshotAtAck: ReturnType<typeof loadSessionEntry>;
       const freshAdmission = vi.fn(async () => {
-        expect(context.chatAbortControllers.get(nextRunId)?.controlUiVisible).toBe(false);
+        expect(context.chatAbortControllers.get(nextRunId)?.controlUiVisible).not.toBe(false);
         return true;
       });
 
@@ -2952,6 +2952,94 @@ describe("gateway server chat", () => {
       );
     } finally {
       dispatchRelease.resolve(undefined);
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+    }
+  });
+
+  test("chat.abort still sees a replacement while its admission callback is running", async () => {
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
+    const callbackEntered = createDeferred();
+    const releaseCallback = createDeferred();
+    const runId = "idem-visible-during-admission-callback";
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            status: "done",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const context = createDirectChatContext({ chatQueuedTurns: new Map() });
+      const sendResponses: Array<{ ok: boolean; payload?: unknown }> = [];
+      const sendPromise = sendControlUiChat({
+        context,
+        idempotencyKey: runId,
+        message: "remain publicly abortable",
+        onAdmissionOwned: async () => {
+          callbackEntered.resolve(undefined);
+          await releaseCallback.promise;
+          return true;
+        },
+        respond: ((ok, payload) => sendResponses.push({ ok, payload })) as RespondFn,
+      });
+      await callbackEntered.promise;
+      expect(context.chatAbortControllers.get(runId)?.controlUiVisible).not.toBe(false);
+
+      const abortResponses: Array<{ ok: boolean; payload?: unknown }> = [];
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      await expectDefined(
+        chatHandlers["chat.abort"],
+        'chatHandlers["chat.abort"] test invariant',
+      )({
+        req: {
+          type: "req",
+          id: "abort-visible-replacement",
+          method: "chat.abort",
+          params: { sessionKey: "main" },
+        },
+        params: { sessionKey: "main" },
+        client: {
+          connect: {
+            client: {
+              id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+              mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            },
+            scopes: ["operator.write", "operator.admin"],
+          },
+        } as never,
+        isWebchatConnect: () => true,
+        respond: ((ok, payload) => abortResponses.push({ ok, payload })) as RespondFn,
+        context,
+      });
+
+      expect(abortResponses).toEqual([
+        {
+          ok: true,
+          payload: { ok: true, aborted: true, runIds: [runId] },
+        },
+      ]);
+      releaseCallback.resolve(undefined);
+      await sendPromise;
+
+      expect(sendResponses).toEqual([
+        {
+          ok: true,
+          payload: expect.objectContaining({
+            runId,
+            status: "timeout",
+            summary: "aborted",
+            stopReason: "rpc",
+          }),
+        },
+      ]);
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    } finally {
+      releaseCallback.resolve(undefined);
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();


### PR DESCRIPTION
## What Problem This Solves

`sessions.steer` used to interrupt the active session and clear queued follow-up work before `chat.send` decided whether the supplied `idempotencyKey` represented a new turn or a replay.

That made a normal retry destructive:

- an in-flight retry could abort the run it was retrying;
- a cached retry could abort unrelated work started later;
- a durable retry after Gateway restart could still interrupt before the persisted claim was replayed.

This is a P1 regression on a default Gateway path. It was introduced when steer interruption moved ahead of dispatch in `0b409a0348c68acf5f5a308ed73a406cf5b2a0f2` (#107677). The canonical pre-admission owner was later extracted in `b958fb6882076aba174a2a9181f6034ca7d9bedf` (#106590), which provides the correct boundary for the repair.

The regression shipped in the 2026.7.2 beta train beginning with `2026.7.2-beta.1` on July 15, 2026. It is also present in beta.2, beta.3, the unpromoted beta.4 tag, and beta.5 published July 28, 2026.

## Why This Change Was Made

The rewrite makes `chat.send` admission the single owner of the replay-or-new-work decision.

1. `chat.send` performs replay, pending, active, and durable-claim checks under exclusive admission.
2. Only the request that actually owns a fresh admission runs the steer interruption callback.
3. Explicit-key concurrent `sessions.steer` retries join one process-local operation and wait for the owner's real success or failure instead of receiving a speculative `in_flight` success.
4. The replacement run remains publicly visible and abortable. Only the internal steer cleanup excludes that exact replacement run id while aborting the prior session work.

This fixes cached, in-flight, concurrent, and post-restart durable replay without duplicating the replay predicate in `sessions.steer`.

## Evidence Map

| Cell | Evidence |
|---|---|
| Changed surface | `chat-send-admission.ts`, `chat-send-handler.ts`, `chat-send-setup.ts`, `sessions-messaging.ts`, and scoped abort/active-run helpers |
| Entry point | `sessions.steer` in `sessions-messaging.ts` |
| Owner boundary | exclusive `chat.send` admission owns replay versus fresh work |
| Caller | Gateway `sessions.steer` RPC |
| Callee | `handleChatSend` / `admitChatSend`, then scoped `handleChatAbortRequestWithLifecycle` |
| Sibling behavior | ordinary `sessions.send` does not interrupt; public `chat.abort` remains able to cancel the replacement |
| Current-main behavior | interruption occurs before canonical replay admission |
| Tests | cached replay, in-flight replay, fresh-key steer, concurrent success/failure, scoped internal abort, public abort during callback, durable restart/admission, and WebSocket RPC |

## User Impact

Retrying `sessions.steer` with the same idempotency key is now non-destructive. The retry receives the original owner result, does not clear queues again, and does not abort either its own replacement or unrelated later work. A fresh steer still interrupts prior work as designed.

## Verification

Validated at exact head `545b15c863bed63b7df3519703c051137ba1e68a` on base `65f3e42f24336308cb955063ab7fcddfb604787e`.

```text
node scripts/run-vitest.mjs src/gateway/server-methods/sessions.send-followup-status.test.ts
  13 passed

node scripts/run-vitest.mjs src/gateway/server-methods/session-active-runs.test.ts
  8 passed

node scripts/run-vitest.mjs src/gateway/server-methods/chat.abort-authorization.test.ts
  32 passed

node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts
  93 passed

node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts \
  src/gateway/server.chat.gateway-server-chat.test.ts \
  -t "sessions.steer accepts dashboard follow-up messages for existing sessions"
  1 passed
```

Targeted `oxfmt`, `oxlint`, `git diff --check`, plugin-boundary, dependency, dead-export, and API baseline gates passed. Blacksmith exact-head `pnpm check:changed` passed, including core and test typechecks: https://github.com/openclaw/openclaw/actions/runs/30681430176.

Hosted CI attempt 2 is terminal green. The initial unrelated `qa-runner-runtime.integration.test.ts` timeout passed on the hosted rerun and in two exact-shard Blacksmith reproductions. Final rollup: 82 passed, 0 failed, 0 pending, and 36 intentionally skipped or neutral: https://github.com/openclaw/openclaw/actions/runs/30681295687.

Fresh exact-head autoreview reported no actionable P0/P1 findings and judged the patch correct. ClawSweeper reviewed the same head with no findings and sufficient proof: https://github.com/openclaw/openclaw/pull/116969#issuecomment-5145886856.

## Real Behavior Proof

```json
{
  "scenario": "sessions.steer idempotent replay and concurrent retry",
  "head": "545b15c863bed63b7df3519703c051137ba1e68a",
  "result": "pass",
  "observed": {
    "cachedReplayInterrupts": false,
    "inflightReplayInterrupts": false,
    "durableReplayInterruptsBeforeReplay": false,
    "concurrentFollowerWaitsForOwner": true,
    "concurrentFailureIsReplayed": true,
    "freshSteerInterruptsPriorRun": true,
    "publicAbortSeesReplacementDuringAdmissionCallback": true,
    "duplicateDispatches": 0
  }
}
```

Thanks @masatohoshino for identifying and implementing the original replay fix.