### PR TITLE
fix(agents): preserve atomic oversized compaction fallback

### DIFF
--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -2,11 +2,15 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { buildSummaryChunksWithWorker } from "./compaction-planning-worker.js";
+import {
+  buildOversizedFallbackPlanWithWorker,
+  buildSummaryChunksWithWorker,
+} from "./compaction-planning-worker.js";
 import { compactionPlanningWorkerTesting } from "./compaction-planning-worker.test-support.js";
 import { estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
 import type { AgentMessage } from "./runtime/index.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 
 function makeMessage(id: number, text = "x".repeat(4000)): AgentMessage {
   return {
@@ -162,6 +166,38 @@ describe("compaction planning worker", () => {
     expect(value.chunkIndexes.flat()).toEqual([0, 1, 2]);
     expect(value.chunkIndexes.length).toBeGreaterThan(1);
   });
+
+  it("preserves original user identity while worker fallback omits an oversized tool batch", async () => {
+    const displacedUser = makeMessage(2, "keep the latest real user request");
+    const messages: AgentMessage[] = [
+      makeAgentAssistantMessage({
+        content: [
+          { type: "text", text: "x".repeat(12_000) },
+          { type: "toolCall", id: "call_large", name: "read", arguments: {} },
+        ],
+        model: "gpt-5.6-luna",
+        stopReason: "stop",
+        timestamp: 1,
+      }),
+      displacedUser,
+      {
+        role: "toolResult",
+        toolCallId: "call_large",
+        toolName: "read",
+        content: [{ type: "text", text: "small result" }],
+        isError: false,
+        timestamp: 3,
+      },
+      ...Array.from({ length: 61 }, (_, index) => makeMessage(index + 4, "keep")),
+    ];
+
+    const plan = await buildOversizedFallbackPlanWithWorker({ messages, contextWindow: 2_000 });
+
+    expect(plan.smallMessages).toHaveLength(62);
+    expect(plan.smallMessages[0]).toBe(displacedUser);
+    expect(plan.smallMessages.every((message) => message.role === "user")).toBe(true);
+    expect(plan.oversizedNotes).toEqual([expect.stringContaining("Large assistant")]);
+  }, 45_000);
 
   it("clamps oversized worker timeouts before scheduling", async () => {
     const workerUrl = createSyntheticWorkerUrl(`

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -79,11 +79,6 @@ export function sanitizeCompactionMessages(messages: AgentMessage[]): AgentMessa
   return stripToolResultDetails(stripRuntimeContextCustomMessages(messages));
 }
 
-/** Estimates one message using the same sanitization path as multi-message planning. */
-function estimateCompactionMessageTokens(message: AgentMessage): number {
-  return estimateMessagesTokens([message]);
-}
-
 function estimateCompactionPlanningTokens(message: AgentMessage): number {
   const omittedChars = readCompactionPlanningOmittedChars(message);
   if (omittedChars === 0) {
@@ -277,12 +272,9 @@ export function computeAdaptiveChunkRatio(messages: AgentMessage[], contextWindo
   return BASE_CHUNK_RATIO;
 }
 
-/**
- * Check if a single message is too large to summarize.
- * If single message > 50% of context, it can't be summarized safely.
- */
+/** Returns whether one message exceeds the safe summarization context share. */
 export function isOversizedForSummary(msg: AgentMessage, contextWindow: number): boolean {
-  const tokens = estimateCompactionMessageTokens(msg) * SAFETY_MARGIN;
+  const tokens = estimateMessagesTokens([msg]) * SAFETY_MARGIN;
   return tokens > contextWindow * 0.5;
 }
 
@@ -304,23 +296,30 @@ export function buildOversizedFallbackPlan(params: {
   const smallMessages: AgentMessage[] = [];
   const oversizedNotes: string[] = [];
 
-  // Sanitize the full array once and reuse per-message token counts; avoids the
-  // per-message [msg] wrap-and-clone (twice per oversized message) of the prior loop.
+  // Reuse one sanitized token estimate per message across atomic fallback groups.
   const perMessageTokens = estimatePerMessageTokens(params.messages);
   const oversizedThreshold = params.contextWindow * 0.5;
+  let messageIndex = 0;
 
-  for (const [index, msg] of params.messages.entries()) {
-    const tokens = perMessageTokens.at(index);
-    if (tokens === undefined) {
-      throw new Error("Compaction token estimates are out of sync with messages");
+  for (const group of groupCompactionMessages(params.messages, perMessageTokens)) {
+    const retainedMessages: AgentMessage[] = [];
+    let omitToolBatch = false;
+    for (const message of group.messages) {
+      const tokens = perMessageTokens[messageIndex++]!;
+      if (tokens * SAFETY_MARGIN > oversizedThreshold) {
+        oversizedNotes.push(
+          `[Large ${message.role} (~${Math.round(tokens / 1000)}K tokens) omitted from summary]`,
+        );
+        omitToolBatch ||= message.role === "assistant" || message.role === "toolResult";
+      } else {
+        retainedMessages.push(message);
+      }
     }
-    if (tokens * SAFETY_MARGIN > oversizedThreshold) {
-      const role = (msg as { role?: string }).role ?? "message";
-      oversizedNotes.push(
-        `[Large ${role} (~${Math.round(tokens / 1000)}K tokens) omitted from summary]`,
-      );
-    } else {
-      smallMessages.push(msg);
+    // Displaced real user turns survive even when their surrounding tool batch cannot.
+    for (const message of retainedMessages) {
+      if (!omitToolBatch || (message.role !== "assistant" && message.role !== "toolResult")) {
+        smallMessages.push(message);
+      }
     }
   }
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -7,13 +7,19 @@ import "./test-helpers/agent-session-token-mock.js";
 
 let estimateMessagesTokens: typeof import("./compaction-planning.js").estimateMessagesTokens;
 let buildHistoryPrunePlan: typeof import("./compaction-planning.js").buildHistoryPrunePlan;
+let buildOversizedFallbackPlan: typeof import("./compaction-planning.js").buildOversizedFallbackPlan;
 let buildStageSplitPlan: typeof import("./compaction-planning.js").buildStageSplitPlan;
 let buildSummaryChunks: typeof import("./compaction-planning.js").buildSummaryChunks;
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ buildHistoryPrunePlan, buildStageSplitPlan, buildSummaryChunks, estimateMessagesTokens } =
-    await import("./compaction-planning.js"));
+  ({
+    buildHistoryPrunePlan,
+    buildOversizedFallbackPlan,
+    buildStageSplitPlan,
+    buildSummaryChunks,
+    estimateMessagesTokens,
+  } = await import("./compaction-planning.js"));
 });
 
 function splitMessagesByTokenShare(messages: AgentMessage[], parts: number): AgentMessage[][] {
@@ -313,6 +319,96 @@ describe("buildSummaryChunks", () => {
     const chunks = buildSummaryChunks({ messages, maxChunkTokens: 700 });
 
     expect(chunks.map((chunk) => chunk.map((message) => message.timestamp))).toEqual([[1], [2]]);
+  });
+});
+
+describe("buildOversizedFallbackPlan", () => {
+  it("drops a small result when its oversized assistant is omitted", () => {
+    const latestUser = makeMessage(3, 100);
+    const plan = buildOversizedFallbackPlan({
+      messages: [
+        makeAssistantToolCall(1, "call_large_assistant", "x".repeat(12_000)),
+        makeToolResult(2, "call_large_assistant", "small result"),
+        latestUser,
+      ],
+      contextWindow: 2_000,
+    });
+
+    expect(plan.smallMessages).toEqual([latestUser]);
+    expect(plan.smallMessages[0]).toBe(latestUser);
+    expect(plan.oversizedNotes).toEqual([expect.stringContaining("Large assistant")]);
+  });
+
+  it("drops a small assistant when its oversized result is omitted", () => {
+    const firstUser = makeMessage(1, 100);
+    const latestUser = makeMessage(4, 100);
+    const plan = buildOversizedFallbackPlan({
+      messages: [
+        firstUser,
+        makeAssistantToolCall(2, "call_large_result", "small assistant"),
+        makeToolResult(3, "call_large_result", "x".repeat(12_000)),
+        latestUser,
+      ],
+      contextWindow: 2_000,
+    });
+
+    expect(plan.smallMessages).toEqual([firstUser, latestUser]);
+    expect(plan.smallMessages[0]).toBe(firstUser);
+    expect(plan.smallMessages[1]).toBe(latestUser);
+    expect(plan.oversizedNotes).toEqual([expect.stringContaining("Large toolResult")]);
+  });
+
+  it("drops every result in an oversized multi-tool batch while preserving displaced users", () => {
+    const displacedUser = makeMessage(3, 100);
+    const latestUser = makeMessage(6, 100);
+    const assistant = makeAgentAssistantMessage({
+      content: [
+        { type: "toolCall", id: "call_first", name: "first", arguments: {} },
+        { type: "toolCall", id: "call_second", name: "second", arguments: {} },
+      ],
+      model: "gpt-5.6-luna",
+      stopReason: "stop",
+      timestamp: 1,
+    });
+    const plan = buildOversizedFallbackPlan({
+      messages: [
+        assistant,
+        makeToolResult(2, "call_first", "x".repeat(12_000)),
+        displacedUser,
+        makeToolResult(4, "call_second", "small result"),
+        latestUser,
+      ],
+      contextWindow: 2_000,
+    });
+
+    expect(plan.smallMessages).toEqual([displacedUser, latestUser]);
+    expect(plan.smallMessages[0]).toBe(displacedUser);
+    expect(plan.smallMessages[1]).toBe(latestUser);
+  });
+
+  it("keeps a valid tool batch when only a displaced user message is oversized", () => {
+    const assistant = makeAssistantToolCall(1, "call_valid", "small assistant");
+    const result = makeToolResult(3, "call_valid", "small result");
+    const latestUser = makeMessage(4, 100);
+    const plan = buildOversizedFallbackPlan({
+      messages: [assistant, makeMessage(2, 12_000), result, latestUser],
+      contextWindow: 2_000,
+    });
+
+    expect(plan.smallMessages).toEqual([assistant, result, latestUser]);
+    expect(plan.smallMessages[0]).toBe(assistant);
+    expect(plan.smallMessages[1]).toBe(result);
+  });
+
+  it("does not treat aborted assistant calls as an active tool batch", () => {
+    const abortedAssistant = makeAssistantToolCall(1, "call_aborted", "small", "aborted");
+    const latestUser = makeMessage(3, 100);
+    const plan = buildOversizedFallbackPlan({
+      messages: [abortedAssistant, makeMessage(2, 12_000), latestUser],
+      contextWindow: 2_000,
+    });
+
+    expect(plan.smallMessages).toEqual([abortedAssistant, latestUser]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Oversized transcript compaction examined each message independently even though provider transcripts require an assistant tool-call turn and its matching tool-result messages to remain atomic. When either side was oversized, fallback kept the other side, producing invalid provider history: orphan tool results, unanswered assistant calls, and lost context around displaced real user messages.

## Why This Change Was Made

The compaction planner already owns canonical atomic assistant/tool-result grouping for normal history splitting and chunking. Oversized fallback was the one sibling path that bypassed it. This change reuses that existing owner instead of adding a repair shim, synthetic tool results, or a second lifecycle policy. It preserves the existing per-message size threshold, original message object identity required by the packaged worker, failed-assistant behavior, and displaced real user turns.

## User Impact

- Compaction no longer sends invalid assistant/tool-result transcripts to model providers after an oversized tool batch.
- The latest genuine user request remains visible even when it appeared inside a displaced oversized tool batch.
- Large-history packaged worker execution behaves identically to direct compaction planning.
- Production source shrinks by one line; no security, configuration, persistence, public SDK, or protocol surface changes.

## Evidence

- Frozen canonical baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact reviewed head: `66d6cc0478345f6471be11f937516c51c70648c1`.
- Genuine baseline red: eight direct and packaged-worker regressions exposed orphan results, unanswered calls, and displaced-user loss.
- Exact-head owner/sibling proof: `PATH=/Users/steipete/.local/bin:$PATH node scripts/run-vitest.mjs src/agents/compaction.test.ts src/agents/compaction-planning-worker.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction.token-sanitize.test.ts src/agents/compaction.tool-result-details.test.ts --project agents-core` — **5 files, 50 tests passed**.
- A real >=64-message worker regression verifies original message identity and displaced-user retention through worker serialization/indexing.
- Exact full-branch genuine Codex Sol/high structured autoreview with explicit `--max-priority P3`: **zero findings; 0.90 confidence**; TruffleHog clean.
- Direct upstream contract inspected: `codex-rs/core/src/compact.rs:59-67` and `codex-rs/core/tests/suite/compact.rs:1348-1357,1448-1457`.
- Distinct root-cause count: **1**. Production delta: **23 added, 24 removed**.
