### PR TITLE
fix(ui): share bounded pagination across live session rosters

### DIFF
--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -188,6 +188,71 @@ describeControlUiE2e("Control UI session transcript search", () => {
     await captureUiProof("04-matching-chat.png");
   });
 
+  it("finds a transcript when updated session order moves across a paged roster", async () => {
+    const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
+    const first = { key: "agent:main:first", kind: "direct", updatedAt: timestamp };
+    const moved = { key: "agent:main:moved", kind: "direct", updatedAt: timestamp + 1 };
+    const missed = { key: "agent:main:missed", kind: "direct", updatedAt: timestamp - 1 };
+    const defaults = { contextTokens: null, model: null, modelProvider: null };
+    const result = (sessions: (typeof first)[], offset: number, hasMore: boolean) => ({
+      count: sessions.length,
+      defaults,
+      hasMore,
+      nextOffset: hasMore ? offset + sessions.length : null,
+      offset,
+      path: "",
+      sessions,
+      totalCount: 3,
+      ts: timestamp,
+    });
+    context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 800, width: 1200 },
+    });
+    page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.search"],
+      methodResponses: {
+        "sessions.list": result([first, moved], 0, true),
+        "sessions.search": {
+          results: [
+            {
+              messageId: "message-missed",
+              role: "assistant",
+              score: 1,
+              sessionId: "missed",
+              sessionKey: missed.key,
+              snippet: "the recovered launch code",
+              timestamp,
+            },
+          ],
+        },
+      },
+    });
+
+    await page.goto(`${server?.baseUrl ?? ""}sessions`);
+    const input = page.getByRole("searchbox", { name: "Search thread transcripts" });
+    await input.waitFor({ state: "visible", timeout: 10_000 });
+    await gateway.setMethodResponse("sessions.list", {
+      cases: [
+        { match: { offset: 2 }, response: result([moved], 2, false) },
+        { response: result([first, missed], 0, true) },
+      ],
+    });
+    await input.fill("launch code");
+    await input.press("Enter");
+
+    await page.getByText("the recovered launch code").waitFor({ state: "visible" });
+    await expect.poll(async () => gateway.getRequests("sessions.search")).toHaveLength(1);
+    expect((await gateway.getRequests("sessions.search"))[0]?.params).toEqual({
+      agentId: "main",
+      limit: 25,
+      query: "launch code",
+      sessionKeys: [first.key, moved.key, missed.key],
+    });
+  });
+
   it.each([
     {
       label: "a later session page cannot be loaded",

--- a/ui/src/lib/sessions/child-session-data.ts
+++ b/ui/src/lib/sessions/child-session-data.ts
@@ -1,7 +1,7 @@
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { SessionCapability } from "./index.ts";
+import { fetchPagedSessionRows } from "./paged-session-rows.ts";
 
-const MAX_CHILD_SESSION_LIST_PASSES = 4;
 // Matches the Gateway default and covers the default 50-child Swarm roster.
 // Custom larger groups keep paging through the bounded retry loop below.
 const CHILD_SESSION_LIST_PAGE_SIZE = 100;
@@ -12,52 +12,23 @@ export async function fetchChildSessionRows(params: {
   isCurrent: () => boolean;
   pageSize?: number;
 }): Promise<GatewaySessionRow[] | null> {
-  const rowsByKey = new Map<string, GatewaySessionRow>();
   const pageSize = params.pageSize ?? CHILD_SESSION_LIST_PAGE_SIZE;
-  for (let pass = 0; pass < MAX_CHILD_SESSION_LIST_PASSES; pass += 1) {
-    const seenOffsets = new Set<number>();
-    const rowsBeforePass = rowsByKey.size;
-    let expectedTotal: number | undefined;
-    let offset = 0;
-    while (!seenOffsets.has(offset)) {
-      seenOffsets.add(offset);
-      const result = await params.sessions.list({
+  return fetchPagedSessionRows({
+    list: (offset) =>
+      params.sessions.list({
         spawnedBy: params.parentKey,
         ...(offset > 0 ? { offset } : {}),
         limit: pageSize,
         includeGlobal: false,
         includeUnknown: false,
         configuredAgentsOnly: true,
-      });
-      if (!params.isCurrent()) {
-        return null;
-      }
-      if (!result) {
-        throw new Error("child session list returned no result");
-      }
-      expectedTotal = result.totalCount;
+      }),
+    isCurrent: params.isCurrent,
+    missingResultError: "child session list returned no result",
+    mapPageRows: (rows) => {
       const runtimeSampledAt = Date.now();
-      for (const row of result.sessions) {
-        // A later pass is a fresher server observation even when the row moved
-        // across an updatedAt-sorted offset boundary.
-        rowsByKey.set(row.key, { ...row, runtimeSampledAt });
-      }
-      const hasMore =
-        result.hasMore ??
-        (typeof result.totalCount === "number" &&
-          offset + result.sessions.length < result.totalCount);
-      const nextOffset = result.nextOffset ?? offset + result.sessions.length;
-      if (!hasMore || nextOffset <= offset) {
-        break;
-      }
-      offset = nextOffset;
-    }
-    const addedThisPass = rowsByKey.size - rowsBeforePass;
-    if (addedThisPass === 0 || expectedTotal === undefined || rowsByKey.size >= expectedTotal) {
-      break;
-    }
-    // updatedAt ordering can move a child across an offset boundary while paging.
-    // Repeat from zero until the deduplicated roster reaches the latest total.
-  }
-  return [...rowsByKey.values()];
+      // Keep each server page's lifecycle sample coherent across sibling rows.
+      return rows.map((row) => ({ ...row, runtimeSampledAt }));
+    },
+  });
 }

--- a/ui/src/lib/sessions/paged-session-rows.ts
+++ b/ui/src/lib/sessions/paged-session-rows.ts
@@ -1,0 +1,65 @@
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+
+const MAX_SESSION_LIST_PASSES = 4;
+
+export async function fetchPagedSessionRows(params: {
+  list: (offset: number) => Promise<SessionsListResult | null>;
+  initialResult?: SessionsListResult | null;
+  isCurrent?: () => boolean;
+  mapPageRows?: (rows: GatewaySessionRow[]) => GatewaySessionRow[];
+  missingResultError: string;
+  stalledPaginationError?: string;
+}): Promise<GatewaySessionRow[] | null> {
+  if (params.initialResult === null) {
+    return [];
+  }
+  const rowsByKey = new Map<string, GatewaySessionRow>();
+  for (let pass = 0; pass < MAX_SESSION_LIST_PASSES; pass += 1) {
+    // Include prefetched rows in first-pass progress so a moving row triggers a retry.
+    const rowsBeforePass = rowsByKey.size;
+    const seenOffsets = new Set<number>();
+    let expectedTotal: number | undefined;
+    let offset = 0;
+    let prefetched = pass === 0 ? params.initialResult : undefined;
+    while (!seenOffsets.has(offset)) {
+      seenOffsets.add(offset);
+      const result = prefetched ?? (await params.list(offset));
+      prefetched = undefined;
+      if (params.isCurrent && !params.isCurrent()) {
+        return null;
+      }
+      if (!result) {
+        throw new Error(params.missingResultError);
+      }
+      expectedTotal = result.totalCount;
+      const rows = params.mapPageRows?.(result.sessions) ?? result.sessions;
+      for (const row of rows) {
+        rowsByKey.set(row.key, row);
+      }
+      const hasMore =
+        result.hasMore ??
+        (typeof result.totalCount === "number" &&
+          offset + result.sessions.length < result.totalCount);
+      if (!hasMore) {
+        break;
+      }
+      const nextOffset = result.nextOffset ?? (result.offset ?? offset) + result.sessions.length;
+      if (nextOffset <= offset) {
+        if (params.stalledPaginationError) {
+          throw new Error(params.stalledPaginationError);
+        }
+        break;
+      }
+      offset = nextOffset;
+    }
+    if (
+      rowsByKey.size === rowsBeforePass ||
+      expectedTotal === undefined ||
+      rowsByKey.size >= expectedTotal
+    ) {
+      break;
+    }
+    // Gateway updatedAt sorting can move rows across offset windows between RPCs.
+  }
+  return [...rowsByKey.values()];
+}

--- a/ui/src/pages/sessions/agent-scope.test.ts
+++ b/ui/src/pages/sessions/agent-scope.test.ts
@@ -84,6 +84,71 @@ describe("searchVisibleSessionTranscripts", () => {
     );
   });
 
+  it("recovers a thread that moves across an updated-at pagination boundary", async () => {
+    const first = { key: "agent:main:first" } as GatewaySessionRow;
+    const moved = { key: "agent:main:moved" } as GatewaySessionRow;
+    const missed = { key: "agent:main:missed" } as GatewaySessionRow;
+    const request = vi.fn(async (_method: string, params: { sessionKeys: string[] }) => ({
+      results: params.sessionKeys.includes(missed.key)
+        ? [
+            {
+              sessionKey: missed.key,
+              sessionId: "missed",
+              messageId: "message-missed",
+              role: "assistant" as const,
+              timestamp: 1,
+              snippet: "the missing launch code",
+              score: 1,
+            },
+          ]
+        : [],
+    }));
+    const listSessions = vi
+      .fn()
+      .mockResolvedValueOnce({
+        count: 1,
+        totalCount: 3,
+        sessions: [moved],
+        offset: 2,
+        hasMore: false,
+      } as SessionsListResult)
+      .mockResolvedValueOnce({
+        count: 2,
+        totalCount: 3,
+        sessions: [first, missed],
+        offset: 0,
+        nextOffset: 2,
+        hasMore: true,
+      } as SessionsListResult)
+      .mockResolvedValueOnce({
+        count: 1,
+        totalCount: 3,
+        sessions: [moved],
+        offset: 2,
+        hasMore: false,
+      } as SessionsListResult);
+
+    const found = await searchVisibleSessionTranscripts({
+      client: { request } as unknown as GatewayBrowserClient,
+      query: "launch code",
+      result: {
+        count: 2,
+        totalCount: 3,
+        sessions: [first, moved],
+        nextOffset: 2,
+        hasMore: true,
+      } as SessionsListResult,
+      listSessions,
+      listOptions: { agentId: "main" },
+      resolveAgentId: () => "main",
+    });
+
+    expect(found.results.map((result) => result.sessionKey)).toEqual([missed.key]);
+    expect(request).toHaveBeenCalledOnce();
+    expect(request.mock.calls[0]?.[1].sessionKeys).toEqual([first.key, moved.key, missed.key]);
+    expect(listSessions.mock.calls.map(([options]) => options.offset)).toEqual([2, 0, 2]);
+  });
+
   it.each([
     {
       label: "a later session page cannot be loaded",

--- a/ui/src/pages/sessions/agent-scope.ts
+++ b/ui/src/pages/sessions/agent-scope.ts
@@ -1,11 +1,8 @@
 import type { SessionsSearchResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type {
-  AgentIdentityResult,
-  GatewaySessionRow,
-  SessionsListResult,
-} from "../../api/types.ts";
+import type { AgentIdentityResult, SessionsListResult } from "../../api/types.ts";
 import type { SessionListOptions } from "../../lib/sessions/index.ts";
+import { fetchPagedSessionRows } from "../../lib/sessions/paged-session-rows.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 
 export function sessionAgentIds(result: SessionsListResult | null): string[] {
@@ -38,32 +35,19 @@ export async function searchVisibleSessionTranscripts(params: {
   resolveAgentId: (sessionKey: string) => string | undefined;
 }): Promise<SessionsSearchResult> {
   const protocolKeyLimit = 200;
-  const sessions: GatewaySessionRow[] = [...(params.result?.sessions ?? [])];
-  let nextOffset =
-    params.result?.hasMore === true
-      ? (params.result.nextOffset ?? (params.result.offset ?? 0) + params.result.sessions.length)
-      : null;
-  while (nextOffset !== null && nextOffset !== undefined) {
-    const page = await params.listSessions({
-      ...params.listOptions,
-      limit: protocolKeyLimit,
-      offset: nextOffset,
-    });
-    if (!page) {
-      throw new Error("Unable to load all sessions for transcript search.");
-    }
-    sessions.push(...page.sessions);
-    if (page.hasMore !== true) {
-      break;
-    }
-    const followingOffset = page.nextOffset ?? (page.offset ?? nextOffset) + page.sessions.length;
-    if (followingOffset <= nextOffset) {
-      throw new Error("Session pagination did not advance during transcript search.");
-    }
-    nextOffset = followingOffset;
-  }
+  const sessions = await fetchPagedSessionRows({
+    initialResult: params.result,
+    list: (offset) =>
+      params.listSessions({
+        ...params.listOptions,
+        limit: protocolKeyLimit,
+        offset,
+      }),
+    missingResultError: "Unable to load all sessions for transcript search.",
+    stalledPaginationError: "Session pagination did not advance during transcript search.",
+  });
   const keysByAgent = new Map<string, string[]>();
-  for (const row of sessions) {
+  for (const row of sessions ?? []) {
     const agentId = params.resolveAgentId(row.key);
     if (!agentId) {
       continue;


### PR DESCRIPTION
## What Problem This Solves

Fixes silent missing transcript-search results when an active session changes its `updatedAt` order while the Control UI loads multiple Gateway session pages. The previous implementation could skip an existing matching session and submit the same session key more than once.

## Why This Change Was Made

The Gateway recalculates its `updatedAt`-sorted offset window for every `sessions.list` request. Swarm/child hydration already handled this with bounded repaging and key deduplication. This change extracts that proven algorithm into one shared UI session-list owner and reuses it for transcript search.

The refactor preserves child and Swarm page sizes, cancellation, once-per-page lifecycle timestamps, filter options, transcript null/stalled-cursor errors, and the Gateway's 200-key search limit.

## User Impact

Transcript search now finds existing messages even when active sessions move between pages during the search. Each session is searched once, and existing child/Swarm roster hydration continues to behave identically.

## Evidence

- Original reproduced frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact current-main base: `727216b014c15ab878486e0e1378c5564b84386e`.
- Exact freshly reviewed rebased head: `1486ced12850e74dd1ae345ced1724d3f17d7def`.
- The rebase preserves the original reviewed stable patch-id exactly: `47b2b57dd35f434284bbb239f472c7911aa5278f`.
- Frozen baseline reproduced the real owner failure: expected existing `agent:main:missed`; transcript search returned an empty result.
- Exact rebased-head server-preferences singleton/isolation regression: **2/2 passed**. Current main already contains the separate isolation fix that caused the earlier unrelated synthetic-merge CI failure.
- Exact rebased-head complete transcript-owner, child-roster, Swarm, and Sessions-page suites: **41/41 passed**.
- Exact rebased-head actual Chromium transcript-search suite: **6/6 passed**, with zero skips, including a dynamically reordered Gateway roster, retryable pagination errors, indexing/stale behavior, and unavailable-method gating.
- Fresh remote production UI and UI-test type checks plus all changed-file formatting: **passed**.
- Genuine fresh exact-head structured Codex autoreview and official TruffleHog secret scan, explicitly including **P0 through P3**: **clean**, zero findings, confidence **0.93**.
- Independent exact-head complete-owner/caller/Gateway/sibling/protocol review: **clean through P3**.
- One canonical bounded session-page owner replaces duplicated pagination policy. No authorization, configuration, public SDK, Gateway protocol, mutation, or persistent-state changes.
- Remote exact-head proof lease stopped and independently verified completed: https://github.com/openclaw/openclaw/actions/runs/30675148057.
