### PR TITLE
fix(whatsapp): preserve transport envelope ownership

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.test.ts
+++ b/extensions/whatsapp/src/inbound/extract.test.ts
@@ -117,6 +117,71 @@ describe("extractMentionedJids", () => {
         },
       },
     },
+    {
+      name: "shared contacts",
+      message: {
+        contactMessage: {
+          displayName: "Alice",
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "shared contact collections",
+      message: {
+        contactsArrayMessage: {
+          contacts: [{ displayName: "Alice" }],
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "location pins",
+      message: {
+        locationMessage: {
+          degreesLatitude: 1,
+          degreesLongitude: 2,
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "live locations",
+      message: {
+        liveLocationMessage: {
+          degreesLatitude: 1,
+          degreesLongitude: 2,
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "interactive button prompts",
+      message: {
+        buttonsMessage: {
+          contentText: "Choose one",
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "interactive lists",
+      message: {
+        listMessage: {
+          title: "Choose one",
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
+    {
+      name: "native interactive prompts",
+      message: {
+        interactiveMessage: {
+          body: { text: "Choose one" },
+          contextInfo: { mentionedJid: [botJid] },
+        },
+      },
+    },
   ])("preserves direct bot mentions from $name", ({ message }) => {
     expect(extractMentionedJids(message as proto.IMessage)).toEqual([botJid]);
   });

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -113,34 +113,12 @@ export function extractContextInfo(
 }
 
 export function extractMentionedJids(rawMessage: proto.IMessage | undefined): string[] | undefined {
-  const message = unwrapMessage(rawMessage);
-  if (!message) {
+  // Context ownership already follows Baileys envelopes without entering quoted messages.
+  const mentionedJids = extractContextInfo(rawMessage)?.mentionedJid?.filter(Boolean);
+  if (!mentionedJids?.length) {
     return undefined;
   }
-
-  const candidates: Array<string[] | null | undefined> = [
-    message.extendedTextMessage?.contextInfo?.mentionedJid,
-    message.imageMessage?.contextInfo?.mentionedJid,
-    message.videoMessage?.contextInfo?.mentionedJid,
-    message.ptvMessage?.contextInfo?.mentionedJid,
-    message.documentMessage?.contextInfo?.mentionedJid,
-    message.audioMessage?.contextInfo?.mentionedJid,
-    message.stickerMessage?.contextInfo?.mentionedJid,
-    message.buttonsResponseMessage?.contextInfo?.mentionedJid,
-    message.listResponseMessage?.contextInfo?.mentionedJid,
-    message.templateButtonReplyMessage?.contextInfo?.mentionedJid,
-    message.interactiveResponseMessage?.contextInfo?.mentionedJid,
-    message.pollCreationMessage?.contextInfo?.mentionedJid,
-    message.pollCreationMessageV2?.contextInfo?.mentionedJid,
-    message.pollCreationMessageV3?.contextInfo?.mentionedJid,
-    message.pollCreationMessageV5?.contextInfo?.mentionedJid,
-  ];
-
-  const flattened = candidates.flatMap((arr) => arr ?? []).filter(Boolean);
-  if (flattened.length === 0) {
-    return undefined;
-  }
-  return uniqueStrings(flattened);
+  return uniqueStrings(mentionedJids);
 }
 
 function extractNativeFlowResponseText(

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -656,22 +656,25 @@ describe("web outbound", () => {
     });
   });
 
-  it("keeps explicit document kind for prehydrated image payloads", async () => {
-    const buf = Buffer.from("image-as-document");
+  it.each([
+    { contentType: "image/png", fileName: "photo.png" },
+    { contentType: "video/mp4", fileName: "clip.mp4" },
+  ])("keeps explicit document delivery for prehydrated $contentType payloads", async (media) => {
+    const buf = Buffer.from("visual-as-document");
 
     await sendMessageWhatsApp("+1555", "doc", {
       verbose: false,
       cfg: WHATSAPP_TEST_CFG,
       mediaPayload: {
         buffer: buf,
-        contentType: "image/png",
+        ...media,
         kind: "document",
-        fileName: "photo.png",
       },
     });
 
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "image/png", {
-      fileName: "photo.png",
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, media.contentType, {
+      asDocument: true,
+      fileName: media.fileName,
     });
   });
 
@@ -833,6 +836,32 @@ describe("web outbound", () => {
       maxSelections: 2,
       durationSeconds: undefined,
       durationHours: undefined,
+    });
+  });
+
+  it("returns the actual outbound poll key when Baileys resolves a LID target", async () => {
+    sendPoll.mockResolvedValueOnce({
+      kind: "poll",
+      messageId: "poll-lid",
+      keys: [
+        {
+          id: "poll-lid",
+          remoteJid: "123456789@lid",
+          fromMe: true,
+        },
+      ],
+      providerAccepted: true,
+    });
+
+    await expect(
+      sendPollWhatsApp(
+        "+1555",
+        { question: "Lunch?", options: ["Pizza", "Sushi"] },
+        { verbose: false, cfg: WHATSAPP_TEST_CFG },
+      ),
+    ).resolves.toEqual({
+      messageId: "poll-lid",
+      toJid: "123456789@lid",
     });
   });
 

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -49,9 +49,10 @@ function buildWhatsAppMediaSendState(params: {
   forceDocument?: boolean;
 }): WhatsAppMediaSendState {
   const { media, caption } = params;
-  const forceDocumentDelivery = Boolean(
-    params.forceDocument && supportsForcedDocumentDelivery(media.kind),
-  );
+  const forceDocumentDelivery =
+    Boolean(params.forceDocument && supportsForcedDocumentDelivery(media.kind)) ||
+    (media.kind === "document" &&
+      (media.mimetype.startsWith("image/") || media.mimetype.startsWith("video/")));
   let text = caption ?? "";
   let documentFileName = media.kind === "document" ? media.fileName : undefined;
   let visibleTextAfterVoice: string | undefined;
@@ -405,7 +406,7 @@ export async function sendPollWhatsApp(
     const durationMs = Date.now() - startedAt;
     outboundLog.info(`Sent poll ${messageId} -> ${redactedJid} (${durationMs}ms)`);
     logger.info({ jid: redactedJid, messageId }, "sent poll");
-    return { messageId, toJid: jid };
+    return { messageId, toJid: resolveActualSentRemoteJid(result, jid) };
   } catch (err) {
     logger.error({ err: String(err), to: redactedTo }, "failed to send poll via web session");
     throw err;


### PR DESCRIPTION
## What Problem This Solves

WhatsApp loses direct mentions on several supported inbound message families, sends explicitly requested image/video documents as normal visual attachments, and reports the wrong destination when an outbound poll resolves from a phone-number address to WhatsApp's LID identity.

## Why This Change Was Made

- Delete the incomplete mention-envelope allowlist and read direct mentions from the existing canonical Baileys context owner; quoted-message mentions remain isolated.
- Preserve an explicitly declared document kind across the existing outbound media/socket boundary so visual MIME does not override the requested document transport.
- Reuse the existing accepted-message-key destination resolver for polls, matching the already-correct ordinary message send path.

## User Impact

1. Direct mentions attached to contacts, contact collections, locations, live locations, button prompts, lists, and native interactive prompts reach WhatsApp group-context consumers.
2. Images and videos explicitly supplied as documents arrive as documents, preserving their filenames.
3. Poll delivery reports the actual accepted WhatsApp LID conversation instead of an unrelated phone-number fallback.

Exactly three private WhatsApp transport-owner root causes; production code shrinks by 21 lines overall.

## Evidence

- Frozen canonical baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`; clean committed candidate: `0fc6142fcb63eda66148cdb1affca71937eac2e5`.
- Authentic frozen-baseline owner regressions demonstrated **10 expected failures**: seven previously unsupported direct-mention envelopes, image/video document classification, and poll LID destination reporting.
- Isolated Blacksmith Testbox `tbx_01kywqe73w7yeymfdnr2e3pjba` independently verified the exact frozen remote Git HEAD and SHA-256 hashes of every committed candidate file before running:

```text
CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test extensions/whatsapp/src/inbound/extract.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/inbound/send-api.test.ts
```

- **151/151 focused WhatsApp owner and real Baileys-boundary tests passed**, with Testbox timing `exitCode=0`: https://github.com/openclaw/openclaw/actions/runs/30655854605
- Direct installed Baileys `7.0.0-rc13` source and type proof covers supported context-bearing envelopes, canonical wrapper normalization, visual/document wire payloads, and accepted message keys.
- Full-branch genuine Codex autoreview with `--max-priority P3`: **zero P0/P1/P2/P3 findings**, confidence **0.90**, real TruffleHog clean.
- Separate independent reviewer inspected complete owners, callers, sibling implementations, and pinned Baileys contracts: **clean**.
- All four changed files pass targeted formatting and `git diff --check`; frozen merge-base and clean committed branch verified; Testbox lease stopped and confirmed completed.

## Explicit Exclusions

No authentication, security decisions, public configuration/SDK, gateway protocol, persistence, database, dependency, live credentials, or other channel changes.
