### PR TITLE
fix(discord): preserve authoritative interaction callback ownership

### DIFF
--- a/extensions/discord/src/internal/interactions.test.ts
+++ b/extensions/discord/src/internal/interactions.test.ts
@@ -1,3 +1,4 @@
+import { RESTJSONErrorCodes } from "discord-api-types/rest";
 // Discord tests cover interactions plugin behavior.
 import {
   ComponentType,
@@ -15,9 +16,11 @@ import {
   createInteraction,
   type RawInteraction,
 } from "./interactions.js";
+import { RequestClient } from "./rest.js";
 import { Message } from "./structures.js";
 import {
   attachRestMock,
+  createJsonResponse,
   createInternalComponentInteractionPayload,
   createInternalInteractionPayload,
   createInternalModalInteractionPayload,
@@ -181,6 +184,181 @@ describe("BaseInteraction", () => {
     expect(interaction.acknowledged).toBe(true);
   });
 
+  it("recovers a deferred callback whose accepted response was lost", async () => {
+    const responseLost = new Error("Deferred callback response connection lost");
+    const fetch = vi
+      .fn()
+      .mockRejectedValueOnce(responseLost)
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          {
+            message: "Interaction has already been acknowledged",
+            code: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+          },
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(createJsonResponse({ id: "recovered-message" }));
+    const client = createInternalTestClient();
+    client.rest = new RequestClient("test-token", {
+      baseUrl: "http://localhost",
+      fetch,
+      queueRequests: false,
+    });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await expect(interaction.defer()).rejects.toBe(responseLost);
+    await expect(interaction.reply("visible recovery")).resolves.toEqual({
+      id: "recovered-message",
+    });
+
+    expect(fetch.mock.calls.map(([, init]) => init?.method)).toEqual(["POST", "POST", "PATCH"]);
+    expect(interaction.responseState).toBe("replied");
+  });
+
+  it("recovers a lost initial reply through a webhook follow-up", async () => {
+    const responseLost = new Error("Initial reply response connection lost");
+    const fetch = vi
+      .fn()
+      .mockRejectedValueOnce(responseLost)
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          {
+            message: "Interaction has already been acknowledged",
+            code: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+          },
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(createJsonResponse({ id: "follow-up-message" }));
+    const client = createInternalTestClient();
+    client.rest = new RequestClient("test-token", {
+      baseUrl: "http://localhost",
+      fetch,
+      queueRequests: false,
+    });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await expect(interaction.reply("lost response")).rejects.toBe(responseLost);
+    await expect(interaction.reply("visible follow-up")).resolves.toEqual({
+      id: "follow-up-message",
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(String(fetch.mock.calls[2]?.[0])).toContain("/webhooks/app1/token1");
+    expect(interaction.responseState).toBe("replied");
+  });
+
+  it("requires a real 400/40060 before reconciling an ambiguous server failure", async () => {
+    const acknowledgedBody = {
+      message: "Interaction has already been acknowledged",
+      code: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+    };
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(acknowledgedBody, { status: 500 }))
+      .mockResolvedValueOnce(createJsonResponse(acknowledgedBody, { status: 400 }))
+      .mockResolvedValueOnce(createJsonResponse({ id: "recovered-message" }));
+    const client = createInternalTestClient();
+    client.rest = new RequestClient("test-token", {
+      baseUrl: "http://localhost",
+      fetch,
+      queueRequests: false,
+    });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await expect(interaction.defer()).rejects.toMatchObject({ status: 500 });
+    expect(interaction.responseState).toBe("unacknowledged");
+
+    await expect(interaction.reply("visible recovery")).resolves.toEqual({
+      id: "recovered-message",
+    });
+
+    expect(fetch.mock.calls.map(([, init]) => init?.method)).toEqual(["POST", "POST", "PATCH"]);
+    expect(interaction.responseState).toBe("replied");
+  });
+
+  it("never converts external acknowledgement into local callback ownership", async () => {
+    const localResponseLost = new Error("Local reply response connection lost");
+    const alreadyAcknowledged = () =>
+      createJsonResponse(
+        {
+          message: "Interaction has already been acknowledged",
+          code: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+        },
+        { status: 400 },
+      );
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(alreadyAcknowledged())
+      .mockRejectedValueOnce(localResponseLost)
+      .mockResolvedValueOnce(alreadyAcknowledged());
+    const client = createInternalTestClient();
+    client.rest = new RequestClient("test-token", {
+      baseUrl: "http://localhost",
+      fetch,
+      queueRequests: false,
+    });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await expect(interaction.reply("external owner")).rejects.toMatchObject({ status: 400 });
+    await expect(interaction.reply("local ambiguity")).rejects.toBe(localResponseLost);
+    await expect(interaction.reply("still external")).rejects.toMatchObject({ status: 400 });
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(interaction.responseState).toBe("unacknowledged");
+  });
+
+  it("does not guess between conflicting ambiguous callback types", async () => {
+    const deferResponseLost = new Error("Deferred callback response connection lost");
+    const replyResponseLost = new Error("Initial reply response connection lost");
+    const fetch = vi
+      .fn()
+      .mockRejectedValueOnce(deferResponseLost)
+      .mockRejectedValueOnce(replyResponseLost)
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          {
+            message: "Interaction has already been acknowledged",
+            code: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+          },
+          { status: 400 },
+        ),
+      );
+    const client = createInternalTestClient();
+    client.rest = new RequestClient("test-token", {
+      baseUrl: "http://localhost",
+      fetch,
+      queueRequests: false,
+    });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await expect(interaction.defer()).rejects.toBe(deferResponseLost);
+    await expect(interaction.reply("possibly accepted reply")).rejects.toBe(replyResponseLost);
+    await expect(interaction.reply("ambiguous owner")).rejects.toMatchObject({
+      status: 400,
+      discordCode: RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(interaction.responseState).toBe("unacknowledged");
+  });
+
   it.each([
     { first: "accepted", nextRoute: "/webhooks/app1/token1" },
     { first: "rejected", nextRoute: "/interactions/interaction1/token1/callback" },
@@ -275,6 +453,35 @@ describe("BaseInteraction", () => {
       undefined,
     );
   });
+
+  it.each(["edit", "delete"] as const)(
+    "waits for the initial callback before a direct %s operation",
+    async (operation) => {
+      let acceptFirst!: () => void;
+      const firstResponse = new Promise<void>((resolve) => {
+        acceptFirst = resolve;
+      });
+      const post = vi.fn(() => firstResponse);
+      const patch = vi.fn(async () => undefined);
+      const del = vi.fn(async () => undefined);
+      const client = createInternalTestClient();
+      attachRestMock(client, { delete: del, patch, post });
+      const interaction = createInteraction(
+        client,
+        createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+      );
+
+      const initial = interaction.reply("first");
+      await vi.waitFor(() => expect(post).toHaveBeenCalledOnce());
+      const direct =
+        operation === "edit" ? interaction.editReply("edited") : interaction.deleteReply();
+      expect(operation === "edit" ? patch : del).not.toHaveBeenCalled();
+      acceptFirst();
+      await Promise.all([initial, direct]);
+
+      expect(operation === "edit" ? patch : del).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     { kind: "command", operation: "defer" },

--- a/extensions/discord/src/internal/interactions.ts
+++ b/extensions/discord/src/internal/interactions.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements interactions behavior.
+import { RESTJSONErrorCodes } from "discord-api-types/rest";
 import {
   ComponentType,
   InteractionResponseType,
@@ -28,6 +29,7 @@ import {
 } from "./interaction-response.js";
 import { extractModalFields, ModalFields } from "./modal-fields.js";
 import { serializePayload, type MessagePayload } from "./payload.js";
+import { DiscordError } from "./rest.js";
 import { assertDiscordInteractionPayload } from "./schemas.js";
 import {
   channelFactory,
@@ -57,6 +59,9 @@ type Modal = {
 };
 
 type ComponentData = Record<string, unknown>;
+type InteractionCallbackProvenance =
+  | { kind: "unique"; type: InteractionResponseType }
+  | { kind: "conflicting" };
 
 export type RawInteraction = APIInteraction & {
   token: string;
@@ -121,6 +126,7 @@ class BaseInteraction {
   message: Message | null = null;
   private readonly response = new InteractionResponseController();
   private pendingResponse: Promise<void> = Promise.resolve();
+  private callbackProvenance: InteractionCallbackProvenance | undefined;
 
   constructor(
     public client: InteractionClient,
@@ -163,14 +169,49 @@ class BaseInteraction {
     if (this.response.acknowledged) {
       throw new Error("Discord interaction has already been acknowledged.");
     }
-    const result = await createInteractionCallback(
-      this.client.rest,
-      this.id,
-      this.token,
-      data === undefined ? { type } : { type, data },
+    try {
+      const result = await createInteractionCallback(
+        this.client.rest,
+        this.id,
+        this.token,
+        data === undefined ? { type } : { type, data },
+      );
+      this.response.recordCallback(type);
+      this.callbackProvenance = undefined;
+      return result;
+    } catch (error) {
+      if (this.isAcknowledgedInteractionError(error)) {
+        if (this.callbackProvenance?.kind === "unique") {
+          // A duplicate rejection proves the one possible earlier callback was accepted.
+          this.response.recordCallback(this.callbackProvenance.type);
+          this.callbackProvenance = undefined;
+        } else {
+          // External or conflicting ownership must never become a guessed local callback.
+          this.callbackProvenance = { kind: "conflicting" };
+        }
+      } else if (!(error instanceof DiscordError) || error.status >= 500) {
+        this.recordAmbiguousCallback(type);
+      }
+      throw error;
+    }
+  }
+
+  private isAcknowledgedInteractionError(error: unknown): error is DiscordError {
+    return (
+      error instanceof DiscordError &&
+      error.status === 400 &&
+      error.discordCode === RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged
     );
-    this.response.recordCallback(type);
-    return result;
+  }
+
+  private recordAmbiguousCallback(type: InteractionResponseType): void {
+    if (!this.callbackProvenance) {
+      this.callbackProvenance = { kind: "unique", type };
+      return;
+    }
+    if (this.callbackProvenance.kind === "unique" && this.callbackProvenance.type !== type) {
+      this.callbackProvenance = { kind: "conflicting" };
+    }
   }
 
   protected async callback(type: InteractionResponseType, data?: unknown) {
@@ -178,19 +219,28 @@ class BaseInteraction {
   }
 
   async reply(payload: MessagePayload): Promise<unknown> {
-    return await this.enqueueResponse(async () => {
-      const action = this.response.nextReplyAction();
-      if (action === "edit") {
-        return await this.performReplyEdit(payload);
-      }
-      if (action === "follow-up") {
-        return await this.performFollowUp(payload);
-      }
+    return await this.enqueueResponse(() => this.performReply(payload));
+  }
+
+  private async performReply(payload: MessagePayload): Promise<unknown> {
+    const action = this.response.nextReplyAction();
+    if (action === "edit") {
+      return await this.performReplyEdit(payload);
+    }
+    if (action === "follow-up") {
+      return await this.performFollowUp(payload);
+    }
+    try {
       return await this.performCallback(
         InteractionResponseType.ChannelMessageWithSource,
         serializePayload(payload),
       );
-    });
+    } catch (error) {
+      if (this.response.acknowledged && this.isAcknowledgedInteractionError(error)) {
+        return await this.performReply(payload);
+      }
+      throw error;
+    }
   }
 
   async defer(options?: { ephemeral?: boolean }): Promise<unknown> {


### PR DESCRIPTION
## What Problem This Solves

Current main correctly records Discord callback state only after the callback promise succeeds and serializes all response operations through one per-interaction queue. A residual failure remains when Discord accepts a callback but the response is lost: local state remains unacknowledged, the next visible reply retries an initial callback, and Discord returns code 40060 without telling OpenClaw whether the accepted callback was a defer or an initial reply.

## Why This Change Was Made

This rewritten candidate preserves current main's canonical response queue and layers bounded callback-type provenance inside that owner. A real Discord HTTP 400 with code 40060 is the only reconciliation signal; unique candidates route to the correct original-message edit or webhook follow-up, while external or conflicting candidates remain unowned. The stale branch's parallel partial queue and 626-line duplicate test suite were discarded.

## User Impact

The candidate can recover visible responses after dropped callback responses without reordering edits, deletes, fetches, or follow-ups. However, it is intentionally **not approved for merge** pending the ownership decision below.

## Evidence

- Pre-fix owner-boundary proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/discord/src/internal/interactions.test.ts` failed 2 of 39 tests; defer recovery and initial-reply recovery both stopped at Discord 40060.
- Candidate focused proof: the same owner suite passed 41/41 tests.
- Candidate sibling proof: five Discord suites passed 100/100 tests.
- Codex autoreview: clean on the first round at the configured P0 threshold, correctness confidence 0.98.
- Production LOC: +66/-16 (net +50). Tests: +207/-0.
- ClawSweeper's queue finding is addressed: `pendingResponse`/`enqueueResponse` remains the sole callback/edit/delete/fetch/follow-up serialization boundary, with new direct edit/delete ordering coverage.

## Maintainer Decision Required

Do not merge this head yet. Discord's 40060 proves only that **some** callback acknowledged the interaction; it does not identify the callback type, payload, or owning process. OpenClaw currently has no cross-process interaction-id owner registry. The default REST scheduler can also reject generic errors before dispatch, so generic rejection is not authoritative evidence that a callback may have reached Discord.

Peter needs to choose the contract before landing:

1. Enforce and document single callback ownership across processes, then unique-candidate reconciliation can be authoritative.
2. Add a typed REST outcome that distinguishes pre-dispatch rejection, definitive HTTP rejection, and dispatched/indeterminate failure, while retaining an unknown-owner state unless exclusivity is proven.
3. Fail visibly on indeterminate ownership and decline automatic recovery rather than infer an owner from 40060.

No configuration, public/plugin API, gateway protocol, SQLite, or product command policy changes are included.
