### PR TITLE
fix(openai): retain Gateway microphone frames during peer startup

### DIFF
--- a/extensions/openai/realtime-quicksilver-audio-buffer.test.ts
+++ b/extensions/openai/realtime-quicksilver-audio-buffer.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   appendOpenAIQuicksilverPendingAudio,
-  OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES,
+  OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
 } from "./realtime-quicksilver-audio-buffer.js";
+
+const MAX_PENDING_AUDIO_BYTES = OPENAI_QUICKSILVER_RELAY_FRAME_BYTES * 250;
 
 describe("GPT-Live pending microphone audio", () => {
   it("copies caller-owned PCM16 and drops an incomplete sample", () => {
@@ -21,16 +23,16 @@ describe("GPT-Live pending microphone audio", () => {
   });
 
   it("retains the newest bounded tail across existing and oversized input", () => {
-    const existing = Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES, 0x01);
+    const existing = Buffer.alloc(MAX_PENDING_AUDIO_BYTES, 0x01);
     const appended = appendOpenAIQuicksilverPendingAudio(existing, Buffer.from([0x02, 0x02]));
-    const oversized = Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES + 2, 0x03);
+    const oversized = Buffer.alloc(MAX_PENDING_AUDIO_BYTES + 2, 0x03);
 
-    expect(appended).toHaveLength(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES);
+    expect(appended).toHaveLength(MAX_PENDING_AUDIO_BYTES);
     expect(appended.subarray(0, -2).every((byte) => byte === 0x01)).toBe(true);
     expect(appended.subarray(-2)).toEqual(Buffer.from([0x02, 0x02]));
     expect(
       appendOpenAIQuicksilverPendingAudio(appended, oversized).equals(
-        Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES, 0x03),
+        Buffer.alloc(MAX_PENDING_AUDIO_BYTES, 0x03),
       ),
     ).toBe(true);
   });

--- a/extensions/openai/realtime-quicksilver-audio-buffer.test.ts
+++ b/extensions/openai/realtime-quicksilver-audio-buffer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendOpenAIQuicksilverPendingAudio,
+  OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES,
+} from "./realtime-quicksilver-audio-buffer.js";
+
+describe("GPT-Live pending microphone audio", () => {
+  it("copies caller-owned PCM16 and drops an incomplete sample", () => {
+    const source = Buffer.from([0x01, 0x02, 0x03]);
+    const pending = appendOpenAIQuicksilverPendingAudio(Buffer.alloc(0), source);
+    source.fill(0xff);
+
+    expect(pending).toEqual(Buffer.from([0x01, 0x02]));
+  });
+
+  it("appends audio in capture order while it fits", () => {
+    const first = appendOpenAIQuicksilverPendingAudio(Buffer.alloc(0), Buffer.from([0x01, 0x02]));
+    const second = appendOpenAIQuicksilverPendingAudio(first, Buffer.from([0x03, 0x04]));
+
+    expect(second).toEqual(Buffer.from([0x01, 0x02, 0x03, 0x04]));
+  });
+
+  it("retains the newest bounded tail across existing and oversized input", () => {
+    const existing = Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES, 0x01);
+    const appended = appendOpenAIQuicksilverPendingAudio(existing, Buffer.from([0x02, 0x02]));
+    const oversized = Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES + 2, 0x03);
+
+    expect(appended).toHaveLength(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES);
+    expect(appended.subarray(0, -2).every((byte) => byte === 0x01)).toBe(true);
+    expect(appended.subarray(-2)).toEqual(Buffer.from([0x02, 0x02]));
+    expect(
+      appendOpenAIQuicksilverPendingAudio(appended, oversized).equals(
+        Buffer.alloc(OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES, 0x03),
+      ),
+    ).toBe(true);
+  });
+});

--- a/extensions/openai/realtime-quicksilver-audio-buffer.ts
+++ b/extensions/openai/realtime-quicksilver-audio-buffer.ts
@@ -4,7 +4,7 @@ const MAX_PENDING_RELAY_FRAMES = 250;
 export const OPENAI_QUICKSILVER_RELAY_FRAME_BYTES = RELAY_FRAME_SAMPLES * 2;
 // One five-second tail spans peer startup and the connected media pump.
 // Keeping the newest PCM bounds latency without changing policy at adoption.
-export const OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES =
+const OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES =
   OPENAI_QUICKSILVER_RELAY_FRAME_BYTES * MAX_PENDING_RELAY_FRAMES;
 
 export function appendOpenAIQuicksilverPendingAudio(pending: Buffer, incoming: Buffer): Buffer {

--- a/extensions/openai/realtime-quicksilver-audio-buffer.ts
+++ b/extensions/openai/realtime-quicksilver-audio-buffer.ts
@@ -1,0 +1,27 @@
+const RELAY_FRAME_SAMPLES = 480;
+const MAX_PENDING_RELAY_FRAMES = 250;
+
+export const OPENAI_QUICKSILVER_RELAY_FRAME_BYTES = RELAY_FRAME_SAMPLES * 2;
+// One five-second tail spans peer startup and the connected media pump.
+// Keeping the newest PCM bounds latency without changing policy at adoption.
+export const OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES =
+  OPENAI_QUICKSILVER_RELAY_FRAME_BYTES * MAX_PENDING_RELAY_FRAMES;
+
+export function appendOpenAIQuicksilverPendingAudio(pending: Buffer, incoming: Buffer): Buffer {
+  const evenLength = incoming.length - (incoming.length % 2);
+  if (evenLength === 0) {
+    return pending;
+  }
+  const audio = incoming.subarray(0, evenLength);
+  if (audio.length >= OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES) {
+    return Buffer.from(audio.subarray(audio.length - OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES));
+  }
+  const pendingBytes = Math.min(
+    pending.length,
+    OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES - audio.length,
+  );
+  return Buffer.concat(
+    [pending.subarray(pending.length - pendingBytes), audio],
+    pendingBytes + audio.length,
+  );
+}

--- a/extensions/openai/realtime-quicksilver-audio-pipeline.test.ts
+++ b/extensions/openai/realtime-quicksilver-audio-pipeline.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { OPENAI_QUICKSILVER_RELAY_FRAME_BYTES } from "./realtime-quicksilver-audio-buffer.js";
+import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
+import {
+  OpenAIQuicksilverAudioPeer,
+  type OpenAIQuicksilverAudioPeerContract,
+} from "./realtime-quicksilver-peer.runtime.js";
+import { createCallResponse, FakeSocket } from "./realtime-quicksilver.test-helpers.js";
+
+const MAX_PENDING_RELAY_FRAMES = 250;
+const MAX_PENDING_AUDIO_BYTES = OPENAI_QUICKSILVER_RELAY_FRAME_BYTES * MAX_PENDING_RELAY_FRAMES;
+
+type TestableAudioPeer = {
+  pendingAudio: Buffer;
+  sequenceNumber: number;
+  timestamp: number;
+  takeNextRelayFrame(): Buffer;
+  state: {
+    peer: {
+      connectionStateChange: {
+        execute(state: "connected"): void;
+      };
+    };
+    transceiver: {
+      sender: {
+        sendRtp(packet: unknown): Promise<void>;
+      };
+    };
+  };
+};
+
+describe("GPT-Live gateway microphone audio pipeline", () => {
+  it("retains the newest five seconds through delayed peer adoption and the RTP pump", async () => {
+    vi.useFakeTimers();
+    let peerCallbacks:
+      | Parameters<typeof OpenAIQuicksilverAudioPeer.create>[0]["callbacks"]
+      | undefined;
+    let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
+    const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve) => {
+      resolvePeer = resolve;
+    });
+    const onError = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn((callbacks) => {
+        peerCallbacks = callbacks;
+        return peerPromise;
+      }),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
+      webSocketFactory: () => new FakeSocket(),
+    });
+    const connection = bridge.connect();
+    const source = Buffer.alloc(256 * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
+    for (let frame = 0; frame < 256; frame += 1) {
+      source
+        .subarray(
+          frame * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+          (frame + 1) * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+        )
+        .fill(frame + 1);
+    }
+    for (let offset = 0; offset < source.length; offset += 8_192) {
+      const callerBuffer = Buffer.from(source.subarray(offset, offset + 8_192));
+      bridge.sendAudio(callerBuffer);
+      callerBuffer.fill(0xff);
+      await vi.advanceTimersByTimeAsync(171);
+    }
+    if (!peerCallbacks) {
+      throw new Error("expected the bridge to start peer creation");
+    }
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: peerCallbacks,
+      iceServers: [],
+    });
+    vi.spyOn(peer, "createOffer").mockResolvedValue("v=offer\r\n");
+    vi.spyOn(peer, "applyAnswer").mockResolvedValue();
+    const testPeer = peer as unknown as TestableAudioPeer;
+    const sendRtp = vi
+      .spyOn(testPeer.state.transceiver.sender, "sendRtp")
+      .mockResolvedValue(undefined);
+    const emittedFrames: Buffer[] = [];
+    const takeNextRelayFrame = testPeer.takeNextRelayFrame.bind(testPeer);
+    vi.spyOn(testPeer, "takeNextRelayFrame").mockImplementation(() => {
+      const frame = takeNextRelayFrame();
+      emittedFrames.push(frame);
+      return frame;
+    });
+    const initialSequenceNumber = testPeer.sequenceNumber;
+    const initialTimestamp = testPeer.timestamp;
+    try {
+      resolvePeer?.(peer);
+      await connection;
+
+      expect(testPeer.pendingAudio).toEqual(
+        source.subarray(source.length - MAX_PENDING_AUDIO_BYTES),
+      );
+
+      testPeer.state.peer.connectionStateChange.execute("connected");
+      await vi.advanceTimersByTimeAsync(4_980);
+
+      expect(testPeer.pendingAudio).toHaveLength(0);
+      expect(emittedFrames).toHaveLength(MAX_PENDING_RELAY_FRAMES);
+      expect(emittedFrames.map((frame) => frame[0])).toEqual([
+        ...Array.from({ length: MAX_PENDING_RELAY_FRAMES - 1 }, (_, index) => index + 7),
+        0,
+      ]);
+      expect(sendRtp).toHaveBeenCalledTimes(MAX_PENDING_RELAY_FRAMES);
+      const packets = sendRtp.mock.calls.map(
+        ([packet]) =>
+          packet as {
+            header: { payloadType: number; sequenceNumber: number; timestamp: number };
+            payload: Buffer;
+          },
+      );
+      expect(packets.every((packet) => packet.header.payloadType === 111)).toBe(true);
+      expect(packets.every((packet) => packet.payload.length > 0)).toBe(true);
+      expect(packets.at(-1)?.header.sequenceNumber).toBe(
+        (initialSequenceNumber + MAX_PENDING_RELAY_FRAMES - 1) & 0xffff,
+      );
+      expect(packets.at(-1)?.header.timestamp).toBe(
+        (initialTimestamp + (MAX_PENDING_RELAY_FRAMES - 1) * 960) >>> 0,
+      );
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      bridge.close();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -1,9 +1,5 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
-import {
-  OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES,
-  OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
-} from "./realtime-quicksilver-audio-buffer.js";
 import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
 import {
   OpenAIQuicksilverAudioPeer,
@@ -583,112 +579,6 @@ describe("GPT-Live gateway relay bridge", () => {
       expect(peer.sendAudio).toHaveBeenCalledTimes(2);
     } finally {
       bridge.close();
-    }
-  });
-
-  it("retains the newest five seconds through delayed peer adoption and the RTP pump", async () => {
-    vi.useFakeTimers();
-    let peerCallbacks:
-      | Parameters<typeof OpenAIQuicksilverAudioPeer.create>[0]["callbacks"]
-      | undefined;
-    let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
-    const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve) => {
-      resolvePeer = resolve;
-    });
-    const onError = vi.fn();
-    const bridge = new OpenAIQuicksilverGatewayBridge({
-      providerConfig: {},
-      model: "gpt-live-1-codex",
-      voice: "marin",
-      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onError,
-      runAgentConsult: vi.fn(async () => ({ text: "done" })),
-      logger: { debug: vi.fn(), warn: vi.fn() },
-      resolveAuth: vi.fn(async () => ({
-        type: "oauth" as const,
-        token: "oauth-token",
-        accountId: "account-1",
-      })),
-      createPeer: vi.fn((callbacks) => {
-        peerCallbacks = callbacks;
-        return peerPromise;
-      }),
-      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
-      webSocketFactory: () => new FakeSocket(),
-    });
-    const connection = bridge.connect();
-    const source = Buffer.alloc(256 * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
-    for (let frame = 0; frame < 256; frame += 1) {
-      source
-        .subarray(
-          frame * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
-          (frame + 1) * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
-        )
-        .fill(frame + 1);
-    }
-    for (let offset = 0; offset < source.length; offset += 8_192) {
-      const callerBuffer = Buffer.from(source.subarray(offset, offset + 8_192));
-      bridge.sendAudio(callerBuffer);
-      callerBuffer.fill(0xff);
-      await vi.advanceTimersByTimeAsync(171);
-    }
-    if (!peerCallbacks) {
-      throw new Error("expected the bridge to start peer creation");
-    }
-    const peer = await OpenAIQuicksilverAudioPeer.create({
-      callbacks: peerCallbacks,
-      iceServers: [],
-    });
-    vi.spyOn(peer, "createOffer").mockResolvedValue("v=offer\r\n");
-    vi.spyOn(peer, "applyAnswer").mockResolvedValue();
-    const testPeer = peer as unknown as TestableAudioPeer;
-    const sendRtp = vi
-      .spyOn(testPeer.state.transceiver.sender, "sendRtp")
-      .mockResolvedValue(undefined);
-    const emittedFrames: Buffer[] = [];
-    const takeNextRelayFrame = testPeer.takeNextRelayFrame.bind(testPeer);
-    vi.spyOn(testPeer, "takeNextRelayFrame").mockImplementation(() => {
-      const frame = takeNextRelayFrame();
-      emittedFrames.push(frame);
-      return frame;
-    });
-    const initialSequenceNumber = testPeer.sequenceNumber;
-    const initialTimestamp = testPeer.timestamp;
-    try {
-      resolvePeer?.(peer);
-      await connection;
-
-      expect(testPeer.pendingAudio).toEqual(
-        source.subarray(source.length - OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES),
-      );
-
-      testPeer.state.peer.connectionStateChange.execute("connected");
-      await vi.advanceTimersByTimeAsync(4_980);
-
-      expect(testPeer.pendingAudio).toHaveLength(0);
-      expect(emittedFrames).toHaveLength(250);
-      expect(emittedFrames.map((frame) => frame[0])).toEqual([
-        ...Array.from({ length: 249 }, (_, index) => index + 7),
-        0,
-      ]);
-      expect(sendRtp).toHaveBeenCalledTimes(250);
-      const packets = sendRtp.mock.calls.map(
-        ([packet]) =>
-          packet as {
-            header: { payloadType: number; sequenceNumber: number; timestamp: number };
-            payload: Buffer;
-          },
-      );
-      expect(packets.every((packet) => packet.header.payloadType === 111)).toBe(true);
-      expect(packets.every((packet) => packet.payload.length > 0)).toBe(true);
-      expect(packets.at(-1)?.header.sequenceNumber).toBe((initialSequenceNumber + 249) & 0xffff);
-      expect(packets.at(-1)?.header.timestamp).toBe((initialTimestamp + 249 * 960) >>> 0);
-      expect(onError).not.toHaveBeenCalled();
-    } finally {
-      bridge.close();
-      vi.useRealTimers();
     }
   });
 

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -522,6 +522,151 @@ describe("GPT-Live werift audio peer", () => {
 });
 
 describe("GPT-Live gateway relay bridge", () => {
+  function createPendingPeerBridge() {
+    let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
+    let rejectPeer: ((error: Error) => void) | undefined;
+    const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve, reject) => {
+      resolvePeer = resolve;
+      rejectPeer = reject;
+    });
+    const peer = {
+      createOffer: vi.fn(async () => "v=offer\r\n"),
+      applyAnswer: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      close: vi.fn(),
+    } satisfies OpenAIQuicksilverAudioPeerContract;
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn(() => peerPromise),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
+      webSocketFactory: () => new FakeSocket(),
+    });
+    const connection = bridge.connect();
+    return {
+      bridge,
+      connection,
+      peer,
+      rejectPeer: (error: Error) => rejectPeer?.(error),
+      resolvePeer: () => resolvePeer?.(peer),
+    };
+  }
+
+  it("preserves caller-owned microphone frames while the media peer is starting", async () => {
+    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
+    try {
+      const source = Buffer.from([0x7f, 0x41]);
+      bridge.sendAudio(source);
+      source.fill(0);
+      bridge.sendAudio(Buffer.from([0x22, 0x23]));
+
+      resolvePeer();
+      await connection;
+
+      expect(peer.sendAudio.mock.calls.map(([audio]) => audio)).toEqual([
+        Buffer.from([0x7f, 0x41]),
+        Buffer.from([0x22, 0x23]),
+      ]);
+      bridge.sendAudio(Buffer.from([0x30, 0x31]));
+      expect(peer.sendAudio).toHaveBeenCalledTimes(3);
+    } finally {
+      bridge.close();
+    }
+  });
+
+  it("bounds queued microphone bytes before copying rejected audio", async () => {
+    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
+    try {
+      bridge.sendAudio(Buffer.alloc(512 * 1024, 0x01));
+      bridge.sendAudio(Buffer.alloc(512 * 1024, 0x02));
+      const overflow = Buffer.alloc(1, 0x03);
+      const copy = vi.spyOn(Buffer, "from");
+      try {
+        bridge.sendAudio(overflow);
+        expect(copy).not.toHaveBeenCalled();
+      } finally {
+        copy.mockRestore();
+      }
+
+      resolvePeer();
+      await connection;
+
+      expect(peer.sendAudio).toHaveBeenCalledTimes(2);
+      expect(peer.sendAudio.mock.calls.map(([audio]) => audio.byteLength)).toEqual([
+        512 * 1024,
+        512 * 1024,
+      ]);
+    } finally {
+      bridge.close();
+    }
+  });
+
+  it("bounds queued microphone frame count before copying rejected audio", async () => {
+    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
+    try {
+      for (let index = 0; index < 320; index += 1) {
+        bridge.sendAudio(Buffer.alloc(2, index));
+      }
+      const overflow = Buffer.alloc(2, 0xff);
+      const copy = vi.spyOn(Buffer, "from");
+      try {
+        bridge.sendAudio(overflow);
+        expect(copy).not.toHaveBeenCalled();
+      } finally {
+        copy.mockRestore();
+      }
+
+      resolvePeer();
+      await connection;
+
+      expect(peer.sendAudio).toHaveBeenCalledTimes(320);
+      expect(peer.sendAudio.mock.calls.at(-1)?.[0]).toEqual(Buffer.alloc(2, 319));
+    } finally {
+      bridge.close();
+    }
+  });
+
+  it("discards queued microphone audio when closed before the media peer resolves", async () => {
+    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
+    bridge.sendAudio(Buffer.from([0x41, 0x42]));
+    bridge.close();
+    resolvePeer();
+
+    await expect(connection).rejects.toThrow("GPT-Live gateway relay bridge closed");
+    await vi.waitFor(() => expect(peer.close).toHaveBeenCalledOnce());
+    expect(peer.sendAudio).not.toHaveBeenCalled();
+    bridge.sendAudio(Buffer.from([0x43, 0x44]));
+    expect(peer.sendAudio).not.toHaveBeenCalled();
+  });
+
+  it("discards queued microphone audio when media peer creation fails", async () => {
+    const { bridge, connection, peer, rejectPeer } = createPendingPeerBridge();
+    const pendingAudioState = bridge as unknown as {
+      pendingAudio: Buffer[];
+      pendingAudioBytes: number;
+    };
+    bridge.sendAudio(Buffer.from([0x41, 0x42]));
+    rejectPeer(new Error("media peer unavailable"));
+
+    await expect(connection).rejects.toThrow("media peer unavailable");
+    expect(pendingAudioState.pendingAudio).toEqual([]);
+    expect(pendingAudioState.pendingAudioBytes).toBe(0);
+    bridge.sendAudio(Buffer.from([0x43, 0x44]));
+    expect(pendingAudioState.pendingAudio).toEqual([]);
+    expect(peer.sendAudio).not.toHaveBeenCalled();
+  });
+
   it("closes a sideband that opens in the abort handoff", async () => {
     const controller = new AbortController();
     const socket = new FakeSocket("manual");

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
+import {
+  OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES,
+  OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+} from "./realtime-quicksilver-audio-buffer.js";
 import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
 import {
   OpenAIQuicksilverAudioPeer,
@@ -46,7 +50,7 @@ type TestableAudioPeer = {
     };
     peer: {
       connectionStateChange: {
-        execute(state: "closed" | "disconnected"): void;
+        execute(state: "closed" | "connected" | "disconnected"): void;
       };
     };
     transceiver: {
@@ -574,66 +578,117 @@ describe("GPT-Live gateway relay bridge", () => {
       resolvePeer();
       await connection;
 
-      expect(peer.sendAudio.mock.calls.map(([audio]) => audio)).toEqual([
-        Buffer.from([0x7f, 0x41]),
-        Buffer.from([0x22, 0x23]),
-      ]);
+      expect(peer.sendAudio).toHaveBeenCalledWith(Buffer.from([0x7f, 0x41, 0x22, 0x23]));
       bridge.sendAudio(Buffer.from([0x30, 0x31]));
-      expect(peer.sendAudio).toHaveBeenCalledTimes(3);
-    } finally {
-      bridge.close();
-    }
-  });
-
-  it("bounds queued microphone bytes before copying rejected audio", async () => {
-    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
-    try {
-      bridge.sendAudio(Buffer.alloc(512 * 1024, 0x01));
-      bridge.sendAudio(Buffer.alloc(512 * 1024, 0x02));
-      const overflow = Buffer.alloc(1, 0x03);
-      const copy = vi.spyOn(Buffer, "from");
-      try {
-        bridge.sendAudio(overflow);
-        expect(copy).not.toHaveBeenCalled();
-      } finally {
-        copy.mockRestore();
-      }
-
-      resolvePeer();
-      await connection;
-
       expect(peer.sendAudio).toHaveBeenCalledTimes(2);
-      expect(peer.sendAudio.mock.calls.map(([audio]) => audio.byteLength)).toEqual([
-        512 * 1024,
-        512 * 1024,
-      ]);
     } finally {
       bridge.close();
     }
   });
 
-  it("bounds queued microphone frame count before copying rejected audio", async () => {
-    const { bridge, connection, peer, resolvePeer } = createPendingPeerBridge();
+  it("retains the newest five seconds through delayed peer adoption and the RTP pump", async () => {
+    vi.useFakeTimers();
+    let peerCallbacks:
+      | Parameters<typeof OpenAIQuicksilverAudioPeer.create>[0]["callbacks"]
+      | undefined;
+    let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
+    const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve) => {
+      resolvePeer = resolve;
+    });
+    const onError = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn((callbacks) => {
+        peerCallbacks = callbacks;
+        return peerPromise;
+      }),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
+      webSocketFactory: () => new FakeSocket(),
+    });
+    const connection = bridge.connect();
+    const source = Buffer.alloc(256 * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
+    for (let frame = 0; frame < 256; frame += 1) {
+      source
+        .subarray(
+          frame * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+          (frame + 1) * OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+        )
+        .fill(frame + 1);
+    }
+    for (let offset = 0; offset < source.length; offset += 8_192) {
+      const callerBuffer = Buffer.from(source.subarray(offset, offset + 8_192));
+      bridge.sendAudio(callerBuffer);
+      callerBuffer.fill(0xff);
+      await vi.advanceTimersByTimeAsync(171);
+    }
+    if (!peerCallbacks) {
+      throw new Error("expected the bridge to start peer creation");
+    }
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: peerCallbacks,
+      iceServers: [],
+    });
+    vi.spyOn(peer, "createOffer").mockResolvedValue("v=offer\r\n");
+    vi.spyOn(peer, "applyAnswer").mockResolvedValue();
+    const testPeer = peer as unknown as TestableAudioPeer;
+    const sendRtp = vi
+      .spyOn(testPeer.state.transceiver.sender, "sendRtp")
+      .mockResolvedValue(undefined);
+    const emittedFrames: Buffer[] = [];
+    const takeNextRelayFrame = testPeer.takeNextRelayFrame.bind(testPeer);
+    vi.spyOn(testPeer, "takeNextRelayFrame").mockImplementation(() => {
+      const frame = takeNextRelayFrame();
+      emittedFrames.push(frame);
+      return frame;
+    });
+    const initialSequenceNumber = testPeer.sequenceNumber;
+    const initialTimestamp = testPeer.timestamp;
     try {
-      for (let index = 0; index < 320; index += 1) {
-        bridge.sendAudio(Buffer.alloc(2, index));
-      }
-      const overflow = Buffer.alloc(2, 0xff);
-      const copy = vi.spyOn(Buffer, "from");
-      try {
-        bridge.sendAudio(overflow);
-        expect(copy).not.toHaveBeenCalled();
-      } finally {
-        copy.mockRestore();
-      }
-
-      resolvePeer();
+      resolvePeer?.(peer);
       await connection;
 
-      expect(peer.sendAudio).toHaveBeenCalledTimes(320);
-      expect(peer.sendAudio.mock.calls.at(-1)?.[0]).toEqual(Buffer.alloc(2, 319));
+      expect(testPeer.pendingAudio).toEqual(
+        source.subarray(source.length - OPENAI_QUICKSILVER_MAX_PENDING_AUDIO_BYTES),
+      );
+
+      testPeer.state.peer.connectionStateChange.execute("connected");
+      await vi.advanceTimersByTimeAsync(4_980);
+
+      expect(testPeer.pendingAudio).toHaveLength(0);
+      expect(emittedFrames).toHaveLength(250);
+      expect(emittedFrames.map((frame) => frame[0])).toEqual([
+        ...Array.from({ length: 249 }, (_, index) => index + 7),
+        0,
+      ]);
+      expect(sendRtp).toHaveBeenCalledTimes(250);
+      const packets = sendRtp.mock.calls.map(
+        ([packet]) =>
+          packet as {
+            header: { payloadType: number; sequenceNumber: number; timestamp: number };
+            payload: Buffer;
+          },
+      );
+      expect(packets.every((packet) => packet.header.payloadType === 111)).toBe(true);
+      expect(packets.every((packet) => packet.payload.length > 0)).toBe(true);
+      expect(packets.at(-1)?.header.sequenceNumber).toBe((initialSequenceNumber + 249) & 0xffff);
+      expect(packets.at(-1)?.header.timestamp).toBe((initialTimestamp + 249 * 960) >>> 0);
+      expect(onError).not.toHaveBeenCalled();
     } finally {
       bridge.close();
+      vi.useRealTimers();
     }
   });
 
@@ -653,17 +708,15 @@ describe("GPT-Live gateway relay bridge", () => {
   it("discards queued microphone audio when media peer creation fails", async () => {
     const { bridge, connection, peer, rejectPeer } = createPendingPeerBridge();
     const pendingAudioState = bridge as unknown as {
-      pendingAudio: Buffer[];
-      pendingAudioBytes: number;
+      pendingAudio: Buffer;
     };
     bridge.sendAudio(Buffer.from([0x41, 0x42]));
     rejectPeer(new Error("media peer unavailable"));
 
     await expect(connection).rejects.toThrow("media peer unavailable");
-    expect(pendingAudioState.pendingAudio).toEqual([]);
-    expect(pendingAudioState.pendingAudioBytes).toBe(0);
+    expect(pendingAudioState.pendingAudio).toHaveLength(0);
     bridge.sendAudio(Buffer.from([0x43, 0x44]));
-    expect(pendingAudioState.pendingAudio).toEqual([]);
+    expect(pendingAudioState.pendingAudio).toHaveLength(0);
     expect(peer.sendAudio).not.toHaveBeenCalled();
   });
 

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -40,6 +40,7 @@ const RELAY_SAMPLE_RATE = 24_000;
 const QUICKSILVER_SESSION_TTL_MS = 30 * 60_000;
 const QUICKSILVER_CONNECT_TIMEOUT_MS = 30_000;
 const WEBSOCKET_OPEN = 1;
+const MAX_PENDING_AUDIO = { chunks: 320, bytes: 1024 * 1024 };
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
@@ -164,6 +165,8 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private closed = false;
   private closeNotified = false;
   private peer: OpenAIQuicksilverAudioPeerContract | undefined;
+  private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
   private ready = false;
   private sideband: ActiveSideband | undefined;
   private timer: ReturnType<typeof setTimeout> | undefined;
@@ -181,7 +184,18 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   }
 
   sendAudio(audio: Buffer): void {
-    this.peer?.sendAudio(audio);
+    if (this.peer) {
+      this.peer.sendAudio(audio);
+    } else if (
+      !this.closed &&
+      !this.abortController.signal.aborted &&
+      this.pendingAudio.length < MAX_PENDING_AUDIO.chunks &&
+      this.pendingAudioBytes + audio.byteLength <= MAX_PENDING_AUDIO.bytes
+    ) {
+      // Relay capture starts before asynchronous peer creation and may recycle its input buffers.
+      this.pendingAudio.push(Buffer.from(audio));
+      this.pendingAudioBytes += audio.byteLength;
+    }
   }
 
   setMediaTimestamp(_ts: number): void {}
@@ -255,6 +269,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
         () => undefined,
       );
       this.peer = await waitForConnectStep(peerPromise, connectSignal);
+      for (const audio of this.pendingAudio.splice(0)) {
+        this.peer.sendAudio(audio);
+      }
+      this.pendingAudioBytes = 0;
       const offerSdp = await waitForConnectStep(this.peer.createOffer(), connectSignal);
       const auth = await waitForConnectStep(this.config.resolveAuth(), connectSignal);
       const requestIds = {
@@ -535,6 +553,8 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private releaseResources(): void {
     releaseOpenAIQuicksilverSession(this);
     this.connected = false;
+    this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
     this.abortController.abort(new Error("GPT-Live gateway relay bridge closed"));
     this.consultController?.abort(new Error("GPT-Live delegation stopped"));
     this.consultController = undefined;

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -7,6 +7,7 @@ import type {
   RealtimeVoiceBridgeCreateRequest,
 } from "openclaw/plugin-sdk/realtime-voice";
 import WebSocket, { type RawData } from "ws";
+import { appendOpenAIQuicksilverPendingAudio } from "./realtime-quicksilver-audio-buffer.js";
 import {
   buildOpenAIQuicksilverDelegationPrompt,
   type OpenAIQuicksilverTranscriptEntry,
@@ -40,7 +41,6 @@ const RELAY_SAMPLE_RATE = 24_000;
 const QUICKSILVER_SESSION_TTL_MS = 30 * 60_000;
 const QUICKSILVER_CONNECT_TIMEOUT_MS = 30_000;
 const WEBSOCKET_OPEN = 1;
-const MAX_PENDING_AUDIO = { chunks: 320, bytes: 1024 * 1024 };
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
@@ -165,8 +165,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private closed = false;
   private closeNotified = false;
   private peer: OpenAIQuicksilverAudioPeerContract | undefined;
-  private pendingAudio: Buffer[] = [];
-  private pendingAudioBytes = 0;
+  private pendingAudio: Buffer = Buffer.alloc(0);
   private ready = false;
   private sideband: ActiveSideband | undefined;
   private timer: ReturnType<typeof setTimeout> | undefined;
@@ -186,15 +185,9 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   sendAudio(audio: Buffer): void {
     if (this.peer) {
       this.peer.sendAudio(audio);
-    } else if (
-      !this.closed &&
-      !this.abortController.signal.aborted &&
-      this.pendingAudio.length < MAX_PENDING_AUDIO.chunks &&
-      this.pendingAudioBytes + audio.byteLength <= MAX_PENDING_AUDIO.bytes
-    ) {
+    } else if (!this.closed && !this.abortController.signal.aborted) {
       // Relay capture starts before asynchronous peer creation and may recycle its input buffers.
-      this.pendingAudio.push(Buffer.from(audio));
-      this.pendingAudioBytes += audio.byteLength;
+      this.pendingAudio = appendOpenAIQuicksilverPendingAudio(this.pendingAudio, audio);
     }
   }
 
@@ -269,10 +262,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
         () => undefined,
       );
       this.peer = await waitForConnectStep(peerPromise, connectSignal);
-      for (const audio of this.pendingAudio.splice(0)) {
-        this.peer.sendAudio(audio);
+      if (this.pendingAudio.length > 0) {
+        this.peer.sendAudio(this.pendingAudio);
+        this.pendingAudio = Buffer.alloc(0);
       }
-      this.pendingAudioBytes = 0;
       const offerSdp = await waitForConnectStep(this.peer.createOffer(), connectSignal);
       const auth = await waitForConnectStep(this.config.resolveAuth(), connectSignal);
       const requestIds = {
@@ -553,8 +546,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private releaseResources(): void {
     releaseOpenAIQuicksilverSession(this);
     this.connected = false;
-    this.pendingAudio = [];
-    this.pendingAudioBytes = 0;
+    this.pendingAudio = Buffer.alloc(0);
     this.abortController.abort(new Error("GPT-Live gateway relay bridge closed"));
     this.consultController?.abort(new Error("GPT-Live delegation stopped"));
     this.consultController = undefined;

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -1,15 +1,16 @@
 // Lazy GPT-Live media runtime: werift peer plus WASM Opus framing and PCM conversion.
 import { randomInt } from "node:crypto";
 import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  appendOpenAIQuicksilverPendingAudio,
+  OPENAI_QUICKSILVER_RELAY_FRAME_BYTES,
+} from "./realtime-quicksilver-audio-buffer.js";
 
 const QUICKSILVER_SAMPLE_RATE = 48_000;
 const RELAY_SAMPLE_RATE = 24_000;
 const QUICKSILVER_CHANNELS = 2;
 const OPUS_FRAME_SAMPLES = 960;
 const OPUS_FRAME_DURATION_MS = 20;
-const RELAY_FRAME_SAMPLES = 480;
-const RELAY_FRAME_BYTES = RELAY_FRAME_SAMPLES * 2;
-const MAX_PENDING_RELAY_FRAMES = 250;
 const INBOUND_REORDER_DEPTH = 4;
 // More than two seconds behind cannot be useful 20 ms reordering; fail instead of corrupting Opus state.
 const INBOUND_MAX_LATE_PACKETS = 100;
@@ -167,7 +168,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   private activeInboundSsrc: number | undefined;
   private inboundRtpState: InboundRtpState = { pendingPackets: new Map() };
   private mediaTimer: ReturnType<typeof setInterval> | undefined;
-  private pendingAudio = Buffer.alloc(0);
+  private pendingAudio: Buffer = Buffer.alloc(0);
   private sequenceNumber = randomInt(0x1_0000);
   private subscribedTracks = new Set<string>();
   private timestamp = randomInt(0x1_0000_0000);
@@ -222,16 +223,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     if (this.closed || audio.length < 2) {
       return;
     }
-    const evenAudio = audio.subarray(0, audio.length - (audio.length % 2));
-    this.pendingAudio =
-      this.pendingAudio.length > 0
-        ? Buffer.concat([this.pendingAudio, evenAudio])
-        : Buffer.from(evenAudio);
-    const maxPendingBytes = RELAY_FRAME_BYTES * MAX_PENDING_RELAY_FRAMES;
-    if (this.pendingAudio.length > maxPendingBytes) {
-      // Keep the newest complete frames. Old microphone audio is less useful than bounded latency.
-      this.pendingAudio = this.pendingAudio.subarray(this.pendingAudio.length - maxPendingBytes);
-    }
+    this.pendingAudio = appendOpenAIQuicksilverPendingAudio(this.pendingAudio, audio);
   }
 
   close(): void {
@@ -440,8 +432,8 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   private takeNextRelayFrame(): Buffer {
     // Relay ticks are framing boundaries: pad partial PCM now, or its tail survives
     // silence and is prepended to a later utterance as stale audio.
-    const frame = Buffer.alloc(RELAY_FRAME_BYTES);
-    const queuedBytes = Math.min(this.pendingAudio.length, RELAY_FRAME_BYTES);
+    const frame = Buffer.alloc(OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
+    const queuedBytes = Math.min(this.pendingAudio.length, OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
     if (queuedBytes > 0) {
       this.pendingAudio.copy(frame, 0, 0, queuedBytes);
       this.pendingAudio = this.pendingAudio.subarray(queuedBytes);


### PR DESCRIPTION
## What Problem This Solves

Gateway-relay Talk returns a usable session identifier while the GPT-Live WebRTC media peer is still being created. Browser microphone capture can therefore begin before the bridge has a peer. The gateway reported those frames as accepted, but the bridge silently discarded them.

## Why This Change Was Made

The gateway bridge and media peer now use one dependency-light PCM16 queue policy:

- retain at most the newest five seconds / 240,000 bytes;
- copy caller-owned input before it can be recycled;
- discard an incomplete trailing PCM16 byte;
- keep the same bounded-latency policy before and after peer adoption;
- clear pending audio on close or failed startup.

The gateway flushes its retained tail once when the real peer is adopted. The peer then uses the same policy while WebRTC connects, eliminating the former 1 MiB keep-oldest queue feeding a 240,000-byte keep-newest queue.

This remains private to the OpenAI plugin. It does not change authentication, configuration, public SDK, provider protocol, or persisted state.

## User Impact

- Normal startup no longer loses the user's opening speech while peer creation is in progress.
- Slow startup retains the newest five seconds instead of building stale latency.
- Recycled producer buffers cannot corrupt queued speech.
- Failed or closed sessions do not resume buffering.

## Evidence

- Rebased baseline: `4fb19fb8c586b2d7801d1c512a4ac21e4d826505`.
- Exact candidate: `fd995d6f78ca389bd3238c5f5aa9e1bd7654fe81`.
- Runtime entry point audited at `src/gateway/talk-realtime-relay-session-create.ts:531` and `src/gateway/talk-realtime-relay-operations.ts:179`: the relay is registered before asynchronous `bridge.connect()` finishes, and microphone frames immediately enter the bridge.
- Direct/native OpenAI realtime siblings and direct Codex WebSocket framing were audited; the WebRTC media peer remains the correct owner for this route.
- Deterministic delayed-start proof uses 30 browser-sized 8,192-byte appends over 5.13 seconds before peer adoption. It offers 256 relay frames, verifies the oldest six are evicted, and retains exactly frames 7 through 256.
- The proof uses the real `OpenAIQuicksilverAudioPeer`, `libopus-wasm` encoder, media timer, `werift` RTP packet construction, sequence/timestamp progression, and 250 ordered `sendRtp` calls. Only external network/DTLS delivery is stubbed.

```json
{
  "proof": "gpt-live-gateway-startup-audio",
  "head": "fd995d6f78ca389bd3238c5f5aa9e1bd7654fe81",
  "peerCreationDelayMs": 5130,
  "browserAppends": 30,
  "acceptedPcmBytes": 245760,
  "retainedPcmBytes": 240000,
  "evictedOldestFrames": 6,
  "firstRetainedFrame": 7,
  "lastRetainedFrame": 256,
  "rtpPacketsSent": 250,
  "errors": 0,
  "result": "pass"
}
```

Validation:

- Exact-head local focused proof: 34/34 passed.
- Repair-head Blacksmith focused proof: 33 passed, one Bun-only environment skip: https://github.com/openclaw/openclaw/actions/runs/30685681632
- Repair-head test types: https://github.com/openclaw/openclaw/actions/runs/30685681707
- Repair-head build: https://github.com/openclaw/openclaw/actions/runs/30685681801
- Exact-head PR CI: 45 successful, 0 failing, including changed tests, lint, Knip/dependencies, max-lines, types, build artifacts, and the merge gate: https://github.com/openclaw/openclaw/actions/runs/30686026968
- Targeted oxlint, formatting, and `git diff --check`: pass.
- Exact-head P1 Codex/Sol autoreview: no accepted or actionable findings, confidence 0.94; TruffleHog clean.

Production delta: 48 additions / 17 deletions across the shared queue contract and its two owners. Test delta: 270 additions / 1 deletion.
