### PR TITLE
fix(telegram): managed gateways exit promptly after shutdown

### DIFF
--- a/extensions/telegram/src/telegram-ingress-worker.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.test.ts
@@ -1,0 +1,80 @@
+import type { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const workerHarness = vi.hoisted(() => ({
+  instances: [] as unknown[],
+}));
+
+vi.mock("node:worker_threads", async () => {
+  const { EventEmitter } = await vi.importActual<typeof import("node:events")>("node:events");
+  return {
+    Worker: class extends EventEmitter {
+      postMessage = vi.fn();
+      terminate = vi.fn(async () => 1);
+
+      constructor() {
+        super();
+        workerHarness.instances.push(this);
+      }
+    },
+  };
+});
+
+import { createTelegramIngressWorker } from "./telegram-ingress-worker.js";
+
+type FakeWorker = EventEmitter & {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn<() => Promise<number>>>;
+};
+
+function createWorker(): {
+  handle: ReturnType<typeof createTelegramIngressWorker>;
+  worker: FakeWorker;
+} {
+  const handle = createTelegramIngressWorker({
+    token: "123456:test",
+    accountId: "default",
+    initialUpdateId: null,
+    spoolDir: "/tmp/openclaw-telegram-worker-test",
+  });
+  const worker = workerHarness.instances.at(-1) as FakeWorker | undefined;
+  if (!worker) {
+    throw new Error("expected Telegram ingress worker");
+  }
+  return { handle, worker };
+}
+
+describe("stopTelegramIngressWorker", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    workerHarness.instances.length = 0;
+  });
+
+  it("preserves cooperative worker shutdown", async () => {
+    vi.useFakeTimers();
+    const { handle, worker } = createWorker();
+
+    const stopping = handle.stop();
+    worker.emit("exit", 0);
+    await stopping;
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: "stop" });
+    expect(worker.terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates a non-cooperative worker inside the channel stop budget", async () => {
+    vi.useFakeTimers();
+    const { handle, worker } = createWorker();
+
+    const stopping = handle.stop();
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(worker.terminate).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await stopping;
+
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: "stop" });
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/telegram/src/telegram-ingress-worker.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.ts
@@ -3,6 +3,7 @@ import { Worker } from "node:worker_threads";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 
 export const TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER = "openclaw.telegram-ingress-worker";
+const TELEGRAM_INGRESS_WORKER_STOP_GRACE_MS = 2_000;
 
 export type TelegramIngressWorkerMessage =
   | {
@@ -86,6 +87,31 @@ export type TelegramIngressWorkerFactory = (
   options: TelegramIngressWorkerOptions,
 ) => TelegramIngressWorkerHandle;
 
+async function stopTelegramIngressWorker(params: {
+  requestStop: () => void;
+  task: Promise<void>;
+  terminate: () => Promise<number>;
+}): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const forcedTermination = new Promise<void>((resolve, reject) => {
+    timeout = setTimeout(() => {
+      void params.terminate().then(() => resolve(), reject);
+    }, TELEGRAM_INGRESS_WORKER_STOP_GRACE_MS);
+    timeout.unref?.();
+  });
+  try {
+    params.requestStop();
+    // Keep the cooperative close path, but finish inside the host channel's
+    // stop budget. Forced termination is replay-safe because updates advance
+    // only after the parent durably spools and acknowledges them.
+    await Promise.race([params.task.catch(() => undefined), forcedTermination]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export const createTelegramIngressWorker: TelegramIngressWorkerFactory = (options) => {
   const listeners = new Set<(message: TelegramIngressWorkerMessage) => void>();
   const worker = new Worker(new URL("./telegram-ingress-worker.runtime.js", import.meta.url), {
@@ -124,18 +150,15 @@ export const createTelegramIngressWorker: TelegramIngressWorkerFactory = (option
       }
     },
     async stop() {
-      Reflect.apply(Reflect.get(worker, "postMessage") as (value: unknown) => void, worker, [
-        { type: "stop" } satisfies TelegramIngressWorkerCommand,
-      ]);
-      const timeout = setTimeout(() => {
-        void worker.terminate();
-      }, 15_000);
-      timeout.unref?.();
-      try {
-        await taskPromise.catch(() => undefined);
-      } finally {
-        clearTimeout(timeout);
-      }
+      await stopTelegramIngressWorker({
+        requestStop: () => {
+          Reflect.apply(Reflect.get(worker, "postMessage") as (value: unknown) => void, worker, [
+            { type: "stop" } satisfies TelegramIngressWorkerCommand,
+          ]);
+        },
+        task: taskPromise,
+        terminate: () => worker.terminate(),
+      });
     },
     task() {
       return taskPromise;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where managed gateways using Telegram isolated polling could remain alive for many seconds after `SIGTERM` when the polling worker stopped responding. This delayed launchd restarts and could consume most of the service's `ExitTimeOut` budget.

## Why This Change Was Made

Telegram now gives its ingress worker a bounded cooperative shutdown window, then awaits `Worker.terminate()` before the worker owner's stop promise resolves. The fix stays inside the Telegram plugin, leaves the gateway's generic channel timeout unchanged, and does not add `process.exit`.

Forced termination remains replay-safe: the worker advances an update only after the parent has durably spooled and acknowledged it, so an interrupted unacknowledged update remains eligible for Telegram redelivery.

## User Impact

Managed gateway restarts no longer wait on a non-cooperative Telegram polling worker until the supervisor timeout. Normal cooperative worker shutdown still closes cleanly without forced termination.

## Evidence

- Fresh unmodified `main` reproduction at `749f5b2e271af41c59a5290cfde67facef2264fd` under a real launchd `KeepAlive` service:
  - blocked Telegram worker remained ref'd after `SIGTERM`
  - listener and managed PID lingered
  - shutdown completed after 9.882s; process exit was called after 10.733s
- Source-blind candidate validation with the same launchd fixture and blocked worker:
  - Telegram worker ownership disappeared 18ms before the clean-completion log
  - listener was gone at approximately 2.55s
  - managed PID exited with code 0 at 3.167s
  - no `SIGKILL` or supervisor timeout
- Blacksmith Testbox `tbx_01kywn162hv5apr7v803jre7kp`:
  - 107 Telegram lifecycle tests passed across `telegram-ingress-worker`, worker runtime, polling session, and channel gateway
  - `pnpm check:changed` passed, including extension production/test typechecks, lint, dead-export scan, plugin boundaries, and import-cycle checks
- Final exact-diff focused test passed on Testbox `tbx_01kywp1bk4yyh81kk1w0es8z9w`.
- Full local packaged build completed successfully for the macOS launchd behavior run.
- Structured autoreview: clean, no accepted/actionable findings.

The real-user Telegram Crabbox runner was attempted but its preflight was blocked before lease allocation because this host lacks the required Convex credential environment file. No personal or production Telegram credentials were used.
