### PR TITLE
fix(openrouter): recognize documented in-progress video jobs

### DIFF
--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -683,10 +683,11 @@ describe("openrouter video generation provider", () => {
       releasedJson({
         id: "job-123",
         polling_url: "/api/v1/videos/job-123",
-        status: "pending",
+        status: "in_progress",
       }),
     );
     fetchWithTimeoutGuardedMock
+      .mockResolvedValueOnce(releasedJson({ id: "job-123", status: "in_progress" }))
       .mockResolvedValueOnce(
         releasedJson({
           id: "job-123",
@@ -802,10 +803,16 @@ describe("openrouter video generation provider", () => {
     expect(requireFetchCallHeaders(0).get("authorization")).toBe("Bearer openrouter-key");
     expectOpenRouterFetchCall(
       1,
+      "https://custom.openrouter.test/api/v1/videos/job-123",
+      "openrouter-video-status",
+    );
+    expectOpenRouterFetchCall(
+      2,
       "https://custom.openrouter.test/api/v1/videos/job-123/content?index=0",
       "openrouter-video-download",
     );
-    expect(requireFetchCallHeaders(1).get("authorization")).toBe("Bearer openrouter-key");
+    expect(requireFetchCallHeaders(2).get("authorization")).toBe("Bearer openrouter-key");
+    expect(waitProviderOperationPollIntervalMock).toHaveBeenCalledOnce();
     const { video, buffer } = requireGeneratedVideoBuffer(result, 0);
     expect(buffer.toString()).toBe("mp4-bytes");
     expect(video.mimeType).toBe("video/mp4");

--- a/extensions/openrouter/video-generation-provider.ts
+++ b/extensions/openrouter/video-generation-provider.ts
@@ -274,8 +274,17 @@ function buildRequestBody(req: VideoGenerationRequest, model: string): Record<st
   return body;
 }
 
-function isTerminalFailure(status: string | undefined): boolean {
-  return status === "failed" || status === "cancelled" || status === "expired";
+function resolveVideoJobState(status: string | undefined): "active" | "completed" | "failure" {
+  if (status === "completed") {
+    return "completed";
+  }
+  if (status === "failed" || status === "cancelled" || status === "expired") {
+    return "failure";
+  }
+  if (status && ["queued", "pending", "in_progress", "processing", "running"].includes(status)) {
+    return "active";
+  }
+  throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE);
 }
 
 async function fetchOpenRouterJson(params: {
@@ -325,17 +334,11 @@ async function pollOpenRouterVideo(params: {
       auditContext: "openrouter-video-status",
     });
     const status = normalizeOptionalString(payload.status);
-    if (
-      !status ||
-      (!["queued", "pending", "processing", "running", "completed"].includes(status) &&
-        !isTerminalFailure(status))
-    ) {
-      throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE);
-    }
-    if (status === "completed") {
+    const state = resolveVideoJobState(status);
+    if (state === "completed") {
       return payload;
     }
-    if (isTerminalFailure(status)) {
+    if (state === "failure") {
       throw new Error(
         normalizeOptionalString(payload.error) ?? `OpenRouter video generation ${status}`,
       );
@@ -517,21 +520,15 @@ export function buildOpenRouterVideoGenerationProvider(): VideoGenerationProvide
           throw new Error("OpenRouter video generation response missing job details");
         }
         const submittedStatus = normalizeOptionalString(submitted.status);
-        if (
-          submittedStatus &&
-          !["queued", "pending", "processing", "running", "completed"].includes(submittedStatus) &&
-          !isTerminalFailure(submittedStatus)
-        ) {
-          throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE);
-        }
-        if (isTerminalFailure(submittedStatus)) {
+        const submittedState = submittedStatus ? resolveVideoJobState(submittedStatus) : "active";
+        if (submittedState === "failure") {
           throw new Error(
             normalizeOptionalString(submitted.error) ??
               `OpenRouter video generation ${submittedStatus}`,
           );
         }
         const completed =
-          submittedStatus === "completed"
+          submittedState === "completed"
             ? submitted
             : await pollOpenRouterVideo({
                 pollingUrl,


### PR DESCRIPTION
## What Problem This Solves

OpenRouter documents `in_progress` as its active video-generation job status, but the provider's separate submission and polling allowlists omitted it. Real video jobs therefore failed with `OpenRouter video generation response malformed` before their completed video could be returned.

## Why This Change Was Made

Move video job-state interpretation into its private provider owner. One canonical closed classifier now recognizes documented active, completed, and terminal-failure states for both submission and polling; the old duplicate allowlists are deleted.

Production: **17 added / 20 removed (net −3 lines)**. No auth, configuration, SDK, protocol, persistence, or dependency changes.

## User Impact

Operators generating video through OpenRouter receive the completed result when the provider reports its documented `in_progress` state. Unknown statuses and provider failure states preserve their existing visible errors.

## Evidence

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact candidate: `b72513130d24a06d7ba7bff4dc6488472a7d34ba`.
- Authentic baseline regression: owner submit → `in_progress` poll → completed poll → download failed with `OpenRouter video generation response malformed`.
- Exact-head Blacksmith Testbox: `pnpm test extensions/openrouter/video-generation-provider.test.ts` → **22 tests passed**, exit 0; [remote run](https://github.com/openclaw/openclaw/actions/runs/30655613457). Lease stopped and verified completed.
- Exact-head structured Codex autoreview with `--max-priority P3`: `gpt-5.6-sol`, high reasoning, verified TruffleHog 3.96.0; **zero P0/P1/P2/P3 findings**, correctness 0.98.
- `git diff --check` and focused `oxfmt --check` clean.
- [Official OpenRouter video job-status documentation](https://openrouter.ai/docs/guides/overview/multimodal/video-generation#job-statuses) explicitly defines `pending`, `in_progress`, `completed`, and `failed`.
