### PR TITLE
fix(ui): restore keyboard and screen-reader session controls

### DIFF
--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -331,6 +331,64 @@ suite.define(() => {
     }
   });
 
+  it("sorts threads from the keyboard and identifies destructive selection targets", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:alpha", "Alpha thread", 1),
+          sessionRow("agent:main:zulu", "Zulu thread", 2),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}sessions`);
+      const table = page.locator(".sessions-table");
+      const rowNames = () =>
+        table.locator("tbody .session-data-row .session-label-chip").allTextContents();
+      await expect.poll(rowNames).toEqual(["Zulu thread", "Alpha thread"]);
+
+      for (const name of ["Key", "Kind", "Updated", "Tokens"]) {
+        await table.getByRole("columnheader", { name }).getByRole("button", { name }).waitFor();
+      }
+
+      const updatedHeader = table.getByRole("columnheader", { name: "Updated" });
+      expect(await updatedHeader.getAttribute("aria-sort")).toBe("descending");
+      await updatedHeader.getByRole("button", { name: "Updated" }).press("Space");
+      await expect.poll(rowNames).toEqual(["Alpha thread", "Zulu thread"]);
+      expect(await updatedHeader.getAttribute("aria-sort")).toBe("ascending");
+
+      const keyHeader = table.getByRole("columnheader", { name: "Key" });
+      await keyHeader.getByRole("button", { name: "Key" }).press("Enter");
+      await expect.poll(rowNames).toEqual(["Zulu thread", "Alpha thread"]);
+      expect(await keyHeader.getAttribute("aria-sort")).toBe("descending");
+      expect(await updatedHeader.getAttribute("aria-sort")).toBeNull();
+
+      const keyHeaderBounds = await keyHeader.boundingBox();
+      if (!keyHeaderBounds) {
+        throw new Error("Expected visible session sort header");
+      }
+      await page.mouse.click(
+        keyHeaderBounds.x + keyHeaderBounds.width - 2,
+        keyHeaderBounds.y + keyHeaderBounds.height / 2,
+      );
+      await expect.poll(rowNames).toEqual(["Alpha thread", "Zulu thread"]);
+      expect(await keyHeader.getAttribute("aria-sort")).toBe("ascending");
+
+      await table.getByRole("checkbox", { name: "Select thread: agent:main:alpha" }).waitFor();
+      await table.getByRole("checkbox", { name: "Select thread: agent:main:zulu" }).waitFor();
+    } finally {
+      await context.close();
+    }
+  });
+
   it("shows a rejected Sessions-page custom group instead of leaking a page error", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -360,7 +418,7 @@ suite.define(() => {
         message: "group name exceeds 512 characters",
       });
 
-      const error = page.locator(".sessions-error");
+      const error = page.getByRole("alert");
       await error.waitFor({ state: "visible" });
       await expect.poll(() => error.textContent()).toContain("group name exceeds 512 characters");
       expect(pageErrors).toEqual([]);

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -103,6 +103,139 @@ function sessionTableHeaders(container: HTMLElement): Array<string | undefined> 
 const SESSION_TABLE_HEADERS = ["", "Key", "Kind", "Status", "Updated", "Tokens", "Actions"];
 
 describe("sessions view", () => {
+  it("makes every session sort header a keyboard-accessible button", async () => {
+    const container = document.createElement("div");
+    const onSortChange = vi.fn();
+    render(
+      renderSessions({
+        ...buildProps(buildMultiResult([])),
+        onSortChange,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    for (const [label, column] of [
+      ["Key", "key"],
+      ["Kind", "kind"],
+      ["Updated", "updated"],
+      ["Tokens", "tokens"],
+    ] as const) {
+      const header = [...container.querySelectorAll<HTMLTableCellElement>("thead th")].find(
+        (cell) => cell.textContent?.trim() === label,
+      );
+      const button = header?.querySelector("button");
+
+      expect(button, `${label} must be a native keyboard-accessible button`).toBeInstanceOf(
+        HTMLButtonElement,
+      );
+      expect(button?.type).toBe("button");
+      const initialCallCount = onSortChange.mock.calls.length;
+      button?.click();
+      expect(onSortChange).toHaveBeenCalledTimes(initialCallCount + 1);
+      expect(onSortChange).toHaveBeenLastCalledWith(column, column === "updated" ? "asc" : "desc");
+
+      header?.click();
+      expect(onSortChange).toHaveBeenCalledTimes(initialCallCount + 2);
+      expect(onSortChange).toHaveBeenLastCalledWith(column, column === "updated" ? "asc" : "desc");
+    }
+  });
+
+  it.each([
+    { direction: "asc", ariaSort: "ascending" },
+    { direction: "desc", ariaSort: "descending" },
+  ] as const)(
+    "announces only the active $direction session sort",
+    async ({ direction, ariaSort }) => {
+      const container = document.createElement("div");
+      render(
+        renderSessions({
+          ...buildProps(buildMultiResult([])),
+          sortColumn: "kind",
+          sortDir: direction,
+        }),
+        container,
+      );
+      await Promise.resolve();
+
+      const headers = [
+        ...container.querySelectorAll<HTMLTableCellElement>("thead th[data-sortable]"),
+      ];
+      expect(headers).toHaveLength(4);
+      expect(
+        headers.find((header) => header.textContent?.trim() === "Kind")?.getAttribute("aria-sort"),
+      ).toBe(ariaSort);
+      expect(
+        headers
+          .filter((header) => header.textContent?.trim() !== "Kind")
+          .map((header) => header.hasAttribute("aria-sort")),
+      ).toEqual([false, false, false]);
+    },
+  );
+
+  it("announces session-list and mutation failures to assistive technology", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(buildMultiResult([])),
+        error: "group name exceeds 512 characters",
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.classList.contains("sessions-error")).toBe(true);
+    expect(alert?.textContent).toContain("group name exceeds 512 characters");
+  });
+
+  it("announces checkpoint failures in their expanded session details", async () => {
+    const sessionKey = "agent:main:checkpoint-failure";
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(buildResult({ key: sessionKey, kind: "direct", updatedAt: 1 })),
+        expandedSessionKey: sessionKey,
+        checkpointErrorByKey: { [sessionKey]: "Checkpoint request timed out" },
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const alert = container.querySelector('.session-details-panel [role="alert"]');
+    expect(alert?.textContent).toContain("Checkpoint request timed out");
+  });
+
+  it("identifies each selectable session before destructive bulk actions", async () => {
+    const container = document.createElement("div");
+    const onToggleSelect = vi.fn();
+    render(
+      renderSessions({
+        ...buildProps(
+          buildMultiResult([
+            { key: "agent:main:first", kind: "direct", updatedAt: 2 },
+            { key: "agent:main:second", kind: "direct", updatedAt: 1 },
+          ]),
+        ),
+        onToggleSelect,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const checkboxes = [
+      ...container.querySelectorAll<HTMLInputElement>('tbody input[type="checkbox"]'),
+    ];
+    expect(checkboxes.map((checkbox) => checkbox.getAttribute("aria-label"))).toEqual([
+      "Select thread: agent:main:first",
+      "Select thread: agent:main:second",
+    ]);
+
+    checkboxes[0]?.dispatchEvent(new Event("change", { bubbles: true }));
+    checkboxes[1]?.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onToggleSelect.mock.calls).toEqual([["agent:main:first"], ["agent:main:second"]]);
+  });
+
   it("uses the stored face for generic session links", async () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -1123,10 +1123,13 @@ export function renderSessions(props: SessionsProps) {
         class=${extraClass}
         data-sortable
         data-sort-dir=${isActive ? props.sortDir : ""}
+        aria-sort=${isActive ? (props.sortDir === "asc" ? "ascending" : "descending") : nothing}
         @click=${() => props.onSortChange(col, isActive ? nextDir : "desc")}
       >
-        ${label}
-        <span class="data-table-sort-icon">${icons.arrowUpDown}</span>
+        <button class="data-table-sort-button" type="button">
+          ${label}
+          <span class="data-table-sort-icon" aria-hidden="true">${icons.arrowUpDown}</span>
+        </button>
       </th>
     `;
   };
@@ -1158,7 +1161,7 @@ export function renderSessions(props: SessionsProps) {
     </button>
   `;
   const children = [
-    props.error ? html`<div class="sessions-error">${props.error}</div>` : nothing,
+    props.error ? html`<div class="sessions-error" role="alert">${props.error}</div>` : nothing,
     props.result
       ? renderSettingsSection({}, renderSessionsOverview(rawRows, liveCount, props.statusFilter))
       : nothing,
@@ -1585,7 +1588,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
           type="checkbox"
           .checked=${props.selectedKeys.has(row.key)}
           @change=${() => props.onToggleSelect(row.key)}
-          aria-label=${t("sessionsView.selectSession")}
+          aria-label=${`${t("sessionsView.selectSession")}: ${row.key}`}
         />
       </td>
       <td class="data-table-key-col">
@@ -1862,7 +1865,7 @@ function renderSessionDetailsRow(params: {
                 ${t("sessionsView.loadingCheckpoints")}
               </div>`
             : checkpointError
-              ? html`<div class="callout danger">${checkpointError}</div>`
+              ? html`<div class="callout danger" role="alert">${checkpointError}</div>`
               : !hasCheckpoints || checkpointItems.length === 0
                 ? html`<div class="muted session-details-empty">
                     ${t("sessionsView.noCheckpoints")}

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2522,6 +2522,14 @@ openclaw-chat-session-rail {
   color: var(--text);
 }
 
+.data-table-sort-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+
 .data-table-sort-icon {
   display: inline-flex;
   vertical-align: middle;


### PR DESCRIPTION
## What Problem This Solves

Fixes three independent accessibility failures in the default Sessions/Threads workflow:

1. The **Key**, **Kind**, **Updated**, and **Tokens** sort headers were pointer-only, and their active ascending/descending state was not exposed to assistive technology.
2. Session-operation/list failures and expanded-session checkpoint failures were rendered without a screen-reader alert.
3. Every checkbox that can lead to destructive bulk deletion exposed the same generic accessible name, making the selected target indistinguishable.

## Root Cause and Fix Ownership

The canonical Sessions view owns the missing table and alert semantics; the Sessions page continues to own sorting state, Gateway calls, and destructive actions.

- Nest a native keyboard-operable `button` within each existing sortable table header.
- Keep the original click handler on the complete padded header, allowing native button events to bubble exactly once without shrinking the pointer/touch target.
- Expose `aria-sort="ascending"` or `aria-sort="descending"` only on the actively sorted header.
- Mark both existing failure-owning surfaces with `role="alert"`.
- Include the canonical unique session key in each destructive-selection checkbox's accessible name.

No authorization, session mutation, sorting policy, pagination, persistence, configuration, Gateway protocol, or public SDK contract changes.

## Exact-Head Baseline and Regression Proof

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact reviewed PR head: `ed6f814c6d428f1f901a748f336fd4334553e6f8`.
- Frozen baseline Sessions owner: **6 intended regression failures**, with 44 existing cases still green.
- Frozen baseline actual Chromium + mocked Gateway: **2 intended failures**, proving missing keyboard sorting and an unannounced rejected Gateway operation.

### Targeted Sessions Owner Proof

```text
node scripts/run-vitest.mjs \
  ui/src/pages/sessions/view.test.ts \
  ui/src/pages/sessions/sessions-page.test.ts \
  --reporter=dot

Test Files  2 passed
Tests       75 passed
```

The owner suite independently covers native activation for all four sort columns, active-only sort direction, preserving the entire header click target without double activation, Sessions-page and checkpoint alert ownership, and unique canonical checkbox labels.

### Actual Chromium + Mocked-Gateway User Proof

```text
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=<installed-Chromium-or-Google-Chrome> \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner \
  ui/src/e2e/session-management.groups.e2e.test.ts \
  --testNamePattern 'sorts threads from the keyboard|shows a rejected Sessions-page custom group' \
  --reporter=dot

Test Files  1 passed
Tests       2 passed | 8 intentionally filtered out
```

The first browser scenario verifies real **Space** and **Enter** input, ascending/descending `aria-sort`, one transition per interaction, a click on the original far-right padded table-header area, and distinct accessible names for both destructive-selection checkboxes. The second scenario sends a real mocked-Gateway rejection and verifies that the existing failure is exposed as an accessible alert.

The complete Chromium sibling file also previously passed **10/10** on the same frozen-base candidate before the final reviewer-requested pointer-target refinement. The final refined candidate separately passed the exact **2/2** affected Chromium scenarios and **75/75** owner tests.

### Additional Exact-Head Review

- Focused formatting, changed CSS stylelint, changed TypeScript boundary lint, and `git diff --check`: **passed**.
- Genuine `gpt-5.6-sol` high-reasoning structured Codex review with `--max-priority P3` and official TruffleHog: **clean**, zero P0/P1/P2/P3 findings, confidence **0.94**.
- Independent complete-owner, caller, sibling, CSS, and real-browser review on exact SHA: **clean through P3**.
- Production change: **+16/-5 lines** across the two existing presentation owners; tests add **192** lines and remove **1** line.
- The final exact proof used the approved trusted local focused fallback after a previous owned remote check orphaned its lease lock. That Testbox was stopped and independently verified completed before the final commit.

## ClawSweeper Rank-Up / Merge Checklist

- [x] Read the completed exact-head ClawSweeper review: **no findings**, proof sufficient, owner boundary confirmed.
- [x] Address its concern about preserving the full sortable-header pointer target with both unit proof and an authentic far-right Chromium click.
- [x] Confirm the reported "persistent data model" signals refer to browser/test serialized fixtures and rendered UI semantics only: **this PR changes no SQLite schema, migration, persisted configuration, or durable session state**.
- [ ] If landing onto a different merge result, rerun the targeted **Sessions owner suites** and **actual Chromium mocked-Gateway scenarios** above against that exact final merge result before merging. The existing results prove the exact PR head, not a future merge commit.
- [ ] Read the newest ClawSweeper comment again after its currently running fresh review finishes, and apply or explicitly waive any new rank-up move.
