### PR TITLE
fix(openai): bound streamed Chat tool arguments correctly

### DIFF
--- a/packages/ai/src/providers/openai-completions-tool-calls.ts
+++ b/packages/ai/src/providers/openai-completions-tool-calls.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
+import { measureUtf8AppendBytes } from "../transports/openai-transport-shared.js";
 
 type ChatCompletionToolCallDelta = ChatCompletionChunk.Choice.Delta.ToolCall;
-const MAX_BUFFERED_LEGACY_TOOL_CALL_ARGUMENT_BYTES = 256_000;
+const MAX_BUFFERED_TOOL_CALL_ARGUMENT_BYTES = 256_000;
 const MAX_BUFFERED_LEGACY_FOLLOWING_DELTA_BYTES = 256_000;
 const MAX_BUFFERED_LEGACY_FOLLOWING_DELTAS = 1_024;
 
@@ -26,6 +27,8 @@ export function createOpenAICompletionsToolCallDeltaNormalizer(): (
   let pendingLegacyArgumentBytes = 0;
   let pendingFollowingDeltaBytes = 0;
   let pendingLegacyToolCall: ChatCompletionToolCallDelta | undefined;
+  type ModernArgumentState = { bytes: number; pendingHighSurrogate: boolean };
+  const modernArguments = new Map<number | string, ModernArgumentState>();
   const pendingFollowingDeltas: ChatCompletionChunk.Choice.Delta[] = [];
 
   const takePendingFollowingDeltas = (): NormalizedOpenAICompletionsDelta[] => {
@@ -79,6 +82,29 @@ export function createOpenAICompletionsToolCallDeltaNormalizer(): (
   return (delta, finishReason) => {
     const ordinaryDelta = withoutToolCalls(delta);
     if (delta.tool_calls && delta.tool_calls.length > 0) {
+      for (const toolCall of delta.tool_calls) {
+        const index = typeof toolCall.index === "number" ? toolCall.index : undefined;
+        // Both consumers resolve index first, then id; bind every supplied alias
+        // to one byte state so compatible id-only continuations cannot reset the cap.
+        const state = (index === undefined ? undefined : modernArguments.get(index)) ??
+          (toolCall.id ? modernArguments.get(toolCall.id) : undefined) ?? {
+            bytes: 0,
+            pendingHighSurrogate: false,
+          };
+        if (index !== undefined) {
+          modernArguments.set(index, state);
+        }
+        if (toolCall.id) {
+          modernArguments.set(toolCall.id, state);
+        }
+        const argumentDelta = toolCall.function?.arguments ?? "";
+        const append = measureUtf8AppendBytes(state.pendingHighSurrogate, argumentDelta);
+        state.bytes += append.bytes;
+        if (state.bytes > MAX_BUFFERED_TOOL_CALL_ARGUMENT_BYTES) {
+          throw new Error("Exceeded tool-call argument buffer limit");
+        }
+        state.pendingHighSurrogate = append.endsWithHighSurrogate;
+      }
       const precedingDeltas = takePendingFollowingDeltas();
       sawModernToolCall = true;
       pendingLegacyArgumentBytes = 0;
@@ -113,10 +139,7 @@ export function createOpenAICompletionsToolCallDeltaNormalizer(): (
       const nextArgumentBytes =
         Buffer.byteLength(functionCall.arguments ?? "", "utf8") +
         Buffer.byteLength(nextFunctionName ?? "", "utf8");
-      if (
-        pendingLegacyArgumentBytes + nextArgumentBytes >
-        MAX_BUFFERED_LEGACY_TOOL_CALL_ARGUMENT_BYTES
-      ) {
+      if (pendingLegacyArgumentBytes + nextArgumentBytes > MAX_BUFFERED_TOOL_CALL_ARGUMENT_BYTES) {
         throw new Error("Exceeded tool-call argument buffer limit");
       }
       pendingLegacyArgumentBytes += nextArgumentBytes;

--- a/packages/ai/src/providers/openai-completions.legacy-function-call.test.ts
+++ b/packages/ai/src/providers/openai-completions.legacy-function-call.test.ts
@@ -32,6 +32,7 @@ const context = {
     },
   ],
 } satisfies Context;
+const TOOL_ARGUMENT_BYTE_LIMIT = 256_000;
 
 function chunk(
   delta: ChatCompletionChunk.Choice.Delta,
@@ -67,6 +68,46 @@ function toolCallDelta({
       arguments: rawArguments,
     },
   };
+}
+
+function idOnlyToolCallDelta(params: {
+  id: string;
+  name?: string;
+  arguments: string;
+}): ChatCompletionChunk.Choice.Delta.ToolCall {
+  return {
+    id: params.id,
+    type: "function",
+    function: {
+      ...(params.name !== undefined ? { name: params.name } : {}),
+      arguments: params.arguments,
+    },
+  } as ChatCompletionChunk.Choice.Delta.ToolCall;
+}
+
+function argumentsWithByteLength(bytes: number, fill = "a"): string {
+  const prefix = '{"query":"';
+  const suffix = '"}';
+  const availableBytes = bytes - Buffer.byteLength(prefix + suffix, "utf8");
+  const characterBytes = Buffer.byteLength(fill, "utf8");
+  const value =
+    prefix +
+    fill.repeat(Math.floor(availableBytes / characterBytes)) +
+    "a".repeat(availableBytes % characterBytes) +
+    suffix;
+  expect(Buffer.byteLength(value, "utf8")).toBe(bytes);
+  return value;
+}
+
+function splitSurrogateArguments(bytes: number): [string, string] {
+  const prefix = '{"query":"';
+  const suffix = '"}';
+  const emoji = "😀";
+  const padding = bytes - Buffer.byteLength(prefix + suffix + emoji, "utf8");
+  const value = `${prefix}${"a".repeat(padding)}${emoji}${suffix}`;
+  expect(Buffer.byteLength(value, "utf8")).toBe(bytes);
+  const surrogateBoundary = value.indexOf(emoji) + 1;
+  return [value.slice(0, surrogateBoundary), value.slice(surrogateBoundary)];
 }
 
 const modernCallChunk = (
@@ -474,6 +515,117 @@ describe.each([
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
     expect(eventTypes).not.toContain("toolcall_start");
+  });
+
+  it("bounds an indexed modern call through an id-only continuation", async () => {
+    const value = argumentsWithByteLength(TOOL_ARGUMENT_BYTE_LIMIT + 1);
+    const { eventTypes, result } = await collectFixture([
+      chunk({
+        tool_calls: [
+          toolCallDelta({
+            index: 0,
+            id: "call_alias",
+            name: "lookup",
+            arguments: value.slice(0, 128_000),
+          }),
+        ],
+      }),
+      chunk({
+        tool_calls: [idOnlyToolCallDelta({ id: "call_alias", arguments: value.slice(128_000) })],
+      }),
+      chunk({}, "tool_calls"),
+    ]);
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
+    expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
+    expect(eventTypes).not.toContain("toolcall_end");
+  });
+
+  it("keeps independent id-only modern calls independently bounded", async () => {
+    const { result } = await collectFixture([
+      chunk({
+        tool_calls: [
+          idOnlyToolCallDelta({
+            id: "call_id_a",
+            name: "lookup",
+            arguments: argumentsWithByteLength(200_000),
+          }),
+          idOnlyToolCallDelta({
+            id: "call_id_b",
+            name: "lookup",
+            arguments: argumentsWithByteLength(200_000),
+          }),
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ]);
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(
+      result.content
+        .filter((block) => block.type === "toolCall")
+        .map((block) => [block.id, Buffer.byteLength(JSON.stringify(block.arguments), "utf8")]),
+    ).toEqual([
+      ["call_id_a", 200_000],
+      ["call_id_b", 200_000],
+    ]);
+  });
+
+  it.each([
+    {
+      name: "accepts an exact-limit surrogate pair split between deltas",
+      bytes: TOOL_ARGUMENT_BYTE_LIMIT,
+      stopReason: "toolUse",
+    },
+    {
+      name: "rejects an oversized surrogate pair split between deltas",
+      bytes: TOOL_ARGUMENT_BYTE_LIMIT + 1,
+      stopReason: "error",
+    },
+  ] as const)("$name", async ({ bytes, stopReason }) => {
+    const [first, second] = splitSurrogateArguments(bytes);
+    const { eventTypes, result } = await collectFixture([
+      chunk({
+        tool_calls: [
+          toolCallDelta({
+            index: 0,
+            id: "call_surrogate",
+            name: "lookup",
+            arguments: first,
+          }),
+        ],
+      }),
+      chunk({ tool_calls: [toolCallDelta({ index: 0, arguments: second })] }),
+      chunk({}, "tool_calls"),
+    ]);
+
+    expect(result.stopReason).toBe(stopReason);
+    if (stopReason === "error") {
+      expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
+      expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
+      expect(eventTypes).not.toContain("toolcall_end");
+      return;
+    }
+    expect(result.content[0]).toMatchObject({ id: "call_surrogate", type: "toolCall" });
+    expect(
+      result.content[0]?.type === "toolCall"
+        ? Buffer.byteLength(JSON.stringify(result.content[0].arguments), "utf8")
+        : undefined,
+    ).toBe(bytes);
+  });
+
+  it("measures multibyte modern arguments by UTF-8 bytes", async () => {
+    const { eventTypes, result } = await collectFixture(
+      confirmedModernCallChunks(argumentsWithByteLength(TOOL_ARGUMENT_BYTE_LIMIT + 1, "é"), {
+        id: "call_multibyte",
+      }),
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
+    expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
+    expect(eventTypes).not.toContain("toolcall_end");
   });
 
   it("coalesces tiny provisional legacy fragments into one bounded executable delta", async () => {

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -75,6 +75,7 @@ import {
   createModelStreamCooperativeScheduler,
   isOpenAICompletionsThinkingEnabled,
   log,
+  measureUtf8AppendBytes,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
   resolvePromptCacheKey,
@@ -393,7 +394,6 @@ async function processOpenAICompletionsStream(
   },
 ) {
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
-  const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256_000;
   const emitReasoning = options?.emitReasoning ?? true;
   const compat = getCompat(model as OpenAIModeModel);
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
@@ -422,7 +422,6 @@ async function processOpenAICompletionsStream(
   const toolCallBlocksByIndex = new Map<number, ToolCallBlock>();
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const provisionalCommentaryTags: PendingCommentaryTags = new Map();
-  const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
   const normalizeToolCallDeltas = createOpenAICompletionsToolCallDeltaNormalizer();
   let sawStopFinishReason = false;
@@ -805,12 +804,6 @@ async function processOpenAICompletionsStream(
             block.thoughtSignature = deltaSig;
           }
           if (toolCall.function?.arguments) {
-            const nextArgumentBytes = measureUtf8Bytes(toolCall.function.arguments);
-            const currentBlockArgBytes = toolCallBlockBytes.get(block) ?? 0;
-            if (currentBlockArgBytes + nextArgumentBytes > MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES) {
-              throw new Error("Exceeded tool-call argument buffer limit");
-            }
-            toolCallBlockBytes.set(block, currentBlockArgBytes + nextArgumentBytes);
             block.partialArgs += toolCall.function.arguments;
             block.arguments = parseStreamingJson(block.partialArgs);
             pushStreamEvent({
@@ -897,7 +890,7 @@ const DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN = Math.max(
   ...DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS.map((token) => token.length),
 );
 
-// Match MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES / MAX_POST_TOOL_CALL_BUFFER_BYTES.
+// Match the shared Chat tool-argument and post-tool-call buffer limits.
 const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
 const DEEPSEEK_DSML_SCAN_BATCH_CHARS = 64 * 1_024;
 
@@ -1013,7 +1006,7 @@ function createDeepSeekDsmlToolCallRecoverer() {
 
   return {
     push(chunk: string) {
-      const append = utf8ByteLengthForAppend(bufferEndsWithHighSurrogate, chunk);
+      const append = measureUtf8AppendBytes(bufferEndsWithHighSurrogate, chunk);
       bufferBytes += append.bytes;
       bufferEndsWithHighSurrogate = append.endsWithHighSurrogate;
       buffer += chunk;
@@ -1227,23 +1220,6 @@ function scanDeepSeekDsmlToolBlock(
     return next;
   }
   return { kind: "incomplete" };
-}
-
-function utf8ByteLengthForAppend(bufferEndsWithHighSurrogate: boolean, chunk: string) {
-  let bytes = Buffer.byteLength(chunk, "utf8");
-  if (!chunk) {
-    return { bytes, endsWithHighSurrogate: bufferEndsWithHighSurrogate };
-  }
-  const nextCodeUnit = chunk.charCodeAt(0);
-  if (bufferEndsWithHighSurrogate && nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
-    // Each isolated surrogate counts as three UTF-8 bytes; the joined scalar is four.
-    bytes -= 2;
-  }
-  const finalCodeUnit = chunk.charCodeAt(chunk.length - 1);
-  return {
-    bytes,
-    endsWithHighSurrogate: finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff,
-  };
 }
 
 function longestDeepSeekDsmlToolOpenPrefixSuffixLength(text: string) {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -111,6 +111,24 @@ export function throwIfModelStreamAborted(signal?: AbortSignal): void {
   }
 }
 
+/** Measure one UTF-8 append without double-counting a surrogate pair split across chunks. */
+export function measureUtf8AppendBytes(bufferEndsWithHighSurrogate: boolean, chunk: string) {
+  let bytes = Buffer.byteLength(chunk, "utf8");
+  if (!chunk) {
+    return { bytes, endsWithHighSurrogate: bufferEndsWithHighSurrogate };
+  }
+  const nextCodeUnit = chunk.charCodeAt(0);
+  if (bufferEndsWithHighSurrogate && nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
+    // Each isolated surrogate counts as three UTF-8 bytes; the joined scalar is four.
+    bytes -= 2;
+  }
+  const finalCodeUnit = chunk.charCodeAt(chunk.length - 1);
+  return {
+    bytes,
+    endsWithHighSurrogate: finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff,
+  };
+}
+
 export function createModelStreamCooperativeScheduler(
   signal?: AbortSignal,
 ): ModelStreamCooperativeScheduler {


### PR DESCRIPTION
## What Problem This Solves

The package-owned OpenAI Chat Completions stream accepted arbitrarily large modern tool-call arguments while the managed sibling enforced a 256,000-byte limit. The managed path also overcounted a Unicode surrogate pair split across SSE deltas. A compatible provider could therefore bypass the bound or have an exact-limit call rejected depending on which producer handled the same stream.

## Why This Change Was Made

Modern per-call byte accounting now lives in the existing tool-call delta normalizer shared by package and managed producers, alongside the legacy bound. Identity follows the consumers' contract: numeric index first, then stable id, with every supplied alias bound to the same state. This preserves id-only compatible-provider streams while preventing indexed-to-id-only continuations from resetting the cap.

The shared normalizer reuses the incremental UTF-8 append measurement already proven by DeepSeek DSML recovery, including split-surrogate accounting. The managed producer's duplicate limit and byte map were deleted. Production delta is +49/-32; the positive 17-line delta establishes the shared ownership/security bound and correct alias state. No public/plugin API, config, authentication, protocol, persistence, dependency, retry, or compatibility surface changes.

## User Impact

Both package and managed Chat producers reject a tool call above 256,000 UTF-8 bytes before execution, accept exact-limit calls, keep independent index-only and id-only calls independently bounded, and handle split Unicode surrogate pairs consistently. Legacy calls and DeepSeek DSML recovery retain their behavior.

## Evidence

Pinned `openai@6.49.0` declares `Delta.ToolCall.index` and streamed string arguments in `src/resources/chat/completions/completions.ts:940-964`, but its raw SSE path JSON-parses and yields compatible-provider data without runtime schema validation. Both OpenClaw consumers intentionally support index-first/id-fallback identity, so id-only streams are an existing compatibility contract.

Fail-before regression:

```text
$ node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.legacy-function-call.test.ts
Test Files  1 failed (1)
Tests       4 failed | 78 passed (82)
package     indexed-to-id-only oversized continuation was accepted
package     oversized split-surrogate and multibyte arguments were accepted
managed     exact-limit split surrogate was rejected
```

Pass-after proof on rebased head `371e907edea0abd4cacbd300a13b26f5ddbcdaaa`:

```text
$ node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.legacy-function-call.test.ts src/agents/openai-transport-stream.deepseek-and-shaping.test.ts src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
Test Files  1 passed + 2 passed
Tests       82 passed + 97 passed = 179 passed
[test] passed 2 Vitest shards in 29.84s
```

The installed-SDK package/managed matrix covers indexed-to-id-only continuation rejection, two independent id-only calls, exact and one-byte-over split-surrogate boundaries, and multibyte UTF-8 overflow. Error cases prove no final tool-call block or `toolcall_end` survives failure.

```text
$ node scripts/check-changed.mjs
[check:changed] lanes=core, coreTests
core production/test typecheck PASS
oxfmt PASS; oxlint 0 warnings, 0 errors
dependency/boundary/dead-code guards PASS
runtime import cycles 0
Blacksmith Testbox tbx_01kzkjh3ebz2ykex12wjj52agg
Actions run 31321441034
exitCode 0

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```

ClawSweeper's rank-up moves were applied: byte state uses the same index/id identity as both consumers; regressions cover id-only continuation and independent id-only calls; and the branch is rebuilt on current main with the current pinned SDK. No finding is silently bypassed.

AI-assisted; owner/caller/sibling paths, upstream SDK source/runtime, before/after behavior, focused tests, changed gates, and independent review were verified.
