### PR TITLE
fix(tui): canonical terminal outcomes, cancellation, and error privacy

### DIFF
--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
+import { createAgentCommandLifecycle } from "./lifecycle.js";
+
+const emitAgentEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../../infra/agent-events.js", () => ({ emitAgentEvent }));
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+describe("createAgentCommandLifecycle", () => {
+  it.each(["finishing", "end"] as const)(
+    "preserves the canonical terminal facts on %s events",
+    (phase) => {
+      emitAgentEvent.mockClear();
+      const metadata = {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        livenessState: "blocked",
+      };
+      const lifecycle = createAgentCommandLifecycle({
+        runId: "terminal-owner",
+        lifecycleGeneration: () => "test-generation",
+        startedAt: 100,
+        state: {
+          currentTurnUserMessagePersisted: true,
+          lifecycleFinishing: false,
+          lifecycleEnded: false,
+        },
+      });
+      const terminal = {
+        metadata,
+        outcome: buildAgentRunTerminalOutcome({ status: "timeout", ...metadata }),
+      };
+
+      if (phase === "finishing") {
+        lifecycle.emitFinishing(terminal);
+      } else {
+        lifecycle.emitEnd(terminal);
+      }
+
+      expect(emitAgentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "terminal-owner",
+          stream: "lifecycle",
+          data: expect.objectContaining({ phase, ...metadata }),
+        }),
+      );
+    },
+  );
+});

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -49,8 +49,11 @@ describe("createAgentCommandLifecycle", () => {
         lifecycle.emitResultError(
           {
             payloads: [],
-            meta: { error: { message: "internal provider diagnostic" } },
-          } as Parameters<typeof lifecycle.emitResultError>[0],
+            meta: {
+              durationMs: 0,
+              error: { kind: "retry_limit", message: "internal provider diagnostic" },
+            },
+          },
           true,
           terminal,
         );
@@ -107,8 +110,8 @@ describe("createAgentCommandLifecycle", () => {
         lifecycle.emitResultError(
           {
             payloads: source === "fallback payload" ? [{ isError: true, text: error }] : [],
-            meta: {},
-          } as Parameters<typeof lifecycle.emitResultError>[0],
+            meta: { durationMs: 0 },
+          },
           source === "fallback payload",
           terminal,
         );
@@ -157,11 +160,7 @@ describe("createAgentCommandLifecycle", () => {
       } else if (phase === "end") {
         lifecycle.emitEnd(terminal);
       } else {
-        lifecycle.emitResultError(
-          { payloads: [], meta: {} } as Parameters<typeof lifecycle.emitResultError>[0],
-          false,
-          terminal,
-        );
+        lifecycle.emitResultError({ payloads: [], meta: { durationMs: 0 } }, false, terminal);
       }
 
       const event = emitAgentEvent.mock.calls[0]?.[0];

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -10,16 +10,21 @@ vi.mock("../../logging/subsystem.js", () => ({
 }));
 
 describe("createAgentCommandLifecycle", () => {
-  it.each(["finishing", "end"] as const)(
-    "preserves the canonical terminal facts on %s events",
+  it.each(["finishing", "end", "error"] as const)(
+    "preserves only canonical terminal facts on %s events",
     (phase) => {
       emitAgentEvent.mockClear();
+      const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
       const metadata = {
         aborted: true,
         stopReason: "timeout",
         timeoutPhase: "provider",
         providerStarted: true,
         livenessState: "blocked",
+        yielded: true,
+        replayInvalid: true,
+        error: { message: `Authorization: Bearer ${secret}`, nested: { secret } },
+        unsafeMetadata: { credential: secret },
       };
       const lifecycle = createAgentCommandLifecycle({
         runId: "terminal-owner",
@@ -38,17 +43,97 @@ describe("createAgentCommandLifecycle", () => {
 
       if (phase === "finishing") {
         lifecycle.emitFinishing(terminal);
-      } else {
+      } else if (phase === "end") {
         lifecycle.emitEnd(terminal);
+      } else {
+        lifecycle.emitResultError(
+          {
+            payloads: [],
+            meta: { error: { message: "internal provider diagnostic" } },
+          } as Parameters<typeof lifecycle.emitResultError>[0],
+          true,
+          terminal,
+        );
       }
 
       expect(emitAgentEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           runId: "terminal-owner",
           stream: "lifecycle",
-          data: expect.objectContaining({ phase, ...metadata }),
+          data: expect.objectContaining({
+            phase,
+            aborted: true,
+            stopReason: "timeout",
+            timeoutPhase: "provider",
+            providerStarted: true,
+            livenessState: "blocked",
+            yielded: true,
+            replayInvalid: true,
+            ...(phase === "error" ? { fallbackExhaustedFailure: true } : {}),
+          }),
         }),
       );
+      expect(JSON.stringify(emitAgentEvent.mock.calls[0]?.[0])).not.toContain(secret);
+      expect(emitAgentEvent.mock.calls[0]?.[0]?.data).not.toHaveProperty("unsafeMetadata");
+    },
+  );
+
+  it.each(["finishing", "end", "error"] as const)(
+    "rejects malformed canonical metadata on %s events",
+    (phase) => {
+      emitAgentEvent.mockClear();
+      const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+      const malicious = { authorization: `Bearer ${secret}`, nested: { secret } };
+      const lifecycle = createAgentCommandLifecycle({
+        runId: "malformed-terminal-owner",
+        lifecycleGeneration: () => "test-generation",
+        startedAt: 100,
+        state: {
+          currentTurnUserMessagePersisted: true,
+          lifecycleFinishing: false,
+          lifecycleEnded: false,
+        },
+      });
+      const terminal = {
+        metadata: {
+          aborted: malicious,
+          stopReason: malicious,
+          yielded: malicious,
+          timeoutPhase: malicious,
+          providerStarted: malicious,
+          livenessState: malicious,
+          replayInvalid: malicious,
+          error: malicious,
+          unknownMetadata: malicious,
+        },
+        outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+      };
+
+      if (phase === "finishing") {
+        lifecycle.emitFinishing(terminal);
+      } else if (phase === "end") {
+        lifecycle.emitEnd(terminal);
+      } else {
+        lifecycle.emitResultError(
+          { payloads: [], meta: {} } as Parameters<typeof lifecycle.emitResultError>[0],
+          false,
+          terminal,
+        );
+      }
+
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data).toMatchObject({ phase, aborted: false, stopReason: "error" });
+      expect(JSON.stringify(event)).not.toContain(secret);
+      for (const field of [
+        "yielded",
+        "timeoutPhase",
+        "providerStarted",
+        "livenessState",
+        "replayInvalid",
+        "unknownMetadata",
+      ]) {
+        expect(event.data).not.toHaveProperty(field);
+      }
     },
   );
 });

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -78,6 +78,49 @@ describe("createAgentCommandLifecycle", () => {
     },
   );
 
+  it.each(["lifecycle callback", "fallback payload", "post-turn error"] as const)(
+    "redacts credentials from a %s before publishing the lifecycle event",
+    (source) => {
+      emitAgentEvent.mockClear();
+      const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+      const error = `The provider failed. Authorization: Bearer ${secret}`;
+      const state = {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+        ...(source === "lifecycle callback" ? { lifecycleError: error } : {}),
+      };
+      const lifecycle = createAgentCommandLifecycle({
+        runId: "secret-safe-terminal-owner",
+        lifecycleGeneration: () => "test-generation",
+        startedAt: 100,
+        state,
+      });
+      const terminal = {
+        metadata: {},
+        outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+      };
+
+      if (source === "post-turn error") {
+        lifecycle.emitPostTurnError(new Error(error));
+      } else {
+        lifecycle.emitResultError(
+          {
+            payloads: source === "fallback payload" ? [{ isError: true, text: error }] : [],
+            meta: {},
+          } as Parameters<typeof lifecycle.emitResultError>[0],
+          source === "fallback payload",
+          terminal,
+        );
+      }
+
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data.error).toContain("The provider failed.");
+      expect(event.data.error).toContain("Authorization: Bearer");
+      expect(JSON.stringify(event)).not.toContain(secret);
+    },
+  );
+
   it.each(["finishing", "end", "error"] as const)(
     "rejects malformed canonical metadata on %s events",
     (phase) => {

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -85,20 +85,30 @@ export function createAgentCommandLifecycle(params: {
       : undefined) ??
     (runResult.meta.error ? "Agent run failed" : undefined);
   const emitTerminalPhase = (
-    phase: "finishing" | "end",
+    phase: "finishing" | "end" | "error",
     terminal: EmbeddedAgentRunEntryTerminal,
+    error?: string,
+    fallbackExhausted?: boolean,
   ) => {
+    const { aborted, yielded, replayInvalid } = terminal.metadata;
+    const { stopReason, livenessState, timeoutPhase, providerStarted } = terminal.outcome;
     emitAgentEvent({
       runId: params.runId,
       lifecycleGeneration: params.lifecycleGeneration(),
       stream: "lifecycle",
       data: {
-        ...terminal.metadata,
         phase,
         startedAt: params.startedAt,
         endedAt: Date.now(),
-        aborted: terminal.metadata.aborted ?? false,
-        stopReason: terminal.outcome.stopReason,
+        aborted: typeof aborted === "boolean" ? aborted : false,
+        stopReason,
+        ...(yielded === true ? { yielded } : {}),
+        ...(replayInvalid === true ? { replayInvalid } : {}),
+        ...(livenessState ? { livenessState } : {}),
+        ...(timeoutPhase ? { timeoutPhase } : {}),
+        ...(providerStarted !== undefined ? { providerStarted } : {}),
+        ...(error ? { error } : {}),
+        ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
         ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
       },
     });
@@ -142,19 +152,7 @@ export function createAgentCommandLifecycle(params: {
       const error =
         resolveResultError(runResult, fallbackExhausted) ??
         (fallbackExhausted ? "All model fallback candidates failed" : "Agent run failed");
-      emitAgentEvent({
-        runId: params.runId,
-        lifecycleGeneration: params.lifecycleGeneration(),
-        stream: "lifecycle",
-        data: {
-          phase: "error",
-          startedAt: params.startedAt,
-          endedAt: Date.now(),
-          error,
-          ...terminal.metadata,
-          ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
-        },
-      });
+      emitTerminalPhase("error", terminal, error, fallbackExhausted);
     },
     emitPostTurnError(error: unknown) {
       if (params.state.lifecycleEnded) {

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -84,6 +84,25 @@ export function createAgentCommandLifecycle(params: {
         )?.text
       : undefined) ??
     (runResult.meta.error ? "Agent run failed" : undefined);
+  const emitTerminalPhase = (
+    phase: "finishing" | "end",
+    terminal: EmbeddedAgentRunEntryTerminal,
+  ) => {
+    emitAgentEvent({
+      runId: params.runId,
+      lifecycleGeneration: params.lifecycleGeneration(),
+      stream: "lifecycle",
+      data: {
+        ...terminal.metadata,
+        phase,
+        startedAt: params.startedAt,
+        endedAt: Date.now(),
+        aborted: terminal.metadata.aborted ?? false,
+        stopReason: terminal.outcome.stopReason,
+        ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
+      },
+    });
+  };
 
   return {
     emitFinishing(terminal: EmbeddedAgentRunEntryTerminal) {
@@ -96,19 +115,7 @@ export function createAgentCommandLifecycle(params: {
       }
       lifecycleFinishingEmitted = true;
       params.state.lifecycleFinishing = true;
-      emitAgentEvent({
-        runId: params.runId,
-        lifecycleGeneration: params.lifecycleGeneration(),
-        stream: "lifecycle",
-        data: {
-          phase: "finishing",
-          startedAt: params.startedAt,
-          endedAt: Date.now(),
-          aborted: terminal.metadata.aborted ?? false,
-          stopReason: terminal.outcome.stopReason,
-          ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
-        },
-      });
+      emitTerminalPhase("finishing", terminal);
     },
     emitEnd(terminal: EmbeddedAgentRunEntryTerminal) {
       if (params.state.lifecycleEnded) {
@@ -120,19 +127,7 @@ export function createAgentCommandLifecycle(params: {
       if (logLevel) {
         log[logLevel](`[agent] run ${params.runId} ended with stopReason=${stopReason}`);
       }
-      emitAgentEvent({
-        runId: params.runId,
-        lifecycleGeneration: params.lifecycleGeneration(),
-        stream: "lifecycle",
-        data: {
-          phase: "end",
-          startedAt: params.startedAt,
-          endedAt: Date.now(),
-          aborted: terminal.metadata.aborted ?? false,
-          stopReason,
-          ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
-        },
-      });
+      emitTerminalPhase("end", terminal);
     },
     resolveResultError,
     emitResultError(

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -1,4 +1,5 @@
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   buildAgentRunTerminalOutcome,
@@ -107,7 +108,7 @@ export function createAgentCommandLifecycle(params: {
         ...(livenessState ? { livenessState } : {}),
         ...(timeoutPhase ? { timeoutPhase } : {}),
         ...(providerStarted !== undefined ? { providerStarted } : {}),
-        ...(error ? { error } : {}),
+        ...(error ? { error: formatErrorMessage(error) } : {}),
         ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
         ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
       },
@@ -167,7 +168,7 @@ export function createAgentCommandLifecycle(params: {
           phase: "error",
           startedAt: params.startedAt,
           endedAt: Date.now(),
-          error: error instanceof Error ? error.message : "Agent run failed",
+          error: formatErrorMessage(error),
           ...resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
         },
       });

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1464,7 +1464,7 @@ describe("EmbeddedTuiBackend", () => {
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps later queued turns behind the active provider when an intermediate turn is canceled", async () => {
+  it("keeps later queued turns behind the active provider when intermediate turns are canceled", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const active = deferred<{ payloads: Array<{ text: string }>; meta: Record<string, unknown> }>();
     let activeSignal: AbortSignal | undefined;
@@ -1501,6 +1501,11 @@ describe("EmbeddedTuiBackend", () => {
       message: "third",
       runId: "queue-third",
     });
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "fourth",
+      runId: "queue-fourth",
+    });
     await backend.abortChat({ sessionKey: "agent:main:main", runId: "queue-second" });
     await flushMicrotasks();
 
@@ -1517,11 +1522,25 @@ describe("EmbeddedTuiBackend", () => {
     expect(activeSignal?.aborted).toBe(false);
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
+    await backend.abortChat({ sessionKey: "agent:main:main", runId: "queue-third" });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "queue-third",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "aborted",
+      },
+    });
+    expect(activeSignal?.aborted).toBe(false);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
     active.resolve({ payloads: [{ text: "the active turn completed" }], meta: {} });
     await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2));
     expect(agentCommandFromIngressMock.mock.calls[1]?.[0]).toMatchObject({
-      runId: "queue-third",
-      message: "third",
+      runId: "queue-fourth",
+      message: "fourth",
     });
   });
 
@@ -2013,6 +2032,7 @@ describe("EmbeddedTuiBackend", () => {
       label: "a provider timeout after mechanical cancellation",
       lifecycle: {
         phase: "end",
+        reason: "transport_cleanup",
         aborted: true,
         stopReason: "timeout",
         timeoutPhase: "provider",
@@ -2217,6 +2237,55 @@ describe("EmbeddedTuiBackend", () => {
         state: "aborted",
       },
     });
+  });
+
+  it.each([
+    {
+      label: "an unrelated completed reason during an actual abort",
+      data: { phase: "end", reason: "completed", aborted: true, stopReason: "aborted" },
+      terminal: { state: "aborted" },
+    },
+    {
+      label: "an unrelated cancelled reason during an actual provider error",
+      data: {
+        phase: "end",
+        reason: "cancelled",
+        aborted: false,
+        error: "real provider failure",
+      },
+      terminal: { state: "error", errorMessage: "real provider failure" },
+    },
+  ])("ignores $label in open lifecycle event data", async ({ data, terminal }) => {
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "trust canonical facts, not an open reason",
+      runId: "open-lifecycle-reason",
+    });
+
+    registeredListener?.({ runId: "open-lifecycle-reason", stream: "lifecycle", data });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "open-lifecycle-reason",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        ...terminal,
+      },
+    });
+    pending.resolve({ payloads: [{ text: "the provider finally settled" }], meta: {} });
+    await flushMicrotasks();
   });
 
   it("preserves a yielded parent turn in the embedded session projection", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1944,6 +1944,9 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  const structuredLifecycleSecret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+  const structuredLifecycleError = `\u001b[31mThe image is too large. Authorization: Bearer ${structuredLifecycleSecret}\u001b[0m`;
+
   it.each([
     {
       label: "a provider timeout after mechanical cancellation",
@@ -1984,34 +1987,81 @@ describe("EmbeddedTuiBackend", () => {
       meta: { error: { kind: "image_size", message: "Internal provider diagnostic" } },
       text: "The image is too large. Resize it and try again.",
     },
-  ])("projects $label as an actionable terminal failure", async ({ lifecycle, meta, text }) => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string; mediaUrl: null }>;
-      meta: Record<string, unknown>;
-    }>();
-    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
-    const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
-    backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "show the actual terminal outcome",
-      runId: "canonical-terminal",
-    });
-    const queuedRunReady = (
-      backend as unknown as { runs: Map<string, { queuedRunReady: Promise<void> }> }
-    ).runs.get("canonical-terminal")?.queuedRunReady;
-    let queueReady = false;
-    void queuedRunReady?.then(() => {
-      queueReady = true;
-    });
+    {
+      label: "a structured lifecycle failure",
+      lifecycle: {
+        phase: "end",
+        aborted: false,
+        error: { kind: "image_size", message: structuredLifecycleError },
+      },
+      meta: {
+        aborted: false,
+        error: { kind: "image_size", message: structuredLifecycleError },
+      },
+      text: "The image is too large. Authorization: Bearer ***",
+      secret: structuredLifecycleSecret,
+    },
+    {
+      label: "an explicit non-aborted failure after controller cancellation",
+      abortBeforeLifecycle: true,
+      lifecycle: {
+        phase: "end",
+        aborted: false,
+        error: { kind: "retry_limit", message: "The provider exhausted its retry limit." },
+      },
+      meta: {
+        aborted: false,
+        error: { kind: "retry_limit", message: "The provider exhausted its retry limit." },
+      },
+      text: "The provider exhausted its retry limit.",
+    },
+  ])(
+    "projects $label as an actionable terminal failure",
+    async ({ lifecycle, meta, text, abortBeforeLifecycle, secret }) => {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      const pending = deferred<{
+        payloads: Array<{ text: string; mediaUrl: null }>;
+        meta: Record<string, unknown>;
+      }>();
+      agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+      const backend = new EmbeddedTuiBackend();
+      const events: Array<{ event: string; payload: unknown }> = [];
+      backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+      backend.start();
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "show the actual terminal outcome",
+        runId: "canonical-terminal",
+      });
+      const queuedRunReady = (
+        backend as unknown as { runs: Map<string, { queuedRunReady: Promise<void> }> }
+      ).runs.get("canonical-terminal")?.queuedRunReady;
+      let queueReady = false;
+      void queuedRunReady?.then(() => {
+        queueReady = true;
+      });
 
-    if (lifecycle) {
-      registeredListener?.({ runId: "canonical-terminal", stream: "lifecycle", data: lifecycle });
+      if (abortBeforeLifecycle) {
+        await backend.abortChat({ sessionKey: "agent:main:main", runId: "canonical-terminal" });
+      }
+      if (lifecycle) {
+        registeredListener?.({ runId: "canonical-terminal", stream: "lifecycle", data: lifecycle });
+        await flushMicrotasks();
+        expect(queueReady).toBe(true);
+        expect(events).toContainEqual({
+          event: "chat",
+          payload: {
+            runId: "canonical-terminal",
+            sessionKey: "agent:main:main",
+            agentId: "main",
+            state: "error",
+            errorMessage: text,
+          },
+        });
+      }
+      pending.resolve({ payloads: [{ text, mediaUrl: null }], meta });
       await flushMicrotasks();
-      expect(queueReady).toBe(true);
+
       expect(events).toContainEqual({
         event: "chat",
         payload: {
@@ -2022,27 +2072,22 @@ describe("EmbeddedTuiBackend", () => {
           errorMessage: text,
         },
       });
-    }
-    pending.resolve({ payloads: [{ text, mediaUrl: null }], meta });
-    await flushMicrotasks();
-
-    expect(events).toContainEqual({
-      event: "chat",
-      payload: {
-        runId: "canonical-terminal",
-        sessionKey: "agent:main:main",
-        agentId: "main",
-        state: "error",
-        errorMessage: text,
-      },
-    });
-    expect(
-      events.filter(
-        ({ event, payload }) =>
-          event === "chat" && (payload as { state?: string }).state === "error",
-      ),
-    ).toHaveLength(1);
-  });
+      expect(
+        events.filter(
+          ({ event, payload }) =>
+            event === "chat" && (payload as { state?: string }).state === "error",
+        ),
+      ).toHaveLength(1);
+      if (secret) {
+        const terminal = events.find(
+          ({ event, payload }) =>
+            event === "chat" && (payload as { state?: string }).state === "error",
+        )?.payload as { errorMessage: string };
+        expect(terminal.errorMessage).not.toContain(secret);
+        expect(terminal.errorMessage).not.toContain("\u001b");
+      }
+    },
+  );
 
   it("preserves a yielded parent turn in the embedded session projection", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -2089,6 +2089,42 @@ describe("EmbeddedTuiBackend", () => {
     },
   );
 
+  it("surfaces canonical error-only thrown outcomes without exposing the wrapped cause", async () => {
+    const { AgentRunTerminalOutcomeError } =
+      await import("../agents/agent-run-terminal-outcome.js");
+    const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+    agentCommandFromIngressMock.mockRejectedValueOnce(
+      new AgentRunTerminalOutcomeError(new Error(`hidden provider credential ${secret}`), {
+        reason: "failed",
+        status: "error",
+      }),
+    );
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "surface the canonical failure",
+      runId: "error-only-terminal",
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "error-only-terminal",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "error",
+        errorMessage: "Agent run failed.",
+      },
+    });
+    expect(JSON.stringify(events)).not.toContain(secret);
+  });
+
   it("preserves a yielded parent turn in the embedded session projection", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1971,13 +1971,13 @@ describe("EmbeddedTuiBackend", () => {
         livenessState: "blocked",
       },
       meta: { aborted: true, stopReason: "aborted", livenessState: "blocked" },
-      text: "No provider completed the response. Please try again.",
+      text: "Agent run blocked before producing a usable result.",
     },
     {
       label: "an abandoned turn without cancellation",
       lifecycle: { phase: "end", livenessState: "abandoned" },
       meta: { livenessState: "abandoned" },
-      text: "The agent stopped before completing its response.",
+      text: "Agent run ended before producing a complete result.",
     },
     {
       label: "a structured agent failure",
@@ -2000,9 +2000,28 @@ describe("EmbeddedTuiBackend", () => {
       message: "show the actual terminal outcome",
       runId: "canonical-terminal",
     });
+    const queuedRunReady = (
+      backend as unknown as { runs: Map<string, { queuedRunReady: Promise<void> }> }
+    ).runs.get("canonical-terminal")?.queuedRunReady;
+    let queueReady = false;
+    void queuedRunReady?.then(() => {
+      queueReady = true;
+    });
 
     if (lifecycle) {
       registeredListener?.({ runId: "canonical-terminal", stream: "lifecycle", data: lifecycle });
+      await flushMicrotasks();
+      expect(queueReady).toBe(true);
+      expect(events).toContainEqual({
+        event: "chat",
+        payload: {
+          runId: "canonical-terminal",
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          state: "error",
+          errorMessage: text,
+        },
+      });
     }
     pending.resolve({ payloads: [{ text, mediaUrl: null }], meta });
     await flushMicrotasks();
@@ -2017,6 +2036,12 @@ describe("EmbeddedTuiBackend", () => {
         errorMessage: text,
       },
     });
+    expect(
+      events.filter(
+        ({ event, payload }) =>
+          event === "chat" && (payload as { state?: string }).state === "error",
+      ),
+    ).toHaveLength(1);
   });
 
   it("preserves a yielded parent turn in the embedded session projection", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -2045,6 +2045,13 @@ describe("EmbeddedTuiBackend", () => {
         providerStarted: true,
       },
       text: "The provider timed out. Please try again.",
+      partialText: "A partial response before the provider timed out.",
+    },
+    {
+      label: "a non-provider timeout with partial assistant output",
+      meta: { stopReason: "timeout" },
+      text: "The provider timed out. Please try again.",
+      partialText: "A partial response before the run timed out.",
     },
     {
       label: "a mechanically aborted blocked turn",
@@ -2056,12 +2063,14 @@ describe("EmbeddedTuiBackend", () => {
       },
       meta: { aborted: true, stopReason: "aborted", livenessState: "blocked" },
       text: "Agent run blocked before producing a usable result.",
+      partialText: "A partial response before the run became blocked.",
     },
     {
       label: "an abandoned turn without cancellation",
       lifecycle: { phase: "end", livenessState: "abandoned" },
       meta: { livenessState: "abandoned" },
       text: "Agent run ended before producing a complete result.",
+      partialText: "A partial response before the run was abandoned.",
     },
     {
       label: "a structured agent failure",
@@ -2098,7 +2107,7 @@ describe("EmbeddedTuiBackend", () => {
     },
   ])(
     "projects $label as an actionable terminal failure",
-    async ({ lifecycle, meta, text, abortBeforeLifecycle, secret }) => {
+    async ({ lifecycle, meta, text, partialText, abortBeforeLifecycle, secret }) => {
       const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
       const pending = deferred<{
         payloads: Array<{ text: string; mediaUrl: null }>;
@@ -2140,7 +2149,7 @@ describe("EmbeddedTuiBackend", () => {
           },
         });
       }
-      pending.resolve({ payloads: [{ text, mediaUrl: null }], meta });
+      pending.resolve({ payloads: [{ text: partialText ?? text, mediaUrl: null }], meta });
       await flushMicrotasks();
 
       expect(events).toContainEqual({
@@ -2169,6 +2178,58 @@ describe("EmbeddedTuiBackend", () => {
       }
     },
   );
+
+  it.each([
+    {
+      label: "a provider timeout",
+      meta: { stopReason: "timeout", timeoutPhase: "provider", providerStarted: true },
+      diagnostic: "The provider timed out. Please try again.",
+    },
+    {
+      label: "a queued timeout",
+      meta: { stopReason: "timeout", timeoutPhase: "queue", providerStarted: false },
+      diagnostic: "The provider timed out. Please try again.",
+    },
+    {
+      label: "a blocked run",
+      meta: { livenessState: "blocked" },
+      diagnostic: "Agent run blocked before producing a usable result.",
+    },
+    {
+      label: "an abandoned run",
+      meta: { livenessState: "abandoned" },
+      diagnostic: "Agent run ended before producing a complete result.",
+    },
+  ])("does not let partial assistant output hide $label", async ({ meta, diagnostic }) => {
+    const partialText = "Partial assistant output before the terminal failure.";
+    agentCommandFromIngressMock.mockResolvedValueOnce({
+      payloads: [{ text: partialText }],
+      meta,
+    });
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "preserve the canonical failure diagnostic",
+      runId: "partial-terminal",
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "partial-terminal",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "error",
+        errorMessage: diagnostic,
+      },
+    });
+  });
 
   it("surfaces canonical error-only thrown outcomes without exposing the wrapped cause", async () => {
     const { AgentRunTerminalOutcomeError } =

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -2757,6 +2757,63 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it("keeps the bounded post-turn timeout visible through canceled queue predecessors", async () => {
+    await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      const active = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      agentCommandFromIngressMock.mockReturnValueOnce(active.promise);
+      loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+        cfg: { messages: { queue: { mode: "followup" } } },
+        canonicalKey: sessionKey,
+        storePath: "/tmp/openclaw-sessions.json",
+        store: {},
+        entry: { queueDebounceMs: 0 },
+      }));
+      const backend = new EmbeddedTuiBackend();
+      const events: Array<{ event: string; payload: unknown }> = [];
+      backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+      backend.start();
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "first",
+        runId: "grace-first",
+      });
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "second",
+        runId: "grace-second",
+      });
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "third",
+        runId: "grace-third",
+      });
+
+      registeredListener?.({
+        runId: "grace-first",
+        stream: "lifecycle",
+        data: { phase: "finishing", stopReason: "stop" },
+      });
+      await backend.abortChat({ sessionKey: "agent:main:main", runId: "grace-second" });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+      expect(events).toContainEqual({
+        event: "chat",
+        payload: expect.objectContaining({
+          runId: "grace-third",
+          state: "error",
+          errorMessage: expect.stringContaining("timed out waiting for previous local run"),
+        }),
+      });
+      active.resolve({ payloads: [{ text: "first eventually settled" }], meta: {} });
+      await flushMicrotasks();
+    });
+  });
+
   it("fails a queued local send immediately when shutdown grace is zero", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "0" }, async () => {
       const { EmbeddedTuiBackend } = await import("./embedded-backend.js");

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1464,6 +1464,67 @@ describe("EmbeddedTuiBackend", () => {
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps later queued turns behind the active provider when an intermediate turn is canceled", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const active = deferred<{ payloads: Array<{ text: string }>; meta: Record<string, unknown> }>();
+    let activeSignal: AbortSignal | undefined;
+    agentCommandFromIngressMock
+      .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+        activeSignal = opts.abortSignal;
+        return active.promise;
+      })
+      .mockResolvedValueOnce({ payloads: [{ text: "the later turn completed" }], meta: {} });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      cfg: { messages: { queue: { mode: "followup" } } },
+      canonicalKey: sessionKey,
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { queueDebounceMs: 0 },
+    }));
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "queue-first",
+    });
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "second",
+      runId: "queue-second",
+    });
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "third",
+      runId: "queue-third",
+    });
+    await backend.abortChat({ sessionKey: "agent:main:main", runId: "queue-second" });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "queue-second",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "aborted",
+      },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(activeSignal?.aborted).toBe(false);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    active.resolve({ payloads: [{ text: "the active turn completed" }], meta: {} });
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2));
+    expect(agentCommandFromIngressMock.mock.calls[1]?.[0]).toMatchObject({
+      runId: "queue-third",
+      message: "third",
+    });
+  });
+
   it("steers same-session sends into the active local run", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
@@ -2123,6 +2184,39 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
     expect(JSON.stringify(events)).not.toContain(secret);
+  });
+
+  it("preserves a wrapped canonical cancellation without redundant abort metadata", async () => {
+    const { AgentRunTerminalOutcomeError } =
+      await import("../agents/agent-run-terminal-outcome.js");
+    agentCommandFromIngressMock.mockRejectedValueOnce(
+      new AgentRunTerminalOutcomeError(new Error("underlying cancellation"), {
+        reason: "cancelled",
+        status: "error",
+      }),
+    );
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "preserve the canonical cancellation",
+      runId: "wrapped-cancellation",
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "wrapped-cancellation",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "aborted",
+      },
+    });
   });
 
   it("preserves a yielded parent turn in the embedded session projection", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1414,6 +1414,56 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it("cancels a queued local turn without waiting for the active provider", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const active = deferred<{ payloads: Array<{ text: string }>; meta: Record<string, unknown> }>();
+    let activeSignal: AbortSignal | undefined;
+    agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+      activeSignal = opts.abortSignal;
+      return active.promise;
+    });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      cfg: { messages: { queue: { mode: "followup" } } },
+      canonicalKey: sessionKey,
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { queueDebounceMs: 0 },
+    }));
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "the active provider does not settle",
+      runId: "active-provider",
+    });
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "cancel this queued turn",
+      runId: "queued-provider",
+    });
+
+    await backend.abortChat({ sessionKey: "agent:main:main", runId: "queued-provider" });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "queued-provider",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "aborted",
+      },
+    });
+    expect(activeSignal?.aborted).toBe(false);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    active.resolve({ payloads: [{ text: "active provider completed" }], meta: {} });
+    await flushMicrotasks();
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+  });
+
   it("steers same-session sends into the active local run", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
@@ -1891,6 +1941,120 @@ describe("EmbeddedTuiBackend", () => {
         state: "aborted",
         errorMessage: "edit tool validation failed: edits: must have required properties edits",
       },
+    });
+  });
+
+  it.each([
+    {
+      label: "a provider timeout after mechanical cancellation",
+      lifecycle: {
+        phase: "end",
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      meta: {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      text: "The provider timed out. Please try again.",
+    },
+    {
+      label: "a mechanically aborted blocked turn",
+      lifecycle: {
+        phase: "end",
+        aborted: true,
+        stopReason: "aborted",
+        livenessState: "blocked",
+      },
+      meta: { aborted: true, stopReason: "aborted", livenessState: "blocked" },
+      text: "No provider completed the response. Please try again.",
+    },
+    {
+      label: "an abandoned turn without cancellation",
+      lifecycle: { phase: "end", livenessState: "abandoned" },
+      meta: { livenessState: "abandoned" },
+      text: "The agent stopped before completing its response.",
+    },
+    {
+      label: "a structured agent failure",
+      meta: { error: { kind: "image_size", message: "Internal provider diagnostic" } },
+      text: "The image is too large. Resize it and try again.",
+    },
+  ])("projects $label as an actionable terminal failure", async ({ lifecycle, meta, text }) => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string; mediaUrl: null }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "show the actual terminal outcome",
+      runId: "canonical-terminal",
+    });
+
+    if (lifecycle) {
+      registeredListener?.({ runId: "canonical-terminal", stream: "lifecycle", data: lifecycle });
+    }
+    pending.resolve({ payloads: [{ text, mediaUrl: null }], meta });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "canonical-terminal",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        state: "error",
+        errorMessage: text,
+      },
+    });
+  });
+
+  it("preserves a yielded parent turn in the embedded session projection", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string; mediaUrl: null }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "wait for the delegated turn",
+      runId: "yielded-parent",
+    });
+
+    registeredListener?.({
+      runId: "yielded-parent",
+      stream: "lifecycle",
+      data: { phase: "end", yielded: true, livenessState: "paused", stopReason: "end_turn" },
+    });
+    pending.resolve({
+      payloads: [{ text: "Delegated work is continuing.", mediaUrl: null }],
+      meta: { yielded: true, livenessState: "paused", stopReason: "end_turn" },
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: expect.objectContaining({
+        runId: "yielded-parent",
+        state: "final",
+        stopReason: "end_turn",
+        yielded: true,
+      }),
     });
   });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -2,6 +2,12 @@
 import { randomUUID } from "node:crypto";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
+import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
+import {
+  AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
+  buildAgentRunTerminalOutcome,
+  findAgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import {
   resolveAgentDir,
@@ -83,6 +89,7 @@ import {
   resolveSessionModelRef,
 } from "../gateway/session-utils.js";
 import { projectSessionsPatchEntry } from "../gateway/sessions-patch.js";
+import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
@@ -125,6 +132,7 @@ type LocalRunState = {
   finishing: boolean;
   lifecycleEnded: boolean;
   lifecycleStopReason?: string;
+  lifecycleYielded?: boolean;
   toolErrorSummary?: string;
   finalSent: boolean;
   registered: boolean;
@@ -153,7 +161,17 @@ type LocalPendingMessage = {
   message: string;
 };
 
-const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
+type LocalRunTerminalMetadata = {
+  aborted?: unknown;
+  status?: unknown;
+  stopReason?: unknown;
+  error?: unknown;
+  livenessState?: unknown;
+  timeoutPhase?: unknown;
+  providerStarted?: unknown;
+  yielded?: unknown;
+  toolErrorSummary?: unknown;
+};
 
 const silentRuntime = {
   log: (..._args: unknown[]) => undefined,
@@ -1214,8 +1232,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.clearPendingLifecycleError(runId);
     const timer = setTimeout(() => {
       this.pendingLifecycleErrors.delete(runId);
-      this.emitChatError(runId, run, errorMessage);
-    }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
+      this.emitChatTerminal(runId, run, "error", errorMessage);
+    }, AGENT_RUN_TERMINAL_RETRY_GRACE_MS);
     timer.unref?.();
     this.pendingLifecycleErrors.set(runId, timer);
   }
@@ -1273,6 +1291,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       agentId: run.agentId,
       state: "final",
       ...(stopReason ? { stopReason } : {}),
+      ...(run.lifecycleYielded ? { yielded: true } : {}),
       ...(shouldIncludeMessage
         ? {
             message: {
@@ -1285,7 +1304,12 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
   }
 
-  private emitChatAborted(runId: string, run: LocalRunState, errorMessage?: string) {
+  private emitChatTerminal(
+    runId: string,
+    run: LocalRunState,
+    state: "aborted" | "error",
+    errorMessage?: string,
+  ) {
     this.clearPendingLifecycleError(runId);
     run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
@@ -1297,35 +1321,79 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     run.registered = true;
     run.lastBroadcastText = undefined;
-    const diagnostic = errorMessage ?? run.toolErrorSummary;
+    const diagnostic = state === "aborted" ? (errorMessage ?? run.toolErrorSummary) : errorMessage;
     this.emit("chat", {
       runId,
       sessionKey: run.sessionKey,
       agentId: run.agentId,
-      state: "aborted",
-      ...(diagnostic ? { errorMessage: diagnostic } : {}),
+      state,
+      ...(diagnostic ? { errorMessage: formatTuiErrorMessage(diagnostic) } : {}),
     });
   }
 
-  private emitChatError(runId: string, run: LocalRunState, errorMessage?: string) {
-    this.clearPendingLifecycleError(runId);
-    run.markQueuedRunReady();
-    const alreadyFinal = run.finalSent;
-    run.finishing = false;
-    run.lifecycleEnded = true;
-    run.finalSent = true;
-    if (alreadyFinal) {
-      return;
-    }
-    run.registered = true;
-    run.lastBroadcastText = undefined;
-    this.emit("chat", {
-      runId,
-      sessionKey: run.sessionKey,
-      agentId: run.agentId,
-      state: "error",
-      ...(errorMessage ? { errorMessage } : {}),
+  private projectTerminalOutcome(
+    runId: string,
+    run: LocalRunState,
+    metadata: LocalRunTerminalMetadata,
+    options: { phase?: string; errorMessage?: string; deferError?: boolean } = {},
+  ): boolean {
+    const aborted = metadata.aborted === true || run.controller.signal.aborted;
+    const stopReason =
+      typeof metadata.stopReason === "string"
+        ? metadata.stopReason
+        : aborted
+          ? "aborted"
+          : undefined;
+    const rawError =
+      typeof metadata.error === "string"
+        ? metadata.error
+        : metadata.error &&
+            typeof metadata.error === "object" &&
+            "message" in metadata.error &&
+            typeof metadata.error.message === "string"
+          ? metadata.error.message
+          : undefined;
+    const status =
+      stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
+        ? "timeout"
+        : aborted ||
+            metadata.error ||
+            options.phase === "error" ||
+            stopReason === "error" ||
+            stopReason === "rpc" ||
+            stopReason === "restart"
+          ? "error"
+          : "ok";
+    const outcome = buildAgentRunTerminalOutcome({
+      status,
+      error: options.errorMessage ?? rawError,
+      stopReason,
+      livenessState: metadata.livenessState,
+      timeoutPhase: metadata.timeoutPhase,
+      providerStarted: metadata.providerStarted,
     });
+    if (outcome.reason === "completed") {
+      return false;
+    }
+    if (outcome.reason === "aborted" || outcome.reason === "cancelled") {
+      this.emitChatTerminal(
+        runId,
+        run,
+        "aborted",
+        readToolValidationErrorSummary(metadata.toolErrorSummary),
+      );
+      return true;
+    }
+    const errorMessage =
+      options.errorMessage ??
+      outcome.error ??
+      (outcome.reason === "hard_timeout" ? "The provider timed out. Please try again." : undefined);
+    if (options.deferError) {
+      this.scheduleChatError(runId, run, errorMessage);
+    } else {
+      this.emitChatTerminal(runId, run, "error", errorMessage);
+    }
+    return true;
   }
 
   private ensureRunRegistered(runId: string, run: LocalRunState) {
@@ -1399,8 +1467,6 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     const phase = lifecyclePhase;
-    const aborted = evt.data?.aborted === true || run.controller.signal.aborted;
-    const toolErrorSummary = readToolValidationErrorSummary(evt.data?.toolErrorSummary);
     if (phase === "finishing") {
       run.finishing = true;
       run.markQueuedRunReady();
@@ -1410,26 +1476,26 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     if (phase === "end") {
       run.finishing = false;
-      if (aborted) {
-        this.emitChatAborted(evt.runId, run, toolErrorSummary);
+      if (
+        this.projectTerminalOutcome(evt.runId, run, evt.data, {
+          phase,
+          deferError: true,
+        })
+      ) {
         return;
       }
       run.lifecycleEnded = true;
       run.markQueuedRunReady();
       run.lifecycleStopReason =
         typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+      run.lifecycleYielded = isAgentLifecycleYieldedWaiting(evt.data);
       return;
     }
 
     if (phase === "error") {
       run.finishing = false;
-      if (aborted) {
-        this.emitChatAborted(evt.runId, run, toolErrorSummary);
-        return;
-      }
-      const errorMessage = typeof evt.data?.error === "string" ? evt.data.error : undefined;
       run.buffer = "";
-      this.scheduleChatError(evt.runId, run, errorMessage);
+      this.projectTerminalOutcome(evt.runId, run, evt.data, { phase, deferError: true });
     }
   }
 
@@ -1447,14 +1513,18 @@ export class EmbeddedTuiBackend implements TuiBackend {
     try {
       if (params.queuedAfter) {
         try {
-          await waitForQueuedLocalRun(params.queuedAfter, params.runId);
+          await Promise.race([
+            waitForQueuedLocalRun(params.queuedAfter, params.runId),
+            waitForAbortSignal(params.controller.signal),
+          ]);
         } catch (error) {
           const run = this.runs.get(params.runId);
           if (run) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            this.emitChatError(
+            this.emitChatTerminal(
               params.runId,
               run,
+              "error",
               `previous run did not finish cleanly: ${errorMessage}`,
             );
           }
@@ -1463,7 +1533,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         if (params.controller.signal.aborted) {
           const run = this.runs.get(params.runId);
           if (run) {
-            this.emitChatAborted(params.runId, run);
+            this.emitChatTerminal(params.runId, run, "aborted");
           }
           return;
         }
@@ -1473,7 +1543,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (activeRun?.pendingQueue) {
         await waitForQueueDebounce(activeRun.pendingQueue, params.controller.signal);
         if (params.controller.signal.aborted) {
-          this.emitChatAborted(params.runId, activeRun);
+          this.emitChatTerminal(params.runId, activeRun, "aborted");
           return;
         }
         message = buildLocalQueuedPrompt(activeRun.pendingQueue);
@@ -1493,7 +1563,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           return;
         }
         if (params.controller.signal.aborted) {
-          this.emitChatAborted(params.runId, run);
+          this.emitChatTerminal(params.runId, run, "aborted");
           return;
         }
         this.emit("chat.side_result", {
@@ -1538,10 +1608,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
-      if (params.controller.signal.aborted || result?.meta?.aborted === true) {
-        this.emitChatAborted(params.runId, run);
+      const metadata = result?.meta;
+      const failed =
+        metadata?.error ||
+        metadata?.aborted ||
+        metadata?.timeoutPhase ||
+        metadata?.stopReason === "timeout" ||
+        metadata?.stopReason === "error" ||
+        metadata?.livenessState === "blocked" ||
+        metadata?.livenessState === "abandoned";
+      const visibleFailureText = failed ? payloadText(result?.payloads) : undefined;
+      if (
+        this.projectTerminalOutcome(params.runId, run, metadata ?? {}, {
+          ...(visibleFailureText ? { errorMessage: visibleFailureText } : {}),
+        })
+      ) {
         return;
       }
+      run.lifecycleYielded ||= isAgentLifecycleYieldedWaiting({ phase: "end", ...result?.meta });
 
       if (run.isBtw) {
         const text = payloadText(result?.payloads);
@@ -1575,12 +1659,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
-      if (params.controller.signal.aborted) {
-        this.emitChatAborted(params.runId, run);
-        return;
-      }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      this.emitChatError(params.runId, run, errorMessage);
+      const outcome = findAgentRunTerminalOutcome(error);
+      this.projectTerminalOutcome(
+        params.runId,
+        run,
+        outcome ?? { error: errorMessage },
+        outcome ? {} : { phase: "error" },
+      );
     } finally {
       this.runs.get(params.runId)?.markQueuedRunReady();
       this.runs.delete(params.runId);

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -284,7 +284,7 @@ function resolveDeltaPayload(text: string, previousText: string | undefined) {
   return { deltaText: text.slice(previousText.length) };
 }
 
-function createQueuedRunReadiness(predecessor?: Promise<void>) {
+function createQueuedRunReadiness(predecessor?: QueuedSessionRun) {
   let resolveReady!: () => void;
   const promise = new Promise<void>((ready) => {
     resolveReady = ready;
@@ -298,7 +298,11 @@ function createQueuedRunReadiness(predecessor?: Promise<void>) {
       }
       settled = true;
       // A canceled queue slot must keep later turns behind its live predecessor.
-      void (predecessor?.then(resolveReady, resolveReady) ?? resolveReady());
+      void (predecessor
+        ? Promise.allSettled([predecessor.run.queuedRunReady, predecessor.promise]).then(
+            resolveReady,
+          )
+        : resolveReady());
     },
   };
 }
@@ -521,7 +525,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       }
     }
     const controller = new AbortController();
-    const queuedRunReadiness = createQueuedRunReadiness(queuedAfter?.promise);
+    const queuedRunReadiness = createQueuedRunReadiness(queuedAfter);
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
       agentId,
@@ -1199,9 +1203,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private clearPendingLifecycleErrors() {
-    for (const pending of this.pendingLifecycleErrors.values()) {
-      clearTimeout(pending);
-    }
+    this.pendingLifecycleErrors.forEach(clearTimeout);
     this.pendingLifecycleErrors.clear();
   }
 
@@ -1281,9 +1283,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
     run: LocalRunState,
     metadata: Partial<Parameters<typeof buildAgentRunTerminalOutcome>[0]> & {
       aborted?: unknown;
+      phase?: unknown;
       toolErrorSummary?: unknown;
     },
-    options: { phase?: string; visibleText?: string; deferError?: boolean } = {},
+    options: {
+      visibleText?: string;
+      terminalOutcome?: ReturnType<typeof buildAgentRunTerminalOutcome>;
+    } = {},
   ): boolean {
     const aborted =
       typeof metadata.aborted === "boolean" ? metadata.aborted : run.controller.signal.aborted;
@@ -1293,23 +1299,23 @@ export class EmbeddedTuiBackend implements TuiBackend {
         ? metadata.error.message
         : metadata.error;
     const outcome =
-      "reason" in metadata
-        ? (metadata as ReturnType<typeof buildAgentRunTerminalOutcome>)
-        : buildAgentRunTerminalOutcome({
-            status:
-              stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
-                ? "timeout"
-                : aborted ||
-                    metadata.error ||
-                    [metadata.status, options.phase, stopReason].includes("error")
-                  ? "error"
-                  : "ok",
-            error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
-            stopReason,
-            livenessState: metadata.livenessState,
-            timeoutPhase: metadata.timeoutPhase,
-            providerStarted: metadata.providerStarted,
-          });
+      options.terminalOutcome ??
+      buildAgentRunTerminalOutcome({
+        status:
+          stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
+            ? "timeout"
+            : aborted ||
+                metadata.error ||
+                metadata.phase === "error" ||
+                [metadata.status, stopReason].includes("error")
+              ? "error"
+              : "ok",
+        error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
+        stopReason,
+        livenessState: metadata.livenessState,
+        timeoutPhase: metadata.timeoutPhase,
+        providerStarted: metadata.providerStarted,
+      });
     if (outcome.reason === "completed") {
       return false;
     }
@@ -1323,7 +1329,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           (outcome.reason === "hard_timeout"
             ? "The provider timed out. Please try again."
             : "Agent run failed.");
-    if (options.deferError && state === "error") {
+    if (metadata.phase === "error" && state === "error") {
       this.scheduleChatError(runId, run, diagnostic);
     } else {
       this.emitChatTerminal(runId, run, state, diagnostic);
@@ -1412,12 +1418,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (phase === "error") {
       run.buffer = "";
     }
-    if (
-      this.projectTerminalOutcome(evt.runId, run, evt.data, {
-        phase,
-        deferError: phase === "error",
-      })
-    ) {
+    if (this.projectTerminalOutcome(evt.runId, run, evt.data)) {
       return;
     }
     run.lifecycleEnded = true;
@@ -1582,8 +1583,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
       this.projectTerminalOutcome(
         params.runId,
         run,
-        outcome ?? { error: errorMessage },
-        outcome ? {} : { phase: "error" },
+        outcome ?? { status: "error", error: errorMessage },
+        outcome ? { terminalOutcome: outcome } : {},
       );
     } finally {
       this.runs.get(params.runId)?.markQueuedRunReady();

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1291,8 +1291,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
     },
     options: { phase?: string; visibleText?: string; deferError?: boolean } = {},
   ): boolean {
-    const aborted = metadata.aborted === true || run.controller.signal.aborted;
+    const aborted =
+      typeof metadata.aborted === "boolean" ? metadata.aborted : run.controller.signal.aborted;
     const stopReason = metadata.stopReason ?? (aborted ? "aborted" : undefined);
+    const terminalError =
+      metadata.error && typeof metadata.error === "object" && "message" in metadata.error
+        ? metadata.error.message
+        : metadata.error;
     const outcome = buildAgentRunTerminalOutcome({
       status:
         stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
@@ -1300,7 +1305,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           : aborted || metadata.error || options.phase === "error" || stopReason === "error"
             ? "error"
             : "ok",
-      error: typeof metadata.error === "string" ? metadata.error : undefined,
+      error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
       stopReason,
       livenessState: metadata.livenessState,
       timeoutPhase: metadata.timeoutPhase,

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1197,10 +1197,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private clearPendingLifecycleError(runId: string) {
-    const pending = this.pendingLifecycleErrors.get(runId);
-    if (pending) {
-      clearTimeout(pending);
-    }
+    clearTimeout(this.pendingLifecycleErrors.get(runId));
     this.pendingLifecycleErrors.delete(runId);
   }
 
@@ -1302,7 +1299,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
       status:
         stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
           ? "timeout"
-          : aborted || metadata.error || options.phase === "error" || stopReason === "error"
+          : aborted ||
+              metadata.error ||
+              [metadata.status, options.phase, stopReason].includes("error")
             ? "error"
             : "ok",
       error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
@@ -1323,7 +1322,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           outcome.error ||
           (outcome.reason === "hard_timeout"
             ? "The provider timed out. Please try again."
-            : undefined);
+            : "Agent run failed.");
     if (options.deferError && state === "error") {
       this.scheduleChatError(runId, run, diagnostic);
     } else {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1315,9 +1315,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const diagnostic =
       state === "aborted"
         ? readToolValidationErrorSummary(metadata.toolErrorSummary)
-        : options.visibleText ||
+        : (outcome.reason === "failed" && options.visibleText) ||
           outcome.error ||
-          (outcome.reason === "hard_timeout"
+          (outcome.status === "timeout"
             ? "The provider timed out. Please try again."
             : "Agent run failed.");
     if (metadata.phase === "error" && state === "error") {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -161,18 +161,6 @@ type LocalPendingMessage = {
   message: string;
 };
 
-type LocalRunTerminalMetadata = {
-  aborted?: unknown;
-  status?: unknown;
-  stopReason?: unknown;
-  error?: unknown;
-  livenessState?: unknown;
-  timeoutPhase?: unknown;
-  providerStarted?: unknown;
-  yielded?: unknown;
-  toolErrorSummary?: unknown;
-};
-
 const silentRuntime = {
   log: (..._args: unknown[]) => undefined,
   error: (..._args: unknown[]) => undefined,
@@ -273,6 +261,10 @@ function payloadText(parts: unknown): string {
     .filter(Boolean)
     .join("\n\n")
     .trim();
+}
+
+function assistantChatMessage(text: string) {
+  return { role: "assistant", content: [{ type: "text", text }], timestamp: Date.now() };
 }
 
 function timeoutSecondsFromMs(timeoutMs?: number): string | undefined {
@@ -1186,38 +1178,29 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private isSameRunScope(run: LocalRunState, params: { sessionKey: string; agentId?: string }) {
-    if (run.sessionKey !== params.sessionKey) {
-      return false;
-    }
-    if (params.sessionKey !== "global") {
-      return true;
-    }
-    return run.agentId === params.agentId;
+    return (
+      run.sessionKey === params.sessionKey &&
+      (params.sessionKey !== "global" || run.agentId === params.agentId)
+    );
   }
 
   private isAbortableRun(runId: string, run: LocalRunState): boolean {
     return !run.lifecycleEnded || this.runPromises.has(runId);
   }
 
-  private nextSeq() {
-    this.seq += 1;
-    return this.seq;
-  }
-
   private emit(event: string, payload: unknown) {
     this.onEvent?.({
       event,
       payload,
-      seq: this.nextSeq(),
+      seq: ++this.seq,
     });
   }
 
   private clearPendingLifecycleError(runId: string) {
     const pending = this.pendingLifecycleErrors.get(runId);
-    if (!pending) {
-      return;
+    if (pending) {
+      clearTimeout(pending);
     }
-    clearTimeout(pending);
     this.pendingLifecycleErrors.delete(runId);
   }
 
@@ -1259,56 +1242,15 @@ export class EmbeddedTuiBackend implements TuiBackend {
       agentId: run.agentId,
       state: "delta",
       ...deltaPayload,
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text }],
-        timestamp: Date.now(),
-      },
-    });
-  }
-
-  private emitChatFinal(runId: string, run: LocalRunState, stopReason?: string) {
-    this.clearPendingLifecycleError(runId);
-    run.markQueuedRunReady();
-    const alreadyFinal = run.finalSent;
-    run.finishing = false;
-    run.lifecycleEnded = true;
-    run.finalSent = true;
-    if (alreadyFinal) {
-      return;
-    }
-    run.registered = true;
-    run.lastBroadcastText = undefined;
-    const normalizedText = normalizeLiveAssistantBufferedText(run.buffer).trim();
-    const projected = projectLiveAssistantBufferedText(normalizedText, {
-      suppressLeadFragments: false,
-    });
-    const text = projected.text.trim();
-    const shouldIncludeMessage = Boolean(text) && !projected.suppress;
-    this.emit("chat", {
-      runId,
-      sessionKey: run.sessionKey,
-      agentId: run.agentId,
-      state: "final",
-      ...(stopReason ? { stopReason } : {}),
-      ...(run.lifecycleYielded ? { yielded: true } : {}),
-      ...(shouldIncludeMessage
-        ? {
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              timestamp: Date.now(),
-            },
-          }
-        : {}),
+      message: assistantChatMessage(text),
     });
   }
 
   private emitChatTerminal(
     runId: string,
     run: LocalRunState,
-    state: "aborted" | "error",
-    errorMessage?: string,
+    state: "final" | "aborted" | "error",
+    detail?: string,
   ) {
     this.clearPendingLifecycleError(runId);
     run.markQueuedRunReady();
@@ -1321,52 +1263,44 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     run.registered = true;
     run.lastBroadcastText = undefined;
-    const diagnostic = state === "aborted" ? (errorMessage ?? run.toolErrorSummary) : errorMessage;
+    const projected = projectLiveAssistantBufferedText(
+      normalizeLiveAssistantBufferedText(run.buffer).trim(),
+      { suppressLeadFragments: false },
+    );
+    const text = state === "final" && !projected.suppress ? projected.text.trim() : "";
     this.emit("chat", {
       runId,
       sessionKey: run.sessionKey,
       agentId: run.agentId,
       state,
-      ...(diagnostic ? { errorMessage: formatTuiErrorMessage(diagnostic) } : {}),
+      ...(state === "final" && detail ? { stopReason: detail } : {}),
+      ...(state === "final" && run.lifecycleYielded ? { yielded: true } : {}),
+      ...(text ? { message: assistantChatMessage(text) } : {}),
+      ...(state !== "final" && (detail || (state === "aborted" && run.toolErrorSummary))
+        ? { errorMessage: formatTuiErrorMessage(detail ?? run.toolErrorSummary) }
+        : {}),
     });
   }
 
   private projectTerminalOutcome(
     runId: string,
     run: LocalRunState,
-    metadata: LocalRunTerminalMetadata,
-    options: { phase?: string; errorMessage?: string; deferError?: boolean } = {},
+    metadata: Partial<Parameters<typeof buildAgentRunTerminalOutcome>[0]> & {
+      aborted?: unknown;
+      toolErrorSummary?: unknown;
+    },
+    options: { phase?: string; visibleText?: string; deferError?: boolean } = {},
   ): boolean {
     const aborted = metadata.aborted === true || run.controller.signal.aborted;
-    const stopReason =
-      typeof metadata.stopReason === "string"
-        ? metadata.stopReason
-        : aborted
-          ? "aborted"
-          : undefined;
-    const rawError =
-      typeof metadata.error === "string"
-        ? metadata.error
-        : metadata.error &&
-            typeof metadata.error === "object" &&
-            "message" in metadata.error &&
-            typeof metadata.error.message === "string"
-          ? metadata.error.message
-          : undefined;
-    const status =
-      stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
-        ? "timeout"
-        : aborted ||
-            metadata.error ||
-            options.phase === "error" ||
-            stopReason === "error" ||
-            stopReason === "rpc" ||
-            stopReason === "restart"
-          ? "error"
-          : "ok";
+    const stopReason = metadata.stopReason ?? (aborted ? "aborted" : undefined);
     const outcome = buildAgentRunTerminalOutcome({
-      status,
-      error: options.errorMessage ?? rawError,
+      status:
+        stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
+          ? "timeout"
+          : aborted || metadata.error || options.phase === "error" || stopReason === "error"
+            ? "error"
+            : "ok",
+      error: typeof metadata.error === "string" ? metadata.error : undefined,
       stopReason,
       livenessState: metadata.livenessState,
       timeoutPhase: metadata.timeoutPhase,
@@ -1375,23 +1309,20 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (outcome.reason === "completed") {
       return false;
     }
-    if (outcome.reason === "aborted" || outcome.reason === "cancelled") {
-      this.emitChatTerminal(
-        runId,
-        run,
-        "aborted",
-        readToolValidationErrorSummary(metadata.toolErrorSummary),
-      );
-      return true;
-    }
-    const errorMessage =
-      options.errorMessage ??
-      outcome.error ??
-      (outcome.reason === "hard_timeout" ? "The provider timed out. Please try again." : undefined);
-    if (options.deferError) {
-      this.scheduleChatError(runId, run, errorMessage);
+    const state =
+      outcome.reason === "aborted" || outcome.reason === "cancelled" ? "aborted" : "error";
+    const diagnostic =
+      state === "aborted"
+        ? readToolValidationErrorSummary(metadata.toolErrorSummary)
+        : options.visibleText ||
+          outcome.error ||
+          (outcome.reason === "hard_timeout"
+            ? "The provider timed out. Please try again."
+            : undefined);
+    if (options.deferError && state === "error") {
+      this.scheduleChatError(runId, run, diagnostic);
     } else {
-      this.emitChatTerminal(runId, run, "error", errorMessage);
+      this.emitChatTerminal(runId, run, state, diagnostic);
     }
     return true;
   }
@@ -1408,11 +1339,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       agentId: run.agentId,
       state: "delta",
       deltaText: "",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "" }],
-        timestamp: Date.now(),
-      },
+      message: assistantChatMessage(""),
     });
   }
 
@@ -1474,29 +1401,26 @@ export class EmbeddedTuiBackend implements TuiBackend {
         typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
       return;
     }
-    if (phase === "end") {
-      run.finishing = false;
-      if (
-        this.projectTerminalOutcome(evt.runId, run, evt.data, {
-          phase,
-          deferError: true,
-        })
-      ) {
-        return;
-      }
-      run.lifecycleEnded = true;
-      run.markQueuedRunReady();
-      run.lifecycleStopReason =
-        typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-      run.lifecycleYielded = isAgentLifecycleYieldedWaiting(evt.data);
+    if (phase !== "end" && phase !== "error") {
       return;
     }
-
+    run.finishing = false;
     if (phase === "error") {
-      run.finishing = false;
       run.buffer = "";
-      this.projectTerminalOutcome(evt.runId, run, evt.data, { phase, deferError: true });
     }
+    if (
+      this.projectTerminalOutcome(evt.runId, run, evt.data, {
+        phase,
+        deferError: phase === "error",
+      })
+    ) {
+      return;
+    }
+    run.lifecycleEnded = true;
+    run.markQueuedRunReady();
+    run.lifecycleStopReason =
+      typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+    run.lifecycleYielded = isAgentLifecycleYieldedWaiting(evt.data);
   }
 
   private async runTurn(params: {
@@ -1575,7 +1499,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           text: result.text,
           ...(result.isError ? { isError: true } : {}),
         });
-        this.emitChatFinal(params.runId, run);
+        this.emitChatTerminal(params.runId, run, "final");
         return;
       }
       const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
@@ -1608,19 +1532,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
-      const metadata = result?.meta;
-      const failed =
-        metadata?.error ||
-        metadata?.aborted ||
-        metadata?.timeoutPhase ||
-        metadata?.stopReason === "timeout" ||
-        metadata?.stopReason === "error" ||
-        metadata?.livenessState === "blocked" ||
-        metadata?.livenessState === "abandoned";
-      const visibleFailureText = failed ? payloadText(result?.payloads) : undefined;
       if (
-        this.projectTerminalOutcome(params.runId, run, metadata ?? {}, {
-          ...(visibleFailureText ? { errorMessage: visibleFailureText } : {}),
+        this.projectTerminalOutcome(params.runId, run, result?.meta ?? {}, {
+          visibleText: payloadText(result?.payloads),
         })
       ) {
         return;
@@ -1639,7 +1553,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
             text,
           });
         }
-        this.emitChatFinal(params.runId, run);
+        this.emitChatTerminal(params.runId, run, "final");
         return;
       }
 
@@ -1652,7 +1566,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         const stopReason =
           run.lifecycleStopReason ??
           (typeof result?.meta?.stopReason === "string" ? result.meta.stopReason : undefined);
-        this.emitChatFinal(params.runId, run, stopReason);
+        this.emitChatTerminal(params.runId, run, "final", stopReason);
       }
     } catch (error) {
       const run = this.runs.get(params.runId);

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -284,15 +284,11 @@ function resolveDeltaPayload(text: string, previousText: string | undefined) {
   return { deltaText: text.slice(previousText.length) };
 }
 
-function createQueuedRunReadiness() {
-  let resolve: (() => void) | undefined;
+function createQueuedRunReadiness(predecessor?: Promise<void>) {
+  let resolveReady!: () => void;
   const promise = new Promise<void>((ready) => {
-    resolve = ready;
+    resolveReady = ready;
   });
-  if (!resolve) {
-    throw new Error("Expected queue readiness resolver to be initialized");
-  }
-  const resolveReady = resolve;
   let settled = false;
   return {
     promise,
@@ -301,7 +297,8 @@ function createQueuedRunReadiness() {
         return;
       }
       settled = true;
-      resolveReady();
+      // A canceled queue slot must keep later turns behind its live predecessor.
+      void (predecessor?.then(resolveReady, resolveReady) ?? resolveReady());
     },
   };
 }
@@ -524,7 +521,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       }
     }
     const controller = new AbortController();
-    const queuedRunReadiness = createQueuedRunReadiness();
+    const queuedRunReadiness = createQueuedRunReadiness(queuedAfter?.promise);
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
       agentId,
@@ -1295,21 +1292,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
       metadata.error && typeof metadata.error === "object" && "message" in metadata.error
         ? metadata.error.message
         : metadata.error;
-    const outcome = buildAgentRunTerminalOutcome({
-      status:
-        stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
-          ? "timeout"
-          : aborted ||
-              metadata.error ||
-              [metadata.status, options.phase, stopReason].includes("error")
-            ? "error"
-            : "ok",
-      error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
-      stopReason,
-      livenessState: metadata.livenessState,
-      timeoutPhase: metadata.timeoutPhase,
-      providerStarted: metadata.providerStarted,
-    });
+    const outcome =
+      "reason" in metadata
+        ? (metadata as ReturnType<typeof buildAgentRunTerminalOutcome>)
+        : buildAgentRunTerminalOutcome({
+            status:
+              stopReason === "timeout" || metadata.status === "timeout" || metadata.timeoutPhase
+                ? "timeout"
+                : aborted ||
+                    metadata.error ||
+                    [metadata.status, options.phase, stopReason].includes("error")
+                  ? "error"
+                  : "ok",
+            error: terminalError ? formatTuiErrorMessage(terminalError) : undefined,
+            stopReason,
+            livenessState: metadata.livenessState,
+            timeoutPhase: metadata.timeoutPhase,
+            providerStarted: metadata.providerStarted,
+          });
     if (outcome.reason === "completed") {
       return false;
     }

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -145,6 +145,7 @@ type LocalRunState = {
     droppedCount: number;
     summaryLines: string[];
   };
+  queuedAfter?: QueuedSessionRun;
   queuedRunReady: Promise<void>;
   markQueuedRunReady: () => void;
 };
@@ -284,27 +285,12 @@ function resolveDeltaPayload(text: string, previousText: string | undefined) {
   return { deltaText: text.slice(previousText.length) };
 }
 
-function createQueuedRunReadiness(predecessor?: QueuedSessionRun) {
-  let resolveReady!: () => void;
+function createQueuedRunReadiness() {
+  let markReady!: () => void;
   const promise = new Promise<void>((ready) => {
-    resolveReady = ready;
+    markReady = ready;
   });
-  let settled = false;
-  return {
-    promise,
-    markReady: () => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      // A canceled queue slot must keep later turns behind its live predecessor.
-      void (predecessor
-        ? Promise.allSettled([predecessor.run.queuedRunReady, predecessor.promise]).then(
-            resolveReady,
-          )
-        : resolveReady());
-    },
-  };
+  return { promise, markReady };
 }
 
 async function waitForLocalRunShutdown(promises: Promise<void>[]): Promise<boolean> {
@@ -334,6 +320,10 @@ async function waitForLocalRunShutdown(promises: Promise<void>[]): Promise<boole
 
 async function waitForQueuedLocalRun(previousRun: QueuedSessionRun, runId: string): Promise<void> {
   await previousRun.run.queuedRunReady;
+  if (previousRun.run.controller.signal.aborted && previousRun.run.queuedAfter) {
+    // Preserve canceled-slot ancestry and the live run's bounded maintenance wait.
+    return await waitForQueuedLocalRun(previousRun.run.queuedAfter, runId);
+  }
   if (!previousRun.run.finishing && !previousRun.run.lifecycleEnded) {
     await previousRun.promise;
     return;
@@ -525,7 +515,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       }
     }
     const controller = new AbortController();
-    const queuedRunReadiness = createQueuedRunReadiness(queuedAfter);
+    const queuedRunReadiness = createQueuedRunReadiness();
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
       agentId,
@@ -538,6 +528,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       finalSent: false,
       registered: false,
       ...(pendingQueue ? { pendingQueue } : {}),
+      ...(queuedAfter ? { queuedAfter } : {}),
       queuedRunReady: queuedRunReadiness.promise,
       markQueuedRunReady: queuedRunReadiness.markReady,
     });
@@ -1468,6 +1459,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         }
       }
       const activeRun = this.runs.get(params.runId);
+      delete activeRun?.queuedAfter;
       let message = params.message;
       if (activeRun?.pendingQueue) {
         await waitForQueueDebounce(activeRun.pendingQueue, params.controller.signal);


### PR DESCRIPTION
## What Problem This Solves

Embedded local-terminal agent turns had three related ownership defects:

1. Lifecycle `finishing`, `end`, and `error` events did not consistently preserve authoritative yielded, liveness, timeout, and provider facts. Their open metadata and raw callback, fallback, and post-turn error messages could expose bearer tokens, OAuth query credentials, API keys, and nested secrets to every lifecycle-event consumer.
2. The embedded TUI inferred terminal status independently from the canonical outcome owner. Provider/queue timeouts, blocked or abandoned runs, wrapped cancellation, yielded parent turns, and structured failures could be displayed as cancellation, success, incomplete output, or misleading partial assistant text.
3. Canceling a queued local turn waited behind its active predecessor. Releasing that queue slot immediately allowed later turns to start a concurrent provider in the same session; chaining the raw predecessor promise instead lost the existing bounded post-turn-maintenance timeout.

## Why This Change Was Made

The lifecycle producer now owns one validated, redacted terminal-event projection for all three phases. It derives safe canonical outcome facts, accepts yielded/replay flags only when explicitly boolean, and formats every published provider error through the existing shared redactor.

The embedded TUI now projects the shared canonical terminal outcome and emits final, aborted, and error chat events through one terminal owner. Canonical timeout and liveness diagnostics take precedence over partial assistant output; sanitized user-facing structured failure payloads remain visible.

The existing bounded local-run wait owner follows canceled queued-slot ancestry back to the still-active provider. Canceled slots report immediately, later turns remain serialized, and the original post-turn shutdown grace still yields an actionable bounded error when maintenance stalls.

This is a bounded ownership refactor, not a compatibility layer: **production code decreases by 9 lines** across the two production owners (174 additions, 183 deletions).

## User Impact

- Paused or yielded parent turns stay visibly paused instead of being marked complete.
- Timeout, blocked, abandoned, canceled, and structured provider failures show the correct actionable terminal outcome.
- Lifecycle subscribers and TUI event consumers no longer receive raw provider credentials through metadata or legitimate error-message paths.
- Canceling a queued prompt responds immediately without aborting the active provider, starting overlapping same-session turns, or hanging indefinitely behind post-turn maintenance.

## Complete Exact-Head and Current-Main Source Review

**ClawSweeper rank-up move addressed:** the full exact merge-head source was refreshed and reviewed from a complete checkout, not the partial/promisor checkout that could not load this branch.

- Reviewed all **10 commits** in the complete source range `36b80ada3ceae2de21b3d8710b883d778e4c4578..f53744b0be7ce33fcaa39888148462c1e19decc6`; the final fixture-only commit was not evaluated in isolation.
- Current `main` was independently resolved to `b6d9b38146c7be78fb2b3678e7f42ca0130d369d`.
- `git merge-tree --write-tree b6d9b38146c7be78fb2b3678e7f42ca0130d369d f53744b0be7ce33fcaa39888148462c1e19decc6` succeeded without conflicts and produced merge tree `c4106e481c5e36f3822f9f2d00f06f29d7944dab`.
- All four touched files in that current-main merge tree are **byte-identical to the exact independently reviewed PR head**; no intervening `main` commit changed any of the four owner/test files. `git diff --check` against the current-main merge tree passed.
- The current-main merge diff contains only `src/agents/command/lifecycle.ts`, `src/agents/command/lifecycle.test.ts`, `src/tui/embedded-backend.ts`, and `src/tui/embedded-backend.test.ts`. Production remains **+174/-183 = -9**; tests add 732 regression lines.
- GitHub reports the exact PR head **MERGEABLE**; the full required [`openclaw/ci-gate` completed successfully](https://github.com/openclaw/openclaw/actions/runs/30667486532/job/91279538482), and the latest [real-behavior-proof check completed successfully](https://github.com/openclaw/openclaw/actions/runs/30668185126/job/91279965943).

### Security concern: every lifecycle error source is redacted

The complete exact-head owner review explicitly traced each route identified by ClawSweeper:

- `src/agents/command/lifecycle.ts:88`: one canonical `emitTerminalPhase` owns `finishing`, `end`, and `error`; it derives `stopReason`, liveness, timeout, and provider facts from the validated canonical outcome rather than spreading arbitrary terminal metadata.
- `src/agents/command/lifecycle.ts:94`: only strictly validated boolean `aborted`, `yielded`, and `replayInvalid` metadata are admitted; malformed nested objects and unknown credential-bearing metadata are excluded.
- `src/agents/command/lifecycle.ts:111`: callback-derived lifecycle errors and fallback error-payload strings are passed through the existing shared `formatErrorMessage` redactor before event publication.
- `src/agents/command/lifecycle.ts:156`: fallback exhaustion uses the same canonical redacted emission owner; it cannot bypass producer-side redaction.
- `src/agents/command/lifecycle.ts:171`: post-turn exceptions, including nested causes, use that same existing shared redactor before publication.
- `src/tui/embedded-backend.ts:1272`: TUI terminal projection consumes canonical outcomes; provider and queue timeouts, blocked and abandoned liveness, and wrapped cancellation are not inferred from arbitrary lifecycle reason strings.
- `src/tui/embedded-backend.ts:1318`: only a genuine ordinary `failed` outcome may use an intended user-facing error payload; canonical timeout and liveness diagnostics cannot be hidden by partial assistant output.
- `src/tui/embedded-backend.ts:321`: canceled queued slots recurse to the original live predecessor inside the existing bounded maintenance owner; `src/tui/embedded-backend.ts:1462` removes ancestry only after actual provider admission.

Independent execution of the **actual exact-head production owner and actual shared redactor**, not mocked redaction, proved bearer credentials, OAuth URL-query secrets, API keys, nested error causes, and malicious nested metadata remain absent from published `finishing`, `end`, and `error` events. Regression cases independently cover lifecycle callback state, fallback payload text, and post-turn exceptions.

ClawSweeper's inferred “persistent data model / vector-embedding metadata” warning is a classification false positive: `terminal.metadata` is transient in-memory lifecycle-event data. The reviewed full branch and current-main merge tree contain **no SQLite, vector database, embedding storage, schema, migration, configuration, or other persistent-state change**.

## Evidence

- Frozen branch baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Exact complete-range independently reviewed candidate: `f53744b0be7ce33fcaa39888148462c1e19decc6`.
- Exact refreshed current-main clean merge tree: `c4106e481c5e36f3822f9f2d00f06f29d7944dab` against `b6d9b38146c7be78fb2b3678e7f42ca0130d369d`.
- Authentic pre-fix REDs cover credential leaks in `finishing`, `end`, and `error`; lifecycle callback, fallback-payload, and post-turn error sources; provider timeout, queue timeout, blocked and abandoned partial-output masking; immediate queue cancellation, overlapping canceled-slot ancestry, and bounded post-turn maintenance.
- Exact-head remote verification on Blacksmith Testbox `tbx_01kywqay0nb16vcsvk9da061kb`:

  ```text
  node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/embedded-backend.test.ts
  node scripts/run-vitest.mjs src/agents/agent-run-terminal-outcome.test.ts src/agents/command/lifecycle.test.ts
  node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts
  node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
  node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/command/lifecycle.ts src/agents/command/lifecycle.test.ts src/tui/embedded-backend.ts src/tui/embedded-backend.test.ts
  node scripts/check-max-lines-ratchet.mjs
  ```

  **169 tests passed, 0 failed:** 85 embedded TUI owner cases, 27 canonical terminal-outcome owner cases, 9 lifecycle producer/security cases, and **48 real interactive PTY scenarios**. Both production and core-test TypeScript graphs passed; 245 lint rules reported zero warnings and zero errors. The real PTY drove the actual interactive TUI loop across Unicode, streaming, subscription recovery, Ctrl+D/`/exit`, workspace approvals, model/session pickers, history gaps, session races, and queued followups. Targeted `oxfmt --check`, the max-lines ratchet, and exact-head/current-main `git diff --check` passed. The owned Blacksmith Testbox lease was stopped after verification.

- Independent actual-production-owner adversarial verification covered bearer/OAuth/API-key/nested-cause redaction, malformed nested metadata across all lifecycle phases, wrapped canonical cancellation, four canonical timeout/liveness classes, contiguous and noncontiguous A-through-F queued cancellations, bounded maintenance through up to three canceled predecessors, zero grace, ignored active-provider abort, and selected-global session isolation. Verdict: **CLEAN**.
- Fresh genuine complete-branch Codex autoreview covered the full 10-commit source range using `--mode branch --base 36b80ada3ceae2de21b3d8710b883d778e4c4578 --max-priority P3` and a real TruffleHog 3.96.0 scan. Preserved validated exact-head review JSON reports **zero P0/P1/P2/P3 findings**, `patch is correct`, confidence **0.87**.
- Full GitHub CI [`openclaw/ci-gate` is green](https://github.com/openclaw/openclaw/actions/runs/30667486532/job/91279538482), and the [real-behavior-proof gate is green](https://github.com/openclaw/openclaw/actions/runs/30668185126/job/91279965943).

No public configuration, authentication, provider selection, plugin SDK, Gateway protocol, persisted state, SQLite, migration, or public contract changes.
