### PR TITLE
fix(telegram): enforce recursive rich-message transport limits

### DIFF
--- a/extensions/telegram/src/rich-block-split.ts
+++ b/extensions/telegram/src/rich-block-split.ts
@@ -189,11 +189,15 @@ function splitOversizedRichBlock(block: InputRichBlock, limits: RichBlockLimits)
       return pieces.map((inner) => ({ ...block, blocks: inner }));
     }
     const { caption, ...album } = block;
-    return pieces.map((inner, index) =>
-      index === 0 && caption !== undefined
-        ? { ...album, blocks: inner, caption }
-        : { ...album, blocks: inner },
-    );
+    const albumPieces: InputRichBlock[] = [];
+    for (const [index, inner] of pieces.entries()) {
+      albumPieces.push(
+        index === 0 && caption !== undefined
+          ? { ...album, blocks: inner, caption }
+          : { ...album, blocks: inner },
+      );
+    }
+    return albumPieces;
   }
   if (block.type === "table") {
     // Row-splitting a table with rowspans would strand spans across messages;

--- a/extensions/telegram/src/rich-block-split.ts
+++ b/extensions/telegram/src/rich-block-split.ts
@@ -132,10 +132,7 @@ function splitRichTextByChars(text: RichText, limit: number): RichText[] {
   return pieces;
 }
 
-function splitOversizedRichBlock(
-  block: InputRichBlock,
-  limits: RichBlockLimits,
-): InputRichBlock[] {
+function splitOversizedRichBlock(block: InputRichBlock, limits: RichBlockLimits): InputRichBlock[] {
   const { textLimit, blockLimit } = limits;
   if (!exceedsRichBlockLimits(measureRichBlocks([block]), limits)) {
     return [block];

--- a/extensions/telegram/src/rich-block-split.ts
+++ b/extensions/telegram/src/rich-block-split.ts
@@ -3,6 +3,7 @@
 import {
   countInputRichBlockChars,
   countInputRichBlockMedia,
+  countInputRichBlocks,
   countRichTextChars,
   normalizeRichText,
   type InputRichBlock,
@@ -11,6 +12,35 @@ import {
   type RichText,
 } from "./rich-block-model.js";
 import { splitTelegramPlainTextChunks, surrogateSafeChunkEnd } from "./rich-plain-fallback.js";
+
+const TELEGRAM_RICH_MEDIA_LIMIT = 50;
+
+type RichBlockBudget = { chars: number; blocks: number; media: number };
+type RichBlockLimits = { textLimit: number; blockLimit: number };
+
+function measureRichBlocks(blocks: readonly InputRichBlock[]): RichBlockBudget {
+  return {
+    chars: blocks.reduce((total, block) => total + countInputRichBlockChars(block), 0),
+    blocks: countInputRichBlocks(blocks),
+    media: blocks.reduce((total, block) => total + countInputRichBlockMedia(block), 0),
+  };
+}
+
+function addRichBlockBudget(left: RichBlockBudget, right: RichBlockBudget): RichBlockBudget {
+  return {
+    chars: left.chars + right.chars,
+    blocks: left.blocks + right.blocks,
+    media: left.media + right.media,
+  };
+}
+
+function exceedsRichBlockLimits(size: RichBlockBudget, limits: RichBlockLimits): boolean {
+  return (
+    size.chars > limits.textLimit ||
+    size.blocks > limits.blockLimit ||
+    size.media > TELEGRAM_RICH_MEDIA_LIMIT
+  );
+}
 
 type RichTextStyleWrap =
   | "bold"
@@ -102,8 +132,12 @@ function splitRichTextByChars(text: RichText, limit: number): RichText[] {
   return pieces;
 }
 
-function splitOversizedRichBlock(block: InputRichBlock, textLimit: number): InputRichBlock[] {
-  if (countInputRichBlockChars(block) <= textLimit) {
+function splitOversizedRichBlock(
+  block: InputRichBlock,
+  limits: RichBlockLimits,
+): InputRichBlock[] {
+  const { textLimit, blockLimit } = limits;
+  if (!exceedsRichBlockLimits(measureRichBlocks([block]), limits)) {
     return [block];
   }
   if (block.type === "pre") {
@@ -119,16 +153,49 @@ function splitOversizedRichBlock(block: InputRichBlock, textLimit: number): Inpu
         : { type: "paragraph", text: piece },
     );
   }
-  if (block.type === "blockquote") {
-    // Reserve the credit's chars while splitting the body, then attach the
-    // credit to the final piece only (attribution belongs at the quote's end).
-    const creditChars = countRichTextChars(block.credit ?? "");
-    const innerLimit = Math.max(1, textLimit - creditChars);
-    const pieces = splitTelegramRichBlocks(block.blocks, { textLimit: innerLimit });
+  if (
+    block.type === "blockquote" ||
+    block.type === "details" ||
+    block.type === "collage" ||
+    block.type === "slideshow"
+  ) {
+    const wrapperChars =
+      block.type === "blockquote"
+        ? countRichTextChars(block.credit ?? "")
+        : block.type === "details"
+          ? countRichTextChars(block.summary)
+          : countRichTextChars(block.caption?.text ?? "") +
+            countRichTextChars(block.caption?.credit ?? "");
+    const remainingText = textLimit - wrapperChars;
+    if (
+      block.blocks.length === 0 ||
+      remainingText < 0 ||
+      (remainingText === 0 && block.blocks.some((child) => countInputRichBlockChars(child) > 0))
+    ) {
+      // Wrapper text cannot be divided without losing its owner; the existing
+      // plain fallback handles this irreducibly oversized semantic unit.
+      return [block];
+    }
+    const pieces = splitTelegramRichBlocks(block.blocks, {
+      textLimit: Math.max(1, remainingText),
+      blockLimit: Math.max(1, blockLimit - 1),
+    });
+    if (block.type === "blockquote") {
+      // Attribution belongs at the quote's end, so emit the credit only once.
+      return pieces.map((inner, index) =>
+        index === pieces.length - 1 && block.credit !== undefined
+          ? { type: "blockquote", blocks: inner, credit: block.credit }
+          : { type: "blockquote", blocks: inner },
+      );
+    }
+    if (block.type === "details") {
+      return pieces.map((inner) => ({ ...block, blocks: inner }));
+    }
+    const { caption, ...album } = block;
     return pieces.map((inner, index) =>
-      index === pieces.length - 1 && block.credit !== undefined
-        ? { type: "blockquote", blocks: inner, credit: block.credit }
-        : { type: "blockquote", blocks: inner },
+      index === 0 && caption !== undefined
+        ? { ...album, blocks: inner, caption }
+        : { ...album, blocks: inner },
     );
   }
   if (block.type === "table") {
@@ -151,7 +218,7 @@ function splitOversizedRichBlock(block: InputRichBlock, textLimit: number): Inpu
     let chars = countRichTextChars(caption ?? "");
     for (const row of block.cells) {
       const rowChars = row.reduce((total, cell) => total + countRichTextChars(cell.text ?? ""), 0);
-      if (rows.length > 0 && chars + rowChars > textLimit) {
+      if (rows.length > 0 && (chars + rowChars > textLimit || rows.length + 2 > blockLimit)) {
         pushPiece(rows);
         rows = [];
         chars = 0;
@@ -167,27 +234,26 @@ function splitOversizedRichBlock(block: InputRichBlock, textLimit: number): Inpu
   if (block.type === "list") {
     const pieces: InputRichBlock[] = [];
     let items: InputRichBlockListItem[] = [];
-    let chars = 0;
+    let size: RichBlockBudget = { chars: 0, blocks: 1, media: 0 };
     for (const item of block.items) {
-      const itemChars = item.blocks.reduce(
-        (total, child) => total + countInputRichBlockChars(child),
-        0,
-      );
-      if (items.length > 0 && chars + itemChars > textLimit) {
+      const measured = measureRichBlocks(item.blocks);
+      const itemSize = { ...measured, blocks: measured.blocks + 1 };
+      const nextSize = addRichBlockBudget(size, itemSize);
+      if (items.length > 0 && exceedsRichBlockLimits(nextSize, limits)) {
         pieces.push({ type: "list", items });
         items = [];
-        chars = 0;
+        size = { chars: 0, blocks: 1, media: 0 };
       }
       items.push(item);
-      chars += itemChars;
+      size = addRichBlockBudget(size, itemSize);
     }
     if (items.length > 0) {
       pieces.push({ type: "list", items });
     }
     return pieces;
   }
-  // Details, media, and remaining container blocks stay atomic; a genuinely
-  // oversized one degrades via the RICH_MESSAGE_TEXT_TOO_LONG plain fallback.
+  // Remaining atomic blocks stay intact and degrade through the existing
+  // structural-error plain fallback if Telegram rejects them.
   return [block];
 }
 
@@ -203,34 +269,26 @@ export function splitTelegramRichBlocks(
   if (blocks.length === 0) {
     return [];
   }
-  const expanded = blocks.flatMap((block) => splitOversizedRichBlock(block, textLimit));
+  const limits = { textLimit, blockLimit };
+  const expanded = blocks.flatMap((block) => splitOversizedRichBlock(block, limits));
   const chunks: InputRichBlock[][] = [];
   let current: InputRichBlock[] = [];
-  let currentChars = 0;
-  // Live-verified message cap: >50 media elements → RICH_MESSAGE_MEDIA_TOO_MANY.
-  const mediaLimit = 50;
-  let currentMedia = 0;
+  let size: RichBlockBudget = { chars: 0, blocks: 0, media: 0 };
 
   const flush = () => {
     if (current.length > 0) {
       chunks.push(current);
       current = [];
-      currentChars = 0;
-      currentMedia = 0;
+      size = { chars: 0, blocks: 0, media: 0 };
     }
   };
   for (const block of expanded) {
-    const chars = countInputRichBlockChars(block);
-    const media = countInputRichBlockMedia(block);
-    const wouldExceedBlocks = current.length >= blockLimit;
-    const wouldExceedChars = current.length > 0 && currentChars + chars > textLimit;
-    const wouldExceedMedia = current.length > 0 && currentMedia + media > mediaLimit;
-    if (wouldExceedBlocks || wouldExceedChars || wouldExceedMedia) {
+    const blockSize = measureRichBlocks([block]);
+    if (current.length > 0 && exceedsRichBlockLimits(addRichBlockBudget(size, blockSize), limits)) {
       flush();
     }
     current.push(block);
-    currentChars += chars;
-    currentMedia += media;
+    size = addRichBlockBudget(size, blockSize);
   }
   flush();
   return chunks;

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -518,15 +518,17 @@ describe("splitTelegramRichBlocks", () => {
       expect(chunks).toHaveLength(2);
       expect(chunks.every((chunk) => countInputRichBlocks(chunk) <= 5)).toBe(true);
       expect(
-        chunks.flat().flatMap((part) =>
-          part.type === "blockquote" || part.type === "details" ? part.blocks : [],
-        ),
+        chunks
+          .flat()
+          .flatMap((part) =>
+            part.type === "blockquote" || part.type === "details" ? part.blocks : [],
+          ),
       ).toEqual(children);
       if (type === "blockquote") {
         expect(
-          chunks.flat().flatMap((part) =>
-            part.type === "blockquote" && part.credit ? [part.credit] : [],
-          ),
+          chunks
+            .flat()
+            .flatMap((part) => (part.type === "blockquote" && part.credit ? [part.credit] : [])),
         ).toEqual(["Author"]);
       }
     },
@@ -583,8 +585,7 @@ describe("splitTelegramRichBlocks", () => {
     ]);
     expect(
       mediaChunks.every(
-        (chunk) =>
-          chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0) <= 50,
+        (chunk) => chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0) <= 50,
       ),
     ).toBe(true);
     expect(albums.flatMap((album) => album.blocks)).toEqual(collage.blocks);

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { markdownToTelegramHtml } from "./format.js";
 import {
   countInputRichBlockChars,
+  countInputRichBlockMedia,
+  countInputRichBlocks,
   inputRichBlocksToPlainText,
   type InputRichBlock,
   type RichText,
@@ -227,26 +229,6 @@ describe("markdownToTelegramRichBlocks", () => {
     }
     expect(hasStyle(paragraph.text, "bold")).toBe(true);
     expect(collectUrls(paragraph.text)).toEqual(["https://example.com"]);
-  });
-
-  it("degrades native lists when their nested block count would exceed 500", () => {
-    const markdown = Array.from({ length: 251 }, (_, index) => `- item ${index + 1}`).join("\n");
-    const rendered = markdownToTelegramRichBlocks(markdown);
-    expect(rendered.degradationReasons).toEqual(["list-limit"]);
-    expect(rendered.blocks).toHaveLength(1);
-    expect(rendered.blocks[0]?.type).toBe("paragraph");
-    expect(rendered.plainText).toContain("• item 251");
-  });
-
-  it("degrades lists when surrounding blocks push the message over 500 blocks", () => {
-    const list = Array.from({ length: 200 }, (_, index) => `- item ${index + 1}`).join("\n");
-    const paragraphs = Array.from({ length: 100 }, (_, index) => `paragraph ${index + 1}`).join(
-      "\n\n",
-    );
-    const rendered = markdownToTelegramRichBlocks(`${list}\n\n${paragraphs}`);
-    expect(rendered.degradationReasons).toEqual(["list-limit"]);
-    expect(rendered.blocks.every((block) => block.type !== "list")).toBe(true);
-    expect(rendered.plainText).toContain("paragraph 100");
   });
 
   it("degrades native lists beyond 16 nesting levels", () => {
@@ -518,9 +500,121 @@ describe("splitTelegramRichBlocks", () => {
       expect(chars).toBeLessThanOrEqual(64);
     }
   });
+
+  it.each(["blockquote", "details"] as const)(
+    "enforces recursive block limits for %s children",
+    (type) => {
+      const children: InputRichBlock[] = Array.from({ length: 6 }, (_, index) => ({
+        type: "paragraph",
+        text: `entry ${index}`,
+      }));
+      const block: InputRichBlock =
+        type === "blockquote"
+          ? { type, blocks: children, credit: "Author" }
+          : { type, blocks: children, summary: "Summary" };
+
+      const chunks = splitTelegramRichBlocks([block], { blockLimit: 5 });
+
+      expect(chunks).toHaveLength(2);
+      expect(chunks.every((chunk) => countInputRichBlocks(chunk) <= 5)).toBe(true);
+      expect(
+        chunks.flat().flatMap((part) =>
+          part.type === "blockquote" || part.type === "details" ? part.blocks : [],
+        ),
+      ).toEqual(children);
+      if (type === "blockquote") {
+        expect(
+          chunks.flat().flatMap((part) =>
+            part.type === "blockquote" && part.credit ? [part.credit] : [],
+          ),
+        ).toEqual(["Author"]);
+      }
+    },
+  );
+
+  it("splits lists by whole items and isolates an indivisible oversized item", () => {
+    const items = [
+      { value: 4, blocks: [{ type: "paragraph" as const, text: "first" }] },
+      {
+        value: 5,
+        has_checkbox: true as const,
+        blocks: Array.from({ length: 5 }, (_, index) => ({
+          type: "paragraph" as const,
+          text: `nested ${index}`,
+        })),
+      },
+      { value: 6, blocks: [{ type: "paragraph" as const, text: "last" }] },
+    ];
+
+    const chunks = splitTelegramRichBlocks([{ type: "list", items }], { blockLimit: 5 });
+    const lists = chunks.flat().filter((block) => block.type === "list");
+
+    expect(chunks).toHaveLength(3);
+    expect(lists.flatMap((list) => list.items)).toEqual(items);
+    expect(countInputRichBlocks(chunks[0] ?? [])).toBeLessThanOrEqual(5);
+    expect(countInputRichBlocks(chunks[1] ?? [])).toBeGreaterThan(5);
+    expect(countInputRichBlocks(chunks[2] ?? [])).toBeLessThanOrEqual(5);
+  });
+
+  it("splits table rows and album media without duplicating captions", () => {
+    const table: InputRichBlock = {
+      type: "table",
+      caption: "Table caption",
+      cells: Array.from({ length: 6 }, (_, index) => [[{ text: `row ${index}` }]]).flat(),
+    };
+    const collage: InputRichBlock = {
+      type: "collage",
+      caption: { text: "Album caption" },
+      blocks: Array.from({ length: 51 }, (_, index) => ({
+        type: "photo" as const,
+        photo: { type: "photo" as const, media: `https://example.com/${index}.jpg` },
+      })),
+    };
+
+    const tableChunks = splitTelegramRichBlocks([table], { blockLimit: 5 });
+    const mediaChunks = splitTelegramRichBlocks([collage]);
+    const tables = tableChunks.flat().filter((block) => block.type === "table");
+    const albums = mediaChunks.flat().filter((block) => block.type === "collage");
+
+    expect(tableChunks.every((chunk) => countInputRichBlocks(chunk) <= 5)).toBe(true);
+    expect(tables.flatMap((part) => part.cells)).toEqual(table.cells);
+    expect(tables.flatMap((part) => (part.caption ? [part.caption] : []))).toEqual([
+      "Table caption",
+    ]);
+    expect(
+      mediaChunks.every(
+        (chunk) =>
+          chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0) <= 50,
+      ),
+    ).toBe(true);
+    expect(albums.flatMap((album) => album.blocks)).toEqual(collage.blocks);
+    expect(albums.flatMap((album) => (album.caption ? [album.caption.text] : []))).toEqual([
+      "Album caption",
+    ]);
+  });
 });
 
 describe("rich message plan wiring", () => {
+  it("preserves ordinary ordered lists across recursive block chunks", () => {
+    const text = Array.from({ length: 250 }, (_, index) => `${index + 1}. item ${index + 1}`).join(
+      "\n",
+    );
+
+    const chunks = splitTelegramRichMessageTextChunks({ text, textLimit: 32_768 });
+    const lists = chunks
+      .flatMap((chunk) => chunk.richMessage.blocks)
+      .filter((block) => block.type === "list");
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => countInputRichBlocks(chunk.richMessage.blocks) <= 500)).toBe(
+      true,
+    );
+    expect(lists.flatMap((list) => list.items).map((item) => item.value)).toEqual(
+      Array.from({ length: 250 }, (_, index) => index + 1),
+    );
+    expect(chunks.flatMap((chunk) => chunk.degradationReasons)).toEqual([]);
+  });
+
   it("emits blocks InputRichMessage and email skip_entity_detection", () => {
     const message = buildTelegramRichMarkdown("Contact owner@example.com for help");
     if (!("blocks" in message)) {

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -13,7 +13,6 @@ import {
   type MarkdownTableMeta,
 } from "openclaw/plugin-sdk/text-chunking";
 import {
-  countInputRichBlocks,
   inputRichBlocksToPlainText,
   maxInputRichBlockNesting,
   normalizeRichText,
@@ -647,10 +646,7 @@ export function markdownToTelegramRichBlocks(
   const hasMarkdownLists = segments.some((segment) => segment.kind === "list");
   const flattenedSegments = segments.filter((segment) => segment.kind !== "list");
   let blocks = emitSegments(ir, segments, 0, ir.text.length, degradationReasons);
-  if (
-    hasMarkdownLists &&
-    (countInputRichBlocks(blocks) > 500 || maxInputRichBlockNesting(blocks) > 16)
-  ) {
+  if (hasMarkdownLists && maxInputRichBlockNesting(blocks) > 16) {
     degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
     degradationReasons.add("list-limit");
     blocks = emitSegments(ir, flattenedSegments, 0, ir.text.length, degradationReasons);

--- a/extensions/telegram/src/rich-plain-fallback.ts
+++ b/extensions/telegram/src/rich-plain-fallback.ts
@@ -10,7 +10,7 @@ const RICH_ENTITY_INVALID_RE = /RICH_MESSAGE_[A-Z_]+_INVALID/i;
 const RICH_CONTENT_REQUIRED_RE = /RICH_MESSAGE_CONTENT_REQUIRED/i;
 const EMPTY_TEXT_RE = /message text is empty|text must be non-empty/i;
 // Structural-limit rejections, live-verified against Bot API 10.2 (2026-07-15):
-// >500 top-level blocks, >16 depth, oversized text, >50 media, >20 table cols.
+// >500 recursively counted blocks, >16 depth, oversized text, >50 media, >20 table cols.
 const RICH_STRUCTURE_INVALID_RE =
   /RICH_MESSAGE_(?:BLOCKS_TOO_MANY|DEPTH_INVALID|TEXT_TOO_LONG|MEDIA_TOO_MANY|TABLE_COLS_TOO_MANY)/i;
 const PARSE_ERR_RE =

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -110,11 +110,11 @@ type RichRawTextTestApi = Omit<TelegramApiOverride, "raw" | "sendMessage"> & {
   ) => Promise<unknown>;
 };
 
-function richTextForTest(richMessage: {
-  blocks?: InputRichBlock[];
-  markdown?: string;
-  html?: string;
-}): string {
+type RichMessageTestPayload = Parameters<
+  NonNullable<NonNullable<RichRawTextTestApi["raw"]>["sendRichMessage"]>
+>[0]["rich_message"];
+
+function richTextForTest(richMessage: RichMessageTestPayload): string {
   if (richMessage.blocks) {
     return inputRichBlocksToPlainText(richMessage.blocks);
   }
@@ -1424,10 +1424,9 @@ describe("sendMessageTelegram", () => {
 
   it("keeps recursive list and album payloads within Telegram transport limits", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
-    const list = Array.from(
-      { length: 250 },
-      (_, index) => `${index + 1}. item ${index + 1}`,
-    ).join("\n");
+    const list = Array.from({ length: 250 }, (_, index) => `${index + 1}. item ${index + 1}`).join(
+      "\n",
+    );
     const photos = Array.from(
       { length: 51 },
       (_, index) => `<img src="https://example.com/${index}.jpg"/>`,
@@ -1442,7 +1441,8 @@ describe("sendMessageTelegram", () => {
       },
     );
 
-    const requests = botRawApi.sendRichMessage.mock.calls.map((call) => call[0]?.rich_message);
+    const requests: Array<RichMessageTestPayload | undefined> =
+      botRawApi.sendRichMessage.mock.calls.map((call) => call[0]?.rich_message);
     const blocks = requests.flatMap((request) => request?.blocks ?? []);
     const items = blocks.flatMap((block) => (block.type === "list" ? block.items : []));
     const albums = blocks.filter((block) => block.type === "collage");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -30,7 +30,12 @@ import {
 } from "./poll-answer-context.js";
 import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";
-import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
+import {
+  countInputRichBlockMedia,
+  countInputRichBlocks,
+  inputRichBlocksToPlainText,
+  type InputRichBlock,
+} from "./rich-block-model.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
   clearTelegramRuntimeForTest as clearTelegramRuntime,
@@ -182,7 +187,7 @@ function markdownTable(columns: number): string {
 }
 
 function countTelegramRichBlocks(blocks: readonly InputRichBlock[] | undefined): number {
-  return blocks?.length ?? 0;
+  return countInputRichBlocks(blocks ?? []);
 }
 
 beforeEach(() => {
@@ -1415,6 +1420,53 @@ describe("sendMessageTelegram", () => {
       .map((call) => inputRichBlocksToPlainText(call[0]?.rich_message.blocks ?? []))
       .join("\n");
     expect(plain).toContain("paragraph 500");
+  });
+
+  it("keeps recursive list and album payloads within Telegram transport limits", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
+    const list = Array.from(
+      { length: 250 },
+      (_, index) => `${index + 1}. item ${index + 1}`,
+    ).join("\n");
+    const photos = Array.from(
+      { length: 51 },
+      (_, index) => `<img src="https://example.com/${index}.jpg"/>`,
+    ).join("");
+
+    await sendMessageTelegram(
+      "123",
+      `${list}\n\n<tg-collage>${photos}<figcaption>Album</figcaption></tg-collage>`,
+      {
+        cfg: { channels: { telegram: { richMessages: true } } },
+        token: "tok",
+      },
+    );
+
+    const requests = botRawApi.sendRichMessage.mock.calls.map((call) => call[0]?.rich_message);
+    const blocks = requests.flatMap((request) => request?.blocks ?? []);
+    const items = blocks.flatMap((block) => (block.type === "list" ? block.items : []));
+    const albums = blocks.filter((block) => block.type === "collage");
+
+    expect(requests.length).toBeGreaterThan(1);
+    expect(requests.every((request) => countInputRichBlocks(request?.blocks ?? []) <= 500)).toBe(
+      true,
+    );
+    expect(
+      requests.every(
+        (request) =>
+          (request?.blocks ?? []).reduce(
+            (total, block) => total + countInputRichBlockMedia(block),
+            0,
+          ) <= 50,
+      ),
+    ).toBe(true);
+    expect(items.map((item) => item.value)).toEqual(
+      Array.from({ length: 250 }, (_, index) => index + 1),
+    );
+    expect(albums.flatMap((album) => album.blocks)).toHaveLength(51);
+    expect(albums.flatMap((album) => (album.caption ? [album.caption.text] : []))).toEqual([
+      "Album",
+    ]);
   });
 
   it("applies rich entity detection skip to every chunk of the document", async () => {


### PR DESCRIPTION
## What Problem This Solves

Telegram counts rich-message wrappers, list items, table rows, nested blocks, and media recursively. The shared splitter on `main` counted only top-level blocks and admitted a single oversized media container, so otherwise valid rich replies could reach Telegram above its 500-block or 50-media transport limits and be rejected.

## Why This Change Was Made

This rewrite makes `splitTelegramRichBlocks` the one transport-limit owner. It measures the existing typed block model recursively, partitions quotes, details, whole list items, non-spanning table rows, collages, and slideshows without losing semantic ownership, and leaves irreducible units to the existing structural-error plain fallback. It also removes renderer-side policy that flattened ordinary Markdown lists merely because the unsplit document exceeded 500 blocks; depth-only degradation remains because pagination cannot repair excessive nesting.

The production growth is required by the Telegram transport ownership boundary: the splitter must preserve list metadata, quote credits, captions, row spans, ordering, and atomic fallback while enforcing three independent wire budgets.

## User Impact

Large nested Telegram replies are planned as valid rich-message pages instead of being rejected or unnecessarily flattened. Ordered/checklist items remain whole, table and album captions appear once, quote attribution stays on the final fragment, and indivisible content still degrades through the existing readable plain-text path.

## Evidence

- Current-main defect: the old splitter accepted text-small nested containers, counted only top-level chunks, and allowed a sole 51-media wrapper. The canonical recursive counters already existed in `rich-block-model.ts`.
- Pinned dependency contract: grammY 1.45.1 resolves `@grammyjs/types` 4.0.0, whose rich-message contract specifies 500 recursively counted blocks/list items/table rows/quotes/details, 16 nesting levels, and 50 media total. Telegram Bot API 10.2 documents the same limits.
- Red proof: restoring the old top-level decisions produced 5 failed / 43 passed focused tests.
- Green proof: `node scripts/run-vitest.mjs extensions/telegram/src/rich-blocks.test.ts extensions/telegram/src/send.test.ts` passed 285/285 tests; the final splitter/transport selection passed 11/11.
- `node scripts/check-changed.mjs -- <five changed paths>` passed every selected format, typecheck, lint, boundary, storage, and import-cycle check on Testbox `tbx_01kzmc9gjc3jwgvrf03hetv30q`; Actions run https://github.com/openclaw/openclaw/actions/runs/31340959611.
- Fresh Codex autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Production/test delta: production +100/-45 (net +55); tests +174/-27 (net +147).
- ClawSweeper has no actionable findings. Its optional rank-up move to tighten the description is addressed by the current problem/implementation/proof/risk detail.
- Known gap: no new live Telegram/Desktop capture was recorded on this head. Deterministic transport-boundary proof covers the changed budget owner; exact-head CI remains required before merge.
