### PR TITLE
fix: updates repair additive agent database schema

### DIFF
--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -116,6 +116,29 @@ export function resolveInitialDoctorHealthContributions(params: {
       run: params.runLegacyStateHealth,
     }),
     createDoctorHealthContribution({
+      id: "doctor:session-transcripts",
+      label: "Session transcripts",
+      healthChecks: {
+        description: "Legacy or branchy session transcript files are represented as findings.",
+        defaultEnabled: false,
+        async detect() {
+          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToHealthFinding } =
+            await import("../commands/doctor-session-transcripts.js");
+          return (await detectSessionTranscriptHealthIssues()).map(
+            sessionTranscriptIssueToHealthFinding,
+          );
+        },
+        repair: legacyOwnedRepair(async () => {
+          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToRepairEffect } =
+            await import("../commands/doctor-session-transcripts.js");
+          return (await detectSessionTranscriptHealthIssues()).map(
+            sessionTranscriptIssueToRepairEffect,
+          );
+        }, "legacy doctor session transcript contribution owns transcript rewrites"),
+      },
+      run: runSessionTranscriptsHealth,
+    }),
+    createDoctorHealthContribution({
       id: "doctor:agent-memory-schema",
       label: "Agent memory schema",
       run: runAgentMemorySchemaHealth,
@@ -302,29 +325,6 @@ export function resolveInitialDoctorHealthContributions(params: {
       label: "Session locks",
       healthCheckIds: ["core/doctor/session-locks"],
       run: runSessionLocksHealth,
-    }),
-    createDoctorHealthContribution({
-      id: "doctor:session-transcripts",
-      label: "Session transcripts",
-      healthChecks: {
-        description: "Legacy or branchy session transcript files are represented as findings.",
-        defaultEnabled: false,
-        async detect() {
-          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToHealthFinding } =
-            await import("../commands/doctor-session-transcripts.js");
-          return (await detectSessionTranscriptHealthIssues()).map(
-            sessionTranscriptIssueToHealthFinding,
-          );
-        },
-        repair: legacyOwnedRepair(async () => {
-          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToRepairEffect } =
-            await import("../commands/doctor-session-transcripts.js");
-          return (await detectSessionTranscriptHealthIssues()).map(
-            sessionTranscriptIssueToRepairEffect,
-          );
-        }, "legacy doctor session transcript contribution owns transcript rewrites"),
-      },
-      run: runSessionTranscriptsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-transcript-headers",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -845,6 +845,20 @@ describe("doctor health contributions", () => {
     expect(ids.indexOf("doctor:plugin-registry")).toBeLessThan(ids.indexOf("doctor:write-config"));
   });
 
+  it("repairs canonical session rows before downstream agent-state checks", () => {
+    const ids = resolveDoctorHealthContributions().map((entry) => entry.id);
+
+    expect(ids.indexOf("doctor:legacy-state")).toBeLessThan(
+      ids.indexOf("doctor:session-transcripts"),
+    );
+    expect(ids.indexOf("doctor:session-transcripts")).toBeLessThan(
+      ids.indexOf("doctor:agent-memory-schema"),
+    );
+    expect(ids.indexOf("doctor:session-transcripts")).toBeLessThan(
+      ids.indexOf("doctor:plugin-registry"),
+    );
+  });
+
   it("orders the config-flow commit before runtime-backed diagnostics", () => {
     const ids = resolveDoctorHealthContributions().map((entry) => entry.id);
     const migrationWriteIndex = ids.indexOf("doctor:write-config-migrations");

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+describe("legacy media persistence additive schema repair", () => {
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    cleanupTempDirs(tempDirs);
+  });
+
+  it("repairs same-version additive session schema before media validation", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-current-additive-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    opened.db
+      .prepare(
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:main:session-1",
+        "session-1",
+        JSON.stringify({ sessionId: "session-1", updatedAt: 1 }),
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      DROP TRIGGER session_nodes_entry_valid_after_insert;
+      DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+      DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+      DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+      DROP TABLE session_key_contract;
+      ALTER TABLE session_nodes DROP COLUMN entry_valid;
+    `);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        repaired
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:main:session-1"),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        repaired.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+      ).toEqual({ main_key: "main" });
+    } finally {
+      repaired.close();
+    }
+  });
+});

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -504,57 +504,6 @@ describe("legacy media persistence doctor migration", () => {
     }
   });
 
-  it("repairs same-version additive session schema before media validation", () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-current-additive-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
-    const databasePath = opened.path;
-    opened.db
-      .prepare(
-        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
-         VALUES (?, ?, ?, ?)`,
-      )
-      .run(
-        "agent:main:session-1",
-        "session-1",
-        JSON.stringify({ sessionId: "session-1", updatedAt: 1 }),
-        1,
-      );
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const database = new DatabaseSync(databasePath);
-    database.exec(`
-      DROP TRIGGER session_nodes_entry_valid_after_insert;
-      DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-      DROP TRIGGER session_nodes_entry_valid_after_identity_update;
-      DROP INDEX idx_agent_session_nodes_entry_valid_pending;
-      DROP TABLE session_key_contract;
-      ALTER TABLE session_nodes DROP COLUMN entry_valid;
-    `);
-    database.close();
-
-    const result = migrateLegacyMediaPersistence({ env });
-    expect(result.warnings).toEqual([]);
-    const repaired = new DatabaseSync(databasePath, { readOnly: true });
-    try {
-      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
-        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
-      });
-      expect(
-        repaired
-          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
-          .get("agent:main:session-1"),
-      ).toEqual({ entry_valid: 1 });
-      expect(
-        repaired.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
-      ).toEqual({ main_key: "main" });
-    } finally {
-      repaired.close();
-    }
-  });
-
   it("upgrades an owned v0 database through the media prerequisite schema", () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-v0-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -504,6 +504,57 @@ describe("legacy media persistence doctor migration", () => {
     }
   });
 
+  it("repairs same-version additive session schema before media validation", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-current-additive-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    opened.db
+      .prepare(
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:main:session-1",
+        "session-1",
+        JSON.stringify({ sessionId: "session-1", updatedAt: 1 }),
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      DROP TRIGGER session_nodes_entry_valid_after_insert;
+      DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+      DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+      DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+      DROP TABLE session_key_contract;
+      ALTER TABLE session_nodes DROP COLUMN entry_valid;
+    `);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        repaired
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:main:session-1"),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        repaired.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+      ).toEqual({ main_key: "main" });
+    } finally {
+      repaired.close();
+    }
+  });
+
   it("upgrades an owned v0 database through the media prerequisite schema", () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-v0-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -25,7 +25,10 @@ import {
   unregisterOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db-registry.js";
 import { assertOpenClawAgentSchemaContains } from "../state/openclaw-agent-db-schema-helpers.js";
-import { migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema } from "../state/openclaw-agent-db-schema.js";
+import {
+  ensureOpenClawAgentDatabaseSchema,
+  migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema,
+} from "../state/openclaw-agent-db-schema.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -341,6 +344,14 @@ function migrateRegisteredDatabase(params: {
       throw new Error(
         `${params.pathname} metadata schema version ${metadata.schemaVersion ?? "invalid"} does not match ${userVersion}`,
       );
+    }
+    if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION) {
+      // Doctor can encounter a current-version database before newly additive schema exists.
+      // Converge it through the canonical agent-schema owner before media validation.
+      ensureOpenClawAgentDatabaseSchema(database, {
+        agentId: params.agentId,
+        path: params.pathname,
+      });
     }
     // Remove after 2026-10-12: drop the v15-to-v16 media cutover once schema 16 is the support floor.
     if (userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION) {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -121,6 +121,19 @@ function hasPendingMemoryChunkMetadataMigration(db: DatabaseSync): boolean {
   return hasLegacyMemoryRecallMetadataColumns(db) || hasLegacyMemoryChunkProvenanceTrigger(db);
 }
 
+function hasPendingSessionKeyContractSchemaMigration(db: DatabaseSync): boolean {
+  const sessionNodeColumns = readSqliteTableColumns(db, "session_nodes");
+  if (!sessionNodeColumns) {
+    return false;
+  }
+  const hasContractTable = Boolean(
+    db
+      .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'session_key_contract'")
+      .get(),
+  );
+  return !sessionNodeColumns.has("entry_valid") || !hasContractTable;
+}
+
 function migrateMemoryChunkMetadataSchema(db: DatabaseSync): void {
   ensureMemoryRecallMetadataSchema(db);
   ensureMemoryChunkProvenance(db);
@@ -512,7 +525,12 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
   const hasPendingMemoryMigration =
     userVersion === OPENCLAW_AGENT_SCHEMA_VERSION &&
     hasPendingMemoryChunkMetadataMigration(database);
-  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingMemoryMigration) {
+  const hasPendingSessionContractMigration =
+    userVersion === OPENCLAW_AGENT_SCHEMA_VERSION &&
+    hasPendingSessionKeyContractSchemaMigration(database);
+  const hasPendingAdditiveMigration =
+    hasPendingMemoryMigration || hasPendingSessionContractMigration;
+  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingAdditiveMigration) {
     verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
       allowMissingColumns: true,
       validateAfterRepair: () =>
@@ -522,7 +540,9 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);
   }
-  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingMemoryMigration) {
+  // Current-version additive surfaces are installed atomically by ensureAgentSchema below.
+  // Validating them here would make the same-version repair path unreachable after an update.
+  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingAdditiveMigration) {
     assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
   }
 }

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3004,6 +3004,59 @@ describe("openclaw agent database", () => {
     ).toEqual([{ key: "key-a" }]);
   });
 
+  it("repairs same-version additive session-key surfaces before schema validation", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = opened.path;
+    opened.db
+      .prepare(
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:worker-1:session-1",
+        "session-1",
+        JSON.stringify({ sessionId: "session-1", updatedAt: 1 }),
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const shippedSchema = new DatabaseSync(databasePath);
+    try {
+      shippedSchema.exec(`
+        DROP TRIGGER session_nodes_entry_valid_after_insert;
+        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP TABLE session_key_contract;
+        ALTER TABLE session_nodes DROP COLUMN entry_valid;
+      `);
+      expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
+        OPENCLAW_AGENT_SCHEMA_VERSION,
+      );
+    } finally {
+      shippedSchema.close();
+    }
+
+    const repaired = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
+    expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(repaired.db))).toEqual(
+      normalizeSqliteSchemaShapeSql(
+        createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
+      ),
+    );
+    expect(
+      repaired.db
+        .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+        .get("agent:worker-1:session-1"),
+    ).toEqual({ entry_valid: 1 });
+    expect(
+      repaired.db.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+    ).toEqual({ main_key: "main" });
+  });
+
   it("rejects a missing current-schema table instead of recreating it empty", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating a current-version installation would have the update fail in `openclaw doctor` when the agent database predated newly added same-version session schema.

PR #116703 added the `session_key_contract`, `entry_valid`, index, triggers, and canonical-key repair. A database already at schema version 16 was rejected as noncanonical before those additive surfaces could be installed, and Doctor scheduled canonical-key repair after downstream checks that could already reject invalid legacy rows.

## Why This Change Was Made

The canonical agent-schema owner now recognizes and atomically installs pending same-version additive session schema before strict validation. Doctor's media migration converges through that same owner instead of maintaining its own premature schema assertion. Canonical session-key repair now runs immediately after legacy state migration, before later agent-state and plugin checks can read rows that still require repair.

## User Impact

Existing installations can update through additive agent-database schema changes without manually editing SQLite, losing sessions, or getting trapped in a doctor/rollback loop.

## Evidence

- Production repro: the supported updater advanced to #116703, built successfully, then rolled back after Doctor rejected the missing session-key contract surfaces.
- Regression tests cover both the ordinary agent-database opener and Doctor's media-migration path with a current-version database missing `entry_valid`, `session_key_contract`, its index, and three triggers. Both preserve an existing session row and verify the repaired projection.
- Doctor ordering test requires canonical session repair after legacy-state migration and before agent-memory and plugin-registry checks.
- Focused Blacksmith Testbox proof: 131 tests passed across agent DB, Doctor media migration, Doctor contribution ordering, and canonical-key repair; 6 additional agent DB cases were skipped by their existing platform gates.
- Full changed gate passed on Blacksmith Testbox: formatting, core/test typechecks, lint, database guards, plugin boundaries, dead exports, and repository guards.
- Exact production-shaped proof at head `9c4f233c7c05412626ea4f65cd6f3c0a4c69b917`: restored a 225,951,744-byte database copy from its immutable backup, built the PR, and ran updater-style `doctor --non-interactive --fix`. Doctor canonicalized 26 session-key groups and completed successfully. Post-run proof was `quick_check=ok`, 309 session rows preserved, one `entry_valid` column, one contract table, one pending index, and three validity triggers. The original backup SHA-256 remained `4f705ab7311a90367117f3ada7ec2e331c00aaa547d98286e6c66426a5800956`.
- Final Codex autoreview: clean, no accepted/actionable findings; patch correctness confidence 0.99.
