### PR TITLE
fix(bedrock): release streaming clients

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -67,6 +67,104 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("Bedrock stream client lifecycle", () => {
+  const context = {
+    messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+  } as never;
+
+  function expectDestroyedClient(
+    send: ReturnType<typeof vi.spyOn>,
+    destroy: ReturnType<typeof vi.spyOn>,
+  ) {
+    expect(send).toHaveBeenCalledOnce();
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(destroy.mock.contexts[0]).toBe(send.mock.contexts[0]);
+    expect(destroy.mock.invocationCallOrder[0]).toBeGreaterThan(
+      send.mock.invocationCallOrder[0] ?? 0,
+    );
+  }
+
+  it("destroys the client after a successful stream", async () => {
+    let markStreamBlocked!: () => void;
+    const streamBlocked = new Promise<void>((resolve) => {
+      markStreamBlocked = resolve;
+    });
+    let releaseStream!: () => void;
+    const streamReleased = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    async function* successfulStream() {
+      yield { messageStart: { role: ConversationRole.ASSISTANT } };
+      markStreamBlocked();
+      await streamReleased;
+      yield { messageStop: { stopReason: BedrockStopReason.END_TURN } };
+    }
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: successfulStream(),
+    } as never);
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const resultPromise = streamBedrockForTest(bedrockModel({}), context).result();
+    await streamBlocked;
+    expect(destroy).not.toHaveBeenCalled();
+
+    releaseStream();
+    const result = await resultPromise;
+
+    expect(result.stopReason).toBe("stop");
+    expectDestroyedClient(send, destroy);
+  });
+
+  it("destroys the client after a provider error", async () => {
+    const send = vi
+      .spyOn(BedrockRuntimeClient.prototype, "send")
+      .mockRejectedValue(new Error("synthetic provider failure"));
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const result = await streamBedrockForTest(bedrockModel({}), context).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("synthetic provider failure");
+    expectDestroyedClient(send, destroy);
+  });
+
+  it("destroys the client when response stream iteration fails", async () => {
+    async function* failingStream() {
+      yield { messageStart: { role: ConversationRole.ASSISTANT } };
+      throw new Error("synthetic iterator failure");
+    }
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: failingStream(),
+    } as never);
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const result = await streamBedrockForTest(bedrockModel({}), context).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("synthetic iterator failure");
+    expectDestroyedClient(send, destroy);
+  });
+
+  it("destroys the client after an aborted request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const send = vi
+      .spyOn(BedrockRuntimeClient.prototype, "send")
+      .mockRejectedValue(new Error("synthetic abort"));
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const result = await streamBedrockForTest(bedrockModel({}), context, {
+      signal: controller.signal,
+    }).result();
+
+    expect(result.stopReason).toBe("aborted");
+    expect(result.errorMessage).toBe("synthetic abort");
+    expectDestroyedClient(send, destroy);
+  });
+});
+
 describe("Bedrock inbound image base64", () => {
   const model = () => bedrockModel({ input: ["text", "image"] });
   const userImage = (data: string) =>

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -239,8 +239,9 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
       config.authSchemePreference = ["httpBearerAuth"];
     }
 
+    let client: BedrockRuntimeClient | undefined;
     try {
-      const client = new BedrockRuntimeClient(config);
+      client = new BedrockRuntimeClient(config);
       const cacheRetention = resolveCacheRetention(options.cacheRetention);
       const additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
       const thinking = (additionalModelRequestFields as Record<string, unknown> | undefined)
@@ -373,6 +374,9 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
       output.errorMessage = formatBedrockError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
+    } finally {
+      // The SDK client owns pooled HTTP resources; release them only after its async stream settles.
+      client?.destroy();
     }
   })();
 


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock streaming creates a fresh `BedrockRuntimeClient` for every model call but never destroys it. Proxy and forced-HTTP/1 routes therefore retain per-request keep-alive agents and sockets until later timeouts, accumulating resources under sustained or retried traffic.

## Why This Change Was Made

The stream invocation remains the client owner. It now retains the per-request client only long enough to destroy it in `finally`, after the response stream settles. That covers success, provider rejection, iterator failure, and cancellation without introducing a cache or shared client whose configuration/lifecycle would be broader than the request.

## User Impact

Bedrock streaming releases its SDK HTTP resources promptly after every terminal path instead of leaking per-request connection pools. Model output, retries, auth, proxy selection, and accounting are unchanged.

## Evidence

- Exact reviewed head: `db7db221858e922dbd05c109fc732e733f738b60`.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30665065916
  - 53/53 Bedrock stream tests passed.
  - 15/15 accounting/replay tests passed.
  - Complete extension changed gate passed: extension/test typecheck, lint, format, dead-code, plugin boundaries, database-first, import-cycle, and related guards.
- Direct pinned dependency inspection: `@aws-sdk/client-bedrock-runtime` 3.1095.0 `BedrockRuntimeClient.destroy()` calls `super.destroy()`; `@smithy/core` 3.30.0 `Client.destroy()` calls `config.requestHandler.destroy()`; `@smithy/node-http-handler` 4.9.11 destroys HTTP/1 agents and the HTTP/2 connection pool/sessions.
- The success regression blocks the async iterable and proves `destroy()` is not called until stream consumption completes; failure/iterator/abort regressions prove exactly-once cleanup of the same client instance.
- Final whole-branch autoreview: clean, confidence 0.98.
- `git diff --check`: passed.

Release-note context: Amazon Bedrock streaming now releases per-request SDK clients after every terminal path.
