### PR TITLE
fix(streaming): preserve final reply tails in both text-end paths

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -470,6 +470,41 @@ describe("handleMessageUpdate text signatures", () => {
     expect(context.state.lastStreamedAssistantCleaned).toBe("Hello");
   });
 
+  it.each([
+    {
+      name: "the directive accumulator has no parsed result",
+      text: "answer part A msg [[E1008]timeout] answer part B",
+      hasParsedDirectives: false,
+    },
+    {
+      name: "the directive accumulator flushes a buffered tail",
+      text: "answer part A msg [[E1008]timeout] answer part B",
+      hasParsedDirectives: true,
+    },
+    {
+      name: "the final text ends with one bracket",
+      text: "answer part A [",
+      hasParsedDirectives: true,
+    },
+  ])("keeps literal final text when $name", ({ text, hasParsedDirectives }) => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      ...(hasParsedDirectives ? {} : { consumePartialReplyDirectives: vi.fn(() => null) }),
+    });
+
+    updateMessage(context, {
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_end", content: text },
+    });
+
+    expect(context.state.lastStreamedAssistantCleaned).toBe(text);
+    expect(firstMockArg(onAgentEvent, "final assistant event")).toMatchObject({
+      stream: "assistant",
+      data: { text },
+    });
+  });
+
   it("keeps stripped reply directives out of later plain deltas", () => {
     const onAgentEvent = vi.fn();
     const context = createMessageUpdateContext({ onAgentEvent });

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -616,10 +616,6 @@ function mergeReplyDirectiveResults(
   };
 }
 
-function parseFullStreamingReplyText(text: string): string {
-  return parseReplyDirectives(splitTrailingDirective(text).text).text;
-}
-
 function containsCompleteMediaDirectiveLine(text: string): boolean {
   return /(?:^|\n)\s*MEDIA:\s*\S[^\n]*(?:\n|$)/i.test(text);
 }
@@ -664,13 +660,16 @@ function resolveStreamingReplyText(params: {
   parsedStreamDirectives: ReplyDirectiveParseResult | null;
   shouldUsePhaseAwareBlockReply: boolean;
 }): string {
-  if (!params.parsedStreamDirectives) {
-    return params.evtType === "text_delta"
-      ? params.previousCleaned
-      : parseFullStreamingReplyText(params.next);
+  if (!params.parsedStreamDirectives && params.evtType === "text_delta") {
+    return params.previousCleaned;
   }
 
-  return resolveIncrementalStreamingReplyText(params) ?? parseFullStreamingReplyText(params.next);
+  return (
+    resolveIncrementalStreamingReplyText(params) ??
+    parseReplyDirectives(
+      params.evtType === "text_end" ? params.next : splitTrailingDirective(params.next).text,
+    ).text
+  );
 }
 
 /** Records parsed reply directives until a sendable reply payload is built. */


### PR DESCRIPTION
## Summary

- Finish the live `text_end` half of the partial repair already landed in #116979: both subscriber fallback arms still re-split completed assistant text and silently discard everything after an unfinished `[[` or a lone trailing `[`.
- Parse completed `text_end` snapshots directly while preserving partial-stream directive buffering, the existing incremental fast path, and all recently landed accumulator, separator, `message_end`, and media behavior.
- Delete the obsolete duplicate whole-text helper; this follow-up touches only the subscriber owner and its existing tests, with **1 fewer line of production code**.

Refs #116775

## Latest-main regression proof

- Swapping only the production owner back to the newest tested `main` makes all three new actual `handleMessageUpdate` regressions fail: no parsed directives, a buffered malformed `[[...` tail, and a lone trailing `[`. Both malformed double-bracket arms truncate the answer to `answer part A msg`; the lone-bracket case truncates to `answer part A`.
- Restoring this exact two-file patch passes:
  - **67/67** real embedded assistant message-handler tests.
  - **102/102** existing directive/parser tests, including the landed separator, reply/audio tags, malformed tails, and `MEDIA:` cases.
  - **6/6** real subscribed-agent duplicate-terminal-event tests.
  - **175 focused tests total**, after an observed three-failure latest-main baseline.
- A passing transient integration test booted the **actual OpenClaw Gateway server**, used an authenticated Control UI WebSocket and real `chat.send`, `chat.final`, and `chat.history`, and routed mocked upstream model events through the real embedded subscriber and changed production handlers. Both operator-visible cases retained the complete final answer/history and delivered exactly once:

```json
{"case":"unterminated-double-bracket","final":"answer part A msg [[E1008]timeout] answer part B","history":true,"deliveries":1}
{"case":"trailing-single-bracket","final":"answer part A [","history":true,"deliveries":1}
```

- Full changed-surface gate passed: core/core-test typechecks, changed-file lint/format, import-cycle checks, dead-export scans, and repository guards (Blacksmith Testbox command exit 0).
- Independent maintainer review and a separate read-only Codex review both returned **PASS** after checking the latest overlapping #116979 implementation, full caller/owner paths, silent-token behavior, media metadata, nonfinal buffering, and duplicate terminal events.
- The local signed TruffleHog binary was unavailable after reboot; the repository maintainer explicitly waived that local preflight. Required hosted secret-scanning / CodeQL checks remain authoritative and must pass.

Production delta: `+8/-9` (**-1**). Test delta: `+35/-0`.

Reviewed two-file diff SHA-256: `679bd691e169124abe25f5de42507a4878433641bb8ca067884410fecb9e5e61`
