### PR TITLE
fix(feishu): unify truthful delivery and media ownership

### DIFF
--- a/extensions/feishu/src/dm-delivery-loopback.test.ts
+++ b/extensions/feishu/src/dm-delivery-loopback.test.ts
@@ -183,7 +183,10 @@ describe("Feishu DM delivery over the real Lark SDK", () => {
         sendMediaFeishu({
           cfg,
           to: "chat:oc_dm_conversation",
-          mediaBuffer: Buffer.from("loopback image"),
+          mediaBuffer: Buffer.from(
+            "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de",
+            "hex",
+          ),
           fileName: "loopback.png",
         }),
       ).resolves.toMatchObject({ chatId: "oc_dm_conversation" });

--- a/extensions/feishu/src/interactive-message-content.ts
+++ b/extensions/feishu/src/interactive-message-content.ts
@@ -1,0 +1,118 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { parsePostContent } from "./post.js";
+
+const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
+const POST_FALLBACK_TEXT = "[Rich text message]";
+
+function normalizeCardTemplateVariable(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readCardTemplateVariables(parsed: Record<string, unknown>): Map<string, string> {
+  const variables = new Map<string, string>();
+  for (const source of [parsed.template_variable, parsed.template_variables]) {
+    if (!isRecord(source)) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(source)) {
+      const normalized = normalizeCardTemplateVariable(value);
+      if (normalized !== undefined) {
+        variables.set(key, normalized);
+      }
+    }
+  }
+  return variables;
+}
+
+function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
+  if (variables.size === 0) {
+    return text;
+  }
+  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
+    const variableName = typeof a === "string" ? a : b;
+    return variables.get(variableName) ?? match;
+  });
+}
+
+function extractInteractiveElementText(
+  element: unknown,
+  variables: Map<string, string>,
+): string | undefined {
+  if (!isRecord(element)) {
+    return undefined;
+  }
+  const tag = typeof element.tag === "string" ? element.tag : "";
+  const text = isRecord(element.text) ? element.text : undefined;
+
+  if (tag === "div" && typeof text?.content === "string") {
+    return applyCardTemplateVariables(text.content, variables);
+  }
+  if ((tag === "markdown" || tag === "lark_md") && typeof element.content === "string") {
+    return applyCardTemplateVariables(element.content, variables);
+  }
+  if (tag === "plain_text" && typeof element.content === "string") {
+    return applyCardTemplateVariables(element.content, variables);
+  }
+  return undefined;
+}
+
+function extractInteractiveElementsText(
+  elements: unknown[],
+  variables: Map<string, string>,
+): string {
+  const texts: string[] = [];
+  for (const element of elements) {
+    const text = extractInteractiveElementText(element, variables);
+    if (text !== undefined) {
+      texts.push(text);
+    }
+  }
+  return texts.join("\n").trim();
+}
+
+function readInteractiveElementArrays(parsed: Record<string, unknown>): unknown[][] {
+  const body = isRecord(parsed.body) ? parsed.body : undefined;
+  const elementArrays: unknown[][] = [];
+
+  for (const candidate of [parsed.elements, body?.elements]) {
+    if (Array.isArray(candidate)) {
+      elementArrays.push(candidate);
+    }
+  }
+
+  for (const candidate of [parsed.i18n_elements, body?.i18n_elements]) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    for (const localeElements of Object.values(candidate)) {
+      if (Array.isArray(localeElements)) {
+        elementArrays.push(localeElements);
+      }
+    }
+  }
+
+  return elementArrays;
+}
+
+export function parseInteractiveCardContent(parsed: unknown): string {
+  if (!isRecord(parsed)) {
+    return INTERACTIVE_CARD_FALLBACK_TEXT;
+  }
+
+  const variables = readCardTemplateVariables(parsed);
+  for (const elements of readInteractiveElementArrays(parsed)) {
+    const text = extractInteractiveElementsText(elements, variables);
+    if (text) {
+      return text;
+    }
+  }
+
+  const postText = parsePostContent(JSON.stringify(parsed)).textContent.trim();
+  return postText && postText !== POST_FALLBACK_TEXT ? postText : INTERACTIVE_CARD_FALLBACK_TEXT;
+}

--- a/extensions/feishu/src/media-upload-contract.test.ts
+++ b/extensions/feishu/src/media-upload-contract.test.ts
@@ -91,6 +91,8 @@ describe("Feishu upload contracts", () => {
     { fileName: "diagram.png", contentType: undefined, buffer: svgImage },
     { fileName: "diagram.png", contentType: "application/octet-stream", buffer: svgImage },
     { fileName: "diagram.png", contentType: "image/png", buffer: svgImage },
+    { fileName: "diagram.heic", contentType: "image/heic", buffer: svgImage },
+    { fileName: "photo.heic", contentType: "image/heic", buffer: Buffer.from("heic image") },
     { fileName: "photo.png", contentType: "image/avif", buffer: avifImage },
     { fileName: "photo.png", contentType: undefined, buffer: avifImage },
     { fileName: "photo.png", contentType: "application/octet-stream", buffer: avifImage },
@@ -138,7 +140,6 @@ describe("Feishu upload contracts", () => {
     { fileName: "photo.heic", contentType: "image/heic", buffer: heicImage },
     { fileName: "download", contentType: "image/heic", buffer: heicImage },
     { fileName: "photo.jpg", contentType: "image/heic", buffer: heicImage },
-    { fileName: "download", contentType: "image/heic", buffer: Buffer.from("heic image") },
   ])("uploads supported HEIC image $fileName as a native image", async (media) => {
     mocks.loadWebMedia.mockResolvedValueOnce({
       buffer: media.buffer,

--- a/extensions/feishu/src/media-upload-contract.test.ts
+++ b/extensions/feishu/src/media-upload-contract.test.ts
@@ -266,7 +266,7 @@ describe("Feishu upload contracts", () => {
     }
 
     expect(isChannelPartialDeliveryError(caught)).toBe(true);
-    if (!isChannelPartialDeliveryError(caught)) {
+    if (!(caught instanceof Error) || !isChannelPartialDeliveryError(caught)) {
       throw new Error("expected an accepted Feishu media delivery without an identity");
     }
     expect(caught.message).toBe(`${media.prefix}: no message_id returned`);

--- a/extensions/feishu/src/media-upload-contract.test.ts
+++ b/extensions/feishu/src/media-upload-contract.test.ts
@@ -1,3 +1,4 @@
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 
@@ -249,17 +250,28 @@ describe("Feishu upload contracts", () => {
   it.each([
     { name: "image", fileName: "photo.png", prefix: "Feishu image send failed" },
     { name: "file", fileName: "notes.pdf", prefix: "Feishu file send failed" },
-  ])("rejects acknowledged $name sends without a platform message identifier", async (media) => {
+  ])("retains accepted $name visibility when its platform identifier is missing", async (media) => {
     mocks.messageCreate.mockResolvedValueOnce({ code: 0, data: {} });
 
-    await expect(
-      sendMediaFeishu({
+    let caught: unknown;
+    try {
+      await sendMediaFeishu({
         cfg: emptyConfig,
         to: "user:ou_target",
         mediaBuffer: media.name === "image" ? pngImage : Buffer.from("attachment"),
         fileName: media.fileName,
-      }),
-    ).rejects.toThrow(`${media.prefix}: no message_id returned`);
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted Feishu media delivery without an identity");
+    }
+    expect(caught.message).toBe(`${media.prefix}: no message_id returned`);
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(mocks.messageCreate).toHaveBeenCalledOnce();
   });
 
   it("rejects empty image and file attachments before contacting Feishu", async () => {

--- a/extensions/feishu/src/media-upload-contract.test.ts
+++ b/extensions/feishu/src/media-upload-contract.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  resolveAccount: vi.fn(),
+  loadWebMedia: vi.fn(),
+  fileCreate: vi.fn(),
+  imageCreate: vi.fn(),
+  messageCreate: vi.fn(),
+  runFfmpeg: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({ createFeishuClient: mocks.createClient }));
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: mocks.resolveAccount,
+  resolveFeishuRuntimeAccount: mocks.resolveAccount,
+}));
+vi.mock("./targets.js", () => ({
+  normalizeFeishuTarget: () => "ou_target",
+  resolveReceiveIdType: () => "open_id",
+}));
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({ media: { loadWebMedia: mocks.loadWebMedia } }),
+}));
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
+  runFfmpeg: mocks.runFfmpeg,
+}));
+
+let sendMediaFeishu: typeof import("./media.js").sendMediaFeishu;
+const emptyConfig: ClawdbotConfig = {};
+
+function resolvedAccount(mediaMaxMb?: number) {
+  return {
+    configured: true,
+    accountId: "main",
+    config: mediaMaxMb === undefined ? {} : { mediaMaxMb },
+    appId: "app_id",
+    appSecret: "app_secret",
+    domain: "feishu",
+  };
+}
+
+function mockCallData(mock: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  return (mock.mock.calls[0]?.[0] as { data?: Record<string, unknown> } | undefined)?.data ?? {};
+}
+
+describe("Feishu upload contracts", () => {
+  beforeAll(async () => {
+    ({ sendMediaFeishu } = await import("./media.js"));
+  });
+
+  afterAll(() => {
+    for (const id of ["./client.js", "./accounts.js", "./targets.js", "./runtime.js"]) {
+      vi.doUnmock(id);
+    }
+    vi.doUnmock("openclaw/plugin-sdk/media-runtime");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveAccount.mockReturnValue(resolvedAccount());
+    mocks.createClient.mockReturnValue({
+      im: {
+        file: { create: mocks.fileCreate },
+        image: { create: mocks.imageCreate },
+        message: { create: mocks.messageCreate, reply: vi.fn() },
+      },
+    });
+    mocks.fileCreate.mockResolvedValue({ code: 0, data: { file_key: "file_1" } });
+    mocks.imageCreate.mockResolvedValue({ code: 0, data: { image_key: "image_1" } });
+    mocks.messageCreate.mockResolvedValue({ code: 0, data: { message_id: "message_1" } });
+  });
+
+  it.each([
+    { fileName: "diagram.svg", contentType: "image/svg+xml" },
+    { fileName: "photo.avif", contentType: "image/avif" },
+    { fileName: "diagram.png", contentType: "image/svg+xml" },
+    { fileName: "photo.png", contentType: "image/avif" },
+    { fileName: "photo.heic", contentType: "image/avif" },
+  ])("sends unsupported image format $contentType as a file attachment", async (media) => {
+    mocks.loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image bytes"),
+      fileName: media.fileName,
+      kind: "image",
+      contentType: media.contentType,
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: `https://example.com/${media.fileName}`,
+    });
+
+    expect(mocks.imageCreate).not.toHaveBeenCalled();
+    expect(mockCallData(mocks.fileCreate).file_type).toBe("stream");
+    expect(mockCallData(mocks.messageCreate).msg_type).toBe("file");
+  });
+
+  it("uses the supported image MIME when the filename has no recognized extension", async () => {
+    mocks.loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("png image"),
+      fileName: "download",
+      kind: "image",
+      contentType: "image/png",
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/download",
+    });
+
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+    expect(mocks.imageCreate).toHaveBeenCalledOnce();
+    expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
+  });
+
+  it.each([
+    { fileName: "photo.heic", contentType: "image/heic" },
+    { fileName: "download", contentType: "image/heic" },
+    { fileName: "photo.jpg", contentType: "image/heic" },
+  ])("uploads supported HEIC image $fileName as a native image", async (media) => {
+    mocks.loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("heic image"),
+      fileName: media.fileName,
+      kind: "image",
+      contentType: media.contentType,
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: `https://example.com/${media.fileName}`,
+    });
+
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+    expect(mocks.imageCreate).toHaveBeenCalledOnce();
+    expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
+  });
+
+  it.each(["scan.tif", "photo.heic"])(
+    "recognizes supported image filename %s",
+    async (fileName) => {
+      await sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.from("image"),
+        fileName,
+      });
+
+      expect(mocks.imageCreate).toHaveBeenCalledOnce();
+      expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
+    },
+  );
+
+  it("rejects images exceeding the platform image-upload limit before contacting Feishu", async () => {
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.alloc(10 * 1024 * 1024 + 1),
+        fileName: "oversized.png",
+      }),
+    ).rejects.toThrow("Feishu image exceeds its 10485760-byte upload limit");
+
+    expect(mocks.imageCreate).not.toHaveBeenCalled();
+    expect(mocks.messageCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects files exceeding the configured attachment limit before contacting Feishu", async () => {
+    mocks.resolveAccount.mockReturnValue(resolvedAccount(1 / (1024 * 1024)));
+
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.from("too large"),
+        fileName: "notes.pdf",
+      }),
+    ).rejects.toThrow("Feishu file exceeds its 1-byte upload limit");
+
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+    expect(mocks.messageCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized voice inputs before starting transcoding", async () => {
+    mocks.resolveAccount.mockReturnValue(resolvedAccount(1 / (1024 * 1024)));
+
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.from("oversized audio"),
+        fileName: "voice.mp3",
+        audioAsVoice: true,
+      }),
+    ).rejects.toThrow("Feishu file exceeds its 1-byte upload limit");
+
+    expect(mocks.runFfmpeg).not.toHaveBeenCalled();
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "image", fileName: "photo.png", prefix: "Feishu image send failed" },
+    { name: "file", fileName: "notes.pdf", prefix: "Feishu file send failed" },
+  ])("rejects acknowledged $name sends without a platform message identifier", async (media) => {
+    mocks.messageCreate.mockResolvedValueOnce({ code: 0, data: {} });
+
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.from("attachment"),
+        fileName: media.fileName,
+      }),
+    ).rejects.toThrow(`${media.prefix}: no message_id returned`);
+  });
+
+  it("rejects empty image and file attachments before contacting Feishu", async () => {
+    for (const fileName of ["empty.png", "empty.pdf"]) {
+      await expect(
+        sendMediaFeishu({
+          cfg: emptyConfig,
+          to: "user:ou_target",
+          mediaBuffer: Buffer.alloc(0),
+          fileName,
+        }),
+      ).rejects.toThrow("Feishu attachments cannot be empty");
+    }
+
+    expect(mocks.imageCreate).not.toHaveBeenCalled();
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/media-upload-contract.test.ts
+++ b/extensions/feishu/src/media-upload-contract.test.ts
@@ -30,6 +30,16 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
 
 let sendMediaFeishu: typeof import("./media.js").sendMediaFeishu;
 const emptyConfig: ClawdbotConfig = {};
+const pngImage = Buffer.from(
+  "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de",
+  "hex",
+);
+const svgImage = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+const avifImage = Buffer.from("00000018667479706176696600000000617669666d696631", "hex");
+const heicImage = Buffer.from("00000018667479706865696300000000686569636d696631", "hex");
+const tiffImage = Buffer.from("49492a000800000000000000", "hex");
+const jpegImage = Buffer.from("ffd8ffe000104a46494600010100000100010000ffdb0043", "hex");
+const icoImage = Buffer.from("00000100010010100000010020006804000016000000", "hex");
 
 function resolvedAccount(mediaMaxMb?: number) {
   return {
@@ -75,14 +85,20 @@ describe("Feishu upload contracts", () => {
   });
 
   it.each([
-    { fileName: "diagram.svg", contentType: "image/svg+xml" },
-    { fileName: "photo.avif", contentType: "image/avif" },
-    { fileName: "diagram.png", contentType: "image/svg+xml" },
-    { fileName: "photo.png", contentType: "image/avif" },
-    { fileName: "photo.heic", contentType: "image/avif" },
+    { fileName: "diagram.svg", contentType: "image/svg+xml", buffer: svgImage },
+    { fileName: "photo.avif", contentType: "image/avif", buffer: avifImage },
+    { fileName: "diagram.png", contentType: "image/svg+xml", buffer: svgImage },
+    { fileName: "diagram.png", contentType: undefined, buffer: svgImage },
+    { fileName: "diagram.png", contentType: "application/octet-stream", buffer: svgImage },
+    { fileName: "diagram.png", contentType: "image/png", buffer: svgImage },
+    { fileName: "photo.png", contentType: "image/avif", buffer: avifImage },
+    { fileName: "photo.png", contentType: undefined, buffer: avifImage },
+    { fileName: "photo.png", contentType: "application/octet-stream", buffer: avifImage },
+    { fileName: "photo.png", contentType: "image/png", buffer: avifImage },
+    { fileName: "photo.heic", contentType: "image/avif", buffer: avifImage },
   ])("sends unsupported image format $contentType as a file attachment", async (media) => {
     mocks.loadWebMedia.mockResolvedValueOnce({
-      buffer: Buffer.from("image bytes"),
+      buffer: media.buffer,
       fileName: media.fileName,
       kind: "image",
       contentType: media.contentType,
@@ -101,7 +117,7 @@ describe("Feishu upload contracts", () => {
 
   it("uses the supported image MIME when the filename has no recognized extension", async () => {
     mocks.loadWebMedia.mockResolvedValueOnce({
-      buffer: Buffer.from("png image"),
+      buffer: pngImage,
       fileName: "download",
       kind: "image",
       contentType: "image/png",
@@ -119,12 +135,13 @@ describe("Feishu upload contracts", () => {
   });
 
   it.each([
-    { fileName: "photo.heic", contentType: "image/heic" },
-    { fileName: "download", contentType: "image/heic" },
-    { fileName: "photo.jpg", contentType: "image/heic" },
+    { fileName: "photo.heic", contentType: "image/heic", buffer: heicImage },
+    { fileName: "download", contentType: "image/heic", buffer: heicImage },
+    { fileName: "photo.jpg", contentType: "image/heic", buffer: heicImage },
+    { fileName: "download", contentType: "image/heic", buffer: Buffer.from("heic image") },
   ])("uploads supported HEIC image $fileName as a native image", async (media) => {
     mocks.loadWebMedia.mockResolvedValueOnce({
-      buffer: Buffer.from("heic image"),
+      buffer: media.buffer,
       fileName: media.fileName,
       kind: "image",
       contentType: media.contentType,
@@ -141,27 +158,52 @@ describe("Feishu upload contracts", () => {
     expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
   });
 
-  it.each(["scan.tif", "photo.heic"])(
-    "recognizes supported image filename %s",
-    async (fileName) => {
-      await sendMediaFeishu({
-        cfg: emptyConfig,
-        to: "user:ou_target",
-        mediaBuffer: Buffer.from("image"),
-        fileName,
-      });
+  it.each([
+    { fileName: "scan.tif", buffer: tiffImage },
+    { fileName: "photo.heic", buffer: heicImage },
+    { fileName: "photo.png", buffer: pngImage },
+  ])("recognizes actual supported image bytes in $fileName", async ({ fileName, buffer }) => {
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaBuffer: buffer,
+      fileName,
+    });
 
-      expect(mocks.imageCreate).toHaveBeenCalledOnce();
-      expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
-    },
-  );
+    expect(mocks.imageCreate).toHaveBeenCalledOnce();
+    expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
+  });
+
+  it.each([
+    { fileName: "photo.bin", contentType: "image/jpg", buffer: jpegImage },
+    { fileName: "scan.bin", contentType: "image/tif", buffer: tiffImage },
+    { fileName: "icon.bin", contentType: "image/ico", buffer: icoImage },
+    { fileName: "download", contentType: "application/octet-stream", buffer: pngImage },
+  ])("routes supported image bytes with $contentType metadata natively", async (media) => {
+    mocks.loadWebMedia.mockResolvedValueOnce({
+      ...media,
+      kind: "image",
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: `https://example.com/${media.fileName}`,
+    });
+
+    expect(mocks.fileCreate).not.toHaveBeenCalled();
+    expect(mocks.imageCreate).toHaveBeenCalledOnce();
+    expect(mockCallData(mocks.messageCreate).msg_type).toBe("image");
+  });
 
   it("rejects images exceeding the platform image-upload limit before contacting Feishu", async () => {
+    const oversizedImage = Buffer.alloc(10 * 1024 * 1024 + 1);
+    pngImage.copy(oversizedImage);
     await expect(
       sendMediaFeishu({
         cfg: emptyConfig,
         to: "user:ou_target",
-        mediaBuffer: Buffer.alloc(10 * 1024 * 1024 + 1),
+        mediaBuffer: oversizedImage,
         fileName: "oversized.png",
       }),
     ).rejects.toThrow("Feishu image exceeds its 10485760-byte upload limit");
@@ -213,7 +255,7 @@ describe("Feishu upload contracts", () => {
       sendMediaFeishu({
         cfg: emptyConfig,
         to: "user:ou_target",
-        mediaBuffer: Buffer.from("attachment"),
+        mediaBuffer: media.name === "image" ? pngImage : Buffer.from("attachment"),
         fileName: media.fileName,
       }),
     ).rejects.toThrow(`${media.prefix}: no message_id returned`);

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -22,6 +22,10 @@ const messageReplyMock = vi.hoisted(() => vi.fn());
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 const emptyConfig: ClawdbotConfig = {};
+const validPngImage = Buffer.from(
+  "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de",
+  "hex",
+);
 
 vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
@@ -447,7 +451,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     await sendMediaFeishu({
       cfg: emptyConfig,
       to: "user:ou_target",
-      mediaBuffer: Buffer.from("image"),
+      mediaBuffer: validPngImage,
       fileName: "photo.png",
     });
 
@@ -475,7 +479,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     const send = sendMediaFeishu({
       cfg: emptyConfig,
       to: "user:ou_target",
-      mediaBuffer: Buffer.from("image"),
+      mediaBuffer: validPngImage,
       fileName: "photo.png",
     });
 
@@ -534,7 +538,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     const result = await sendMediaFeishu({
       cfg: emptyConfig,
       to: "user:ou_target",
-      mediaBuffer: Buffer.from("image"),
+      mediaBuffer: validPngImage,
       fileName: "photo.png",
       replyToMessageId: "om_parent",
     });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -5,7 +5,7 @@ import { Readable } from "node:stream";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
-import { mediaKindFromMime } from "openclaw/plugin-sdk/media-mime";
+import { detectMime, mediaKindFromMime, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
 import {
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
   runFfmpeg,
@@ -42,29 +42,20 @@ const FEISHU_VOICE_FILE_NAME = "voice.ogg";
 const FEISHU_VOICE_SAMPLE_RATE_HZ = 48_000;
 const FEISHU_VOICE_BITRATE = "64k";
 
-const FEISHU_SUPPORTED_IMAGE_EXTENSIONS = new Set([
-  ".jpg",
-  ".jpeg",
-  ".png",
-  ".gif",
-  ".webp",
-  ".bmp",
-  ".ico",
-  ".heic",
-  ".tif",
-  ".tiff",
-]);
 const FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES = new Set([
   "image/jpeg",
+  "image/jpg",
   "image/png",
   "image/gif",
   "image/webp",
   "image/bmp",
   "image/x-ms-bmp",
   "image/tiff",
+  "image/tif",
   // The platform accepts HEIC even though older generated SDK comments omit it.
   "image/heic",
   "image/x-icon",
+  "image/ico",
   "image/vnd.microsoft.icon",
 ]);
 
@@ -713,21 +704,23 @@ function detectFileType(
   }
 }
 
-function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?: string }): {
+async function resolveFeishuOutboundMediaKind(params: {
+  buffer: Buffer;
+  fileName: string;
+  contentType?: string;
+}): Promise<{
   fileType?: "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream";
   msgType: "image" | "file" | "audio" | "media";
-} {
-  const { fileName, contentType } = params;
+}> {
+  const { buffer, fileName, contentType } = params;
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));
-  const normalizedContentType = normalizeLowercaseStringOrEmpty(contentType?.split(";", 1)[0]);
-  const hasUnsupportedImageContentType =
-    normalizedContentType.startsWith("image/") &&
-    !FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(normalizedContentType);
-
+  const normalizedContentType = normalizeMimeType(contentType) ?? "";
+  // Never pass a filename to signature detection: an image-looking name must not
+  // disguise SVG, AVIF, documents, or unrecognized bytes as native Feishu images.
+  const detectedContentType = normalizeMimeType(await detectMime({ buffer })) ?? "";
   if (
-    !hasUnsupportedImageContentType &&
-    (FEISHU_SUPPORTED_IMAGE_EXTENSIONS.has(ext) ||
-      FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(normalizedContentType))
+    FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(detectedContentType) ||
+    (!detectedContentType && normalizedContentType === "image/heic")
   ) {
     return { msgType: "image" };
   }
@@ -1029,7 +1022,9 @@ export async function sendMediaFeishu(params: {
   name = loaded.name;
   contentType = loaded.contentType;
 
-  const loadedRouting = resolveFeishuOutboundMediaKind({ fileName: name, contentType });
+  const loadedRouting = await runBeforeFeishuMessageDispatch(() =>
+    resolveFeishuOutboundMediaKind({ buffer, fileName: name, contentType }),
+  );
   await runBeforeFeishuMessageDispatch(() =>
     assertFeishuUploadWithinEnvelope({
       buffer,
@@ -1050,7 +1045,14 @@ export async function sendMediaFeishu(params: {
   name = prepared.fileName;
   contentType = prepared.contentType;
 
-  const routing = resolveFeishuOutboundMediaKind({ fileName: name, contentType });
+  const routing =
+    prepared.buffer === loaded.buffer &&
+    prepared.fileName === loaded.name &&
+    prepared.contentType === loaded.contentType
+      ? loadedRouting
+      : await runBeforeFeishuMessageDispatch(() =>
+          resolveFeishuOutboundMediaKind({ buffer, fileName: name, contentType }),
+        );
   const voiceIntentDegradedToFile = audioAsVoice === true && routing.msgType !== "audio";
 
   await runBeforeFeishuMessageDispatch(() =>

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -36,9 +36,37 @@ import { resolveFeishuSendTarget } from "./send-target.js";
 import { sendReplyOrFallbackDirect } from "./send.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
+const FEISHU_MAX_FILE_UPLOAD_BYTES = 30 * 1024 * 1024;
+const FEISHU_MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024;
 const FEISHU_VOICE_FILE_NAME = "voice.ogg";
 const FEISHU_VOICE_SAMPLE_RATE_HZ = 48_000;
 const FEISHU_VOICE_BITRATE = "64k";
+
+const FEISHU_SUPPORTED_IMAGE_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".ico",
+  ".heic",
+  ".tif",
+  ".tiff",
+]);
+const FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/x-ms-bmp",
+  "image/tiff",
+  // The platform accepts HEIC even though older generated SDK comments omit it.
+  "image/heic",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+]);
 
 const FEISHU_TRANSCODABLE_AUDIO_EXTS = new Set([
   ".aac",
@@ -580,7 +608,7 @@ async function sendImageFeishu(params: {
     { includeNestedErrorLogId: true },
   );
   assertFeishuMessageApiSuccess(response, "Feishu image send failed");
-  return toFeishuSendResult(response, receiveId, "media");
+  return toFeishuSendResult(response, receiveId, "media", "Feishu image send failed");
 }
 
 /**
@@ -646,7 +674,12 @@ async function sendFileFeishu(params: {
     { includeNestedErrorLogId: true },
   );
   assertFeishuMessageApiSuccess(response, "Feishu file send failed");
-  return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
+  return toFeishuSendResult(
+    response,
+    receiveId,
+    resolveFeishuReceiptKind(msgType),
+    "Feishu file send failed",
+  );
 }
 
 /**
@@ -686,12 +719,16 @@ function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?
 } {
   const { fileName, contentType } = params;
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));
-  const mimeKind = mediaKindFromMime(contentType);
+  const normalizedContentType = normalizeLowercaseStringOrEmpty(contentType?.split(";", 1)[0]);
+  const hasUnsupportedImageContentType =
+    normalizedContentType.startsWith("image/") &&
+    !FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(normalizedContentType);
 
-  const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
-    ext,
-  );
-  if (isImageExt || mimeKind === "image") {
+  if (
+    !hasUnsupportedImageContentType &&
+    (FEISHU_SUPPORTED_IMAGE_EXTENSIONS.has(ext) ||
+      FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(normalizedContentType))
+  ) {
     return { msgType: "image" };
   }
 
@@ -725,6 +762,24 @@ function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?
             ? "media"
             : "file",
   };
+}
+
+function assertFeishuUploadWithinEnvelope(params: {
+  buffer: Buffer;
+  mediaMaxBytes: number;
+  msgType: "image" | "file" | "audio" | "media";
+}): void {
+  if (params.buffer.byteLength === 0) {
+    throw new Error("Feishu attachments cannot be empty");
+  }
+  const maxBytes =
+    params.msgType === "image"
+      ? Math.min(params.mediaMaxBytes, FEISHU_MAX_IMAGE_UPLOAD_BYTES)
+      : params.mediaMaxBytes;
+  if (params.buffer.byteLength > maxBytes) {
+    const label = params.msgType === "image" ? "image" : "file";
+    throw new Error(`Feishu ${label} exceeds its ${String(maxBytes)}-byte upload limit`);
+  }
 }
 
 function isFeishuNativeVoiceAudio(params: { fileName: string; contentType?: string }): boolean {
@@ -943,7 +998,10 @@ export async function sendMediaFeishu(params: {
     }
     return resolved;
   });
-  const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
+  const mediaMaxBytes = Math.min(
+    (account.config?.mediaMaxMb ?? 30) * 1024 * 1024,
+    FEISHU_MAX_FILE_UPLOAD_BYTES,
+  );
 
   let buffer: Buffer;
   let name: string;
@@ -971,6 +1029,15 @@ export async function sendMediaFeishu(params: {
   name = loaded.name;
   contentType = loaded.contentType;
 
+  const loadedRouting = resolveFeishuOutboundMediaKind({ fileName: name, contentType });
+  await runBeforeFeishuMessageDispatch(() =>
+    assertFeishuUploadWithinEnvelope({
+      buffer,
+      mediaMaxBytes,
+      msgType: loadedRouting.msgType,
+    }),
+  );
+
   const prepared = await runBeforeFeishuMessageDispatch(() =>
     prepareFeishuVoiceMedia({
       buffer,
@@ -985,6 +1052,10 @@ export async function sendMediaFeishu(params: {
 
   const routing = resolveFeishuOutboundMediaKind({ fileName: name, contentType });
   const voiceIntentDegradedToFile = audioAsVoice === true && routing.msgType !== "audio";
+
+  await runBeforeFeishuMessageDispatch(() =>
+    assertFeishuUploadWithinEnvelope({ buffer, mediaMaxBytes, msgType: routing.msgType }),
+  );
 
   if (routing.msgType === "image") {
     const { imageKey } = await runBeforeFeishuMessageDispatch(() =>

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -5,7 +5,7 @@ import { Readable } from "node:stream";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
-import { detectMime, mediaKindFromMime, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
+import { detectMime, mediaKindFromMime } from "openclaw/plugin-sdk/media-mime";
 import {
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
   runFfmpeg,
@@ -714,14 +714,10 @@ async function resolveFeishuOutboundMediaKind(params: {
 }> {
   const { buffer, fileName, contentType } = params;
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));
-  const normalizedContentType = normalizeMimeType(contentType) ?? "";
   // Never pass a filename to signature detection: an image-looking name must not
   // disguise SVG, AVIF, documents, or unrecognized bytes as native Feishu images.
-  const detectedContentType = normalizeMimeType(await detectMime({ buffer })) ?? "";
-  if (
-    FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(detectedContentType) ||
-    (!detectedContentType && normalizedContentType === "image/heic")
-  ) {
+  const detectedContentType = (await detectMime({ buffer })) ?? "";
+  if (FEISHU_SUPPORTED_IMAGE_CONTENT_TYPES.has(detectedContentType)) {
     return { msgType: "image" };
   }
 

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -454,27 +454,30 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     );
   });
 
-  it("sends an absolute existing local image path as media", async () => {
-    const { dir, file } = await createTmpImage();
-    try {
-      const result = await sendText({
-        cfg: emptyConfig,
-        to: "chat_1",
-        text: file,
-        accountId: "main",
-        mediaLocalRoots: [dir],
-      });
+  it.each([".png", ".heic", ".tif", ".tiff"])(
+    "sends an existing absolute %s image path as media instead of leaking it",
+    async (extension) => {
+      const { dir, file } = await createTmpImage(extension);
+      try {
+        const result = await sendText({
+          cfg: emptyConfig,
+          to: "chat_1",
+          text: file,
+          accountId: "main",
+          mediaLocalRoots: [dir],
+        });
 
-      expect(sendMediaCall()?.to).toBe("chat_1");
-      expect(sendMediaCall()?.mediaUrl).toBe(file);
-      expect(sendMediaCall()?.accountId).toBe("main");
-      expect(sendMediaCall()?.mediaLocalRoots).toEqual([dir]);
-      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-      expectFeishuResult(result, "media_msg");
-    } finally {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-  });
+        expect(sendMediaCall()?.to).toBe("chat_1");
+        expect(sendMediaCall()?.mediaUrl).toBe(file);
+        expect(sendMediaCall()?.accountId).toBe("main");
+        expect(sendMediaCall()?.mediaLocalRoots).toEqual([dir]);
+        expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+        expectFeishuResult(result, "media_msg");
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("keeps non-path text on the text-send path", async () => {
     await sendText({

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { verifyChannelMessageAdapterCapabilityProofs } from "openclaw/plugin-sdk/channel-outbound";
 import {
   adaptMessagePresentationForChannel,
@@ -533,6 +534,31 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       expect(sendMessageCall()?.text).toBe("Media upload failed. Please try again.");
       expect(sendMessageCall()?.text).not.toContain(file);
       expect(sendMessageCall()?.accountId).toBe("main");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not send fallback text after an accepted local-image send loses its receipt", async () => {
+    const { dir, file } = await createTmpImage();
+    const acceptedError = createChannelPartialDeliveryError(
+      new Error("Feishu image reply failed: no message_id returned"),
+      { messageIds: [], visibleReplySent: true },
+    );
+    sendMediaFeishuMock.mockRejectedValueOnce(acceptedError);
+
+    try {
+      await expect(
+        sendText({
+          cfg: emptyConfig,
+          to: "chat_1",
+          text: file,
+          accountId: "main",
+          mediaLocalRoots: [dir],
+        }),
+      ).rejects.toBe(acceptedError);
+      expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
@@ -2508,6 +2534,27 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
       "fallback_msg",
     ]);
     expectFeishuResult(result, "fallback_msg");
+  });
+
+  it("does not send fallback text after an accepted media send loses its receipt", async () => {
+    const acceptedError = createChannelPartialDeliveryError(
+      new Error("Feishu image send failed: no message_id returned"),
+      { messageIds: [], visibleReplySent: true },
+    );
+    sendMediaFeishuMock.mockRejectedValueOnce(acceptedError);
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "main",
+      }),
+    ).rejects.toBe(acceptedError);
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 
   it("does not resend successful media when delivery progress persistence fails", async () => {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,5 +1,6 @@
 // Feishu plugin module implements outbound behavior.
 import path from "node:path";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createReplyToFanout } from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
@@ -788,6 +789,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             mediaLocalRoots,
           });
         } catch (err) {
+          if (isChannelPartialDeliveryError(err)) {
+            // The image already reached Feishu; fallback text would duplicate a visible send.
+            throw err;
+          }
           console.error(`[feishu] local image path auto-send failed:`, err);
           return await sendOutboundText({
             cfg,
@@ -928,6 +933,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
         } catch (err) {
+          if (isChannelPartialDeliveryError(err)) {
+            // Accepted media is not an upload failure and must never trigger a second send.
+            throw err;
+          }
           // Log the error for debugging
           console.error(`[feishu] sendMediaFeishu failed:`, err);
           const fallbackText = await buildFeishuMediaFallbackText({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -87,9 +87,18 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   }
 
   const ext = normalizeLowercaseStringOrEmpty(path.extname(raw));
-  const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
-    ext,
-  );
+  const isImageExt = [
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".ico",
+    ".heic",
+    ".tif",
+    ".tiff",
+  ].includes(ext);
   if (!isImageExt) {
     return null;
   }

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1,6 +1,10 @@
 // Feishu tests cover reply dispatcher plugin behavior.
 import os from "node:os";
 import path from "node:path";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StreamingSessionStub = {
@@ -1582,6 +1586,72 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(error).toBe(marker);
   });
+
+  it("never sends media fallback text after an accepted attachment loses its receipt", async () => {
+    useNonStreamingAutoAccount();
+    const acceptedError = createChannelPartialDeliveryError(
+      new Error("Feishu image send failed: no message_id returned"),
+      { messageIds: [], visibleReplySent: true },
+    );
+    sendMediaFeishuMock.mockRejectedValueOnce(acceptedError);
+    const { result, options } = createDispatcherHarness();
+
+    const error = await options
+      .deliver(
+        {
+          text: "caption that must not be duplicated",
+          mediaUrl: "https://example.com/reply.mp3",
+          audioAsVoice: true,
+        },
+        { kind: "final" },
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState().visibleReplySent).toBe(true);
+    await expect(result.ensureNoVisibleReplyFallback("accepted-no-id")).resolves.toBe(false);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      kind: "text",
+      text: "already accepted",
+      provider: sendMessageFeishuMock,
+    },
+    {
+      kind: "card",
+      text: "| first | second |\n| - | - |",
+      provider: sendStructuredCardFeishuMock,
+    },
+  ])(
+    "never sends no-visible fallback after an accepted $kind reply loses its receipt",
+    async ({ text, provider }) => {
+      useNonStreamingAutoAccount();
+      const acceptedError = createChannelPartialDeliveryError(
+        new Error("Feishu reply failed: no message_id returned"),
+        { messageIds: [], visibleReplySent: true },
+      );
+      provider.mockRejectedValueOnce(acceptedError);
+      const { result, options } = createDispatcherHarness();
+
+      const error = await options
+        .deliver({ text }, { kind: "final" })
+        .catch((caught: unknown) => caught);
+
+      expect(isChannelPartialDeliveryError(error)).toBe(true);
+      expect(provider).toHaveBeenCalledOnce();
+      await options.onError?.(error, { kind: "final" });
+      expect(result.getVisibleReplyState().visibleReplySent).toBe(true);
+      await expect(result.ensureNoVisibleReplyFallback("accepted-no-id")).resolves.toBe(false);
+      expect(provider).toHaveBeenCalledOnce();
+      if (provider !== sendMessageFeishuMock) {
+        expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("retains the finalized streaming card when companion media never dispatches", async () => {
     const marker = Object.assign(

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1643,7 +1643,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
       expect(isChannelPartialDeliveryError(error)).toBe(true);
       expect(provider).toHaveBeenCalledOnce();
-      await options.onError?.(error, { kind: "final" });
+      await Promise.resolve(options.onError?.(error, { kind: "final" }));
       expect(result.getVisibleReplyState().visibleReplySent).toBe(true);
       await expect(result.ensureNoVisibleReplyFallback("accepted-no-id")).resolves.toBe(false);
       expect(provider).toHaveBeenCalledOnce();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -765,6 +765,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         acceptedChunks.push(chunk);
         markVisibleReplySent();
       } catch (error: unknown) {
+        if (isChannelPartialDeliveryError(error)) {
+          markVisibleReplySent();
+        }
         throw createFeishuPartialReplyDeliveryError(
           error,
           createFeishuReplyDeliveryResult({
@@ -843,7 +846,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         onError:
           options?.fallbackText === undefined
             ? undefined
-            : async ({ mediaUrl }) => {
+            : async ({ error, mediaUrl }) => {
+                if (isChannelPartialDeliveryError(error)) {
+                  // The attachment is already visible; text recovery would duplicate delivery.
+                  markVisibleReplySent();
+                  throw error;
+                }
                 const fallbackText = await buildFeishuMediaFallbackText({
                   text: sentFallbackText ? undefined : options.fallbackText,
                   mediaUrl,
@@ -858,6 +866,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
     } catch (error: unknown) {
       const partial = isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
+      if (partial) {
+        markVisibleReplySent();
+      }
       throw createFeishuPartialReplyDeliveryError(
         error,
         mergeFeishuReplyDeliveryResults([...results, ...(partial ? [partial] : [])]),
@@ -1215,6 +1226,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     },
   };
   const handleDeliveryError = async (error: unknown, info: { kind: string }) => {
+    if (isChannelPartialDeliveryError(error)) {
+      // Core invokes this before no-visible recovery; keep accepted sends visible even
+      // when their normal success bookkeeping could not run.
+      markVisibleReplySent();
+    }
     params.runtime.error?.(
       `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
     );

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -850,7 +850,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 if (isChannelPartialDeliveryError(error)) {
                   // The attachment is already visible; text recovery would duplicate delivery.
                   markVisibleReplySent();
-                  throw error;
+                  throw toError(error);
                 }
                 const fallbackText = await buildFeishuMediaFallbackText({
                   text: sentFallbackText ? undefined : options.fallbackText,

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { toFeishuSendResult } from "./send-result.js";
+
+describe("toFeishuSendResult", () => {
+  it.each([undefined, "", "   "])(
+    "rejects an acknowledged send without a real message identifier: %s",
+    (messageId) => {
+      expect(() =>
+        toFeishuSendResult({ code: 0, data: { message_id: messageId } }, "oc_chat", "text"),
+      ).toThrow("Feishu send failed: no message_id returned");
+    },
+  );
+
+  it("normalizes the accepted platform identifier consistently across the result and receipt", () => {
+    const result = toFeishuSendResult(
+      { code: 0, data: { message_id: "  om_accepted  " } },
+      "oc_chat",
+      "card",
+    );
+
+    expect(result.messageId).toBe("om_accepted");
+    expect(result.receipt.primaryPlatformMessageId).toBe("om_accepted");
+  });
+});

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,3 +1,4 @@
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it } from "vitest";
 import { toFeishuSendResult } from "./send-result.js";
 
@@ -5,9 +6,19 @@ describe("toFeishuSendResult", () => {
   it.each([undefined, "", "   "])(
     "rejects an acknowledged send without a real message identifier: %s",
     (messageId) => {
-      expect(() =>
-        toFeishuSendResult({ code: 0, data: { message_id: messageId } }, "oc_chat", "text"),
-      ).toThrow("Feishu send failed: no message_id returned");
+      let caught: unknown;
+      try {
+        toFeishuSendResult({ code: 0, data: { message_id: messageId } }, "oc_chat", "text");
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      if (!isChannelPartialDeliveryError(caught)) {
+        throw new Error("expected an accepted Feishu delivery without an identity");
+      }
+      expect(caught.message).toBe("Feishu send failed: no message_id returned");
+      expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
     },
   );
 

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -14,7 +14,7 @@ describe("toFeishuSendResult", () => {
       }
 
       expect(isChannelPartialDeliveryError(caught)).toBe(true);
-      if (!isChannelPartialDeliveryError(caught)) {
+      if (!(caught instanceof Error) || !isChannelPartialDeliveryError(caught)) {
         throw new Error("expected an accepted Feishu delivery without an identity");
       }
       expect(caught.message).toBe("Feishu send failed: no message_id returned");

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -67,12 +67,16 @@ export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,
   kind?: MessageReceiptPartKind,
+  errorPrefix = "Feishu send failed",
 ): {
   messageId: string;
   chatId: string;
   receipt: MessageReceipt;
 } {
-  const messageId = response.data?.message_id ?? "unknown";
+  const messageId = response.data?.message_id?.trim();
+  if (!messageId) {
+    throw new Error(`${errorPrefix}: no message_id returned`);
+  }
   return {
     messageId,
     chatId,

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements send result behavior.
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -75,7 +76,11 @@ export function toFeishuSendResult(
 } {
   const messageId = response.data?.message_id?.trim();
   if (!messageId) {
-    throw new Error(`${errorPrefix}: no message_id returned`);
+    // Feishu already accepted this send; an ordinary error would invite a duplicate retry.
+    throw createChannelPartialDeliveryError(new Error(`${errorPrefix}: no message_id returned`), {
+      messageIds: [],
+      visibleReplySent: true,
+    });
   }
   return {
     messageId,

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -142,7 +142,6 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     "never duplicates an accepted $label reply with a missing platform id",
     async ({ prefix, send }) => {
       replyMock.mockResolvedValueOnce({ code: 0, data: {} });
-      createMock.mockResolvedValueOnce({ code: 0, data: { message_id: "om_duplicate" } });
 
       let caught: unknown;
       try {

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -151,7 +151,7 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       }
 
       expect(isChannelPartialDeliveryError(caught)).toBe(true);
-      if (!isChannelPartialDeliveryError(caught)) {
+      if (!(caught instanceof Error) || !isChannelPartialDeliveryError(caught)) {
         throw new Error("expected an accepted Feishu reply without an identity");
       }
       expect(caught.message).toBe(`${prefix}: no message_id returned`);

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -1,4 +1,5 @@
 // Feishu tests cover send.reply fallback plugin behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
@@ -113,6 +114,53 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       "om_new",
     );
   });
+
+  it.each([
+    {
+      label: "text",
+      prefix: "Feishu reply failed",
+      send: () =>
+        sendMessageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_parent",
+        }),
+    },
+    {
+      label: "card",
+      prefix: "Feishu card reply failed",
+      send: () =>
+        sendCardFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          card: { schema: "2.0" },
+          replyToMessageId: "om_parent",
+        }),
+    },
+  ])(
+    "never duplicates an accepted $label reply with a missing platform id",
+    async ({ prefix, send }) => {
+      replyMock.mockResolvedValueOnce({ code: 0, data: {} });
+      createMock.mockResolvedValueOnce({ code: 0, data: { message_id: "om_duplicate" } });
+
+      let caught: unknown;
+      try {
+        await send();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      if (!isChannelPartialDeliveryError(caught)) {
+        throw new Error("expected an accepted Feishu reply without an identity");
+      }
+      expect(caught.message).toBe(`${prefix}: no message_id returned`);
+      expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+      expect(replyMock).toHaveBeenCalledOnce();
+      expect(createMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("falls back to create for withdrawn card replies", async () => {
     replyMock.mockResolvedValue({

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -826,6 +826,35 @@ describe("getMessageFeishu", () => {
     expect(result.at(-1)?.messageId).toBe("om_51");
   });
 
+  it("deduplicates overlapping continuation pages without consuming the history limit", async () => {
+    mockClientList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          has_more: true,
+          page_token: "overlapping-page",
+          items: [{ message_id: "om_newer", body: { content: '{"text":"newer"}' } }],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            { message_id: "om_newer", body: { content: '{"text":"duplicate"}' } },
+            { message_id: "om_older", body: { content: '{"text":"older"}' } },
+          ],
+        },
+      });
+
+    const result = await listFeishuThreadMessages({
+      cfg: {} as ClawdbotConfig,
+      threadId: "omt_1",
+      limit: 2,
+    });
+
+    expect(result.map((message) => message.messageId)).toEqual(["om_older", "om_newer"]);
+  });
+
   it.each([
     { name: "missing", firstToken: undefined, secondToken: undefined },
     { name: "repeated", firstToken: "same-page", secondToken: "same-page" },

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -213,6 +213,24 @@ describe("getMessageFeishu", () => {
     });
   });
 
+  it("rejects direct text deliveries that acknowledge no platform message identifier", async () => {
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create: vi.fn().mockResolvedValue({ code: 0, data: {} }),
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    await expect(
+      sendMessageFeishu({ cfg: {} as ClawdbotConfig, to: "oc_send", text: "hello" }),
+    ).rejects.toThrow("Feishu send failed: no message_id returned");
+  });
+
   it("sends automatic mentions as native post elements without rewriting body text", async () => {
     const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_mentions" } });
     mockCreateFeishuClient.mockReturnValue({
@@ -734,6 +752,100 @@ describe("getMessageFeishu", () => {
         createTime: undefined,
       },
     ]);
+  });
+
+  it("fills thread history from continuation pages after excluding the current and root messages", async () => {
+    mockClientList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          has_more: true,
+          page_token: "older-history",
+          items: [
+            { message_id: "om_current", body: { content: '{"text":"current"}' } },
+            { message_id: "om_root", body: { content: '{"text":"root"}' } },
+            { message_id: "om_newer", body: { content: '{"text":"newer"}' } },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          has_more: false,
+          items: [{ message_id: "om_older", body: { content: '{"text":"older"}' } }],
+        },
+      });
+
+    const result = await listFeishuThreadMessages({
+      cfg: {} as ClawdbotConfig,
+      threadId: "omt_1",
+      currentMessageId: "om_current",
+      rootMessageId: "om_root",
+      limit: 2,
+    });
+
+    expect(result.map((message) => message.messageId)).toEqual(["om_older", "om_newer"]);
+    expect(mockClientList).toHaveBeenNthCalledWith(2, {
+      params: {
+        container_id_type: "thread",
+        container_id: "omt_1",
+        sort_type: "ByCreateTimeDesc",
+        page_size: 3,
+        page_token: "older-history",
+        card_msg_content_type: "user_card_content",
+      },
+    });
+  });
+
+  it("reads thread history beyond the SDK's maximum single-page size", async () => {
+    const pageOne = Array.from({ length: 50 }, (_value, index) => ({
+      message_id: `om_${String(51 - index)}`,
+      body: { content: JSON.stringify({ text: String(51 - index) }) },
+    }));
+    mockClientList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: pageOne, has_more: true, page_token: "last-message" },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ message_id: "om_1", body: { content: '{"text":"1"}' } }],
+          has_more: false,
+        },
+      });
+
+    const result = await listFeishuThreadMessages({
+      cfg: {} as ClawdbotConfig,
+      threadId: "omt_1",
+      limit: 51,
+    });
+
+    expect(result).toHaveLength(51);
+    expect(result[0]?.messageId).toBe("om_1");
+    expect(result.at(-1)?.messageId).toBe("om_51");
+  });
+
+  it.each([
+    { name: "missing", firstToken: undefined, secondToken: undefined },
+    { name: "repeated", firstToken: "same-page", secondToken: "same-page" },
+  ])("rejects $name thread history continuation tokens", async ({ firstToken, secondToken }) => {
+    mockClientList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [], has_more: true, ...(firstToken ? { page_token: firstToken } : {}) },
+    });
+    if (firstToken) {
+      mockClientList.mockResolvedValueOnce({
+        code: 0,
+        data: { items: [], has_more: true, ...(secondToken ? { page_token: secondToken } : {}) },
+      });
+    }
+
+    await expect(
+      listFeishuThreadMessages({ cfg: {} as ClawdbotConfig, threadId: "omt_1" }),
+    ).rejects.toThrow(
+      `Feishu thread history pagination returned a ${firstToken ? "repeated" : "missing"} page token`,
+    );
   });
 
   it("logs a safe diagnostic (not raw content) when message content is not valid JSON", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -2,15 +2,13 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import {
-  isRecord,
-  normalizeLowercaseStringOrEmpty,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
+import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import {
   assertFeishuPostWithinEnvelope,
   buildFeishuPostMessageContent,
@@ -31,8 +29,6 @@ import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./type
 export { resolveFeishuCardTemplate };
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
-const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
-const POST_FALLBACK_TEXT = "[Rich text message]";
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
     return true;
@@ -133,7 +129,12 @@ async function sendFallbackDirect(
     { includeNestedErrorLogId: true },
   );
   assertFeishuMessageApiSuccess(response, errorPrefix);
-  return toFeishuSendResult(response, params.receiveId, resolveFeishuReceiptKind(params.msgType));
+  return toFeishuSendResult(
+    response,
+    params.receiveId,
+    resolveFeishuReceiptKind(params.msgType),
+    errorPrefix,
+  );
 }
 
 export async function sendReplyOrFallbackDirect(
@@ -200,124 +201,8 @@ export async function sendReplyOrFallbackDirect(
     response,
     params.directParams.receiveId,
     resolveFeishuReceiptKind(params.msgType),
+    params.replyErrorPrefix,
   );
-}
-
-function normalizeCardTemplateVariable(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
-  return undefined;
-}
-
-function readCardTemplateVariables(parsed: Record<string, unknown>): Map<string, string> {
-  const variables = new Map<string, string>();
-  for (const source of [parsed.template_variable, parsed.template_variables]) {
-    if (!isRecord(source)) {
-      continue;
-    }
-    for (const [key, value] of Object.entries(source)) {
-      const normalized = normalizeCardTemplateVariable(value);
-      if (normalized !== undefined) {
-        variables.set(key, normalized);
-      }
-    }
-  }
-  return variables;
-}
-
-function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
-  if (variables.size === 0) {
-    return text;
-  }
-  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
-    const variableName = typeof a === "string" ? a : b;
-    return variables.get(variableName) ?? match;
-  });
-}
-
-function extractInteractiveElementText(
-  element: unknown,
-  variables: Map<string, string>,
-): string | undefined {
-  if (!isRecord(element)) {
-    return undefined;
-  }
-  const tag = typeof element.tag === "string" ? element.tag : "";
-  const text = isRecord(element.text) ? element.text : undefined;
-
-  if (tag === "div" && typeof text?.content === "string") {
-    return applyCardTemplateVariables(text.content, variables);
-  }
-  if ((tag === "markdown" || tag === "lark_md") && typeof element.content === "string") {
-    return applyCardTemplateVariables(element.content, variables);
-  }
-  if (tag === "plain_text" && typeof element.content === "string") {
-    return applyCardTemplateVariables(element.content, variables);
-  }
-  return undefined;
-}
-
-function extractInteractiveElementsText(
-  elements: unknown[],
-  variables: Map<string, string>,
-): string {
-  const texts: string[] = [];
-  for (const element of elements) {
-    const text = extractInteractiveElementText(element, variables);
-    if (text !== undefined) {
-      texts.push(text);
-    }
-  }
-  return texts.join("\n").trim();
-}
-
-function readInteractiveElementArrays(parsed: Record<string, unknown>): unknown[][] {
-  const body = isRecord(parsed.body) ? parsed.body : undefined;
-  const elementArrays: unknown[][] = [];
-
-  for (const candidate of [parsed.elements, body?.elements]) {
-    if (Array.isArray(candidate)) {
-      elementArrays.push(candidate);
-    }
-  }
-
-  for (const candidate of [parsed.i18n_elements, body?.i18n_elements]) {
-    if (!isRecord(candidate)) {
-      continue;
-    }
-    for (const localeElements of Object.values(candidate)) {
-      if (Array.isArray(localeElements)) {
-        elementArrays.push(localeElements);
-      }
-    }
-  }
-
-  return elementArrays;
-}
-
-function parseInteractivePostFallback(parsed: unknown): string | undefined {
-  const textContent = parsePostContent(JSON.stringify(parsed)).textContent.trim();
-  return textContent && textContent !== POST_FALLBACK_TEXT ? textContent : undefined;
-}
-
-function parseInteractiveCardContent(parsed: unknown): string {
-  if (!isRecord(parsed)) {
-    return INTERACTIVE_CARD_FALLBACK_TEXT;
-  }
-
-  const variables = readCardTemplateVariables(parsed);
-  for (const elements of readInteractiveElementArrays(parsed)) {
-    const text = extractInteractiveElementsText(elements, variables);
-    if (text) {
-      return text;
-    }
-  }
-
-  return parseInteractivePostFallback(parsed) ?? INTERACTIVE_CARD_FALLBACK_TEXT;
 }
 
 function parseFeishuMessageContent(
@@ -470,61 +355,78 @@ export async function listFeishuThreadMessages(params: {
 
   const client = createFeishuClient(account);
 
-  const response = (await client.im.message.list({
-    params: {
-      container_id_type: "thread",
-      container_id: threadId,
-      // Fetch newest messages first so long threads keep the most recent turns.
-      // Results are reversed below to restore chronological order.
-      sort_type: "ByCreateTimeDesc",
-      page_size: Math.min(limit + 1, 50),
-      card_msg_content_type: "user_card_content",
-    },
-  })) as {
-    code?: number;
-    msg?: string;
-    data?: {
-      items?: Array<
-        {
-          message_id?: string;
-          root_id?: string;
-          parent_id?: string;
-        } & FeishuMessageGetItem
-      >;
-    };
-  };
-
-  if (response.code !== 0) {
-    throw new Error(
-      `Feishu thread list failed: code=${response.code} msg=${response.msg ?? "unknown"}`,
-    );
-  }
-
-  const items = response.data?.items ?? [];
   const results: FeishuThreadMessageInfo[] = [];
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
 
-  for (const item of items) {
-    if (currentMessageId && item.message_id === currentMessageId) {
-      continue;
+  while (results.length < limit) {
+    const response = (await client.im.message.list({
+      params: {
+        container_id_type: "thread",
+        container_id: threadId,
+        // Feishu pages newest-first; reverse only after all accepted pages are gathered.
+        sort_type: "ByCreateTimeDesc",
+        page_size: Math.min(limit + 1, 50),
+        ...(pageToken ? { page_token: pageToken } : {}),
+        card_msg_content_type: "user_card_content",
+      },
+    })) as {
+      code?: number;
+      msg?: string;
+      data?: {
+        items?: Array<
+          {
+            message_id?: string;
+            root_id?: string;
+            parent_id?: string;
+          } & FeishuMessageGetItem
+        >;
+        has_more?: boolean;
+        page_token?: string;
+      };
+    };
+
+    if (response.code !== 0) {
+      throw new Error(
+        `Feishu thread list failed: code=${response.code} msg=${response.msg ?? "unknown"}`,
+      );
     }
-    if (rootMessageId && item.message_id === rootMessageId) {
-      continue;
+
+    for (const item of response.data?.items ?? []) {
+      if (
+        (currentMessageId && item.message_id === currentMessageId) ||
+        (rootMessageId && item.message_id === rootMessageId)
+      ) {
+        continue;
+      }
+
+      const parsed = parseFeishuMessageItem(item);
+      results.push({
+        messageId: parsed.messageId,
+        senderId: parsed.senderId,
+        senderType: parsed.senderType,
+        content: parsed.content,
+        contentType: parsed.contentType,
+        createTime: parsed.createTime,
+      });
+
+      if (results.length >= limit) {
+        break;
+      }
     }
 
-    const parsed = parseFeishuMessageItem(item);
-
-    results.push({
-      messageId: parsed.messageId,
-      senderId: parsed.senderId,
-      senderType: parsed.senderType,
-      content: parsed.content,
-      contentType: parsed.contentType,
-      createTime: parsed.createTime,
-    });
-
-    if (results.length >= limit) {
+    if (results.length >= limit || response.data?.has_more !== true) {
       break;
     }
+
+    const nextPageToken = response.data.page_token?.trim();
+    if (!nextPageToken || seenPageTokens.has(nextPageToken)) {
+      throw new Error(
+        `Feishu thread history pagination returned a ${nextPageToken ? "repeated" : "missing"} page token`,
+      );
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
   }
 
   // Restore chronological order (oldest first) since we fetched newest-first.

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -356,6 +356,7 @@ export async function listFeishuThreadMessages(params: {
   const client = createFeishuClient(account);
 
   const results: FeishuThreadMessageInfo[] = [];
+  const seenMessageIds = new Set<string>();
   const seenPageTokens = new Set<string>();
   let pageToken: string | undefined;
 
@@ -395,12 +396,16 @@ export async function listFeishuThreadMessages(params: {
     for (const item of response.data?.items ?? []) {
       if (
         (currentMessageId && item.message_id === currentMessageId) ||
-        (rootMessageId && item.message_id === rootMessageId)
+        (rootMessageId && item.message_id === rootMessageId) ||
+        (item.message_id && seenMessageIds.has(item.message_id))
       ) {
         continue;
       }
 
       const parsed = parseFeishuMessageItem(item);
+      if (parsed.messageId) {
+        seenMessageIds.add(parsed.messageId);
+      }
       results.push({
         messageId: parsed.messageId,
         senderId: parsed.senderId,


### PR DESCRIPTION
## What Problem This Solves

Four independent Feishu delivery defects share private plugin ownership:

1. Thread bootstrap silently stopped at one API page, counted root/current entries, and duplicated overlapping page items.
2. Accepted text, card, native reply, image, and file sends without a platform identifier fabricated a receipt and could trigger duplicate outbound/dispatcher recovery.
3. Filename/header-based routing sent unsupported SVG/AVIF or spoofed PNG/HEIC to the rejecting native-image endpoint, while supported local HEIC/TIF/TIFF paths could escape as plain text.
4. Original and prepared attachments lacked consistent empty-file, configured, 10 MiB native-image, and 30 MiB file enforcement.

## Why This Change Was Made

Keep each invariant at its private Feishu owner. Thread history follows bounded, validated, deduplicated page continuation and restores chronological order. A platform `code: 0` acknowledges the send even when `message_id` is absent, so all send producers emit the canonical visible partial-delivery error and all native-reply, outbound-media, dispatcher, and no-visible-reply consumers avoid replaying that already accepted operation. Ordinary rejected operations still use normal recovery.

Canonical real-byte MIME signatures alone choose native images; extensions and HTTP metadata cannot promote unsupported SVG, AVIF, or spoofed content. Actual PNG/JPEG/TIFF/ICO/HEIC remain supported, including opaque downloads and local `.heic`, `.tif`, and `.tiff` paths. Current [official Feishu image-upload documentation](https://open.feishu.cn/document/server-docs/im-v1/image/create?lang=zh-CN) confirms HEIC beyond stale pinned generated SDK comments. Original and transcoded buffers both satisfy configured and provider limits before contact. Existing interactive-card parsing moves into a dedicated private owner to keep the refactor readable.

## User Impact

- Complete, chronological, duplicate-free thread context across all API pages.
- Truthful provider receipts and no second visible text/card/media send after an already accepted delivery.
- Real supported images, including HEIC and TIFF, display natively; unsupported formats remain useful file attachments and supported local paths never leak.
- Empty or oversized attachments fail before upload, including after voice preparation.
- No public SDK, configuration/auth, Gateway protocol, persistence, SQLite, dependency, or platform-contract surface changes.

## Evidence

Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`. Exact reviewed and CI-tested head: `a1cdddd258ddb72dd3f01dee030b7ce26817174c`. Exact tree: `2fbb3c3d442b594d3a2322cd10aa36c4050bb967`. Independent root causes: **4**. Production delta: **+327/-190 (net 137)** across **14 changed files**.

### Redacted accepted-without-ID and no-duplicate behavior

These are controlled, source-backed Feishu provider-response regressions; they are **not represented as a hosted/live Feishu account**. The exact successful provider shape and asserted outcomes are:

```json
{
  "provider_response": { "code": 0, "data": {} },
  "text_reply": {
    "reply_api_calls": 1,
    "fallback_create_api_calls": 0,
    "error_code": "CHANNEL_PARTIAL_DELIVERY",
    "delivery_result": { "messageIds": [], "visibleReplySent": true }
  },
  "card_reply": {
    "reply_api_calls": 1,
    "fallback_create_api_calls": 0,
    "error_code": "CHANNEL_PARTIAL_DELIVERY",
    "delivery_result": { "messageIds": [], "visibleReplySent": true }
  },
  "accepted_image_or_file": {
    "message_create_api_calls": 1,
    "delivery_result": { "messageIds": [], "visibleReplySent": true }
  },
  "accepted_media_dispatcher": {
    "media_send_calls": 1,
    "fallback_text_send_calls": 0,
    "no_visible_reply_fallback_sent": false
  },
  "rejected_withdrawn_reply_control": {
    "reply_api_calls": 1,
    "fallback_create_api_calls": 1
  }
}
```

- Native text and card: `extensions/feishu/src/send.reply-fallback.test.ts:142` feeds `{ code: 0, data: {} }`, asserts exactly one provider reply, **zero fallback creates**, and `{ messageIds: [], visibleReplySent: true }` for both message kinds. The neighboring withdrawn-reply control still performs one ordinary fallback create.
- Native image and file: `extensions/feishu/src/media-upload-contract.test.ts:250` feeds the same accepted response shape and asserts exactly one platform message-create plus the visible partial result.
- Dispatcher media: `extensions/feishu/src/reply-dispatcher.test.ts:1590` asserts one accepted media send, **zero fallback text sends**, `visibleReplySent: true`, and `ensureNoVisibleReplyFallback(...) === false`; text/card siblings at `extensions/feishu/src/reply-dispatcher.test.ts:1630` prove the same invariant.
- Both local-image and remote-media outbound owners independently assert **one media send and zero fallback text sends** at `extensions/feishu/src/outbound.test.ts:545` and `extensions/feishu/src/outbound.test.ts:2542`.

### Actual installed SDK + local HTTP missing-ID proof

As an additional source-unchanged runtime probe on exact commit `a1cdddd258ddb72dd3f01dee030b7ce26817174c`, the **actual installed `@larksuiteoapi/node-sdk`**, its real tenant-token exchange, a controlled local HTTP server, and the actual production `sendReplyOrFallbackDirect` owner were exercised together. No SDK method was mocked. The local server returned successful HTTP 200 / `{ "code": 0, "data": {} }` responses without a message ID; real SDK reply/create HTTP requests were counted. Placeholder identities and credentials are redacted:

```text
{"sdk":"@larksuiteoapi/node-sdk","transport":"actual SDK -> local HTTP server","scenario":"post provider HTTP 200 {code:0,data:{}}","providerReplies":1,"fallbackCreates":0,"partialDelivery":true,"visibleReplySent":true,"messageIds":[],"error":"Feishu reply failed: no message_id returned"}
{"sdk":"@larksuiteoapi/node-sdk","transport":"actual SDK -> local HTTP server","scenario":"interactive provider HTTP 200 {code:0,data:{}}","providerReplies":1,"fallbackCreates":0,"partialDelivery":true,"visibleReplySent":true,"messageIds":[],"error":"Feishu card reply failed: no message_id returned"}
{"sdk":"@larksuiteoapi/node-sdk","transport":"actual SDK -> local HTTP server","scenario":"withdrawn reply safely falls back","providerReplies":1,"fallbackCreates":1,"fallbackMessageId":"om_redacted_fallback"}
```

Thus both actual text and interactive-card SDK HTTP operations receive an accepted missing-ID response, report a visible typed partial delivery, and emit **exactly one reply and zero fallback creates**. The rejected withdrawn-reply control emits **one reply and one normal fallback create**. This is an actual installed-SDK/local-network behavior probe, **not a hosted/live Feishu account claim**; no tracked source files were modified.

### Installed Lark SDK local HTTP loopback

`extensions/feishu/src/dm-delivery-loopback.test.ts:22` exercises the **actual installed `@larksuiteoapi/node-sdk` and actual localhost HTTP transport**, not a mocked SDK method. Its controlled local Feishu-compatible server performs real tenant-token exchange and records authenticated provider requests. The provider image endpoint returns this redacted success response:

```json
{
  "http_status": 200,
  "endpoint": "/open-apis/im/v1/images",
  "authorization": "Bearer [REDACTED]",
  "provider_response": {
    "code": 0,
    "msg": "success",
    "data": { "image_key": "img_dm_loopback" }
  },
  "outcomes": [
    "account-scoped tenant authentication succeeds",
    "text and interactive-card messages reach the real SDK HTTP transport",
    "genuine PNG signature bytes upload through /im/v1/images",
    "the image message is sent exactly through the authenticated message API",
    "thread replies and secondary-account tokens remain isolated",
    "intentional provider errors 230101 and 230027 remain ordinary rejected operations"
  ]
}
```

The authentic PNG fixture is at `extensions/feishu/src/dm-delivery-loopback.test.ts:182`; the local server's actual image-success response is at `extensions/feishu/src/dm-delivery-loopback.test.ts:79`. This is a **controlled local provider loopback**, not a claim of hosted/live Feishu proof. Combined with the source-backed accepted-without-ID cases above, it directly exercises the real SDK transport while separately proving every no-duplicate fallback owner.

```text
Feishu DM delivery over the real Lark SDK
  authenticates conversation replies and preserves account, group, thread, and error boundaries

Test Files  1 passed (1)
Tests       1 passed (1)
```

The exact-head changed-node CI shard contains this actual loopback terminal output and also runs the accepted image/file contract regressions: [checks-node-changed-1 — success](https://github.com/openclaw/openclaw/actions/runs/30665697882/job/91272288075).

### Pagination and attachment owner proof

- Thread-history regressions cover root/current exclusion, requests exceeding 50 entries, overlapping page-ID deduplication, chronological output, and missing/repeated page-token termination in `extensions/feishu/src/send.test.ts:757`, `extensions/feishu/src/send.test.ts:800`, `extensions/feishu/src/send.test.ts:829`, and `extensions/feishu/src/send.test.ts:861`.
- Authentic signature regressions cover PNG/JPEG/TIFF/ICO/HEIC, metadata aliases, opaque downloads, SVG/AVIF/spoof rejection, and supported local HEIC/TIF/TIFF paths.
- Attachment-envelope regressions cover empty files, operator-configured limits, Feishu's 10 MiB native-image and 30 MiB file limits, and both pre- and post-transcoding buffers.

### Exact-head CI, typed lint, and complete regression suite

The following are **public GitHub jobs for the exact head `a1cdddd258ddb72dd3f01dee030b7ce26817174c`**, all successful:

- [Changed-node shard, including the installed-SDK local HTTP loopback](https://github.com/openclaw/openclaw/actions/runs/30665697882/job/91272288075).
- [Full CI type-aware lint](https://github.com/openclaw/openclaw/actions/runs/30665697882/job/91272288305).
- [Full CI test-type checking](https://github.com/openclaw/openclaw/actions/runs/30665697882/job/91272288289).
- [Final required CI gate](https://github.com/openclaw/openclaw/actions/runs/30665697882/job/91272991874).

An isolated Blacksmith worker independently imported the reviewed commit, verified exact detached Git head and tree, then ran the actual hydrated extension type-aware linter, `pnpm tsgo:extensions:test`, and all eight owner suites. The worker was explicitly stopped and confirmed completed; its backing workflow is **not** cited as an exact-head CI run.

```text
git rev-parse HEAD
a1cdddd258ddb72dd3f01dee030b7ce26817174c

git rev-parse HEAD^{tree}
2fbb3c3d442b594d3a2322cd10aa36c4050bb967

node scripts/run-oxlint.mjs --type-aware --tsconfig config/tsconfig/oxlint.extensions.json [14 changed Feishu paths]
PASS

pnpm tsgo:extensions:test
PASS

OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/feishu/src/dm-delivery-loopback.test.ts \
  extensions/feishu/src/send.test.ts \
  extensions/feishu/src/send-result.test.ts \
  extensions/feishu/src/media.test.ts \
  extensions/feishu/src/media-upload-contract.test.ts \
  extensions/feishu/src/send.reply-fallback.test.ts \
  extensions/feishu/src/outbound.test.ts \
  extensions/feishu/src/reply-dispatcher.test.ts

Test Files  8 passed (8)
Tests       352 passed (352)
```

The earlier CI failures are resolved at the exact owner boundaries:

- The changed-node failure used plain-text bytes mislabeled `.png`; the real SDK loopback now uses genuine PNG bytes while retaining strict content-signature routing.
- Type-aware lint now preserves the existing `Error` identity via `toError(error)` and correctly awaits the sync-typed error callback through `Promise.resolve(...)`.
- Extension test types now narrow caught values to both `Error` and the structural visible-partial envelope before reading `.message`.

### ClawSweeper rank-up moves addressed

1. **Add redacted after-fix Feishu delivery evidence:** the actual installed SDK + local HTTP probe above returns successful `{ "code": 0, "data": {} }` for real text/card reply requests and records exactly one accepted provider reply, zero fallback creates, and visible partial delivery. Image/file regressions cover the same success shape; the existing real-SDK loopback independently records account/auth/image/thread/error transport behavior.
2. **Show pagination behavior:** the exact pagination owner tests and covered continuation/deduplication cases are listed above.
3. **Prove rejected operations still recover:** the withdrawn-reply control retains exactly one fallback create; real loopback provider error codes `230101` and `230027` remain rejected.
4. **Resolve exact-head CI concerns:** all four required exact-`a1c` public CI jobs are green; hydrated type-aware lint, extension test-type checking, and eight suites / **352 tests** independently pass on the verified detached commit/tree.

Independent second-agent whole-owner, sibling, and upstream dependency review: **clean P0–P3**. Genuine exact-head `gpt-5.6-sol` / `high` autoreview explicitly used `--max-priority P3`: **zero findings, patch correct, confidence 0.97**; genuine TruffleHog scan clean.
