### PR TITLE
fix(providers): canonicalize model families and stream outcomes

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
@@ -1,0 +1,110 @@
+import {
+  BedrockRuntimeClient,
+  ConversationRole,
+  StopReason as BedrockStopReason,
+} from "@aws-sdk/client-bedrock-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamSimpleBedrock } from "./stream.runtime.js";
+
+const model = {
+  api: "bedrock-converse-stream",
+  provider: "amazon-bedrock",
+  id: "amazon.nova-micro-v1:0",
+  name: "Nova Micro",
+  baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4096,
+} as const;
+
+async function* events(items: unknown[]) {
+  yield* items;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Bedrock provider-owned stream lifecycle", () => {
+  it.each([
+    {
+      label: "text",
+      blocks: [{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "ready" } } }],
+      endEvent: "text_end",
+      stopReason: BedrockStopReason.END_TURN,
+    },
+    {
+      label: "thinking",
+      blocks: [
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: "considered" } },
+          },
+        },
+      ],
+      endEvent: "thinking_end",
+      stopReason: BedrockStopReason.END_TURN,
+    },
+    {
+      label: "redacted thinking",
+      blocks: [
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { redactedContent: new Uint8Array([1, 2, 3]) } },
+          },
+        },
+      ],
+      endEvent: "thinking_end",
+      stopReason: BedrockStopReason.END_TURN,
+    },
+    {
+      label: "tool call",
+      blocks: [
+        {
+          contentBlockStart: {
+            contentBlockIndex: 0,
+            start: { toolUse: { toolUseId: "call_lookup", name: "lookup" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { toolUse: { input: '{"query":"ready"}' } },
+          },
+        },
+      ],
+      endEvent: "toolcall_end",
+      stopReason: BedrockStopReason.TOOL_USE,
+    },
+  ])("finalizes the active $label block at the provider terminal boundary", async (scenario) => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: events([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        ...scenario.blocks,
+        { messageStop: { stopReason: scenario.stopReason } },
+      ]),
+    } as never);
+
+    const stream = streamSimpleBedrock(model as never, {
+      messages: [{ role: "user", content: "Continue", timestamp: 0 }],
+    });
+    const observed = [];
+    for await (const event of stream) {
+      observed.push(event.type);
+    }
+    const output = await stream.result();
+
+    expect(observed.at(-2)).toBe(scenario.endEvent);
+    expect(observed.at(-1)).toBe("done");
+    expect(output.content[0]).not.toHaveProperty("index");
+    expect(output.content[0]).not.toHaveProperty("partialJson");
+    if (scenario.label === "redacted thinking") {
+      expect(output.content[0]).toMatchObject({ redacted: true, thinkingSignature: "AQID" });
+    }
+  });
+});

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -356,6 +356,18 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
         throw new Error(output.errorMessage ?? "An unknown error occurred");
       }
 
+      // Some valid provider streams omit contentBlockStop; never persist their scratch state.
+      for (const block of blocks) {
+        if (block.index !== undefined) {
+          handleContentBlockStop(
+            { contentBlockIndex: block.index },
+            blocks,
+            output,
+            eventSink,
+            redactedReasoningChunks,
+          );
+        }
+      }
       refusalBuffer?.flush();
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();

--- a/extensions/openrouter/chat-owner-regression.test.ts
+++ b/extensions/openrouter/chat-owner-regression.test.ts
@@ -1,0 +1,116 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import openrouterPlugin from "./index.js";
+
+async function captureProviderPayload(
+  modelId: string,
+  thinkingLevel: string,
+  payload: Record<string, unknown>,
+) {
+  const provider = await registerSingleProviderPlugin(openrouterPlugin);
+  const baseStreamFn = vi.fn(((model, _context, options) => {
+    void options?.onPayload?.(payload, model);
+    return { async *[Symbol.asyncIterator]() {} };
+  }) as StreamFn);
+  const wrapped = provider.wrapStreamFn?.({
+    provider: "openrouter",
+    modelId,
+    thinkingLevel,
+    streamFn: baseStreamFn,
+  } as never);
+
+  wrapped?.(
+    {
+      provider: "openrouter",
+      api: "openai-completions",
+      id: modelId,
+      baseUrl: "https://openrouter.ai/api/v1",
+      compat: {},
+    } as never,
+    { messages: [] },
+    {},
+  );
+
+  expect(baseStreamFn).toHaveBeenCalledOnce();
+  return payload;
+}
+
+describe("OpenRouter chat owner invariants", () => {
+  it.each([
+    "openrouter/anthropic/claude-sonnet-5",
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/moonshotai/kimi-k3",
+    "z-ai/glm-5.2",
+    "openrouter/z-ai/glm-5.2",
+    "~anthropic/claude-opus-latest",
+    "~moonshotai/kimi-latest",
+  ])("recognizes the live upstream cacheable model reference %s", async (modelId) => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(provider.isCacheTtlEligible?.({ provider: "openrouter", modelId } as never)).toBe(true);
+  });
+
+  it.each(["openai/gpt-5.4", "~openai/gpt-5.4", "openrouter/openai/gpt-5.4"])(
+    "does not infer provider cache support for unrelated model reference %s",
+    async (modelId) => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+      expect(provider.isCacheTtlEligible?.({ provider: "openrouter", modelId } as never)).toBe(
+        false,
+      );
+    },
+  );
+
+  it("preserves assistant prefill when the provider reasoning object disables reasoning", async () => {
+    const payload = await captureProviderPayload("anthropic/claude-opus-5", "off", {
+      reasoning: { enabled: false },
+      messages: [
+        { role: "user", content: "Return JSON." },
+        { role: "assistant", content: "{" },
+      ],
+    });
+
+    expect(payload.messages).toEqual([
+      { role: "user", content: "Return JSON." },
+      { role: "assistant", content: "{" },
+    ]);
+  });
+
+  it.each(["~anthropic/claude-opus-latest", "openrouter/~anthropic/claude-opus-latest"])(
+    "removes unsupported assistant prefill for reasoning model alias %s",
+    async (modelId) => {
+      const payload = await captureProviderPayload(modelId, "high", {
+        reasoning: { effort: "high" },
+        messages: [
+          { role: "user", content: "Continue." },
+          { role: "assistant", content: "{" },
+        ],
+      });
+
+      expect(payload.messages).toEqual([{ role: "user", content: "Continue." }]);
+    },
+  );
+
+  it("recognizes the live dated DeepSeek V4 model in its owner thinking profile", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openrouter",
+        modelId: "deepseek/deepseek-v4-flash-0731",
+      } as never),
+    ).toMatchObject({ defaultLevel: "high" });
+  });
+
+  it("backfills reasoning replay for the live dated DeepSeek V4 model", async () => {
+    const payload = await captureProviderPayload("deepseek/deepseek-v4-flash-0731", "high", {
+      messages: [{ role: "assistant", content: "done" }],
+    });
+
+    expect(payload.reasoning).toEqual({ effort: "high" });
+    expect(payload.messages).toEqual([
+      { role: "assistant", content: "done", reasoning_content: "" },
+    ]);
+  });
+});

--- a/extensions/openrouter/chat-owner-regression.test.ts
+++ b/extensions/openrouter/chat-owner-regression.test.ts
@@ -1,4 +1,5 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import openrouterPlugin from "./index.js";
@@ -9,10 +10,10 @@ async function captureProviderPayload(
   payload: Record<string, unknown>,
 ) {
   const provider = await registerSingleProviderPlugin(openrouterPlugin);
-  const baseStreamFn = vi.fn(((model, _context, options) => {
-    void options?.onPayload?.(payload, model);
-    return { async *[Symbol.asyncIterator]() {} };
-  }) as StreamFn);
+  const baseStreamFn = vi.fn((...args: Parameters<StreamFn>): ReturnType<StreamFn> => {
+    void args[2]?.onPayload?.(payload, args[0]);
+    return createAssistantMessageEventStream();
+  });
   const wrapped = provider.wrapStreamFn?.({
     provider: "openrouter",
     modelId,
@@ -20,7 +21,7 @@ async function captureProviderPayload(
     streamFn: baseStreamFn,
   } as never);
 
-  wrapped?.(
+  void wrapped?.(
     {
       provider: "openrouter",
       api: "openai-completions",

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -18,7 +18,11 @@ import { asOptionalRecord as readRecord } from "openclaw/plugin-sdk/string-coerc
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import { isOpenRouterMistralModelId, normalizeOpenRouterApiModelId } from "./models.js";
+import {
+  isOpenRouterMistralModelId,
+  normalizeOpenRouterApiModelId,
+  normalizeOpenRouterModelFamilyId,
+} from "./models.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 import { createOpenRouterOAuthAuthMethod } from "./oauth.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -43,13 +47,7 @@ import {
 const PROVIDER_ID = "openrouter";
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_FUSION_MODEL_ID = "openrouter/fusion";
-const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
-  "anthropic/",
-  "deepseek/",
-  "moonshot/",
-  "moonshotai/",
-  "zai/",
-] as const;
+const OPENROUTER_CACHE_TTL_MODEL_FAMILY = /^(?:anthropic|deepseek|moonshot(?:ai)?|z-?ai)\//;
 const MAX_PROMPT_MODEL_ID_DISPLAY_CHARS = 256;
 
 type OpenRouterFusionPromptContext = {
@@ -253,10 +251,6 @@ export default defineSingleProviderPluginEntry({
       };
     }
 
-    function isOpenRouterCacheTtlModel(modelId: string): boolean {
-      return OPENROUTER_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
-    }
-
     const passthroughGeminiReplayHooks = buildProviderReplayFamilyHooks({
       family: "passthrough-gemini",
     });
@@ -335,7 +329,8 @@ export default defineSingleProviderPluginEntry({
       resolveSystemPromptContribution: resolveOpenRouterFusionPromptContribution,
       extraParamsForTransport: resolveOpenRouterExtraParamsForTransport,
       wrapStreamFn: wrapOpenRouterProviderStream,
-      isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
+      isCacheTtlEligible: ({ modelId }) =>
+        OPENROUTER_CACHE_TTL_MODEL_FAMILY.test(normalizeOpenRouterModelFamilyId(modelId) ?? ""),
       resolveUsageAuth: async (ctx) => {
         const apiKey = ctx.resolveApiKeyFromConfigAndStore({
           envDirect: [ctx.env.OPENROUTER_API_KEY],

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -21,14 +21,12 @@ const OPENROUTER_SHORT_TO_API_MODEL_ID = new Map([
   ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
 ]);
 
-function normalizeOpenRouterModelId(modelId: unknown): string | undefined {
+export function normalizeOpenRouterModelFamilyId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
   }
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return normalized.startsWith(OPENROUTER_MODEL_PREFIX)
-    ? normalized.slice(OPENROUTER_MODEL_PREFIX.length)
-    : normalized;
+  return normalized.replace(/^openrouter\//, "").replace(/^~/, "");
 }
 
 export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefined {
@@ -50,17 +48,14 @@ export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefi
 }
 
 export function isOpenRouterMistralModelId(modelId: unknown): boolean {
-  const normalized = normalizeOpenRouterModelId(modelId);
+  const normalized = normalizeOpenRouterModelFamilyId(modelId);
   return Boolean(
     normalized && OPENROUTER_MISTRAL_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix)),
   );
 }
 
 export function isOpenRouterDeepSeekV4ModelId(modelId: unknown): boolean {
-  const normalized = normalizeOpenRouterModelId(modelId);
-  if (!normalized?.startsWith("deepseek/")) {
-    return false;
-  }
-  const deepSeekModelId = normalized.slice("deepseek/".length).split(":", 1)[0];
-  return deepSeekModelId === "deepseek-v4-flash" || deepSeekModelId === "deepseek-v4-pro";
+  return /^deepseek\/deepseek-v4-(?:flash|pro)(?:-\d{4,8})?(?::[^/]*)?$/.test(
+    normalizeOpenRouterModelFamilyId(modelId) ?? "",
+  );
 }

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -8,7 +8,7 @@ import {
   normalizeOpenAICompatibleReasoningReplay,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { isOpenRouterDeepSeekV4ModelId } from "./models.js";
+import { isOpenRouterDeepSeekV4ModelId, normalizeOpenRouterModelFamilyId } from "./models.js";
 import {
   isOpenRouterProxyReasoningUnsupportedModel,
   normalizeOpenRouterBaseUrl,
@@ -20,14 +20,6 @@ const openRouterThinkingStreamHooks = buildProviderStreamFamilyHooks("openrouter
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim() : undefined;
-}
-
-function isOpenRouterAnthropicModelId(modelId: unknown): boolean {
-  const normalized = readString(modelId)?.toLowerCase();
-  return (
-    normalized?.startsWith("anthropic/") === true ||
-    normalized?.startsWith("openrouter/anthropic/") === true
-  );
 }
 
 function isVerifiedOpenRouterRoute(model: Parameters<StreamFn>[0]): boolean {
@@ -43,7 +35,7 @@ function shouldPatchAnthropicOpenRouterPayload(model: Parameters<StreamFn>[0]): 
   const api = readString(model.api);
   return (
     (api === undefined || api === "openai-completions") &&
-    isOpenRouterAnthropicModelId(model.id) &&
+    normalizeOpenRouterModelFamilyId(model.id)?.startsWith("anthropic/") === true &&
     isVerifiedOpenRouterRoute(model)
   );
 }
@@ -154,7 +146,11 @@ function isEnabledReasoningValue(value: unknown): boolean {
     return normalized !== "" && normalized !== "off" && normalized !== "none";
   }
   if (typeof value === "object" && !Array.isArray(value)) {
-    const effort = (value as Record<string, unknown>).effort;
+    const reasoning = value as Record<string, unknown>;
+    if (reasoning.enabled === false) {
+      return false;
+    }
+    const effort = reasoning.effort;
     if (typeof effort === "string") {
       const normalized = effort.trim().toLowerCase();
       return normalized !== "" && normalized !== "off" && normalized !== "none";


### PR DESCRIPTION
## Summary

- Finalize successful Bedrock Converse text, reasoning, redacted-reasoning, and tool blocks even when their stream omits `contentBlockStop`.
- Normalize OpenRouter model families in their provider owner so qualified references, `~` routes, `z-ai` models, and dated DeepSeek V4 variants reach the correct cache, reasoning, replay, and assistant-prefill decisions.
- Honor `reasoning.enabled: false` without deleting a valid trailing assistant prefill.
- Fix four independently reproduced provider-owner invariants while reducing production code by **two lines**.

## Current reviewed head and merge status

```text
PR:        https://github.com/openclaw/openclaw/pull/116998
HEAD:      60df12e4bc8b3b8153ad9153fc8b068d02cfd342
TREE:      91d1171faeeb78dd08b6bf996c0ad5e03c904b7b
BASE:      eb0087dc7c96e6a6832b7a894b0a43c6ba26d753
Mergeable: MERGEABLE

openclaw/ci-gate: SUCCESS
check-lint:       SUCCESS
check-test-types: SUCCESS
```

- [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/30668197881/job/91280579942)
- [Exact-head full lint job](https://github.com/openclaw/openclaw/actions/runs/30668197881/job/91280179303)
- [Exact-head full test-types job](https://github.com/openclaw/openclaw/actions/runs/30668197881/job/91280179292)

The earlier review referenced superseded head `a0c6fe8b`; the current `60df12e4` follow-up repairs both previously failing CI gates with the canonical typed OpenRouter stream-test fixture.

## What was actually exercised

| Evidence | Source | Realism / limitation |
| --- | --- | --- |
| Bedrock terminal stream behavior | Actual Bedrock provider stream owner plus a mocked AWS SDK `BedrockRuntimeClient.send` event stream | Local deterministic provider-owner execution; **not** a live AWS inference request. |
| OpenRouter qualified/dated request handling | Actual OpenRouter plugin registration, cache hook, stream wrapper, and captured owner-mutated payload | Local deterministic provider-owner execution; **not** a live OpenRouter inference request or response. |
| OpenRouter model availability | Live unauthenticated `GET https://openrouter.ai/api/v1/models` | Real public catalog response only; it does **not** prove paid/authenticated model inference. |
| SDK compatibility | Installed `@aws-sdk/client-bedrock-runtime@3.1095.0`, `openai@6.49.0`, and `@openrouter/sdk@1.2.3` types/source | Direct dependency contract inspection; no credentialed provider call. |

No credentials, private endpoints, account identifiers, or real customer content are included below. Synthetic tool identifiers and model-independent fixture content are redacted where appropriate.

## Bedrock: redacted actual local provider-owner stream trace

`extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts` invokes the actual `streamSimpleBedrock` owner. The AWS SDK client is mocked to return an HTTP-200 async event stream that **deliberately omits `contentBlockStop`**:

```json
{
  "evidence": "local provider-owner execution; mocked AWS SDK response",
  "model": "<bedrock-model-redacted>",
  "endpoint": "<bedrock-endpoint-redacted>",
  "sdkHttpStatus": 200,
  "providerEvents": [
    { "messageStart": { "role": "assistant" } },
    {
      "contentBlockDelta": {
        "contentBlockIndex": 0,
        "delta": { "text": "ready" }
      }
    },
    { "messageStop": { "stopReason": "end_turn" } }
  ],
  "contentBlockStopEmittedByProvider": false,
  "observedTerminalOwnerEvents": ["text_end", "done"],
  "persistedContent": { "type": "text", "text": "ready" },
  "persistedScratchFields": []
}
```

The same actual provider-owner loop is exercised for all four fixture variants:

```text
text delta                       -> text_end     -> done; no persisted index
reasoning text delta             -> thinking_end -> done; no persisted index
redacted reasoning bytes         -> thinking_end -> done; redacted=true; signature preserved
tool start + streamed JSON delta -> toolcall_end -> done; no persisted index or partialJson
```

These are real outputs of the shipped provider owner driven by a synthetic SDK event stream; they are **not presented as live Bedrock traffic**. The directly inspected installed SDK declares `ContentBlockDeltaEvent`, `ContentBlockStopEvent`, `MessageStopEvent`, and redacted-reasoning bytes in its public event contract.

## OpenRouter: redacted actual local owner request/response traces

`extensions/openrouter/chat-owner-regression.test.ts` registers the actual OpenRouter plugin and invokes its real cache/thinking/stream-wrapper hooks. The following traces show deterministic **in-process hook inputs and captured transformed payloads**, not network requests or provider inference responses.

### Qualified references and live-catalog families

```json
{
  "evidence": "local plugin cache-hook execution; no provider network call",
  "isCacheTtlEligible": {
    "openrouter/anthropic/claude-sonnet-5": true,
    "openrouter/deepseek/deepseek-v4-pro": true,
    "openrouter/moonshotai/kimi-k3": true,
    "z-ai/glm-5.2": true,
    "openrouter/z-ai/glm-5.2": true,
    "~anthropic/claude-opus-latest": true,
    "~moonshotai/kimi-latest": true,
    "openai/gpt-5.4": false,
    "~openai/gpt-5.4": false,
    "openrouter/openai/gpt-5.4": false
  }
}
```

### Dated DeepSeek V4 model: captured request transformation

```json
{
  "evidence": "local OpenRouter stream-wrapper payload capture; no HTTP request",
  "configuredModelReference": "deepseek/deepseek-v4-flash-0731",
  "thinkingProfile": { "defaultLevel": "high" },
  "inputPayload": {
    "messages": [{ "role": "assistant", "content": "done" }]
  },
  "capturedOutputPayload": {
    "reasoning": { "effort": "high" },
    "messages": [
      { "role": "assistant", "content": "done", "reasoning_content": "" }
    ]
  }
}
```

### Qualified/latest Anthropic model: captured request transformation

```json
{
  "evidence": "local OpenRouter stream-wrapper payload capture; no HTTP request",
  "configuredModelReferences": [
    "~anthropic/claude-opus-latest",
    "openrouter/~anthropic/claude-opus-latest"
  ],
  "inputPayload": {
    "reasoning": { "effort": "high" },
    "messages": [
      { "role": "user", "content": "Continue." },
      { "role": "assistant", "content": "{" }
    ]
  },
  "capturedOutputPayload": {
    "reasoning": { "effort": "high" },
    "messages": [{ "role": "user", "content": "Continue." }]
  }
}
```

### Explicitly disabled reasoning preserves assistant prefill

```json
{
  "evidence": "local OpenRouter stream-wrapper payload capture; no HTTP request",
  "configuredModelReference": "anthropic/claude-opus-5",
  "inputPayload": {
    "reasoning": { "enabled": false },
    "messages": [
      { "role": "user", "content": "Return JSON." },
      { "role": "assistant", "content": "{" }
    ]
  },
  "capturedOutputPayload": {
    "reasoning": { "enabled": false },
    "messages": [
      { "role": "user", "content": "Return JSON." },
      { "role": "assistant", "content": "{" }
    ]
  }
}
```

## Actual live public OpenRouter catalog response

An unauthenticated live call to `GET https://openrouter.ai/api/v1/models` returned all four affected public model identifiers:

```json
{
  "evidence": "live public OpenRouter model-catalog response; no authenticated inference",
  "deepseek/deepseek-v4-flash-0731": true,
  "z-ai/glm-5.2": true,
  "~anthropic/claude-opus-latest": true,
  "~moonshotai/kimi-latest": true
}
```

This proves that the regression fixtures correspond to currently advertised model references; it does not claim that a live generation request was made.

## Frozen-baseline red reproduction

Baseline commit: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.

```text
node scripts/run-vitest.mjs \
  extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts \
  extensions/openrouter/chat-owner-regression.test.ts

Test Files  2 failed (2)
Tests       16 failed | 3 passed (19)
```

The failing cases cover missing Bedrock terminal events, leaked streaming scratch state, qualified/cacheable model families, `~` aliases, explicitly disabled reasoning, and dated DeepSeek thinking/replay.

## Exact-current-head independent verification

The final candidate was fetched into a separate detached remote checkout with its immutable Git identity and clean tree asserted **before** running validation:

```text
HEAD=60df12e4bc8b3b8153ad9153fc8b068d02cfd342
TREE=91d1171faeeb78dd08b6bf996c0ad5e03c904b7b
git status --porcelain: clean

node scripts/run-tsgo.mjs \
  -p test/tsconfig/tsconfig.extensions.test.json \
  --incremental \
  --tsBuildInfoFile /tmp/openclaw-bedrock-openrouter-ci-test.tsbuildinfo
=> PASS: full extension test types

node scripts/run-oxlint.mjs \
  --tsconfig config/tsconfig/oxlint.extensions.json \
  extensions
=> PASS: full extension lint

node scripts/run-vitest.mjs \
  extensions/amazon-bedrock/stream.runtime.test.ts \
  extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts \
  extensions/openrouter/index.test.ts \
  extensions/openrouter/chat-owner-regression.test.ts
=> Test Files  4 passed (4)
=> Tests       111 passed (111)
```

- [Independent exact-head Blacksmith proof](https://github.com/openclaw/openclaw/actions/runs/30667839839)
- Remote command exit: `0`; final Testbox lease stopped and independently verified `completed`.
- Production delta: `+33/-35`, net **-2**.

## Independent full-branch review

```text
Reviewed head: 60df12e4bc8b3b8153ad9153fc8b068d02cfd342
Review base:   36b80ada3ceae2de21b3d8710b883d778e4c4578
Engine:        codex / gpt-5.6-sol / high
Scope:         full branch, --max-priority P3
TruffleHog:    clean
P0/P1/P2/P3:   0 actionable findings
Verdict:       patch is correct
Confidence:    0.90
```

## Response to ClawSweeper rank-up moves

1. **Bedrock stream behavior:** Added redacted terminal-event input/output traces from actual Bedrock provider-owner execution. The SDK event stream is mocked; no live AWS inference is claimed.
2. **OpenRouter qualified/dated behavior:** Added exact qualified-reference cache decisions, dated-model payload capture, alias prefill capture, disabled-reasoning capture, and a real unauthenticated public model-catalog response. No authenticated OpenRouter inference is claimed.
3. **Current head / validation:** Updated every verification and review reference to current head `60df12e4`, recorded the current `MERGEABLE` state, linked the successful current-head CI gates, and reproduced the previously failing full test-type/lint lanes plus all 111 owner tests on an independently clean exact-head checkout.

**Remaining evidence limitation:** No credentialed live Bedrock or OpenRouter generation was executed. If real paid/authenticated provider inference is a strict merge requirement, this PR documents that limitation explicitly instead of presenting fixture output as live-provider traffic.
