### PR TITLE
fix(codex): preserve provider-owned token usage breakdown

### DIFF
--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -197,7 +197,7 @@ function createClientFactory(
                 cachedInputTokens: 2,
                 cacheWriteInputTokens: 1,
                 outputTokens: 4,
-                reasoningOutputTokens: 0,
+                reasoningOutputTokens: 3,
               },
             },
           });
@@ -399,6 +399,7 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
         output: 4,
         cacheRead: 2,
         cacheWrite: 1,
+        reasoningTokens: 3,
         total: 12,
       },
     });

--- a/extensions/codex/src/app-server/event-projector-assistant-message.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant-message.ts
@@ -1,21 +1,18 @@
 import {
   formatErrorMessage,
   type EmbeddedRunAttemptParams,
+  type NormalizedUsage,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 
+type CodexAssistantUsage = Usage & {
+  // Codex is a managed runtime; keep reasoning telemetry private to managed consumers.
+  reasoningTokens?: number;
+};
+
 export type AssistantMessageOptions = {
-  tokenUsage:
-    | {
-        input?: number;
-        output?: number;
-        cacheRead?: number;
-        cacheWrite?: number;
-        total?: number;
-        contextUsage?: Usage["contextUsage"];
-      }
-    | undefined;
+  tokenUsage: NormalizedUsage | undefined;
   aborted: boolean;
   promptError: unknown;
 };
@@ -41,12 +38,15 @@ export function createAssistantMessage(
   options: AssistantMessageOptions,
 ): AssistantMessage {
   const attribution = resolveCodexLocalRuntimeAttribution(params);
-  const usage: Usage = options.tokenUsage
+  const usage: CodexAssistantUsage = options.tokenUsage
     ? {
         input: options.tokenUsage.input ?? 0,
         output: options.tokenUsage.output ?? 0,
         cacheRead: options.tokenUsage.cacheRead ?? 0,
         cacheWrite: options.tokenUsage.cacheWrite ?? 0,
+        ...(options.tokenUsage.reasoningTokens !== undefined
+          ? { reasoningTokens: options.tokenUsage.reasoningTokens }
+          : {}),
         ...(options.tokenUsage.contextUsage
           ? { contextUsage: options.tokenUsage.contextUsage }
           : {}),

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -65,67 +65,67 @@ export function normalizeCodexThreadTokenUsage(
 ): ReturnType<typeof normalizeUsage> {
   // Thread usage preserves per-response accounting on older app servers, but
   // its `last` snapshot is not guaranteed to describe the final response.
-  const inputTokens = readNumber(record, "inputTokens");
-  const cacheRead = readNumber(record, "cachedInputTokens");
-  const input =
-    inputTokens !== undefined && cacheRead !== undefined
-      ? Math.max(0, inputTokens - cacheRead)
-      : inputTokens;
-  const usage = normalizeUsage({
-    input,
-    output: readNumber(record, "outputTokens"),
-    cacheRead,
-    total: readNumber(record, "totalTokens"),
-  });
-  return usage ? { ...usage, contextUsage: { state: "unavailable" } } : undefined;
+  return normalizeCodexTokenUsageBreakdown(record, "thread");
 }
 
 export function normalizeCodexResponseTokenUsage(
   record: JsonObject,
 ): ReturnType<typeof normalizeUsage> {
+  return normalizeCodexTokenUsageBreakdown(record, "response");
+}
+
+function normalizeCodexTokenUsageBreakdown(
+  record: JsonObject,
+  source: "thread" | "response",
+): ReturnType<typeof normalizeUsage> {
   // v2 TokenUsageBreakdown. inputTokens includes cached input; OpenClaw usage
-  // tracks uncached input and cache reads separately.
-  const totalTokens = readTokenCount(record, "totalTokens");
-  const inputTokens = readTokenCount(record, "inputTokens");
-  const cacheRead = readTokenCount(record, "cachedInputTokens");
-  const output = readTokenCount(record, "outputTokens");
-  const reasoningOutput = readTokenCount(record, "reasoningOutputTokens");
-  const rawCacheWrite = record.cacheWriteInputTokens;
+  // tracks uncached input, cache reads, and cache writes separately.
+  const readCount = source === "response" ? readTokenCount : readNumber;
+  const totalTokens = readCount(record, "totalTokens");
+  const inputTokens = readCount(record, "inputTokens");
+  const cacheRead = readCount(record, "cachedInputTokens");
+  const output = readCount(record, "outputTokens");
+  const reasoningTokens = readCount(record, "reasoningOutputTokens");
   const cacheWrite =
-    rawCacheWrite === undefined ? 0 : readTokenCount(record, "cacheWriteInputTokens");
+    record.cacheWriteInputTokens === undefined && source === "response"
+      ? 0
+      : readCount(record, "cacheWriteInputTokens");
   if (
-    totalTokens === undefined ||
-    inputTokens === undefined ||
-    cacheRead === undefined ||
-    cacheWrite === undefined ||
-    output === undefined ||
-    reasoningOutput === undefined ||
-    cacheRead + cacheWrite > inputTokens ||
-    totalTokens !== inputTokens + output
+    source === "response" &&
+    (totalTokens === undefined ||
+      inputTokens === undefined ||
+      cacheRead === undefined ||
+      cacheWrite === undefined ||
+      output === undefined ||
+      reasoningTokens === undefined ||
+      cacheRead + cacheWrite > inputTokens ||
+      totalTokens !== inputTokens + output)
   ) {
     return undefined;
   }
 
   const usage = normalizeUsage({
-    input: inputTokens - cacheRead - cacheWrite,
+    input:
+      inputTokens === undefined
+        ? undefined
+        : Math.max(0, inputTokens - (cacheRead ?? 0) - (cacheWrite ?? 0)),
     output,
     cacheRead,
     cacheWrite,
+    reasoningTokens,
     total: totalTokens,
   });
   if (!usage) {
     return undefined;
   }
 
-  // `rawResponse/completed` is exact for one provider response. The projector
-  // replaces this snapshot on every response so the final one owns freshness.
+  // Only exact provider completions own fresh context; thread snapshots may be stale.
   return {
     ...usage,
-    contextUsage: {
-      state: "available",
-      promptTokens: inputTokens,
-      totalTokens,
-    },
+    contextUsage:
+      source === "response" && inputTokens !== undefined && totalTokens !== undefined
+        ? { state: "available", promptTokens: inputTokens, totalTokens }
+        : { state: "unavailable" },
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -1,3 +1,4 @@
+import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   describe,
   registerCodexEventProjectorTestLifecycle,
@@ -71,6 +72,7 @@ describe("CodexAppServerEventProjector assistant projection", () => {
       promptTokens: 5,
       totalTokens: 12,
     });
+    expect(result.attemptUsage?.reasoningTokens).toBe(3);
     expectUsageFields(result.lastAssistant?.usage, {
       input: 2,
       output: 7,
@@ -83,6 +85,8 @@ describe("CodexAppServerEventProjector assistant projection", () => {
       promptTokens: 5,
       totalTokens: 12,
     });
+    expect(normalizeUsage(result.lastAssistant?.usage)?.reasoningTokens).toBe(3);
+    expect(normalizeUsage(result.currentAttemptAssistant?.usage)?.reasoningTokens).toBe(3);
     expect(result.replayMetadata.replaySafe).toBe(true);
   });
 

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -1,3 +1,4 @@
+import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   describe,
   registerCodexEventProjectorTestLifecycle,
@@ -123,7 +124,9 @@ describe("CodexAppServerEventProjector usage projection", () => {
             totalTokens: 12,
             inputTokens: 5,
             cachedInputTokens: 2,
+            cacheWriteInputTokens: 1,
             outputTokens: 7,
+            reasoningOutputTokens: 3,
           },
         },
       }),
@@ -132,15 +135,24 @@ describe("CodexAppServerEventProjector usage projection", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(result.assistantTexts).toEqual(["done"]);
-    expectUsageFields(result.attemptUsage, { input: 3, output: 7, cacheRead: 2, total: 12 });
-    expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
-    expectUsageFields(result.lastAssistant?.usage, {
-      input: 3,
+    expectUsageFields(result.attemptUsage, {
+      input: 2,
       output: 7,
       cacheRead: 2,
+      cacheWrite: 1,
+      total: 12,
+    });
+    expect(result.attemptUsage?.reasoningTokens).toBe(3);
+    expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+    expectUsageFields(result.lastAssistant?.usage, {
+      input: 2,
+      output: 7,
+      cacheRead: 2,
+      cacheWrite: 1,
       total: 12,
     });
     expect(result.lastAssistant?.usage.contextUsage).toEqual({ state: "unavailable" });
+    expect(normalizeUsage(result.lastAssistant?.usage)?.reasoningTokens).toBe(3);
   });
 
   it.each([

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -1,4 +1,7 @@
-import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  normalizeUsage,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
@@ -105,7 +108,14 @@ describe("runCodexSettledTurnFinalization", () => {
       text: "The update was sent successfully.",
       items: [],
       model: "gpt-5.4",
-      usage: { input: 5, output: 4, cacheRead: 2, cacheWrite: 1, total: 12 },
+      usage: {
+        input: 5,
+        output: 4,
+        cacheRead: 2,
+        cacheWrite: 1,
+        reasoningTokens: 3,
+        total: 12,
+      },
     });
     mocks.mirror.mockReset();
     mocks.mirror.mockImplementation(
@@ -175,7 +185,14 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(result).toMatchObject({
       assistantTranscriptOwned: true,
       assistantTranscriptIdempotencyKey: "codex-settled-finalizer:run-1:assistant",
-      usage: { input: 5, output: 4, cacheRead: 2, cacheWrite: 1, total: 12 },
+      usage: {
+        input: 5,
+        output: 4,
+        cacheRead: 2,
+        cacheWrite: 1,
+        reasoningTokens: 3,
+        total: 12,
+      },
       assistant: {
         role: "assistant",
         content: [{ type: "text", text: "The update was sent successfully." }],
@@ -191,6 +208,7 @@ describe("runCodexSettledTurnFinalization", () => {
       cacheWrite: 1,
       totalTokens: 12,
     });
+    expect(normalizeUsage(result.assistant.usage)?.reasoningTokens).toBe(3);
   });
 
   it("rejects an empty final answer before transcript mutation", async () => {


### PR DESCRIPTION
## What Problem This Solves

Codex app-server usage notifications lost provider-owned cache-write and reasoning token counts. Fallback thread usage subtracted only cache reads, overstating uncached input, while exact response usage validated reasoning tokens but discarded them. Final assistant and settled-finalizer results therefore omitted reasoning usage.

## Why This Change Was Made

Both app-server notifications carry the same upstream `TokenUsageBreakdown`, so one private Codex normalizer now owns exact and fallback mappings. Exact responses retain strict validation and fresh context snapshots; permissive fallback snapshots retain unavailable context freshness. The final assistant owner uses the established private managed-telemetry shape to carry reasoning without changing shipped public `Usage`.

This intentionally follows merged #117043: managed transports expose exact reasoning telemetry privately while package/public `Usage` remains narrower. The ClawSweeper move to add public `reasoningTokens` is explicitly skipped because it would contradict that contract and require a public Plugin SDK decision. Worker protocol projection remains intentionally narrower and unaffected.

Production delta is net-neutral: +48/-48. No public/plugin API, config, environment, authentication, security boundary, persistence schema, worker protocol, SQLite version, dependency, retry, or compatibility surface changes.

## User Impact

Codex exact and fallback app-server turns now report correct uncached input, cache-write, and reasoning token counts. Ordinary projector results, bounded turns, final assistant messages, and settled transcript-finalizer results retain the authoritative breakdown without changing completion or error lifecycles.

## Evidence

Mandatory direct Codex source inspection covered the recorded upstream paths requested for this repair:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1579-1646`
- `codex-rs/protocol/src/protocol.rs:2067-2081`
- `codex-rs/app-server/src/bespoke_event_handling.rs:1072-1081`
- `codex-rs/app-server/src/bespoke_event_handling.rs:1577-1592`
- `codex-rs/app-server/src/bespoke_event_handling.rs:3844-3861`

Current sibling Codex at `e1895710addb863acf335ef18b4c43b128439567` has moved the producer but preserves the same contract: `codex-rs/core/src/session/mod.rs:3780-3887` records and emits total/last usage, `codex-rs/protocol/src/protocol.rs:2055-2081` defines cache-write and reasoning fields, `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1502-1569` carries every field through its conversion, and `codex-rs/app-server/src/bespoke_event_handling.rs:1568-1592` forwards the notification.

Fail-before regression:

```text
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.assistant.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts
Test Files  2 failed (2)
Tests       2 failed | 24 passed (26)
Exact       expected reasoningTokens=3, received undefined
Fallback    expected uncached input=2, received 3
```

Pass-after proof on rebased head `ef7c2d171d2bc1de1d4938300f528f3b6a5d92c6`:

```text
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.assistant.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/settled-turn-finalizer.test.ts
Test Files  4 passed (4)
Tests       48 passed (48)
[test] passed 1 Vitest shard in 114.86s

$ node scripts/check-changed.mjs
[check:changed] lanes=extensions, extensionTests
extension production/test typecheck PASS
oxfmt PASS; oxlint 0 warnings, 0 errors
doctor contract closure tests 5 passed
dead export scans 0 entries; runtime import cycles 0
Blacksmith Testbox tbx_01kzkgy7x9zsz24hbegyvhmwr4
Actions run 31320201458
exitCode 0

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```

ClawSweeper rank-up work is addressed or explicitly skipped above; no finding is silently bypassed.

AI-assisted; current owner/caller/sibling paths, merged reasoning-telemetry contract, tests, history, and direct upstream Rust producers were independently reviewed.
