### PR TITLE
fix(restart): give the stale-pid lsof scan a 5s budget

### DIFF
--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -272,6 +272,24 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expectWarningContaining(`lsof failed during initial stale-pid scan for port 18789: ${code}`);
     });
 
+    it("finds stale pids when lsof needs seconds to answer", () => {
+      // macOS hosts with many mounted volumes need seconds per lsof call. When
+      // the default budget expires first, spawnSync reports ETIMEDOUT and the
+      // stale gateway is never killed, so the restart fails on the busy port.
+      const slowLsofMs = 3000;
+      const stalePid = process.pid + 105;
+      mockSpawnSync.mockImplementation((command: unknown, _args: unknown, options: unknown) => {
+        if (command !== "lsof") {
+          return createLsofResult();
+        }
+        const timeout = (options as { timeout?: number }).timeout ?? 0;
+        return timeout >= slowLsofMs
+          ? createOpenClawBusyResult(stalePid)
+          : createErrnoResult("ETIMEDOUT", "lsof timed out");
+      });
+      expect(findGatewayPidsOnPortSync(18789)).toStrictEqual([stalePid]);
+    });
+
     it("parses openclaw-gateway pids and excludes the current process", () => {
       const stalePid = process.pid + 1;
       mockSpawnSync.mockReturnValue({
@@ -525,7 +543,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(findGatewayPidsOnPortSync(18789)).toStrictEqual([]);
     });
 
-    it("forwards the spawnTimeoutMs argument to spawnSync", () => {
+    it("uses the explicit timeout for the lsof scan", () => {
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout: "", stderr: "" });
       findGatewayPidsOnPortSync(18789, 400);
       const lsofCall = mockCall(mockSpawnSync);
@@ -534,7 +552,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(mockCallRecordArg(mockSpawnSync, 0, 2, "lsof options").timeout).toBe(400);
     });
 
-    it("uses the caller timeout for macOS ancestor ps probes", () => {
+    it("uses the explicit timeout for macOS ancestor ps probes", () => {
       const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
       const gatewayParentPid = process.pid + 3151;
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
@@ -1512,6 +1530,12 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
               call[0] === "ps" && Array.isArray(call[1]) && (call[1] as unknown[])[0] === "-o",
           )
           .map((call) => (call[2] as { timeout?: number } | undefined)?.timeout);
+        const initialLsofTimeout = (
+          mockSpawnSync.mock.calls.find((call) => call[0] === "lsof")?.[2] as
+            | { timeout?: number }
+            | undefined
+        )?.timeout;
+        expect(initialLsofTimeout).toBe(5000);
         expect(ancestorPsTimeouts).toContain(2000);
         expect(ancestorPsTimeouts).not.toContain(400);
         expect(lsofCall).toBe(3);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -21,7 +21,10 @@ import {
   type WindowsListeningPidsResult,
 } from "./windows-port-pids.js";
 
-const SPAWN_TIMEOUT_MS = 2000;
+// macOS lsof needs seconds on hosts with many mounted volumes; keep that
+// allowance separate so process and ancestor probes retain their tighter bound.
+const INITIAL_LSOF_TIMEOUT_MS = 5000;
+const PROCESS_INSPECTION_TIMEOUT_MS = 2000;
 const STALE_SIGTERM_WAIT_MS = 600;
 const STALE_SIGKILL_WAIT_MS = 400;
 /**
@@ -31,7 +34,7 @@ const STALE_SIGKILL_WAIT_MS = 400;
  * `systemctl restart`). Without this wait the new process races the dying
  * process for the port and systemd enters an EADDRINUSE restart loop.
  *
- * POLL_SPAWN_TIMEOUT_MS is intentionally much shorter than SPAWN_TIMEOUT_MS
+ * POLL_SPAWN_TIMEOUT_MS is intentionally much shorter than the initial scan
  * so that a single slow or hung lsof invocation does not consume the entire
  * polling budget. At 400 ms per call, up to five independent lsof attempts
  * fit within PORT_FREE_TIMEOUT_MS = 2000 ms, each with a definitive outcome.
@@ -154,7 +157,9 @@ function readParentPidFromPs(pid: number, spawnTimeoutMs: number): number | null
  * `/proc/<pid>/status` payloads) — there is no reachable override for
  * runtime callers to mutate.
  */
-export function getSelfAndAncestorPidsSync(spawnTimeoutMs = SPAWN_TIMEOUT_MS): Set<number> {
+export function getSelfAndAncestorPidsSync(
+  spawnTimeoutMs = PROCESS_INSPECTION_TIMEOUT_MS,
+): Set<number> {
   const pids = new Set<number>([process.pid]);
   const immediateParent = getParentPid();
   if (!Number.isFinite(immediateParent) || immediateParent <= 0) {
@@ -202,7 +207,7 @@ function getExcludedGatewayPidsSync(spawnTimeoutMs: number, protectedPid?: numbe
  * `MAX_ANCESTOR_WALK_DEPTH` entries from `/proc/<pid>/status`; each read is
  * a virtual-filesystem access (no disk I/O, no external process), wrapped
  * in try/catch and degrades silently. On macOS the lookup shells out to `ps`
- * with the caller's spawn timeout. Windows only uses the in-memory direct
+ * with the process-inspection timeout. Windows only uses the in-memory direct
  * parent from `process.ppid`.
  */
 function parseLsofEntries(stdout: string): Array<{ pid: number; cmd?: string }> {
@@ -295,7 +300,7 @@ function parsePidsFromLsofOutput(
  * `getSelfAndAncestorPidsSync`).
  */
 function filterVerifiedWindowsGatewayPids(rawPids: number[], protectedPid?: number): number[] {
-  const excluded = getExcludedGatewayPidsSync(SPAWN_TIMEOUT_MS, protectedPid);
+  const excluded = getExcludedGatewayPidsSync(PROCESS_INSPECTION_TIMEOUT_MS, protectedPid);
   return uniqueValues(rawPids)
     .filter((pid) => Number.isFinite(pid) && pid > 0 && !excluded.has(pid))
     .filter((pid) => {
@@ -309,7 +314,7 @@ function filterVerifiedWindowsGatewayPidsResult(
   processArgsResult: (pid: number) => WindowsProcessArgsResult,
   protectedPid?: number,
 ): WindowsListeningPidsResult {
-  const excluded = getExcludedGatewayPidsSync(SPAWN_TIMEOUT_MS, protectedPid);
+  const excluded = getExcludedGatewayPidsSync(PROCESS_INSPECTION_TIMEOUT_MS, protectedPid);
   const verified: number[] = [];
   for (const pid of uniqueValues(rawPids)) {
     if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
@@ -364,7 +369,8 @@ function findVerifiedWindowsGatewayPidsOnPortResultSync(
 
 function findGatewayPidsOnPortWithProtectedPidSync(
   port: number,
-  spawnTimeoutMs: number,
+  lsofTimeoutMs: number,
+  processInspectionTimeoutMs: number,
   options?: CleanStaleGatewayProcessesOptions,
 ): number[] {
   if (process.platform === "win32") {
@@ -375,7 +381,7 @@ function findGatewayPidsOnPortWithProtectedPidSync(
   const lsof = resolveLsofCommandSync();
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
     encoding: "utf8",
-    timeout: spawnTimeoutMs,
+    timeout: lsofTimeoutMs,
   });
   if (res.error) {
     const code = (res.error as NodeJS.ErrnoException).code;
@@ -404,7 +410,7 @@ function findGatewayPidsOnPortWithProtectedPidSync(
   }
   return parsePidsFromLsofOutput(
     res.stdout,
-    spawnTimeoutMs,
+    processInspectionTimeoutMs,
     resolveProtectedPidAfterEnumeration(options),
   );
 }
@@ -413,11 +419,14 @@ function findGatewayPidsOnPortWithProtectedPidSync(
  * Find PIDs of gateway processes listening on the given port using synchronous lsof.
  * Returns only PIDs that belong to openclaw gateway processes (not the current process).
  */
-export function findGatewayPidsOnPortSync(
-  port: number,
-  spawnTimeoutMs = SPAWN_TIMEOUT_MS,
-): number[] {
-  return findGatewayPidsOnPortWithProtectedPidSync(port, spawnTimeoutMs);
+export function findGatewayPidsOnPortSync(port: number, spawnTimeoutMs?: number): number[] {
+  // An explicit timeout keeps the existing contract: it bounds every child
+  // process used by this probe. Only the default path splits slow lsof from ps.
+  return findGatewayPidsOnPortWithProtectedPidSync(
+    port,
+    spawnTimeoutMs ?? INITIAL_LSOF_TIMEOUT_MS,
+    spawnTimeoutMs ?? PROCESS_INSPECTION_TIMEOUT_MS,
+  );
 }
 
 /**
@@ -657,7 +666,12 @@ export function cleanStaleGatewayProcessesSync(
             waitForPortFreeSync(port);
             return [];
           })()
-        : findGatewayPidsOnPortWithProtectedPidSync(port, SPAWN_TIMEOUT_MS, options);
+        : findGatewayPidsOnPortWithProtectedPidSync(
+            port,
+            INITIAL_LSOF_TIMEOUT_MS,
+            PROCESS_INSPECTION_TIMEOUT_MS,
+            options,
+          );
     if (stalePids.length === 0) {
       return [];
     }

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -102,7 +102,7 @@ describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => 
     expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.encoding).toBe(
       "utf8",
     );
-    expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.timeout).toBe(2000);
+    expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.timeout).toBe(5000);
   });
 
   it("returns empty when lsof fails", () => {
@@ -171,7 +171,7 @@ describe.runIf(process.platform !== "win32")("cleanStaleGatewayProcessesSync", (
     expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.encoding).toBe(
       "utf8",
     );
-    expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.timeout).toBe(2000);
+    expect((options as { encoding?: unknown; timeout?: unknown } | undefined)?.timeout).toBe(5000);
     expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
     expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGKILL");
   });


### PR DESCRIPTION
Related: #116950
Related: #90548

## What Problem This Solves

Fixes an issue where `openclaw gateway restart` could leave a stale gateway
listener in place when the initial macOS `lsof` scan needed more than two
seconds. The restart would then abort because the port was still busy.

## Why This Change Was Made

The initial `lsof` scan now has a dedicated five-second default budget. Process
and ancestor `ps` inspection keeps its two-second budget, and the post-kill
poll keeps its 400 ms per-spawn budget and two-second wall-clock limit.

An explicit `findGatewayPidsOnPortSync(port, timeout)` argument still bounds
every child process used by that probe. This preserves the existing override
contract while avoiding a five-second default for unrelated process
inspection.

This is a bounded mitigation for the residual slow-scan report in #116950. It
does not change LaunchAgent ownership behavior fixed by #89096 or the broader
macOS polling architecture tracked by #90548.

## User Impact

Gateway restart can detect and clean up stale listeners on macOS hosts where
the initial `lsof` scan takes between two and five seconds. Other process
inspection and post-kill polling timeouts are unchanged.

## Evidence

- Focused regression suites: 63 passed, 2 skipped across
  `src/infra/restart-stale-pids.test.ts` and `src/infra/restart.test.ts`.
- New assertions cover the five-second default `lsof` budget, the two-second
  default process/ancestor budget, the unchanged 400 ms post-kill poll, and
  explicit timeout override behavior.
- Real macOS proof on exact head `074df478a817d85366bbfb5b58a988d163251936`:
  an isolated LaunchAgent was started on a dedicated loopback port, then the
  restart command's actual `/usr/sbin/lsof` child was suspended with `SIGSTOP`
  for 3.204 seconds and resumed. The exact-head restart exited 0 with
  `result: "restarted"`, and the listener PID changed after launchd restarted
  the service:

  ```text
  platform=Darwin arm64
  lsof_suspended_seconds=3.204
  restart_exit=0
  listener_replacement_ok=1
  ```

  This used the real macOS service and system `lsof`; only the proof process
  suspension induced the slow scan. The primary LaunchAgent and port were
  untouched.
- Fresh autoreview on the repaired diff: no findings; patch correct at 0.98
  confidence.
- Blacksmith Testbox changed-surface gate: passed on lease
  `tbx_01kyx749qkcy65fqj7khc4g0wm` (8m03s command, exit 0):
  https://github.com/openclaw/openclaw/actions/runs/30672182046

Reported by @NirvanaCh7.
