### PR TITLE
fix(google): normalize provider stream lifecycle and usage ownership

### DIFF
--- a/extensions/google/provider-hooks.test.ts
+++ b/extensions/google/provider-hooks.test.ts
@@ -1,5 +1,98 @@
+import { createCapturedThinkingConfigStream } from "openclaw/plugin-sdk/provider-test-contracts";
 import { describe, expect, it } from "vitest";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
+
+describe("GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn", () => {
+  it.each([
+    {
+      label: "direct Gemma",
+      api: "google-generative-ai",
+      provider: "google",
+      modelId: "gemma-4-26b-a4b-it",
+      thinkingLevel: "high",
+      expected: { thinkingLevel: "HIGH" },
+    },
+    {
+      label: "provider-qualified Gemma",
+      api: "google-generative-ai",
+      provider: "google",
+      modelId: "google/gemma-4-26b-a4b-it",
+      thinkingLevel: "high",
+      expected: { thinkingLevel: "HIGH" },
+    },
+    {
+      label: "resource-qualified Gemma",
+      api: "google-generative-ai",
+      provider: "google",
+      modelId: "models/gemma-4-26b-a4b-it",
+      thinkingLevel: "high",
+      expected: { thinkingLevel: "HIGH" },
+    },
+    {
+      label: "Vertex Gemma",
+      api: "google-vertex",
+      provider: "google-vertex",
+      modelId: "gemma-4-26b-a4b-it",
+      thinkingLevel: "low",
+      expected: { thinkingLevel: "MINIMAL" },
+    },
+    {
+      label: "disabled Vertex Gemma",
+      api: "google-vertex",
+      provider: "google-vertex",
+      modelId: "gemma-4-26b-a4b-it",
+      thinkingLevel: "off",
+      expected: undefined,
+    },
+    {
+      label: "adaptive Vertex Gemini 2.5",
+      api: "google-vertex",
+      provider: "google-vertex",
+      modelId: "gemini-2.5-flash",
+      thinkingLevel: "adaptive",
+      expected: { thinkingBudget: -1 },
+    },
+    {
+      label: "adaptive Vertex Gemini 3",
+      api: "google-vertex",
+      provider: "google-vertex",
+      modelId: "gemini-3-flash-preview",
+      thinkingLevel: "adaptive",
+      expected: undefined,
+    },
+    {
+      label: "Gemini CLI native Google transport",
+      api: "google-generative-ai",
+      provider: "google-gemini-cli",
+      modelId: "gemini-3-pro-preview",
+      thinkingLevel: "high",
+      expected: { thinkingLevel: "HIGH" },
+    },
+    {
+      label: "unrelated transport",
+      api: "openai-completions",
+      provider: "other",
+      modelId: "gemma-4-26b-a4b-it",
+      thinkingLevel: "high",
+      expected: { thinkingBudget: -1 },
+    },
+  ] as const)("normalizes $label", ({ api, provider, modelId, thinkingLevel, expected }) => {
+    const capture = createCapturedThinkingConfigStream();
+    const wrapped = GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn({
+      provider,
+      modelId,
+      thinkingLevel,
+      streamFn: capture.streamFn,
+    });
+
+    void wrapped({ api, provider, id: modelId } as never, { messages: [] } as never, {});
+
+    const capturedConfig = capture.getCapturedPayload()?.config as
+      | { thinkingConfig?: unknown }
+      | undefined;
+    expect(capturedConfig?.thinkingConfig).toEqual(expected);
+  });
+});
 
 describe("GOOGLE_GEMINI_PROVIDER_HOOKS.classifyFailoverReason", () => {
   it.each([

--- a/extensions/google/provider-hooks.ts
+++ b/extensions/google/provider-hooks.ts
@@ -3,11 +3,16 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/core";
-import type { ProviderFailoverErrorContext } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  ProviderFailoverErrorContext,
+  ProviderWrapStreamFnContext,
+} from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { stripGoogleProviderPrefix } from "./model-id.js";
 import { resolveGoogleThinkingProfile } from "./provider-policy.js";
-import { createGoogleThinkingStreamWrapper } from "./thinking-api.js";
+import { sanitizeGoogleThinkingPayload } from "./thinking-api.js";
 
 // Google-family gRPC status codes stay with the shared Gemini provider hook.
 function classifyGoogleFailoverCode(code: string | undefined) {
@@ -23,6 +28,19 @@ function classifyGoogleFailoverCode(code: string | undefined) {
   }
 }
 
+function wrapGoogleThinkingStream(ctx: ProviderWrapStreamFnContext) {
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
+    if (model.api !== "google-generative-ai" && model.api !== "google-vertex") {
+      return;
+    }
+    sanitizeGoogleThinkingPayload({
+      payload,
+      modelId: stripGoogleProviderPrefix(model.id).replace(/^models\//u, ""),
+      thinkingLevel: ctx.thinkingLevel,
+    });
+  });
+}
+
 export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   ...buildProviderReplayFamilyHooks({
     family: "google-gemini",
@@ -30,7 +48,7 @@ export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   ...buildProviderToolCompatFamilyHooks("gemini"),
   resolveThinkingProfile: (context: ProviderDefaultThinkingPolicyContext) =>
     resolveGoogleThinkingProfile(context) satisfies ProviderThinkingProfile | undefined,
-  wrapStreamFn: createGoogleThinkingStreamWrapper,
+  wrapStreamFn: wrapGoogleThinkingStream,
   classifyFailoverReason: ({ code }: ProviderFailoverErrorContext) =>
     classifyGoogleFailoverCode(code),
 };

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -587,6 +587,30 @@ describe("google transport stream", () => {
     });
   });
 
+  it("retains prompt, cache, and tool-token facts across sparse Google usage chunks", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          usageMetadata: {
+            promptTokenCount: 100,
+            cachedContentTokenCount: 40,
+            toolUsePromptTokenCount: 6,
+            candidatesTokenCount: 1,
+            totalTokenCount: 107,
+          },
+        },
+        {
+          candidates: [{ finishReason: "STOP" }],
+          usageMetadata: { candidatesTokenCount: 12, thoughtsTokenCount: 3 },
+        },
+      ]),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.usage).toMatchObject({ input: 66, output: 15, cacheRead: 40, totalTokens: 121 });
+  });
+
   it.each([
     {
       provider: "google",
@@ -931,7 +955,7 @@ describe("google transport stream", () => {
     ]);
   });
 
-  it("keeps duplicate tool-call ids distinct while retaining the first signature", async () => {
+  it("keeps duplicate tool-call ids and their own thought signatures distinct", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([
         {
@@ -982,8 +1006,8 @@ describe("google transport stream", () => {
     expect(toolCalls[1]).toMatchObject({
       name: "second",
       arguments: { value: 2 },
-      thoughtSignature: "first_signature",
     });
+    expect(toolCalls[1]).not.toHaveProperty("thoughtSignature", "first_signature");
     expect(toolCalls[1]?.id).not.toBe("call_1");
   });
 
@@ -1058,6 +1082,88 @@ describe("google transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
+  });
+
+  it("rejects an incomplete SSE frame after an otherwise terminal Google response", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(
+        'data: {"candidates":[{"finishReason":"STOP"}]}\n\ndata: {"candidates":[',
+      ),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("incomplete");
+  });
+
+  it.each([
+    { label: "keepalive comment", tail: ": keepalive\n" },
+    { label: "control fields", tail: "event: ping\nid: heartbeat" },
+    { label: "empty data field", tail: "data:\n" },
+  ])("ignores trailing $label when the Google SSE connection closes", async ({ tail }) => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(`data: {"candidates":[{"finishReason":"STOP"}]}\n\r${tail}`),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("stop");
+  });
+
+  it("surfaces a framed provider error arriving after a terminal Google response", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(
+        'data: {"candidates":[{"finishReason":"STOP"}]}\n\n' +
+          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exceeded"}}\n\n',
+      ),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorCode: "RESOURCE_EXHAUSTED",
+      errorMessage: expect.stringContaining("quota exceeded"),
+    });
+  });
+
+  it.each([
+    { label: "carriage-return-only", delimiter: "\r\r" },
+    { label: "line-feed then carriage-return", delimiter: "\n\r" },
+    { label: "line-feed then CRLF", delimiter: "\n\r\n" },
+    { label: "CRLF then carriage-return", delimiter: "\r\n\r" },
+    { label: "CRLF then line-feed", delimiter: "\r\n\n" },
+    { label: "carriage-return then CRLF", delimiter: "\r\r\n" },
+  ])("accepts $label SSE frame delimiters", async ({ delimiter }) => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(`data: {"candidates":[{"finishReason":"STOP"}]}${delimiter}`),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("stop");
+  });
+
+  it("does not mistake one CRLF for an SSE frame delimiter", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse('data: {"candidates":[{"finishReason":"STOP"}]}\r\n'),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("incomplete");
+  });
+
+  it("keeps CRLF-separated data lines in the same SSE event", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse('data: {"candidates":[\r\ndata: {"finishReason":"STOP"}]}\r\n\r\n'),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("stop");
   });
 
   it("cancels open Gemini SSE bodies when parsing fails", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -35,6 +35,7 @@ import {
   type WritableTransportStream,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import {
+  isRecord,
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -94,6 +95,7 @@ type GoogleGenerateContentRequest = {
 
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
+const GOOGLE_SSE_EVENT_BOUNDARY_RE = /(?:\r\n|\r(?!\n)|\n){2}/u;
 
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
@@ -1190,28 +1192,49 @@ async function* parseGoogleSseChunks(
       }
       const { done, value } = await reader.read();
       if (done) {
+        buffer += decoder.decode();
+        if (
+          buffer
+            .split(/\r\n|\n|\r/u)
+            .some((line) => line.startsWith("data:") && line.slice(5).trim().length > 0)
+        ) {
+          throw new Error("Google SSE stream ended with an incomplete frame");
+        }
         completed = true;
         break;
       }
-      buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
-      let boundary = buffer.indexOf("\n\n");
-      while (boundary >= 0) {
-        const rawEvent = buffer.slice(0, boundary);
-        buffer = buffer.slice(boundary + 2);
-        boundary = buffer.indexOf("\n\n");
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = GOOGLE_SSE_EVENT_BOUNDARY_RE.exec(buffer);
+      while (boundary) {
+        const rawEvent = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary[0].length);
+        boundary = GOOGLE_SSE_EVENT_BOUNDARY_RE.exec(buffer);
         const data = rawEvent
-          .split("\n")
+          .split(/\r\n|\n|\r/u)
           .filter((line) => line.startsWith("data:"))
           .map((line) => line.slice(5).trim())
           .join("\n");
         if (!data || data === "[DONE]") {
           continue;
         }
+        let chunk: unknown;
         try {
-          yield JSON.parse(data) as GoogleSseChunk;
+          chunk = JSON.parse(data);
         } catch {
           throw new Error("Google SSE stream returned malformed JSON");
         }
+        if (isRecord(chunk) && isRecord(chunk.error)) {
+          const providerError = chunk.error;
+          throw Object.assign(
+            new Error(normalizeOptionalString(providerError.message) ?? "Google stream failed"),
+            {
+              code: normalizeOptionalString(providerError.status) ?? "GOOGLE_STREAM_ERROR",
+              status: typeof providerError.code === "number" ? providerError.code : undefined,
+              type: "google_stream_failed",
+            },
+          );
+        }
+        yield chunk as GoogleSseChunk;
       }
     }
   } finally {
@@ -1227,21 +1250,29 @@ function updateUsage(
   output: MutableAssistantOutput,
   model: GoogleTransportModel,
   chunk: GoogleSseChunk,
-) {
-  const usage = chunk.usageMetadata;
-  if (!usage) {
+  knownUsage: NonNullable<GoogleSseChunk["usageMetadata"]>,
+): void {
+  if (!chunk.usageMetadata) {
     return;
   }
-  const promptTokens = usage.promptTokenCount || 0;
-  const cacheRead = usage.cachedContentTokenCount || 0;
-  const toolUsePromptTokens = usage.toolUsePromptTokenCount || 0;
-  const outputTokens = (usage.candidatesTokenCount || 0) + (usage.thoughtsTokenCount || 0);
+  for (const field of Object.keys(knownUsage) as Array<keyof typeof knownUsage>) {
+    const value = chunk.usageMetadata[field];
+    if (typeof value === "number") {
+      knownUsage[field] = value;
+    }
+  }
+  const promptTokens = knownUsage.promptTokenCount ?? 0;
+  const cacheRead = knownUsage.cachedContentTokenCount ?? 0;
+  const toolUsePromptTokens = knownUsage.toolUsePromptTokenCount ?? 0;
+  const outputTokens =
+    (knownUsage.candidatesTokenCount ?? 0) + (knownUsage.thoughtsTokenCount ?? 0);
   output.usage = {
     input: Math.max(0, promptTokens - cacheRead) + toolUsePromptTokens,
     output: outputTokens,
     cacheRead,
     cacheWrite: 0,
-    totalTokens: usage.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
+    totalTokens:
+      chunk.usageMetadata.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };
   calculateCost(model, output.usage);
@@ -1338,6 +1369,13 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
         let currentBlockIndex = -1;
         let sawTerminalReason = false;
         let terminalGenerationError: Error | undefined;
+        const knownUsage: NonNullable<GoogleSseChunk["usageMetadata"]> = {
+          promptTokenCount: 0,
+          cachedContentTokenCount: 0,
+          toolUsePromptTokenCount: 0,
+          candidatesTokenCount: 0,
+          thoughtsTokenCount: 0,
+        };
         const toolCallBlocksById = new Map<
           string,
           Extract<GoogleTransportContentBlock, { type: "toolCall" }>
@@ -1351,7 +1389,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
               })(sse.firstChunk);
         for await (const chunk of chunks) {
           output.responseId ||= chunk.responseId;
-          updateUsage(output, model, chunk);
+          updateUsage(output, model, chunk, knownUsage);
           const candidate = chunk.candidates?.[0];
           const promptFeedback = chunk.promptFeedback;
           if (!candidate && promptFeedback) {
@@ -1455,10 +1493,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
-                  thoughtSignature: retainThoughtSignature(
-                    existingToolCall?.thoughtSignature,
-                    part.thoughtSignature,
-                  ),
+                  ...(part.thoughtSignature ? { thoughtSignature: part.thoughtSignature } : {}),
                 };
                 output.content.push(toolCall);
                 if (!toolCallBlocksById.has(toolCall.id)) {

--- a/packages/ai/src/providers/google-client-auth.test.ts
+++ b/packages/ai/src/providers/google-client-auth.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model } from "../types.js";
 
-const googleMockState = vi.hoisted(() => ({ configs: [] as unknown[] }));
+const googleMockState = vi.hoisted(() => ({ configs: [] as unknown[], requests: [] as unknown[] }));
 
 vi.mock("@google/genai", () => ({
   GoogleGenAI: class MockGoogleGenAI {
     models = {
-      generateContentStream: vi.fn(() => {
+      generateContentStream: vi.fn((params: unknown) => {
+        googleMockState.requests.push(params);
         throw new Error("stop after constructor");
       }),
     };
@@ -26,7 +27,7 @@ vi.mock("@google/genai", () => ({
   },
 }));
 
-import { streamGoogleVertex } from "./google-vertex.js";
+import { streamGoogleVertex, streamSimpleGoogleVertex } from "./google-vertex.js";
 import { streamGoogle } from "./google.js";
 
 const context = {
@@ -61,6 +62,7 @@ function vertexModel(): Model<"google-vertex"> {
 describe("Google SDK construction auth", () => {
   beforeEach(() => {
     googleMockState.configs = [];
+    googleMockState.requests = [];
   });
 
   afterEach(() => {
@@ -121,4 +123,53 @@ describe("Google SDK construction auth", () => {
     expect(JSON.stringify(googleMockState.configs[0])).not.toContain(sentinel);
     expect(buildModelFetch).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      modelId: "gemma-4-26b-a4b-it",
+      reasoning: "low",
+      expectedThinking: { includeThoughts: true, thinkingLevel: "MINIMAL" },
+    },
+    {
+      modelId: "gemma-4-26b-a4b-it",
+      reasoning: "adaptive",
+      expectedThinking: { includeThoughts: true, thinkingLevel: "HIGH" },
+    },
+    {
+      modelId: "gemini-2.5-flash-lite",
+      reasoning: "minimal",
+      expectedThinking: { includeThoughts: true, thinkingBudget: 512 },
+    },
+  ] as const)(
+    "keeps the supported Vertex thinking policy for $modelId",
+    async ({ modelId, reasoning, expectedThinking }) => {
+      configureAiTransportHost({ resolveSecretSentinel: (value) => value });
+
+      await streamSimpleGoogleVertex({ ...vertexModel(), id: modelId }, context, {
+        apiKey: "test-vertex-key",
+        reasoning: reasoning as never,
+      }).result();
+
+      expect(googleMockState.requests[0]).toMatchObject({
+        config: { thinkingConfig: expectedThinking },
+      });
+    },
+  );
+
+  it.each(["gemma-4-26b-a4b-it", "gemini-2.5-pro"])(
+    "keeps unsupported disabled-thinking config out of Vertex requests for %s",
+    async (modelId) => {
+      configureAiTransportHost({ resolveSecretSentinel: (value) => value });
+
+      await streamSimpleGoogleVertex({ ...vertexModel(), id: modelId }, context, {
+        apiKey: "test-vertex-key",
+        reasoning: "off",
+      }).result();
+
+      expect(googleMockState.requests[0]).toMatchObject({ config: {} });
+      expect((googleMockState.requests[0] as { config: unknown }).config).not.toHaveProperty(
+        "thinkingConfig",
+      );
+    },
+  );
 });

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -32,6 +32,19 @@ function requireRecordProperty(
 }
 
 describe("google-shared convertTools", () => {
+  it("keeps Google tool declarations stable across discovery order", () => {
+    const tools = [
+      { name: "zeta", description: "Last", parameters: { type: "object" } },
+      { name: "alpha", description: "First", parameters: { type: "object" } },
+    ] as Tool[];
+
+    expect(convertTools(tools)).toEqual(convertTools(tools.toReversed()));
+    expect(convertTools(tools)?.[0]?.functionDeclarations.map((tool) => tool.name)).toEqual([
+      "alpha",
+      "zeta",
+    ]);
+  });
+
   it("preserves parameters when type is missing", () => {
     const tools = [
       {
@@ -154,6 +167,36 @@ describe("google-shared convertTools", () => {
 });
 
 describe("google-shared convertMessages", () => {
+  it.each([
+    { label: "empty user text", messages: [{ role: "user", content: "" }] },
+    {
+      label: "empty user text part",
+      messages: [{ role: "user", content: [{ type: "text", text: "" }] }],
+    },
+    { label: "empty user parts", messages: [{ role: "user", content: [] }] },
+    {
+      label: "whitespace-only assistant history",
+      messages: [makeGoogleAssistantMessage("gemini-3-flash", [{ type: "text", text: "   " }])],
+    },
+  ])("keeps $label valid for the Google SDK", ({ messages }) => {
+    expect(convertMessagesForTest(makeModel("gemini-3-flash"), { messages } as Context)).toEqual([
+      { role: "user", parts: [{ text: " " }] },
+    ]);
+  });
+
+  it("supplies the documented Gemini 3 thought-signature placeholder for unsigned calls", () => {
+    const model = makeModel("gemini-3-flash");
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "provider_alpha", name: "lookup", arguments: {} },
+        ]),
+      ],
+    } as Context);
+
+    expect(contents[0]?.parts?.[0]?.thoughtSignature).toBe("skip_thought_signature_validator");
+  });
+
   function expectConsecutiveMessagesNotMerged(params: {
     modelId: string;
     first: string;

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -56,6 +56,50 @@ function createOutput(): AssistantMessage {
 }
 
 describe("buildGoogleSimpleThinking", () => {
+  it.each([
+    { id: "gemini-pro-latest", expectedLevel: "LOW" },
+    { id: "gemini-flash-latest", expectedLevel: "LOW" },
+  ])("recognizes the supported $id Gemini 3 alias", ({ id, expectedLevel }) => {
+    const aliasModel = { ...model, id };
+
+    expect(buildGoogleSimpleThinking(aliasModel, { reasoning: "low" })).toEqual({
+      enabled: true,
+      level: expectedLevel,
+    });
+    expect(
+      buildGoogleGenerateContentParams(
+        aliasModel,
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        { thinking: { enabled: false } },
+      ).config?.thinkingConfig,
+    ).not.toHaveProperty("thinkingBudget");
+  });
+
+  it.each([
+    { id: "gemini-2.5-pro", expected: { enabled: true, budgetTokens: -1 } },
+    { id: "gemini-2.5-flash", expected: { enabled: true, budgetTokens: -1 } },
+    { id: "gemini-3.1-pro-preview", expected: { enabled: true } },
+    { id: "gemini-3-flash-preview", expected: { enabled: true } },
+    { id: "gemma-4-26b-a4b-it", expected: { enabled: true, level: "HIGH" } },
+  ])("keeps Google's dynamic adaptive thinking for $id", ({ id, expected }) => {
+    expect(buildGoogleSimpleThinking({ ...model, id }, { reasoning: "adaptive" } as never)).toEqual(
+      expected,
+    );
+  });
+
+  it.each(["gemini-2.5-pro", "gemma-4-26b-a4b-it"])(
+    "omits unsupported disabled-thinking config for %s",
+    (id) => {
+      const params = buildGoogleGenerateContentParams(
+        { ...model, id },
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        { thinking: { enabled: false } },
+      );
+
+      expect(params.config).not.toHaveProperty("thinkingConfig");
+    },
+  );
+
   it("keeps thinking disabled when a non-reasoning model clamps low to off", () => {
     const nonReasoningModel = { ...model, reasoning: false };
 
@@ -218,6 +262,53 @@ describe("consumeGoogleGenerateContentStream", () => {
       totalTokens: expectedTotal,
       cost: { input: expectedInput / 1_000_000 },
     });
+  });
+
+  it("retains prompt, cache, and tool-token facts across sparse Google usage chunks", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          usageMetadata: {
+            promptTokenCount: 100,
+            cachedContentTokenCount: 40,
+            toolUsePromptTokenCount: 6,
+            candidatesTokenCount: 1,
+            totalTokenCount: 107,
+          },
+        } as GenerateContentResponse,
+        {
+          candidates: [{ finishReason: FinishReason.STOP }],
+          usageMetadata: { candidatesTokenCount: 12, thoughtsTokenCount: 3 },
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(output.usage).toMatchObject({ input: 66, output: 15, cacheRead: 40, totalTokens: 121 });
+  });
+
+  it("never reports negative input when Google only provides sparse cached-token facts", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [{ finishReason: FinishReason.STOP }],
+          usageMetadata: { cachedContentTokenCount: 40, toolUsePromptTokenCount: 6 },
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(output.usage).toMatchObject({ input: 6, cacheRead: 40 });
   });
 
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -31,6 +31,7 @@ import type {
   StreamOptions,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { formatProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
@@ -172,7 +173,6 @@ export function convertMessages<T extends GoogleApiType>(
   };
 
   const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
-
   // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
   // live inside functionResponse, so hold them until the consecutive result run ends.
   const pendingToolResultImageTurns: Content[] = [];
@@ -191,12 +191,12 @@ export function convertMessages<T extends GoogleApiType>(
       if (typeof msg.content === "string") {
         contents.push({
           role: "user",
-          parts: [{ text: sanitizeSurrogates(msg.content) }],
+          parts: [{ text: sanitizeSurrogates(msg.content) || " " }],
         });
       } else {
         const parts: Part[] = msg.content.map((item) => {
           if (item.type === "text") {
-            return { text: sanitizeSurrogates(item.text) };
+            return { text: sanitizeSurrogates(item.text) || " " };
           }
           return {
             inlineData: {
@@ -206,7 +206,7 @@ export function convertMessages<T extends GoogleApiType>(
           };
         });
         if (parts.length === 0) {
-          continue;
+          parts.push({ text: " " });
         }
         contents.push({
           role: "user",
@@ -255,10 +255,12 @@ export function convertMessages<T extends GoogleApiType>(
             });
           }
         } else if (block.type === "toolCall") {
-          const thoughtSignature = resolveThoughtSignature(
-            isSameProviderAndModel,
-            block.thoughtSignature,
-          );
+          const thoughtSignature =
+            resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature) ??
+            (model.provider !== "google-gemini-cli" &&
+            (isGemini3ProModel(model) || isGemini3FlashModel(model))
+              ? "skip_thought_signature_validator"
+              : undefined);
           const part: Part = {
             functionCall: {
               name: block.name,
@@ -336,62 +338,28 @@ export function convertMessages<T extends GoogleApiType>(
   }
 
   flushToolResultRun();
+  if (contents.length === 0) {
+    contents.push({ role: "user", parts: [{ text: " " }] });
+  }
   return contents;
-}
-
-const JSON_SCHEMA_META_DECLARATIONS = new Set([
-  "$schema",
-  "$id",
-  "$anchor",
-  "$dynamicAnchor",
-  "$vocabulary",
-  "$comment",
-  "$defs",
-  "definitions", // pre-draft-2019-09 equivalent of $defs
-]);
-
-/**
- * Strip meta-declarations from a schema obj
- */
-function sanitizeForOpenApi(schema: unknown): unknown {
-  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
-    return schema;
-  }
-
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema)) {
-    if (JSON_SCHEMA_META_DECLARATIONS.has(key)) {
-      continue;
-    }
-    result[key] = sanitizeForOpenApi(value);
-  }
-  return result;
 }
 
 /**
  * Convert tools to Gemini function declarations format.
- *
- * By default uses `parametersJsonSchema` which supports full JSON Schema (including
- * anyOf, oneOf, const, etc.). Set `useParameters` to true to use the legacy `parameters`
- * field instead (OpenAPI 3.03 Schema). This is needed for Cloud Code Assist with Claude
- * models, where the API translates `parameters` into Anthropic's `input_schema`.
  * @internal Directly tested provider implementation detail.
  */
 export function convertTools(
   tools: Tool[],
-  useParameters = false,
 ): { functionDeclarations: Record<string, unknown>[] }[] | undefined {
   if (tools.length === 0) {
     return undefined;
   }
   return [
     {
-      functionDeclarations: tools.map((tool) => ({
+      functionDeclarations: sortPromptCacheToolsByName(tools).map((tool) => ({
         name: tool.name,
         description: tool.description,
-        ...(useParameters
-          ? { parameters: sanitizeForOpenApi(tool.parameters as unknown) }
-          : { parametersJsonSchema: tool.parameters }),
+        parametersJsonSchema: tool.parameters,
       })),
     },
   ];
@@ -481,9 +449,6 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   model: Model<T>,
   context: Context,
   options: GoogleProviderOptions = {},
-  configHooks?: {
-    getDisabledThinkingConfig?: (model: Model<T>) => ThinkingConfig;
-  },
 ): GenerateContentParameters {
   const contents = convertMessages(model, context);
 
@@ -525,9 +490,10 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
     }
     config.thinkingConfig = thinkingConfig;
   } else if (model.reasoning && options.thinking && !options.thinking.enabled) {
-    config.thinkingConfig = configHooks?.getDisabledThinkingConfig
-      ? configHooks.getDisabledThinkingConfig(model)
-      : getDisabledGoogleThinkingConfig(model);
+    const disabledThinkingConfig = getDisabledGoogleThinkingConfig(model);
+    if (Object.keys(disabledThinkingConfig).length > 0) {
+      config.thinkingConfig = disabledThinkingConfig;
+    }
   }
 
   if (options.signal) {
@@ -544,6 +510,10 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   };
 }
 
+function isAdaptiveGoogleReasoningLevel(value: unknown): value is "adaptive" {
+  return value === "adaptive";
+}
+
 export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   model: Model<T>,
   options: SimpleStreamOptions | undefined,
@@ -554,6 +524,17 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
 ): GoogleThinkingOptions {
   if (!options?.reasoning || options.reasoning === "off") {
     return { enabled: false };
+  }
+  if (isAdaptiveGoogleReasoningLevel(options.reasoning)) {
+    if (!model.reasoning) {
+      return { enabled: false };
+    }
+    if (isGemma4Model(model)) {
+      return { enabled: true, level: ThinkingLevel.HIGH };
+    }
+    return isGemini3ProModel(model) || isGemini3FlashModel(model)
+      ? { enabled: true }
+      : { enabled: true, budgetTokens: -1 };
   }
 
   const clampedReasoning = clampThinkingLevel(model, options.reasoning);
@@ -585,12 +566,7 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   };
 }
 
-export function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(
-  model: Model<T>,
-  config?: {
-    includeGemma4?: boolean;
-  },
-): ThinkingConfig {
+function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(model: Model<T>): ThinkingConfig {
   // Google docs: Gemini 3.1 Pro cannot disable thinking, and Gemini 3 Flash / Flash-Lite
   // do not support full thinking-off either. For Gemini 3 models, use the lowest supported
   // thinkingLevel without includeThoughts so hidden thinking remains invisible to OpenClaw.
@@ -600,8 +576,8 @@ export function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(
   if (isGemini3FlashModel(model)) {
     return { thinkingLevel: ThinkingLevel.MINIMAL };
   }
-  if (config?.includeGemma4 && isGemma4Model(model)) {
-    return { thinkingLevel: ThinkingLevel.MINIMAL };
+  if (isGemma4Model(model) || model.id.toLowerCase().includes("gemini-2.5-pro")) {
+    return {};
   }
 
   // Gemini 2.x supports disabling via thinkingBudget = 0.
@@ -614,11 +590,11 @@ function isGemma4Model<T extends GoogleApiType>(model: Model<T>): boolean {
 }
 
 function isGemini3ProModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
+  return /gemini-(?:3(?:\.\d+)?-pro|pro-latest)/.test(model.id.toLowerCase());
 }
 
 function isGemini3FlashModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
+  return /gemini-(?:3(?:\.\d+)?-flash|flash(?:-lite)?-latest)/.test(model.id.toLowerCase());
 }
 
 function getGoogleThinkingLevel<T extends GoogleApiType>(
@@ -749,6 +725,13 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   const blocks = params.output.content;
   let sawTerminalReason = false;
   let terminalGenerationError: (Error & { code: string; type: string }) | undefined;
+  const knownUsage = {
+    promptTokenCount: 0,
+    cachedContentTokenCount: 0,
+    toolUsePromptTokenCount: 0,
+    candidatesTokenCount: 0,
+    thoughtsTokenCount: 0,
+  };
   const toolCallIds = new Set<string>();
   for (const block of blocks) {
     if (block.type === "toolCall") {
@@ -782,14 +765,18 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   for await (const chunk of params.chunks) {
     params.output.responseId ||= chunk.responseId;
     if (chunk.usageMetadata) {
-      const promptTokens = chunk.usageMetadata.promptTokenCount || 0;
-      const cacheRead = chunk.usageMetadata.cachedContentTokenCount || 0;
-      const toolUsePromptTokens = chunk.usageMetadata.toolUsePromptTokenCount || 0;
-      const outputTokens =
-        (chunk.usageMetadata.candidatesTokenCount || 0) +
-        (chunk.usageMetadata.thoughtsTokenCount || 0);
+      for (const field of Object.keys(knownUsage) as Array<keyof typeof knownUsage>) {
+        const value = chunk.usageMetadata[field];
+        if (typeof value === "number") {
+          knownUsage[field] = value;
+        }
+      }
+      const promptTokens = knownUsage.promptTokenCount;
+      const cacheRead = knownUsage.cachedContentTokenCount;
+      const toolUsePromptTokens = knownUsage.toolUsePromptTokenCount;
+      const outputTokens = knownUsage.candidatesTokenCount + knownUsage.thoughtsTokenCount;
       params.output.usage = {
-        input: promptTokens - cacheRead + toolUsePromptTokens,
+        input: Math.max(0, promptTokens - cacheRead) + toolUsePromptTokens,
         output: outputTokens,
         cacheRead,
         cacheWrite: 0,

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -63,7 +63,10 @@ export const streamSimpleGoogleVertex: StreamFunction<"google-vertex", SimpleStr
   const base = buildBaseOptions(model, options, undefined);
   return streamGoogleVertex(model, context, {
     ...base,
-    thinking: buildGoogleSimpleThinking(model, options),
+    thinking: buildGoogleSimpleThinking(model, options, {
+      includeGemma4ThinkingLevel: true,
+      useFlashLiteBudgets: true,
+    }),
   } satisfies GoogleVertexOptions);
 };
 

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -8,7 +8,6 @@ import {
   buildGoogleGenerateContentParams,
   buildGoogleSimpleThinking,
   createGoogleAssistantOutput,
-  getDisabledGoogleThinkingConfig,
   type GoogleProviderOptions,
   runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
@@ -94,8 +93,5 @@ function buildParams(
   context: Context,
   options: GoogleOptions = {},
 ): GenerateContentParameters {
-  return buildGoogleGenerateContentParams(model, context, options, {
-    getDisabledThinkingConfig: (modelLocal) =>
-      getDisabledGoogleThinkingConfig(modelLocal, { includeGemma4: true }),
-  });
+  return buildGoogleGenerateContentParams(model, context, options);
 }


### PR DESCRIPTION
# fix(google): restore canonical Gemini and Vertex provider invariants

## What problem this solves

The Google plugin and the separately published `@openclaw/ai` Google/Vertex adapters drifted apart. The resulting bugs included rejected empty requests, silently incorrect token accounting and costs, invalid model-specific thinking payloads, lost or misattributed thought signatures, nondeterministic tool schemas, and incorrectly successful or failed streaming responses.

The replacement is rebuilt directly from the frozen maintainer baseline. It does not reuse the previously held streaming PR, unsupported partial-argument machinery, public SDK changes, or weakened fetch security.

## Root causes repaired

1. Reject incomplete response frames after an otherwise successful terminal response.
2. Parse carriage-return and independently mixed SSE line endings without treating one CRLF as two terminators.
3. Surface framed provider errors that arrive after a terminal candidate.
4. Ignore valid comment/control/empty-data EOF tails, including supported operator proxies with mixed delimiters or mislabeled response content types.
5. Preserve independently sparse prompt, cache, tool, output, and thinking usage fields in both Google implementations.
6. Clamp cache-only input accounting before adding billed tool-use tokens so usage and costs cannot become negative.
7. Keep opaque thought signatures attached to their originating streamed function calls.
8. Add the documented Gemini 3 unsigned-tool-call signature placeholder without affecting Gemini CLI.
9. Keep Google function declarations deterministic across tool discovery order.
10. Preserve valid placeholder content when empty user messages or filtered history would otherwise make both published adapters fail before issuing a request.
11. Recognize supported `gemini-*-latest` aliases in package-private model-thinking policy.
12. Preserve adaptive Gemini 2.5/Gemini 3/Gemma 4 thinking semantics.
13. Omit invalid disabled-thinking payloads for Gemini 2.5 Pro and Gemma 4.
14. Restore native Vertex Gemma 4 level selection in the published adapter.
15. Restore Vertex Gemini 2.5 Flash-Lite's provider-specific minimum token budget.
16. Apply the existing Google-owned thinking sanitizer consistently to direct, provider-qualified, resource-qualified, and native Vertex models.

## Verification

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact reviewed head: `f2891aa560de51e3a04d1f566d39611b41e6e0af`.
- Exact reviewed tree: `760ebff4cbb0d5e09cc633bf1b017f531e9656e2`.
- Blacksmith Testbox `tbx_01kywv88hfdkx0xww9sx6bp3pg`, [exact-head run](https://github.com/openclaw/openclaw/actions/runs/30660195552): immutable Git bundle, detached clean head, exact tree, frozen ancestry, and all ten committed blobs independently verified.
- **209/209 exact-head tests passed:** 66 package-owner tests and 143 Google-provider plugin tests across seven focused suites.
- Three separate exact-head, source/dependency/security reviews: **zero P0/P1/P2/P3 findings**.
- Genuine full-branch Codex `gpt-5.6-sol` / high / explicitly `--max-priority P3` autoreview: **clean, confidence 0.96**; official TruffleHog credential scan: **clean**.
- Installed `@google/genai@2.13.0` and real guarded-provider probes covered 28 proxy/content-type/EOF scenarios, fragmented UTF-8, mixed delimiters, provider errors, sparse billing, and malformed frames. An independent exhaustive streaming check covered 264,528 chunk combinations.
- A previous exact semantic ancestor passed all four core/core-test/extension/extension-test TypeScript lanes. The final exact-head changed gate passed conflict, environment, max-lines, changelog, dependency, formatting, SDK-contract, deprecated-API, plugin-boundary, patch, and dead-export checks, then Blacksmith lost DNS during the core TypeScript lane.
- **Outstanding required proof: exact-head GitHub CI must pass before landing.** Do not treat the interrupted final changed gate as green.
- No public SDK, provider configuration, protocol, package export, lockfile, authentication, SQLite, or shared security-owner changes.
- Existing 16 MiB protection for delimiter-free pending SSE buffers remains unchanged. A fully-delimited oversized single-read bypass was reproduced equally on the frozen baseline and this candidate; it is pre-existing generic security-owner follow-up and is intentionally outside this Google-provider PR.
