### PR TITLE
test(sandbox): preserve authoritative exclusive-create collision outcomes

### DIFF
--- a/src/agents/sandbox/remote-fs-bridge.test-helpers.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test-helpers.ts
@@ -1,0 +1,87 @@
+// Local subprocess-backed remote bridge fixtures shared by focused sandbox tests.
+import { spawnSync } from "node:child_process";
+import {
+  SANDBOX_CREATE_EXISTS_EXIT_CODE,
+  SANDBOX_PINNED_MUTATION_PYTHON,
+} from "./fs-bridge-mutation-helper.js";
+import type { RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
+
+export type LocalRemoteShellSpawnResult = {
+  stdout: string | Buffer | null;
+  stderr: string | Buffer | null;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+};
+
+export type LocalRemoteShellSpawn = (
+  file: string,
+  args: string[],
+  stdin?: string | Buffer,
+) => LocalRemoteShellSpawnResult;
+
+const PINNED_MUTATION_MARKER = 'python3 /dev/fd/3 "$@" 3<<';
+
+function spawnLocalRemoteShell(file: string, args: string[], stdin?: string | Buffer) {
+  return spawnSync(file, args, {
+    input: stdin,
+    encoding: "buffer",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export function createLocalRemoteShellScriptRunner(params?: {
+  spawn?: LocalRemoteShellSpawn;
+  onCommand?: (command: Parameters<RemoteShellSandboxHandle["runRemoteShellScript"]>[0]) => void;
+  shellArg0?: string;
+}): RemoteShellSandboxHandle["runRemoteShellScript"] {
+  return async (command) => {
+    params?.onCommand?.(command);
+    const runsPinnedMutation = command.script.includes(PINNED_MUTATION_MARKER);
+    const spawn = params?.spawn ?? spawnLocalRemoteShell;
+    const result = runsPinnedMutation
+      ? spawn(
+          "python3",
+          ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])],
+          command.stdin,
+        )
+      : spawn(
+          "sh",
+          [
+            "-c",
+            command.script,
+            params?.shellArg0 ?? "openclaw-sandbox-fs",
+            ...(command.args ?? []),
+          ],
+          command.stdin,
+        );
+    const stdout = Buffer.isBuffer(result.stdout)
+      ? result.stdout
+      : Buffer.from(result.stdout ?? []);
+    const stderr = Buffer.isBuffer(result.stderr)
+      ? result.stderr
+      : Buffer.from(result.stderr ?? []);
+    const code = result.status ?? (result.signal ? 128 : 1);
+    // A pinned exclusive create may exit before consuming stdin. Preserve its
+    // reserved collision status; every other spawn failure remains fatal.
+    const expectedCreatePipeClose =
+      runsPinnedMutation &&
+      command.args?.[0] === "create" &&
+      command.allowFailure === true &&
+      result.status === SANDBOX_CREATE_EXISTS_EXIT_CODE &&
+      result.signal === null &&
+      result.error &&
+      "code" in result.error &&
+      result.error.code === "EPIPE";
+    if (result.error && !expectedCreatePipeClose) {
+      throw result.error;
+    }
+    if (code !== 0 && !command.allowFailure) {
+      throw Object.assign(
+        new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
+        { code, stdout, stderr },
+      );
+    }
+    return { stdout, stderr, code };
+  };
+}

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -1,15 +1,19 @@
 // Remote filesystem bridge tests cover SSH-style sandbox file operations using
 // the pinned mutation helper and remote stat/path guards.
-import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
+import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-helper.js";
 import { createSandbox } from "./fs-bridge.test-helpers.js";
 import {
   createRemoteShellSandboxFsBridge,
   type RemoteShellSandboxHandle,
 } from "./remote-fs-bridge.js";
+import {
+  createLocalRemoteShellScriptRunner,
+  type LocalRemoteShellSpawn,
+  type LocalRemoteShellSpawnResult,
+} from "./remote-fs-bridge.test-helpers.js";
 
 function shellResult(stdout: string) {
   return { stdout: Buffer.from(stdout), stderr: Buffer.alloc(0), code: 0 };
@@ -43,6 +47,7 @@ function createStatRuntime(
 function createLocalRemoteRuntime(params: {
   remoteWorkspaceDir: string;
   remoteAgentWorkspaceDir: string;
+  spawn?: LocalRemoteShellSpawn;
 }) {
   // Execute remote shell snippets locally so the bridge scripts are exercised
   // without a real SSH host.
@@ -50,37 +55,10 @@ function createLocalRemoteRuntime(params: {
   const runtime: RemoteShellSandboxHandle = {
     remoteWorkspaceDir: params.remoteWorkspaceDir,
     remoteAgentWorkspaceDir: params.remoteAgentWorkspaceDir,
-    runRemoteShellScript: async (command) => {
-      calls.push(command);
-      const result = command.script.includes("python3 /dev/fd/3 \"$@\" 3<<'PY'")
-        ? spawnSync("python3", ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])], {
-            input: command.stdin,
-            encoding: "buffer",
-            stdio: ["pipe", "pipe", "pipe"],
-          })
-        : spawnSync("sh", ["-c", command.script, "openclaw-sandbox-fs", ...(command.args ?? [])], {
-            input: command.stdin,
-            encoding: "buffer",
-            stdio: ["pipe", "pipe", "pipe"],
-          });
-      const stdout = Buffer.isBuffer(result.stdout)
-        ? result.stdout
-        : Buffer.from(result.stdout ?? []);
-      const stderr = Buffer.isBuffer(result.stderr)
-        ? result.stderr
-        : Buffer.from(result.stderr ?? []);
-      const code = result.status ?? (result.signal ? 128 : 1);
-      if (result.error) {
-        throw result.error;
-      }
-      if (code !== 0 && !command.allowFailure) {
-        throw Object.assign(
-          new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
-          { code, stdout, stderr },
-        );
-      }
-      return { stdout, stderr, code };
-    },
+    runRemoteShellScript: createLocalRemoteShellScriptRunner({
+      spawn: params.spawn,
+      onCommand: (command) => calls.push(command),
+    }),
   };
   return { calls, runtime };
 }
@@ -100,6 +78,89 @@ function createWorkspaceReadBridge(workspaceDir: string) {
 }
 
 describe("remote sandbox fs bridge", () => {
+  it("preserves an authoritative create collision when stdin closes with EPIPE", async () => {
+    const pipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    const { runtime } = createLocalRemoteRuntime({
+      remoteWorkspaceDir: "/workspace",
+      remoteAgentWorkspaceDir: "/workspace",
+      spawn: () => ({
+        error: pipeError,
+        status: SANDBOX_CREATE_EXISTS_EXIT_CODE,
+        signal: null,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+      }),
+    });
+
+    await expect(
+      runtime.runRemoteShellScript({
+        script: "python3 /dev/fd/3 \"$@\" 3<<'PY'",
+        args: ["create", "/workspace", "", "existing.txt", "1"],
+        stdin: Buffer.alloc(1_048_576),
+        allowFailure: true,
+      }),
+    ).resolves.toMatchObject({ code: SANDBOX_CREATE_EXISTS_EXIT_CODE });
+  });
+
+  it.each([
+    {
+      name: "an unrecognized script",
+      command: { script: "exit 17" },
+      result: {},
+    },
+    {
+      name: "a non-create operation",
+      command: { args: ["read", "/workspace", "", "existing.txt"] },
+      result: {},
+    },
+    {
+      name: "a disallowed failure",
+      command: { allowFailure: false },
+      result: {},
+    },
+    {
+      name: "a different exit status",
+      command: {},
+      result: { status: SANDBOX_CREATE_EXISTS_EXIT_CODE + 1 },
+    },
+    {
+      name: "a signaled child",
+      command: {},
+      result: { status: null, signal: "SIGTERM" as NodeJS.Signals },
+    },
+    {
+      name: "a non-EPIPE spawn error",
+      command: {},
+      result: { errorCode: "ECONNRESET" },
+    },
+  ])("keeps spawn errors fatal for $name", async ({ command, result }) => {
+    const spawnError = Object.assign(new Error("spawn failed"), {
+      code: "errorCode" in result ? result.errorCode : "EPIPE",
+    });
+    const spawnResult: LocalRemoteShellSpawnResult = {
+      error: spawnError,
+      status: result.status === undefined ? SANDBOX_CREATE_EXISTS_EXIT_CODE : result.status,
+      signal: result.signal === undefined ? null : result.signal,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+    };
+    const { runtime } = createLocalRemoteRuntime({
+      remoteWorkspaceDir: "/workspace",
+      remoteAgentWorkspaceDir: "/workspace",
+      spawn: () => spawnResult,
+    });
+
+    await expect(
+      runtime.runRemoteShellScript({
+        script: "python3 /dev/fd/3 \"$@\" 3<<'PY'",
+        args: ["create", "/workspace", "", "existing.txt", "1"],
+        stdin: Buffer.alloc(1_048_576),
+        allowFailure: true,
+        ...command,
+      }),
+    ).rejects.toBe(spawnError);
+  });
+
   it.runIf(process.platform !== "win32")(
     "creates files exclusively and preserves existing entries",
     async () => {
@@ -159,7 +220,7 @@ describe("remote sandbox fs bridge", () => {
         expect(createFileExclusive).toBeTypeOf("function");
 
         await expect(
-          createFileExclusive!({ filePath: "link.txt", data: "replacement" }),
+          createFileExclusive!({ filePath: "link.txt", data: Buffer.alloc(1_048_576) }),
         ).resolves.toBe("exists");
         await expect(fs.readFile(path.join(workspaceDir, "target.txt"), "utf8")).resolves.toBe(
           "keep",

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -1,45 +1,20 @@
 // Workspace skills bridge tests cover read-only skill mounts across local and
 // remote sandbox filesystem bridges.
-import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
 import { createSandbox, withTempDir } from "./fs-bridge.test-helpers.js";
 import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./fs-paths.js";
 import {
   createRemoteShellSandboxFsBridge,
   type RemoteShellSandboxHandle,
 } from "./remote-fs-bridge.js";
+import { createLocalRemoteShellScriptRunner } from "./remote-fs-bridge.test-helpers.js";
 
-const runRemoteShellScript: RemoteShellSandboxHandle["runRemoteShellScript"] = async (command) => {
-  // Run the remote shell bridge scripts locally so path and permission checks are
-  // exercised without an SSH server.
-  const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
-    ? spawnSync("python3", ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])], {
-        input: command.stdin,
-        encoding: "buffer",
-        stdio: ["pipe", "pipe", "pipe"],
-      })
-    : spawnSync("sh", ["-c", command.script, "openclaw-test", ...(command.args ?? [])], {
-        input: command.stdin,
-        encoding: "buffer",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-  const stdout = Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.from(result.stdout ?? []);
-  const stderr = Buffer.isBuffer(result.stderr) ? result.stderr : Buffer.from(result.stderr ?? []);
-  const code = result.status ?? (result.signal ? 128 : 1);
-  if (result.error) {
-    throw result.error;
-  }
-  if (code !== 0 && !command.allowFailure) {
-    throw Object.assign(
-      new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
-      { code, stdout, stderr },
-    );
-  }
-  return { stdout, stderr, code };
-};
+// Run remote shell snippets locally so path and permission checks are exercised
+// without an SSH server.
+const runRemoteShellScript: RemoteShellSandboxHandle["runRemoteShellScript"] =
+  createLocalRemoteShellScriptRunner({ shellArg0: "openclaw-test" });
 
 describe("workspace skills bridge mount policy", () => {
   it("resolves workspace skill roots as read-only", async () => {


### PR DESCRIPTION
## What Problem This Solves

The local remote-sandbox test fixture could report `spawnSync python3 EPIPE` while the pinned helper had already returned its authoritative exclusive-create collision status. Because the fixture threw `result.error` before returning status 17, unrelated pull requests could fail intermittently even though sandbox production behavior was correct.

## Why This Change Was Made

This is a test-owner repair only. A concept-specific shared local remote-shell fixture now serves both duplicated sandbox test adapters. It preserves the helper's reserved collision status only for the exact tuple: recognized pinned helper, exclusive `create`, `allowFailure: true`, status 17, no signal, and `EPIPE`. Every mismatched script, operation, failure policy, status, signal, or error code still throws the original spawn error.

The deterministic regression injects representative subprocess outcomes instead of depending on OS pipe scheduling. One real 1 MiB symlink collision remains as integration/security proof, and current main's symlinked-mount-root escape coverage is preserved unchanged. Sandbox production code and public behavior are untouched.

## User Impact

Unrelated pull requests no longer fail intermittently when an expected exclusive-create collision closes unread test stdin. Existing symlink targets remain unchanged, while unexpected subprocess failures continue to fail closed.

## Evidence

- Pre-fix deterministic proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/sandbox/remote-fs-bridge.test.ts` failed 1 of 14 tests with `write EPIPE` instead of returning status 17.
- Post-fix focused proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/sandbox/remote-fs-bridge.test.ts src/agents/sandbox/workspace-skills-bridge-readonly.test.ts` passed 2 files and 25 tests.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzkjdhq0nydgp6etj9gkj482`; Actions run: https://github.com/openclaw/openclaw/actions/runs/31321354940
- Codex autoreview: clean on the first round, no accepted/actionable findings, correctness confidence 0.99.
- Production LOC: +0/-0. Tests: +187/-64.
- ClawSweeper moves addressed: deterministic positive and negative matcher coverage replaces race-dependent controls, and the current mount-root coverage is retained on a clean current-main rewrite.
- Historical hosted reproduction: run 30658341350 attempt 1 failed with `EPIPE`; attempt 2 passed unchanged.
