### PR TITLE
fix(openai): enforce image stream framing and terminal outcomes

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1660,6 +1660,293 @@ describe("openai image generation provider", () => {
 
   it.each([
     {
+      name: "data fields without optional whitespace",
+      frame: (event: string) => `data:${event}\n\n`,
+    },
+    {
+      name: "one event split across multiple data fields",
+      frame: (event: string) => `data:${event.replace(',"item":', ',\ndata:"item":')}\n\n`,
+    },
+  ])("parses Codex SSE $name", async ({ frame }) => {
+    mockCodexAuthOnly();
+    const item = JSON.stringify({
+      type: "response.output_item.done",
+      item: {
+        type: "image_generation_call",
+        result: Buffer.from("framed-image").toString("base64"),
+      },
+    });
+    const completed = JSON.stringify({ type: "response.completed", response: { output: [] } });
+    mockCodexRawStream(`${frame(item)}data:${completed}\n\n`);
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw an image from a standards-compliant SSE frame",
+      cfg: {},
+    });
+
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("framed-image"));
+  });
+
+  it("surfaces the authoritative nested Codex response failure", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: { code: "rate_limit_exceeded", message: "quota was exhausted" },
+        },
+      })}\n\n`,
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image after the provider rejects the turn",
+        cfg: {},
+      }),
+    ).rejects.toThrow("quota was exhausted");
+  });
+
+  it("rejects incomplete Codex image turns with their provider reason", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      `data: ${JSON.stringify({
+        type: "response.incomplete",
+        response: { status: "incomplete", incomplete_details: { reason: "max_output_tokens" } },
+      })}\n\n`,
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image before the model runs out of output tokens",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/incomplete.*max_output_tokens/i);
+  });
+
+  it("rejects Codex image output when the stream closes before its terminal response", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      `data: ${JSON.stringify({
+        type: "response.output_item.done",
+        item: {
+          type: "image_generation_call",
+          result: Buffer.from("unconfirmed-image").toString("base64"),
+        },
+      })}\n\n`,
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image on an interrupted stream",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/closed before response\.completed/i);
+  });
+
+  it("rejects completed Codex turns that contain no generated image", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      `data: ${JSON.stringify({ type: "response.completed", response: { output: [] } })}\n\n`,
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image instead of silently returning no assets",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/did not produce an image/i);
+  });
+
+  it("uses the completed Codex response as the authoritative image snapshot", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      [
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            result: Buffer.from("stale-image").toString("base64"),
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            output: [
+              {
+                type: "image_generation_call",
+                result: Buffer.from("final-image").toString("base64"),
+              },
+            ],
+          },
+        },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join(""),
+    );
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw an image from the final provider-owned snapshot",
+      cfg: {},
+    });
+
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("final-image"));
+  });
+
+  it.each([
+    { name: "completed without an image", status: "completed", result: null },
+    { name: "failed without an image", status: "failed", result: null },
+    {
+      name: "failed with stale image data",
+      status: "failed",
+      result: Buffer.from("failed-image").toString("base64"),
+    },
+    {
+      name: "in progress with stale image data",
+      status: "in_progress",
+      result: Buffer.from("in-progress-image").toString("base64"),
+    },
+    {
+      name: "generating with stale image data",
+      status: "generating",
+      result: Buffer.from("generating-image").toString("base64"),
+    },
+  ])("rejects an authoritative completed image call $name", async ({ status, result }) => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      [
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            status: "completed",
+            result: Buffer.from("stale-interim-image").toString("base64"),
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            output: [{ type: "image_generation_call", status, result }],
+          },
+        },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join(""),
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Honor the authoritative completed image status instead of a stale interim image",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/did not produce an image|image call did not complete/i);
+  });
+
+  it("rejects a failed interim image when the completed snapshot omits image calls", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      [
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            status: "failed",
+            result: Buffer.from("failed-interim-image").toString("base64"),
+          },
+        },
+        { type: "response.completed", response: { output: [] } },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join(""),
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Reject a failed compatibility image instead of returning it",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/image call did not complete/i);
+  });
+
+  it("ignores malformed interim image data when the completed snapshot provides the final image", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      [
+        {
+          type: "response.output_item.done",
+          item: { type: "image_generation_call", result: "not valid base64" },
+        },
+        {
+          type: "response.completed",
+          response: {
+            output: [
+              {
+                type: "image_generation_call",
+                result: Buffer.from("final-image").toString("base64"),
+              },
+            ],
+          },
+        },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join(""),
+    );
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Use the completed image instead of an invalid interim snapshot",
+      cfg: {},
+    });
+
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("final-image"));
+  });
+
+  it("does not let malformed interim image data hide an authoritative provider failure", async () => {
+    mockCodexAuthOnly();
+    mockCodexRawStream(
+      [
+        {
+          type: "response.output_item.done",
+          item: { type: "image_generation_call", result: "not valid base64" },
+        },
+        {
+          type: "response.failed",
+          response: { error: { message: "provider account is over quota" } },
+        },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join(""),
+    );
+
+    await expect(
+      buildOpenAIImageGenerationProvider().generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Return the real provider failure instead of an interim decoding error",
+        cfg: {},
+      }),
+    ).rejects.toThrow("provider account is over quota");
+  });
+
+  it.each([
+    {
       name: "invalid alphabet from output item",
       event: {
         type: "response.output_item.done",
@@ -1698,7 +1985,11 @@ describe("openai image generation provider", () => {
     },
   ])("rejects malformed Codex image base64 from $name events", async ({ event }) => {
     mockCodexAuthOnly();
-    mockCodexRawStream(`data: ${JSON.stringify(event)}\n\n`);
+    const terminal =
+      event.type === "response.completed"
+        ? ""
+        : `data: ${JSON.stringify({ type: "response.completed", response: { output: [] } })}\n\n`;
+    mockCodexRawStream(`data: ${JSON.stringify(event)}\n\n${terminal}`);
 
     const provider = buildOpenAIImageGenerationProvider();
     await expect(
@@ -1717,7 +2008,7 @@ describe("openai image generation provider", () => {
       `data: ${JSON.stringify({
         type: "response.output_item.done",
         item: { type: "image_generation_call", result: "\u0085aGVsbG8=\u0085" },
-      })}\n\n`,
+      })}\n\ndata: ${JSON.stringify({ type: "response.completed", response: { output: [] } })}\n\n`,
     );
 
     const provider = buildOpenAIImageGenerationProvider();

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -469,19 +469,25 @@ function isCodexSubscriptionAuthMode(mode: unknown): boolean {
   return mode === "oauth" || mode === "token";
 }
 
+type OpenAICodexImageGenerationItem = {
+  type?: string;
+  result?: string | null;
+  revised_prompt?: string;
+  status?: "in_progress" | "completed" | "generating" | "failed";
+};
+
 type OpenAICodexImageGenerationEvent = {
   type?: string;
-  item?: {
-    type?: string;
-    result?: string;
-    revised_prompt?: string;
-  };
+  item?: OpenAICodexImageGenerationItem;
   response?: {
-    output?: Array<{
-      type?: string;
-      result?: string;
-      revised_prompt?: string;
-    }>;
+    error?: {
+      code?: string;
+      message?: string;
+    };
+    incomplete_details?: {
+      reason?: string;
+    };
+    output?: OpenAICodexImageGenerationItem[];
     usage?: unknown;
     tool_usage?: unknown;
   };
@@ -544,11 +550,13 @@ async function readResponseBodyText(response: Response): Promise<string> {
 
 function parseCodexImageGenerationEvents(body: string): OpenAICodexImageGenerationEvent[] {
   const events: OpenAICodexImageGenerationEvent[] = [];
-  for (const line of body.split(/\r?\n/)) {
-    if (!line.startsWith("data: ")) {
-      continue;
-    }
-    const data = line.slice(6).trim();
+  for (const frame of body.replace(/\r\n?/g, "\n").split("\n\n")) {
+    const data = frame
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).replace(/^ /, ""))
+      .join("\n")
+      .trim();
     if (!data || data === "[DONE]") {
       continue;
     }
@@ -591,10 +599,13 @@ function decodeCodexImagePayload(payload: string): Buffer {
 }
 
 function toCodexImage(
-  entry: { result?: string; revised_prompt?: string },
+  entry: OpenAICodexImageGenerationItem,
   index: number,
   outputFormat?: ImageGenerationOutputFormat,
 ): ImageGenerationResult["images"][number] | null {
+  if (entry.status && entry.status !== "completed") {
+    throw new Error(`OpenAI Codex image generation image call did not complete (${entry.status})`);
+  }
   if (typeof entry.result !== "string" || entry.result.length === 0) {
     return null;
   }
@@ -615,48 +626,56 @@ function extractCodexImageGenerationResult(params: {
   outputFormat?: ImageGenerationOutputFormat;
 }): ImageGenerationResult {
   const events = parseCodexImageGenerationEvents(params.body);
-  const failure = events.find(
-    (event) => event.type === "response.failed" || event.type === "error",
-  );
-  if (failure) {
-    const message =
-      failure.error?.message ??
-      failure.message ??
-      (failure.error?.code ? `OpenAI Codex image generation failed (${failure.error.code})` : "");
-    throw new Error(message || "OpenAI Codex image generation failed");
+  const outputItems: Array<NonNullable<OpenAICodexImageGenerationEvent["item"]>> = [];
+  let completedResponse: OpenAICodexImageGenerationEvent["response"];
+  for (const event of events) {
+    if (event.type === "response.failed" || event.type === "error") {
+      const error = event.response?.error ?? event.error;
+      const message =
+        error?.message ??
+        event.message ??
+        (error?.code ? `OpenAI Codex image generation failed (${error.code})` : "");
+      throw new Error(message || "OpenAI Codex image generation failed");
+    }
+    if (event.type === "response.incomplete") {
+      const reason = event.response?.incomplete_details?.reason ?? "unknown";
+      throw new Error(`OpenAI Codex image generation response incomplete: ${reason}`);
+    }
+    if (event.type === "response.completed") {
+      completedResponse = event.response;
+      break;
+    }
+    if (
+      event.type === "response.output_item.done" &&
+      event.item?.type === "image_generation_call" &&
+      outputItems.length < OPENAI_MAX_IMAGE_RESULTS
+    ) {
+      outputItems.push(event.item);
+    }
   }
-  const completedResponse = events.find((event) => event.type === "response.completed");
-  const outputItemImages = events
-    .filter(
-      (event) =>
-        event.type === "response.output_item.done" &&
-        event.item?.type === "image_generation_call" &&
-        typeof event.item.result === "string" &&
-        event.item.result.length > 0,
-    )
-    .slice(0, OPENAI_MAX_IMAGE_RESULTS)
-    .map((event, index) =>
-      event.item ? toCodexImage(event.item, index, params.outputFormat) : null,
-    )
-    .filter((image): image is NonNullable<typeof image> => image !== null);
-  const completedOutputImages = (completedResponse?.response?.output ?? [])
+  if (!completedResponse) {
+    throw new Error("OpenAI Codex image generation stream closed before response.completed");
+  }
+  const completedOutputItems = (completedResponse.output ?? [])
     .filter((entry) => entry.type === "image_generation_call")
-    .slice(0, OPENAI_MAX_IMAGE_RESULTS)
-    .map((entry, index) => toCodexImage(entry, index, params.outputFormat))
+    .slice(0, OPENAI_MAX_IMAGE_RESULTS);
+  // The completed snapshot owns final provider state; done events only recover
+  // compatible streams that omit their image from the terminal output.
+  const selectedOutputItems = completedOutputItems.length > 0 ? completedOutputItems : outputItems;
+  const images = selectedOutputItems
+    .map((item, index) => toCodexImage(item, index, params.outputFormat))
     .filter((image): image is NonNullable<typeof image> => image !== null);
-  const images = outputItemImages.length > 0 ? outputItemImages : completedOutputImages;
+  if (images.length === 0) {
+    throw new Error("OpenAI Codex image generation completed but did not produce an image");
+  }
 
   return {
     images,
     model: params.model,
-    ...(completedResponse?.response
-      ? {
-          metadata: {
-            usage: completedResponse.response.usage,
-            toolUsage: completedResponse.response.tool_usage,
-          },
-        }
-      : {}),
+    metadata: {
+      usage: completedResponse.usage,
+      toolUsage: completedResponse.tool_usage,
+    },
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

OpenAI Codex image generation could reject valid provider streams, hide the real provider error, or silently report success even though the turn never completed, produced no image, or ended with a failed image call.

Six independently reproduced root causes:

1. Standards-compliant SSE events using `data:` without a space or multiple `data:` lines were rejected.
2. Nested `response.failed` provider error messages were replaced with a generic failure.
3. `response.incomplete` turns were returned as successful empty image results.
4. Interrupted streams could return interim images without receiving `response.completed`.
5. Completed turns containing no generated image were reported as successful.
6. Interim image selection/decoding could override the authoritative completed image item, including its explicit null result or `failed`, `in_progress`, and `generating` statuses, and mask the provider failure.

## Why This Change Was Made

The existing private OpenAI image owner now parses SSE frames using the pinned official SDK framing contract, models its nullable image result and complete status union, processes provider terminal states in order, and selects completed image items by their presence before materializing any image.

Done-event compatibility fallback is permitted only when completed output contains no image-generation item. Every explicitly non-completed image status fails, including fallback items. Interim payloads remain undecoded unless a genuine completed response actually needs them.

Existing event, response-size, and Base64 limits; authorization, provider configuration, SSRF policy, request transport, public interfaces, and persistence remain unchanged.

## User Impact

- Valid Codex image streams work with either standard SSE data-field shape.
- Provider failures and incomplete reasons remain visible and actionable.
- Interrupted turns, empty image results, and failed or unfinished image calls fail explicitly.
- The completed image item always wins over stale interim content, even when its result is null.
- Invalid interim image bytes cannot hide a valid final image or the actual provider error.

## Evidence

- Frozen canonical baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Immutable reviewed candidate: `8edb9e672e8a9afa74843a51534124195617f177`.
- **15 new red-to-green production-boundary regression cases.**
- Genuine reviewer-found P2 eager-decoding issue reproduced **2/2 red**, repaired, then a second independent reviewer found the SDK nullable/status P1 and reproduced **6/6 red** before the final canonical repair.
- Exact focused command:

  ```bash
  PATH=/Users/steipete/.local/bin:$PATH node scripts/run-vitest.mjs extensions/openai/image-generation-provider.test.ts
  ```

- **92/92 image-provider owner tests passed**, including malformed Base64, Unicode whitespace, event-count, and payload-size coverage.
- Actual pinned official SDK `_iterSSEMessages` confirmed both no-space `data:` and multiline `data:` event parsing.
- Official SDK source inspected directly: `node_modules/openai/src/core/streaming.ts:315-358` and `node_modules/openai/src/resources/responses/responses.ts:4291-4305` (`result: string | null`; `in_progress | completed | generating | failed`).
- Direct sibling Codex source inspected: `../codex/codex-rs/codex-api/src/sse/responses.rs:327`, `../codex/codex-rs/codex-api/src/sse/responses.rs:387`, `../codex/codex-rs/codex-api/src/sse/responses.rs:434`, `../codex/codex-rs/codex-api/src/sse/responses.rs:499`, and `../codex/codex-rs/protocol/src/models.rs:996`.
- Final immutable full-branch genuine Codex/Sol high-reasoning autoreview with explicit `--max-priority P3`: **zero actionable P0/P1/P2/P3 findings**, **0.98 confidence**; genuine TruffleHog clean.
- **Two fresh independent exact-SHA blind OpenAI owner/SDK/Codex reviews: clean across P0/P1/P2/P3.**
- Production delta: **70 additions / 51 deletions = +19 lines** for one canonical SDK-accurate SSE/item/terminal owner; regression tests: **293 additions / 2 deletions**.
- Targeted formatting, `git diff --check`, frozen merge-base, and final clean worktree: clean.
