### PR TITLE
fix(channels): reset metadata ownership across lifecycle changes

### DIFF
--- a/src/channels/bundled-channel-catalog-read.test.ts
+++ b/src/channels/bundled-channel-catalog-read.test.ts
@@ -33,6 +33,7 @@ vi.mock("../infra/openclaw-root.js", () => ({
 }));
 
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { listBundledChannelCatalogEntries } from "./bundled-channel-catalog-read.js";
 
 const tempDirs: string[] = [];
@@ -235,5 +236,44 @@ describe("listBundledChannelCatalogEntries", () => {
 
     const entries = listBundledChannelCatalogEntries();
     expect(entries.map((entry) => entry.id)).toContain("fallback-channel");
+  });
+
+  it("reloads installed bundled package metadata after an explicit plugin lifecycle reset", () => {
+    const root = seedRoot("bcr-package-lifecycle-");
+    const extensionsRoot = path.join(root, "dist", "extensions");
+    const packagePath = path.join(extensionsRoot, "alpha", "package.json");
+    seedChannelPkg(packagePath, { id: "alpha", docsPath: "/channels/alpha", label: "Before" });
+    useBundledPluginsDir(extensionsRoot);
+
+    expect(
+      listBundledChannelCatalogEntries().find((entry) => entry.id === "alpha")?.channel.label,
+    ).toBe("Before");
+    seedChannelPkg(packagePath, { id: "alpha", docsPath: "/channels/alpha", label: "After" });
+    clearPluginMetadataLifecycleCaches();
+
+    expect(
+      listBundledChannelCatalogEntries().find((entry) => entry.id === "alpha")?.channel.label,
+    ).toBe("After");
+  });
+
+  it("discovers a generated catalog created after an explicit plugin lifecycle reset", () => {
+    const root = seedRoot("bcr-generated-lifecycle-");
+    useBundledPluginsDir(undefined);
+
+    expect(
+      listBundledChannelCatalogEntries().find((entry) => entry.id === "generated"),
+    ).toBeUndefined();
+    seedGeneratedChannelCatalog(root, {
+      packageName: "@openclaw/generated",
+      id: "generated",
+      label: "Generated after reset",
+      docsPath: "/channels/generated",
+      blurb: "generated channel",
+    });
+    clearPluginMetadataLifecycleCaches();
+
+    expect(
+      listBundledChannelCatalogEntries().find((entry) => entry.id === "generated")?.channel.label,
+    ).toBe("Generated after reset");
   });
 });

--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -11,6 +11,7 @@ import { tryReadJsonSync } from "../infra/json-files.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
 import type { PluginPackageChannel } from "../plugins/manifest.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 
 type ChannelCatalogEntryLike = {
   openclaw?: {
@@ -28,6 +29,11 @@ type BundledChannelCatalogEntry = {
 const OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH = path.join("dist", "channel-catalog.json");
 const officialCatalogFileCache = new Map<string, ChannelCatalogEntryLike[] | null>();
 const bundledPackageCatalogCache = new Map<string, ChannelCatalogEntryLike[] | null>();
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  officialCatalogFileCache.clear();
+  bundledPackageCatalogCache.clear();
+});
 
 function listPackageRoots(): string[] {
   // Source checkouts and packaged installs can resolve OpenClaw from different roots; scan both

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -1,6 +1,10 @@
 // Channel plugin catalog tests cover plugin catalog entries and metadata normalization.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginChannelCatalogEntry } from "../../plugins/channel-catalog-registry.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 
 const listChannelCatalogEntriesMock = vi.hoisted(() =>
   vi.fn<() => PluginChannelCatalogEntry[]>(() => []),
@@ -12,9 +16,36 @@ vi.mock("../../plugins/channel-catalog-registry.js", () => ({
 
 import { getChannelPluginCatalogEntry } from "./catalog.js";
 
+const tempDirs: string[] = [];
+
 beforeEach(() => {
   listChannelCatalogEntriesMock.mockReset().mockReturnValue([]);
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function writeChannelCatalog(catalogPath: string, id: string, label: string): void {
+  fs.mkdirSync(path.dirname(catalogPath), { recursive: true });
+  fs.writeFileSync(
+    catalogPath,
+    JSON.stringify({
+      entries: [
+        {
+          name: `@example/${id}`,
+          openclaw: {
+            channel: { id, label, selectionLabel: label, docsPath: `/channels/${id}`, blurb: id },
+            install: { npmSpec: `@example/${id}` },
+          },
+        },
+      ],
+    }),
+  );
+}
 
 describe("channel plugin catalog", () => {
   it("keeps third-party channel ids mapped with catalog install trust", () => {
@@ -73,5 +104,36 @@ describe("channel plugin catalog", () => {
         excludePluginRefs: [{ pluginId: "telegram", origin: "config" }],
       })?.origin,
     ).toBe("bundled");
+  });
+  it("reloads external catalog entries after the explicit plugin metadata lifecycle reset", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-external-catalog-"));
+    tempDirs.push(root);
+    const catalogPath = path.join(root, "catalog.json");
+    const options = { catalogPaths: [catalogPath], workspaceDir: root, env: {} };
+
+    expect(getChannelPluginCatalogEntry("lifecycle-external", options)).toBeUndefined();
+    writeChannelCatalog(catalogPath, "lifecycle-external", "After external install");
+    clearPluginMetadataLifecycleCaches();
+
+    expect(getChannelPluginCatalogEntry("lifecycle-external", options)?.meta.label).toBe(
+      "After external install",
+    );
+  });
+
+  it("reloads official generated catalog entries after the explicit plugin metadata lifecycle reset", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-official-catalog-"));
+    tempDirs.push(root);
+    fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+    vi.spyOn(process, "cwd").mockReturnValue(root);
+    const catalogPath = path.join(root, "dist", "channel-catalog.json");
+    const options = { catalogPaths: [path.join(root, "external.json")], env: {} };
+
+    expect(getChannelPluginCatalogEntry("lifecycle-official", options)).toBeUndefined();
+    writeChannelCatalog(catalogPath, "lifecycle-official", "After official update");
+    clearPluginMetadataLifecycleCaches();
+
+    expect(getChannelPluginCatalogEntry("lifecycle-official", options)?.meta.label).toBe(
+      "After official update",
+    );
   });
 });

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -23,6 +23,7 @@ import {
 import type { OpenClawPackageManifest } from "../../plugins/manifest.js";
 import type { PluginPackageChannel, PluginPackageInstall } from "../../plugins/manifest.js";
 import { listOfficialExternalChannelCatalogEntries } from "../../plugins/official-external-plugin-catalog.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../../plugins/plugin-metadata-lifecycle.js";
 import type { PluginOrigin } from "../../plugins/plugin-origin.types.js";
 import { isRecord, resolveConfigDir, resolveUserPath } from "../../utils.js";
 import { buildManifestChannelMeta } from "./channel-meta.js";
@@ -116,6 +117,11 @@ const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALO
 const OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH = path.join("dist", "channel-catalog.json");
 const officialCatalogEntriesByPath = new Map<string, ExternalCatalogEntry[] | null>();
 const externalCatalogEntriesByPath = new Map<string, ExternalCatalogEntry[] | null>();
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  officialCatalogEntriesByPath.clear();
+  externalCatalogEntriesByPath.clear();
+});
 
 type ManifestKey = typeof MANIFEST_KEY;
 

--- a/src/media/channel-inbound-roots.fast-path.test.ts
+++ b/src/media/channel-inbound-roots.fast-path.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 
 const publicSurfaceLoaderMocks = vi.hoisted(() => ({
   loadBundledPluginPublicArtifactModuleSync: vi.fn(),
@@ -172,5 +173,38 @@ describe("channel inbound roots fast path", () => {
         artifactBasename: "media-contract-api.js",
       },
     );
+  });
+
+  it("reloads a channel media contract installed after the explicit plugin lifecycle reset", () => {
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockImplementation(
+      ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
+        throw unableToResolve(dirName, artifactBasename);
+      },
+    );
+    expect(
+      resolveChannelInboundAttachmentRootsForChannel({
+        cfg,
+        channelId: "installedchat",
+        accountId: "work",
+      }),
+    ).toBeUndefined();
+
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockReturnValue({
+      resolveInboundAttachmentRoots: ({ accountId }: { accountId?: string }) => [
+        `/installed/${accountId}`,
+      ],
+    });
+    clearPluginMetadataLifecycleCaches();
+
+    expect(
+      resolveChannelInboundAttachmentRootsForChannel({
+        cfg,
+        channelId: "installedchat",
+        accountId: "work",
+      }),
+    ).toEqual(["/installed/work"]);
+    expect(
+      publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync,
+    ).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/media/channel-inbound-roots.ts
+++ b/src/media/channel-inbound-roots.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import { loadBundledPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
 
 type ChannelMediaContractApi = {
@@ -17,6 +18,10 @@ type ChannelMediaContractApi = {
 type ChannelMediaRootResolver = keyof ChannelMediaContractApi;
 
 const mediaContractApiByChannel = new Map<string, ChannelMediaContractApi | null>();
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  mediaContractApiByChannel.clear();
+});
 
 function loadChannelMediaContractApi(
   channelId: string,


### PR DESCRIPTION
## What Problem This Solves

Plugin installation, update, and explicit metadata lifecycle resets left multiple channel process-local caches stale: newly created official or external channel catalogs stayed invisible, bundled channel labels/generated catalogs kept old values, and a previously unavailable inbound attachment contract remained disabled.

## Why This Change Was Made

The repository already owns one explicit plugin metadata lifecycle for installation/index changes and runtime resets. This change wires each of the three existing private memo owners into that same lifecycle, clearing only its own maps while retaining steady-state memoization, channel trust filtering, catalog precedence, and narrow media artifact loading.

## User Impact

1. Channel catalogs reflect installed/updated official, external, bundled package and generated metadata after authorized plugin lifecycle changes.
2. Newly installed channel attachment contracts enable inbound roots after the existing lifecycle reset instead of remaining permanently negatively cached.

## Evidence

- Frozen baseline `36b80ada3ceae2de21b3d8710b883d778e4c4578`; immutable reviewed candidate `8286acf7a698d57712095c0b9c91a41f6652e282`.
- Real baseline failures reproduced official/external missing-to-installed metadata and bundled package old-to-new metadata.
- Exact committed-head five-owner/sibling command:

```text
PATH=/Users/steipete/.local/bin:$PATH node scripts/run-vitest.mjs src/channels/plugins/catalog.test.ts src/channels/bundled-channel-catalog-read.test.ts src/media/channel-inbound-roots.fast-path.test.ts src/channels/plugins/read-only.test.ts src/plugins/plugin-registry-snapshot.lifecycle.test.ts
```

- **48/48 passed** across three Vitest shards (five media, one plugin snapshot lifecycle, 42 channel owner/sibling tests).
- Remote-proof availability caveat: two separate fresh Blacksmith leases (`tbx_01kywrh2p1gzx1ptykxfajj4xz`, `tbx_01kywrj6rkz98k6y1s3c67842e`) shut down before accepting the command; both were independently status-verified `completed`. Repository policy explicitly permits trusted-source local fallback when the remote backend is unavailable, so **no hosted remote proof is claimed**.
- Genuine full-branch canonical structured autoreview (`gpt-5.6-sol`, high, P3) found **zero P0/P1/P2/P3**, confidence **0.91**, TruffleHog clean.
- A separate channel-owner agent independently reviewed all owners, callers, lifecycle, import cycles, trust/exclusion policy, hot paths and final proof.
- Production delta **+17 owner-local registration lines**, necessary for three independent map owners; no oversized/suppressed bundled loader, polling, configuration, auth policy, public SDK, protocol, persistence, or dependency changes.
