### PR TITLE
fix(openai): preserve managed Chat response hook lifecycle

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -19,11 +19,16 @@ import {
 } from "../transports/openai-completions-compat.js";
 import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
 import {
+  createOpenAIResponseHook,
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
 } from "../transports/openai-transport-shared.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import {
+  assignTransportErrorDetails,
+  transportAbortError,
+  withProviderResponseHook,
+} from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
   CacheRetention,
@@ -44,7 +49,6 @@ import {
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { formatProviderError } from "../utils/provider-error.js";
@@ -187,11 +191,13 @@ export const streamOpenAICompletions: StreamFunction<
           requestOptions,
         )
         .withResponse();
-      await options?.onResponse?.(
-        { status: response.status, headers: headersToRecord(response.headers) },
-        model,
-      );
-      stream.push({ type: "start", partial: output });
+      const hookedOpenAIStream = withProviderResponseHook({
+        stream: openaiStream,
+        signal: firstEventAbort.signal,
+        abort: firstEventAbort.abort,
+        hook: createOpenAIResponseHook(options?.onResponse, response, model),
+        onReady: () => stream.push({ type: "start", partial: output }),
+      });
 
       interface StreamingToolCallBlock extends ToolCall {
         partialArgs?: string;
@@ -380,7 +386,7 @@ export const streamOpenAICompletions: StreamFunction<
         }
       };
 
-      const guardedOpenaiStream = withFirstStreamEventTimeout(openaiStream, {
+      const guardedOpenaiStream = withFirstStreamEventTimeout(hookedOpenAIStream, {
         provider: model.provider,
         api: model.api,
         model: model.id,
@@ -605,7 +611,12 @@ export const streamOpenAICompletions: StreamFunction<
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
     } catch (error) {
-      output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      const errorReason = options?.signal?.aborted ? "aborted" : "error";
+      if (options?.signal?.aborted) {
+        assignTransportErrorDetails(output, error, options.signal);
+      } else {
+        output.stopReason = errorReason;
+      }
       finalizeOpenAICompletionsToolCalls(output, { allowSilentToolCallPromotion: false });
       for (const block of output.content) {
         delete (block as { index?: number }).index;
@@ -620,7 +631,7 @@ export const streamOpenAICompletions: StreamFunction<
       if (rawMetadata && !output.errorMessage.includes(rawMetadata)) {
         output.errorMessage += `\n${rawMetadata}`;
       }
-      stream.push({ type: "error", reason: output.stopReason, error: output });
+      stream.push({ type: "error", reason: errorReason, error: output });
       stream.end();
     } finally {
       firstEventAbort?.dispose();

--- a/packages/ai/src/transports/openai-completions-transport.response-hook.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.response-hook.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import { streamOpenAICompletions } from "../providers/openai-completions.js";
+import type { AssistantMessageEventStreamLike, Context, Model, StreamOptions } from "../types.js";
+import { createOpenAICompletionsTransportStreamFn } from "./openai-completions-transport.js";
+
+const model = {
+  id: "gpt-5.5",
+  name: "Response hook lifecycle",
+  api: "openai-completions",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+} satisfies Model<"openai-completions">;
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 1 }],
+} satisfies Context;
+
+type RequestLifecycle = {
+  requestAborted: ReturnType<typeof vi.fn>;
+  assertListenersRemoved(): void;
+};
+
+function installResponse(): RequestLifecycle {
+  let addAbortListener: MockInstance<AbortSignal["addEventListener"]> | undefined;
+  let removeAbortListener: MockInstance<AbortSignal["removeEventListener"]> | undefined;
+  const requestAborted = vi.fn();
+  const chunk = {
+    id: "chatcmpl-response-hook",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: model.id,
+    choices: [{ index: 0, delta: { content: "hello" }, finish_reason: "stop" }],
+  };
+  const body = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`;
+  configureAiTransportHost({
+    buildModelFetch: () => async (_input, init) => {
+      const signal = init?.signal;
+      if (signal) {
+        signal.addEventListener("abort", requestAborted, { once: true });
+        addAbortListener = vi.spyOn(signal, "addEventListener");
+        removeAbortListener = vi.spyOn(signal, "removeEventListener");
+      }
+      return new Response(body, {
+        status: 202,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-ratelimit-remaining-requests": "42",
+          "x-request-id": "req_observable",
+        },
+      });
+    },
+  });
+  return {
+    requestAborted,
+    assertListenersRemoved() {
+      for (const [event, listener] of addAbortListener?.mock.calls ?? []) {
+        if (event === "abort") {
+          expect(removeAbortListener).toHaveBeenCalledWith("abort", listener);
+        }
+      }
+    },
+  };
+}
+
+const createManagedStream = createOpenAICompletionsTransportStreamFn();
+
+function createManagedFixtureStream(
+  fixtureModel: Model<"openai-completions">,
+  fixtureContext: Context,
+  fixtureOptions?: StreamOptions,
+): AssistantMessageEventStreamLike {
+  const stream = createManagedStream(fixtureModel, fixtureContext, fixtureOptions);
+  if (stream instanceof Promise) {
+    throw new Error("OpenAI Chat transport must return its event stream synchronously");
+  }
+  return stream;
+}
+
+async function settleWithin<T>(promise: Promise<T>, timeoutMs = 250): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error("response hook lifecycle timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+let previousHost: ReturnType<typeof getAiTransportHost>;
+
+beforeEach(() => {
+  previousHost = getAiTransportHost();
+});
+
+afterEach(() => {
+  configureAiTransportHost(previousHost);
+});
+
+describe.each([
+  { name: "package", createStream: streamOpenAICompletions },
+  { name: "managed", createStream: createManagedFixtureStream },
+])("$name OpenAI Chat response hook", ({ createStream }) => {
+  it("awaits response metadata before exposing the first stream event", async () => {
+    installResponse();
+    const order: string[] = [];
+    let continueHook!: () => void;
+    const hookCompleted = new Promise<void>((resolve) => {
+      continueHook = resolve;
+    });
+    const onResponse = vi.fn<NonNullable<StreamOptions["onResponse"]>>(async () => {
+      order.push("hook:start");
+      await hookCompleted;
+      order.push("hook:end");
+    });
+    const stream = createStream(model, context, { apiKey: "fixture-token", onResponse });
+    const consume = (async () => {
+      for await (const event of stream) {
+        order.push(event.type);
+      }
+    })();
+
+    await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
+    expect(order).toEqual(["hook:start"]);
+    expect(onResponse).toHaveBeenCalledWith(
+      {
+        status: 202,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-ratelimit-remaining-requests": "42",
+          "x-request-id": "req_observable",
+        },
+      },
+      model,
+    );
+
+    continueHook();
+    await consume;
+    expect((await stream.result()).stopReason).toBe("stop");
+    expect(order.slice(0, 3)).toEqual(["hook:start", "hook:end", "start"]);
+  });
+
+  it.each(["throw", "reject"] as const)(
+    "preserves a hook %s and closes the unread request",
+    async (failure) => {
+      const lifecycle = installResponse();
+      const hookError = new Error("after_provider_response hook failed");
+      const onResponse = vi.fn<NonNullable<StreamOptions["onResponse"]>>(() => {
+        if (failure === "throw") {
+          throw hookError;
+        }
+        return Promise.reject(hookError);
+      });
+      const stream = createStream(model, context, { apiKey: "fixture-token", onResponse });
+      const eventTypes: string[] = [];
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+      const result = await stream.result();
+
+      expect(onResponse).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorMessage: "after_provider_response hook failed",
+      });
+      expect(eventTypes).toEqual(["error"]);
+      expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+      lifecycle.assertListenersRemoved();
+    },
+  );
+
+  it("applies the first-event timeout while the hook is pending", async () => {
+    const lifecycle = installResponse();
+    const onFirstEventTimeout = vi.fn();
+    const onResponse = vi.fn(() => new Promise<void>(() => {}));
+    const stream = createStream(model, context, {
+      apiKey: "fixture-token",
+      firstEventTimeoutMs: 20,
+      onFirstEventTimeout,
+      onResponse,
+    });
+    const eventTypes: string[] = [];
+    const consume = (async () => {
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+    })();
+    const result = await settleWithin(stream.result());
+    await consume;
+
+    expect(onResponse).toHaveBeenCalledOnce();
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(
+      /completions HTTP stream opened but did not deliver a first SSE event within 20ms/,
+    );
+    expect(onFirstEventTimeout).toHaveBeenCalledWith(expect.any(Error));
+    expect(eventTypes).toEqual(["error"]);
+    expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+    lifecycle.assertListenersRemoved();
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "keeps caller cancellation terminal after a late hook %s",
+    async (settlement) => {
+      const lifecycle = installResponse();
+      const controller = new AbortController();
+      let settleHook!: () => void;
+      const pendingHook = new Promise<void>((resolve, reject) => {
+        settleHook = () => {
+          if (settlement === "resolve") {
+            resolve();
+          } else {
+            reject(new Error("late response hook rejection"));
+          }
+        };
+      });
+      const onResponse = vi.fn(() => pendingHook);
+      const stream = createStream(model, context, {
+        apiKey: "fixture-token",
+        signal: controller.signal,
+        onResponse,
+      });
+      const eventTypes: string[] = [];
+      const consume = (async () => {
+        for await (const event of stream) {
+          eventTypes.push(event.type);
+        }
+      })();
+
+      await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
+      const abortReason = Object.assign(new Error("caller canceled the provider response"), {
+        code: "CALLER_ABORTED",
+      });
+      controller.abort(abortReason);
+      const result = await settleWithin(stream.result());
+      await consume;
+      expect(result).toMatchObject({
+        stopReason: "aborted",
+        errorCode: "CALLER_ABORTED",
+        errorMessage: "caller canceled the provider response",
+      });
+      expect(eventTypes).toEqual(["error"]);
+      expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+
+      settleHook();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(eventTypes).toEqual(["error"]);
+      lifecycle.assertListenersRemoved();
+    },
+  );
+});

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -73,6 +73,7 @@ import {
 import {
   GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP,
   createModelStreamCooperativeScheduler,
+  createOpenAIResponseHook,
   isOpenAICompletionsThinkingEnabled,
   log,
   parseOpenAICompletionsUsage,
@@ -84,7 +85,11 @@ import {
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
-import { failTransportStream, finalizeTransportStream } from "./transport-stream-shared.js";
+import {
+  failTransportStream,
+  finalizeTransportStream,
+  withProviderResponseHook,
+} from "./transport-stream-shared.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   estimateStringChars,
@@ -342,15 +347,23 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           options as OpenAICompletionsOptions | undefined,
         );
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const responseStream = (await client.chat.completions.create(
-          params as never,
-          buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
-            timeoutMs: options?.timeoutMs,
-            maxRetries: options?.maxRetries,
-          }),
-        )) as unknown as AsyncIterable<ChatCompletionChunk>;
-        stream.push({ type: "start", partial: output as never });
-        await processOpenAICompletionsStream(responseStream, output, model, stream, {
+        const { data: responseStream, response } = await client.chat.completions
+          .create(
+            params as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+            buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+              timeoutMs: options?.timeoutMs,
+              maxRetries: options?.maxRetries,
+            }),
+          )
+          .withResponse();
+        const hookedResponseStream = withProviderResponseHook({
+          stream: responseStream,
+          signal: firstEventAbort.signal,
+          abort: firstEventAbort.abort,
+          hook: createOpenAIResponseHook(options?.onResponse, response, model),
+          onReady: () => stream.push({ type: "start", partial: output as never }),
+        });
+        await processOpenAICompletionsStream(hookedResponseStream, output, model, stream, {
           signal: options?.signal,
           emitReasoning,
           firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -5,6 +5,7 @@ import { applyProviderReportedUsageCost, calculateCost } from "../model-utils.js
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 /** Shared options, usage shape, cache identity, ordering, and stream scheduling for OpenAI APIs. */
 import { clampOpenAIPromptCacheKey } from "../providers/openai-prompt-cache.js";
+import { headersToRecord } from "../utils/headers.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 
 export { sortPromptCacheToolsByName as sortTransportToolsByName } from "../utils/prompt-cache-stability.js";
@@ -99,6 +100,17 @@ export function parseOpenAICompletionsUsage(
   calculateCost(model, usage);
   applyProviderReportedUsageCost(usage, rawUsage.cost);
   return usage;
+}
+
+export function createOpenAIResponseHook(
+  onResponse: BaseOpenAIStreamOptions["onResponse"],
+  response: Response,
+  model: Model,
+): (() => void | Promise<void>) | undefined {
+  return onResponse
+    ? () =>
+        onResponse({ status: response.status, headers: headersToRecord(response.headers) }, model)
+    : undefined;
 }
 
 type ModelStreamCooperativeScheduler = {

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -136,6 +136,47 @@ export function transportAbortError(signal?: AbortSignal): Error {
     : new Error("Request was aborted");
 }
 
+/** Run a provider-response hook before start/body consumption inside the first-event deadline. */
+export function withProviderResponseHook<T>(params: {
+  stream: AsyncIterable<T>;
+  signal: AbortSignal;
+  abort: (reason: Error) => void;
+  hook?: () => void | Promise<void>;
+  onReady: () => void;
+}): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      let onAbort: (() => void) | undefined;
+      try {
+        if (params.signal.aborted) {
+          throw transportAbortError(params.signal);
+        }
+        if (params.hook) {
+          await Promise.race([
+            Promise.resolve().then(params.hook),
+            new Promise<never>((_resolve, reject) => {
+              onAbort = () => reject(transportAbortError(params.signal));
+              params.signal.addEventListener("abort", onAbort, { once: true });
+            }),
+          ]);
+        }
+      } catch (error) {
+        params.abort(error instanceof Error ? error : new Error(String(error)));
+        throw error;
+      } finally {
+        if (onAbort) {
+          params.signal.removeEventListener("abort", onAbort);
+        }
+      }
+      if (params.signal.aborted) {
+        throw transportAbortError(params.signal);
+      }
+      params.onReady();
+      yield* params.stream;
+    },
+  };
+}
+
 export function finalizeTransportStream(params: {
   stream: WritableTransportStream;
   output: TransportOutputShape;

--- a/packages/ai/src/utils/stream-first-event-timeout.ts
+++ b/packages/ai/src/utils/stream-first-event-timeout.ts
@@ -104,8 +104,8 @@ export function withFirstStreamEventTimeout<T>(
           timer = setTimeout(() => {
             const timeoutError = createFirstStreamEventTimeoutError(timeoutContext);
             timeoutContext.onTimeout?.(timeoutError);
-            timeoutContext.abort?.(timeoutError);
             reject(timeoutError);
+            timeoutContext.abort?.(timeoutError);
           }, timeoutMs);
           timer.unref?.();
           iterator.next().then(resolve, reject);


### PR DESCRIPTION
## What Problem This Solves

Managed OpenAI Chat requests silently skipped the documented `onResponse` lifecycle, so `after_provider_response` plugin handlers received no HTTP status, request ID, or rate-limit headers. The stale candidate also placed the new hook wait outside the first-event watchdog, allowing a never-settling hook to stall indefinitely after headers.

The package Chat sibling already invoked the hook but had the same timeout, caller-cancellation, and unread-stream cleanup gaps.

## Why This Change Was Made

Both Chat implementations now use one abort-aware response-hook iterable decorator inside the existing first-event watchdog. The hook completes before `start` or body consumption; one deadline spans hook latency plus the first SSE event; hook failures and caller/timeout aborts close the unread SDK stream; listeners are always removed; and late hook settlement cannot publish stale events.

Managed Chat obtains the parsed stream plus raw HTTP response through openai-node's `.withResponse()` contract and uses the current streaming request type. Package Chat uses the same lifecycle owner. Production delta is +98/-21; the +77 net lines are required to establish one shared package+managed pre-first-event response-hook lifecycle owner—metadata normalization, cancellation race, unread-stream abort, listener cleanup, and one deadline—instead of duplicate per-producer race/timer stacks. No config, public/plugin API, authentication, protocol, persistence, SQLite, dependency, retry, or compatibility change.

## User Impact

Plugin `after_provider_response` handlers receive real managed Chat response status and headers exactly once before stream events begin. Hook throw/reject, first-event timeout, and caller cancellation produce one truthful terminal error, close the unread request, and cannot leak a later `start`. Existing package and managed success/error snapshots remain unchanged.

## Evidence

Pinned openai-node 6.49.0 source was inspected directly:

- `src/core/api-promise.ts:71-74` returns parsed data plus raw `Response` via `.withResponse()`.
- `src/internal/parse.ts:24-44` constructs the SDK `Stream` without consuming the SSE body.
- `src/core/streaming.ts:21-31,43-101` exposes the request controller and closes unfinished iteration.
- `src/client.ts:1005-1032` links the supplied request signal and ends the SDK request timeout once headers arrive, making OpenClaw's first-event deadline the authoritative post-header lifecycle.

Fail-before regression:

```text
$ node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-transport.response-hook.test.ts
Test Files  1 failed (1)
Tests       11 failed | 1 passed (12)
managed     never invoked metadata hooks
package     hook failure left unread request open
package     pending hook bypassed timeout and cancellation
both        late-settlement/listener lifecycle was incomplete
```

Pass-after proof on rebased head `148c0e4687ab5bab86624e4bc10dabcac4e0f64e`:

```text
$ node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-transport.response-hook.test.ts packages/ai/src/providers/openai-completions.test.ts packages/ai/src/utils/stream-first-event-timeout.test.ts packages/ai/src/provider-transport-parity.test.ts src/agents/openai-transport-stream.base.test.ts
Test Files  4 passed + 1 passed
Tests       83 passed + 47 passed = 130 passed
[test] passed 2 Vitest shards in 97.07s
```

The lifecycle suite verifies metadata and ordering, sync throw/async rejection, shared first-event timeout, caller abort with coded reason, late resolve/reject, exact single terminal event, unread request abort, and derived-signal listener cleanup for package and managed producers. Provider parity snapshots stayed byte-identical.

```text
$ node scripts/check-changed.mjs
[check:changed] lanes=core, coreTests
core production/test typecheck PASS
oxfmt PASS; oxlint 0 warnings, 0 errors
Plugin SDK/boundary/dead-code PASS
runtime import cycles 0
Blacksmith Testbox tbx_01kzkkpcwtmbqzcxhwbprb0bfj
Actions run 31322351234
exitCode 0

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```

ClawSweeper's rank-up moves were applied: the hook wait is inside the existing first-event lifecycle, pending-hook timeout is covered, the branch is rebuilt on current main, and the installed SDK contract was verified. A queued or late-publishing re-review is informational after these moves and exact-head code checks are green.

Named follow-up: OpenAI Responses, ChatGPT Responses, and Anthropic hook families have provider-specific retry/body semantics and should adopt the shared pre-first-event lifecycle in separate focused repairs rather than expanding this Chat PR.

AI-assisted; current owner/caller/sibling paths, dependency source, before/after lifecycle behavior, focused tests, changed gates, and independent review were verified.
