### PR TITLE
fix(auto-reply): keep final replies after unmatched brackets

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -1476,6 +1476,46 @@ describe("handleMessageUpdate commentary phase", () => {
 });
 
 describe("handleMessageEnd", () => {
+  it.each(["answer part A msg [[E1008]timeout] answer part B", "answer ending ["])(
+    "keeps malformed directive-looking final text identical across delivery paths: %s",
+    (text) => {
+      const onAgentEvent = vi.fn();
+      const emitBlockReply = vi.fn();
+      const flushBlockReplyBuffer = vi.fn();
+      const accumulator = createStreamingDirectiveAccumulator();
+      const streamed = accumulator.consume(text)?.text ?? "";
+      const ctx = createMessageEndContext({
+        onAgentEvent,
+        emitBlockReply,
+        flushBlockReplyBuffer,
+        consumeReplyDirectives: vi.fn((chunk: string, options?: { final?: boolean }) =>
+          accumulator.consume(chunk, options),
+        ),
+        blockChunker: {
+          hasBuffered: () => true,
+          reset: vi.fn(),
+        },
+        state: {
+          blockBuffer: streamed,
+          deltaBuffer: streamed,
+        },
+      });
+
+      void endMessage(ctx, {
+        message: { role: "assistant", content: [{ type: "text", text }] },
+      });
+
+      expect(firstMockArg(onAgentEvent, "agent event")).toMatchObject({
+        stream: "assistant",
+        data: { text, delta: text },
+      });
+      const finalBlockText = (firstMockArg(emitBlockReply, "block reply") as { text?: string })
+        .text;
+      expect(`${streamed}${finalBlockText ?? ""}`).toBe(text);
+      expect(ctx.finalizeAssistantTexts).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    },
+  );
+
   it.each([
     {
       name: "counts a completed provider assistant message",
@@ -1893,10 +1933,15 @@ describe("handleMessageEnd", () => {
     expect(emitBlockReply).not.toHaveBeenCalled();
   });
 
-  it("emits final media after flushing buffered message_end text", () => {
+  it("emits final media and malformed pending text after flushing buffered message_end text", () => {
     const emitBlockReply = vi.fn();
     const flushBlockReplyBuffer = vi.fn();
-    const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
+    const accumulator = createStreamingDirectiveAccumulator();
+    const text = "Caption [[oops\nMEDIA:/tmp/final.png";
+    const streamed = accumulator.consume(text)?.text ?? "";
+    const consumeReplyDirectives = vi.fn((chunk: string, options?: { final?: boolean }) =>
+      accumulator.consume(chunk, options),
+    );
     const ctx = createMessageEndContext({
       emitBlockReply,
       flushBlockReplyBuffer,
@@ -1907,17 +1952,17 @@ describe("handleMessageEnd", () => {
       },
       state: {
         emittedAssistantUpdate: true,
-        lastStreamedAssistantCleaned: "Caption",
+        lastStreamedAssistantCleaned: "Caption [[oops",
         blockReplyBreak: "message_end",
-        deltaBuffer: "Caption",
-        blockBuffer: "Caption",
+        deltaBuffer: streamed,
+        blockBuffer: streamed,
       },
     });
 
     void endMessage(ctx, {
       message: {
         role: "assistant",
-        content: [{ type: "text", text: "Caption\nMEDIA:/tmp/final.png" }],
+        content: [{ type: "text", text }],
         usage: { input: 10, output: 5, total: 15 },
       },
     });
@@ -1926,11 +1971,16 @@ describe("handleMessageEnd", () => {
       assistantMessageIndex: undefined,
       final: true,
     });
-    expect(consumeReplyDirectives).not.toHaveBeenCalled();
-    expect(firstMockArg(emitBlockReply, "block reply")).toMatchObject({
-      text: "",
+    expect(consumeReplyDirectives).toHaveBeenCalledWith("", { final: true });
+    const finalReply = firstMockArg(emitBlockReply, "block reply") as {
+      text?: string;
+      mediaUrls?: string[];
+    };
+    expect(finalReply).toMatchObject({
+      text: " [[oops",
       mediaUrls: ["/tmp/final.png"],
     });
+    expect(`${streamed}${finalReply.text ?? ""}`).toBe("Caption [[oops");
   });
 
   it("preserves literal reasoning-looking tags in unphased final visible text", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -15,6 +15,7 @@ import {
 import { splitTrailingDirective } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { AssistantMessage } from "../llm/types.js";
+import { splitMediaFromOutput } from "../media/parse.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 import {
   parseAssistantTextSignature,
@@ -1314,9 +1315,7 @@ export function handleMessageEnd(
       : "";
   const trimmedReasoning = rawThinking ? rawThinking.trim() : "";
   const trimmedText = text.trim();
-  const parsedText = trimmedText
-    ? parseReplyDirectives(splitTrailingDirective(trimmedText, { final: true }).text)
-    : null;
+  const parsedText = trimmedText ? parseReplyDirectives(trimmedText) : null;
   const cleanedText = parsedText?.text ?? "";
   const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedText ?? {});
 
@@ -1450,6 +1449,27 @@ export function handleMessageEnd(
     }
   };
 
+  const consumeFinalReplyDirectives = () => {
+    const bufferedResult = ctx.consumeReplyDirectives("", { final: true });
+    if (!hasMedia || !parsedText) {
+      return bufferedResult;
+    }
+    const bufferedRawText = bufferedResult?.text ?? "";
+    const leadingWhitespace = bufferedRawText.match(/^\s+/u)?.[0] ?? "";
+    const strippedBufferedText = bufferedRawText ? splitMediaFromOutput(bufferedRawText).text : "";
+    const bufferedText =
+      leadingWhitespace &&
+      strippedBufferedText &&
+      !strippedBufferedText.startsWith(leadingWhitespace)
+        ? `${leadingWhitespace}${strippedBufferedText}`
+        : strippedBufferedText;
+    return {
+      ...bufferedResult,
+      ...parsedText,
+      text: bufferedText,
+    };
+  };
+
   const hasBufferedBlockReply = ctx.blockChunker
     ? ctx.blockChunker.hasBuffered()
     : ctx.state.blockBuffer.length > 0;
@@ -1478,14 +1498,7 @@ export function handleMessageEnd(
       // Final-flush the streaming directive accumulator so any partial
       // inline reply/audio tag held back by splitTrailingDirective gets
       // emitted on the message_end / blockReplyChunking path.
-      emitSplitResultAsBlockReply(
-        hasMedia && parsedText
-          ? {
-              ...parsedText,
-              text: "",
-            }
-          : ctx.consumeReplyDirectives("", { final: true }),
-      );
+      emitSplitResultAsBlockReply(consumeFinalReplyDirectives());
     } else if (text !== ctx.state.lastBlockReplyText || hasMedia) {
       // Guard: for text_end channels, if text_end already delivered content
       // (lastBlockReplyText is set), skip this safety send. The text comparison

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -83,7 +83,8 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     emit({ type: "message_end", message: assistantMessage });
 
     expect(onBlockReply).toHaveBeenCalledTimes(2);
-    expect(replyTexts(onBlockReply)).toEqual(["Hello", "[["]);
+    expect(replyTexts(onBlockReply)).toEqual(["Hello", " [["]);
+    expect(replyTexts(onBlockReply).join("")).toBe("Hello [[");
   });
 
   it("streams partial replies past reply_to tags split across chunks", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -6,6 +6,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import { matchesMentionWithExplicit } from "./mentions.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import { parseReplyDirectives } from "./reply-directives.js";
 import { createReplyReferencePlanner, isSingleUseReplyToMode } from "./reply-reference.js";
 import {
   extractShortModelName,
@@ -1328,15 +1329,53 @@ describe("createStreamingDirectiveAccumulator", () => {
     expect(result?.replyToCurrent).toBe(true);
   });
 
-  it("does not emit padding before a buffered trailing reply tag", () => {
+  it("preserves padding when a buffered trailing reply tag stays incomplete", () => {
     const accumulator = createStreamingDirectiveAccumulator();
 
     const first = accumulator.consume("Hello [[");
     expect(first?.text).toBe("Hello");
 
     const second = accumulator.consume("", { final: true });
-    expect(second?.text).toBe("[[");
+    expect(second?.text).toBe(" [[");
   });
+
+  it.each([
+    ["reply", "Hello [[", "reply_to_current]] Yo", "Yo"],
+    ["audio", "Hello [[", "audio_as_voice]] Yo", "Yo"],
+  ])(
+    "keeps existing %s directive completion whitespace",
+    (_name, firstChunk, secondChunk, text) => {
+      const accumulator = createStreamingDirectiveAccumulator();
+
+      expect(accumulator.consume(firstChunk)?.text).toBe("Hello");
+      expect(accumulator.consume(secondChunk)?.text).toBe(text);
+    },
+  );
+
+  it.each(["answer part A msg [[E1008]timeout] answer part B", "answer ending ["])(
+    "releases malformed directive-looking final text verbatim: %s",
+    (text) => {
+      const accumulator = createStreamingDirectiveAccumulator();
+      const first = accumulator.consume(text);
+      const final = accumulator.consume("", { final: true });
+
+      expect(`${first?.text ?? ""}${final?.text ?? ""}`).toBe(text);
+    },
+  );
+
+  it.each([
+    ["answer [[", "bogus]] tail", "answer [[bogus]] tail"],
+    ["answer [[", "bogus]] [[reply_to_current]] tail", "answer [[bogus]] tail"],
+  ])(
+    "restores padding when a pending tail resolves as literal text",
+    (firstChunk, secondChunk, text) => {
+      const accumulator = createStreamingDirectiveAccumulator();
+      const first = accumulator.consume(firstChunk);
+      const second = accumulator.consume(secondChunk);
+
+      expect(`${first?.text ?? ""}${second?.text ?? ""}`).toBe(text);
+    },
+  );
 
   it("propagates explicit reply ids across current and subsequent chunks", () => {
     const accumulator = createStreamingDirectiveAccumulator();
@@ -1469,10 +1508,14 @@ describe("createStreamingDirectiveAccumulator", () => {
     expect(result?.mediaUrls).toBeUndefined();
   });
 
-  it("does not strip a complete final MEDIA line when parsing final text", () => {
-    expect(splitTrailingDirective("Here.\nMEDIA:/tmp/final.png", { final: true })).toEqual({
-      text: "Here.\nMEDIA:/tmp/final.png",
-      tail: "",
+  it("keeps a complete final MEDIA line available to the final parser", () => {
+    expect(splitTrailingDirective("Here.\nMEDIA:/tmp/final.png")).toEqual({
+      text: "Here.\n",
+      tail: "MEDIA:/tmp/final.png",
+    });
+    expect(parseReplyDirectives("Here.\nMEDIA:/tmp/final.png")).toMatchObject({
+      text: "Here.",
+      mediaUrls: ["/tmp/final.png"],
     });
   });
 });

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -26,16 +26,9 @@ type ConsumeOptions = {
   silentToken?: string;
 };
 
-type SplitTrailingDirectiveOptions = {
-  final?: boolean;
-};
-
 // Holds back incomplete inline directive tails so parseChunk only ever sees
 // complete reply/audio tags.
-export const splitTrailingDirective = (
-  text: string,
-  options: SplitTrailingDirectiveOptions = {},
-): { text: string; tail: string } => {
+export const splitTrailingDirective = (text: string): { text: string; tail: string } => {
   let bufferStart = text.length;
   let trimTextBeforeTail = false;
 
@@ -50,17 +43,6 @@ export const splitTrailingDirective = (
   if (text.endsWith("[") && text.length - 1 < bufferStart) {
     bufferStart = text.length - 1;
     trimTextBeforeTail = true;
-  }
-
-  if (options.final) {
-    if (bufferStart >= text.length) {
-      return { text, tail: "" };
-    }
-
-    return {
-      text: text.slice(0, bufferStart),
-      tail: text.slice(bufferStart),
-    };
   }
 
   // Keep a possible final-reply MEDIA directive out of partial streaming
@@ -130,21 +112,34 @@ const hasRenderableContent = (parsed: ReplyDirectiveParseResult): boolean =>
 
 export function createStreamingDirectiveAccumulator() {
   let pendingTail = "";
+  let pendingSeparator = "";
   let pendingReply: PendingReplyState = { sawCurrent: false, hasTag: false };
   let activeReply: PendingReplyState = { sawCurrent: false, hasTag: false };
 
   const reset = () => {
     pendingTail = "";
+    pendingSeparator = "";
     pendingReply = { sawCurrent: false, hasTag: false };
     activeReply = { sawCurrent: false, hasTag: false };
   };
 
   const consume = (raw: string, options: ConsumeOptions = {}): ReplyDirectiveParseResult | null => {
+    const hadPendingTail = pendingTail.length > 0;
+    const heldSeparator = pendingSeparator;
     let combined = `${pendingTail}${raw ?? ""}`;
     pendingTail = "";
+    pendingSeparator = "";
 
     if (!options.final) {
       const split = splitTrailingDirective(combined);
+      if (split.tail) {
+        const tailStart = combined.length - split.tail.length;
+        const separator = combined.slice(split.text.length, tailStart);
+        // The separator is not part of a possible directive. Hold it separately
+        // so valid completions keep existing streaming behavior while a final
+        // malformed tail can be restored verbatim.
+        pendingSeparator = split.text ? separator : `${heldSeparator}${separator}`;
+      }
       combined = split.text;
       pendingTail = split.tail;
     }
@@ -154,6 +149,9 @@ export function createStreamingDirectiveAccumulator() {
     }
 
     const parsed = parseChunk(combined, { silentToken: options.silentToken });
+    if (hadPendingTail && heldSeparator && parsed.text.startsWith("[")) {
+      parsed.text = `${heldSeparator}${parsed.text}`;
+    }
     const hasTag = activeReply.hasTag || pendingReply.hasTag || parsed.replyToTag;
     const sawCurrent =
       activeReply.sawCurrent || pendingReply.sawCurrent || parsed.replyToCurrent === true;


### PR DESCRIPTION
Closes #116775

## What Problem This Solves

Fixes an issue where final assistant replies could silently lose everything from an unmatched `[[` sequence or a lone trailing `[` when message finalization treated the text as an incomplete directive.

## Why This Change Was Made

Final message snapshots now go directly through the complete reply-directive parser instead of the streaming-only tail splitter. Streaming still buffers possible directives, but it retains the separator separately and releases malformed tails verbatim; buffered `MEDIA:` delivery drains that pending text before attaching media.

This keeps the streaming/finalization boundary explicit: partial chunks may wait for more bytes, while a final snapshot cannot discard literal user-visible text.

## User Impact

Replies containing ordinary bracket text, malformed directive-looking output, or a malformed tail followed by final media are delivered completely across Gateway events and channel block replies. Valid reply, audio, and media directives retain their existing behavior.

## Evidence

- Reproduced on `main`: `answer part A msg [[E1008]timeout] answer part B` lost the unmatched suffix, and `answer ending [` lost the trailing bracket.
- Exact signed head: `11b5961f27b8c35a2295efc6066bcaaabbeb0cf3`, based on `main` `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Blacksmith Testbox focused proof: 169/169 tests passed (`reply-utils`: 102, message handlers and subscriber: 67): https://github.com/openclaw/openclaw/actions/runs/30655045524
- Exact final subscriber regression: 3/3 tests passed: https://github.com/openclaw/openclaw/actions/runs/30655404619
- Exact-head changed gate passed: formatting, core/core-test typecheck, lint, dependency/API/owner boundaries, dead-code, state/database/media/runtime/import-cycle/webhook/pairing guards: https://github.com/openclaw/openclaw/actions/runs/30655567101
- Fresh autoreview on the final tree: clean, no actionable findings (0.98 confidence).
