### PR TITLE
fix(cli): honor shell-owned completion profile locations

### DIFF
--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -58,7 +58,17 @@ async function withIsolatedCompletionState(
   const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
 
   try {
-    await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir, ...env }, run);
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: undefined,
+        ZDOTDIR: undefined,
+        ...env,
+      },
+      run,
+    );
   } finally {
     await fs.rm(stateDir, { recursive: true, force: true });
     await fs.rm(homeDir, { recursive: true, force: true });

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -1,7 +1,6 @@
 // Completion runtime tests cover shell completion generation and runtime file writes.
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -21,13 +20,41 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withBashCompletionHome(
   run: (paths: { homeDir: string; stateDir: string }) => Promise<void>,
+  stateDirPrefix = "openclaw-bash-completion-state-",
 ): Promise<void> {
   const homeDir = tempDirs.make("openclaw-bash-completion-home-");
-  const stateDir = tempDirs.make("openclaw-bash-completion-state-");
+  const stateDir = tempDirs.make(stateDirPrefix);
 
-  await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
-    await run({ homeDir, stateDir });
-  });
+  await withEnvAsync(
+    {
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      OPENCLAW_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: undefined,
+      ZDOTDIR: undefined,
+    },
+    async () => {
+      await run({ homeDir, stateDir });
+    },
+  );
+}
+
+function expectAvailableShellToSucceed(
+  shellName: "bash" | "zsh",
+  result: SpawnSyncReturns<string>,
+): void {
+  if (result.error) {
+    if (
+      shellName === "zsh" &&
+      "code" in result.error &&
+      (result.error.code === "ENOENT" || result.error.code === "EACCES")
+    ) {
+      return;
+    }
+    throw result.error;
+  }
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
 }
 
 describe("completion-runtime", () => {
@@ -71,8 +98,7 @@ describe("completion-runtime", () => {
             encoding: "utf8",
             env: process.env,
           });
-          expect(shell.stderr).toBe("");
-          expect(shell.status).toBe(0);
+          expectAvailableShellToSucceed("zsh", shell);
         }
       },
     );
@@ -383,6 +409,7 @@ describe("completion-runtime", () => {
       await fs.writeFile(profilePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf-8");
 
       const reloadCommand = formatCompletionReloadCommand(shellName, profilePath);
+      expect(reloadCommand).toBe(`source '${profilePath.replaceAll("'", "'\\''")}'`);
       const shell = spawnSync(
         shellName,
         ["-c", `${reloadCommand}; [ "$OPENCLAW_COMPLETION_LOADED" = ready ]`],
@@ -390,9 +417,7 @@ describe("completion-runtime", () => {
           encoding: "utf8",
         },
       );
-
-      expect(shell.stderr).toBe("");
-      expect(shell.status).toBe(0);
+      expectAvailableShellToSucceed(shellName, shell);
     },
   );
 
@@ -460,40 +485,24 @@ describe("completion-runtime", () => {
   });
 
   it("installs PowerShell completion into the concrete profile path", async () => {
-    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-bob's-"));
+    await withBashCompletionHome(async () => {
+      const cachePath = resolveCompletionCachePath("powershell", "openclaw");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "# powershell completion\n", "utf-8");
 
-    try {
-      await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const cachePath = resolveCompletionCachePath("powershell", "openclaw");
-        await fs.mkdir(path.dirname(cachePath), { recursive: true });
-        await fs.writeFile(cachePath, "# powershell completion\n", "utf-8");
+      await installCompletion("powershell", true, "openclaw");
 
-        await installCompletion("powershell", true, "openclaw");
-
-        const profilePath = resolveCompletionProfilePath("powershell");
-        const profile = await fs.readFile(profilePath, "utf-8");
-        expect(profile).toBe(`# OpenClaw Completion\n. '${cachePath.replace(/'/g, "''")}'\n`);
-      });
-    } finally {
-      await fs.rm(homeDir, { recursive: true, force: true });
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+      const profilePath = resolveCompletionProfilePath("powershell");
+      const profile = await fs.readFile(profilePath, "utf-8");
+      expect(profile).toBe(`# OpenClaw Completion\n. '${cachePath.replace(/'/g, "''")}'\n`);
+    }, "openclaw-completion-state-bob's-");
   });
 
   it("rejects install when the completion cache is missing", async () => {
-    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
-
-    try {
-      await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
-        await expect(installCompletion("zsh", true, "openclaw")).rejects.toThrow(
-          "Completion cache not found",
-        );
-      });
-    } finally {
-      await fs.rm(homeDir, { recursive: true, force: true });
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    await withBashCompletionHome(async () => {
+      await expect(installCompletion("zsh", true, "openclaw")).rejects.toThrow(
+        "Completion cache not found",
+      );
+    });
   });
 });

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -2,7 +2,7 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -11,6 +11,7 @@ import {
   installCompletion,
   isCompletionInstalled,
   resolveCompletionCachePath,
+  resolveCompletionProfileHint,
   resolveCompletionProfilePath,
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
@@ -113,6 +114,154 @@ describe("completion-runtime", () => {
     ).toBe(path.join(path.sep, ".zshrc"));
   });
 
+  it.skipIf(process.platform === "win32")(
+    "preserves Zsh and Fish symlink traversal before parent path components",
+    async () => {
+      for (const testCase of [
+        { shell: "zsh" as const, variable: "ZDOTDIR", profileName: ".zshrc" },
+        {
+          shell: "fish" as const,
+          variable: "XDG_CONFIG_HOME",
+          profileName: path.join("fish", "config.fish"),
+        },
+      ]) {
+        await withBashCompletionHome(async ({ homeDir }) => {
+          const profileParent = tempDirs.make(`openclaw-${testCase.shell}-symlink-profiles-`);
+          const nestedProfiles = path.join(profileParent, "nested");
+          const linkedProfiles = path.join(homeDir, "linked-profiles");
+          await fs.mkdir(nestedProfiles, { recursive: true });
+          await fs.symlink(nestedProfiles, linkedProfiles, "dir");
+
+          await withEnvAsync(
+            { [testCase.variable]: `${linkedProfiles}${path.sep}..` },
+            async () => {
+              const cachePath = resolveCompletionCachePath(testCase.shell, "openclaw");
+              await fs.mkdir(path.dirname(cachePath), { recursive: true });
+              await fs.writeFile(cachePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf8");
+
+              await installCompletion(testCase.shell, true, "openclaw");
+
+              const profilePath = path.join(profileParent, testCase.profileName);
+              await expect(fs.readFile(profilePath, "utf8")).resolves.toContain(cachePath);
+              expect(resolveCompletionProfileHint(testCase.shell)).toBe(
+                `~${path.sep}linked-profiles${path.sep}..${path.sep}${testCase.profileName}`,
+              );
+            },
+          );
+        });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves every shell's default profile traversal through a symlinked HOME",
+    async () => {
+      const fixtureRoot = tempDirs.make("openclaw-completion-home-symlink-");
+      const realHome = path.join(fixtureRoot, "real-home");
+      const nestedHome = path.join(realHome, "nested");
+      const linkedHome = path.join(fixtureRoot, "linked-home");
+      await fs.mkdir(nestedHome, { recursive: true });
+      await fs.symlink(nestedHome, linkedHome, "dir");
+
+      for (const testCase of [
+        { shell: "zsh" as const, profileName: ".zshrc" },
+        { shell: "bash" as const, profileName: ".bash_profile" },
+        { shell: "fish" as const, profileName: path.join(".config", "fish", "config.fish") },
+        {
+          shell: "powershell" as const,
+          profileName: path.join(".config", "powershell", "Microsoft.PowerShell_profile.ps1"),
+        },
+      ]) {
+        const stateDir = tempDirs.make(`openclaw-${testCase.shell}-home-symlink-state-`);
+        await withEnvAsync(
+          {
+            HOME: `${linkedHome}${path.sep}..`,
+            USERPROFILE: `${linkedHome}${path.sep}..`,
+            OPENCLAW_STATE_DIR: stateDir,
+            XDG_CONFIG_HOME: undefined,
+            ZDOTDIR: undefined,
+          },
+          async () => {
+            const cachePath = resolveCompletionCachePath(testCase.shell, "openclaw");
+            await fs.mkdir(path.dirname(cachePath), { recursive: true });
+            await fs.writeFile(cachePath, `# cached ${testCase.shell} completion\n`, "utf8");
+
+            await installCompletion(testCase.shell, true, "openclaw");
+
+            const actualStartupProfile = path.join(realHome, testCase.profileName);
+            await expect(fs.readFile(actualStartupProfile, "utf8")).resolves.toContain(cachePath);
+            expect(resolveCompletionProfileHint(testCase.shell)).toBe(
+              testCase.shell === "powershell"
+                ? `${linkedHome}${path.sep}..${path.sep}${testCase.profileName}`
+                : `~/${testCase.profileName}`,
+            );
+          },
+        );
+      }
+    },
+  );
+
+  it.each(["relative-xdg", "~/relative-xdg"])(
+    "ignores invalid relative Fish XDG configuration roots: %s",
+    (configHome) => {
+      const homeDir = path.join(path.sep, "tmp", "openclaw-home");
+      expect(
+        resolveCompletionProfilePath("fish", {
+          env: { HOME: homeDir, XDG_CONFIG_HOME: configHome },
+          homeDir: () => homeDir,
+        }),
+      ).toBe(path.join(homeDir, ".config", "fish", "config.fish"));
+    },
+  );
+
+  it("preserves significant trailing whitespace in an absolute Fish XDG directory", () => {
+    const homeDir = path.join(path.sep, "tmp", "openclaw-home");
+    const configHome = path.join(path.sep, "tmp", "Fish Config ");
+    expect(
+      resolveCompletionProfilePath("fish", {
+        env: { HOME: homeDir, XDG_CONFIG_HOME: configHome },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(configHome, "fish", "config.fish"));
+  });
+
+  it.each([
+    {
+      configHome: "C:\\Users\\Ada\\Fish Config",
+      expected: "C:\\Users\\Ada\\Fish Config\\fish\\config.fish",
+    },
+    {
+      configHome: "relative-fish",
+      expected: "C:\\Users\\Ada\\.config\\fish\\config.fish",
+    },
+    {
+      configHome: "\\\\fileserver\\profiles\\Fish Config",
+      expected: "\\\\fileserver\\profiles\\Fish Config\\fish\\config.fish",
+    },
+  ])("resolves Windows Fish profiles with Windows separators: $configHome", (testCase) => {
+    const homeDir = "C:\\Users\\Ada";
+    expect(
+      resolveCompletionProfilePath("fish", {
+        env: { HOME: homeDir, XDG_CONFIG_HOME: testCase.configHome },
+        homeDir: () => homeDir,
+        platform: "win32",
+      }),
+    ).toBe(testCase.expected);
+  });
+
+  it.each(["~/literal startup", "~root/startup", "-startup", "../startup"])(
+    "keeps relative Zsh profile hints literal: %s",
+    async (profileRoot) => {
+      await withEnvAsync({ HOME: "/tmp/openclaw-home", ZDOTDIR: profileRoot }, async () => {
+        const profilePath = path.join(profileRoot, ".zshrc");
+        const expected = profilePath.startsWith(`..${path.sep}`)
+          ? profilePath
+          : `.${path.sep}${profilePath}`;
+        expect(resolveCompletionProfileHint("zsh")).toBe(expected);
+      });
+    },
+  );
+
   it("resolves the documented Bash login profile when .bashrc is absent", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       expect(resolveCompletionProfilePath("bash")).toBe(path.join(homeDir, ".bash_profile"));
@@ -147,6 +296,25 @@ describe("completion-runtime", () => {
       expect(shell.stderr).toBe("");
       expect(shell.status).toBe(0);
       expect(shell.stdout).toContain("complete -W 'status' openclaw");
+    });
+  });
+
+  it("prints the same canonical reload hint used by Doctor and onboarding", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf8");
+      await fs.writeFile(path.join(homeDir, ".zshrc"), "", "utf8");
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        await installCompletion("zsh", false, "openclaw");
+        expect(log).toHaveBeenCalledWith(
+          "Completion installed. Restart your shell or run: source ~/.zshrc",
+        );
+      } finally {
+        log.mockRestore();
+      }
     });
   });
 

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -31,6 +31,62 @@ async function withBashCompletionHome(
 }
 
 describe("completion-runtime", () => {
+  it.each([
+    {
+      shell: "zsh" as const,
+      variable: "ZDOTDIR",
+      profileName: ".zshrc",
+    },
+    {
+      shell: "fish" as const,
+      variable: "XDG_CONFIG_HOME",
+      profileName: path.join("fish", "config.fish"),
+    },
+  ])("installs $shell completion into its configured shell startup directory", async (testCase) => {
+    const homeDir = tempDirs.make("openclaw-shell-profile-home-");
+    const stateDir = tempDirs.make("openclaw-shell-profile-state-");
+    const configDir = tempDirs.make(`openclaw-${testCase.shell} profile config-`);
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        ZDOTDIR: testCase.variable === "ZDOTDIR" ? configDir : undefined,
+        XDG_CONFIG_HOME: testCase.variable === "XDG_CONFIG_HOME" ? configDir : undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath(testCase.shell, "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf-8");
+
+        await installCompletion(testCase.shell, true, "openclaw");
+
+        const profilePath = path.join(configDir, testCase.profileName);
+        expect(resolveCompletionProfilePath(testCase.shell)).toBe(profilePath);
+        await expect(fs.readFile(profilePath, "utf-8")).resolves.toContain(cachePath);
+        await expect(isCompletionInstalled(testCase.shell, "openclaw")).resolves.toBe(true);
+
+        if (testCase.shell === "zsh") {
+          const shell = spawnSync("zsh", ["-ic", '[[ "$OPENCLAW_COMPLETION_LOADED" = ready ]]'], {
+            encoding: "utf8",
+            env: process.env,
+          });
+          expect(shell.stderr).toBe("");
+          expect(shell.status).toBe(0);
+        }
+      },
+    );
+  });
+
+  it("preserves zsh's set-but-empty startup directory contract", () => {
+    expect(
+      resolveCompletionProfilePath("zsh", {
+        env: { HOME: "/tmp/openclaw-home", ZDOTDIR: "" },
+        homeDir: () => "/tmp/openclaw-home",
+      }),
+    ).toBe(path.join(path.sep, ".zshrc"));
+  });
+
   it("resolves the documented Bash login profile when .bashrc is absent", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       expect(resolveCompletionProfilePath("bash")).toBe(path.join(homeDir, ".bash_profile"));
@@ -318,6 +374,42 @@ describe("completion-runtime", () => {
       ". 'C:\\Users\\Ada\\profile.ps1'",
     );
   });
+
+  it.each(["bash", "zsh"] as const)(
+    "reloads a %s profile when its absolute path contains spaces",
+    async (shellName) => {
+      const profileDir = tempDirs.make(`openclaw ${shellName} Ada's !42 reload profile-`);
+      const profilePath = path.join(profileDir, ".shellrc");
+      await fs.writeFile(profilePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf-8");
+
+      const reloadCommand = formatCompletionReloadCommand(shellName, profilePath);
+      const shell = spawnSync(
+        shellName,
+        ["-c", `${reloadCommand}; [ "$OPENCLAW_COMPLETION_LOADED" = ready ]`],
+        {
+          encoding: "utf8",
+        },
+      );
+
+      expect(shell.stderr).toBe("");
+      expect(shell.status).toBe(0);
+    },
+  );
+
+  it("quotes Fish reload profile paths containing spaces", () => {
+    expect(formatCompletionReloadCommand("fish", "/tmp/Ada's !42 Lovelace/config.fish")).toBe(
+      "source '/tmp/Ada\\'s !42 Lovelace/config.fish'",
+    );
+  });
+
+  it.each(["bash", "zsh"] as const)(
+    "preserves tilde expansion while quoting %s profile paths",
+    (shellName) => {
+      expect(formatCompletionReloadCommand(shellName, "~/Ada's !42 profile/.shellrc")).toBe(
+        "source ~/'Ada'\\''s !42 profile/.shellrc'",
+      );
+    },
+  );
 
   it("detects PowerShell shell names from Windows paths", () => {
     expect(resolveShellFromEnv({ SHELL: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" })).toBe(

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -100,7 +100,14 @@ export function formatCompletionReloadCommand(shell: CompletionShell, profilePat
   if (shell === "powershell") {
     return `. '${escapePowerShellSingleQuotedString(profilePath)}'`;
   }
-  return `source ${profilePath}`;
+  if (/^[a-zA-Z0-9_./~+-]+$/u.test(profilePath)) {
+    return `source ${profilePath}`;
+  }
+  const homePrefix = profilePath.startsWith("~/") ? "~/" : "";
+  const value = profilePath.slice(homePrefix.length);
+  const escapedPath =
+    shell === "fish" ? value.replace(/[\\']/gu, "\\$&") : value.replaceAll("'", "'\\''");
+  return `source ${homePrefix}'${escapedPath}'`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {
@@ -267,7 +274,7 @@ export function resolveCompletionProfilePath(
   const platform = options.platform ?? process.platform;
   const home = env.HOME || homeDir();
   if (shell === "zsh") {
-    return path.join(home, ".zshrc");
+    return path.join(env.ZDOTDIR === undefined ? home : env.ZDOTDIR || path.sep, ".zshrc");
   }
   if (shell === "bash") {
     // Installation, status, and repairs must inspect the same real Bash profile.
@@ -275,7 +282,8 @@ export function resolveCompletionProfilePath(
     return existsSync(bashrc) ? bashrc : path.join(home, ".bash_profile");
   }
   if (shell === "fish") {
-    return path.join(home, ".config", "fish", "config.fish");
+    const configHome = normalizeOptionalString(env.XDG_CONFIG_HOME) ?? path.join(home, ".config");
+    return path.join(configHome, "fish", "config.fish");
   }
   if (platform === "win32") {
     const shellPath = normalizeOptionalString(env.SHELL) ?? "";
@@ -348,26 +356,8 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
     );
   }
 
-  let profilePath: string;
-  let sourceLine: string;
-  switch (shell) {
-    case "zsh":
-      profilePath = resolveCompletionProfilePath("zsh");
-      sourceLine = formatCompletionSourceLine("zsh", cachePath);
-      break;
-    case "bash":
-      profilePath = resolveCompletionProfilePath("bash");
-      sourceLine = formatCompletionSourceLine("bash", cachePath);
-      break;
-    case "fish":
-      profilePath = resolveCompletionProfilePath("fish");
-      sourceLine = formatCompletionSourceLine("fish", cachePath);
-      break;
-    case "powershell":
-      profilePath = resolveCompletionProfilePath("powershell");
-      sourceLine = formatCompletionSourceLine("powershell", cachePath);
-      break;
-  }
+  const profilePath = resolveCompletionProfilePath(shell);
+  const sourceLine = formatCompletionSourceLine(shell, cachePath);
 
   try {
     try {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -95,6 +95,17 @@ function formatCompletionSourceLine(shell: CompletionShell, cachePath: string): 
   return `[ -f "${cachePath}" ] && source "${cachePath}"`;
 }
 
+function appendCompletionProfilePath(
+  directory: string,
+  pathApi: typeof path.posix,
+  ...segments: string[]
+): string {
+  // Shell startup resolves symlinks before `..`; path.join would select a different profile.
+  const nativeDirectory = pathApi.sep === "\\" ? directory.replaceAll("/", pathApi.sep) : directory;
+  const separator = nativeDirectory.endsWith(pathApi.sep) ? "" : pathApi.sep;
+  return `${nativeDirectory}${separator}${segments.join(pathApi.sep)}`;
+}
+
 /** Formats the command users can run to reload the shell profile after installation. */
 export function formatCompletionReloadCommand(shell: CompletionShell, profilePath: string): string {
   if (shell === "powershell") {
@@ -272,31 +283,64 @@ export function resolveCompletionProfilePath(
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? os.homedir;
   const platform = options.platform ?? process.platform;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
   const home = env.HOME || homeDir();
   if (shell === "zsh") {
-    return path.join(env.ZDOTDIR === undefined ? home : env.ZDOTDIR || path.sep, ".zshrc");
+    const profileDirectory = env.ZDOTDIR === undefined ? home : env.ZDOTDIR || pathApi.sep;
+    return appendCompletionProfilePath(profileDirectory, pathApi, ".zshrc");
   }
   if (shell === "bash") {
     // Installation, status, and repairs must inspect the same real Bash profile.
-    const bashrc = path.join(home, ".bashrc");
-    return existsSync(bashrc) ? bashrc : path.join(home, ".bash_profile");
+    const bashrc = appendCompletionProfilePath(home, pathApi, ".bashrc");
+    return existsSync(bashrc)
+      ? bashrc
+      : appendCompletionProfilePath(home, pathApi, ".bash_profile");
   }
   if (shell === "fish") {
-    const configHome = normalizeOptionalString(env.XDG_CONFIG_HOME) ?? path.join(home, ".config");
-    return path.join(configHome, "fish", "config.fish");
+    const configuredHome = env.XDG_CONFIG_HOME;
+    const configHome =
+      configuredHome && pathApi.isAbsolute(configuredHome)
+        ? configuredHome
+        : appendCompletionProfilePath(home, pathApi, ".config");
+    return appendCompletionProfilePath(configHome, pathApi, "fish", "config.fish");
   }
   if (platform === "win32") {
     const shellPath = normalizeOptionalString(env.SHELL) ?? "";
     const shellName = shellPath ? resolveShellBasename(shellPath, platform) : "";
     const profileDirectory = shellName === "powershell" ? "WindowsPowerShell" : "PowerShell";
-    return path.win32.join(
+    return appendCompletionProfilePath(
       env.USERPROFILE || home,
+      pathApi,
       "Documents",
       profileDirectory,
       "Microsoft.PowerShell_profile.ps1",
     );
   }
-  return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+  return appendCompletionProfilePath(
+    home,
+    pathApi,
+    ".config",
+    "powershell",
+    "Microsoft.PowerShell_profile.ps1",
+  );
+}
+
+/** Formats the resolved startup profile relative to HOME when that preserves its actual location. */
+export function resolveCompletionProfileHint(shell: CompletionShell): string {
+  const profilePath = resolveCompletionProfilePath(shell);
+  if (shell === "powershell") {
+    return profilePath;
+  }
+  if (!path.isAbsolute(profilePath)) {
+    return profilePath.startsWith(`.${path.sep}`) || profilePath.startsWith(`..${path.sep}`)
+      ? profilePath
+      : `.${path.sep}${profilePath}`;
+  }
+  const home = process.env.HOME;
+  // Keep lexical parent components so reload follows the same symlink path as installation.
+  return home && profilePath.startsWith(`${home}${path.sep}`)
+    ? `~/${profilePath.slice(home.length + 1)}`
+    : profilePath;
 }
 
 /** Returns whether a shell profile already contains an OpenClaw completion block or source line. */
@@ -387,7 +431,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
     await fs.writeFile(profilePath, update.next, "utf-8");
     if (!yes) {
       console.log(
-        `Completion installed. Restart your shell or run: ${formatCompletionReloadCommand(shell, profilePath)}`,
+        `Completion installed. Restart your shell or run: ${formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell))}`,
       );
     }
   } catch (err) {

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -19,6 +19,8 @@ const originalEnv = captureEnv([
   "HOME",
   "OPENCLAW_STATE_DIR",
   "SHELL",
+  "XDG_CONFIG_HOME",
+  "ZDOTDIR",
   COMPLETION_SKIP_PLUGIN_COMMANDS_ENV,
 ]);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -256,6 +258,33 @@ describe("doctorShellCompletion", () => {
     expect(installCompletionMock).toHaveBeenCalledWith("bash", true, "openclaw");
     expect(noteSpy).toHaveBeenCalledWith(
       expect.stringContaining("source ~/.bash_profile"),
+      "Shell completion",
+    );
+  });
+
+  it.each([
+    { shell: "zsh", variable: "ZDOTDIR", profile: ".zshrc" },
+    {
+      shell: "fish",
+      variable: "XDG_CONFIG_HOME",
+      profile: path.join("fish", "config.fish"),
+    },
+  ])("reports the configured $shell startup profile after installation", async (testCase) => {
+    const homeDir = tempDirs.make("openclaw-doctor-custom-profile-home-");
+    const stateDir = tempDirs.make("openclaw-doctor-custom-profile-state-");
+    const configDir = tempDirs.make(`openclaw doctor ${testCase.shell} profile-`);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", `/bin/${testCase.shell}`);
+    setTestEnvValue(testCase.variable, configDir);
+    installCompletionMock.mockResolvedValue(undefined);
+    const noteSpy = vi.spyOn(noteModule, "note");
+
+    await doctorShellCompletion({} as never, mockPrompter());
+
+    expect(installCompletionMock).toHaveBeenCalledWith(testCase.shell, true, "openclaw");
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`source '${path.join(configDir, testCase.profile)}'`),
       "Shell completion",
     );
   });

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -10,6 +10,7 @@ import {
   installCompletion,
   isCompletionInstalled,
   resolveCompletionCachePath,
+  resolveCompletionProfileHint,
   resolveCompletionProfilePath,
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
@@ -40,22 +41,6 @@ function findProfileWriteError(err: unknown): NodeJS.ErrnoException | undefined 
   return err instanceof Error ? findProfileWriteError(err.cause) : undefined;
 }
 
-function resolveCompletionReloadPath(shell: CompletionShell): string {
-  const profilePath = resolveCompletionProfilePath(shell);
-  const home = process.env.HOME;
-  return shell !== "powershell" && home && profilePath.startsWith(`${home}${path.sep}`)
-    ? `~/${path.relative(home, profilePath)}`
-    : profilePath;
-}
-
-function formatCompletionReloadNote(
-  shell: CompletionShell,
-  action: "installed" | "upgraded",
-): string {
-  const profilePath = resolveCompletionReloadPath(shell);
-  return `Shell completion ${action}. Restart your shell or run: ${formatCompletionReloadCommand(shell, profilePath)}`;
-}
-
 async function installCompletionForDoctor(
   shell: CompletionShell,
   cliName: string,
@@ -63,7 +48,11 @@ async function installCompletionForDoctor(
 ): Promise<void> {
   try {
     await installCompletion(shell, true, cliName);
-    note(formatCompletionReloadNote(shell, action), "Shell completion");
+    const reloadCommand = formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell));
+    note(
+      `Shell completion ${action}. Restart your shell or run: ${reloadCommand}`,
+      "Shell completion",
+    );
   } catch (err) {
     // Completion is optional, but only profile permission failures are safe to downgrade.
     const writeError = findProfileWriteError(err);

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -41,13 +41,11 @@ function findProfileWriteError(err: unknown): NodeJS.ErrnoException | undefined 
 }
 
 function resolveCompletionReloadPath(shell: CompletionShell): string {
-  if (shell === "powershell") {
-    return resolveCompletionProfilePath("powershell");
-  }
-  if (shell === "bash") {
-    return `~/${path.basename(resolveCompletionProfilePath("bash"))}`;
-  }
-  return `~/.${shell === "zsh" ? "zshrc" : "config/fish/config.fish"}`;
+  const profilePath = resolveCompletionProfilePath(shell);
+  const home = process.env.HOME;
+  return shell !== "powershell" && home && profilePath.startsWith(`${home}${path.sep}`)
+    ? `~/${path.relative(home, profilePath)}`
+    : profilePath;
 }
 
 function formatCompletionReloadNote(

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -1,8 +1,17 @@
 // Setup completion tests cover final onboarding instructions and paths.
+import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
-import { resolveCompletionProfilePath } from "../cli/completion-runtime.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  formatCompletionReloadCommand,
+  resolveCompletionCachePath,
+  resolveCompletionProfilePath,
+} from "../cli/completion-runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { setupWizardShellCompletion } from "./setup.completion.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withLocale(locale: string, run: () => Promise<void>): Promise<void> {
   const previousLocale = process.env.OPENCLAW_LOCALE;
@@ -128,6 +137,51 @@ describe("setupWizardShellCompletion", () => {
         "Shell completion",
       );
     });
+  });
+
+  it.each([
+    { shell: "zsh" as const, variable: "ZDOTDIR", profileName: ".zshrc" },
+    {
+      shell: "fish" as const,
+      variable: "XDG_CONFIG_HOME",
+      profileName: path.join("fish", "config.fish"),
+    },
+  ])("installs and reports the actual configured $shell startup profile", async (testCase) => {
+    const homeDir = tempDirs.make("openclaw-wizard-completion-home-");
+    const stateDir = tempDirs.make("openclaw-wizard-completion-state-");
+    const profileRoot = tempDirs.make(`openclaw wizard ${testCase.shell} Ada's !42 profile-`);
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        SHELL: `/bin/${testCase.shell}`,
+        ZDOTDIR: undefined,
+        XDG_CONFIG_HOME: undefined,
+        [testCase.variable]: profileRoot,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath(testCase.shell, "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf8");
+        const prompter = createPrompter();
+
+        await setupWizardShellCompletion({
+          flow: "quickstart",
+          prompter,
+          deps: { ensureCompletionCacheExists: async () => true },
+        });
+
+        const profilePath = path.join(profileRoot, testCase.profileName);
+        expect(resolveCompletionProfilePath(testCase.shell)).toBe(profilePath);
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toContain(cachePath);
+        expect(prompter.note).toHaveBeenCalledWith(
+          `Shell completion installed. Restart your shell or run: ${formatCompletionReloadCommand(testCase.shell, profilePath)}`,
+          "Shell completion",
+        );
+      },
+    );
   });
 
   it("resolves the concrete Windows PowerShell profile path", () => {

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -1,11 +1,9 @@
 // Setup completion helpers render completion instructions after onboarding.
-import os from "node:os";
-import path from "node:path";
 import { resolveCliName } from "../cli/cli-name.js";
 import {
   formatCompletionReloadCommand,
   installCompletion,
-  resolveCompletionProfilePath,
+  resolveCompletionProfileHint,
 } from "../cli/completion-runtime.js";
 import type {
   CompletionCacheGenerationOptions,
@@ -15,7 +13,6 @@ import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,
 } from "../commands/doctor-completion.js";
-import { pathExists } from "../utils.js";
 import { t } from "./i18n/index.js";
 import type { WizardPrompter } from "./prompts.js";
 import type { WizardFlow } from "./setup.types.js";
@@ -29,30 +26,6 @@ type CompletionDeps = {
   ) => Promise<boolean>;
   installCompletion: (shell: string, yes: boolean, binName?: string) => Promise<void>;
 };
-
-async function resolveProfileHint(shell: ShellCompletionStatus["shell"]): Promise<string> {
-  const home = process.env.HOME || os.homedir();
-  if (shell === "zsh") {
-    return "~/.zshrc";
-  }
-  if (shell === "bash") {
-    const bashrc = path.join(home, ".bashrc");
-    return (await pathExists(bashrc)) ? "~/.bashrc" : "~/.bash_profile";
-  }
-  if (shell === "fish") {
-    return "~/.config/fish/config.fish";
-  }
-  return resolveCompletionProfilePath("powershell");
-}
-
-function formatReloadHint(shell: ShellCompletionStatus["shell"], profileHint: string): string {
-  if (shell === "powershell") {
-    return t("wizard.completion.reloadPowerShell", {
-      command: formatCompletionReloadCommand("powershell", profileHint),
-    });
-  }
-  return t("wizard.completion.reloadShell", { profile: profileHint });
-}
 
 export async function setupWizardShellCompletion(params: {
   flow: WizardFlow;
@@ -124,11 +97,14 @@ export async function setupWizardShellCompletion(params: {
     // Install to shell profile
     await deps.installCompletion(completionStatus.shell, true, cliName);
 
-    const profileHint = await resolveProfileHint(completionStatus.shell);
+    const shell = completionStatus.shell;
+    const command = formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell));
+    const reloadHint =
+      shell === "powershell"
+        ? t("wizard.completion.reloadPowerShell", { command })
+        : t("wizard.completion.reloadShell", { profile: command.slice("source ".length) });
     await params.prompter.note(
-      t("wizard.completion.installed", {
-        reloadHint: formatReloadHint(completionStatus.shell, profileHint),
-      }),
+      t("wizard.completion.installed", { reloadHint }),
       t("wizard.completion.title"),
     );
   }


### PR DESCRIPTION
## What Problem This Solves

Two operator-visible root causes affected shell-completion installation and recovery:

1. Installation, installed-state checks, onboarding, and Doctor disagreed about the startup file owned by Zsh `$ZDOTDIR`, Fish `$XDG_CONFIG_HOME`, Bash, or PowerShell. The wizard could install completion into the correct custom profile and immediately instruct the operator to reload a different file.
2. Reload instructions interpolated shell-profile paths unsafely, so spaces, apostrophes, history-expansion characters, literal relative paths, or symlink traversal could prevent completion from loading.

## Why This Change Was Made

- Use one canonical profile-path owner and one canonical display hint for the installer, installed-state checks, onboarding, and Doctor.
- Preserve Zsh's explicitly empty `$ZDOTDIR`, shell-owned relative directories, and filesystem symlink-before-`..` traversal.
- Honor absolute Fish `$XDG_CONFIG_HOME` values verbatim, including meaningful whitespace; ignore invalid relative values as required by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/0.8/).
- Generate shell-correct quoted reload commands while preserving executable `~/` expansion, existing localized onboarding text, Bash profile selection, and PowerShell dot sourcing.
- Delete installer shell switches, the wizard's duplicated async profile lookup, Doctor's parallel path resolver, and single-use formatting wrappers.

## User Impact

Completion is written into the file the actual shell reads. Direct installation, onboarding, and Doctor all display an executable reload command for that same file. No CLI flags, configuration keys, migrations, storage, or security behavior are added.

## Inspectable Real-Behavior Proof

**Exact tested head:** `0048d0527156fd4161028b91dde50910ab0b5437`.

The following is redacted output captured from the actual production onboarding function, production completion installer, production Doctor repair, and a real interactive `/bin/zsh` process. The run used temporary `HOME`, `USERPROFILE`, state, and profile directories; all temporary state was removed. Completion caches were prewritten and verified instead of invoking the unrelated cache-generation subprocess.

```text
HEAD=0048d0527156fd4161028b91dde50910ab0b5437

ZDOTDIR profile=<TEMP>/zsh/Ada's !42 startup/.zshrc
Zsh expected reload=source '<TEMP>/zsh/Ada'\''s !42 startup/.zshrc'
Zsh actual wizard=Shell completion installed. Restart your shell or run: source '<TEMP>/zsh/Ada'\''s !42 startup/.zshrc'
Zsh actual Doctor=Shell completion upgraded. Restart your shell or run: source '<TEMP>/zsh/Ada'\''s !42 startup/.zshrc'
Zsh actual wizard wrote canonical profile=true
Zsh actual Doctor repaired slow profile=true
Zsh real interactive startup=true

XDG_CONFIG_HOME profile=<TEMP>/fish/Ada's !42 startup/fish/config.fish
Fish expected reload=source '<TEMP>/fish/Ada\'s !42 startup/fish/config.fish'
Fish actual wizard=Shell completion installed. Restart your shell or run: source '<TEMP>/fish/Ada\'s !42 startup/fish/config.fish'
Fish actual Doctor=Shell completion upgraded. Restart your shell or run: source '<TEMP>/fish/Ada\'s !42 startup/fish/config.fish'
Fish actual wizard wrote canonical profile=true
Fish actual Doctor repaired slow profile=true

RESULT=PASS
```

The Fish installer, startup-profile contents, onboarding output, and Doctor repair were exercised directly; a native Fish shell executable was not available, so native Fish execution is not claimed.

## Focused Verification

```bash
node scripts/run-vitest.mjs src/cli/completion-runtime.test.ts src/cli/completion-cli.write-state.test.ts src/cli/completion-cli.test.ts
node scripts/run-vitest.mjs src/wizard/setup.completion.test.ts
node scripts/run-vitest.mjs src/commands/doctor-completion.test.ts
```

- macOS with real interactive Zsh: **92 CLI tests passed**.
- Linux-style environment where launching Zsh genuinely returns `ENOENT`: the same **92 CLI tests passed**; Bash execution remains mandatory.
- Actual-installer-backed onboarding: **10 wizard tests passed**, including custom Zsh and Fish roots containing spaces, apostrophes, and `!`.
- Doctor completion and recovery: **19 tests passed**.
- Real filesystem regressions cover symlink/`..` traversal for Zsh, Bash, Fish, and PowerShell; explicit empty `$ZDOTDIR`; valid whitespace-bearing XDG roots; rejected relative XDG roots; Windows drive and UNC paths; literal relative Zsh roots; and consistent direct-install reload output.
- Existing Chinese localization and concrete PowerShell reload instructions remain unchanged.
- Whole-branch production delta: **+76/-79 (net -3)**; tests are counted separately.
- Independent owner-boundary reviews found no remaining P0/P1/P2/P3 issues.
- Exact-head structured whole-branch Codex Sol/high `--max-priority P3` review: **zero findings; patch correct; confidence 0.92; real TruffleHog clean**.

## ClawSweeper Rank-Up Moves

- **Canonical owner:** installation, status, onboarding, direct CLI reload output, and Doctor now all consume the canonical shell-profile resolver and display hint.
- **Real behavior proof:** the redacted transcript above shows actual custom Zsh/Fish installation, actual wizard and Doctor reload guidance, and a real interactive Zsh startup on the exact candidate head.
- **Current-head / merge-result freshness:** evidence is tied to the exact SHA shown above. If GitHub requires a merge-result refresh, perform it during the normal maintainer prepare/merge flow; no unnecessary rebase is claimed.

## Explicit Exclusions

No public CLI/setup flags, configuration or environment-variable surface, persisted state, SQLite/schema, authentication/security policy, plugin SDK, Gateway protocol, dependency, locale-catalog, or release-note changes.
