### PR TITLE
fix(gateway): preserve static HEAD representation metadata

### DIFF
--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -159,16 +159,16 @@ export function resolveControlUiHtmlEncoding(req: IncomingMessage): ControlUiEnc
 }
 
 type OpenedControlUiRepresentation = {
-  bodyFile: { path: string; fd: number };
+  bodyFile: { path: string; fd: number; size: number };
   contentPath: string;
   encoding?: ControlUiContentEncoding;
 };
 
 export function resolveOpenedControlUiRepresentation(params: {
   req: IncomingMessage;
-  sourceFile: { path: string; fd: number };
+  sourceFile: { path: string; fd: number; size: number };
   precompressed: boolean;
-  openPrecompressedFile: (filePath: string) => { path: string; fd: number } | null;
+  openPrecompressedFile: (filePath: string) => { path: string; fd: number; size: number } | null;
 }): OpenedControlUiRepresentation | null {
   const { req, sourceFile, precompressed, openPrecompressedFile } = params;
   const extension = path.extname(sourceFile.path).toLowerCase();
@@ -187,7 +187,7 @@ export function resolveOpenedControlUiRepresentation(params: {
     }
 
     const suffix = selected === "br" ? ".br" : ".gz";
-    let compressedFile: { path: string; fd: number } | null;
+    let compressedFile: { path: string; fd: number; size: number } | null;
     try {
       compressedFile = openPrecompressedFile(`${sourceFile.path}${suffix}`);
     } catch (error) {
@@ -236,10 +236,13 @@ function setControlUiFileHeaders(
 export function respondHeadForControlUiFile(
   res: ServerResponse,
   filePath: string,
-  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding },
+  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding; contentLength?: number },
 ) {
   res.statusCode = 200;
   setControlUiFileHeaders(res, filePath, options);
+  if (options?.contentLength !== undefined) {
+    res.setHeader("Content-Length", String(options.contentLength));
+  }
   res.end();
 }
 

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -2567,7 +2567,7 @@ describe("handleControlUiHttpRequest", () => {
               req: {
                 headers: { "accept-encoding": "br, identity;q=0" },
               } as IncomingMessage,
-              sourceFile: { path: filePath, fd },
+              sourceFile: { path: filePath, fd, size: fsSync.fstatSync(fd).size },
               precompressed: true,
               openPrecompressedFile: () => {
                 throw openError;
@@ -2749,6 +2749,38 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it.each(["identity", "gzip", "br"] as const)(
+    "preserves the selected %s static-asset Content-Length for HEAD",
+    async (encoding) => {
+      await withControlUiRoot({
+        fn: async (tmp) => {
+          const source = "console.log('static asset metadata');\n".repeat(12);
+          const { filePath } = await writeAssetFile(tmp, "app-HeAd1234.js", source);
+          await fs.writeFile(`${filePath}.gz`, gzipSync(source));
+          await fs.writeFile(`${filePath}.br`, brotliCompressSync(source));
+          const request = {
+            url: "/assets/app-HeAd1234.js",
+            rootPath: tmp,
+            rootKind: "bundled" as const,
+            headers: { "accept-encoding": encoding },
+          };
+          const get = await runControlUiRequest({ ...request, method: "GET" });
+          const head = await runControlUiRequest({ ...request, method: "HEAD" });
+          const body = get.end.mock.calls[0]?.[0];
+
+          expect(Buffer.isBuffer(body)).toBe(true);
+          expect(head.setHeader).toHaveBeenCalledWith("Content-Length", String(body.byteLength));
+          expect(firstEndCallLength(head.end)).toBe(0);
+          if (encoding === "identity") {
+            expect(head.setHeader).not.toHaveBeenCalledWith("Content-Encoding", expect.anything());
+          } else {
+            expect(head.setHeader).toHaveBeenCalledWith("Content-Encoding", encoding);
+          }
+        },
+      });
+    },
+  );
 
   it.each([
     {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -885,7 +885,7 @@ function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
   rejectHardlinks: boolean,
-): { path: string; fd: number } | null {
+): { path: string; fd: number; size: number } | null {
   const opened = openRootFileSync({
     absolutePath: filePath,
     rootPath: rootReal,
@@ -902,7 +902,7 @@ function resolveSafeControlUiFile(
       fallback: () => null,
     });
   }
-  return { path: opened.path, fd: opened.fd };
+  return { path: opened.path, fd: opened.fd, size: opened.stat.size };
 }
 
 function isSafeRelativePath(relPath: string) {
@@ -1214,6 +1214,7 @@ export async function handleControlUiHttpRequest(
         respondHeadForControlUiFile(res, representation.contentPath, {
           immutable: immutableAsset,
           encoding: representation.encoding,
+          contentLength: representation.bodyFile.size,
         });
         return true;
       } finally {


### PR DESCRIPTION
## What Problem This Solves

Control UI static assets returned correct representation bytes for `GET`, but their `HEAD` responses omitted `Content-Length`. This affected the uncompressed asset and both precompressed Brotli/gzip sidecars, so clients probing the selected representation could not discover its actual size.

## Why This Change Was Made

The existing safe-open owner already captures the authoritative pinned descriptor stat. Preserve that size through canonical representation selection and let the existing static-response owner emit the exact selected descriptor size for `HEAD`. Dynamic HTML remains deliberately untouched: its response is rewritten or compressed, and `HEAD` must not start reading or generating a body merely to manufacture a length.

## User Impact

- Static `HEAD` responses now report the same representation length as the equivalent `GET` for identity, gzip, and Brotli.
- `Content-Encoding`, cache headers, and empty `HEAD` bodies stay correct.
- Dynamic index `HEAD` retains its existing no-body/no-content-generation fast path.
- No authentication, security, public protocol, configuration, SDK, or persistent-state behavior changes.

## Evidence

### Exact root cause and dependency contracts

`src/gateway/control-ui.ts` discarded `opened.stat.size` even though installed `@openclaw/fs-safe` obtains that stat directly from the opened descriptor (`node_modules/@openclaw/fs-safe/dist/root-file.js:48` and `node_modules/@openclaw/fs-safe/dist/pinned-open.js:37`). Node's HTTP implementation suppresses `HEAD` bodies and cannot infer the representation length; the installed `send` implementation explicitly sets `Content-Length` before ending a `HEAD` response (`node_modules/send/index.js:582`).

### Real production route and TCP, before/after

On exact base `e4568f6bdddfc38d0f8dfe8cd22bde155adac5dd`, actual loopback TCP requests through `handleControlUiHttpRequest` observed:

```json
{"encoding":"identity","getLength":"19","headLength":null,"getEncoding":null,"headEncoding":null}
{"encoding":"gzip","getLength":"39","headLength":null,"getEncoding":"gzip","headEncoding":"gzip"}
{"encoding":"br","getLength":"23","headLength":null,"getEncoding":"br","headEncoding":"br"}
```

Exact immutable candidate `e58b1861129d1fe7fe03aa97d8188ae46986bc8d`:

```json
{"encoding":"identity","getLength":"19","headLength":"19","getEncoding":null,"headEncoding":null}
{"encoding":"gzip","getLength":"39","headLength":"39","getEncoding":"gzip","headEncoding":"gzip"}
{"encoding":"br","getLength":"23","headLength":"23","getEncoding":"br","headEncoding":"br"}
{"route":"dynamic-index","headLength":null,"empty":true}
```

- Regression-first run failed on all nine identity/gzip/Brotli cases across the three gateway Vitest projects before the fix.
- Exact candidate owner suite: `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts --project gateway-core` — **119 passed, 0 failed**.
- Exact candidate type-aware focused `node scripts/run-oxlint.mjs ... --tsconfig config/tsconfig/oxlint.core.json`, targeted `oxfmt --check`, and `git diff --check`: all passed.
- Production delta **+11/-7, net +4**, necessary to carry the already-owned descriptor size and emit the genuinely missing response metadata; no fallback, compatibility shim, extra filesystem stat, or dynamic-body generation.
- Fresh genuine whole-branch `autoreview --mode branch --base e4568f6bdddfc38d0f8dfe8cd22bde155adac5dd --max-priority P3`: **zero P0/P1/P2/P3 findings**, verdict **“patch is correct”**, confidence **0.97**.
- A separate strict immutable-candidate reviewer independently reproduced baseline/candidate real TCP behavior for all three encodings, configured roots, dynamic rewritten index and SPA routes, 404/406, hidden sidecars, outside symlinks, and configured hardlinks: **zero P0/P1/P2/P3 findings**, confidence **0.99**.
