### PR TITLE
chore(msteams): add private Gateway QA adapter

### DIFF
--- a/extensions/msteams/openclaw.plugin.json
+++ b/extensions/msteams/openclaw.plugin.json
@@ -6,6 +6,12 @@
     "onStartup": false
   },
   "channels": ["msteams"],
+  "qaRunners": [
+    {
+      "commandName": "msteams",
+      "description": "Run Microsoft Teams Gateway QA against a local Bot Framework mock"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/msteams/runtime-api.ts
+++ b/extensions/msteams/runtime-api.ts
@@ -1,6 +1,8 @@
 // Private runtime barrel for the bundled Microsoft Teams extension.
 // Keep this barrel thin and aligned with the local extension surface.
 
+import { msteamsQaCliRegistration } from "./src/qa/cli.js";
+
 export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 export type { AllowlistMatch } from "openclaw/plugin-sdk/allow-from";
 export {
@@ -66,3 +68,5 @@ export { normalizeStringEntries } from "openclaw/plugin-sdk/string-normalization
 export { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 export { DEFAULT_WEBHOOK_MAX_BODY_BYTES } from "openclaw/plugin-sdk/webhook-ingress";
 export { setMSTeamsRuntime } from "./src/runtime.js";
+
+export const qaRunnerCliRegistrations = [msteamsQaCliRegistration];

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -30,6 +30,7 @@ import {
   extractMSTeamsPollVote,
   type MSTeamsPollStore,
 } from "./polls.js";
+import { resolveMSTeamsPrivateQaRuntime } from "./qa/private-runtime.js";
 import {
   looksLikeMSTeamsConversationId,
   projectStableMSTeamsGroupAllowlist,
@@ -576,8 +577,14 @@ export async function monitorMSTeamsProvider(
   ingress.start();
 
   // Start listening and fail fast if bind/listen fails.
+  // skipAuth is private-QA-only and must never expose an unauthenticated
+  // webhook beyond loopback. Production keeps Express' existing bind behavior.
+  const privateQaRuntime = resolveMSTeamsPrivateQaRuntime();
   const httpServer = await new Promise<Server>((resolve, reject) => {
-    const server = expressApp.listen(port, (err) => (err ? reject(err) : resolve(server)));
+    const onListen = (err?: Error) => (err ? reject(err) : resolve(server));
+    const server = privateQaRuntime
+      ? expressApp.listen(port, privateQaRuntime.listenHost, onListen)
+      : expressApp.listen(port, onListen);
   }).catch(async (err: unknown) => {
     log.error("msteams server error", { error: formatUnknownError(err) });
     await ingress.stop();

--- a/extensions/msteams/src/qa/adapter.runtime.test.ts
+++ b/extensions/msteams/src/qa/adapter.runtime.test.ts
@@ -1,0 +1,205 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMSTeamsQaTransportAdapter } from "./adapter.runtime.js";
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    createdDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("Microsoft Teams QA transport adapter", () => {
+  it("creates a private bootstrap, sends real webhook-shaped inbound, and cleans up", async () => {
+    // openclaw-temp-dir: allow extension tests cannot import repo-only test helpers; afterEach removes it.
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-qa-"));
+    createdDirs.push(outputDir);
+    const addInboundMessage = vi.fn(async (input) => ({
+      ...input,
+      id: "bus-inbound-1",
+      direction: "inbound",
+      timestamp: Date.now(),
+    }));
+    const addOutboundMessage = vi.fn(async (input) => ({
+      ...input,
+      id: "bus-outbound-1",
+      direction: "outbound",
+      timestamp: Date.now(),
+    }));
+    const adapter = await createMSTeamsQaTransportAdapter({
+      adapterOptions: { transportPolicy: { requireGroupMention: true } },
+      channelId: "msteams",
+      credentials: {} as never,
+      driver: "live",
+      messages: {
+        addInboundMessage,
+        addOutboundMessage,
+        editMessage: vi.fn(),
+      },
+      outputDir,
+    });
+
+    const env = adapter.createRuntimeEnvPatch?.();
+    expect(env?.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
+    expect(env).not.toHaveProperty("OPENCLAW_QA_MSTEAMS_CONNECTOR_URL");
+    const bootstrapUrl = /--import=(\S+)/u.exec(env?.NODE_OPTIONS ?? "")?.[1];
+    expect(bootstrapUrl).toMatch(/^file:/u);
+    const bootstrapPath = fileURLToPath(bootstrapUrl!);
+    const bootstrap = await fs.readFile(bootstrapPath, "utf8");
+    expect(bootstrap).toContain('Symbol.for("openclaw.msteams.privateQaRuntime")');
+    expect(bootstrap).toContain("http://127.0.0.1:");
+    const bootstrapConfig = JSON.parse(
+      /globalThis\[key\] = (.+);$/mu.exec(bootstrap)?.[1] ?? "{}",
+    ) as { connectorUrl?: string; nonce?: string; botToken?: string };
+    expect(bootstrapConfig).toMatchObject({
+      connectorUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/u),
+      nonce: expect.any(String),
+      botToken: expect.any(String),
+    });
+    expect(bootstrapConfig.botToken?.split(".")).toHaveLength(3);
+
+    const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
+    const webhookPort = config.channels?.msteams?.webhook?.port;
+    expect(webhookPort).toEqual(expect.any(Number));
+    let inboundActivity: Record<string, unknown> | undefined;
+    const webhook = createServer((request, response) => {
+      void (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        inboundActivity = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        response.writeHead(202).end();
+      })();
+    });
+    webhook.listen(webhookPort, "127.0.0.1");
+    await once(webhook, "listening");
+    try {
+      await adapter.sendInbound({
+        accountId: "default",
+        conversation: { id: "qa-primary", kind: "channel" },
+        senderId: "driver",
+        senderName: "Driver",
+        text: "@openclaw qa ingress",
+        threadId: "thread-root",
+      });
+      expect(inboundActivity).toMatchObject({
+        text: "<at>openclaw</at> qa ingress",
+        entities: [
+          {
+            type: "mention",
+            text: "<at>openclaw</at>",
+            mentioned: { id: "qa-msteams-app", name: "OpenClaw QA" },
+          },
+        ],
+        serviceUrl: "https://smba.trafficmanager.net/qa",
+        conversation: {
+          id: "19:qa-primary@thread.tacv2;messageid=thread-root",
+          conversationType: "channel",
+        },
+      });
+      expect(addInboundMessage).toHaveBeenCalledTimes(1);
+      expect(config.channels?.msteams?.requireMention).toBe(true);
+    } finally {
+      webhook.close();
+      await once(webhook, "close");
+    }
+
+    const outboundResponse = await fetch(
+      `${bootstrapConfig.connectorUrl}qa/v3/conversations/${encodeURIComponent(
+        "19:qa-primary@thread.tacv2;messageid=thread-root",
+      )}/activities`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${bootstrapConfig.botToken}`,
+          "content-type": "application/json",
+          "x-openclaw-msteams-qa-nonce": bootstrapConfig.nonce!,
+        },
+        body: JSON.stringify({ type: "message", text: "qa outbound" }),
+      },
+    );
+    expect(outboundResponse.status).toBe(200);
+    expect(addOutboundMessage).toHaveBeenCalledWith({
+      accountId: "default",
+      senderId: "qa-msteams-app",
+      text: "qa outbound",
+      threadId: "thread-root",
+      timestamp: expect.any(Number),
+      to: "channel:qa-primary",
+    });
+
+    await adapter.cleanup?.();
+    await expect(fs.access(bootstrapPath)).rejects.toThrow();
+  });
+
+  it("does not follow webhook redirects to another loopback origin", async () => {
+    // openclaw-temp-dir: allow extension tests cannot import repo-only test helpers; afterEach removes it.
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-qa-"));
+    createdDirs.push(outputDir);
+    const addInboundMessage = vi.fn();
+    const adapter = await createMSTeamsQaTransportAdapter({
+      adapterOptions: {},
+      channelId: "msteams",
+      credentials: {} as never,
+      driver: "live",
+      messages: {
+        addInboundMessage,
+        addOutboundMessage: vi.fn(),
+        editMessage: vi.fn(),
+      },
+      outputDir,
+    });
+    const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
+    const webhookPort = config.channels?.msteams?.webhook?.port;
+    if (!webhookPort) {
+      throw new Error("expected Microsoft Teams QA webhook port");
+    }
+    let redirectedRequests = 0;
+    const redirectTarget = createServer((_request, response) => {
+      redirectedRequests += 1;
+      response.writeHead(200).end();
+    });
+    redirectTarget.listen(0, "127.0.0.1");
+    await once(redirectTarget, "listening");
+    const targetAddress = redirectTarget.address();
+    if (!targetAddress || typeof targetAddress === "string") {
+      throw new Error("expected redirect target address");
+    }
+    const webhook = createServer((_request, response) => {
+      response
+        .writeHead(302, {
+          location: `http://127.0.0.1:${targetAddress.port}/internal`,
+        })
+        .end();
+    });
+    webhook.listen(webhookPort, "127.0.0.1");
+    await once(webhook, "listening");
+
+    try {
+      await expect(
+        adapter.sendInbound({
+          accountId: "default",
+          conversation: { id: "qa-primary", kind: "channel" },
+          senderId: "driver",
+          text: "qa ingress",
+        }),
+      ).rejects.toThrow("Too many redirects (limit: 0)");
+      expect(redirectedRequests).toBe(0);
+      expect(addInboundMessage).not.toHaveBeenCalled();
+    } finally {
+      const closed = [once(webhook, "close"), once(redirectTarget, "close")];
+      webhook.close();
+      redirectTarget.close();
+      await Promise.all(closed);
+      await adapter.cleanup?.();
+    }
+  });
+});

--- a/extensions/msteams/src/qa/adapter.runtime.ts
+++ b/extensions/msteams/src/qa/adapter.runtime.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  reserveMSTeamsQaWebhookPort,
+  startMSTeamsQaBotFrameworkServer,
+} from "./bot-framework-server.js";
+
+type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
+type FactoryContext = Parameters<AdapterFactory["create"]>[0];
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
+
+const SERVICE_URL = "https://smba.trafficmanager.net/qa";
+const APP_ID = "qa-msteams-app";
+const TENANT_ID = "qa-msteams-tenant";
+const DRIVER_ID = "qa-msteams-driver";
+const TEAM_ID = "qa-msteams-team";
+const TEAM_AAD_GROUP_ID = "00000000-0000-4000-8000-000000000001";
+const DEFAULT_ACCOUNT_ID = "default";
+
+function nativeConversationId(logicalId: string) {
+  return logicalId.startsWith("19:") ? logicalId : `19:${logicalId}@thread.tacv2`;
+}
+
+function renderMSTeamsQaText(text: string) {
+  const mentionText = "<at>openclaw</at>";
+  const renderedText = text.replace(/@openclaw\b/giu, mentionText);
+  return {
+    text: renderedText,
+    ...(renderedText === text
+      ? {}
+      : {
+          entities: [
+            {
+              type: "mention",
+              text: mentionText,
+              mentioned: { id: APP_ID, name: "OpenClaw QA" },
+            },
+          ],
+        }),
+  };
+}
+
+function activityText(activity: Record<string, unknown>) {
+  return typeof activity.text === "string" ? activity.text : "";
+}
+
+function createMSTeamsQaBotToken() {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  // Teams SDK decodes custom tokens before attaching them to Connector requests.
+  // This unsigned value is accepted only by the nonce-protected loopback server.
+  return [
+    encode({ alg: "none", typ: "JWT" }),
+    encode({ appid: APP_ID, jti: randomUUID(), tid: TENANT_ID }),
+    "qa",
+  ].join(".");
+}
+
+async function waitForMSTeamsChannelReady(
+  gateway: Parameters<AdapterDefinition["waitReady"]>[0]["gateway"],
+  timeoutMs = 60_000,
+  pollIntervalMs = 500,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastAccounts: unknown;
+  while (Date.now() < deadline) {
+    const payload = (await gateway.call(
+      "channels.status",
+      { probe: false, timeoutMs: 2_000 },
+      { timeoutMs: 5_000 },
+    )) as {
+      channelAccounts?: Record<string, Array<Record<string, unknown>>>;
+    };
+    const accounts = payload.channelAccounts?.msteams ?? [];
+    lastAccounts = accounts;
+    const account = accounts.find((entry) => entry.accountId === DEFAULT_ACCOUNT_ID);
+    if (account?.running === true && account.restartPending !== true) {
+      return;
+    }
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(`msteams did not become ready; last accounts: ${JSON.stringify(lastAccounts)}`);
+}
+
+export async function createMSTeamsQaTransportAdapter(
+  context: FactoryContext,
+): Promise<AdapterDefinition> {
+  const accountId = context.adapterOptions?.sutAccountId?.trim() || DEFAULT_ACCOUNT_ID;
+  const webhookPort = await reserveMSTeamsQaWebhookPort();
+  const nonce = randomUUID();
+  const botToken = createMSTeamsQaBotToken();
+  const bootstrapPath = path.join(context.outputDir, ".msteams-private-qa-bootstrap.mjs");
+  const busByNativeMessageId = new Map<string, string>();
+  const nativeByBusMessageId = new Map<string, string>();
+  const conversationKindByNativeId = new Map<string, "channel" | "direct" | "group">();
+  const logicalConversationByNativeId = new Map<string, string>();
+  const requireGroupMention = context.adapterOptions?.transportPolicy?.requireGroupMention === true;
+  const connector = await startMSTeamsQaBotFrameworkServer({
+    botToken,
+    nonce,
+    async onOutbound(outbound) {
+      const kind = conversationKindByNativeId.get(outbound.conversationId) ?? "channel";
+      const conversationId =
+        logicalConversationByNativeId.get(outbound.conversationId) ?? outbound.conversationId;
+      const message = await context.messages.addOutboundMessage({
+        accountId,
+        to: `${kind === "direct" ? "dm" : kind}:${conversationId}`,
+        senderId: APP_ID,
+        text: activityText(outbound.activity),
+        timestamp: Date.now(),
+        ...(outbound.threadId
+          ? { threadId: busByNativeMessageId.get(outbound.threadId) ?? outbound.threadId }
+          : {}),
+      });
+      nativeByBusMessageId.set(message.id, outbound.activityId);
+      busByNativeMessageId.set(outbound.activityId, message.id);
+      conversationKindByNativeId.set(outbound.conversationId, kind);
+    },
+  });
+  try {
+    await fs.mkdir(context.outputDir, { recursive: true });
+    await fs.writeFile(
+      bootstrapPath,
+      [
+        'const key = Symbol.for("openclaw.msteams.privateQaRuntime");',
+        `globalThis[key] = ${JSON.stringify({
+          connectorUrl: connector.baseUrl,
+          nonce,
+          botToken,
+        })};`,
+        "",
+      ].join("\n"),
+      { encoding: "utf8", mode: 0o600 },
+    );
+  } catch (error) {
+    await connector.close().catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    id: "msteams",
+    label: "Microsoft Teams live",
+    accountId,
+    requiredPluginIds: ["msteams"],
+    supportedActions: [],
+    async sendInbound(input) {
+      const conversationId = nativeConversationId(input.conversation.id);
+      const nativeThreadId = input.threadId
+        ? (nativeByBusMessageId.get(input.threadId) ?? input.threadId)
+        : undefined;
+      conversationKindByNativeId.set(conversationId, input.conversation.kind);
+      logicalConversationByNativeId.set(conversationId, input.conversation.id);
+      const activityId = `qa-inbound-${randomUUID()}`;
+      const rendered = renderMSTeamsQaText(input.text);
+      const activity = {
+        id: activityId,
+        type: "message",
+        ...rendered,
+        timestamp: new Date().toISOString(),
+        channelId: "msteams",
+        serviceUrl: SERVICE_URL,
+        from: {
+          id: DRIVER_ID,
+          aadObjectId: DRIVER_ID,
+          name: input.senderName ?? "Teams QA Driver",
+        },
+        recipient: { id: APP_ID, name: "OpenClaw QA" },
+        conversation: {
+          id: nativeThreadId ? `${conversationId};messageid=${nativeThreadId}` : conversationId,
+          conversationType:
+            input.conversation.kind === "direct"
+              ? "personal"
+              : input.conversation.kind === "group"
+                ? "groupChat"
+                : "channel",
+          tenantId: TENANT_ID,
+        },
+        channelData: {
+          tenant: { id: TENANT_ID },
+          team: { id: TEAM_ID, aadGroupId: TEAM_AAD_GROUP_ID },
+          channel: { id: conversationId },
+        },
+      };
+      const webhookUrl = `http://127.0.0.1:${webhookPort}/api/messages`;
+      const { response, release } = await fetchWithSsrFGuard({
+        url: webhookUrl,
+        init: {
+          method: "POST",
+          headers: {
+            authorization: "Bearer private-qa",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(activity),
+        },
+        policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(webhookUrl),
+        maxRedirects: 0,
+        auditContext: "msteams-private-qa-ingress",
+      });
+      try {
+        await response.text();
+        if (!response.ok) {
+          throw new Error(`Microsoft Teams QA ingress returned HTTP ${response.status}`);
+        }
+      } finally {
+        await release();
+      }
+      const message = await context.messages.addInboundMessage({
+        ...input,
+        accountId,
+        senderId: DRIVER_ID,
+      });
+      nativeByBusMessageId.set(message.id, activityId);
+      busByNativeMessageId.set(activityId, message.id);
+      return message;
+    },
+    resetTransport() {
+      busByNativeMessageId.clear();
+      nativeByBusMessageId.clear();
+      conversationKindByNativeId.clear();
+      logicalConversationByNativeId.clear();
+    },
+    createGatewayConfig: () =>
+      ({
+        channels: {
+          msteams: {
+            enabled: true,
+            appId: APP_ID,
+            appPassword: "private-qa-secret",
+            tenantId: TENANT_ID,
+            groupPolicy: "open",
+            requireMention: requireGroupMention,
+            replyStyle: "thread",
+            webhook: { port: webhookPort, path: "/api/messages" },
+          },
+        },
+      }) as Pick<OpenClawConfig, "channels" | "messages">,
+    createRuntimeEnvPatch: () => ({
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      NODE_OPTIONS: [
+        process.env.NODE_OPTIONS?.trim(),
+        `--import=${pathToFileURL(bootstrapPath).href}`,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    }),
+    waitReady: async ({ gateway, timeoutMs, pollIntervalMs }) =>
+      await waitForMSTeamsChannelReady(gateway, timeoutMs, pollIntervalMs),
+    buildAgentDelivery: ({ target }) => ({
+      channel: "msteams",
+      to: target,
+      replyChannel: "msteams",
+      replyTo: target,
+    }),
+    async handleAction() {
+      throw new Error("Microsoft Teams live QA adapter does not implement transport actions");
+    },
+    createReportNotes: () => [
+      "Uses a loopback Bot Framework Connector with the real Microsoft Teams plugin and Gateway.",
+    ],
+    async cleanup() {
+      try {
+        await connector.close();
+      } finally {
+        await fs.rm(bootstrapPath, { force: true });
+      }
+    },
+  };
+}

--- a/extensions/msteams/src/qa/bot-framework-server.test.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { startMSTeamsQaBotFrameworkServer } from "./bot-framework-server.js";
+
+describe("Microsoft Teams QA Bot Framework server", () => {
+  it("rejects missing per-run credentials", async () => {
+    const server = await startMSTeamsQaBotFrameworkServer({
+      botToken: "bot-token",
+      nonce: "qa-nonce",
+      onOutbound: vi.fn(),
+    });
+    try {
+      const response = await fetch(`${server.baseUrl}qa/v3/conversations/channel/activities`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "message", text: "blocked" }),
+      });
+      expect(response.status).toBe(401);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("parses encoded conversation threads and captures outbound activity", async () => {
+    const onOutbound = vi.fn(async () => {});
+    const server = await startMSTeamsQaBotFrameworkServer({
+      botToken: "bot-token",
+      nonce: "qa-nonce",
+      onOutbound,
+    });
+    try {
+      const conversation = "19:qa-primary@thread.tacv2;messageid=thread-root";
+      const response = await fetch(
+        `${server.baseUrl}qa/v3/conversations/${encodeURIComponent(conversation)}/activities`,
+        {
+          method: "POST",
+          headers: {
+            authorization: "Bearer bot-token",
+            "content-type": "application/json",
+            "x-openclaw-msteams-qa-nonce": "qa-nonce",
+          },
+          body: JSON.stringify({ type: "message", text: "captured" }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(onOutbound).toHaveBeenCalledWith({
+        activity: { type: "message", text: "captured" },
+        activityId: expect.stringMatching(/^qa-outbound-/u),
+        conversationId: "19:qa-primary@thread.tacv2",
+        threadId: "thread-root",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("stops accepting requests after cleanup", async () => {
+    const server = await startMSTeamsQaBotFrameworkServer({
+      botToken: "bot-token",
+      nonce: "qa-nonce",
+      onOutbound: vi.fn(),
+    });
+    const url = server.baseUrl;
+    await server.close();
+    await expect(fetch(url)).rejects.toThrow();
+  });
+});

--- a/extensions/msteams/src/qa/bot-framework-server.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+type MSTeamsQaOutboundActivity = {
+  activity: Record<string, unknown>;
+  activityId: string;
+  conversationId: string;
+  threadId?: string;
+};
+
+type ServerOptions = {
+  botToken: string;
+  nonce: string;
+  onOutbound: (activity: MSTeamsQaOutboundActivity) => Promise<void>;
+};
+
+async function readJson(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const body = Buffer.concat(chunks).toString("utf8");
+  return body ? (JSON.parse(body) as Record<string, unknown>) : {};
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function parseConversationPath(pathname: string) {
+  const match = /\/v3\/conversations\/([^/]+)\/activities(?:\/[^/]+)?$/u.exec(pathname);
+  if (!match) {
+    return undefined;
+  }
+  const encodedConversationId = match[1];
+  if (!encodedConversationId) {
+    return undefined;
+  }
+  const rawConversationId = decodeURIComponent(encodedConversationId);
+  const [conversationId, threadId] = rawConversationId.split(";messageid=", 2);
+  if (!conversationId) {
+    return undefined;
+  }
+  return { conversationId, threadId };
+}
+
+export async function startMSTeamsQaBotFrameworkServer(options: ServerOptions) {
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (
+        request.headers["x-openclaw-msteams-qa-nonce"] !== options.nonce ||
+        request.headers.authorization !== `Bearer ${options.botToken}`
+      ) {
+        sendJson(response, 401, { error: "unauthorized" });
+        return;
+      }
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const route = parseConversationPath(url.pathname);
+      if (request.method !== "POST" || !route) {
+        sendJson(response, 404, { error: "not found" });
+        return;
+      }
+      const activity = await readJson(request);
+      const activityId = `qa-outbound-${randomUUID()}`;
+      await options.onOutbound({
+        activity,
+        activityId,
+        conversationId: route.conversationId,
+        ...(route.threadId ? { threadId: route.threadId } : {}),
+      });
+      sendJson(response, 200, { id: activityId });
+    })().catch((error: unknown) => {
+      sendJson(response, 500, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}/`,
+    async close() {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+export async function reserveMSTeamsQaWebhookPort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  server.close();
+  await once(server, "close");
+  return port;
+}

--- a/extensions/msteams/src/qa/cli.test.ts
+++ b/extensions/msteams/src/qa/cli.test.ts
@@ -1,0 +1,67 @@
+import { Command } from "commander";
+import type { LiveTransportQaSuiteCommandOptions } from "openclaw/plugin-sdk/qa-runner-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runLiveTransportQaSuiteCommand = vi.hoisted(() =>
+  vi.fn<(params: LiveTransportQaSuiteCommandOptions) => Promise<void>>(async () => {}),
+);
+
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/qa-runner-runtime")>()),
+  runLiveTransportQaSuiteCommand,
+}));
+
+import { msteamsQaCliRegistration } from "./cli.js";
+
+describe("Microsoft Teams QA CLI", () => {
+  beforeEach(() => {
+    runLiveTransportQaSuiteCommand.mockClear();
+  });
+
+  it("runs the shared channel canary by default", async () => {
+    const qa = new Command();
+    msteamsQaCliRegistration.register(qa);
+
+    await qa.parseAsync([
+      "node",
+      "openclaw",
+      "msteams",
+      "--provider-mode",
+      "mock-openai",
+      "--output-dir",
+      "/tmp/msteams-qa",
+    ]);
+
+    const params = runLiveTransportQaSuiteCommand.mock.calls[0]?.[0];
+    expect(params).toMatchObject({
+      channelId: "msteams",
+      defaultProviderMode: "mock-openai",
+      options: {
+        outputDir: "/tmp/msteams-qa",
+        providerMode: "mock-openai",
+      },
+    });
+    expect(
+      params?.selectScenarioIds({
+        primaryModel: "openai/gpt-5.4",
+        providerMode: "mock-openai",
+      }),
+    ).toEqual(["channel-canary"]);
+  });
+
+  it("honors explicit scenario selection", async () => {
+    const qa = new Command();
+    msteamsQaCliRegistration.register(qa);
+
+    await qa.parseAsync(["node", "openclaw", "msteams", "--scenario", "channel-canary"]);
+
+    const params = runLiveTransportQaSuiteCommand.mock.calls[0]?.[0];
+    expect(
+      params?.selectScenarioIds({
+        primaryModel: "openai/gpt-5.4",
+        providerMode: "mock-openai",
+        scenarioIds: params.options.scenarioIds,
+      }),
+    ).toEqual(["channel-canary"]);
+  });
+});

--- a/extensions/msteams/src/qa/cli.ts
+++ b/extensions/msteams/src/qa/cli.ts
@@ -1,0 +1,44 @@
+import {
+  createLazyCliRuntimeLoader,
+  createLiveTransportQaCliRegistration,
+  runLiveTransportQaSuiteCommand,
+  type LiveTransportQaCliRegistration,
+  type LiveTransportQaCommandOptions,
+} from "openclaw/plugin-sdk/qa-runner-runtime";
+
+const DEFAULT_MSTEAMS_QA_SCENARIOS = ["channel-canary"] as const;
+
+const loadMSTeamsQaAdapterRuntime = createLazyCliRuntimeLoader<
+  typeof import("./adapter.runtime.js")
+>(() => import("./adapter.runtime.js"));
+
+async function runQaMSTeams(options: LiveTransportQaCommandOptions) {
+  await runLiveTransportQaSuiteCommand({
+    channelId: "msteams",
+    defaultProviderMode: "mock-openai",
+    options,
+    selectScenarioIds: ({ scenarioIds }) =>
+      scenarioIds?.length ? [...scenarioIds] : [...DEFAULT_MSTEAMS_QA_SCENARIOS],
+  });
+}
+
+export const msteamsQaCliRegistration: LiveTransportQaCliRegistration =
+  createLiveTransportQaCliRegistration({
+    commandName: "msteams",
+    adapterFactory: {
+      id: "msteams",
+      isolatesInstances: true,
+      matches: ({ channelId, driver }) => channelId === "msteams" && driver === "live",
+      async create(context) {
+        return await (await loadMSTeamsQaAdapterRuntime()).createMSTeamsQaTransportAdapter(context);
+      },
+    },
+    defaultProviderMode: "mock-openai",
+    description: "Run Microsoft Teams Gateway QA against a local Bot Framework mock",
+    providerModeHelp: "Provider mode: mock-openai, aimock, or live-frontier",
+    outputDirHelp: "Microsoft Teams QA artifact directory",
+    allowFailuresHelp: "Write artifacts without setting a failing exit code when scenarios fail",
+    scenarioHelp: "Run only the named Microsoft Teams QA scenario (repeatable)",
+    sutAccountHelp: "Normalized Microsoft Teams SUT account id in QA artifacts",
+    run: runQaMSTeams,
+  });

--- a/extensions/msteams/src/qa/private-runtime.test.ts
+++ b/extensions/msteams/src/qa/private-runtime.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveMSTeamsPrivateQaRuntime } from "./private-runtime.js";
+
+const completeEnv = {
+  OPENCLAW_BUILD_PRIVATE_QA: "1",
+};
+const completeBootstrap = {
+  connectorUrl: "http://127.0.0.1:43123/",
+  nonce: "qa-nonce",
+  botToken: "qa-bot-token",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Microsoft Teams private QA runtime", () => {
+  it("leaves the production runtime unchanged without private QA inputs", () => {
+    expect(resolveMSTeamsPrivateQaRuntime({})).toBeUndefined();
+  });
+
+  it("rejects private QA inputs outside the private QA build", () => {
+    expect(() =>
+      resolveMSTeamsPrivateQaRuntime(
+        {
+          ...completeEnv,
+          OPENCLAW_BUILD_PRIVATE_QA: undefined,
+        },
+        completeBootstrap,
+      ),
+    ).toThrow("requires OPENCLAW_BUILD_PRIVATE_QA=1");
+  });
+
+  it.each(["connectorUrl", "nonce", "botToken"] as const)(
+    "rejects a partial private QA bootstrap missing %s",
+    (missing) => {
+      expect(() =>
+        resolveMSTeamsPrivateQaRuntime(
+          {
+            ...completeEnv,
+          },
+          {
+            ...completeBootstrap,
+            [missing]: undefined,
+          },
+        ),
+      ).toThrow("bootstrap requires connector URL, nonce, and bot token");
+    },
+  );
+
+  it("rejects a non-loopback connector", () => {
+    expect(() =>
+      resolveMSTeamsPrivateQaRuntime(completeEnv, {
+        ...completeBootstrap,
+        connectorUrl: "https://example.com/",
+      }),
+    ).toThrow("must use loopback HTTP");
+  });
+
+  it("returns a skip-auth runtime with the per-run token", async () => {
+    const runtime = resolveMSTeamsPrivateQaRuntime(completeEnv, completeBootstrap);
+    expect(runtime?.skipAuth).toBe(true);
+    expect(runtime?.listenHost).toBe("127.0.0.1");
+    await expect(runtime?.token()).resolves.toBe("qa-bot-token");
+  });
+
+  it("does not follow Connector redirects to another loopback origin", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://localhost:65535/internal" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = resolveMSTeamsPrivateQaRuntime(completeEnv, completeBootstrap);
+    if (!runtime) {
+      throw new Error("expected Microsoft Teams private QA runtime");
+    }
+
+    await expect(runtime.client.get("/v3/conversations/test/activities")).rejects.toThrow(
+      "Too many redirects (limit: 0)",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/msteams/src/qa/private-runtime.ts
+++ b/extensions/msteams/src/qa/private-runtime.ts
@@ -1,0 +1,162 @@
+// Private QA runtime support for the Microsoft Teams live transport adapter.
+import type { RequestConfig } from "@microsoft/teams.common";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+
+const PRIVATE_QA_BUILD_ENV = "OPENCLAW_BUILD_PRIVATE_QA";
+const PRIVATE_QA_NONCE_HEADER = "x-openclaw-msteams-qa-nonce";
+const PRIVATE_QA_RUNTIME_SYMBOL = Symbol.for("openclaw.msteams.privateQaRuntime");
+
+type PrivateQaEnv = Partial<Record<typeof PRIVATE_QA_BUILD_ENV, string>>;
+
+type PrivateQaBootstrap = {
+  connectorUrl?: string;
+  nonce?: string;
+  botToken?: string;
+};
+
+type HttpResponse<T = unknown> = {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  config: RequestConfig;
+};
+
+type PrivateQaHttpClientOptions = {
+  headers?: Record<string, string>;
+  token?: string | (() => string | Promise<string>);
+};
+
+class PrivateQaHttpClient {
+  constructor(
+    private readonly connectorUrl: string,
+    private readonly nonce: string,
+    private readonly options: PrivateQaHttpClientOptions = {},
+  ) {}
+
+  clone(options: PrivateQaHttpClientOptions = {}) {
+    return new PrivateQaHttpClient(this.connectorUrl, this.nonce, {
+      ...this.options,
+      ...options,
+      headers: { ...this.options.headers, ...options.headers },
+    });
+  }
+
+  async request<T = unknown>(config: RequestConfig): Promise<HttpResponse<T>> {
+    const sourceUrl = new URL(config.url ?? "", "https://smba.trafficmanager.net");
+    const targetUrl = new URL(`${sourceUrl.pathname}${sourceUrl.search}`, this.connectorUrl);
+    const headers = new Headers(this.options.headers);
+    for (const [key, value] of Object.entries(config.headers ?? {})) {
+      if (value != null) {
+        headers.set(key, String(value));
+      }
+    }
+    headers.set(PRIVATE_QA_NONCE_HEADER, this.nonce);
+    const token =
+      typeof this.options.token === "function" ? await this.options.token() : this.options.token;
+    if (token) {
+      headers.set("authorization", `Bearer ${token}`);
+    }
+    const method = String(config.method ?? "GET").toUpperCase();
+    const { response, release } = await fetchWithSsrFGuard({
+      url: targetUrl.toString(),
+      init: {
+        method,
+        headers,
+        body:
+          method === "GET" || method === "HEAD" || config.data == null
+            ? undefined
+            : typeof config.data === "string"
+              ? config.data
+              : JSON.stringify(config.data),
+      },
+      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(targetUrl.toString()),
+      maxRedirects: 0,
+      auditContext: "msteams-private-qa-connector",
+    });
+    try {
+      const text = await response.text();
+      const data = text ? (JSON.parse(text) as T) : (undefined as T);
+      if (!response.ok) {
+        throw new Error(`Microsoft Teams private QA connector returned HTTP ${response.status}`);
+      }
+      return {
+        data,
+        status: response.status,
+        statusText: response.statusText,
+        headers: Object.fromEntries(response.headers),
+        config,
+      };
+    } finally {
+      await release();
+    }
+  }
+
+  get<T = unknown>(url: string, config: RequestConfig = {}) {
+    return this.request<T>({ ...config, method: "GET", url });
+  }
+
+  post<T = unknown>(url: string, data?: unknown, config: RequestConfig = {}) {
+    return this.request<T>({ ...config, data, method: "POST", url });
+  }
+
+  put<T = unknown>(url: string, data?: unknown, config: RequestConfig = {}) {
+    return this.request<T>({ ...config, data, method: "PUT", url });
+  }
+
+  patch<T = unknown>(url: string, data?: unknown, config: RequestConfig = {}) {
+    return this.request<T>({ ...config, data, method: "PATCH", url });
+  }
+
+  delete<T = unknown>(url: string, config: RequestConfig = {}) {
+    return this.request<T>({ ...config, method: "DELETE", url });
+  }
+}
+
+type MSTeamsPrivateQaRuntime = {
+  client: PrivateQaHttpClient;
+  listenHost: "127.0.0.1";
+  skipAuth: true;
+  token: () => Promise<string>;
+};
+
+export function resolveMSTeamsPrivateQaRuntime(
+  env: PrivateQaEnv = process.env,
+  bootstrap: PrivateQaBootstrap | undefined = (
+    globalThis as typeof globalThis & {
+      [PRIVATE_QA_RUNTIME_SYMBOL]?: PrivateQaBootstrap;
+    }
+  )[PRIVATE_QA_RUNTIME_SYMBOL],
+): MSTeamsPrivateQaRuntime | undefined {
+  if (!bootstrap) {
+    return undefined;
+  }
+  if (env[PRIVATE_QA_BUILD_ENV] !== "1") {
+    throw new Error("Microsoft Teams private QA runtime requires OPENCLAW_BUILD_PRIVATE_QA=1");
+  }
+  const connectorUrl = bootstrap.connectorUrl?.trim();
+  const nonce = bootstrap.nonce?.trim();
+  const botToken = bootstrap.botToken?.trim();
+  if (!connectorUrl || !nonce || !botToken) {
+    throw new Error(
+      "Microsoft Teams private QA bootstrap requires connector URL, nonce, and bot token",
+    );
+  }
+  const parsedConnectorUrl = new URL(connectorUrl);
+  if (
+    parsedConnectorUrl.protocol !== "http:" ||
+    (parsedConnectorUrl.hostname !== "127.0.0.1" && parsedConnectorUrl.hostname !== "localhost")
+  ) {
+    throw new Error("Microsoft Teams private QA connector must use loopback HTTP");
+  }
+  const client = new PrivateQaHttpClient(parsedConnectorUrl.toString(), nonce);
+  return {
+    client,
+    listenHost: "127.0.0.1",
+    skipAuth: true,
+    token: async () => botToken,
+  };
+}

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -1,7 +1,16 @@
 // Msteams tests cover sdk plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { startMSTeamsQaBotFrameworkServer } from "./qa/bot-framework-server.js";
+import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
 import { createMSTeamsTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import type { MSTeamsCredentials, MSTeamsFederatedCredentials } from "./token.js";
+
+const privateQaRuntimeSymbol = Symbol.for("openclaw.msteams.privateQaRuntime");
+const privateQaBotToken = [
+  Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url"),
+  Buffer.from(JSON.stringify({ appid: "test-app-id", tid: "test-tenant" })).toString("base64url"),
+  "qa",
+].join(".");
 
 const { readSecretFile } = vi.hoisted(() => ({
   readSecretFile: vi
@@ -35,6 +44,12 @@ vi.mock("@azure/identity", () => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
+  delete (
+    globalThis as typeof globalThis & {
+      [privateQaRuntimeSymbol]?: unknown;
+    }
+  )[privateQaRuntimeSymbol];
   vi.restoreAllMocks();
   readSecretFile
     .mockReset()
@@ -70,6 +85,135 @@ describe("createMSTeamsApp", () => {
 
     const app = await createMSTeamsApp(creds);
     expect(app).toBeDefined();
+  });
+
+  it("keeps private QA App options absent in production", async () => {
+    const app = await createMSTeamsApp({
+      type: "secret",
+      appId: "test-app-id",
+      appPassword: "test-secret",
+      tenantId: "test-tenant",
+    });
+    const options = (app as unknown as { options?: Record<string, unknown> }).options;
+    expect(options?.skipAuth).toBeUndefined();
+    expect(options?.token).toBeUndefined();
+  });
+
+  it("passes the complete private QA bootstrap into the SDK App", async () => {
+    vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "1");
+    vi.stubEnv("CLIENT_SECRET", "ambient-private-qa-secret");
+    (
+      globalThis as typeof globalThis & {
+        [privateQaRuntimeSymbol]?: {
+          connectorUrl: string;
+          nonce: string;
+          botToken: string;
+        };
+      }
+    )[privateQaRuntimeSymbol] = {
+      connectorUrl: "http://127.0.0.1:43123/",
+      nonce: "qa-nonce",
+      botToken: privateQaBotToken,
+    };
+
+    const app = await createMSTeamsApp({
+      type: "secret",
+      appId: "test-app-id",
+      appPassword: "test-secret",
+      tenantId: "test-tenant",
+    });
+    const options = (app as unknown as { options?: Record<string, unknown> }).options;
+    expect(options?.skipAuth).toBe(true);
+    expect(options?.clientSecret).toBe("");
+    expect(options?.client).toEqual(expect.objectContaining({ clone: expect.any(Function) }));
+    expect(options?.token).toEqual(expect.any(Function));
+    const token = options?.token;
+    if (typeof token !== "function") {
+      throw new Error("expected private QA token factory");
+    }
+    await expect(token()).resolves.toBe(privateQaBotToken);
+    const credentials = (
+      app as unknown as {
+        credentials?: Record<string, unknown>;
+      }
+    ).credentials;
+    expect(credentials).toMatchObject({
+      clientId: "test-app-id",
+      token: expect.any(Function),
+    });
+    expect(credentials).not.toHaveProperty("clientSecret");
+    expect(String(await app.tokenManager.getBotToken())).toBe(privateQaBotToken);
+  });
+
+  it("routes a private QA proactive send through the loopback Connector", async () => {
+    vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "1");
+    vi.stubEnv("CLIENT_SECRET", "ambient-private-qa-secret");
+    const outbound: Array<{
+      activity: Record<string, unknown>;
+      activityId: string;
+      conversationId: string;
+      threadId?: string;
+    }> = [];
+    const connector = await startMSTeamsQaBotFrameworkServer({
+      botToken: privateQaBotToken,
+      nonce: "qa-nonce",
+      onOutbound: async (activity) => {
+        outbound.push(activity);
+      },
+    });
+    (
+      globalThis as typeof globalThis & {
+        [privateQaRuntimeSymbol]?: {
+          connectorUrl: string;
+          nonce: string;
+          botToken: string;
+        };
+      }
+    )[privateQaRuntimeSymbol] = {
+      connectorUrl: connector.baseUrl,
+      nonce: "qa-nonce",
+      botToken: privateQaBotToken,
+    };
+
+    try {
+      const app = await createMSTeamsApp({
+        type: "secret",
+        appId: "test-app-id",
+        appPassword: "test-secret",
+        tenantId: "test-tenant",
+      });
+      const result = await sendMSTeamsActivityWithReference(
+        app,
+        {
+          serviceUrl: "https://smba.trafficmanager.net/qa",
+          agent: { id: "test-app-id", name: "OpenClaw QA", role: "bot" },
+          user: { id: "qa-driver" },
+          conversation: {
+            id: "19:qa-primary@thread.tacv2",
+            conversationType: "channel",
+            tenantId: "test-tenant",
+          },
+          channelId: "msteams",
+        },
+        { type: "message", text: "qa outbound" },
+        { threadActivityId: "thread-root" },
+      );
+
+      expect(result.id).toMatch(/^qa-outbound-/u);
+      expect(outbound).toEqual([
+        {
+          activity: expect.objectContaining({
+            type: "message",
+            text: "qa outbound",
+          }),
+          activityId: result.id,
+          conversationId: "19:qa-primary@thread.tacv2",
+          threadId: "thread-root",
+        },
+      ]);
+    } finally {
+      await connector.close();
+    }
   });
 
   it("creates app with federated certificate credentials", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -3,6 +3,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import { normalizeBotFrameworkServiceUrl } from "./bot-framework-service-url.js";
 import type { MSTeamsCloudName } from "./cloud.js";
+import { resolveMSTeamsPrivateQaRuntime } from "./qa/private-runtime.js";
 import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
 import type { MSTeamsCredentials, MSTeamsFederatedCredentials } from "./token.js";
 import { buildOpenClawUserAgentFragment } from "./user-agent.js";
@@ -262,6 +263,7 @@ async function createMSTeamsApp(
   options?: CreateMSTeamsAppOptions,
 ): Promise<MSTeamsApp> {
   const { App, cloudFromName } = await loadSdkModules();
+  const privateQaRuntime = resolveMSTeamsPrivateQaRuntime();
   // Tag outbound SDK HTTP calls with a User-Agent fragment so the Teams
   // backend can identify OpenClaw traffic for usage telemetry. Teams SDK
   // 2.0.11+ preserves both its own `teams.ts[apps]/<sdk-version>` identifier
@@ -271,10 +273,20 @@ async function createMSTeamsApp(
     ? normalizeBotFrameworkServiceUrl(options.serviceUrl)
     : undefined;
   const appOptions: Record<string, unknown> = {
-    client: options?.httpClient ?? {
-      headers: { "User-Agent": buildOpenClawUserAgentFragment() },
-      timeout: MSTEAMS_REQUEST_TIMEOUT_MS,
-    },
+    client: privateQaRuntime?.client ??
+      options?.httpClient ?? {
+        headers: { "User-Agent": buildOpenClawUserAgentFragment() },
+        timeout: MSTEAMS_REQUEST_TIMEOUT_MS,
+      },
+    ...(privateQaRuntime
+      ? {
+          // Teams SDK prefers clientSecret over token and falls back to CLIENT_SECRET.
+          // Clear it explicitly so private QA cannot escape to real Azure auth.
+          clientSecret: "",
+          skipAuth: privateQaRuntime.skipAuth,
+          token: privateQaRuntime.token,
+        }
+      : {}),
     ...(options?.httpServerAdapter ? { httpServerAdapter: options.httpServerAdapter } : {}),
     ...(options?.messagingEndpoint ? { messagingEndpoint: options.messagingEndpoint } : {}),
     cloud: cloudFromName(cloud),

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -136,6 +136,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";',
     'export { DEFAULT_WEBHOOK_MAX_BODY_BYTES } from "openclaw/plugin-sdk/webhook-ingress";',
     'export { setMSTeamsRuntime } from "./src/runtime.js";',
+    "export const qaRunnerCliRegistrations = [msteamsQaCliRegistration];",
   ],
   [bundledPluginFile({ rootDir: ROOT_DIR, pluginId: "irc", relativePath: "runtime-api.ts" })]: [
     'export { setIrcRuntime } from "./src/runtime.js";',


### PR DESCRIPTION
Related: #116398

## What Problem This Solves

Microsoft Teams channel changes could not produce the repository's accepted real-behavior proof without external Teams credentials. The QA suite had no live Teams adapter that exercised the bundled plugin, ephemeral Gateway, provider turn, and Bot Framework outbound path together.

## Why This Change Was Made

Add a private-build-only Microsoft Teams QA adapter backed by a nonce-protected loopback Bot Framework Connector. The adapter preserves logical QA conversation identities, encodes portable mentions as native Teams mention entities, honors the scenario mention policy, and explicitly prevents the Teams SDK from selecting real Azure client-secret authentication.

The production runtime remains unchanged unless a private QA build receives the per-run bootstrap object; private webhooks bind only to loopback.

## User Impact

No user-visible production behavior changes. Maintainers gain a credential-free real Gateway proof lane for Microsoft Teams channel work.

## Evidence

Exact head: `c7830497da90cf07a409d3014fe354bd95ae9143`

- Focused local proof: 52 tests passed across the private runtime, adapter, Bot Framework connector, CLI, packaging, and Microsoft Teams runtime guardrails.
- Targeted oxfmt, oxlint, `git diff --check`, and scrub checks passed.
- Exact-head hosted CI and `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/30665431247
- Exact-head hosted real-behavior proof passed: https://github.com/openclaw/openclaw/actions/runs/30665429658/job/91271200781
- Blacksmith Testbox `pnpm check:changed` passed, then the private QA build + real ephemeral Gateway + bundled `msteams` plugin + `mock-openai` + loopback Bot Framework Connector passed `channel-canary` 1/1: https://github.com/openclaw/openclaw/actions/runs/30665595301
- Exact-head autoreview reported no P0/P1 findings: patch correct, confidence 0.86.
- Pinned `@microsoft/teams.apps` 2.0.14 source was inspected directly: the SDK clones the supplied client into API/Graph/activity clients, an explicit empty `clientSecret` blocks ambient `CLIENT_SECRET`, and the supplied token factory is selected.
- Clean merge tree `21f5a33c32789ba41ae0b3542b7991ab2af5c672` against current `main` `b6d9b38146c7be78fb2b3678e7f42ca0130d369d`; zero drift across 14 touched paths and zero unresolved review threads.

AI-assisted: yes. The implementation, dependency contract, and proof results were reviewed before opening this PR.
