### PR TITLE
fix: live updater no-op restarts healthy gateways

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1479,11 +1479,7 @@ function verifyGateway(runCommand, checkout, expectedSha, deployment = null) {
       ["gateway", "status", "--deep", "--require-rpc", "--json"],
       deployment,
     );
-    runBuiltGatewayCli(
-      checkout,
-      ["health", "--verbose", "--json"],
-      deployment,
-    );
+    runBuiltGatewayCli(checkout, ["health", "--verbose", "--json"], deployment);
     return;
   }
   runCommand(

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1481,7 +1481,7 @@ function verifyGateway(runCommand, checkout, expectedSha, deployment = null) {
     );
     runBuiltGatewayCli(
       checkout,
-      ["health", "--port", String(deployment.port), "--verbose", "--json"],
+      ["health", "--verbose", "--json"],
       deployment,
     );
     return;

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -278,6 +278,7 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     checkout: string,
     expectedSha: string,
     sleep?: (ms: number) => void,
+    deployment?: GatewayDeployment | null,
   ): void;
   export function findExactMacTarget(
     processes: string,

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -550,6 +550,54 @@ describe("openclaw live updater", () => {
     ]);
   });
 
+  test("routes managed Gateway health through the injected port", () => {
+    const { root, mirror } = makeFixture();
+    writeBuild(mirror);
+    const entrypoint = path.join(mirror, "dist/index.js");
+    const callsPath = path.join(root, "managed-probe-calls.jsonl");
+    writeFileSync(
+      entrypoint,
+      `import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
+  args,
+  port: process.env.OPENCLAW_GATEWAY_PORT,
+}) + "\\n");
+if (args.includes("--port")) process.exit(2);
+`,
+    );
+
+    verifyGatewayReadiness(
+      () => {
+        throw new Error("managed probes must use the exact built Gateway CLI");
+      },
+      mirror,
+      git(mirror, "rev-parse", "HEAD"),
+      () => {},
+      {
+        configPath: path.join(root, "openclaw.json"),
+        entrypoint,
+        executable: process.execPath,
+        invocationPrefix: [entrypoint],
+        port: 18789,
+        runtime: process.execPath,
+      },
+    );
+
+    expect(
+      readFileSync(callsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      {
+        args: ["gateway", "status", "--deep", "--require-rpc", "--json"],
+        port: "18789",
+      },
+      { args: ["health", "--verbose", "--json"], port: "18789" },
+    ]);
+  });
+
   test("bounds built Gateway CLI probes and cleans their config overlay", () => {
     const { root, mirror } = makeFixture();
     writeBuild(mirror);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the managed macOS live updater would reject every Gateway health probe because it passed the unsupported `--port` option to `openclaw health`. A healthy current build was therefore restarted unnecessarily, and the update heartbeat could fail on unrelated restart-window channel errors.

## Why This Change Was Made

The managed CLI runner already injects the owned Gateway port through its exact config overlay and `OPENCLAW_GATEWAY_PORT`. The health probe now uses that canonical routing path, matching the non-managed probe instead of duplicating the port as a CLI option.

## User Impact

Operators can run no-op live-update heartbeats without an unnecessary Gateway restart. Actual updates retain the same exact-build, deep RPC, verbose health, and restart-log gates.

## Evidence

- Live ClawMac repro before the fix: `openclaw health` rejected `--port`, the updater entered self-heal, and restarted a healthy exact-SHA Gateway.
- Blacksmith Testbox `tbx_01kywza7kknvn76ed3vew50z2r`: 55/55 focused updater tests passed, including a regression that requires the managed status and health probes to receive port `18789` through the injected environment and rejects any `--port` argument.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30664660939
- Autoreview: clean, no accepted/actionable findings.
