### PR TITLE
fix(telegram): preserve visible voice-privacy fallback

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements delivery.replies behavior.
-import { type Bot, GrammyError } from "grammy";
+import type { Bot } from "grammy";
 import type { Message } from "grammy/types";
 import {
   createOutboundPayloadPlan,
@@ -57,7 +57,11 @@ import {
   type TelegramInputRichMessage,
 } from "../rich-message.js";
 import { isTelegramEmptyContentError } from "../rich-plain-fallback.js";
-import { isTelegramPhotoLimitError } from "../send-error-predicates.js";
+import {
+  isTelegramCaptionTooLongError,
+  isTelegramPhotoLimitError,
+  isTelegramVoiceMessagesForbiddenError,
+} from "../send-error-predicates.js";
 import { reportTelegramProviderDelivery } from "../send-outbound.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { recordSentMessage } from "../sent-message-cache.js";
@@ -75,11 +79,6 @@ import {
   sendChunkedTelegramReplyText,
   type DeliveryProgress as ReplyThreadDeliveryProgress,
 } from "./reply-threading.js";
-
-const VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
-const CAPTION_TOO_LONG_RE = /caption is too long/i;
-const GrammyErrorCtor: typeof GrammyError | undefined =
-  typeof GrammyError === "function" ? GrammyError : undefined;
 
 type DeliveryProgress = ReplyThreadDeliveryProgress & {
   deliveredCount: number;
@@ -316,20 +315,6 @@ async function deliverTextReply(params: {
   return firstDeliveredMessageId;
 }
 
-function isVoiceMessagesForbidden(err: unknown): boolean {
-  if (GrammyErrorCtor && err instanceof GrammyErrorCtor) {
-    return err.description.includes(VOICE_FORBIDDEN_MARKER);
-  }
-  return formatErrorMessage(err).includes(VOICE_FORBIDDEN_MARKER);
-}
-
-function isCaptionTooLong(err: unknown): boolean {
-  if (GrammyErrorCtor && err instanceof GrammyErrorCtor) {
-    return CAPTION_TOO_LONG_RE.test(err.description);
-  }
-  return CAPTION_TOO_LONG_RE.test(formatErrorMessage(err));
-}
-
 function resolveVoiceFallbackText(reply: ReplyPayload): string | undefined {
   if (reply.text?.trim()) {
     return reply.text;
@@ -536,9 +521,9 @@ async function deliverMediaReply(params: {
 
       await params.onVoiceRecording?.();
       try {
-        await sendVoiceMedia(mediaParams, (err) => !isVoiceMessagesForbidden(err));
+        await sendVoiceMedia(mediaParams, (err) => !isTelegramVoiceMessagesForbiddenError(err));
       } catch (voiceErr) {
-        if (isVoiceMessagesForbidden(voiceErr)) {
+        if (isTelegramVoiceMessagesForbiddenError(voiceErr)) {
           const fallbackText = resolveVoiceFallbackText(params.reply);
           if (!fallbackText || !fallbackText.trim()) {
             throw voiceErr;
@@ -564,7 +549,7 @@ async function deliverMediaReply(params: {
           markDelivered(params.progress);
           continue;
         }
-        if (isCaptionTooLong(voiceErr)) {
+        if (isTelegramCaptionTooLongError(voiceErr)) {
           logVerbose(
             "telegram sendVoice caption too long; resending voice without caption + text separately",
           );

--- a/extensions/telegram/src/send-error-predicates.ts
+++ b/extensions/telegram/src/send-error-predicates.ts
@@ -1,13 +1,24 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+const TELEGRAM_CAPTION_TOO_LONG_RE = /caption is too long/i;
 const TELEGRAM_PHOTO_LIMIT_ERROR_RE = /\b(?:PHOTO_INVALID_DIMENSIONS|PHOTO_TOO_BIG)\b/i;
+const TELEGRAM_VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
+
+function resolveTelegramErrorDescription(error: unknown): string {
+  return isRecord(error) && typeof error.description === "string"
+    ? error.description
+    : formatErrorMessage(error);
+}
+
+export function isTelegramCaptionTooLongError(error: unknown): boolean {
+  return TELEGRAM_CAPTION_TOO_LONG_RE.test(resolveTelegramErrorDescription(error));
+}
 
 export function isTelegramPhotoLimitError(error: unknown): boolean {
-  const description =
-    error && typeof error === "object" && "description" in error
-      ? (error as { description?: unknown }).description
-      : undefined;
-  return TELEGRAM_PHOTO_LIMIT_ERROR_RE.test(
-    typeof description === "string" ? description : formatErrorMessage(error),
-  );
+  return TELEGRAM_PHOTO_LIMIT_ERROR_RE.test(resolveTelegramErrorDescription(error));
+}
+
+export function isTelegramVoiceMessagesForbiddenError(error: unknown): boolean {
+  return resolveTelegramErrorDescription(error).includes(TELEGRAM_VOICE_FORBIDDEN_MARKER);
 }

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { renderTelegramHtmlText } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
@@ -35,7 +36,10 @@ import {
   withTelegramNativeQuoteFallback,
   type TelegramApiContext,
 } from "./send-context.js";
-import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
+import {
+  isTelegramPhotoLimitError,
+  isTelegramVoiceMessagesForbiddenError,
+} from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
 import { reportTelegramProviderDelivery } from "./send-outbound.js";
@@ -297,7 +301,11 @@ async function sendMessageTelegramWithContext(
         plainCaption: htmlCaption ? plainCaption : undefined,
         ...(label === "photo"
           ? { shouldLog: (error: unknown) => !isTelegramPhotoLimitError(error) }
-          : {}),
+          : label === "voice"
+            ? {
+                shouldLog: (error: unknown) => !isTelegramVoiceMessagesForbiddenError(error),
+              }
+            : {}),
         send: (requestParams, shouldLog) =>
           withTelegramNativeQuoteFallback({
             label,
@@ -325,6 +333,22 @@ async function sendMessageTelegramWithContext(
       deliveredCaption = delivery.result.deliveredCaption;
       deliveredMediaSender = delivery.sender;
     } catch (error) {
+      if (
+        mediaSender.label === "voice" &&
+        isTelegramVoiceMessagesForbiddenError(error) &&
+        text.trim()
+      ) {
+        logVerbose(
+          "telegram sendVoice forbidden by recipient privacy settings; falling back to text",
+        );
+        const textResult = await sendChunkedText(text, "voice fallback text send");
+        recordChannelActivity({
+          channel: "telegram",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+        return textResult;
+      }
       opts.promptContextProjectionPlan?.cursor.invalidate();
       throw error;
     }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3497,6 +3497,117 @@ describe("sendMessageTelegram", () => {
     expect(sendDocument).not.toHaveBeenCalled();
   });
 
+  it.each([false, true])(
+    "preserves delivery context for voice privacy fallback with rich messages %s",
+    async (richMessages) => {
+      const chatId = "-1001234567890";
+      const storePath = `/tmp/openclaw-telegram-voice-fallback-${process.pid}-${richMessages}.json`;
+      const onDeliveryResult = vi.fn();
+      const cursor = createTelegramPromptContextProjectionCursor({
+        transcriptMessageId: "assistant-voice-fallback",
+      });
+      const buttons = [[{ text: "Open", callback_data: "open" }]];
+      botApi.sendVoice.mockRejectedValueOnce({
+        description: "Bad Request: VOICE_MESSAGES_FORBIDDEN",
+      });
+      const deliveredFallback = {
+        message_id: 77,
+        message_thread_id: 271,
+        chat: { id: chatId },
+      };
+      botApi.sendMessage.mockResolvedValueOnce(deliveredFallback);
+      botRawApi.sendRichMessage.mockResolvedValueOnce(deliveredFallback);
+      mockLoadedMedia({
+        buffer: Buffer.from("voice"),
+        contentType: "audio/ogg",
+        fileName: "note.ogg",
+      });
+
+      const result = await sendMessageTelegram(chatId, "Hello **there**", {
+        cfg: {
+          channels: { telegram: { richMessages } },
+          session: { store: storePath },
+        },
+        token: "tok",
+        mediaUrl: "https://example.com/note.ogg",
+        asVoice: true,
+        messageThreadId: 271,
+        replyToMessageId: 500,
+        buttons,
+        silent: true,
+        onDeliveryResult,
+        promptContextProjectionPlan: { cursor, finalPart: true },
+      });
+
+      expect(botApi.sendVoice).toHaveBeenCalledOnce();
+      const fallback = richMessages ? botRawApi.sendRichMessage : botApi.sendMessage;
+      const unusedFallback = richMessages ? botApi.sendMessage : botRawApi.sendRichMessage;
+      expect(fallback).toHaveBeenCalledOnce();
+      expect(unusedFallback).not.toHaveBeenCalled();
+      const fallbackOptions = richMessages
+        ? botRawApi.sendRichMessage.mock.calls[0]?.[0]
+        : botApi.sendMessage.mock.calls[0]?.[2];
+      expect(fallbackOptions).toEqual(
+        expect.objectContaining({
+          message_thread_id: 271,
+          disable_notification: true,
+          ...(richMessages
+            ? { reply_parameters: { message_id: 500, allow_sending_without_reply: true } }
+            : { reply_to_message_id: 500, allow_sending_without_reply: true }),
+          reply_markup: { inline_keyboard: buttons },
+        }),
+      );
+      expect(onDeliveryResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "77",
+          chatId,
+          meta: { telegramDeliveredText: "Hello there", telegramHasInlineKeyboard: true },
+          receipt: expect.objectContaining({
+            primaryPlatformMessageId: "77",
+            platformMessageIds: ["77"],
+            threadId: "271",
+          }),
+        }),
+      );
+      const cached = await createTelegramMessageCache({
+        scope: resolveTelegramMessageCacheScope(storePath),
+      }).get({ accountId: "default", chatId, messageId: "77" });
+      expect(cached?.promptContextProjectionMarker).toEqual({
+        kind: "valid",
+        projection: { ...cursor.source, partIndex: 0, finalPart: true },
+      });
+      expect(result).toMatchObject({
+        messageId: "77",
+        chatId,
+        receipt: { primaryPlatformMessageId: "77", platformMessageIds: ["77"], threadId: "271" },
+      });
+    },
+  );
+
+  it.each([
+    { name: "without visible text", text: "   ", reason: "VOICE_MESSAGES_FORBIDDEN" },
+    { name: "for unrelated errors", text: "Visible", reason: "VOICE_MESSAGE_INVALID" },
+  ])("rethrows voice failure $name", async ({ text, reason }) => {
+    const voiceError = new Error(`Bad Request: ${reason}`);
+    botApi.sendVoice.mockRejectedValueOnce(voiceError);
+    mockLoadedMedia({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      fileName: "note.ogg",
+    });
+
+    await expect(
+      sendMessageTelegram("123", text, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        mediaUrl: "https://example.com/note.ogg",
+        asVoice: true,
+      }),
+    ).rejects.toBe(voiceError);
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "images",


### PR DESCRIPTION
## What problem this solves

Telegram can reject a voice note with `VOICE_MESSAGES_FORBIDDEN` while the same outbound payload already contains useful visible text. Streaming replies recovered to text; durable/direct sends threw the error and delivered nothing.

## Root fix

- Classify Telegram error descriptions in one shared predicate owner.
- Recover only the durable voice + exact privacy-error + nonblank-text case through the existing chunked text sender.
- Preserve topic, reply, buttons, silent delivery, receipts, activity, and prompt projection.
- Keep voice-only sends and unrelated errors fail-loud.
- Remove the streaming funnel's duplicate grammY-specific voice/caption parsing.

No config/default, protocol, SDK, auth, or persistence changes. Production delta: `+53/-33` (net `+20`) for the missing capability/owner boundary; tests: `+111/-0`.

## Verification

- Exact head: `0954d35edd747cbc9a2412b11f5fa01aa8e36e7b`; validated from main base `b8b878ed334fe0358e38deb9f489a47516ac72d7`.
- OpenClaw Testbox: focused Telegram suites `335/335`; touched-file oxlint `0` warnings/errors; `tsgo:extensions` and `tsgo:test:extensions` pass. [Run](https://github.com/openclaw/openclaw/actions/runs/31140249839)
- Full changed gate reached an unrelated main-baseline max-lines ratchet for `src/security/install-policy.ts`; the direct touched lanes above pass. [Run](https://github.com/openclaw/openclaw/actions/runs/31140097788)
- Distill: one predicate owner; no generic media-or-text abstraction.
- Greybeard: cold error path; no media reload, retry loop, cache, or hot-path work.
- Codex P0-P3 autoreview: clean, no findings, confidence `0.94`.

Real Telegram userbot proof used the dedicated QA account and the exact built head. A mock Bot API boundary rejected `sendVoice` with the real Telegram marker; fallback `sendMessage` continued to Telegram's live API. The real user recorder observed exactly one visible text message and no voice/error duplicate.

```json
{
  "passed": true,
  "sourceHead": "0954d35edd747cbc9a2412b11f5fa01aa8e36e7b",
  "injectedBotApiError": "VOICE_MESSAGES_FORBIDDEN",
  "fallbackOperation": "sendMessage",
  "realUserObservation": {
    "kind": "message",
    "contentType": "messageText",
    "botApiMessageId": 569,
    "text": "OPENCLAW_E2E_VOICE_PRIVACY_117022",
    "sutMessageCount": 1
  },
  "duplicateVoiceCount": 0,
  "visibleErrorCount": 0
}
```
