### PR TITLE
fix(channels): preserve accepted LINE and Mattermost delivery

### DIFF
--- a/extensions/line/src/auto-reply-delivery-recovery.test.ts
+++ b/extensions/line/src/auto-reply-delivery-recovery.test.ts
@@ -1,5 +1,6 @@
 // LINE auto-reply tests cover HTTP rejection recovery and replay safety.
 import { HTTPFetchError, type messagingApi } from "@line/bot-sdk";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it, vi } from "vitest";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import {
@@ -11,6 +12,65 @@ import {
 } from "./auto-reply-delivery.test-helpers.js";
 
 describe("deliverLineAutoReply HTTP recovery", () => {
+  it("does not replay an accepted reply after local bookkeeping fails", async () => {
+    const acceptedError = createChannelPartialDeliveryError(
+      new Error("activity store unavailable"),
+      { messageIds: ["line-reply-final"], visibleReplySent: true },
+    );
+    const replyMessageLine = vi.fn(async () => {
+      throw acceptedError;
+    });
+    const { deps, pushMessagesLine } = createDeps({
+      replyMessageLine: replyMessageLine as LineAutoReplyDeps["replyMessageLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "already delivered" },
+      lineData: {},
+      deps,
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      replyTokenUsed: true,
+      visibleReplySent: true,
+      error: acceptedError,
+    });
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it("preserves a provider-accepted push when local bookkeeping fails", async () => {
+    const acceptedError = createChannelPartialDeliveryError(
+      new Error("activity store unavailable"),
+      { messageIds: ["line-push-final"], visibleReplySent: true },
+    );
+    const pushMessagesLine = vi.fn(async () => {
+      throw acceptedError;
+    });
+    const { deps, replyMessageLine } = createDeps({
+      pushMessagesLine: pushMessagesLine as LineAutoReplyDeps["pushMessagesLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      replyToken: undefined,
+      payload: { text: "already delivered" },
+      lineData: {},
+      deps,
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      replyTokenUsed: false,
+      visibleReplySent: true,
+      error: acceptedError,
+    });
+    expect(pushMessagesLine).toHaveBeenCalledOnce();
+    expect(replyMessageLine).not.toHaveBeenCalled();
+  });
+
   it("retries push-only quick-reply text after a mixed batch is rejected", async () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements auto reply delivery behavior.
 import { HTTPFetchError, type messagingApi } from "@line/bot-sdk";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
@@ -93,6 +94,9 @@ export async function deliverLineAutoReply(params: {
       visibleReplySent = true;
       return result;
     } catch (error) {
+      if (isChannelPartialDeliveryError(error)) {
+        visibleReplySent = true;
+      }
       if (visibleReplySent) {
         throw markLineVisibleDeliveryError(error);
       }
@@ -127,7 +131,7 @@ export async function deliverLineAutoReply(params: {
           }),
         );
       } catch (error) {
-        if (typeof error === "object" && error !== null) {
+        if (!isChannelPartialDeliveryError(error) && typeof error === "object" && error !== null) {
           failedPushSegments.set(error, {
             allowFailedBatchTextRecovery,
             failedBatch: batch,
@@ -157,6 +161,10 @@ export async function deliverLineAutoReply(params: {
         });
       } catch (err) {
         deps.onReplyError?.(err);
+        // The reply is already provider-visible; replaying its batch as a push duplicates it.
+        if (isChannelPartialDeliveryError(err)) {
+          throw err;
+        }
         // A transport-failed reply may have landed; only a definitive LINE 400
         // makes text recovery after a rejected push fallback safe.
         await pushLineMessages(

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -769,7 +769,12 @@ describe("handleLineWebhookEvents", () => {
         : new Error("provider delivery rejected");
       pairingDeliveryMocks.replyMessageLine.mockRejectedValueOnce(replyError);
       const event = createTestMessageEvent({
-        message: { id: "pairing-final", type: "text", text: "hello" },
+        message: {
+          id: "pairing-final",
+          type: "text",
+          text: "hello",
+          quoteToken: "pairing-final-quote",
+        },
         source: { type: "user", userId: "pairing-user" },
         webhookEventId: "pairing-final-event",
       });

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -7,18 +7,45 @@ import type { LineAccountConfig } from "./types.js";
 
 type MessageEvent = webhook.MessageEvent;
 
+const pairingDeliveryMocks = vi.hoisted(() => ({
+  invokePairingReply: false,
+  pushMessageLine: vi.fn(async () => {
+    throw new Error("pushMessageLine should not be called from bot-handlers tests");
+  }),
+  replyMessageLine: vi.fn(async () => {
+    throw new Error("replyMessageLine should not be called from bot-handlers tests");
+  }),
+}));
+
 // Avoid pulling in globals/pairing/media dependencies; this suite only asserts
 // allowlist/groupPolicy gating and message-context wiring.
 vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
   buildMentionRegexes: () => [],
+  isChannelPartialDeliveryError: (error: unknown) =>
+    Boolean(
+      error &&
+      typeof error === "object" &&
+      (error as { code?: unknown }).code === "CHANNEL_PARTIAL_DELIVERY",
+    ),
   matchesMentionPatterns: () => false,
 }));
 vi.mock("openclaw/plugin-sdk/channel-pairing", () => ({
   createChannelPairingChallengeIssuer:
     ({ upsertPairingRequest }: { upsertPairingRequest: (args: unknown) => Promise<unknown> }) =>
-    async ({ senderId, onCreated }: { senderId: string; onCreated?: () => void }) => {
+    async ({
+      senderId,
+      onCreated,
+      sendPairingReply,
+    }: {
+      senderId: string;
+      onCreated?: () => void;
+      sendPairingReply?: (text: string) => Promise<void>;
+    }) => {
       await upsertPairingRequest({ id: senderId, meta: {} });
       onCreated?.();
+      if (pairingDeliveryMocks.invokePairingReply) {
+        await sendPairingReply?.("Pairing challenge");
+      }
     },
 }));
 vi.mock("openclaw/plugin-sdk/command-auth-native", () => ({
@@ -141,12 +168,8 @@ vi.mock("./download.js", async (importActual) => ({
 }));
 
 vi.mock("./send.js", () => ({
-  pushMessageLine: async () => {
-    throw new Error("pushMessageLine should not be called from bot-handlers tests");
-  },
-  replyMessageLine: async () => {
-    throw new Error("replyMessageLine should not be called from bot-handlers tests");
-  },
+  pushMessageLine: pairingDeliveryMocks.pushMessageLine,
+  replyMessageLine: pairingDeliveryMocks.replyMessageLine,
 }));
 
 const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted(() => ({
@@ -307,6 +330,9 @@ describe("handleLineWebhookEvents", () => {
   });
 
   beforeEach(() => {
+    pairingDeliveryMocks.invokePairingReply = false;
+    pairingDeliveryMocks.pushMessageLine.mockClear();
+    pairingDeliveryMocks.replyMessageLine.mockClear();
     buildLineMessageContextMock.mockReset();
     buildLineMessageContextMock.mockImplementation(async () => ({
       ctxPayload: { From: "line:group:group-1" },
@@ -727,6 +753,36 @@ describe("handleLineWebhookEvents", () => {
     expect(pairingRequest?.id).toBe("user-5");
     expect(pairingRequest?.accountId).toBe("default");
   });
+
+  it.each([
+    { name: "already accepted", delivered: true, fallbackPushCount: 0 },
+    { name: "not delivered", delivered: false, fallbackPushCount: 1 },
+  ])(
+    "avoids duplicate delivery when the pairing reply was $name",
+    async ({ delivered, fallbackPushCount }) => {
+      pairingDeliveryMocks.invokePairingReply = true;
+      const replyError = delivered
+        ? Object.assign(new Error("activity store unavailable"), {
+            code: "CHANNEL_PARTIAL_DELIVERY",
+            deliveryResult: { messageIds: ["line-final"], visibleReplySent: true },
+          })
+        : new Error("provider delivery rejected");
+      pairingDeliveryMocks.replyMessageLine.mockRejectedValueOnce(replyError);
+      const event = createTestMessageEvent({
+        message: { id: "pairing-final", type: "text", text: "hello" },
+        source: { type: "user", userId: "pairing-user" },
+        webhookEventId: "pairing-final-event",
+      });
+
+      await handleLineWebhookEvents(
+        [event],
+        createLineWebhookTestContext({ processMessage: vi.fn(), dmPolicy: "pairing" }),
+      );
+
+      expect(pairingDeliveryMocks.replyMessageLine).toHaveBeenCalledOnce();
+      expect(pairingDeliveryMocks.pushMessageLine).toHaveBeenCalledTimes(fallbackPushCount);
+    },
+  );
 
   it("does not authorize DM senders from another account's pairing-store entries", async () => {
     const processMessage = vi.fn();

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -1,6 +1,10 @@
 // Line plugin module implements bot handlers behavior.
 import type { webhook } from "@line/bot-sdk";
-import { buildMentionRegexes, matchesMentionPatterns } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  buildMentionRegexes,
+  isChannelPartialDeliveryError,
+  matchesMentionPatterns,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
@@ -136,6 +140,10 @@ async function sendLinePairingReply(params: {
           return;
         } catch (err) {
           logVerbose(`line pairing reply failed for ${senderId}: ${String(err)}`);
+          // A visible reply survived failed bookkeeping; a fallback push would duplicate it.
+          if (isChannelPartialDeliveryError(err)) {
+            return;
+          }
         }
       }
       try {

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -1,5 +1,6 @@
 // Line tests cover channel.sendPayload plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   verifyChannelMessageAdapterCapabilityProofs,
   verifyChannelMessageReceiveAckPolicyAdapterProofs,
@@ -138,6 +139,59 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
 }
 
 describe("line outbound sendPayload", () => {
+  it.each([
+    { name: "empty", text: "" },
+    { name: "whitespace-only", text: "   " },
+  ])("rejects a $name payload instead of fabricating a delivery", async ({ text }) => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+
+    await expect(
+      lineOutboundAdapter.sendPayload!({
+        to: "line:user:U123",
+        text,
+        payload: { text },
+        accountId: "default",
+        cfg: { channels: { line: {} } } as OpenClawConfig,
+      }),
+    ).rejects.toThrow("Message must be non-empty for LINE sends");
+    expect(mocks.pushMessageLine).not.toHaveBeenCalled();
+    expect(mocks.pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it("preserves the finalized receipt when its delivery observer rejects", async () => {
+    const { runtime } = createRuntime();
+    setLineRuntime(runtime);
+    const onDeliveryResult = vi.fn(async () => {
+      throw new Error("delivery observer unavailable");
+    });
+
+    let caught: unknown;
+    try {
+      await lineOutboundAdapter.sendPayload!({
+        to: "line:user:U123",
+        text: "Hello",
+        payload: { text: "Hello" },
+        accountId: "default",
+        cfg: { channels: { line: {} } } as OpenClawConfig,
+        onDeliveryResult,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial LINE delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["m-text"],
+      receipt: { primaryPlatformMessageId: "m-text" },
+      visibleReplySent: true,
+    });
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+  });
+
   it("returns the provider receipt for a Flex-only legacy text send", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -1,6 +1,8 @@
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Line plugin module implements outbound behavior.
 import {
   defineChannelMessageAdapter,
+  listMessageReceiptPlatformIds,
   type ChannelMessageSendResult,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -54,7 +56,16 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     ): Promise<LineSendResult> => {
       const result = await resultPromise;
       lastResult = result;
-      await onDeliveryResult?.(createEmptyChannelResult("line", { ...result }));
+      try {
+        await onDeliveryResult?.(createEmptyChannelResult("line", { ...result }));
+      } catch (error) {
+        // Observers run after provider acceptance; losing this receipt invites duplicate delivery.
+        throw createChannelPartialDeliveryError(error, {
+          messageIds: listMessageReceiptPlatformIds(result.receipt),
+          receipt: result.receipt,
+          visibleReplySent: true,
+        });
+      }
       return result;
     };
     const quickReplies = lineData.quickReplies ?? [];
@@ -268,10 +279,10 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     }
 
     const completedResult = lastResult as LineSendResult | null;
-    if (completedResult) {
-      return createEmptyChannelResult("line", { ...completedResult });
+    if (!completedResult) {
+      throw new Error("Message must be non-empty for LINE sends");
     }
-    return createEmptyChannelResult("line", { messageId: "empty", chatId: to });
+    return createEmptyChannelResult("line", { ...completedResult });
   },
   ...createAttachedChannelResultAdapter({
     channel: "line",

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -1,10 +1,13 @@
+import { HTTPFetchError } from "@line/bot-sdk";
 // Line tests cover send plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   pushMessageMock,
   replyMessageMock,
+  lineFetchMock,
   showLoadingAnimationMock,
   getProfileMock,
   MessagingApiClientMock,
@@ -17,6 +20,7 @@ const {
 } = vi.hoisted(() => {
   const pushMessageMockLocal = vi.fn();
   const replyMessageMockLocal = vi.fn();
+  const lineFetchMockLocal = vi.fn();
   const showLoadingAnimationMockLocal = vi.fn();
   const getProfileMockLocal = vi.fn();
   const MessagingApiClientMockLocal = vi.fn(function () {
@@ -36,6 +40,7 @@ const {
   return {
     pushMessageMock: pushMessageMockLocal,
     replyMessageMock: replyMessageMockLocal,
+    lineFetchMock: lineFetchMockLocal,
     showLoadingAnimationMock: showLoadingAnimationMockLocal,
     getProfileMock: getProfileMockLocal,
     MessagingApiClientMock: MessagingApiClientMockLocal,
@@ -48,9 +53,13 @@ const {
   };
 });
 
-vi.mock("@line/bot-sdk", () => ({
-  messagingApi: { MessagingApiClient: MessagingApiClientMock },
-}));
+vi.mock("@line/bot-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@line/bot-sdk")>();
+  return {
+    ...actual,
+    messagingApi: { ...actual.messagingApi, MessagingApiClient: MessagingApiClientMock },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/plugin-config-runtime", () => ({
   requireRuntimeConfig: requireRuntimeConfigMock,
@@ -124,6 +133,7 @@ describe("LINE send helpers", () => {
     vi.setSystemTime(fixedSentAt);
     pushMessageMock.mockReset();
     replyMessageMock.mockReset();
+    lineFetchMock.mockReset();
     showLoadingAnimationMock.mockReset();
     getProfileMock.mockReset();
     MessagingApiClientMock.mockReset();
@@ -152,9 +162,21 @@ describe("LINE send helpers", () => {
     pushMessageMock.mockResolvedValue({ sentMessages: [{ id: "push" }] });
     replyMessageMock.mockResolvedValue({ sentMessages: [{ id: "reply" }] });
     showLoadingAnimationMock.mockResolvedValue({});
+    lineFetchMock.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      const requestUrl = typeof url === "string" ? url : url.toString();
+      const payload = JSON.parse(String(init?.body));
+      const provider = requestUrl.endsWith("/push") ? pushMessageMock : replyMessageMock;
+      const body = await provider(payload);
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", lineFetchMock);
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -554,15 +576,144 @@ describe("LINE send helpers", () => {
         }),
       provider: replyMessageMock,
     },
+  ])("preserves a finalized $label when activity recording fails", async ({ send, provider }) => {
+    provider.mockResolvedValueOnce({ sentMessages: [{ id: "line-provider-final" }] });
+    recordChannelActivityMock.mockImplementationOnce(() => {
+      throw new Error("activity store unavailable");
+    });
+
+    let caught: unknown;
+    try {
+      await send();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial LINE delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["line-provider-final"],
+      receipt: {
+        primaryPlatformMessageId: "line-provider-final",
+        platformMessageIds: ["line-provider-final"],
+        threadId: "U123",
+        parts: [
+          {
+            platformMessageId: "line-provider-final",
+            kind: "text",
+            raw: { chatId: "U123", meta: { messageCount: 1 } },
+          },
+        ],
+      },
+      visibleReplySent: true,
+    });
+  });
+
+  it.each([
+    {
+      label: "push",
+      send: () => sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }),
+      provider: pushMessageMock,
+    },
+    {
+      label: "reply",
+      send: () =>
+        sendModule.sendMessageLine("U123", "Hello", {
+          cfg: LINE_TEST_CFG,
+          replyToken: "reply-token",
+        }),
+      provider: replyMessageMock,
+    },
   ])(
-    "rejects a $label response that omits its provider message ids",
+    "preserves accepted delivery when a $label response omits its provider message ids",
     async ({ send, provider }) => {
       provider.mockResolvedValueOnce({ sentMessages: [] });
 
-      await expect(send()).rejects.toThrow(/sent message id/i);
+      let caught: unknown;
+      try {
+        await send();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      if (!isChannelPartialDeliveryError(caught)) {
+        throw new Error("expected an accepted LINE delivery without an identity");
+      }
+      expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
       expect(recordChannelActivityMock).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    { operation: "push", body: "{" },
+    { operation: "push", body: "" },
+    { operation: "reply", body: "{" },
+    { operation: "reply", body: "" },
+  ])("does not retry an accepted $operation response with an unreadable receipt", async (input) => {
+    lineFetchMock.mockResolvedValueOnce(
+      new Response(input.body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const send =
+      input.operation === "push"
+        ? () => sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG })
+        : () =>
+            sendModule.sendMessageLine("U123", "Hello", {
+              cfg: LINE_TEST_CFG,
+              replyToken: "reply-token",
+            });
+
+    let caught: unknown;
+    try {
+      await send();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted LINE delivery without a readable identity");
+    }
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    expect(recordChannelActivityMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps rejected LINE sends distinguishable from accepted delivery", async () => {
+    lineFetchMock.mockResolvedValueOnce(
+      new Response("invalid payload", { status: 400, statusText: "Bad Request" }),
+    );
+
+    let caught: unknown;
+    try {
+      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(HTTPFetchError);
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toMatchObject({
+      status: 400,
+      statusText: "Bad Request",
+      body: "invalid payload",
+    });
+  });
+
+  it("does not misclassify network SyntaxErrors as provider acceptance", async () => {
+    const failure = new SyntaxError("upstream network decoder failed");
+    lineFetchMock.mockRejectedValueOnce(failure);
+
+    await expect(sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG })).rejects.toBe(
+      failure,
+    );
+    expect(isChannelPartialDeliveryError(failure)).toBe(false);
+  });
 
   it.each([
     {
@@ -583,16 +734,53 @@ describe("LINE send helpers", () => {
       provider: replyMessageMock,
     },
   ])(
-    "rejects a partially invalid $label provider receipt without recording delivery",
+    "retains valid identities from a partially invalid accepted $label response",
     async ({ send, provider }) => {
       provider.mockResolvedValueOnce({
         sentMessages: [{ id: "line-provider-delivered" }, { id: "   " }],
       });
 
-      await expect(send()).rejects.toThrow(/sent message id/i);
+      let caught: unknown;
+      try {
+        await send();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      if (!isChannelPartialDeliveryError(caught)) {
+        throw new Error("expected a partially identifiable accepted LINE delivery");
+      }
+      expect(caught.deliveryResult).toEqual({
+        messageIds: ["line-provider-delivered"],
+        visibleReplySent: true,
+      });
       expect(recordChannelActivityMock).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    { name: "object receipt container", sentMessages: {} },
+    { name: "null receipt entry", sentMessages: [null] },
+    { name: "missing entry identifier", sentMessages: [{}] },
+  ])("preserves accepted delivery for a malformed $name", async ({ sentMessages }) => {
+    pushMessageMock.mockResolvedValueOnce({ sentMessages });
+
+    let caught: unknown;
+    try {
+      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted LINE delivery with a malformed receipt");
+    }
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(pushMessageMock).toHaveBeenCalledOnce();
+    expect(recordChannelActivityMock).not.toHaveBeenCalled();
+  });
 
   it("preserves literal internal-looking text in low-level sends", async () => {
     const text = "⚠️ 🛠️ `search repos (agent)` failed";

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -163,8 +163,11 @@ describe("LINE send helpers", () => {
     replyMessageMock.mockResolvedValue({ sentMessages: [{ id: "reply" }] });
     showLoadingAnimationMock.mockResolvedValue({});
     lineFetchMock.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
-      const requestUrl = typeof url === "string" ? url : url.toString();
-      const payload = JSON.parse(String(init?.body));
+      const requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+      if (typeof init?.body !== "string") {
+        throw new Error("LINE test fetch requires a JSON string request body");
+      }
+      const payload = JSON.parse(init.body);
       const provider = requestUrl.endsWith("/push") ? pushMessageMock : replyMessageMock;
       const body = await provider(payload);
       return new Response(JSON.stringify(body), {

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -1,6 +1,8 @@
 // Line plugin module implements send behavior.
-import { messagingApi } from "@line/bot-sdk";
+import { HTTPFetchError, messagingApi } from "@line/bot-sdk";
+import lineBotSdkPackage from "@line/bot-sdk/package.json" with { type: "json" };
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
@@ -71,18 +73,23 @@ interface LinePushBehavior {
   verboseMessage?: (chatId: string, messageCount: number) => string;
 }
 
-interface LineReplyBehavior {
-  verboseMessage?: (messageCount: number) => string;
-}
-
 function resolveLineProviderMessageIds(
   response: messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse,
   operation: "push" | "reply",
 ): { messageId: string; messageIds: string[] } {
-  const messageIds = response?.sentMessages?.map(({ id }) => id.trim()) ?? [];
+  const sentMessages = Array.isArray(response?.sentMessages) ? response.sentMessages : [];
+  const messageIds = sentMessages.flatMap((entry) => {
+    const id = entry && typeof entry === "object" ? entry.id : undefined;
+    const messageId = typeof id === "string" ? id.trim() : "";
+    return messageId ? [messageId] : [];
+  });
   const messageId = messageIds[0];
-  if (!messageId || messageIds.some((id) => !id)) {
-    throw new Error(`LINE ${operation} response did not include a sent message id`);
+  if (!messageId || messageIds.length !== sentMessages.length) {
+    // A successful LINE response means delivery was accepted even when its receipt is malformed.
+    throw createChannelPartialDeliveryError(
+      new Error(`LINE ${operation} response did not include a sent message id`),
+      { messageIds, visibleReplySent: true },
+    );
   }
   return { messageId, messageIds };
 }
@@ -122,9 +129,9 @@ function isLineUserChatId(chatId: string): boolean {
   return /^U/i.test(chatId);
 }
 
-function createLineMessagingClient(opts: LineClientOpts): {
+function resolveLineMessagingAccount(opts: LineClientOpts): {
   account: ReturnType<typeof resolveLineAccount>;
-  client: messagingApi.MessagingApiClient;
+  token: string;
 } {
   const cfg = requireRuntimeConfig(opts.cfg, "LINE send");
   const account = resolveLineAccount({
@@ -132,10 +139,18 @@ function createLineMessagingClient(opts: LineClientOpts): {
     accountId: opts.accountId,
   });
   const token = resolveLineChannelAccessToken(opts.channelAccessToken, account);
-  const client = new messagingApi.MessagingApiClient({
-    channelAccessToken: token,
-  });
-  return { account, client };
+  return { account, token };
+}
+
+function createLineMessagingClient(opts: LineClientOpts): {
+  account: ReturnType<typeof resolveLineAccount>;
+  client: messagingApi.MessagingApiClient;
+} {
+  const { account, token } = resolveLineMessagingAccount(opts);
+  return {
+    account,
+    client: new messagingApi.MessagingApiClient({ channelAccessToken: token }),
+  };
 }
 
 function createLinePushContext(
@@ -143,12 +158,47 @@ function createLinePushContext(
   opts: LineClientOpts,
 ): {
   account: ReturnType<typeof resolveLineAccount>;
-  client: messagingApi.MessagingApiClient;
+  token: string;
   chatId: string;
 } {
-  const { account, client } = createLineMessagingClient(opts);
+  const { account, token } = resolveLineMessagingAccount(opts);
   const chatId = normalizeTarget(to);
-  return { account, client, chatId };
+  return { account, token, chatId };
+}
+
+async function sendLineProviderMessages(
+  operation: "push" | "reply",
+  token: string,
+  request: messagingApi.PushMessageRequest | messagingApi.ReplyMessageRequest,
+): Promise<messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse> {
+  const response = await fetch(`https://api.line.me/v2/bot/message/${operation}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": `@line/bot-sdk/${lineBotSdkPackage.version}`,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      body: await response.text(),
+    });
+  }
+
+  try {
+    const text = await response.text();
+    return (text ? JSON.parse(text) : null) as
+      | messagingApi.PushMessageResponse
+      | messagingApi.ReplyMessageResponse;
+  } catch (error) {
+    // LINE accepted this exact request before its receipt became unreadable; retrying duplicates it.
+    throw createChannelPartialDeliveryError(error, { messageIds: [], visibleReplySent: true });
+  }
 }
 
 function createTextMessage(text: string): TextMessage {
@@ -217,12 +267,24 @@ function logLineHttpError(err: unknown, context: string): void {
   }
 }
 
-function recordLineOutboundActivity(accountId: string): void {
-  recordChannelActivity({
-    channel: "line",
-    accountId,
-    direction: "outbound",
-  });
+function recordLineOutboundActivity(
+  accountId: string,
+  delivery: { messageIds: string[]; receipt?: LineSendResult["receipt"] },
+): void {
+  try {
+    recordChannelActivity({
+      channel: "line",
+      accountId,
+      direction: "outbound",
+    });
+  } catch (error) {
+    // Provider delivery is already final; retain its identity if local bookkeeping fails.
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: delivery.messageIds,
+      ...(delivery.receipt ? { receipt: delivery.receipt } : {}),
+      visibleReplySent: true,
+    });
+  }
 }
 
 function resolveLineReceiptKind(messages: readonly Message[]) {
@@ -252,9 +314,9 @@ async function pushLineMessages(
     throw new Error("Message must be non-empty for LINE sends");
   }
 
-  const { account, client, chatId } = createLinePushContext(to, opts);
+  const { account, token, chatId } = createLinePushContext(to, opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
-  const pushRequest = client.pushMessage({
+  const pushRequest = sendLineProviderMessages("push", token, {
     to: chatId,
     messages: normalizedMessages,
   });
@@ -266,17 +328,7 @@ async function pushLineMessages(
       })
     : await pushRequest;
   const { messageId, messageIds } = resolveLineProviderMessageIds(response, "push");
-
-  recordLineOutboundActivity(account.accountId);
-
-  if (opts.verbose) {
-    const logMessage =
-      behavior.verboseMessage?.(chatId, messages.length) ??
-      `line: pushed ${messages.length} messages to ${chatId}`;
-    logVerbose(logMessage);
-  }
-
-  return {
+  const result: LineSendResult = {
     messageId,
     chatId,
     receipt: createLineSendReceipt({
@@ -287,33 +339,33 @@ async function pushLineMessages(
       messageCount: messages.length,
     }),
   };
+
+  recordLineOutboundActivity(account.accountId, { messageIds, receipt: result.receipt });
+
+  if (opts.verbose) {
+    const logMessage =
+      behavior.verboseMessage?.(chatId, messages.length) ??
+      `line: pushed ${messages.length} messages to ${chatId}`;
+    logVerbose(logMessage);
+  }
+
+  return result;
 }
 
 async function replyLineMessages(
   replyToken: string,
   messages: Message[],
   opts: LinePushOpts,
-  behavior: LineReplyBehavior = {},
-): Promise<{ messageId: string; messageIds: string[] }> {
-  const { account, client } = createLineMessagingClient(opts);
+): Promise<{ messageId: string; messageIds: string[]; accountId: string }> {
+  const { account, token } = resolveLineMessagingAccount(opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
 
-  const response = await client.replyMessage({
+  const response = await sendLineProviderMessages("reply", token, {
     replyToken,
     messages: normalizedMessages,
   });
   const result = resolveLineProviderMessageIds(response, "reply");
-
-  recordLineOutboundActivity(account.accountId);
-
-  if (opts.verbose) {
-    logVerbose(
-      behavior.verboseMessage?.(messages.length) ??
-        `line: replied with ${messages.length} messages`,
-    );
-  }
-
-  return result;
+  return { ...result, accountId: account.accountId };
 }
 
 export async function sendMessageLine(
@@ -361,11 +413,12 @@ export async function sendMessageLine(
   }
 
   if (opts.replyToken) {
-    const { messageId, messageIds } = await replyLineMessages(opts.replyToken, messages, opts, {
-      verboseMessage: () => `line: replied to ${chatId}`,
-    });
-
-    return {
+    const { messageId, messageIds, accountId } = await replyLineMessages(
+      opts.replyToken,
+      messages,
+      opts,
+    );
+    const result: LineSendResult = {
       messageId,
       chatId,
       receipt: createLineSendReceipt({
@@ -376,6 +429,11 @@ export async function sendMessageLine(
         messageCount: messages.length,
       }),
     };
+    recordLineOutboundActivity(accountId, { messageIds, receipt: result.receipt });
+    if (opts.verbose) {
+      logVerbose(`line: replied to ${chatId}`);
+    }
+    return result;
   }
 
   return pushLineMessages(chatId, messages, opts, {
@@ -396,7 +454,11 @@ export async function replyMessageLine(
   messages: Message[],
   opts: LinePushOpts,
 ): Promise<void> {
-  await replyLineMessages(replyToken, messages, opts);
+  const { messageIds, accountId } = await replyLineMessages(replyToken, messages, opts);
+  recordLineOutboundActivity(accountId, { messageIds });
+  if (opts.verbose) {
+    logVerbose(`line: replied with ${messages.length} messages`);
+  }
 }
 
 export async function pushMessagesLine(

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -7,6 +7,7 @@ import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import { messageAction, normalizeLineMessageActions } from "./actions.js";
@@ -171,15 +172,18 @@ async function sendLineProviderMessages(
   token: string,
   request: messagingApi.PushMessageRequest | messagingApi.ReplyMessageRequest,
 ): Promise<messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse> {
-  const response = await fetch(`https://api.line.me/v2/bot/message/${operation}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-      "User-Agent": `@line/bot-sdk/${lineBotSdkPackage.version}`,
+  const response = await fetchWithRuntimeDispatcherOrMockedGlobal(
+    `https://api.line.me/v2/bot/message/${operation}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": `@line/bot-sdk/${lineBotSdkPackage.version}`,
+      },
+      body: JSON.stringify(request),
     },
-    body: JSON.stringify(request),
-  });
+  );
 
   if (!response.ok) {
     throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,5 +1,6 @@
 // Mattermost tests cover client plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it, vi } from "vitest";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -27,7 +28,7 @@ import {
 
 function createMockFetch(response?: { status?: number; body?: unknown; contentType?: string }) {
   const status = response?.status ?? 200;
-  const body = response?.body ?? {};
+  const body = response && "body" in response ? response.body : {};
   const contentType = response?.contentType ?? "application/json";
 
   const calls: Array<{ url: string; init?: RequestInit }> = [];
@@ -35,7 +36,7 @@ function createMockFetch(response?: { status?: number; body?: unknown; contentTy
   const mockFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     const urlStr = requestUrl(url);
     calls.push({ url: urlStr, init });
-    return new Response(JSON.stringify(body), {
+    return new Response(status === 204 ? null : JSON.stringify(body), {
       status,
       headers: { "content-type": contentType },
     });
@@ -594,6 +595,134 @@ describe("fetchMattermostChannelPosts", () => {
 // ── createMattermostPost ─────────────────────────────────────────────
 
 describe("createMattermostPost", () => {
+  it.each(["{", ""])(
+    "preserves accepted visibility when a successful post receipt cannot be decoded (%j)",
+    async (body) => {
+      const mockFetch = vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      const client = createMattermostClient({
+        baseUrl: "http://localhost:8065",
+        botToken: "tok",
+        fetchImpl: mockFetch,
+      });
+
+      let caught: unknown;
+      try {
+        await createMattermostPost(client, { channelId: "ch123", message: "hello" });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      if (!isChannelPartialDeliveryError(caught)) {
+        throw new Error("expected an accepted Mattermost delivery with an unreadable identity");
+      }
+      expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+      expect(mockFetch).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not mark rejected Mattermost posts as accepted", async () => {
+    const mockFetch = vi.fn(
+      async () => new Response("{", { status: 400, statusText: "Bad Request" }),
+    );
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    let caught: unknown;
+    try {
+      await createMattermostPost(client, { channelId: "ch123", message: "hello" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Mattermost API 400 Bad Request");
+  });
+
+  it("does not misclassify Mattermost network SyntaxErrors as accepted", async () => {
+    const failure = new SyntaxError("network response parser failed");
+    const mockFetch = vi.fn(async () => {
+      throw failure;
+    });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await expect(
+      createMattermostPost(client, { channelId: "ch123", message: "hello" }),
+    ).rejects.toBe(failure);
+    expect(isChannelPartialDeliveryError(failure)).toBe(false);
+  });
+
+  it("does not mark unreadable non-delivery responses as visible posts", async () => {
+    const mockFetch = vi.fn(
+      async () =>
+        new Response("{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    let caught: unknown;
+    try {
+      await client.request("/users/me");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+  });
+
+  it.each([
+    { name: "missing", response: { body: { message: "sent" } } },
+    { name: "empty", response: { body: { id: "" } } },
+    { name: "blank", response: { body: { id: "  " } } },
+    { name: "null", response: { body: null } },
+    { name: "no-content", response: { status: 204 } },
+  ])("preserves accepted visibility for a $name provider post identity", async ({ response }) => {
+    const { client } = createTestClient(response);
+
+    let caught: unknown;
+    try {
+      await createMattermostPost(client, { channelId: "ch123", message: "hello" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted Mattermost delivery without an identity");
+    }
+    expect(caught.message).toBe("Mattermost post creation response did not include a post id");
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+  });
+
+  it("normalizes the provider post identity before callers consume it", async () => {
+    const { client } = createTestClient({ body: { id: "  post-123  " } });
+
+    await expect(
+      createMattermostPost(client, { channelId: "ch123", message: "hello" }),
+    ).resolves.toMatchObject({ id: "post-123" });
+  });
+
   it("sends channel_id and message", async () => {
     const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
     const client = createMattermostClient({

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -708,7 +708,7 @@ describe("createMattermostPost", () => {
     }
 
     expect(isChannelPartialDeliveryError(caught)).toBe(true);
-    if (!isChannelPartialDeliveryError(caught)) {
+    if (!isChannelPartialDeliveryError(caught) || !(caught instanceof Error)) {
       throw new Error("expected an accepted Mattermost delivery without an identity");
     }
     expect(caught.message).toBe("Mattermost post creation response did not include a post id");

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module implements client behavior.
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
@@ -287,11 +288,19 @@ export function createMattermostClient(params: {
       return undefined as T;
     }
 
-    const contentType = res.headers.get("content-type") ?? "";
-    if (contentType.includes("application/json")) {
-      return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`);
+    try {
+      const contentType = res.headers.get("content-type") ?? "";
+      if (contentType.includes("application/json")) {
+        return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`);
+      }
+      return (await readMattermostSuccessText(res, path)) as T;
+    } catch (error) {
+      if (path === "/posts" && init?.method?.toUpperCase() === "POST") {
+        // POST already succeeded; a lost/unreadable receipt must never schedule another visible post.
+        throw createChannelPartialDeliveryError(error, { messageIds: [], visibleReplySent: true });
+      }
+      throw error;
     }
-    return (await readMattermostSuccessText(res, path)) as T;
   };
 
   return { baseUrl, apiBaseUrl, token, request, fetchImpl };
@@ -709,10 +718,19 @@ export async function createMattermostPost(
   if (params.props) {
     payload.props = params.props;
   }
-  return await client.request<MattermostPost>("/posts", {
+  const post = await client.request<MattermostPost>("/posts", {
     method: "POST",
     body: JSON.stringify(payload),
   });
+  const postId = post && typeof post === "object" ? normalizeOptionalString(post.id) : undefined;
+  if (!postId) {
+    // Successful POST may already be visible; retrying because its receipt is malformed duplicates it.
+    throw createChannelPartialDeliveryError(
+      new Error("Mattermost post creation response did not include a post id"),
+      { messageIds: [], visibleReplySent: true },
+    );
+  }
+  return postId === post.id ? post : { ...post, id: postId };
 }
 
 type MattermostTeam = {

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -1,4 +1,5 @@
 // Mattermost tests cover draft stream plugin behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
 import {
@@ -209,6 +210,45 @@ describe("createMattermostDraftStream", () => {
     expect(stream.postId()).toBeUndefined();
   });
 
+  it("retains an accepted preview failure after its background flush has settled", async () => {
+    const warn = vi.fn();
+    const { client, requestMock } = createMockClient();
+    requestMock.mockResolvedValueOnce({ message: "already visible" });
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      warn,
+    });
+
+    stream.update("Already delivered");
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
+
+    let caught: unknown;
+    try {
+      await stream.flush();
+    } catch (error) {
+      caught = error;
+    }
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(requestMock.mock.calls[0]?.[0]).toBe("/posts");
+    stream.update("Must not create another accepted post");
+    await expect(stream.flush()).rejects.toThrow("did not include a post id");
+    expect(requestMock).toHaveBeenCalledOnce();
+    for (const finish of [
+      () => stream.discardPending(),
+      () => stream.clear(),
+      () => stream.seal(),
+      () => stream.stop(),
+      () => stream.forceNewMessage(),
+      () => stream.settleBoundaries(),
+    ]) {
+      await expect(finish()).rejects.toThrow("did not include a post id");
+    }
+    expect(requestMock).toHaveBeenCalledOnce();
+  });
+
   it("truncates on a code-point boundary so a straddling emoji is dropped whole", async () => {
     const { client, calls } = createMockClient();
     // maxChars=12 => cut point is maxChars-3=9. The emoji 😀 occupies UTF-16
@@ -285,6 +325,82 @@ describe("createMattermostDraftStream", () => {
 });
 
 describe("createMattermostDraftStream forceNewMessage", () => {
+  it("propagates a provider-accepted boundary post without an identity", async () => {
+    const { client, requestMock } = createMockClient();
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      maxChars: 10,
+      chunkText: () => ["aaaaaaaaaa", "bbbbbbbbbb"],
+    });
+
+    stream.updateAssistantText("aaaaaaaaaabbbbbbbbbb");
+    await stream.flush();
+    requestMock
+      .mockResolvedValueOnce({ id: "post-1", message: "aaaaaaaaaa" })
+      .mockResolvedValueOnce({ message: "already visible" });
+
+    await expect(stream.forceNewMessage()).rejects.toThrow("did not include a post id");
+    await expect(stream.flush()).rejects.toThrow("did not include a post id");
+    expect(requestMock.mock.calls.filter(([path]) => path === "/posts")).toHaveLength(2);
+  });
+
+  it("retains accepted boundary failures before synchronous warning callbacks re-enter", async () => {
+    const { client, requestMock } = createMockClient();
+    let reenteredBoundary: Promise<void> | undefined;
+    const warn = vi.fn(() => {
+      stream.update("must not publish twice");
+      reenteredBoundary = stream.forceNewMessage();
+      void reenteredBoundary.catch(() => {});
+    });
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      maxChars: 10,
+      chunkText: () => ["aaaaaaaaaa", "bbbbbbbbbb"],
+      warn,
+    });
+
+    stream.updateAssistantText("aaaaaaaaaabbbbbbbbbb");
+    await stream.flush();
+    requestMock
+      .mockResolvedValueOnce({ id: "post-1", message: "aaaaaaaaaa" })
+      .mockResolvedValueOnce({ message: "already visible" });
+
+    await expect(stream.forceNewMessage()).rejects.toThrow("did not include a post id");
+    await expect(reenteredBoundary).rejects.toThrow("did not include a post id");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(requestMock.mock.calls.filter(([path]) => path === "/posts")).toHaveLength(2);
+  });
+
+  it("propagates an accepted background failure that settles during boundary rotation", async () => {
+    const { client, requestMock } = createMockClient();
+    let releaseCreate: (() => void) | undefined;
+    const createReady = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    requestMock.mockImplementationOnce(async () => {
+      await createReady;
+      return { message: "already visible" };
+    });
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+    });
+
+    stream.update("Accepted background preview");
+    await vi.waitFor(() => expect(requestMock).toHaveBeenCalledOnce());
+    const boundary = stream.forceNewMessage();
+    releaseCreate?.();
+
+    await expect(boundary).rejects.toThrow("did not include a post id");
+    await expect(stream.flush()).rejects.toThrow("did not include a post id");
+    expect(requestMock).toHaveBeenCalledOnce();
+  });
+
   it("creates a new post on the next update after forceNewMessage", async () => {
     const { client, calls } = createMockClient();
     const stream = createMattermostDraftStream({

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -15,7 +15,7 @@ type RequestRecord = {
 function createMockClient(): {
   client: MattermostClient;
   calls: RequestRecord[];
-  requestMock: ReturnType<typeof vi.fn>;
+  requestMock: ReturnType<typeof vi.fn<MattermostClient["request"]>>;
 } {
   const calls: RequestRecord[] = [];
   let nextId = 1;

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,6 +1,7 @@
 // Mattermost plugin module implements draft stream behavior.
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -119,7 +120,7 @@ export function createMattermostDraftStream(params: {
   );
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const streamState = { stopped: false, final: false };
-  let terminalAcceptedDeliveryError: unknown;
+  let terminalAcceptedDeliveryError: Error | undefined;
   const assertNoAcceptedDeliveryFailure = () => {
     if (terminalAcceptedDeliveryError !== undefined) {
       throw terminalAcceptedDeliveryError;
@@ -183,16 +184,18 @@ export function createMattermostDraftStream(params: {
     } catch (err) {
       // Stop immediately so a discarded background failure cannot queue a second visible post.
       streamState.stopped = true;
-      const acceptedDeliveryFailed = isChannelPartialDeliveryError(err);
-      if (acceptedDeliveryFailed) {
+      const acceptedDeliveryError = isChannelPartialDeliveryError(err)
+        ? toErrorObject(err, "Mattermost accepted delivery failed")
+        : undefined;
+      if (acceptedDeliveryError) {
         // Warning handlers can synchronously re-enter finalization; retain the failure first.
-        terminalAcceptedDeliveryError = err;
+        terminalAcceptedDeliveryError = acceptedDeliveryError;
       }
       params.warn?.(
         `mattermost stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      if (acceptedDeliveryFailed) {
-        throw err;
+      if (acceptedDeliveryError) {
+        throw acceptedDeliveryError;
       }
       return false;
     }
@@ -334,11 +337,13 @@ export function createMattermostDraftStream(params: {
           sealedAssistantTexts.push({ text: assistantText, requiresBlockBoundary: true });
         }
       } catch (err) {
-        const acceptedDeliveryFailed = isChannelPartialDeliveryError(err);
-        if (acceptedDeliveryFailed) {
+        const acceptedDeliveryError = isChannelPartialDeliveryError(err)
+          ? toErrorObject(err, "Mattermost accepted delivery failed")
+          : undefined;
+        if (acceptedDeliveryError) {
           // Publish terminal state before warning hooks can re-enter update or forceNewMessage.
           streamState.stopped = true;
-          terminalAcceptedDeliveryError = err;
+          terminalAcceptedDeliveryError = acceptedDeliveryError;
         }
         const publishedAssistantPrefix = assistantText?.slice(0, publishedAssistantOffset).trim();
         if (publishedAssistantPrefix) {
@@ -352,8 +357,8 @@ export function createMattermostDraftStream(params: {
         params.warn?.(
           `mattermost stream preview boundary flush failed: ${err instanceof Error ? err.message : String(err)}`,
         );
-        if (acceptedDeliveryFailed) {
-          throw err;
+        if (acceptedDeliveryError) {
+          throw acceptedDeliveryError;
         }
       }
     })();

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module implements draft stream behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -118,6 +119,12 @@ export function createMattermostDraftStream(params: {
   );
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const streamState = { stopped: false, final: false };
+  let terminalAcceptedDeliveryError: unknown;
+  const assertNoAcceptedDeliveryFailure = () => {
+    if (terminalAcceptedDeliveryError !== undefined) {
+      throw terminalAcceptedDeliveryError;
+    }
+  };
   type DraftGeneration = {
     postId?: string;
     lastSentText: string;
@@ -168,22 +175,25 @@ export function createMattermostDraftStream(params: {
           message: normalized,
           rootId: params.rootId,
         });
-        const postId = sent.id?.trim();
-        if (!postId) {
-          streamState.stopped = true;
-          params.warn?.("mattermost stream preview stopped (missing post id from create)");
-          return false;
-        }
-        target.postId = postId;
+        target.postId = sent.id;
         target.lastProviderText = sent.message ?? normalized;
       }
       target.lastSentText = normalized;
       return true;
     } catch (err) {
+      // Stop immediately so a discarded background failure cannot queue a second visible post.
       streamState.stopped = true;
+      const acceptedDeliveryFailed = isChannelPartialDeliveryError(err);
+      if (acceptedDeliveryFailed) {
+        // Warning handlers can synchronously re-enter finalization; retain the failure first.
+        terminalAcceptedDeliveryError = err;
+      }
       params.warn?.(
         `mattermost stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (acceptedDeliveryFailed) {
+        throw err;
+      }
       return false;
     }
   };
@@ -216,6 +226,9 @@ export function createMattermostDraftStream(params: {
   });
 
   const forceNewMessage = () => {
+    if (terminalAcceptedDeliveryError !== undefined) {
+      return Promise.reject(terminalAcceptedDeliveryError);
+    }
     if (streamState.stopped || streamState.final) {
       return Promise.resolve();
     }
@@ -229,8 +242,11 @@ export function createMattermostDraftStream(params: {
     const boundary = (async () => {
       try {
         await sealed.ready;
+        assertNoAcceptedDeliveryFailure();
         await inFlightAtBoundary;
+        assertNoAcceptedDeliveryFailure();
         if (streamState.stopped && !streamState.final) {
+          assertNoAcceptedDeliveryFailure();
           return;
         }
         const sourceText = pendingText.trim() ? pendingText : sealed.latestSourceText;
@@ -283,14 +299,10 @@ export function createMattermostDraftStream(params: {
             message: firstChunk,
             rootId: params.rootId,
           });
-          const firstPostId = firstPost.id?.trim();
-          if (!firstPostId) {
-            throw new Error("missing post id from boundary create");
-          }
           if (assistantText) {
             const publishedContent = firstPost.message ?? firstChunk;
             trackPublishedAssistantPart({
-              messageId: firstPostId,
+              messageId: firstPost.id,
               content: publishedContent,
             });
             publishedAssistantOffset =
@@ -307,13 +319,9 @@ export function createMattermostDraftStream(params: {
             message: chunk,
             rootId: params.rootId,
           });
-          const postId = post.id?.trim();
-          if (!postId) {
-            throw new Error("missing post id from boundary create");
-          }
           if (assistantText) {
             const publishedContent = post.message ?? chunk;
-            trackPublishedAssistantPart({ messageId: postId, content: publishedContent });
+            trackPublishedAssistantPart({ messageId: post.id, content: publishedContent });
             publishedAssistantOffset =
               consumeMattermostPublishedChunk({
                 source: assistantText,
@@ -326,6 +334,12 @@ export function createMattermostDraftStream(params: {
           sealedAssistantTexts.push({ text: assistantText, requiresBlockBoundary: true });
         }
       } catch (err) {
+        const acceptedDeliveryFailed = isChannelPartialDeliveryError(err);
+        if (acceptedDeliveryFailed) {
+          // Publish terminal state before warning hooks can re-enter update or forceNewMessage.
+          streamState.stopped = true;
+          terminalAcceptedDeliveryError = err;
+        }
         const publishedAssistantPrefix = assistantText?.slice(0, publishedAssistantOffset).trim();
         if (publishedAssistantPrefix) {
           // A later physical chunk failed after this exact source prefix became durable.
@@ -338,6 +352,9 @@ export function createMattermostDraftStream(params: {
         params.warn?.(
           `mattermost stream preview boundary flush failed: ${err instanceof Error ? err.message : String(err)}`,
         );
+        if (acceptedDeliveryFailed) {
+          throw err;
+        }
       }
     })();
     currentGeneration = {
@@ -350,23 +367,33 @@ export function createMattermostDraftStream(params: {
   };
 
   const flush = async () => {
+    assertNoAcceptedDeliveryFailure();
     await loop.flush();
     await currentGeneration.ready;
+    assertNoAcceptedDeliveryFailure();
   };
   const discardPending = async () => {
+    assertNoAcceptedDeliveryFailure();
     await stopForClear();
     await currentGeneration.ready;
+    assertNoAcceptedDeliveryFailure();
   };
   const clear = async () => {
+    assertNoAcceptedDeliveryFailure();
     await clearWithStop(discardPending);
+    assertNoAcceptedDeliveryFailure();
   };
   const seal = async () => {
+    assertNoAcceptedDeliveryFailure();
     await sealLifecycle();
     await currentGeneration.ready;
+    assertNoAcceptedDeliveryFailure();
   };
   const stop = async () => {
+    assertNoAcceptedDeliveryFailure();
     await stopLifecycle();
     await currentGeneration.ready;
+    assertNoAcceptedDeliveryFailure();
   };
   const update = (text: string) => {
     currentGeneration.latestSourceText = text;
@@ -379,7 +406,9 @@ export function createMattermostDraftStream(params: {
     updateLifecycle(text);
   };
   const settleBoundaries = async () => {
+    assertNoAcceptedDeliveryFailure();
     await currentGeneration.ready;
+    assertNoAcceptedDeliveryFailure();
   };
   const resolveFinalText = (text: string) => {
     const publishedParts = [...publishedAssistantParts.values()];

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -110,16 +110,16 @@ function createMattermostSendReceipt(params: {
   kind: MessageReceiptPartKind;
   replyToId?: string;
 }): MessageReceipt {
-  const messageIds =
-    params.messageId.trim() && params.messageId !== "unknown" ? [params.messageId] : [];
   return createMessageReceiptFromOutboundResults({
     kind: params.kind,
     ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-    results: messageIds.map((messageId) => ({
-      channel: "mattermost",
-      messageId,
-      channelId: params.channelId,
-    })),
+    results: [
+      {
+        channel: "mattermost",
+        messageId: params.messageId,
+        channelId: params.channelId,
+      },
+    ],
   });
 }
 
@@ -496,7 +496,7 @@ export async function sendMessageMattermost(
     props,
   });
 
-  const messageId = post.id ?? "unknown";
+  const messageId = post.id;
   const receipt = createMattermostSendReceipt({
     messageId,
     channelId,


### PR DESCRIPTION
## What Problem This Solves

LINE reported fabricated success for empty outbound payloads and could resend already-accepted push/reply messages after malformed HTTP 200 responses, missing platform identities, failed local activity/observer bookkeeping, pairing fallback, or automatic-reply recovery.

Mattermost likewise treated malformed successful POST responses and missing post identities as ordinary failures. Background streaming previews and finalization races could then publish the same visible message twice.

The installed LINE SDK makes this especially subtle: its generated push/reply methods parse the accepted response body **before** exposing HTTP status, so a plain JSON `SyntaxError` cannot prove whether delivery was accepted. Catching arbitrary parse errors would incorrectly classify network/rejected requests and suppress legitimate retries.

## Why This Change Was Made

- Route only LINE push/reply through one private owner-controlled HTTP boundary that observes actual acceptance before reading the receipt. Preserve the SDK's exact provider endpoints, bearer token, JSON payload, package-version User-Agent, and exported `HTTPFetchError` rejection contract; leave profile/loading operations on the SDK.
- Canonicalize accepted LINE response identities, retain completed receipts when local bookkeeping fails, suppress duplicate pairing/automatic-reply fallback, and reject genuinely empty outbound payloads.
- Normalize Mattermost post identities at the canonical post owner, classify unreadable successful responses only for `POST /posts`, and retain accepted terminal failures through every streaming-preview lifecycle boundary and synchronous warning re-entry.

## User Impact

1. Empty LINE sends fail truthfully rather than inventing a delivered message.
2. Provider-accepted LINE push/reply sends are never duplicated after malformed/missing receipts or local post-delivery failures; real HTTP rejections and network failures retain their normal retry/error behavior.
3. Provider-accepted Mattermost posts and streaming previews are never duplicated after unreadable/missing receipts, deferred background failures, warning callbacks, or finalization races.

Exactly three private channel-owner root causes; production code adds 238 lines and deletes 93.

## Evidence

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`; exact immutable PR head: `42214999d7ad7dca0d350d58dd92ad34a778cfa0`; exact reviewed tree: `2a145018b2d9049b66d1e1206099f7658134ca92`.
- Exact-head verification:

```text
OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test extensions/line/src/auto-reply-delivery-recovery.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/auto-reply-delivery.test.ts extensions/line/src/send.test.ts extensions/line/src/bot-handlers.test.ts extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/send.test.ts extensions/mattermost/src/mattermost/draft-stream.test.ts
```

- **259/259 owner tests passed:** LINE **134/134** across five suites; Mattermost **125/125** across three suites; two real repository-managed Vitest shards, exit 0.
- Real HTTP-response regressions cover malformed/empty accepted responses, incomplete identities, rejected HTTP 400, network `SyntaxError`, SDK error parity, post-acceptance bookkeeping failures, pairing/automatic-reply fallback, and all affected Mattermost streaming lifecycle edges.
- Installed upstream dependency proof: `@line/bot-sdk@11.2.0` generated `messagingApiClient.ts:1968-1983,2043-2051`, `http-fetch.ts:82-95,195-210`, `version.ts`, exported package metadata, and the [official LINE Messaging API reference](https://developers.line.biz/en/reference/messaging-api/nojs/).
- Mattermost's exact authenticated post-creation contract is documented in its [official message-attachment API reference](https://developers.mattermost.com/integrate/reference/message-attachments/).
- Genuine full-branch Codex autoreview explicitly `--max-priority P3` on the final immutable head: **zero P0/P1/P2/P3 findings**, confidence **0.91**, real TruffleHog clean.
- **Two separate independent transport-owner reviewers** inspected complete owners/callers/siblings and actual installed upstream SDK source: both **strict P0–P3 clean**.
- All 13 paths pass actual `oxfmt --check`, `oxlint --deny-warnings`, clean frozen merge-base, clean committed branch, and `git diff --check`.

## Controlled, Redacted Transport Proof

All proof uses synthetic provider responses and placeholder values; no credentials, authorization headers, account identifiers, or live message content are included.

```text
LINE POST /message/push or /message/reply
  accepted: HTTP 200 + malformed/empty receipt -> visibleReplySent=true; exactly 1 provider request; no replay
  rejected: HTTP 400 -> HTTPFetchError(status=400); not marked accepted; normal failure/retry behavior retained

Mattermost POST /posts
  accepted: HTTP 200 + malformed/empty receipt -> visibleReplySent=true; accepted terminal state retained; no second post
  rejected: HTTP 400 -> ordinary provider error; not marked accepted
```

- LINE accepted malformed/empty HTTP receipts and **exactly one** provider request: `extensions/line/src/send.test.ts:658`; rejected HTTP 400 remains a genuine non-partial `HTTPFetchError`: `extensions/line/src/send.test.ts:690`; network failures retain their original rejection: `extensions/line/src/send.test.ts:711`.
- Accepted LINE replies never take the fallback push path: `extensions/line/src/auto-reply-delivery-recovery.test.ts:15`; pairing distinguishes accepted/no-fallback from rejected/one-fallback delivery: `extensions/line/src/bot-handlers.test.ts:757`.
- Mattermost accepted malformed/empty POST responses preserve visible partial delivery without a second request: `extensions/mattermost/src/mattermost/client.test.ts:599`; rejected HTTP 400 remains an ordinary, non-partial error: `extensions/mattermost/src/mattermost/client.test.ts:630`; network parser failures propagate normally: `extensions/mattermost/src/mattermost/client.test.ts:652`.
- Accepted Mattermost draft failures cannot create another post across flush/finalization or synchronous warning re-entry: `extensions/mattermost/src/mattermost/draft-stream.test.ts:213`, `extensions/mattermost/src/mattermost/draft-stream.test.ts:349`.

## Exact-Head Typed and Boundary Proof

Hosted proof first checked out the exact immutable PR commit and independently verified its tree and all six repaired source/test SHA-256 hashes before executing checks.

```text
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile /tmp/openclaw-117024-extensions.tsbuildinfo
node scripts/check-no-raw-channel-fetch.mjs
node scripts/run-additional-boundary-checks.mjs
```

- **Extensions test typecheck: PASS** on exact head `42214999d7ad7dca0d350d58dd92ad34a778cfa0`.
- **All 22 additional boundary checks: PASS**, including the previously failing raw channel-fetch guard and plugin SDK ownership checks.
- **All 259 transport-owner tests: PASS** on the same immutable hosted checkout; LINE **134/134**, Mattermost **125/125**.
- Exact six repaired files pass `oxfmt --check` and `oxlint --deny-warnings`; hosted command exit code **0** and the dedicated worker was stopped.
- GitHub exact-head checks `check-test-types`, `check-additional-boundaries-bcd`, `check-lint`, and `openclaw/ci-gate` all completed **SUCCESS**.

## ClawSweeper Rank-Up Moves: Addressed

1. **Controlled redacted malformed-acceptance/rejection proof:** Addressed by the synthetic LINE and Mattermost response-boundary regressions above: malformed accepted responses never replay; definitive rejected requests still fail normally.
2. **Exact-head typed and boundary validation:** Addressed by the successful full extensions test typecheck, all **22/22** additional boundary checks, all **259/259** owner tests, and successful exact-head GitHub CI checks above.

No authentication/security policy, public configuration/SDK, gateway protocol, persistence, database, dependency version, live credentials/device, or canonical-main changes.
