### PR TITLE
fix(openai): preserve truthful ChatGPT terminal outcomes

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses-terminal-truth.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-terminal-truth.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Context, Model } from "../types.js";
+import {
+  closeOpenAICodexWebSocketSessions,
+  resetOpenAICodexWebSocketStateForTest,
+  streamOpenAICodexResponses,
+} from "./openai-chatgpt-responses.js";
+
+const model = {
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  api: "openai-chatgpt-responses",
+  provider: "openai",
+  baseUrl: "https://chatgpt.test/backend-api",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 16_000,
+} satisfies Model<"openai-chatgpt-responses">;
+
+const context = {
+  messages: [{ role: "user", content: "Explain the answer", timestamp: 1 }],
+} satisfies Context;
+
+function createAccessToken(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-terminal" } }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+type ProviderTerminal = {
+  type: "response.completed" | "response.done" | "response.incomplete";
+  response: {
+    id: string;
+    status?: "completed" | "incomplete";
+    incomplete_details?: { reason: "content_filter" | "max_output_tokens" };
+    output: Array<Record<string, unknown>>;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+      input_tokens_details?: { cached_tokens: number; cache_write_tokens: number };
+    };
+  };
+};
+
+async function runTerminal(terminal: ProviderTerminal, transport: "sse" | "websocket" | "auto") {
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(`data: ${JSON.stringify(terminal)}\n\n`, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  if (transport !== "sse") {
+    class TerminalWebSocket extends EventTarget {
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(): void {
+        queueMicrotask(() => {
+          this.dispatchEvent(
+            Object.assign(new Event("message"), { data: JSON.stringify(terminal) }),
+          );
+        });
+      }
+
+      close(): void {}
+    }
+    vi.stubGlobal("WebSocket", TerminalWebSocket);
+  }
+
+  const stream = streamOpenAICodexResponses(model, context, {
+    apiKey: createAccessToken(),
+    transport,
+    maxRetries: 0,
+  });
+  const events = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return { events, result: await stream.result(), fetchMock };
+}
+
+function incompleteTerminal(params: {
+  transport: "sse" | "websocket" | "auto";
+  reason: "content_filter" | "max_output_tokens";
+  status?: "incomplete";
+}): ProviderTerminal {
+  return {
+    type: "response.incomplete",
+    response: {
+      id: `resp-${params.transport}-${params.reason}-${params.status ?? "omitted"}`,
+      ...(params.status ? { status: params.status } : {}),
+      incomplete_details: { reason: params.reason },
+      output: [
+        {
+          type: "message",
+          id: "msg_partial",
+          role: "assistant",
+          content: [{ type: "output_text", text: "PROVIDER_PARTIAL" }],
+        },
+        ...(params.reason === "max_output_tokens"
+          ? [
+              {
+                type: "function_call",
+                id: "fc_truncated",
+                call_id: "call_truncated",
+                name: "write",
+                arguments: '{"path":"unfinished',
+              },
+            ]
+          : []),
+      ],
+      usage: {
+        input_tokens: 21,
+        output_tokens: 4,
+        total_tokens: 25,
+        input_tokens_details: { cached_tokens: 6, cache_write_tokens: 2 },
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  closeOpenAICodexWebSocketSessions();
+  resetOpenAICodexWebSocketStateForTest();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("OpenAI ChatGPT Responses truthful terminal ownership", () => {
+  it.each([
+    { transport: "sse", status: undefined },
+    { transport: "sse", status: "incomplete" },
+    { transport: "websocket", status: undefined },
+    { transport: "websocket", status: "incomplete" },
+  ] as const)(
+    "rejects filtered $transport terminals with $status status without leaking blocked text",
+    async ({ transport, status }) => {
+      const terminal = incompleteTerminal({ transport, reason: "content_filter", status });
+      const { events, result, fetchMock } = await runTerminal(terminal, transport);
+
+      expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+      expect(result).toMatchObject({
+        stopReason: "error",
+        responseId: terminal.response.id,
+        errorMessage: "Provider incomplete_reason: content_filter",
+        content: [],
+        usage: { input: 13, output: 4, cacheRead: 6, cacheWrite: 2, totalTokens: 25 },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(transport === "sse" ? 1 : 0);
+    },
+  );
+
+  it.each([
+    { transport: "sse", status: undefined },
+    { transport: "sse", status: "incomplete" },
+    { transport: "websocket", status: undefined },
+    { transport: "websocket", status: "incomplete" },
+  ] as const)(
+    "preserves truncated $transport text without exposing an unfinished tool ($status status)",
+    async ({ transport, status }) => {
+      const terminal = incompleteTerminal({ transport, reason: "max_output_tokens", status });
+      const { events, result, fetchMock } = await runTerminal(terminal, transport);
+
+      expect(events.at(-1)).toMatchObject({ type: "done", reason: "length" });
+      expect(result).toMatchObject({
+        stopReason: "length",
+        responseId: terminal.response.id,
+        content: [{ type: "text", text: "PROVIDER_PARTIAL" }],
+        usage: { input: 13, output: 4, cacheRead: 6, cacheWrite: 2, totalTokens: 25 },
+      });
+      expect(result.content.some((block) => block.type === "toolCall")).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(transport === "sse" ? 1 : 0);
+    },
+  );
+
+  it("does not retry a filtered provider WebSocket turn over SSE in automatic mode", async () => {
+    const terminal = incompleteTerminal({ transport: "auto", reason: "content_filter" });
+    const { events, result, fetchMock } = await runTerminal(terminal, "auto");
+
+    expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Provider incomplete_reason: content_filter",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["response.completed", "response.done"] as const)(
+    "preserves valid $0 completed aliases and successful usage",
+    async (type) => {
+      const { events, result } = await runTerminal(
+        {
+          type,
+          response: {
+            id: `resp-valid-${type}`,
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_valid",
+                role: "assistant",
+                content: [{ type: "output_text", text: "VALID" }],
+              },
+            ],
+            usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+          },
+        },
+        "sse",
+      );
+
+      expect(events.at(-1)).toMatchObject({ type: "done", reason: "stop" });
+      expect(result).toMatchObject({
+        stopReason: "stop",
+        content: [{ type: "text", text: "VALID" }],
+      });
+    },
+  );
+});

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -37,7 +37,10 @@ import { parseRetryAfterHttpDateMs } from "../internal/retry-after.js";
 import { sleepWithAbort } from "../internal/retry-sleep.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import {
+  finalizeTransportStream,
+  transportAbortError,
+} from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -341,6 +344,9 @@ export const streamOpenAICodexResponses: StreamFunction<
             if (activeSignal?.aborted) {
               throw transportAbortError(activeSignal);
             }
+            if (output.stopReason === "aborted" || output.stopReason === "error") {
+              throw new CodexApiError(output.errorMessage ?? "An unknown error occurred");
+            }
             stream.push({
               type: "done",
               reason: output.stopReason as "stop" | "length" | "toolUse",
@@ -478,17 +484,7 @@ export const streamOpenAICodexResponses: StreamFunction<
 
       stream.push({ type: "start", partial: output });
       await processStream(response, output, stream, model, options, firstEventAbort.abort);
-
-      if (activeSignal?.aborted) {
-        throw transportAbortError(activeSignal);
-      }
-
-      stream.push({
-        type: "done",
-        reason: output.stopReason as "stop" | "length" | "toolUse",
-        message: output,
-      });
-      stream.end();
+      finalizeTransportStream({ stream, output, signal: activeSignal });
     } catch (error) {
       const normalizedError =
         isRequestTimeoutError(error, options?.signal, requestTimeoutSignal, requestTimeoutMs) &&
@@ -777,7 +773,7 @@ async function* mapCodexEvents(
         : response;
       yield {
         ...event,
-        type: "response.completed",
+        type: type === "response.done" ? "response.completed" : type,
         response: normalizedResponse,
       } as ResponseStreamEvent;
       return;


### PR DESCRIPTION
## What Problem This Solves

The ChatGPT Responses provider rewrote SDK `response.incomplete` events into `response.completed` before the canonical terminal owner saw them. It also duplicated final success/error handling. Consequently, both SSE and WebSocket exposed safety-filtered partial text as a successful answer; token-truncated turns with unfinished tool JSON failed instead of retaining their safe partial text.

## Why This Change Was Made

Preserve the authoritative provider terminal event and use the existing shared `finalizeTransportStream` owner for SSE completion, abort, and provider errors. Keep WebSocket failures typed as `CodexApiError` so automatic transport does not replay a policy rejection over SSE. Existing canonical Responses terminal ownership then suppresses filtered text, retains safe token-truncated output, avoids unfinished tool execution, and keeps usage authoritative.

Production: **9 added / 13 removed, net -4 lines**.

## User Impact

- Filtered responses consistently produce an actionable provider error without revealing blocked text.
- Token-limited responses retain safe partial text and correct usage with a `length` stop; unfinished tool calls are never executed.
- SSE, WebSocket, and automatic transport agree; valid `response.completed` and `response.done` turns remain unchanged.
- No public SDK, model default, authentication, provider configuration, protocol, persistence, security-boundary, or snapshot changes.

## Evidence

- Frozen baseline: `36b80ada3ceae2de21b3d8710b883d778e4c4578`; exact immutable candidate: `fd456e7d49208c35cc4adf869e8cf159b75a9e91`.
- Authentic frozen baseline: **9 failing user-path regressions and 2 passing completed-event controls**.
- Exact candidate: **7 focused provider and canonical-terminal suites, 98/98 tests passed**.
- Actual production SSE + WebSocket proof: **4/4** safety-filter and token-truncation outcomes passed.
- Combined with independently accepted SSE framing fix `cf8a7298dea0b0d1dfd2caf01f7e662a1a50c65d`: **8 suites, 108/108 tests passed** with both changes simultaneously applied.
- Exact whole-branch Codex/Sol/high autoreview `--max-priority P3`: **zero P0/P1/P2/P3 findings**, confidence **0.96**; two independent exact-head strict blind reviews also found **CLEAN**, confidence **0.98** each.
- Direct pinned SDK contract: `node_modules/openai/src/resources/responses/responses.ts:1295` and `:3774` distinguish `content_filter`, `max_output_tokens`, and `response.incomplete`.
- Personally inspected sibling Codex failure ownership: `../codex/codex-rs/codex-api/src/sse/responses.rs:423` and `../codex/codex-rs/core/src/session/turn.rs:2252`.
- `oxfmt --check`, `git diff --check`, exact sole frozen parent, clean worktree, and accepted sibling merge trees all pass.
