### PR TITLE
feat(plugins): externalize Novita provider

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8504,7 +8504,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Setup
   - H2: Defaults
-  - H2: Bundled model catalog
+  - H2: Model catalog
   - H2: When to choose Novita
   - H2: Troubleshooting
   - H2: Related

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-58 plugins
+57 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -121,8 +121,6 @@ Each entry lists the package, distribution route, and description.
 
 - **[minimax](/plugins/reference/minimax)** (`@openclaw/minimax-provider`) - included in OpenClaw. Adds MiniMax, MiniMax Portal model provider support to OpenClaw.
 
-- **[novita](/plugins/reference/novita)** (`@openclaw/novita-provider`) - included in OpenClaw. Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
-
 - **[nvidia](/plugins/reference/nvidia)** (`@openclaw/nvidia-provider`) - included in OpenClaw. Adds NVIDIA model provider support to OpenClaw.
 
 - **[oc-path](/plugins/reference/oc-path)** (`@openclaw/oc-path`) - included in OpenClaw. Adds the openclaw path CLI for oc:// workspace file addressing.
@@ -171,7 +169,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-87 plugins
+88 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -280,6 +278,8 @@ Each entry lists the package, distribution route, and description.
 - **[nextcloud-talk](/plugins/reference/nextcloud-talk)** (`@openclaw/nextcloud-talk`) - npm; ClawHub. OpenClaw Nextcloud Talk channel plugin for conversations.
 
 - **[nostr](/plugins/reference/nostr)** (`@openclaw/nostr`) - npm; ClawHub. OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.
+
+- **[novita](/plugins/reference/novita)** (`@openclaw/novita-provider`) - npm; ClawHub: `clawhub:@openclaw/novita-provider`. Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
 
 - **[openshell](/plugins/reference/openshell)** (`@openclaw/openshell-sandbox`) - npm; ClawHub. OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.
 

--- a/docs/plugins/reference/novita.md
+++ b/docs/plugins/reference/novita.md
@@ -12,7 +12,7 @@ Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/novita-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/novita-provider`
 
 ## Surface
 

--- a/docs/providers/novita.md
+++ b/docs/providers/novita.md
@@ -7,11 +7,18 @@ title: "NovitaAI"
 ---
 
 NovitaAI is a hosted AI infrastructure provider with an OpenAI-compatible API.
-It ships as a bundled OpenClaw provider (no separate plugin install), so
-credentials go through the normal model auth flow and model refs look like
-`novita/deepseek/deepseek-v4-pro`.
+OpenClaw provides NovitaAI through the official external
+`@openclaw/novita-provider` plugin. Model refs use the
+`novita/deepseek/deepseek-v4-pro` form.
 
 ## Setup
+
+Install the plugin and restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/novita-provider
+openclaw gateway restart
+```
 
 Create an API key at [novita.ai/settings/key-management](https://novita.ai/settings/key-management), then run:
 
@@ -29,13 +36,14 @@ export NOVITA_API_KEY="<your-novita-api-key>" # pragma: allowlist secret
 
 | Setting       | Value                             |
 | ------------- | --------------------------------- |
+| Plugin        | `@openclaw/novita-provider`       |
 | Provider id   | `novita`                          |
 | Aliases       | `novita-ai`, `novitaai`           |
 | Base URL      | `https://api.novita.ai/openai/v1` |
 | Env var       | `NOVITA_API_KEY`                  |
 | Default model | `novita/deepseek/deepseek-v4-pro` |
 
-## Bundled model catalog
+## Model catalog
 
 - `novita/moonshotai/kimi-k3`
 - `novita/moonshotai/kimi-k2.7-code`

--- a/extensions/novita/README.md
+++ b/extensions/novita/README.md
@@ -1,0 +1,15 @@
+# OpenClaw NovitaAI provider
+
+Official OpenClaw provider plugin for NovitaAI's OpenAI-compatible API.
+
+## Install
+
+```sh
+openclaw plugins install @openclaw/novita-provider
+openclaw gateway restart
+```
+
+## Docs
+
+See `docs/providers/novita.md` in the OpenClaw repository, or the published
+docs at `https://docs.openclaw.ai/providers/novita`.

--- a/extensions/novita/index.ts
+++ b/extensions/novita/index.ts
@@ -10,7 +10,7 @@ const PROVIDER_ID = "novita";
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "NovitaAI Provider",
-  description: "Bundled NovitaAI provider plugin",
+  description: "Official OpenClaw NovitaAI provider plugin",
   manifest,
   provider: {
     label: "NovitaAI",

--- a/extensions/novita/package.json
+++ b/extensions/novita/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/novita-provider",
   "version": "2026.7.2",
-  "private": true,
   "description": "OpenClaw NovitaAI provider plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/novita-provider",
+      "npmSpec": "@openclaw/novita-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
     "!dist/extensions/mxc/**",
     "!dist/extensions/nextcloud-talk/**",
     "!dist/extensions/nostr/**",
+    "!dist/extensions/novita/**",
     "!dist/extensions/parallel/**",
     "!dist/extensions/perplexity/**",
     "!dist/extensions/qianfan/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -913,6 +913,56 @@
       }
     },
     {
+      "name": "@openclaw/novita-provider",
+      "description": "OpenClaw NovitaAI provider plugin",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "novita",
+          "label": "NovitaAI"
+        },
+        "providerEndpoints": [
+          {
+            "endpointClass": "novita-native",
+            "hosts": ["api.novita.ai"]
+          }
+        ],
+        "providers": [
+          {
+            "id": "novita",
+            "aliases": ["novita-ai", "novitaai"],
+            "name": "NovitaAI",
+            "docs": "/providers/novita",
+            "categories": ["cloud", "llm"],
+            "envVars": ["NOVITA_API_KEY"],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "novita-api-key",
+                "choiceLabel": "NovitaAI API key",
+                "choiceHint": "OpenAI-compatible NovitaAI endpoint",
+                "groupId": "novita",
+                "groupLabel": "NovitaAI",
+                "groupHint": "OpenAI-compatible NovitaAI endpoint",
+                "optionKey": "novitaApiKey",
+                "cliFlag": "--novita-api-key",
+                "cliOption": "--novita-api-key <key>",
+                "cliDescription": "NovitaAI API key",
+                "onboardingScopes": ["text-inference"]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/novita-provider",
+          "npmSpec": "@openclaw/novita-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/groq-provider",
       "description": "OpenClaw Groq media-understanding provider.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -168,6 +168,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
     ["byteplus", "@openclaw/byteplus-provider", true],
     ["duckduckgo", "@openclaw/duckduckgo-plugin", false],
     ["mistral", "@openclaw/mistral-provider", true],
+    ["novita", "@openclaw/novita-provider", true],
     ["synthetic", "@openclaw/synthetic-provider", true],
     ["teams-meetings", "@openclaw/teams-meetings", true],
     ["volcengine", "@openclaw/volcengine-provider", true],

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2171,6 +2171,19 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("maps NovitaAI provider aliases and credentials to the external plugin", () => {
+    expect(
+      resolveOfficialExternalProviderPluginIds({
+        providerIds: new Set(["novita", "novita-ai", "novitaai"]),
+      }),
+    ).toEqual(["novita"]);
+    expect(
+      resolveOfficialExternalProviderPluginIdsForEnv({
+        NOVITA_API_KEY: "novita-key",
+      }),
+    ).toEqual(["novita"]);
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/src/plugins/official-external-provider-endpoints.test.ts
+++ b/src/plugins/official-external-provider-endpoints.test.ts
@@ -133,6 +133,7 @@ describe("official external provider endpoint catalog mirror", () => {
     expect(endpointClasses).toContain("modelstudio-native");
     expect(endpointClasses).toContain("moonshot-native");
     expect(endpointClasses).toContain("meta-native");
+    expect(endpointClasses).toContain("novita-native");
     expect(endpointClasses).toContain("xiaomi-native");
     expect(endpointClasses).toContain("zai-native");
   });

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -236,6 +236,16 @@ describe("OpenClaw dual-published plugin metadata", () => {
         npmSpec: "@openclaw/gmi-provider",
       },
     },
+    {
+      extensionId: "novita",
+      packageName: "@openclaw/novita-provider",
+      install: {
+        clawhubSpec: "clawhub:@openclaw/novita-provider",
+        defaultChoice: "npm",
+        minHostVersion: ">=2026.7.2",
+        npmSpec: "@openclaw/novita-provider",
+      },
+    },
   ] as const;
 
   it("keeps dual-published plugins selectable through both ClawHub and npm release paths", () => {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -342,7 +342,7 @@ describe("bundled plugin build entries", () => {
   it("excludes externalized model providers from bundled artifacts", () => {
     const artifacts = listBundledPluginPackArtifacts();
 
-    for (const pluginId of ["byteplus", "cohere", "meta", "mistral", "xiaomi"]) {
+    for (const pluginId of ["byteplus", "cohere", "meta", "mistral", "novita", "xiaomi"]) {
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/index.js`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/openclaw.plugin.json`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/package.json`);


### PR DESCRIPTION
## What Problem This Solves

NovitaAI currently ships inside the core OpenClaw distribution, so operators cannot install or update the provider independently and every core package carries its runtime surface.

## Why This Change Was Made

Externalizes NovitaAI as the official `@openclaw/novita-provider` plugin. The official catalog now owns its aliases, credentials, endpoint, install metadata, and npm/ClawHub publication contract; the core artifact explicitly excludes the plugin.

The upgrade contract preserves existing enabled bundled installs through the generic persisted-location bridge. During update repair, `novita` resolves to the external npm/ClawHub package before restart. This branch is based on the generic doctor/update ordering correction that landed with the Mistral externalization in https://github.com/openclaw/openclaw/pull/116919 (`8b93fd963c9c289b0934e1ce47253773caff3499`), so it reuses that owner-neutral ordering rather than adding Novita-specific core policy.

## User Impact

New users install `@openclaw/novita-provider`, configure `NOVITA_API_KEY`, and restart OpenClaw. Existing users with the formerly bundled Novita provider keep its enabled-by-default state and are repaired to the official external package during upgrade.

## Evidence

- exact reviewed head: `89e5f8969139e948c909d1b9fd851c77bfd4273d`
- 280 focused tests passed across four Vitest shards, covering Novita registration, official catalog aliases and credentials, endpoint ownership, persisted bundled upgrade bridging, artifact exclusion, and npm/ClawHub release contracts
- plugin inventory and docs-map generation checks, docs formatting, targeted `oxfmt`, and `git diff --check` passed
- Codex autoreview: no findings; patch correct at 0.99 confidence
- clean-install proof plan: install the selected npm package, configure the provider, restart, and confirm discovery from the installed plugin root
- bundled-upgrade proof plan: seed the persisted bundled `novita` record, run update repair, confirm replacement with `@openclaw/novita-provider`, then restart and confirm discovery

AI-assisted: yes; the changes and generated surfaces were reviewed and understood.
