### PR TITLE
fix(agents): give external attempt cancellation one owner

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -6,6 +6,7 @@ import {
   createEmbeddedAttemptRunAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
+import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
 import { SESSIONS_YIELD_ABORT_REASON } from "./attempt.sessions-yield.js";
 
@@ -136,6 +137,76 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     expect(state.markAborted).not.toHaveBeenCalled();
     expect(state.setPromptError).not.toHaveBeenCalled();
     controller.dispose();
+  });
+
+  it("hands an external timeout to the live attempt exactly once", async () => {
+    const source = new AbortController();
+    const runAbortController = new AbortController();
+    const state = createAbortState();
+    const abortActiveSession = vi.fn(async () => {});
+    const onAttemptTimeout = vi.fn();
+    const releaseHeldLockForAbort = vi.fn(async () => {});
+    const attempt = {
+      abortSignal: source.signal,
+      onAttemptTimeout,
+      runId: "run-external-timeout",
+      sessionFile: "agent:main:main",
+      sessionId: "session-external-timeout",
+      sessionKey: "agent:main:main",
+      timeoutMs: 60_000,
+    };
+    const controller = createEmbeddedAttemptExternalAbortController({
+      abortSignal: source.signal,
+      cleanupAfterEarlyAbort: vi.fn(async () => {}),
+      runAbortController,
+      runId: attempt.runId,
+      state: state.port,
+    });
+    const abortRun = createEmbeddedAttemptRunAbort({
+      abortActiveSession,
+      activeSession: { abortCompaction: vi.fn(), isCompacting: false },
+      attempt,
+      getQueueHandle: () => ({}) as EmbeddedAgentQueueHandle,
+      isProbeSession: true,
+      log: { warn: vi.fn() },
+      runAbortController,
+      sessionLockController: { releaseHeldLockForAbort },
+      state: state.port,
+    });
+    controller.setRunAbort(abortRun);
+    controller.setCompactionState({
+      isPendingOrRetrying: () => false,
+      isInFlight: () => false,
+    });
+    controller.arm();
+    const timeout = prepareEmbeddedAttemptTimeout({
+      attempt,
+      activeSession: { isCompacting: false, isStreaming: false },
+      compactionState: { isCompacting: () => false },
+      compactionTimeoutMs: 1_000,
+      isProbeSession: true,
+      abortRun,
+      markTimedOutDuringCompaction: state.markTimedOutDuringCompaction,
+      markTimedOutByRunBudget: vi.fn(),
+    });
+
+    try {
+      const reason = new Error("upstream request timed out");
+      reason.name = "TimeoutError";
+      source.abort(reason);
+      await Promise.resolve();
+
+      expect(state.markExternalAbort).toHaveBeenCalledOnce();
+      expect(state.markAborted).toHaveBeenCalledOnce();
+      expect(state.markTimedOut).toHaveBeenCalledOnce();
+      expect(onAttemptTimeout).toHaveBeenCalledOnce();
+      expect(abortActiveSession).toHaveBeenCalledOnce();
+      expect(mocks.markActiveEmbeddedRunAbandoned).toHaveBeenCalledOnce();
+      expect(releaseHeldLockForAbort).toHaveBeenCalledOnce();
+    } finally {
+      timeout.clearTimers();
+      controller.dispose();
+    }
   });
 
   it("cleans prepared resources before rejecting a pre-fired signal", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -40,7 +40,6 @@ function createFixture() {
   const subscription = { unsubscribe, waitForPendingEvents };
   const detachBackend = vi.fn(() => order.push("detach-backend"));
   const clearTimers = vi.fn(() => order.push("clear-timers"));
-  const removeAbortSignalListener = vi.fn(() => order.push("remove-abort-listener"));
   const getBeforeAgentFinalizeRevisionReason = vi.fn(() => "revision");
   const promptActiveSession = vi.fn(async () => undefined);
   const activeSession = {
@@ -88,7 +87,6 @@ function createFixture() {
     timeout: {
       getRunAbortDeadlineAtMs: vi.fn(() => 123),
       clearTimers,
-      removeAbortSignalListener,
     },
   };
   const sessionRuntime = {
@@ -230,7 +228,6 @@ function createFixture() {
     input,
     order,
     queueHandle,
-    removeAbortSignalListener,
     result,
     sessionRuntimeState,
     state,
@@ -258,7 +255,6 @@ describe("runEmbeddedAttemptSettledPhase", () => {
       "unsubscribe",
       "detach-backend",
       "clear-active-run",
-      "remove-abort-listener",
       "result",
     ]);
     expect(fixture.state).toEqual(
@@ -329,7 +325,6 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     expect(mocks.completeResult).not.toHaveBeenCalled();
     expect(fixture.clearTimers).toHaveBeenCalledOnce();
     expect(fixture.detachBackend).toHaveBeenCalledWith(fixture.queueHandle);
-    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
     expect(mocks.logError).toHaveBeenCalledWith(
       expect.stringContaining("unsubscribe failed, possible resource leak"),
     );
@@ -347,7 +342,6 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
 
     expect(mocks.clearActiveEmbeddedRun).toHaveBeenCalledOnce();
-    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
     expect(mocks.logError).toHaveBeenCalledWith(
       expect.stringContaining("backend detach failed, possible resource leak"),
     );
@@ -364,10 +358,9 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
 
     expect(mocks.clearActiveEmbeddedRun).toHaveBeenCalledOnce();
-    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
   });
 
-  it("reports active-run cleanup failure after releasing the abort listener", async () => {
+  it("reports active-run cleanup failure after detaching the backend", async () => {
     const fixture = createFixture();
     const failure = new Error("active run cleanup failed");
     mocks.clearActiveEmbeddedRun.mockImplementationOnce(() => {
@@ -378,7 +371,6 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
 
     expect(fixture.detachBackend).toHaveBeenCalledOnce();
-    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
   });
 
   it("re-arms delivered children only after a yielded requester becomes idle", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -29,7 +29,6 @@ type StreamCleanupInput = {
   clearAttemptTimeoutTimers: () => void;
   isProbeSession: boolean;
   queueHandle: PreparedStreamRuntime["stream"]["queueHandle"];
-  removeAttemptAbortSignalListener: () => void;
   state: EmbeddedAttemptExecutionState;
   unsubscribe: () => void;
 };
@@ -63,7 +62,6 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): Error
           attempt.sessionFile,
         ),
     ],
-    ["abort listener cleanup", input.removeAttemptAbortSignalListener],
   ] as const) {
     try {
       cleanup();
@@ -143,11 +141,7 @@ export async function runEmbeddedAttemptSettledPhase(
     getBeforeAgentFinalizeRevisionEntryId,
   } = preparedStream;
   const { unsubscribe, waitForPendingEvents } = subscription;
-  const {
-    getRunAbortDeadlineAtMs,
-    clearTimers: clearAttemptTimeoutTimers,
-    removeAbortSignalListener: removeAttemptAbortSignalListener,
-  } = attemptTimeout;
+  const { getRunAbortDeadlineAtMs, clearTimers: clearAttemptTimeoutTimers } = attemptTimeout;
   let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
   let lastAssistant: AssistantMessage | undefined;
   let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
@@ -421,7 +415,6 @@ export async function runEmbeddedAttemptSettledPhase(
       clearAttemptTimeoutTimers,
       isProbeSession,
       queueHandle,
-      removeAttemptAbortSignalListener,
       state,
       unsubscribe,
     });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts
@@ -62,7 +62,6 @@ function createFixture(options: { aborted?: boolean } = {}) {
   const timeoutResult = {
     getRunAbortDeadlineAtMs: vi.fn(() => 123),
     clearTimers: vi.fn(),
-    removeAbortSignalListener: vi.fn(),
   };
   const activeSession = {
     agent: { streamFn: vi.fn() },

--- a/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.ts
@@ -176,7 +176,6 @@ export async function prepareEmbeddedAttemptStreamRuntime(input: {
     compactionTimeoutMs: input.compactionTimeoutMs,
     isProbeSession,
     abortRun,
-    markExternalAbort: input.lifecycle.markExternalAbort,
     markTimedOutDuringCompaction: input.lifecycle.markTimedOutDuringCompaction,
     markTimedOutByRunBudget: input.lifecycle.markTimedOutByRunBudget,
   });

--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
@@ -4,19 +4,12 @@ import { createEmbeddedAttemptRunAbort } from "./attempt-abort.js";
 import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
 
-function createTimeoutHarness(options?: {
-  activeCompaction?: boolean;
-  pendingCompaction?: boolean;
-  timeoutMs?: number;
-}) {
+function createTimeoutHarness(options?: { pendingCompaction?: boolean; timeoutMs?: number }) {
   const state = {
-    activeCompaction: options?.activeCompaction ?? false,
     pendingCompaction: options?.pendingCompaction ?? false,
     streaming: false,
   };
-  const abortController = new AbortController();
   const abortRun = vi.fn();
-  const markExternalAbort = vi.fn();
   const markTimedOutDuringCompaction = vi.fn();
   const markTimedOutByRunBudget = vi.fn();
   const onAttemptTimeoutArmed = vi.fn();
@@ -25,13 +18,10 @@ function createTimeoutHarness(options?: {
       runId: "run-1",
       sessionId: "session-1",
       timeoutMs: options?.timeoutMs ?? 100,
-      abortSignal: abortController.signal,
       onAttemptTimeoutArmed,
     },
     activeSession: {
-      get isCompacting() {
-        return state.activeCompaction;
-      },
+      isCompacting: false,
       get isStreaming() {
         return state.streaming;
       },
@@ -42,14 +32,11 @@ function createTimeoutHarness(options?: {
     compactionTimeoutMs: 50,
     isProbeSession: true,
     abortRun,
-    markExternalAbort,
     markTimedOutDuringCompaction,
     markTimedOutByRunBudget,
   });
   return {
-    abortController,
     abortRun,
-    markExternalAbort,
     markTimedOutDuringCompaction,
     markTimedOutByRunBudget,
     onAttemptTimeoutArmed,
@@ -118,7 +105,6 @@ describe("prepareEmbeddedAttemptTimeout", () => {
       compactionTimeoutMs: 50,
       isProbeSession: true,
       abortRun,
-      markExternalAbort: vi.fn(),
       markTimedOutDuringCompaction: vi.fn(),
       markTimedOutByRunBudget: vi.fn(),
     });
@@ -147,28 +133,12 @@ describe("prepareEmbeddedAttemptTimeout", () => {
     harness.timeout.clearTimers();
   });
 
-  it("classifies an external timeout during compaction", () => {
-    const harness = createTimeoutHarness({ activeCompaction: true });
-    const reason = new Error("request timed out");
-    reason.name = "TimeoutError";
-
-    harness.abortController.abort(reason);
-
-    expect(harness.markExternalAbort).toHaveBeenCalledOnce();
-    expect(harness.markTimedOutDuringCompaction).toHaveBeenCalledOnce();
-    expect(harness.abortRun).toHaveBeenCalledWith(true, reason);
-    harness.timeout.clearTimers();
-  });
-
-  it("cleans up both the timer and external abort listener", async () => {
+  it("cleans up the run budget timer", async () => {
     const harness = createTimeoutHarness();
 
     harness.timeout.clearTimers();
-    harness.timeout.removeAbortSignalListener();
-    harness.abortController.abort(new Error("late abort"));
     await vi.advanceTimersByTimeAsync(100);
 
-    expect(harness.markExternalAbort).not.toHaveBeenCalled();
     expect(harness.markTimedOutByRunBudget).not.toHaveBeenCalled();
     expect(harness.abortRun).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
@@ -1,7 +1,6 @@
 /**
- * Owns the run deadline, compaction grace, and external abort listener.
+ * Owns the run deadline and compaction grace.
  */
-import { isSignalTimeoutReason } from "../../failover-error.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { log } from "../logger.js";
 import {
@@ -16,12 +15,8 @@ type AttemptCompactionState = {
 
 type EmbeddedAttemptTimeoutParams = Pick<
   EmbeddedRunAttemptParams,
-  "abortSignal" | "onAttemptTimeoutArmed" | "runId" | "sessionId" | "timeoutMs"
+  "onAttemptTimeoutArmed" | "runId" | "sessionId" | "timeoutMs"
 >;
-
-function getAbortReason(signal: AbortSignal): unknown {
-  return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
-}
 
 export function prepareEmbeddedAttemptTimeout(input: {
   attempt: EmbeddedAttemptTimeoutParams;
@@ -30,7 +25,6 @@ export function prepareEmbeddedAttemptTimeout(input: {
   compactionTimeoutMs: number;
   isProbeSession: boolean;
   abortRun: (isTimeout?: boolean, reason?: unknown) => void;
-  markExternalAbort: () => void;
   markTimedOutDuringCompaction: () => void;
   markTimedOutByRunBudget: () => void;
 }) {
@@ -99,29 +93,6 @@ export function prepareEmbeddedAttemptTimeout(input: {
   scheduleAbortTimer(attempt.timeoutMs, "initial");
   attempt.onAttemptTimeoutArmed?.();
 
-  const onAbort = () => {
-    input.markExternalAbort();
-    const reason = attempt.abortSignal ? getAbortReason(attempt.abortSignal) : undefined;
-    const timeout = reason ? isSignalTimeoutReason(reason) : false;
-    if (
-      shouldFlagCompactionTimeout({
-        isTimeout: timeout,
-        isCompactionPendingOrRetrying: input.compactionState.isCompacting(),
-        isCompactionInFlight: activeSession.isCompacting,
-      })
-    ) {
-      input.markTimedOutDuringCompaction();
-    }
-    input.abortRun(timeout, reason);
-  };
-  if (attempt.abortSignal) {
-    if (attempt.abortSignal.aborted) {
-      onAbort();
-    } else {
-      attempt.abortSignal.addEventListener("abort", onAbort, { once: true });
-    }
-  }
-
   return {
     getRunAbortDeadlineAtMs: () => runAbortDeadlineAtMs,
     clearTimers: () => {
@@ -131,9 +102,6 @@ export function prepareEmbeddedAttemptTimeout(input: {
       if (abortWarnTimer) {
         clearTimeout(abortWarnTimer);
       }
-    },
-    removeAbortSignalListener: () => {
-      attempt.abortSignal?.removeEventListener("abort", onAbort);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

One external embedded-agent cancellation or provider timeout was processed twice. Both the early-armed external-abort controller and the later run-deadline helper independently subscribed to the same `AbortSignal`, then invoked the same live attempt-abort owner. A single cancellation therefore aborted the native session twice, released its session lock twice, and, for timeouts, duplicated compaction cancellation, the timeout callback, and queue-abandon cleanup.

The defect was invisible to existing unit tests because each owner was tested separately and the stream-runtime composition mocked the timeout helper.

## Why This Change Was Made

The external-abort controller already owns signal registration, setup-race fences, timeout attribution, compaction state, and guaranteed outer disposal. The deadline helper should own deadlines and compaction grace only.

This refactor deletes the deadline helper's duplicate listener, removes its obsolete cleanup contract from the settlement owner, and updates the real owner-composition regression. Existing cancellation ordering, internal deadlines, exactly one compaction-grace extension, lock release, queue cleanup, and timeout reasons remain unchanged.

Production code decreases by **40 lines**: three production files add 3 lines and delete 43. Four focused owner-test files add 75 lines and delete 43.

## User Impact

Stopping or timing out an embedded agent now produces one authoritative cancellation transition. Native provider cancellation, session cleanup, timeout notification, and queued-turn ownership are each handled once, eliminating duplicate side effects and preventing inconsistent lock or queue lifecycle state.

## Evidence

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact reviewed candidate: `8c8bc4d608adab41b298083c0f2eab20cd91cf25`.
- Authentic pre-fix composed regression: a single external timeout invoked seven independent cancellation effects **twice**; the same real-owner regression failed in all three selected projects before the repair.
- Exact-head remote verification on Blacksmith Testbox `tbx_01kywqhmd7ayf9tb4w608yqwds`:

  ```text
  CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
  ```

  **4 owner-test files, 28 tests passed, 0 failed.** Testbox provisioning run: https://github.com/openclaw/openclaw/actions/runs/30655979477. The owned lease was stopped after verification.

- Independent production-module execution covered manual abort, external timeout during active compaction, internal deadline plus one compaction grace window, original abort reasons, setup race, queue ownership, and lock cleanup.
- Seven changed files pass the existing targeted formatter; `git diff --check`, exact frozen merge-base, and clean candidate checkout all pass.
- Genuine complete-branch Codex review used `--max-priority P3`, a real TruffleHog 3.96.0 scan, and exact immutable candidate content. Preserved validated review JSON reports **zero P0/P1/P2/P3 findings**, `patch is correct`, confidence **0.92**.
- A separate independent reviewer inspected the complete owners, callers, siblings, setup fence, runtime handoff, outer disposal, and direct upstream Codex cancellation contract; verdict **CLEAN**.
- Direct Codex contract evidence: `codex-rs/protocol/src/protocol.rs:523`, `codex-rs/app-server/src/request_processors/turn_processor.rs:1428`, and `codex-rs/core/src/session/tests.rs:10173`.

No public configuration, authentication, Gateway protocol, plugin SDK, persistent state, SQLite, migration, or provider-routing surface changes.
