### PR TITLE
fix: tolerate slower Gateway readiness after updates

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -36,7 +36,7 @@ import {
 const DEFAULT_CHECKOUT = "/Users/steipete/openclaw";
 const DEFAULT_EXPECTED_ORIGIN = "openclaw/openclaw";
 const FULL_SHA_RE = /^[0-9a-f]{40}$/u;
-const GATEWAY_READINESS_ATTEMPTS = 3;
+const GATEWAY_READINESS_ATTEMPTS = 7;
 const GATEWAY_READINESS_RETRY_DELAY_MS = 5_000;
 const GATEWAY_CLI_TIMEOUT_MS = 30_000;
 const GATEWAY_STOP_PROOF_ATTEMPTS = 100;

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -528,7 +528,7 @@ describe("openclaw live updater", () => {
       (command: string, args: string[]) => {
         const call = [command, ...args].join(" ");
         calls.push(call);
-        if (call.includes("gateway status") && ++statusAttempts < 3) {
+        if (call.includes("gateway status") && ++statusAttempts < 7) {
           throw new Error("RPC warming up");
         }
       },
@@ -537,8 +537,12 @@ describe("openclaw live updater", () => {
       (ms: number) => delays.push(ms),
     );
 
-    expect(delays).toEqual([5_000, 5_000]);
+    expect(delays).toEqual([5_000, 5_000, 5_000, 5_000, 5_000, 5_000]);
     expect(calls).toEqual([
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
       "pnpm openclaw gateway status --deep --require-rpc --json",
       "pnpm openclaw gateway status --deep --require-rpc --json",
       "pnpm openclaw gateway status --deep --require-rpc --json",
@@ -1809,7 +1813,7 @@ describe("openclaw live updater", () => {
         },
       ),
     ).toThrow("RPC unavailable");
-    expect(statusCalls).toBe(4);
+    expect(statusCalls).toBe(8);
     expect(auditCalls).toBe(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the live main updater could report `update_failed` after a successful build and Gateway restart when a real Gateway needed more than 10 seconds to become RPC-ready.

## Why This Change Was Made

Keeps the existing 5-second bounded retry cadence and extends the readiness window from three attempts to seven. Every attempt still requires deep RPC status and verbose health; this changes only how long the updater waits for a legitimately starting Gateway.

## User Impact

Live source deployments no longer produce a false update failure merely because plugin/channel startup takes 10-30 seconds after launch.

## Evidence

- ClawMac reproduced the issue twice at exact built main: the updater exhausted three readiness attempts and returned `update_failed`, while the same managed overlay status call succeeded once Gateway startup settled. Canonical RPC, health, event loop, and plugin drift were all clean.
- Blacksmith Testbox: all 54 live-updater tooling tests passed.
- Regression proof now requires six 5-second delays before the seventh status attempt succeeds, and preserves the restart-window log audit expectation when all seven attempts fail.
- Final Codex autoreview: clean, no accepted/actionable findings; correctness confidence 0.99.
