### PR TITLE
fix(gateway): honor authoritative HTTP If-Range date validators

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -650,6 +650,72 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("bounds future-dated assistant media validators across conditional response plans", async () => {
+    const nowMs = Math.floor(Date.now() / 1000) * 1000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    try {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-future-mtime-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "photo.png");
+          const body = Buffer.from("future-assistant-media");
+          const future = new Date(nowMs + 60_000);
+          await fs.writeFile(filePath, body);
+          await fs.utimes(filePath, future, future);
+          const futureLastModified = (await fs.stat(filePath)).mtime.toUTCString();
+          const expectedLastModified = new Date(nowMs).toUTCString();
+          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+
+          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
+          expect(initial.res.statusCode).toBe(200);
+          expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
+          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
+
+          const partial = await runAssistantMediaRequest({
+            url,
+            method: "GET",
+            auth,
+            headers: { range: "bytes=0-5", "if-range": expectedLastModified },
+          });
+          expect(partial.res.statusCode).toBe(206);
+          expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
+
+          const futureRange = await runAssistantMediaRequest({
+            url,
+            method: "GET",
+            auth,
+            headers: { range: "bytes=0-5", "if-range": futureLastModified },
+          });
+          expect(futureRange.res.statusCode).toBe(200);
+
+          const unchanged = await runAssistantMediaRequest({
+            url,
+            method: "GET",
+            auth,
+            headers: { "if-none-match": String(etag) },
+          });
+          expect(unchanged.res.statusCode).toBe(304);
+          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
+
+          const unsatisfiable = await runAssistantMediaRequest({
+            url,
+            method: "GET",
+            auth,
+            headers: { range: `bytes=${body.byteLength}-` },
+          });
+          expect(unsatisfiable.res.statusCode).toBe(416);
+          expect(unsatisfiable.setHeader).toHaveBeenCalledWith(
+            "Last-Modified",
+            expectedLastModified,
+          );
+        },
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("returns 202 while assistant playback media is preparing", async () => {
     resolvePlaybackTranscodeMock.mockResolvedValueOnce({ kind: "preparing" });
     await withAllowedAssistantMediaRoot({

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -605,6 +605,51 @@ describe("handleControlUiHttpRequest", () => {
     },
   );
 
+  it("resumes assistant media only for an exact If-Range HTTP-date", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-if-range-date-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.png");
+        const body = Buffer.from("assistant-media-bytes");
+        const modified = new Date("2025-07-08T18:40:00.789Z");
+        await fs.writeFile(filePath, body);
+        await fs.utimes(filePath, modified, modified);
+        const lastModified = (await fs.stat(filePath)).mtime.toUTCString();
+        const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+        const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+
+        const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
+        expect(initial.res.statusCode).toBe(200);
+        expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+
+        const partial = await runAssistantMediaRequest({
+          url,
+          method: "GET",
+          auth,
+          headers: { range: "bytes=0-8", "if-range": lastModified },
+        });
+        expect(partial.res.statusCode).toBe(206);
+        expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+        expect(partial.setHeader).toHaveBeenCalledWith(
+          "Content-Range",
+          `bytes 0-8/${body.byteLength}`,
+        );
+
+        const future = await runAssistantMediaRequest({
+          url,
+          method: "GET",
+          auth,
+          headers: {
+            range: "bytes=0-8",
+            "if-range": new Date(Date.parse(lastModified) + 1000).toUTCString(),
+          },
+        });
+        expect(future.res.statusCode).toBe(200);
+        expect(future.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+      },
+    });
+  });
+
   it("returns 202 while assistant playback media is preparing", async () => {
     resolvePlaybackTranscodeMock.mockResolvedValueOnce({ kind: "preparing" });
     await withAllowedAssistantMediaRoot({

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -102,6 +102,72 @@ describe("resolveByteResponse", () => {
   });
 
   it.each([
+    { label: "full GET", method: "GET", rangeHeader: undefined, statusCode: 200 },
+    { label: "full HEAD", method: "HEAD", rangeHeader: undefined, statusCode: 200 },
+    { label: "partial", method: "GET", rangeHeader: "bytes=1-2", statusCode: 206 },
+    { label: "unsatisfiable", method: "GET", rangeHeader: "bytes=10-11", statusCode: 416 },
+  ])("bounds a future file timestamp to the $label response origin", (params) => {
+    const nowMs = FILE.mtimeMs - 60_000;
+    const plan = resolveByteResponse({ file: FILE, nowMs, ...params });
+
+    expect(plan.statusCode).toBe(params.statusCode);
+    expect(plan.lastModified).toBe(new Date(nowMs).toUTCString());
+  });
+
+  it("uses one response-origin timestamp without changing the file identity ETag", () => {
+    const nowMs = FILE.mtimeMs - 60_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    try {
+      const future = resolveByteResponse({ file: FILE, method: "GET" });
+
+      expect(dateNow).toHaveBeenCalledOnce();
+      expect(future.lastModified).toBe(new Date(nowMs).toUTCString());
+      expect(future.etag).toBe(resolveByteResponse({ file: FILE, nowMs: FILE.mtimeMs }).etag);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("matches an If-Range date against the bounded emitted validator", () => {
+    const nowMs = FILE.mtimeMs - 60_000;
+    const emittedLastModified = new Date(nowMs).toUTCString();
+
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        nowMs,
+        method: "GET",
+        rangeHeader: "bytes=1-2",
+        ifRangeHeader: emittedLastModified,
+      }),
+    ).toMatchObject({ kind: "partial", statusCode: 206, lastModified: emittedLastModified });
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        nowMs,
+        method: "GET",
+        rangeHeader: "bytes=1-2",
+        ifRangeHeader: LAST_MODIFIED,
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, lastModified: emittedLastModified });
+  });
+
+  it.each(["GET", "HEAD"])(
+    "bounds the future Last-Modified validator on %s not-modified responses",
+    (method) => {
+      const nowMs = FILE.mtimeMs - 60_000;
+      const etag = resolveByteResponse({ file: FILE, nowMs }).etag;
+
+      expect(resolveByteResponse({ file: FILE, method, nowMs, ifNoneMatchHeader: etag })).toEqual({
+        kind: "not-modified",
+        statusCode: 304,
+        etag,
+        lastModified: new Date(nowMs).toUTCString(),
+      });
+    },
+  );
+
+  it.each([
     {
       label: "an earlier HTTP-date",
       header: new Date(Date.parse(LAST_MODIFIED) - 1000).toUTCString(),

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./http-byte-range.js";
 
 const FILE = { size: 10, mtimeMs: 1_752_000_000_123.5 };
+const LAST_MODIFIED = new Date(FILE.mtimeMs).toUTCString();
 
 describe("resolveByteResponse", () => {
   it("resolves an open-ended range", () => {
@@ -84,6 +85,57 @@ describe("resolveByteResponse", () => {
     ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
   });
 
+  it("honors an If-Range HTTP-date at the file's fractional modification second", () => {
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        rangeHeader: "bytes=1-2",
+        ifRangeHeader: LAST_MODIFIED,
+      }),
+    ).toMatchObject({
+      kind: "partial",
+      statusCode: 206,
+      lastModified: LAST_MODIFIED,
+      range: { start: 1, end: 2 },
+    });
+  });
+
+  it.each([
+    {
+      label: "an earlier HTTP-date",
+      header: new Date(Date.parse(LAST_MODIFIED) - 1000).toUTCString(),
+    },
+    {
+      label: "a future HTTP-date",
+      header: new Date(Date.parse(LAST_MODIFIED) + 1000).toUTCString(),
+    },
+    {
+      label: "an ISO timestamp for the same second",
+      header: new Date(Date.parse(LAST_MODIFIED)).toISOString(),
+    },
+    {
+      label: "a non-HTTP timezone for the same second",
+      header: LAST_MODIFIED.replace("GMT", "UTC"),
+    },
+    {
+      label: "a lowercase weekday for the same second",
+      header: LAST_MODIFIED.replace("Tue", "tue"),
+    },
+    { label: "a malformed HTTP-date", header: "not-an-http-date" },
+    { label: "a weak ETag", header: `W/${resolveByteResponse({ file: FILE }).etag}` },
+    { label: "multiple validator values", header: [LAST_MODIFIED, LAST_MODIFIED] },
+  ])("ignores a range for $label If-Range", ({ header }) => {
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        rangeHeader: "bytes=1-2",
+        ifRangeHeader: header,
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
+  });
+
   it("falls back to a full response for a mismatched If-Range ETag", () => {
     expect(
       resolveByteResponse({
@@ -109,12 +161,18 @@ describe("resolveByteResponse", () => {
       ifNoneMatchHeader: header(etag),
     });
 
-    expect(plan).toEqual({ kind: "not-modified", statusCode: 304, etag });
+    expect(plan).toEqual({
+      kind: "not-modified",
+      statusCode: 304,
+      etag,
+      lastModified: LAST_MODIFIED,
+    });
     const setHeader = vi.fn();
     const res = { statusCode: 0, setHeader } as unknown as ServerResponse;
     writeByteHeaders(res, plan);
     expect(res.statusCode).toBe(304);
     expect(setHeader).toHaveBeenCalledWith("ETag", etag);
+    expect(setHeader).toHaveBeenCalledWith("Last-Modified", LAST_MODIFIED);
     expect(setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
   });
 
@@ -131,7 +189,7 @@ describe("resolveByteResponse", () => {
           ifRangeHeader: '"stale"',
           ifNoneMatchHeader: etag,
         }),
-      ).toEqual({ kind: "not-modified", statusCode: 304, etag });
+      ).toEqual({ kind: "not-modified", statusCode: 304, etag, lastModified: LAST_MODIFIED });
     },
   );
 
@@ -148,6 +206,24 @@ describe("resolveByteResponse", () => {
       }),
     ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
   });
+
+  it.each([
+    { label: "full", rangeHeader: undefined, statusCode: 200 },
+    { label: "partial", rangeHeader: "bytes=1-2", statusCode: 206 },
+    { label: "unsatisfiable", rangeHeader: "bytes=10-11", statusCode: 416 },
+  ])(
+    "emits the same Last-Modified validator on $label responses",
+    ({ rangeHeader, statusCode }) => {
+      const plan = resolveByteResponse({ file: FILE, method: "GET", rangeHeader });
+      const setHeader = vi.fn();
+      const res = { statusCode: 0, setHeader } as unknown as ServerResponse;
+
+      writeByteHeaders(res, plan);
+
+      expect(res.statusCode).toBe(statusCode);
+      expect(setHeader).toHaveBeenCalledWith("Last-Modified", LAST_MODIFIED);
+    },
+  );
 });
 
 describe("byte ETag generation", () => {

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -84,13 +84,16 @@ function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "u
 
 export function resolveByteResponse(params: {
   file: FileIdentity;
+  nowMs?: number;
   method?: string;
   rangeHeader?: string | string[];
   ifRangeHeader?: string | string[];
   ifNoneMatchHeader?: string | string[];
 }): ByteResponsePlan {
   const etag = createByteEtag(params.file);
-  const lastModified = new Date(params.file.mtimeMs).toUTCString();
+  const originatedAtMs = params.nowMs ?? Date.now();
+  // Filesystem clocks may lead this host; validators cannot postdate message origination.
+  const lastModified = new Date(Math.min(params.file.mtimeMs, originatedAtMs)).toUTCString();
   if (
     (params.method === "GET" || params.method === "HEAD") &&
     matchesHttpIfNoneMatch(params.ifNoneMatchHeader, etag)

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -13,18 +13,19 @@ type ByteSlice = {
   end: number;
 };
 
-type ByteResponsePlan =
+type ByteResponsePlan = {
+  etag: string;
+  lastModified: string;
+} & (
   | {
       kind: "full";
       statusCode: 200;
       contentLength: number;
-      etag: string;
     }
   | {
       kind: "partial";
       statusCode: 206;
       contentLength: number;
-      etag: string;
       range: ByteSlice;
       size: number;
     }
@@ -32,14 +33,13 @@ type ByteResponsePlan =
       kind: "unsatisfiable";
       statusCode: 416;
       contentLength: 0;
-      etag: string;
       size: number;
     }
   | {
       kind: "not-modified";
       statusCode: 304;
-      etag: string;
-    };
+    }
+);
 
 function createByteEtag(file: FileIdentity): string {
   // Gateway media files are write-once, so size + mtimeMs uniquely version their bytes here.
@@ -90,23 +90,30 @@ export function resolveByteResponse(params: {
   ifNoneMatchHeader?: string | string[];
 }): ByteResponsePlan {
   const etag = createByteEtag(params.file);
+  const lastModified = new Date(params.file.mtimeMs).toUTCString();
   if (
     (params.method === "GET" || params.method === "HEAD") &&
     matchesHttpIfNoneMatch(params.ifNoneMatchHeader, etag)
   ) {
     // RFC 9110 evaluates representation validators before Range or If-Range.
-    return { kind: "not-modified", statusCode: 304, etag };
+    return { kind: "not-modified", statusCode: 304, etag, lastModified };
   }
   const full = {
     kind: "full",
     statusCode: 200,
     contentLength: params.file.size,
     etag,
+    lastModified,
   } as const;
   if (params.method !== "GET" || typeof params.rangeHeader !== "string") {
     return full;
   }
-  if (params.ifRangeHeader !== undefined && params.ifRangeHeader !== etag) {
+  if (
+    params.ifRangeHeader !== undefined &&
+    params.ifRangeHeader !== etag &&
+    // If-Range must exactly match the emitted HTTP-date; parsing accepts invalid lookalikes.
+    params.ifRangeHeader !== lastModified
+  ) {
     return full;
   }
 
@@ -120,6 +127,7 @@ export function resolveByteResponse(params: {
       statusCode: 416,
       contentLength: 0,
       etag,
+      lastModified,
       size: params.file.size,
     };
   }
@@ -128,6 +136,7 @@ export function resolveByteResponse(params: {
     statusCode: 206,
     contentLength: range.end - range.start + 1,
     etag,
+    lastModified,
     range,
     size: params.file.size,
   };
@@ -137,6 +146,7 @@ export function writeByteHeaders(res: ServerResponse, plan: ByteResponsePlan): v
   res.statusCode = plan.statusCode;
   res.setHeader("Accept-Ranges", "bytes");
   res.setHeader("ETag", plan.etag);
+  res.setHeader("Last-Modified", plan.lastModified);
   if (plan.kind === "not-modified") {
     return;
   }

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -450,6 +450,56 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(future.result.body.toString("utf8")).toBe("original-image");
   });
 
+  it("bounds future managed-media validators to the actual HTTP response date", async () => {
+    const nowMs = Math.floor(Date.now() / 1000) * 1000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    try {
+      const { attachmentId, sessionKey, originalPath } = await createFixture(stateDir);
+      const future = new Date(nowMs + 60_000);
+      await fs.utimes(originalPath, future, future);
+      const futureLastModified = (await fs.stat(originalPath)).mtime.toUTCString();
+      const expectedLastModified = new Date(nowMs).toUTCString();
+      const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+      const request = { stateDir, pathName, authResponse: { authMethod: "token" } };
+
+      const initial = await requestManagedImage({ ...request, method: "HEAD" });
+      expect(initial.result.statusCode).toBe(200);
+      expect(initial.result.headers["last-modified"]).toBe(expectedLastModified);
+      expect(Date.parse(initial.result.headers.date ?? "")).toBeGreaterThanOrEqual(
+        Date.parse(expectedLastModified),
+      );
+
+      const partial = await requestManagedImage({
+        ...request,
+        headers: { range: "bytes=0-4", "if-range": expectedLastModified },
+      });
+      expect(partial.result.statusCode).toBe(206);
+      expect(partial.result.headers["last-modified"]).toBe(expectedLastModified);
+
+      const stale = await requestManagedImage({
+        ...request,
+        headers: { range: "bytes=0-4", "if-range": futureLastModified },
+      });
+      expect(stale.result.statusCode).toBe(200);
+
+      const unchanged = await requestManagedImage({
+        ...request,
+        headers: { "if-none-match": String(initial.result.headers.etag) },
+      });
+      expect(unchanged.result.statusCode).toBe(304);
+      expect(unchanged.result.headers["last-modified"]).toBe(expectedLastModified);
+
+      const unsatisfiable = await requestManagedImage({
+        ...request,
+        headers: { range: "bytes=999-" },
+      });
+      expect(unsatisfiable.result.statusCode).toBe(416);
+      expect(unsatisfiable.result.headers["last-modified"]).toBe(expectedLastModified);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it.each(["GET", "HEAD"])(
     "revalidates managed media ETags before ranges for %s",
     async (method) => {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -417,6 +417,39 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.body.toString("utf8")).toBe("image");
   });
 
+  it("resumes managed media only for an exact If-Range HTTP-date", async () => {
+    const { attachmentId, sessionKey, originalPath } = await createFixture(stateDir);
+    const modified = new Date("2025-07-08T18:40:00.789Z");
+    await fs.utimes(originalPath, modified, modified);
+    const lastModified = (await fs.stat(originalPath)).mtime.toUTCString();
+    const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+    const request = { stateDir, pathName, authResponse: { authMethod: "token" } };
+
+    const initial = await requestManagedImage({ ...request, method: "HEAD" });
+    expect(initial.result.statusCode).toBe(200);
+    expect(initial.result.headers["last-modified"]).toBe(lastModified);
+    expect(initial.result.body).toHaveLength(0);
+
+    const partial = await requestManagedImage({
+      ...request,
+      headers: { range: "bytes=9-13", "if-range": lastModified },
+    });
+    expect(partial.result.statusCode).toBe(206);
+    expect(partial.result.headers["last-modified"]).toBe(lastModified);
+    expect(partial.result.body.toString("utf8")).toBe("image");
+
+    const future = await requestManagedImage({
+      ...request,
+      headers: {
+        range: "bytes=9-13",
+        "if-range": new Date(Date.parse(lastModified) + 1000).toUTCString(),
+      },
+    });
+    expect(future.result.statusCode).toBe(200);
+    expect(future.result.headers["last-modified"]).toBe(lastModified);
+    expect(future.result.body.toString("utf8")).toBe("original-image");
+  });
+
   it.each(["GET", "HEAD"])(
     "revalidates managed media ETags before ranges for %s",
     async (method) => {


### PR DESCRIPTION
## What Problem This Solves

Gateway assistant-media and managed outgoing-media routes advertised byte ranges and entity tags, but silently rejected every valid HTTP-date `If-Range` validator. Neither route emitted `Last-Modified`, so clients resuming media from a date validator always downloaded the complete representation instead of the requested range.

## Why This Change Was Made

Both routes already share a canonical byte-response planner and header owner. This change groups the shared representation validators once, captures the response-origination clock exactly once, bounds filesystem timestamps to that origin at HTTP's whole-second precision, evaluates HTTP-date validators by exact equality, and emits the same `Last-Modified` validator on full, partial, unsatisfiable, not-modified, and `HEAD` responses.

[RFC 9110 §13.1.5](https://www.rfc-editor.org/rfc/rfc9110.html#name-if-range) explicitly requires **exact** date equality. The installed `send@1.2.1` dependency uses a legacy earlier-than-or-equal comparison; copying that behavior would incorrectly accept future dates, so this implementation intentionally follows the authoritative current protocol.

## User Impact

- Assistant-media and managed-media clients can safely resume using the representation's `Last-Modified` HTTP-date.
- Fractional filesystem modification timestamps compare correctly at HTTP's whole-second precision.
- Exact emitted HTTP-date or strong ETag validators produce `206 Partial Content`; earlier dates, future dates, malformed dates, same-second ISO/UTC/lowercase lookalikes, weak ETags, and repeated validators fall back to the complete `200` response.
- `If-None-Match` keeps precedence; `304`, `416`, full/partial responses, and `HEAD` expose consistent representation validators without introducing a `304` body length.
- Files whose filesystem clocks are ahead of the Gateway never emit a `Last-Modified` later than the actual HTTP response `Date`; resume validation uses the emitted bounded date, while strong ETags continue to identify the unchanged raw file.
- No authentication, security, public protocol schema, configuration, SDK, or persistent-state behavior changes.

## Evidence

### Regression-first refreshed parent

Exact independent parent: `e4568f6bdddfc38d0f8dfe8cd22bde155adac5dd`.

New owner and sibling regressions failed authentically on the parent: **three test files, six failures** covering exact fractional-second HTTP dates, both assistant and managed routes, and missing `Last-Modified` on full, partial, and unsatisfiable responses.

Real loopback TCP through the actual assistant-media handler, with filesystem modification time `1752000000789`:

```json
{"kind":"exact-http-date","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":null,"expected":206}
{"kind":"strong-etag","status":206,"body":"jklmnop","lastModified":null,"expected":206}
{"actualModified":1752000000789,"lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","fractionalMs":789}
```

### Exact immutable candidate

Candidate: `3ace181a0dbe6b5bace4de27280ae8def2f8fb18` (fast-forward correction of previously reviewed `47c8b51e77e445bcfa36238aab74d5bce7f4a014`).

Real loopback TCP through the same production route:

```json
{"kind":"exact-http-date","status":206,"body":"jklmnop","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":206}
{"kind":"older-http-date","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":200}
{"kind":"future-http-date","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":200}
{"kind":"same-second-iso","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":200}
{"kind":"same-second-utc","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":200}
{"kind":"strong-etag","status":206,"body":"jklmnop","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":206}
{"kind":"weak-etag","status":200,"body":"abcdefghijklmnopqrstuvwxyz","lastModified":"Tue, 08 Jul 2025 18:40:00 GMT","expected":200}
```

- Exact candidate complete canonical-owner and both sibling suites: `node scripts/run-vitest.mjs src/gateway/http-byte-range.test.ts src/gateway/control-ui.http.test.ts src/gateway/managed-image-attachments.test.ts` — **228 passed, 0 failed**. Managed sibling regressions exercise an actual HTTP/TCP server and verify the actual emitted HTTP `Date`.
- Exact candidate genuine type-aware focused `node scripts/run-oxlint.mjs ... --tsconfig config/tsconfig/oxlint.core.json`, targeted `oxfmt --check`, and `git diff --check`: all passed.
- Production touches only the shared owner: **+21/-8, net +13**. This adds the genuinely missing representation validator, bounds future filesystem timestamps once at message origination, emits it consistently, and implements standards-correct date matching without route-specific branches, permissive generic date parsing, extra dependencies, or compatibility shims.
- Existing dependency contract inspected directly: `node_modules/send/index.js:344-359`, `:751-761`, and `:934-940`; authoritative RFC exact-date equality takes precedence over that dependency's stale comparison.
- A genuine strict whole-branch autoreview caught and blocked an earlier permissive `Date.parse` implementation as **P2**. Three new regression-first cases reproduced the defect on that rejected SHA; the final candidate removes parsing altogether and compares the exact emitted canonical validator.
- A separate strict final-immutable reviewer independently reran all **228 owner/sibling tests**, inspected RFC 9110 and both production callers, and confirmed the raw file ETag never changes when its emitted timestamp is bounded: **zero P0/P1/P2/P3 findings**, confidence **0.99**.
- A second independent reviewer exercised **14 real bearer-authenticated TCP groups across both production routes**. Managed media used a real isolated canonical SQLite session, transcript, and record; exact date/strong ETag, malformed same-second validators, future/stale/weak/duplicate validators, `HEAD`, GET/HEAD `304`, and `416` all passed: **zero P0/P1/P2/P3 findings**, confidence **0.99**.

### ClawSweeper rank-up moves resolved: future filesystem timestamps

ClawSweeper correctly found that previously published head `47c8b51e77e445bcfa36238aab74d5bce7f4a014` copied a future filesystem timestamp directly into `Last-Modified`. [RFC 9110 §8.8.2.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2.1) requires replacing implementation-derived future timestamps with the response message-origination date.

- **Clamp future file timestamps (P2): resolved.** Regression-first proof against exact prior head produced **10 failing assertions** across the shared planner, assistant-media route, and real managed-media HTTP route. The canonical planner now captures the response-origin clock once and emits `min(file.mtimeMs, originMs)` for every response shape; the ETag still hashes the unmodified descriptor identity.
- **Resolve merge risk (P1): resolved.** Independent bearer-authenticated loopback TCP through **both actual production routes**, backed by a real isolated canonical SQLite session/transcript/managed record, passed **109 assertions** on immutable `3ace181a0dbe6b5bace4de27280ae8def2f8fb18`. `HEAD`, full `200`, partial `206`, GET/HEAD `304`, and `416` all satisfy `Last-Modified <= Date`; the previous raw future date changes from incorrect `206` to correct `200`, the exact emitted bounded date remains `206`, strong ETags stay identical, and unauthorized requests remain `401`.
- **Complete the shared-owner mechanical repair (P2): resolved.** Only `src/gateway/http-byte-range.ts` changes in production; both existing callers inherit the correction without route duplication, new configuration, changed protocol, or changed authentication.

```json
{"previousHead":"47c8b51e77e445bcfa36238aab74d5bce7f4a014","candidate":"3ace181a0dbe6b5bace4de27280ae8def2f8fb18","assertionsPassed":109,"assistant":{"previousLastModified":"Tue, 08 Jul 2036 18:40:00 GMT","date":"Fri, 31 Jul 2026 22:15:06 GMT","lastModified":"Fri, 31 Jul 2026 22:15:06 GMT","exactEmittedDate":206,"rawFutureDateBefore":206,"rawFutureDateAfter":200,"notModified":304,"unsatisfiable":416,"unauthorized":401},"managed":{"previousLastModified":"Tue, 08 Jul 2036 18:40:00 GMT","date":"Fri, 31 Jul 2026 22:15:06 GMT","lastModified":"Fri, 31 Jul 2026 22:15:06 GMT","exactEmittedDate":206,"rawFutureDateBefore":206,"rawFutureDateAfter":200,"notModified":304,"unsatisfiable":416,"unauthorized":401}}
```

- Fresh genuine whole-branch `autoreview --mode branch --base e4568f6bdddfc38d0f8dfe8cd22bde155adac5dd --max-priority P3` on corrected immutable `3ace181a0dbe6b5bace4de27280ae8def2f8fb18`: **zero P0/P1/P2/P3 findings**, TruffleHog clean, verdict **patch is correct**, confidence **0.98**.
