### PR TITLE
fix(text): preserve fenced tool markers in visible-text sanitizer (#116939)

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -5,6 +5,7 @@ import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
+  stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "./assistant-visible-text.js";
@@ -858,6 +859,21 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("preserves fenced log lines quoting tool markers through delivery", () => {
+    const input = [
+      "Log format explainer:",
+      "",
+      "```text",
+      "[Tool Result for ID abc]",
+      "stdout: hello",
+      "```",
+      "",
+      "Then we continue the answer with important details.",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("strips minimax, tool XML, downgraded tool markers, and think tags in one pass", () => {
     const input = [
       '<invoke name="read">payload</invoke></minimax:tool_call>',
@@ -1016,5 +1032,70 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
     expect(sanitizeAssistantVisibleTextWithProfile(input, "tool-progress")).toBe(
       "🛠️ run git status",
     );
+  });
+});
+
+describe("stripDowngradedToolCallText", () => {
+  it("preserves fenced log lines that quote [Tool Result for ID ...]", () => {
+    const input = [
+      "Log format explainer:",
+      "",
+      "```text",
+      "[Tool Result for ID abc]",
+      "stdout: hello",
+      "```",
+      "",
+      "Then we continue the answer with important details.",
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("preserves fenced log lines that quote [Tool Call: ...] and Arguments", () => {
+    const input = [
+      "Log format explainer:",
+      "",
+      "```text",
+      "[Tool Call: bash (ID: 7)]",
+      'Arguments: {"cmd":"ls"}',
+      "```",
+      "",
+      "Then we continue the answer with important details.",
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("preserves fenced log lines that quote [Historical context: ...]", () => {
+    const input = [
+      "Log format explainer:",
+      "",
+      "```text",
+      "[Historical context: earlier run]",
+      "stdout: hello",
+      "```",
+      "",
+      "Then we continue the answer with important details.",
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("strips real [Tool Result for ID ...] blocks outside code", () => {
+    const input = ["[Tool Result for ID abc]", "stdout: hello"].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe("");
+  });
+
+  it("strips real [Tool Call: ...] blocks outside code", () => {
+    const input = ["[Tool Call: read (ID: toolu_1)]", 'Arguments: {"path":"/tmp/x"}'].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe("");
+  });
+
+  it("strips real [Historical context: ...] markers outside code", () => {
+    const input = "[Historical context: earlier run]\nVisible answer";
+
+    expect(stripDowngradedToolCallText(input)).toBe("Visible answer");
   });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -815,11 +815,15 @@ export function stripDowngradedToolCallText(text: string): string {
 
   const stripToolCalls = (input: string): string => {
     const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
+    const codeRegions = findCodeRegions(input);
     let result = "";
     let cursor = 0;
     for (const match of input.matchAll(toolCallRe)) {
       const start = match.index ?? 0;
       if (start < cursor) {
+        continue;
+      }
+      if (isInsideCode(start, codeRegions)) {
         continue;
       }
       result += input.slice(cursor, start);
@@ -871,11 +875,19 @@ export function stripDowngradedToolCallText(text: string): string {
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
   let cleaned = stripToolCalls(text);
 
-  // Remove [Tool Result for ID ...] blocks and their content.
-  cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");
+  // Remove [Tool Result for ID ...] blocks and their content, unless the
+  // marker is quoted inside a fenced code block where it is reference material.
+  let codeRegions = findCodeRegions(cleaned);
+  cleaned = cleaned.replace(
+    /\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi,
+    (match, offset: number) => (isInsideCode(offset, codeRegions) ? match : ""),
+  );
 
   // Remove [Historical context: ...] markers (self-contained within brackets).
-  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
+  codeRegions = findCodeRegions(cleaned);
+  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, (match, offset: number) =>
+    isInsideCode(offset, codeRegions) ? match : "",
+  );
 
   return cleaned.trim();
 }


### PR DESCRIPTION
## What Problem This Solves
`sanitizeAssistantVisibleText` (via `stripDowngradedToolCallText` in `src/shared/text/assistant-visible-text.ts`) strips `[Tool Result for ID ...]`, `[Tool Call: ...]`, and `[Historical context: ...]` markers even when they appear as quoted reference material inside fenced code blocks in the assistant's reply. When a model quotes a tool log inside a markdown fence, the sanitizer deletes the fence content, corrupting user-visible output. Example from the issue: a 126-byte fenced log line drops to 30 bytes because the `[Tool Result for ID[^\]]*\]\n?[\s\S]*?` regex consumes everything after the marker up to the next `[Tool ` or end of input.

## Why This Change Was Made
The regexes are meant to remove live tool-call scaffolding from model output, not to erase quoted log material a model intentionally preserves inside fences for the user. The repo already has `findCodeRegions`/`isInsideCode` helpers (used by `stripReasoningProgressTagsOutsideCode` in `src/channels/progress-draft-status-text.ts:94`) precisely for this "skip code regions" behavior. Guarding all three marker passes with `isInsideCode` reuses the established pattern and makes the sanitizer fence-aware.

## User Impact
Assistant replies that quote tool logs/context inside fenced code blocks are delivered intact instead of having their quoted content silently truncated or removed. Replies that contain live, unfenced tool markers are still stripped exactly as before (all pre-existing cases unchanged).

## Evidence
Before this change, running the public sanitizer on a fenced quote:

```
Log format explainer:

```text
[Tool Result for ID abc]
stdout: hello
```

Then we continue the answer with important details.
```

produced `126 -> 30` bytes (fence content after the marker eaten). After the change the input is returned byte-identical.

Regression tests added in `src/shared/text/assistant-visible-text.test.ts`:
- `describe("stripDowngradedToolCallText")` — preserves fenced `[Tool Result ...]`, `[Tool Call: ...]`, `[Historical context: ...]`; strips the unfenced variants.
- `describe("sanitizeAssistantVisibleText")` — fenced quote preserved through the full delivery pipeline.

Result: `121/121` tests pass. `oxfmt` and `oxlint` are clean on both changed files; `git diff --check` is clean.

Closes #116939
