### PR TITLE
fix(test): avoid macOS release gate deadlocks

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -74,6 +74,46 @@ function runCiGateFixture(requiredResults: string, selectedResults: string) {
   });
 }
 
+function quoteShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function runWorkflowShellScript(
+  script: string,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv },
+) {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-workflow-shell-"));
+  const modulePaths: string[] = [];
+  try {
+    let moduleIndex = 0;
+    const moduleRoot = options.cwd ?? process.cwd();
+    const rewritten = script.replace(
+      /node --input-type=module <<'EOF'\n([\s\S]*?)\nEOF/gu,
+      (_match, body: string) => {
+        const modulePath = path.join(
+          moduleRoot,
+          `.openclaw-${path.basename(root)}-${moduleIndex}.mjs`,
+        );
+        moduleIndex += 1;
+        modulePaths.push(modulePath);
+        writeFileSync(modulePath, `${body}\n`, "utf8");
+        return `${quoteShell(process.execPath)} ${quoteShell(modulePath)}`;
+      },
+    );
+    const scriptPath = path.join(root, "run.sh");
+    writeFileSync(scriptPath, rewritten.endsWith("\n") ? rewritten : `${rewritten}\n`, "utf8");
+    return spawnSync("bash", [scriptPath], {
+      ...options,
+      encoding: "utf8",
+    });
+  } finally {
+    for (const modulePath of modulePaths) {
+      rmSync(modulePath, { force: true });
+    }
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
 function runCiManifestFixture(options: {
   bundledPlanner: boolean;
   changedPlannerImportFails?: boolean;
@@ -216,9 +256,8 @@ function runCiManifestFixture(options: {
     const manifestStep = readCiWorkflow().jobs.preflight.steps.find(
       (step: { name?: string }) => step.name === "Build CI manifest",
     );
-    const run = spawnSync("bash", ["-c", manifestStep.run], {
+    const run = runWorkflowShellScript(manifestStep.run, {
       cwd: root,
-      encoding: "utf8",
       env: {
         ...process.env,
         GITHUB_OUTPUT: outputPath,
@@ -3110,8 +3149,7 @@ describe("ci workflow guards", () => {
     expect(validateStep.run).toContain("requestedRegion !== process.env.BLACKSMITH_REGION");
     expect(validateStep.run).toContain("requestedKey !== requestedKey.trim()");
     expect(validateStep.run).toContain("disk?.key === requestedKey");
-    const rejectedKey = spawnSync("bash", ["-c", validateStep.run], {
-      encoding: "utf8",
+    const rejectedKey = runWorkflowShellScript(validateStep.run, {
       env: {
         ...process.env,
         BLACKSMITH_ENV: "production-amd64",
@@ -3123,8 +3161,7 @@ describe("ci workflow guards", () => {
     });
     expect(rejectedKey.status).not.toBe(0);
     expect(rejectedKey.stderr).toContain("identity is not allowlisted for retirement");
-    const paddedKey = spawnSync("bash", ["-c", validateStep.run], {
-      encoding: "utf8",
+    const paddedKey = runWorkflowShellScript(validateStep.run, {
       env: {
         ...process.env,
         BLACKSMITH_ENV: "production-amd64",

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -8,6 +8,9 @@ import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = join(process.cwd(), "scripts/github/find-reusable-release-validation.sh");
+// Homebrew Bash 5.3 can deadlock in nested command substitutions under Node's
+// synchronous child runner on macOS; CI executes this script with system Bash.
+const BASH_PATH = process.platform === "darwin" ? "/bin/bash" : "bash";
 const tempDirs = createTempDirTracker();
 const sharedTempDirs = createTempDirTracker();
 
@@ -472,7 +475,7 @@ function runResolver(args: {
     );
   }
   return spawnSync(
-    "bash",
+    BASH_PATH,
     [
       SCRIPT_PATH,
       "--target-sha",


### PR DESCRIPTION
## Summary

- execute workflow `run:` fixtures from temporary script files instead of `bash -c`
- materialize inline Node module heredocs as temporary `.mjs` files at the simulated checkout root
- use macOS system Bash for release-evidence resolver fixtures instead of Homebrew Bash 5.3
- remove two independent macOS deadlocks that blocked the repo-native full test gate

## Root causes

1. `test/scripts/ci-workflow-guards.test.ts` replayed GitHub Actions `run:` blocks containing Node heredocs through synchronous `bash -c`. On macOS this could deadlock inside Vitest. The harness now mirrors GitHub Actions by writing script files and materializing inline modules.
2. `test/scripts/find-reusable-release-validation.test.ts` intermittently deadlocked in nested command substitutions when Homebrew Bash 5.3 was launched through Node's synchronous child runner. GitHub Actions uses system Bash, so the macOS fixture now selects `/bin/bash`.

## Validation

- combined focused run: 130 passed, 1 skipped
- release reuse fixture: unfixed repeated loop hung on run 3
- release reuse fixture: fixed loop passed 10 consecutive runs (38 tests each)
- `./node_modules/.bin/oxfmt --check test/scripts/ci-workflow-guards.test.ts test/scripts/find-reusable-release-validation.test.ts`
- `git diff --check`

No changelog entry: test harness reliability only.
