### PR TITLE
perf(cli): overlap gateway runtime import with preflight

### DIFF
--- a/src/cli/gateway-cli/run-command.test.ts
+++ b/src/cli/gateway-cli/run-command.test.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addGatewayRunCommand } from "./run-command.js";
+
+const runGatewayCommandMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("./run.js", () => ({
+  runGatewayCommand: runGatewayCommandMock,
+}));
+
+describe("addGatewayRunCommand", () => {
+  beforeEach(() => {
+    runGatewayCommandMock.mockClear();
+  });
+
+  it("consumes an injected prepared runtime after preflight", async () => {
+    const order: string[] = [];
+    const loadRuntime = vi.fn(async () => {
+      order.push("runtime");
+      return { runGatewayCommand: runGatewayCommandMock };
+    });
+    const program = new Command();
+    addGatewayRunCommand(program.command("gateway"), {
+      beforeRun: async () => {
+        order.push("preflight");
+      },
+      loadRuntime,
+    });
+
+    await program.parseAsync(["gateway"], { from: "user" });
+
+    expect(order).toEqual(["preflight", "runtime"]);
+    expect(loadRuntime).toHaveBeenCalledTimes(1);
+    expect(runGatewayCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the default runtime import for callers without a prepared module", async () => {
+    const program = new Command();
+    addGatewayRunCommand(program.command("gateway"));
+
+    await program.parseAsync(["gateway"], { from: "user" });
+
+    expect(runGatewayCommandMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -13,6 +13,7 @@ function formatModeChoices(modes: readonly string[]): string {
 
 type GatewayRunCommandHooks = {
   beforeRun?: (opts: Pick<GatewayRunOpts, "force" | "reset">) => Promise<void> | void;
+  loadRuntime?: () => Promise<Pick<typeof import("./run.js"), "runGatewayCommand">>;
 };
 
 export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks = {}): Command {
@@ -69,7 +70,7 @@ export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks
     .action(async (opts, command) => {
       const resolved = resolveGatewayRunOptions(opts, command);
       await hooks.beforeRun?.(resolved);
-      const { runGatewayCommand } = await import("./run.js");
+      const { runGatewayCommand } = await (hooks.loadRuntime?.() ?? import("./run.js"));
       await runGatewayCommand(resolved, getGatewayRunRuntimeHooks());
     });
 }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -127,6 +127,7 @@ const resolveControlUiLinksMock = vi.hoisted(() =>
 const commanderParseAsyncMock = vi.hoisted(() => vi.fn(async () => {}));
 type GatewayRunCommandHooks = {
   beforeRun?: (opts: { reset?: boolean }) => Promise<void>;
+  loadRuntime?: () => Promise<Pick<typeof import("./gateway-cli/run.js"), "runGatewayCommand">>;
 };
 type CliExecutionBootstrapOptions = {
   beforeStateMigrations?: (snapshot?: ConfigSnapshotStub) => Promise<boolean>;
@@ -647,6 +648,16 @@ describe("runCli exit behavior", () => {
       "gateway",
       "--force",
     ]);
+  });
+
+  it("shares one prepared gateway runtime across both foreground command forms", async () => {
+    await runCli(["node", "openclaw", "gateway", "--force"]);
+
+    const rootHooks = addGatewayRunCommandMock.mock.calls[0]?.[1];
+    const runHooks = addGatewayRunCommandMock.mock.calls[1]?.[1];
+    expect(rootHooks?.loadRuntime).toEqual(expect.any(Function));
+    expect(runHooks?.loadRuntime).toEqual(expect.any(Function));
+    expect(await rootHooks?.loadRuntime?.()).toBe(await runHooks?.loadRuntime?.());
   });
 
   it("installs console capture before parsing the gateway foreground fast path", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -158,6 +158,7 @@ function isGatewayRunInvocationArgv(argv: string[]): boolean {
 async function tryRunGatewayRunFastPath(
   argv: string[],
   startupTrace: ReturnType<typeof createGatewayStartupTrace>,
+  preparedRuntime?: Promise<Pick<typeof import("./gateway-cli/run.js"), "runGatewayCommand">>,
 ): Promise<boolean> {
   if (!isGatewayRunFastPathArgv(argv)) {
     return false;
@@ -242,11 +243,17 @@ async function tryRunGatewayRunFastPath(
   };
   const gateway = addGatewayRunCommand(
     program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
-    { beforeRun },
+    {
+      beforeRun,
+      ...(preparedRuntime ? { loadRuntime: () => preparedRuntime } : {}),
+    },
   );
   addGatewayRunCommand(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),
-    { beforeRun },
+    {
+      beforeRun,
+      ...(preparedRuntime ? { loadRuntime: () => preparedRuntime } : {}),
+    },
   );
   try {
     await startupTrace.measure("gateway-run-parse", () => program.parseAsync(argv));
@@ -1275,6 +1282,12 @@ async function runCliWithPreparedOutputMode(
       refreshManagedProxy: replaceStartedProxy,
     });
   }
+  const preparedGatewayRunRuntime = isGatewayRunFastPathArgv(normalizedArgv)
+    ? startupTrace.measure("gateway-run-runtime-import", () => import("./gateway-cli/run.js"))
+    : undefined;
+  // Gateway runtime modules can observe selected paths and env at import time. Prepare exactly one
+  // import after selection so mandatory preflight can overlap the same cold graph it will consume.
+  void preparedGatewayRunRuntime?.catch(() => {});
 
   try {
     if (shouldUseRootHelpFastPath(normalizedArgv)) {
@@ -1399,7 +1412,7 @@ async function runCliWithPreparedOutputMode(
       shouldUseCliEnvProxy && shouldBootstrapCliProxyBeforeFastPath();
     if (
       !bootstrapProxyBeforeFastPath &&
-      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace))
+      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace, preparedGatewayRunRuntime))
     ) {
       return;
     }
@@ -1412,7 +1425,7 @@ async function runCliWithPreparedOutputMode(
 
     if (
       bootstrapProxyBeforeFastPath &&
-      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace))
+      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace, preparedGatewayRunRuntime))
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- prepare the foreground gateway runtime import immediately after gateway environment selection
- overlap that single import promise with the existing CLI bootstrap/preflight work
- inject the prepared module into both `gateway` and `gateway run` while preserving the existing lazy import for other callers
- add a startup trace phase plus focused ordering, reuse, and fallback coverage

## Problem

On Wilfred at upstream `5332641ed3bab552d23fb16c67bc697a373ea9d7`, gateway bootstrap began at 10:55:04.246, the first timestamped `loading configuration` log appeared at 10:55:18.593, `starting` appeared at 10:55:18.705, the HTTP listener appeared at 10:55:27.860, and readiness completed at 10:55:28.759. That leaves a 14.347s pre-log bucket containing CLI dispatch, gateway-run imports, and pre-bootstrap work.

The exact-base trace on `749f5b2e271af41c59a5290cfde67facef2264fd` showed that the foreground runtime chunk was still imported sequentially after mandatory preflight began. A bounded CPU/import probe measured the cold `gateway-cli/run` chunk at 187.8ms on Testbox; the built chunk was 70,932 bytes.

This change starts exactly one import after environment selection, then consumes the same promise after preflight. It adds no workers, polling, cache, repeated discovery, or unbounded concurrency.

## Evidence

Checked-in benchmark, 5 measured runs after 1 warmup:

| Case | Base HTTP listen p50 | Head HTTP listen p50 | Base ready p50 | Head ready p50 | Base RSS p50 | Head RSS p50 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `skipChannels` | 3724.8ms | 3376.8ms | 3733.0ms | 3395.0ms | 855.3MB | 844.8MB |
| `default` | 3613.7ms | 4020.1ms | 3704.6ms | 4163.7ms | 1031.9MB | 1025.5MB |

`skipChannels`, which removes channel/sidecar variance around the changed CLI and module-loading path, improved HTTP-listen p50 by 348.0ms (9.3%). The default comparison was noisy across separate runners, including large unrelated session-lock recovery variance, so this PR does not claim a default-case benchmark win from that sample.

The new `cli.main.gateway-run-runtime-import` trace completed once per foreground invocation. Its p50 duration was 33.4ms in the default case and 24.4ms with channels skipped; its p50 completion point was 637.0ms and 561.4ms from CLI trace start, respectively, confirming that it overlaps the later preflight path rather than extending it.

Black-box behavior validation against the production build:

- `openclaw gateway`: `/healthz` 200, `/readyz` 200, one prepared-runtime trace
- `openclaw gateway run`: `/healthz` 200, `/readyz` 200, one prepared-runtime trace
- `openclaw gateway --help`: exit 0, gateway help rendered, zero prepared-runtime traces

Base Testbox: `tbx_01kywk2jcgt6k9qq3qrwevwwvq` ([run](https://github.com/openclaw/openclaw/actions/runs/30650795694))

Head Testbox: `tbx_01kywkqhpr811vbs2p2tjaezek` ([run](https://github.com/openclaw/openclaw/actions/runs/30651545218))

## Validation

- `pnpm test src/cli/gateway-cli/run-command.test.ts src/cli/run-main.exit.test.ts test/scripts/bench-gateway-startup.test.ts` (225 tests)
- `pnpm build`
- `pnpm test:startup:gateway --case default --case skipChannels --runs 5 --warmup 1 --timeout-ms 60000`
- `pnpm check:changed`
- source-blind foreground/help behavior contract
- autoreview: clean, no actionable findings

## Related work

Related to #114615. Open PR #114663 optimizes plugin-free RPC command preflight; this PR targets the distinct foreground gateway runtime handoff.

## Release note

Improved foreground gateway cold-start by loading its runtime module in parallel with mandatory CLI preflight.
