### PR TITLE
fix(plugins): refresh bundled native artifact locations

### DIFF
--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -246,6 +246,57 @@ describe("bundled plugin public surface loader", () => {
     expect(createJiti).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { firstLocation: "root", nextLocation: "dist" },
+    { firstLocation: "dist", nextLocation: "root" },
+  ] as const)(
+    "refreshes native ESM artifact locations from $firstLocation to $nextLocation with plugin metadata",
+    async ({ firstLocation, nextLocation }) => {
+      const publicSurfaceLoader = await importFreshModule<
+        typeof import("./public-surface-loader.js")
+      >(
+        import.meta.url,
+        `./public-surface-loader.js?scope=esm-artifact-relocation-${firstLocation}-${nextLocation}`,
+      );
+      const { clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js");
+      const tempRoot = fs.realpathSync(createTempDir());
+      const bundledPluginsDir = path.join(tempRoot, "extensions");
+      const pluginDir = path.join(bundledPluginsDir, "demo");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, "package.json"), '{"type":"module"}\n', "utf8");
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+      process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
+
+      const artifactPath = (location: "root" | "dist") =>
+        path.join(pluginDir, ...(location === "dist" ? ["dist"] : []), "api.js");
+      const writeArtifact = (location: "root" | "dist") => {
+        const modulePath = artifactPath(location);
+        fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+        fs.writeFileSync(
+          modulePath,
+          `export const marker = ${JSON.stringify(location)};\n`,
+          "utf8",
+        );
+      };
+      const loadArtifact = () =>
+        publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync<{ marker: string }>({
+          dirName: "demo",
+          artifactBasename: "api.js",
+        }).marker;
+
+      writeArtifact(firstLocation);
+      expect(loadArtifact()).toBe(firstLocation);
+
+      fs.unlinkSync(artifactPath(firstLocation));
+      writeArtifact(nextLocation);
+      expect(loadArtifact()).toBe(firstLocation);
+
+      clearPluginMetadataLifecycleCaches();
+
+      expect(loadArtifact()).toBe(nextLocation);
+    },
+  );
+
   it.runIf(process.platform !== "win32")(
     "allows hardlinked bundled public artifacts under the trusted bundled root",
     async () => {

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
   createPluginModuleLoaderCache,
   getCachedPluginModuleLoader,
@@ -32,6 +33,10 @@ const publicSurfaceLocationCache = new Map<
   }
 >();
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  publicSurfaceLocationCache.clear();
+});
 
 function isSourceArtifactPath(modulePath: string): boolean {
   switch (path.extname(modulePath).toLowerCase()) {


### PR DESCRIPTION
## Root cause

The private bundled public-artifact location cache outlived the canonical plugin metadata lifecycle. When an actual native ESM plugin artifact moved between the plugin root and package-local `dist`, install/doctor/reload metadata refresh retained the old location and silently kept returning its old namespace. Register the existing location memo with the existing lifecycle owner; module exports, Node/Jiti caches, authorization, path validation, hardlink policy, SDK APIs, config, storage, and schema remain unchanged.

Frozen base: `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`.

Exact reviewed rescue commit: `c4b093ace77c42f6471b7ff8b7d4201b5ce88e1f`.

Only changed production owner: `src/plugins/public-surface-loader.ts` (+5 lines); regression owner: `src/plugins/public-surface-loader.test.ts` (+51 lines). No provider-policy/auth/security changes.

## Reproducible actual native-ESM proof

Node binary: `/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node` (`v24.18.0`). Each generated plugin has an actual `package.json` containing `{"type":"module"}` and a native ESM `api.js`; no mocked module loader is used. `staleBeforeMetadataRefresh` proves the original fast-path cache remains unchanged before its owning lifecycle event. The lifecycle event is `clearPluginMetadataLifecycleCaches()`; the installed-plugin index calls it after updating install metadata.

Command:

```sh
/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node --import tsx \
  /private/tmp/openclaw-qa400-plugin-facade-native-esm-proof.mjs \
  /private/tmp/openclaw-qa400-plugin-facade-runtime \
  /private/tmp/openclaw-qa400-plugin-facade-c4b093a-after.jsonl --public-only
```

Frozen base: both directions reproduce the bug:

```json
{"phase":"proof-environment","nodeBinary":"/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node","nodeVersion":"v24.18.0","sha":"fdcb321bfaaadb5a1e7d123b6be7a934980f8b12"}
{"phase":"native-esm-artifact-relocation","sha":"fdcb321bfaaadb5a1e7d123b6be7a934980f8b12","packageType":"module","beforeLocation":"root","afterLocation":"dist","before":"root","staleBeforeMetadataRefresh":"root","after":"root","expectedAfter":"dist","passed":false}
{"phase":"native-esm-artifact-relocation","sha":"fdcb321bfaaadb5a1e7d123b6be7a934980f8b12","packageType":"module","beforeLocation":"dist","afterLocation":"root","before":"dist","staleBeforeMetadataRefresh":"dist","after":"dist","expectedAfter":"root","passed":false}
```

Exact rescue commit: both directions pass after the owner lifecycle event:

```json
{"phase":"proof-environment","nodeBinary":"/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node","nodeVersion":"v24.18.0","sha":"c4b093ace77c42f6471b7ff8b7d4201b5ce88e1f"}
{"phase":"native-esm-artifact-relocation","sha":"c4b093ace77c42f6471b7ff8b7d4201b5ce88e1f","packageType":"module","beforeLocation":"root","afterLocation":"dist","before":"root","staleBeforeMetadataRefresh":"root","after":"dist","expectedAfter":"dist","passed":true}
{"phase":"native-esm-artifact-relocation","sha":"c4b093ace77c42f6471b7ff8b7d4201b5ce88e1f","packageType":"module","beforeLocation":"dist","afterLocation":"root","before":"dist","staleBeforeMetadataRefresh":"dist","after":"root","expectedAfter":"root","passed":true}
{"phase":"summary","sha":"c4b093ace77c42f6471b7ff8b7d4201b5ce88e1f","cases":2,"passed":2}
```

## Verification

```sh
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-qa400-facade-vitest-module-cache.json \
PATH=/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin:$PATH \
/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin/node \
  scripts/run-vitest.mjs src/plugins/public-surface-loader.test.ts
```

```text
[test] starting test/vitest/vitest.plugins.config.ts

 RUN  v4.1.10 /private/tmp/openclaw-qa400-plugin-facade-runtime

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  18.77s (transform 14.05s, setup 5.14s, import 1.56s, tests 11.59s, environment 0ms)

[test] passed 1 Vitest shard in 37.69s
```

- `git diff fdcb321bfaaadb5a1e7d123b6be7a934980f8b12...HEAD --check`: clean.
- Exact native ESM real-behavior proof: **2/2 passed** (both root/dist directions).
- Independent full-branch P0–P3 autoreview against the immutable frozen base: **CLEAN**, no findings, `overall_correctness: patch is correct`, confidence `0.93`; full structured artifact `/private/tmp/openclaw-qa400-plugin-facade-c4b093a-p3.json`.
- Independent second-agent full-branch P0–P3 review: **CLEAN**; exact scope, native before/after evidence, lifecycle ownership, and held provider-policy boundary verified.
- Independent third-agent full-branch P0–P3 review: **CLEAN**; personally reran both actual native-ESM directions (**2/2 passed**), checked pre-lifecycle cached behavior, and inspected the complete loader/lifecycle/resolver/native-loader/module-cache owners and sibling policy boundary.
- Latest ClawSweeper request addressed: inspectable actual native ESM before/after transcripts for both directions, owner lifecycle event, immutable base/head SHAs, focused 10/10 regression suite, and independent full-branch review.
