### PR TITLE
fix(openai): use canonical multipart video submissions

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -34,14 +34,6 @@ beforeAll(async () => {
 
 installProviderHttpMockCleanup();
 
-function postJsonRequest(index = 0): Record<string, unknown> {
-  const request = postJsonRequestMock.mock.calls[index]?.[0] as Record<string, unknown> | undefined;
-  if (!request) {
-    throw new Error(`expected postJsonRequest call ${index}`);
-  }
-  return request;
-}
-
 function postMultipartRequest(index = 0): Record<string, unknown> {
   const request = postMultipartRequestMock.mock.calls[index]?.[0] as
     | Record<string, unknown>
@@ -188,8 +180,8 @@ describe("openai video generation provider", () => {
     expect(postJsonRequestMock).not.toHaveBeenCalled();
   });
 
-  it("uses JSON for text-only Sora requests", async () => {
-    postJsonRequestMock.mockResolvedValue({
+  it("uses SDK-compatible multipart for text-only Sora requests", async () => {
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_123",
         model: "sora-2",
@@ -221,7 +213,13 @@ describe("openai video generation provider", () => {
       durationSeconds: 4,
     });
 
-    expect(postJsonRequest().url).toBe("https://api.openai.com/v1/videos");
+    const createRequest = postMultipartRequest();
+    expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
+    const form = createRequest.body as FormData;
+    expect(form.get("prompt")).toBe("A paper airplane gliding through golden hour light");
+    expect(form.get("model")).toBe("sora-2");
+    expect(form.get("seconds")).toBe("4");
+    expect(form.get("input_reference")).toBeNull();
     const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
     expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_123");
     expect(pollInit?.method).toBe("GET");
@@ -238,7 +236,7 @@ describe("openai video generation provider", () => {
     "surfaces an immediately failed OpenAI submission before polling or validating id (%s)",
     async (videoId) => {
       const release = vi.fn(async () => {});
-      postJsonRequestMock.mockResolvedValue({
+      postMultipartRequestMock.mockResolvedValueOnce({
         response: streamedJsonResponse({
           ...(videoId ? { id: videoId } : {}),
           status: "failed",
@@ -264,7 +262,7 @@ describe("openai video generation provider", () => {
 
   it("downloads an immediately completed OpenAI submission without polling it again", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_completed",
         model: "sora-2",
@@ -296,7 +294,7 @@ describe("openai video generation provider", () => {
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_too_large",
         model: "sora-2",
@@ -325,8 +323,8 @@ describe("openai video generation provider", () => {
     ).rejects.toThrow("OpenAI generated video download exceeds 1 bytes");
   });
 
-  it("uses JSON input_reference.image_url for image-to-video requests", async () => {
-    postJsonRequestMock.mockResolvedValue({
+  it("uploads the SDK-compatible image reference in a multipart video request", async () => {
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_456",
         model: "sora-2",
@@ -356,11 +354,15 @@ describe("openai video generation provider", () => {
       inputImages: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
     });
 
-    const createRequest = postJsonRequest();
+    const createRequest = postMultipartRequest();
     expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
-    expect((createRequest.body as Record<string, unknown>).input_reference).toEqual({
-      image_url: "data:image/png;base64,cG5nLWJ5dGVz",
-    });
+    const form = createRequest.body as FormData;
+    const reference = form.get("input_reference");
+    expect(reference).toBeInstanceOf(File);
+    const referenceFile = reference as File;
+    expect(referenceFile.name).toBe("reference-image.png");
+    expect(referenceFile.type).toBe("image/png");
+    expect(Buffer.from(await referenceFile.arrayBuffer())).toEqual(Buffer.from("png-bytes"));
     const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
     expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_456");
     expect(pollInit?.method).toBe("GET");
@@ -369,7 +371,7 @@ describe("openai video generation provider", () => {
   });
 
   it("keeps configured local baseUrl private-network blocked unless explicitly enabled", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_local",
         model: "sora-2",
@@ -409,13 +411,13 @@ describe("openai video generation provider", () => {
 
     expect(providerHttpConfigRequest().baseUrl).toBe("http://127.0.0.1:44080/v1");
     expect(providerHttpConfigRequest().request).toBeUndefined();
-    const createRequest = postJsonRequest();
+    const createRequest = postMultipartRequest();
     expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
     expect(createRequest.allowPrivateNetwork).toBe(false);
   });
 
   it("honors configured request allowPrivateNetwork for local video providers", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_local",
         model: "sora-2",
@@ -459,7 +461,7 @@ describe("openai video generation provider", () => {
     });
     expect(providerHttpConfigRequest().baseUrl).toBe("http://127.0.0.1:44080/v1");
     expect(providerHttpConfigRequest().request).toEqual({ allowPrivateNetwork: true });
-    const createRequest = postJsonRequest();
+    const createRequest = postMultipartRequest();
     expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
     expect(createRequest.allowPrivateNetwork).toBe(true);
     const statusRequest = pollProviderOperationRequest();
@@ -490,7 +492,7 @@ describe("openai video generation provider", () => {
         throw new Error(label);
       })
       .mockImplementationOnce(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_local",
         model: "sora-2",
@@ -559,7 +561,7 @@ describe("openai video generation provider", () => {
       .mockImplementationOnce(async (_response, label) => {
         throw new Error(label);
       });
-    postJsonRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_local",
         model: "sora-2",

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -1,5 +1,4 @@
 // Openai provider module implements model/runtime integration.
-import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
@@ -12,7 +11,6 @@ import {
   fetchProviderDownloadResponse,
   fetchWithTimeoutGuarded,
   pollProviderOperationJson,
-  postJsonRequest,
   postMultipartRequest,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
@@ -39,7 +37,7 @@ const OPENAI_VIDEO_SIZES = ["720x1280", "1280x720", "1024x1792", "1792x1024"] as
 
 type OpenAIVideoRequestPolicy = {
   allowPrivateNetwork: boolean;
-  dispatcherPolicy?: Parameters<typeof postJsonRequest>[0]["dispatcherPolicy"];
+  dispatcherPolicy?: Parameters<typeof postMultipartRequest>[0]["dispatcherPolicy"];
 };
 
 type OpenAIVideoStatus = "queued" | "in_progress" | "completed" | "failed";
@@ -47,8 +45,6 @@ type OpenAIVideoStatus = "queued" | "in_progress" | "completed" | "failed";
 type OpenAIReferenceAsset = {
   kind: Extract<MediaKind, "image" | "video">;
   file: File;
-  buffer: Buffer;
-  mimeType: string;
 };
 
 type OpenAIVideoResponse = {
@@ -142,8 +138,6 @@ function resolveReferenceAsset(req: VideoGenerationRequest): OpenAIReferenceAsse
   return {
     kind,
     file: new File([toBlobBytes(asset.buffer)], fileName, { type: mimeType }),
-    buffer: asset.buffer,
-    mimeType,
   };
 }
 
@@ -360,73 +354,37 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
         resolution: req.resolution,
       });
       const referenceAsset = resolveReferenceAsset(req);
-      const requestResult = referenceAsset
-        ? referenceAsset.kind === "image"
-          ? await (() => {
-              const jsonHeaders = new Headers(headers);
-              jsonHeaders.set("Content-Type", "application/json");
-              return postJsonRequest({
-                url: `${baseUrl}/videos`,
-                headers: jsonHeaders,
-                body: {
-                  prompt: req.prompt,
-                  model,
-                  ...(seconds ? { seconds } : {}),
-                  ...(size ? { size } : {}),
-                  input_reference: {
-                    image_url: toImageDataUrl(referenceAsset),
-                  },
-                },
-                timeoutMs: resolveProviderOperationTimeoutMs({
-                  deadline,
-                  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-                }),
-                fetchFn,
-                allowPrivateNetwork,
-                dispatcherPolicy,
-              });
-            })()
-          : await (() => {
-              const form = new FormData();
-              form.set("prompt", req.prompt);
-              form.set("video", referenceAsset.file);
-              const multipartHeaders = new Headers(headers);
-              multipartHeaders.delete("Content-Type");
-              return postMultipartRequest({
-                url: `${baseUrl}/videos/edits`,
-                headers: multipartHeaders,
-                body: form,
-                timeoutMs: resolveProviderOperationTimeoutMs({
-                  deadline,
-                  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-                }),
-                fetchFn,
-                allowPrivateNetwork,
-                dispatcherPolicy,
-              });
-            })()
-        : await (() => {
-            const jsonHeaders = new Headers(headers);
-            jsonHeaders.set("Content-Type", "application/json");
-            return postJsonRequest({
-              url: `${baseUrl}/videos`,
-              headers: jsonHeaders,
-              body: {
-                prompt: req.prompt,
-                model,
-                ...(seconds ? { seconds } : {}),
-                ...(size ? { size } : {}),
-              },
-              timeoutMs: resolveProviderOperationTimeoutMs({
-                deadline,
-                defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-              }),
-              fetchFn,
-              allowPrivateNetwork,
-              dispatcherPolicy,
-            });
-          })();
-      const { response, release } = requestResult;
+      const isVideoEdit = referenceAsset?.kind === "video";
+      const form = new FormData();
+      form.set("prompt", req.prompt);
+      if (isVideoEdit) {
+        form.set("video", referenceAsset.file);
+      } else {
+        form.set("model", model);
+        if (seconds) {
+          form.set("seconds", seconds);
+        }
+        if (size) {
+          form.set("size", size);
+        }
+        if (referenceAsset) {
+          form.set("input_reference", referenceAsset.file);
+        }
+      }
+      const multipartHeaders = new Headers(headers);
+      multipartHeaders.delete("Content-Type");
+      const { response, release } = await postMultipartRequest({
+        url: `${baseUrl}/videos${isVideoEdit ? "/edits" : ""}`,
+        headers: multipartHeaders,
+        body: form,
+        timeoutMs: resolveProviderOperationTimeoutMs({
+          deadline,
+          defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+        }),
+        fetchFn,
+        allowPrivateNetwork,
+        dispatcherPolicy,
+      });
 
       try {
         await assertOkOrThrowHttpError(response, "OpenAI video generation failed");


### PR DESCRIPTION
## What Problem This Solves

OpenAI Sora video generation sent both text-only and image-reference requests as JSON even though the official OpenAI API and the installed `openai@6.49.0` SDK require multipart uploads for `POST /v1/videos`.

Two independently verified user-visible root causes:

1. Text-to-video creation used `application/json` instead of multipart `prompt`, `model`, and generation options.
2. Image-to-video creation encoded a JSON data URL instead of uploading its actual image as the multipart `input_reference` file.

## Why This Change Was Made

The private OpenAI video owner now builds one canonical multipart request for text generation, image-reference generation, and existing video edits. Text and image creation target `/videos`; edits continue targeting `/videos/edits` with only the SDK-supported `prompt` and `video` fields.

The refactor deletes duplicate JSON/data-URL request branches and **removes 42 production lines**. Authentication, SSRF policy, dispatcher policy, polling, timeout budgets, download bounds, release cleanup, and public provider contracts remain unchanged.

## User Impact

- Text-to-video requests match OpenAI's actual Sora upload contract.
- Image-to-video requests upload the reference image with its correct filename, MIME type, and bytes.
- Existing video edits, immediate terminal failures, polling, configured request policy, and bounded downloads continue to work.

## Evidence

- Frozen canonical baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Immutable reviewed candidate: `31c962e4f769736e9b4d7ece9a7b763fdd5b024c`.
- Official OpenAI SDK inspected directly: `node_modules/openai/src/resources/videos.ts:14`, `:84`, `:178`, and `:225`.
- Actual installed SDK capture-fetch proof confirmed that text creation, image-reference creation, and video edits all emit multipart requests; the image is uploaded under `input_reference` and edits send only `prompt` plus `video`.
- Remote Blacksmith Testbox recreated a detached worktree from the exact frozen baseline, verified both changed Git blobs, and proved its complete staged tree exactly matched immutable candidate tree `be47a1ed9fca5486d677a89f218a117eefa3ce75`.
- Exact reconstructed candidate owner suite:

  ```bash
  pnpm test extensions/openai/video-generation-provider.test.ts
  ```

- **19/19 owner tests passed**. Provider: `blacksmith-testbox`; lease: `tbx_01kywr09d6pf5bxg0a89kzfs2h`; run: https://github.com/openclaw/openclaw/actions/runs/30656525347. The lease was stopped and its completed status verified.
- Exact full-branch Codex/Sol high-reasoning autoreview with explicit `--max-priority P3`: **zero actionable P0/P1/P2/P3 findings**, confidence **0.96**, genuine TruffleHog clean.
- Separate blind owner/SDK/source review: **clean across P0/P1/P2/P3**.
- Targeted oxfmt, oxlint, `git diff --check`, immutable base/tree/blob guards, and clean final worktree: passed.
- Production delta: **32 additions / 74 deletions = -42 lines**; regression tests: **28 additions / 26 deletions**.
