### PR TITLE
docs: drop retired gateway.reload keys and modes from config docs [AI-assisted]

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -761,9 +761,7 @@ See [Multiple Gateways](/gateway/multiple-gateways).
 {
   gateway: {
     reload: {
-      mode: "hybrid", // off | restart | hot | hybrid
-      debounceMs: 500,
-      deferralTimeoutMs: 300000,
+      mode: "hybrid", // off | hybrid
     },
   },
 }
@@ -771,11 +769,11 @@ See [Multiple Gateways](/gateway/multiple-gateways).
 
 - `mode`: controls how config edits are applied at runtime.
   - `"off"`: ignore live edits; changes require an explicit restart.
-  - `"restart"`: always restart the gateway process on config change.
-  - `"hot"`: apply changes in-process without restarting.
-  - `"hybrid"` (default): try hot reload first; fall back to restart if required.
-- `debounceMs`: debounce window in ms before config changes are applied (non-negative integer; default: `300`).
-- `deferralTimeoutMs`: optional maximum time in ms to wait for in-flight operations before forcing a restart or channel hot reload. Omit it to use the default bounded wait (`300000`); set `0` to wait indefinitely and log periodic still-pending warnings.
+  - `"hybrid"` (default): apply hot-safe changes in-process, then restart when a change requires it.
+
+The earlier `"restart"` and `"hot"` values are retired; [`openclaw doctor --fix`](/cli/doctor) maps both to `"hybrid"`.
+
+Reload debounce and in-flight operation deferral are no longer configurable and run behind built-in defaults. [`openclaw doctor --fix`](/cli/doctor) removes the retired `debounceMs` and `deferralTimeoutMs` keys from older config files.
 
 ---
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -535,20 +535,20 @@ for the checklist.
 
 ### Reload modes
 
-| Mode                   | Behavior                                                                                |
-| ---------------------- | --------------------------------------------------------------------------------------- |
-| **`hybrid`** (default) | Hot-applies safe changes instantly. Automatically restarts for critical ones.           |
-| **`hot`**              | Hot-applies safe changes only. Logs a warning when a restart is needed - you handle it. |
-| **`restart`**          | Restarts the Gateway on any config change, safe or not.                                 |
-| **`off`**              | Disables file watching. Changes take effect on the next manual restart.                 |
+| Mode                   | Behavior                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **`hybrid`** (default) | Hot-applies safe changes instantly. Automatically restarts for critical ones. |
+| **`off`**              | Disables file watching. Changes take effect on the next manual restart.       |
 
 ```json5
 {
   gateway: {
-    reload: { mode: "hybrid", debounceMs: 300 },
+    reload: { mode: "hybrid" },
   },
 }
 ```
+
+The earlier `hot` and `restart` modes are retired; [`openclaw doctor --fix`](/cli/doctor) maps both to `hybrid`. Reload debounce is no longer configurable and runs behind a built-in default.
 
 ### What hot-applies vs what needs a restart
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -113,9 +113,9 @@ Gateway startup uses the same effective port and bind when it seeds local Contro
 | `gateway.reload.mode` | Behavior                                   |
 | --------------------- | ------------------------------------------ |
 | `off`                 | No config reload                           |
-| `hot`                 | Apply only hot-safe changes                |
-| `restart`             | Restart on reload-required changes         |
 | `hybrid` (default)    | Hot-apply when safe, restart when required |
+
+The earlier `hot` and `restart` modes are retired; [`openclaw doctor --fix`](/cli/doctor) maps both to `hybrid`.
 
 ## Operator command set
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -592,7 +592,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
   </Accordion>
 
   <Accordion title="Do I have to restart after changing config?">
-    The Gateway watches the config and supports hot-reload: `gateway.reload.mode: "hybrid"` (default) hot-applies safe changes and restarts for critical ones. `hot`, `restart`, and `off` are also supported. Most `tools.*`, `agents.*` policy, `session.*`, and `messages.*` changes apply immediately with no reload action at all; `gateway.*` binding/port changes require a restart.
+    The Gateway watches the config and supports hot-reload: `gateway.reload.mode: "hybrid"` (default) hot-applies safe changes and restarts for critical ones. `off` disables config reload; the earlier `hot` and `restart` modes are retired. Most `tools.*`, `agents.*` policy, `session.*`, and `messages.*` changes apply immediately with no reload action at all; `gateway.*` binding/port changes require a restart.
   </Accordion>
 
   <Accordion title="How do I enable web search (and web fetch)?">


### PR DESCRIPTION
Closes #116973

## What Problem This Solves

Fixes an issue where operators configuring `gateway.reload` from the shipped documentation would write keys the gateway rejects, causing it to fail closed on unrecognized config and enter a restart loop on upgrade.

The `gateway.reload` docs advertised four settings. The build accepts one. `gateway.reload` is a `strictObject` whose only property is `mode`, and `mode` is a union of `"off" | "hybrid"`:

```ts
// src/config/zod-schema.gateway.ts
reload: z
  .strictObject({
    mode: z.union([z.literal("off"), z.literal("hybrid")]).optional(),
  })
  .optional(),
```

So every one of these, taken straight from the docs, was rejected:

| Documented | Status in the build |
| --- | --- |
| `debounceMs` | Retired — in `RETIRED_TUNING_PATHS`, stripped by `openclaw doctor --fix` |
| `deferralTimeoutMs` | Retired — same |
| `mode: "restart"` | Retired — mapped to `"hybrid"` by `openclaw doctor --fix` |
| `mode: "hot"` | Retired — same |
| `mode: "off"` / `"hybrid"` | Live |

Because `strictObject` rejects unknown keys, the two retired keys are what tripped the reporter's gateway into a restart loop. The retired `mode` values fail the union instead. Same defect, same doc block, same user-visible outcome.

## Why This Change Was Made

Documentation-only. The issue asked to remove the retired keys or mark them retired with their replacement behaviour; this does the latter, matching the existing idiom already used in `configuration-reference.md` for other retired settings (for example the `logging.consoleStyle: "compact"` note).

The issue reported the two retired **keys** in `configuration-reference.md`. Two things were widened, both disclosed here rather than assumed:

1. **The retired `mode` values are corrected too.** `"restart"` and `"hot"` sit in the same doc block and fail the same way. Leaving them would have meant knowingly shipping wrong values in the block being corrected.
2. **Three further pages carried the same defect** and are corrected identically: `docs/gateway/configuration.md` (reload-modes table + `debounceMs` in the example), `docs/gateway/index.md` (reload-modes table), and `docs/help/faq.md`. Fixing only the reference page would leave the reported failure reproducible from three other pages.

Happy to trim this back to just the two keys in `configuration-reference.md` if you would rather keep the change minimal.

Historical release notes (`docs/releases/2026.7.1.md`) mention `deferralTimeoutMs` and are deliberately left alone as a record of what shipped at the time. Unrelated live `debounceMs` keys under `messages.queue` and `memory.*` are untouched.

## User Impact

Operators configuring `gateway.reload` from the docs now write only keys and values the gateway accepts, instead of a config that fails validation on startup. The docs also now state what replaced the removed knobs — reload debounce and active-work deferral still exist, but run behind built-in defaults and are no longer configurable, which was previously not discoverable anywhere.

## Evidence

Verified against `origin/main` @ `0388d0095e`. Every claim in the diff was checked against source:

- **Schema** — `src/config/zod-schema.gateway.ts:102-106`: `strictObject`, `mode` is `"off" | "hybrid"`.
- **The repo's own fixture agrees** — `src/config/schema.help.quality.test-fixtures.ts:359` independently asserts the allowed values, and it matches this diff exactly:
  ```ts
  "gateway.reload.mode": ['"off"', '"hybrid"'],
  ```
- **Retired keys** — `legacy-config-migrations.runtime.retired-media.ts:165-166` lists both under `RETIRED_TUNING_PATHS`; `stripRetiredTuningKnobs` (same file, :246) deletes them via `deleteRetiredPath`, which is what the docs now say `doctor --fix` does.
- **Retired mode values** — `legacy-config-migrations.runtime.retired.ts:405-407` maps `"restart"` and `"hot"` to `"hybrid"`.
- **Replacement behaviour** — `src/gateway/config-reload-settings.ts` honours only `off`/`hybrid` and pins `debounceMs: 300` as a built-in default. Active-work deferral still exists (`src/cli/daemon-cli/lifecycle-safe-restart.ts`), it is simply no longer configurable — hence the wording "run behind built-in defaults" rather than "removed".
- **Completeness sweep** — grepped `docs/` for remaining live references to the retired keys and modes. Remaining hits are unrelated config paths (`messages.queue.debounceMs`, `memory.*`), the internal `reloadKind` classification in `protocol.md`, `afterWrite.mode` in `sdk-runtime.md`, and the historical release notes.

I could not execute the repo's docs checks (`docs:check-mdx`) or the test suite locally — the checks need a full workspace install. The changes are plain markdown using constructs already present in each file (tables, a `json5` fence, `(/cli/doctor)` links, and one reworded sentence inside an existing `<Accordion>`), and `docs/cli/doctor.md` exists as the link target. CI is the real check here.

## Open questions

The issue also suggested a build-time guard asserting that no key path documented in `configuration-reference.md` appears in `RETIRED_TUNING_PATHS`. **That is not in this PR.** There is no existing docs↔schema test harness, and a reliable key-path extractor for a ~1500-line reference doc is a design decision I did not want to make unilaterally. It would have caught this class of bug at build time rather than at a user's upgrade, and seems worth doing — happy to follow up with it if you tell me where you would want it to live.

This PR is AI-assisted, per CONTRIBUTING.md.
