### PR TITLE
fix(openai): validate bounded realtime tool-argument lifecycles

### DIFF
--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -36,6 +36,7 @@ import {
   normalizeResolvedSecretInputString,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import WebSocket from "ws";
 import {
   asFiniteNumber,
@@ -184,6 +185,7 @@ type RealtimeEvent = {
     name?: string;
     call_id?: string;
     arguments?: string;
+    status?: "completed" | "incomplete" | "in_progress";
   };
   response?: {
     id?: string;
@@ -610,6 +612,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private static readonly CONNECT_TIMEOUT_MS = 10_000;
   private static readonly MAX_PENDING_AUDIO_CHUNKS = 320;
   private static readonly MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
+  // Match the established Code Mode per-batch pending-tool concurrency limit.
+  private static readonly MAX_PENDING_TOOL_CALLS = 16;
   readonly supportsToolResultContinuation = true;
   readonly supportsToolResultSuppression = true;
 
@@ -636,6 +640,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private connectionUrl = "";
   private toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
   private deliveredToolCallKeys = new Set<string>();
+  private pendingInvalidToolCalls = new Map<string, Error>();
+  private pendingToolCallOverflowed = false;
   private readonly flowId = randomUUID();
   private sessionReadyFired = false;
   private reconnectReason: string | undefined;
@@ -1428,6 +1434,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
       case "response.cancelled":
       case "response.done":
+        this.finalizePendingToolCalls(event);
         this.responseActive = false;
         this.responseCreateInFlight = false;
         this.manualResponseCreateEventId = null;
@@ -1464,13 +1471,18 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           name: buffered?.name || event.name,
           // The done payload owns the final JSON; streamed chunks may be stale or incomplete.
           rawArgs: event.arguments ?? buffered?.args,
+          authoritative: false,
         });
         this.toolCallBuffers.delete(key);
         return;
       }
 
       case "conversation.item.done": {
-        if (event.item?.type !== "function_call") {
+        if (
+          event.item?.type !== "function_call" ||
+          event.item.status === "incomplete" ||
+          event.item.status === "in_progress"
+        ) {
           return;
         }
         this.emitToolCallOnce({
@@ -1478,6 +1490,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           callId: event.item.call_id ?? event.call_id ?? event.item.id ?? event.item_id,
           name: event.item.name ?? event.name,
           rawArgs: event.item.arguments ?? event.arguments,
+          authoritative: true,
         });
         return;
       }
@@ -1591,8 +1604,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     callId?: string;
     name?: string;
     rawArgs?: string;
+    authoritative: boolean;
   }): void {
-    if (!this.config.onToolCall) {
+    if (!this.config.onToolCall || this.pendingToolCallOverflowed) {
       return;
     }
     const itemId = fields.itemId || fields.callId || "unknown";
@@ -1602,17 +1616,76 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.deliveredToolCallKeys.has(dedupeKey)) {
       return;
     }
-    this.deliveredToolCallKeys.add(dedupeKey);
-    let args: unknown = {};
+    let args: unknown;
+    let validationError: Error | undefined;
     try {
       args = JSON.parse(fields.rawArgs || "{}");
-    } catch {}
+    } catch {
+      validationError = new Error(
+        `OpenAI realtime tool call "${name || callId}" has invalid JSON arguments`,
+      );
+    }
+    if (!validationError && !isRecord(args)) {
+      validationError = new Error(
+        `OpenAI realtime tool call "${name || callId}" arguments must be a JSON object`,
+      );
+    }
+    if (validationError) {
+      if (!fields.authoritative) {
+        // Final-arguments events can precede a corrected authoritative conversation item.
+        if (
+          !this.pendingInvalidToolCalls.has(dedupeKey) &&
+          this.pendingInvalidToolCalls.size >= OpenAIRealtimeVoiceBridge.MAX_PENDING_TOOL_CALLS
+        ) {
+          this.pendingInvalidToolCalls.clear();
+          this.pendingToolCallOverflowed = true;
+          this.config.onError?.(
+            new Error(
+              `OpenAI realtime tool call pending argument limit exceeded (${OpenAIRealtimeVoiceBridge.MAX_PENDING_TOOL_CALLS})`,
+            ),
+          );
+          return;
+        }
+        this.pendingInvalidToolCalls.set(dedupeKey, validationError);
+        return;
+      }
+      this.pendingInvalidToolCalls.delete(dedupeKey);
+      this.config.onError?.(validationError);
+      return;
+    }
+    this.pendingInvalidToolCalls.delete(dedupeKey);
+    this.deliveredToolCallKeys.add(dedupeKey);
     this.config.onToolCall({
       itemId,
       callId,
       name,
       args,
     });
+  }
+
+  private finalizePendingToolCalls(event: RealtimeEvent): void {
+    if (this.pendingToolCallOverflowed) {
+      this.pendingToolCallOverflowed = false;
+      this.pendingInvalidToolCalls.clear();
+      return;
+    }
+    if (this.pendingInvalidToolCalls.size === 0) {
+      return;
+    }
+    const pendingError = this.pendingInvalidToolCalls.values().next().value;
+    this.pendingInvalidToolCalls.clear();
+    const status = event.response?.status;
+    if (
+      event.type === "response.cancelled" ||
+      status === "cancelled" ||
+      status === "failed" ||
+      status === "incomplete"
+    ) {
+      return;
+    }
+    if (pendingError) {
+      this.config.onError?.(pendingError);
+    }
   }
 
   private requestResponseCreate(): void {
@@ -1675,6 +1748,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.lastAssistantItemId = null;
     this.toolCallBuffers.clear();
     this.deliveredToolCallKeys.clear();
+    this.pendingInvalidToolCalls.clear();
+    this.pendingToolCallOverflowed = false;
   }
 
   private enqueuePendingAudio(audio: Buffer): void {

--- a/extensions/openai/realtime-voice-tool-args.test.ts
+++ b/extensions/openai/realtime-voice-tool-args.test.ts
@@ -1,0 +1,460 @@
+import { once } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocketServer, type WebSocket } from "ws";
+import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+
+type RealtimeBridgeFixture = {
+  serverSocket: WebSocket;
+  onToolCall: ReturnType<typeof vi.fn>;
+  onError: ReturnType<typeof vi.fn>;
+  onEvent: ReturnType<typeof vi.fn>;
+};
+
+async function withRealtimeBridge(
+  run: (fixture: RealtimeBridgeFixture) => Promise<void>,
+  options?: { closeOnError?: boolean },
+): Promise<void> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected an available local realtime WebSocket address");
+  }
+
+  let serverSocket: WebSocket | undefined;
+  server.once("connection", (socket) => {
+    serverSocket = socket;
+    socket.once("message", () => {
+      socket.send(JSON.stringify({ type: "session.updated" }));
+    });
+  });
+
+  const onToolCall = vi.fn();
+  const onError = vi.fn((_error: Error) => {
+    if (options?.closeOnError) {
+      bridge.close();
+    }
+  });
+  const onEvent = vi.fn();
+  const bridge = buildOpenAIRealtimeVoiceProvider().createBridge({
+    providerConfig: {
+      apiKey: "fixture-local", // pragma: allowlist secret
+      azureEndpoint: `http://127.0.0.1:${address.port}`,
+      azureDeployment: "fixture-realtime",
+    },
+    onAudio: vi.fn(),
+    onClearAudio: vi.fn(),
+    onToolCall,
+    onError,
+    onEvent,
+  });
+
+  try {
+    await bridge.connect();
+    if (!serverSocket) {
+      throw new Error("expected the provider to connect to its local realtime WebSocket");
+    }
+    await run({ serverSocket, onToolCall, onError, onEvent });
+  } finally {
+    bridge.close();
+    for (const client of server.clients) {
+      client.terminate();
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function sendToolArguments(
+  socket: WebSocket,
+  argumentsJson: string,
+  type:
+    | "response.function_call_arguments.done"
+    | "conversation.item.done" = "response.function_call_arguments.done",
+  options?: {
+    itemId?: string;
+    callId?: string;
+    itemStatus?: "completed" | "incomplete" | "in_progress";
+  },
+): Promise<void> {
+  const itemId = options?.itemId ?? "item-consult";
+  const callId = options?.callId ?? "call-consult";
+  const event =
+    type === "conversation.item.done"
+      ? {
+          type,
+          item: {
+            id: itemId,
+            type: "function_call",
+            call_id: callId,
+            name: "openclaw_agent_consult",
+            arguments: argumentsJson,
+            ...(options?.itemStatus ? { status: options.itemStatus } : {}),
+          },
+        }
+      : {
+          type,
+          item_id: itemId,
+          call_id: callId,
+          name: "openclaw_agent_consult",
+          arguments: argumentsJson,
+        };
+  await new Promise<void>((resolve, reject) => {
+    socket.send(JSON.stringify(event), (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function sendResponseTerminal(
+  socket: WebSocket,
+  status: "completed" | "cancelled" | "failed" | "incomplete",
+  type: "response.done" | "response.cancelled" = "response.done",
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    socket.send(JSON.stringify({ type, response: { id: "response-consult", status } }), (error) =>
+      error ? reject(error) : resolve(),
+    );
+  });
+}
+
+async function waitForServerEvent(
+  onEvent: ReturnType<typeof vi.fn>,
+  type: string,
+  minimumCount = 1,
+): Promise<void> {
+  await vi.waitFor(() => {
+    const matches = onEvent.mock.calls.filter(([event]) => {
+      const fields = event as { direction?: string; type?: string };
+      return fields.direction === "server" && fields.type === type;
+    });
+    expect(matches.length).toBeGreaterThanOrEqual(minimumCount);
+  });
+}
+
+describe("OpenAI realtime tool argument ownership", () => {
+  it.each([
+    { name: "truncated JSON", argumentsJson: '{"question":', diagnosis: "invalid JSON" },
+    { name: "malformed JSON", argumentsJson: '{"question":}', diagnosis: "invalid JSON" },
+    { name: "a JSON array", argumentsJson: '["unsafe"]', diagnosis: "must be a JSON object" },
+    { name: "JSON null", argumentsJson: "null", diagnosis: "must be a JSON object" },
+    { name: "a JSON number", argumentsJson: "42", diagnosis: "must be a JSON object" },
+    { name: "a JSON boolean", argumentsJson: "true", diagnosis: "must be a JSON object" },
+  ])(
+    "reports authoritative $name without dispatching a tool",
+    async ({ argumentsJson, diagnosis }) => {
+      await withRealtimeBridge(async ({ serverSocket, onToolCall, onError }) => {
+        await sendToolArguments(serverSocket, argumentsJson, "conversation.item.done");
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+
+        expect(onToolCall).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining(diagnosis),
+          }),
+        );
+      });
+    },
+  );
+
+  it.each([
+    { name: "truncated JSON", argumentsJson: '{"question":', diagnosis: "invalid JSON" },
+    { name: "malformed JSON", argumentsJson: '{"question":}', diagnosis: "invalid JSON" },
+    { name: "a JSON array", argumentsJson: '["unsafe"]', diagnosis: "must be a JSON object" },
+    { name: "JSON null", argumentsJson: "null", diagnosis: "must be a JSON object" },
+    { name: "a JSON number", argumentsJson: "42", diagnosis: "must be a JSON object" },
+    { name: "a JSON boolean", argumentsJson: "true", diagnosis: "must be a JSON object" },
+  ])(
+    "defers provisional $name until its authoritative item",
+    async ({ argumentsJson, diagnosis }) => {
+      await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+        await sendToolArguments(serverSocket, argumentsJson);
+        await waitForServerEvent(onEvent, "response.function_call_arguments.done");
+
+        expect(onToolCall).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+
+        await sendToolArguments(serverSocket, argumentsJson, "conversation.item.done");
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+
+        expect(onToolCall).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining(diagnosis),
+          }),
+        );
+      });
+    },
+  );
+
+  it.each([
+    { name: "the shipped empty argument contract", argumentsJson: "", expectedArguments: {} },
+    {
+      name: "a valid argument object",
+      argumentsJson: '{"question":"valid request"}',
+      expectedArguments: { question: "valid request" },
+    },
+  ])("preserves $name", async ({ argumentsJson, expectedArguments }) => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError }) => {
+      await sendToolArguments(serverSocket, argumentsJson);
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalledOnce());
+
+      expect(onToolCall).toHaveBeenCalledWith({
+        itemId: "item-consult",
+        callId: "call-consult",
+        name: "openclaw_agent_consult",
+        args: expectedArguments,
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  it("recovers the authoritative item with a consumer that closes its bridge on errors", async () => {
+    await withRealtimeBridge(
+      async ({ serverSocket, onToolCall, onError, onEvent }) => {
+        await sendToolArguments(serverSocket, '{"question":');
+        await waitForServerEvent(onEvent, "response.function_call_arguments.done");
+
+        expect(onError).not.toHaveBeenCalled();
+        expect(onToolCall).not.toHaveBeenCalled();
+
+        await sendToolArguments(
+          serverSocket,
+          '{"question":"authoritative recovery"}',
+          "conversation.item.done",
+        );
+        await vi.waitFor(() => {
+          expect(onToolCall).toHaveBeenCalledWith({
+            itemId: "item-consult",
+            callId: "call-consult",
+            name: "openclaw_agent_consult",
+            args: { question: "authoritative recovery" },
+          });
+        });
+
+        expect(onToolCall).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+      },
+      { closeOnError: true },
+    );
+  });
+
+  it.each(["incomplete", "in_progress"] as const)(
+    "keeps a closing consumer alive while an authoritative item remains %s",
+    async (itemStatus) => {
+      await withRealtimeBridge(
+        async ({ serverSocket, onToolCall, onError, onEvent }) => {
+          await sendToolArguments(serverSocket, '{"question":');
+          await waitForServerEvent(onEvent, "response.function_call_arguments.done");
+          await sendToolArguments(serverSocket, '{"question":', "conversation.item.done", {
+            itemStatus,
+          });
+          await waitForServerEvent(onEvent, "conversation.item.done");
+
+          expect(onError).not.toHaveBeenCalled();
+          expect(onToolCall).not.toHaveBeenCalled();
+
+          await sendResponseTerminal(serverSocket, "cancelled");
+          await waitForServerEvent(onEvent, "response.done");
+
+          expect(onError).not.toHaveBeenCalled();
+          expect(onToolCall).not.toHaveBeenCalled();
+        },
+        { closeOnError: true },
+      );
+    },
+  );
+
+  it.each(["incomplete", "in_progress"] as const)(
+    "does not execute valid arguments from an unfinished %s item",
+    async (itemStatus) => {
+      await withRealtimeBridge(
+        async ({ serverSocket, onToolCall, onError, onEvent }) => {
+          await sendToolArguments(
+            serverSocket,
+            '{"question":"unfinished but syntactically valid"}',
+            "conversation.item.done",
+            { itemStatus },
+          );
+          await waitForServerEvent(onEvent, "conversation.item.done");
+
+          expect(onToolCall).not.toHaveBeenCalled();
+          expect(onError).not.toHaveBeenCalled();
+
+          await sendResponseTerminal(serverSocket, "cancelled");
+          await waitForServerEvent(onEvent, "response.done");
+
+          expect(onToolCall).not.toHaveBeenCalled();
+          expect(onError).not.toHaveBeenCalled();
+        },
+        { closeOnError: true },
+      );
+    },
+  );
+
+  it("executes a corrected completed item after ignoring its valid unfinished predecessor", async () => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      await sendToolArguments(serverSocket, '{"question":"unfinished"}', "conversation.item.done", {
+        itemStatus: "incomplete",
+      });
+      await waitForServerEvent(onEvent, "conversation.item.done");
+
+      expect(onToolCall).not.toHaveBeenCalled();
+
+      await sendToolArguments(serverSocket, '{"question":"completed"}', "conversation.item.done", {
+        itemStatus: "completed",
+      });
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalledOnce());
+
+      expect(onToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ args: { question: "completed" } }),
+      );
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  it("tracks parallel invalid identities independently through correction", async () => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      await sendToolArguments(serverSocket, '{"first":', "response.function_call_arguments.done", {
+        itemId: "item-first",
+        callId: "call-first",
+      });
+      await sendToolArguments(serverSocket, '{"second":', "response.function_call_arguments.done", {
+        itemId: "item-second",
+        callId: "call-second",
+      });
+      await waitForServerEvent(onEvent, "response.function_call_arguments.done", 2);
+
+      expect(onError).not.toHaveBeenCalled();
+
+      await sendToolArguments(serverSocket, '{"second":"recovered"}', "conversation.item.done", {
+        itemId: "item-second",
+        callId: "call-second",
+      });
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalledOnce());
+      expect(onToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemId: "item-second",
+          callId: "call-second",
+          args: { second: "recovered" },
+        }),
+      );
+
+      await sendToolArguments(serverSocket, '{"first":', "conversation.item.done", {
+        itemId: "item-first",
+        callId: "call-first",
+      });
+      await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+
+      expect(onToolCall).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("invalid JSON") }),
+      );
+    });
+  });
+
+  it("does not spend pending-identity capacity on repeated provisional frames", async () => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      for (let index = 0; index < 20; index += 1) {
+        await sendToolArguments(serverSocket, '{"question":');
+      }
+      await waitForServerEvent(onEvent, "response.function_call_arguments.done", 20);
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onToolCall).not.toHaveBeenCalled();
+
+      await sendToolArguments(serverSocket, '{"question":"recovered"}', "conversation.item.done");
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalledOnce());
+
+      expect(onToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ args: { question: "recovered" } }),
+      );
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  it("hard-caps hostile pending identities and reports exactly one overflow", async () => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      for (let index = 0; index < 33; index += 1) {
+        await sendToolArguments(
+          serverSocket,
+          '{"question":',
+          "response.function_call_arguments.done",
+          {
+            itemId: `item-hostile-${index}`,
+            callId: `call-hostile-${index}`,
+          },
+        );
+      }
+      await waitForServerEvent(onEvent, "response.function_call_arguments.done", 33);
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("pending argument limit exceeded (16)"),
+        }),
+      );
+
+      await sendResponseTerminal(serverSocket, "cancelled");
+      await waitForServerEvent(onEvent, "response.done");
+      await sendToolArguments(serverSocket, '{"question":"fresh response"}');
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalledOnce());
+
+      expect(onToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ args: { question: "fresh response" } }),
+      );
+      expect(onError).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("reports unresolved malformed arguments when the response completes", async () => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      await sendToolArguments(serverSocket, '{"question":');
+      await waitForServerEvent(onEvent, "response.function_call_arguments.done");
+
+      expect(onError).not.toHaveBeenCalled();
+
+      await sendResponseTerminal(serverSocket, "completed");
+      await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("invalid JSON") }),
+      );
+    });
+  });
+
+  it.each([
+    { name: "a cancelled response", status: "cancelled" as const, type: "response.done" as const },
+    {
+      name: "an explicit response cancellation",
+      status: "cancelled" as const,
+      type: "response.cancelled" as const,
+    },
+    { name: "a failed response", status: "failed" as const, type: "response.done" as const },
+    {
+      name: "an incomplete response",
+      status: "incomplete" as const,
+      type: "response.done" as const,
+    },
+  ])("drops provisional invalid arguments for $name", async ({ status, type }) => {
+    await withRealtimeBridge(async ({ serverSocket, onToolCall, onError, onEvent }) => {
+      await sendToolArguments(serverSocket, '{"question":');
+      await waitForServerEvent(onEvent, "response.function_call_arguments.done");
+      await sendResponseTerminal(serverSocket, status, type);
+      await waitForServerEvent(onEvent, type);
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(
+        onError.mock.calls.filter(([error]) =>
+          (error as Error).message.includes("invalid JSON arguments"),
+        ),
+      ).toHaveLength(0);
+
+      const previousErrorCount = onError.mock.calls.length;
+      await sendResponseTerminal(serverSocket, "completed");
+      await waitForServerEvent(onEvent, "response.done", type === "response.done" ? 2 : 1);
+      expect(onError).toHaveBeenCalledTimes(previousErrorCount);
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The private OpenAI realtime voice owner dispatched function calls before checking that their arguments were a valid JSON object. Malformed JSON silently became `{}`, arrays/null/scalars reached real tool handlers, and an invalid preliminary event consumed the delivery identity so a later authoritative corrected item was discarded.

The first attempted fix surfaced malformed preliminary arguments immediately. Independent review caught a genuine P2: Meeting Bot and Gateway consumers treat `onError` as terminal, so they closed the actual voice session before the corrected authoritative item could arrive. That attempted SHA was held, reproduced **12/20 red**, and replaced.

## Why This Change Was Made

The existing canonical Plugin SDK record guard now validates parsed arguments at their private producer boundary. Malformed `response.function_call_arguments.done` events are provisional: their producer-owned failure remains scoped to the current response until an authoritative `conversation.item.done` settles the tool.

- A valid authoritative item clears the pending error and invokes its tool exactly once without terminating the session.
- An invalid authoritative item reports one visible, actionable realtime error and never invokes the tool.
- A completed response with no authoritative correction surfaces the pending error once.
- Cancelled, failed, and incomplete responses leave terminal precedence to their existing response owner.
- Authoritative events, response terminals, and session reset all clear pending producer state.

The shipped empty-arguments-to-empty-object contract and ordinary valid object arguments remain unchanged. There are no authorization, provider configuration, defaults, public API, SDK, schema, protocol, database, or persistence changes.

## User Impact

- Truncated or malformed tool JSON and arrays/null/scalars never reach realtime tool handlers.
- An authoritative corrected item reaches real Meeting Bot/Gateway consumers because no premature error closes their session.
- Uncorrected successful turns fail visibly; interrupted, cancelled, failed, and incomplete turns keep their existing terminal semantics.
- Existing empty arguments and valid argument objects behave exactly as before.

## Evidence

- Frozen canonical baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Final immutable reviewed candidate: `289c6a37a6b840e03060a89d5a88db194ca0b422`, with direct parent exactly `36b80ada3ceae2de21b3d8710b883d778e4c4578`.
- Initial frozen-base actual-localhost-WebSocket boundary reproduction: **7 regressions / 2 passing shipped compatibility controls**.
- A fresh independent blind reviewer found a genuine consumer-terminal P2 in the first attempted repair; the expanded actual-WebSocket suite reproduced **12 failing cases / 8 passing controls** against the explicitly rejected immutable SHA, including a real `onError` consumer that closes its bridge.
- Exact final owner command:

  ```bash
  PATH=/Users/steipete/.local/bin:$PATH node scripts/run-vitest.mjs extensions/openai/realtime-voice-tool-args.test.ts extensions/openai/realtime-voice-provider.test.ts
  ```

- Exact-head structured review found another genuine interrupted-item P2; the next candidate reproduced **3 failures / 22 passing controls** for `incomplete`/`in_progress` malformed items and uncapped hostile identities, leading to the established **16-call hard cap**, response-scoped overflow ownership, and status-aware deferral.
- A fresh blind then caught that valid JSON in unfinished items could still dispatch; the final lean owner guard reproduced **3 failures / 25 passing controls** and now skips every unfinished item before dispatch while retaining the shipped valid preliminary-event path.
- Final corrected private realtime owners: **125/125 passed**, covering valid and malformed unfinished items with actual closing consumers, completed corrected-item replay, concurrent A/B identities, 20 duplicate-frame replays, 33 hostile identities with one visible overflow and state reset, all six malformed/non-object types, completed-orphan error, cancelled/failed/incomplete precedence and cleanup, and existing empty/valid-object behavior.
- Pinned official OpenAI SDK documents that `response.function_call_arguments.done` is also emitted on interrupted, incomplete, or cancelled responses: `node_modules/openai/src/resources/realtime/realtime.ts:4768-4813`.
- Direct sibling Codex parser rejects invalid tool JSON visibly: `../codex/codex-rs/core/src/tools/handlers/mod.rs:83-91`; direct realtime owner preserves empty-argument compatibility and authoritative item processing: `../codex/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:185-208`.
- Actual downstream terminal consumers inspected: `src/meeting-bot/realtime-engine.ts:623` and `src/gateway/talk-realtime-relay-session-create.ts:423`.
- Clean composition with the independently reviewed realtime `response.done` candidate: `git merge-tree --write-tree 41b5e4111256267a7f7612ef728d190a9d439ac9 289c6a37a6b840e03060a89d5a88db194ca0b422` (**exit 0**, combined tree `efc6b4fcee416a78037322b0520d9db7a4f1df5f`); the independently reviewed native/GPT-Live audio repair also merges cleanly.
- **Two fresh independent exact-SHA strict blind reviews found zero actionable P0/P1/P2/P3 issues**, including the original reviewer who found the earlier genuine P2.
- Genuine full-branch Codex/Sol/high structured autoreview with explicit `--max-priority P3`: **zero actionable findings**, **0.95 confidence**, exact frozen-parent immutable SHA, and genuine TruffleHog clean.
- Production delta: **80 additions / 5 deletions = +75 lines** for one canonical, hard-capped, SDK-status-aware response-scoped producer lifecycle; dedicated authentic-WebSocket regression suite: **460 lines**.
- Targeted formatting, frozen merge-base, final clean isolated worktree, and `git diff --check`: clean.
