### PR TITLE
fix(ui): prevent hidden session selection from bulk deletion

### DIFF
--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -16,6 +16,64 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it("never deletes a hidden thread selected before changing the roster search", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const alpha = "agent:main:alpha";
+    const bravo = "agent:main:bravo";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.delete": { ok: true, deleted: true },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(alpha, "Alpha", Date.parse("2026-07-01T15:00:00.000Z")),
+          sessionRow(bravo, "Bravo", Date.parse("2026-07-01T14:00:00.000Z")),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}sessions`);
+      const rowFor = (label: string) =>
+        page.locator(".session-data-row").filter({ hasText: label });
+
+      await rowFor("Alpha").locator('input[type="checkbox"]').check();
+      await page.locator(".data-table-bulk-bar").getByText("1 selected").waitFor();
+      await page.locator('.sessions-toolbar__search input[type="text"]').fill("Bravo");
+
+      await expect.poll(() => rowFor("Alpha").count()).toBe(0);
+      await expect.poll(() => page.locator(".data-table-bulk-bar").count()).toBe(0);
+
+      await rowFor("Bravo").locator('input[type="checkbox"]').check();
+      page.once("dialog", (dialog) => void dialog.accept());
+      await page
+        .locator(".data-table-bulk-bar")
+        .getByRole("button", { name: "Delete", exact: true })
+        .click();
+      await gateway.waitForRequest("sessions.delete");
+
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.delete")).map(
+            (request) => requireRecord(request.params).key,
+          ),
+        )
+        .toEqual([bravo]);
+      const request = (await gateway.getRequests("sessions.delete"))[0];
+      expect(requireRecord(request?.params)).toMatchObject({
+        key: bravo,
+        deleteTranscript: true,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("archives a session from the Sessions page context menu and kebab", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1400,6 +1400,7 @@ class SessionsPage extends OpenClawLightDomElement {
           onSearchChange: (query) => {
             this.searchQuery = query;
             this.page = 0;
+            this.selectedKeys = new Set();
           },
           onTranscriptSearchChange: (query) => this.updateTranscriptSearchQuery(query),
           onTranscriptSearch: () => void this.runTranscriptSearch(),


### PR DESCRIPTION
## What Problem This Solves

Fixes a destructive Sessions-page bug where selecting a thread, changing the roster search, and deleting a newly visible thread could silently delete the previously selected hidden thread and its transcript as well.

## Why This Change Was Made

The canonical roster-search owner now clears the local bulk selection whenever the visible roster population changes. Existing intentional cross-page selection, sorting, grouping, Gateway authorization, and deletion behavior remain unchanged.

## User Impact

Bulk deletion can no longer retain invisible selections from an earlier roster search. Users receive an immediate, accurate selection state before choosing visible threads to delete.

## Evidence

- Original reproduced frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact current-main base: `727216b014c15ab878486e0e1378c5564b84386e`.
- Exact freshly reviewed rebased head: `85ce28efeec63acb3d9f33a0ca5845c79f09187d`.
- The rebase preserves the original reviewed stable patch-id exactly: `d97b37ca060c28338a5e2f32aee8ad2df702af7b`.
- Actual Chromium reproduced the frozen-baseline failure: a newly hidden selected thread remained selected after changing the roster search.
- Exact rebased-head server-preferences singleton/isolation regression: **2/2 passed**. Current main already contains the separate isolation fix that caused the earlier unrelated synthetic-merge CI failure.
- Exact rebased-head Sessions owner suite: **25/25 passed**.
- Exact rebased-head actual Chromium archive/deletion sibling suite: **7/7 passed**, with zero skips.
- The new browser regression inspects actual Gateway WebSocket requests and proves that only visible `agent:main:bravo` receives `sessions.delete` with `deleteTranscript: true`.
- Genuine full structured Codex autoreview and TruffleHog secret scan, explicitly including **P0 through P3**: **clean**, zero findings, confidence **0.97**.
- Independent exact-head owner/caller/Gateway/sibling review: **clean through P3**.
- Production delta: **one line**; no authorization, configuration, public SDK, protocol, persistent-state, or cross-page selection changes.
- Remote current-head proof lease was stopped and independently verified completed: https://github.com/openclaw/openclaw/actions/runs/30675010399.
