### PR TITLE
fix(telegram): canonicalize topic-qualified mutation targets

### DIFF
--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -7,7 +7,6 @@ import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import {
   createTelegramRequestWithDiag,
   isTelegramMessageDeleteNoopError,
-  normalizeMessageId,
   resolveAndPersistChatId,
   resolveTelegramApiContext,
   withTelegramApiContextLease,
@@ -102,23 +101,16 @@ async function reactMessageTelegramWithContext(
   opts: TelegramReactionOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true } | { ok: false; warning: string }> {
-  const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const messageId = normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "react" }),
+  const { api } = context;
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    messageIdInput,
+    request: {
+      kind: "standard",
+      shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "react" }),
+    },
   });
   const remove = opts.remove === true;
   const trimmedEmoji = emoji.trim();
@@ -132,7 +124,7 @@ async function reactMessageTelegramWithContext(
     throw new Error("Telegram reactions are unavailable in this bot API.");
   }
   try {
-    await requestWithDiag(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
+    await request(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
   } catch (err: unknown) {
     const msg = formatErrorMessage(err);
     if (/REACTION_INVALID/i.test(msg)) {
@@ -172,26 +164,19 @@ async function deleteMessageTelegramWithContext(
   opts: TelegramDeleteOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true } | { ok: false; warning: string }> {
-  const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const messageId = normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "delete" }),
+  const { api } = context;
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    messageIdInput,
+    request: {
+      kind: "standard",
+      shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "delete" }),
+    },
   });
   try {
-    await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage", {
+    await request(() => api.deleteMessage(chatId, messageId), "deleteMessage", {
       shouldLog: (err) => !isTelegramMessageDeleteNoopError(err),
     });
   } catch (err: unknown) {
@@ -264,24 +249,15 @@ async function unpinMessageTelegramWithContext(
   opts: TelegramDeleteOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true; chatId: string; messageId?: string }> {
-  const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
+  const { api } = context;
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    ...(messageIdInput !== undefined ? { messageIdInput } : {}),
+    request: { kind: "standard" },
   });
-  const messageId = messageIdInput === undefined ? undefined : normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-  });
-  await requestWithDiag(() => api.unpinChatMessage(chatId, messageId), "unpinChatMessage");
+  await request(() => api.unpinChatMessage(chatId, messageId), "unpinChatMessage");
   logVerbose(
     `[telegram] Unpinned ${messageId != null ? `message ${messageId}` : "active message"} in chat ${chatId}`,
   );

--- a/extensions/telegram/src/send-mutation-targets.test.ts
+++ b/extensions/telegram/src/send-mutation-targets.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getTelegramSendTestMocks,
+  importTelegramSendModule,
+  installTelegramSendTestHooks,
+} from "./send.test-harness.js";
+
+installTelegramSendTestHooks();
+
+const { botApi, maybePersistResolvedTelegramTarget } = getTelegramSendTestMocks();
+const { deleteMessageTelegram, pinMessageTelegram, reactMessageTelegram, unpinMessageTelegram } =
+  await importTelegramSendModule();
+
+const chatId = "-1001234567890";
+const messageId = 321;
+const getChat = vi.fn(async () => ({ id: Number(chatId) }));
+const opts = {
+  cfg: {},
+  token: "tok",
+  accountId: "default",
+  api: { ...botApi, getChat } as unknown as Parameters<typeof reactMessageTelegram>[3]["api"],
+  gatewayClientScopes: ["operator.write"],
+};
+
+const mutations = [
+  {
+    name: "reaction",
+    run: (target: string) => reactMessageTelegram(target, messageId, "✅", opts),
+    assertCall: () =>
+      expect(botApi.setMessageReaction).toHaveBeenCalledWith(chatId, messageId, [
+        { type: "emoji", emoji: "✅" },
+      ]),
+  },
+  {
+    name: "delete",
+    run: (target: string) => deleteMessageTelegram(target, messageId, opts),
+    assertCall: () => expect(botApi.deleteMessage).toHaveBeenCalledWith(chatId, messageId),
+  },
+  {
+    name: "pin",
+    run: (target: string) => pinMessageTelegram(target, messageId, opts),
+    assertCall: () =>
+      expect(botApi.pinChatMessage).toHaveBeenCalledWith(chatId, messageId, {
+        disable_notification: true,
+      }),
+  },
+  {
+    name: "unpin",
+    run: (target: string) => unpinMessageTelegram(target, messageId, opts),
+    assertCall: () => expect(botApi.unpinChatMessage).toHaveBeenCalledWith(chatId, messageId),
+  },
+  {
+    name: "unpin without an explicit message",
+    run: (target: string) => unpinMessageTelegram(target, undefined, opts),
+    assertCall: () => expect(botApi.unpinChatMessage).toHaveBeenCalledWith(chatId, undefined),
+  },
+] as const;
+
+describe("Telegram topic-qualified message mutations", () => {
+  it.each(
+    mutations.flatMap((mutation) => [
+      { ...mutation, target: `${chatId}:topic:77` },
+      { ...mutation, target: `telegram:group:${chatId}:topic:77` },
+      { ...mutation, target: "@mychannel:topic:77" },
+    ]),
+  )(
+    "routes $name mutations for $target to their base chat",
+    async ({ run, assertCall, target }) => {
+      botApi.setMessageReaction.mockResolvedValue(true);
+      botApi.deleteMessage.mockResolvedValue(true);
+      botApi.pinChatMessage.mockResolvedValue(true);
+      botApi.unpinChatMessage.mockResolvedValue(true);
+      getChat.mockClear();
+
+      await run(target);
+
+      assertCall();
+      expect(maybePersistResolvedTelegramTarget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rawTarget: target,
+          resolvedChatId: chatId,
+          gatewayClientScopes: ["operator.write"],
+        }),
+      );
+      if (target.startsWith("@")) {
+        expect(getChat).toHaveBeenCalledWith("@mychannel");
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram reactions, message deletions, and unpin operations failed for valid topic-qualified chat targets even though pinning the same target already worked.

## Why This Change Was Made

The three affected mutation paths duplicated obsolete raw-target resolution. They now use the existing canonical outbound target preparation already used by Telegram pinning, preserving existing authorization, retry, no-op, and gateway-scope behavior while removing duplicate production code.

## User Impact

Agents and operators can react to, delete, and unpin messages using Telegram forum-topic-qualified numeric IDs, internal targets, and usernames. Existing plain chat targets, pinning, and unpinning without a specific message continue to work.

## Evidence

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`; exact reviewed head: `371186debcdc3d01d69931f1cbbe393557d73519`.
- Before the repair, **6 of 8** topic-qualified owner calls failed while the existing canonical pin controls passed.
- Exact-source Blacksmith proof verified the frozen parent and both changed Git blobs before running **246 passing tests** across Telegram send owners, outbound adapters, and 15 topic-qualified mutation cases.
- Validation run: https://github.com/openclaw/openclaw/actions/runs/30656771664.
- Genuine full-branch P0–P3 Codex autoreview and TruffleHog secret scanning: **clean**, zero findings, confidence **0.91**.
- Production delta: **−24 lines**. No authorization, configuration, public SDK, protocol, or persistent-state changes.
