### PR TITLE
fix(test): use system bash for release reuse fixtures

### DIFF
--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -8,6 +8,9 @@ import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = join(process.cwd(), "scripts/github/find-reusable-release-validation.sh");
+// Homebrew Bash 5.3 can deadlock in nested command substitutions under Node's
+// synchronous child runner on macOS; CI executes this script with system Bash.
+const BASH_PATH = process.platform === "darwin" ? "/bin/bash" : "bash";
 const tempDirs = createTempDirTracker();
 const sharedTempDirs = createTempDirTracker();
 
@@ -472,7 +475,7 @@ function runResolver(args: {
     );
   }
   return spawnSync(
-    "bash",
+    BASH_PATH,
     [
       SCRIPT_PATH,
       "--target-sha",


### PR DESCRIPTION
## Summary

- run the release-evidence resolver fixture with macOS system Bash instead of Homebrew Bash
- retain PATH-based Bash discovery on other platforms
- document the Homebrew Bash 5.3 synchronous child-runner deadlock

## Root cause

The repo-wide test gate intermittently stalled forever in `test/scripts/find-reusable-release-validation.test.ts`. The resolver's nested command substitutions deadlock under Homebrew Bash 5.3 when launched through Node's synchronous child runner on macOS. GitHub Actions uses system Bash; selecting `/bin/bash` on macOS aligns the fixture with CI and removes the local release-gate deadlock.

## Validation

- unfixed harness: repeated full-file loop hung on run 3
- fixed harness: 10 consecutive `node scripts/run-vitest.mjs test/scripts/find-reusable-release-validation.test.ts` runs passed (38 tests each)
- `./node_modules/.bin/oxfmt --check test/scripts/find-reusable-release-validation.test.ts`
- `git diff --check`

No changelog entry: test harness reliability only.
