### PR TITLE
fix(slack): recover identity after transient startup auth failure

### DIFF
--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -234,7 +234,7 @@ describe("slack web client config", () => {
     expect(WebClient).toHaveBeenCalledWith("xoxb-startup", {
       fetch: customFetch,
       rejectRateLimitedCalls: true,
-      retryConfig: { retries: 0 },
+      retryConfig: { retries: 1, minTimeout: 0 },
       slackApiUrl: "https://slack.test/api/",
       timeout: 10_000,
     });

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -234,7 +234,7 @@ describe("slack web client config", () => {
     expect(WebClient).toHaveBeenCalledWith("xoxb-startup", {
       fetch: customFetch,
       rejectRateLimitedCalls: true,
-      retryConfig: { retries: 1, minTimeout: 0 },
+      retryConfig: { retries: 2, minTimeout: 0 },
       slackApiUrl: "https://slack.test/api/",
       timeout: 10_000,
     });

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -37,12 +37,12 @@ export function createSlackReadClient(token: string, options: WebClientOptions =
 }
 
 export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {
-  // Startup identity stays degraded until restart after auth.test fails. Retry one transient
-  // transport failure before committing that state, without delaying on Slack rate limits.
+  // Startup identity stays degraded until restart after auth.test fails. Retry two transient
+  // transport failures before committing that state, without delaying on Slack rate limits.
   return createSlackWebClient(token, {
     ...options,
     rejectRateLimitedCalls: true,
-    retryConfig: { retries: 1, minTimeout: 0 },
+    retryConfig: { retries: 2, minTimeout: 0 },
     timeout: 10_000,
   });
 }

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -37,12 +37,12 @@ export function createSlackReadClient(token: string, options: WebClientOptions =
 }
 
 export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {
-  // Startup degrades after auth.test fails, so terminate this one-shot request without
-  // imposing the same short deadline on Bolt's long-lived client.
+  // Startup identity stays degraded until restart after auth.test fails. Retry one transient
+  // transport failure before committing that state, without delaying on Slack rate limits.
   return createSlackWebClient(token, {
     ...options,
     rejectRateLimitedCalls: true,
-    retryConfig: { retries: 0 },
+    retryConfig: { retries: 1, minTimeout: 0 },
     timeout: 10_000,
   });
 }

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -2,10 +2,11 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { WebClient } from "@slack/web-api";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createSlackLookupClient,
   createSlackReadClient,
+  createSlackStartupAuthClient,
   createSlackWebClient,
   getSlackListenerUploadCompletionClient,
 } from "./client.js";
@@ -187,6 +188,41 @@ afterEach(() => {
 });
 
 describe("Slack Web API routing", () => {
+  it("retries one transient startup auth failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("request timed out"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, team_id: "TMOCK", user_id: "UMOCK" }), {
+          status: 200,
+        }),
+      );
+    const client = createSlackStartupAuthClient("startup-fixture", {
+      fetch: fetchMock as never,
+    });
+
+    await expect(client.auth.test()).resolves.toMatchObject({
+      ok: true,
+      team_id: "TMOCK",
+      user_id: "UMOCK",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a permanent startup auth error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: "invalid_auth" }), {
+        status: 200,
+      }),
+    );
+    const client = createSlackStartupAuthClient("invalid-fixture", {
+      fetch: fetchMock as never,
+    });
+
+    await expect(client.auth.test()).rejects.toThrow("invalid_auth");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts a stalled-header lookup after one request", async () => {
     for (const key of TEST_ENV_KEYS) {
       delete process.env[key];

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -188,10 +188,11 @@ afterEach(() => {
 });
 
 describe("Slack Web API routing", () => {
-  it("retries one transient startup auth failure", async () => {
+  it("retries two transient startup auth failures", async () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error("request timed out"))
+      .mockRejectedValueOnce(new Error("connection reset"))
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ ok: true, team_id: "TMOCK", user_id: "UMOCK" }), {
           status: 200,
@@ -206,7 +207,7 @@ describe("Slack Web API routing", () => {
       team_id: "TMOCK",
       user_id: "UMOCK",
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry a permanent startup auth error", async () => {

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -271,10 +271,10 @@ describe("auth.test boot call", () => {
       runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
     });
     try {
-      await vi.waitFor(() => expect(appStartMock).toHaveBeenCalledTimes(1), { timeout: 12_000 });
+      await vi.waitFor(() => expect(appStartMock).toHaveBeenCalledTimes(1), { timeout: 35_000 });
       await vi.waitFor(() => expect(events).toContain("socket-closed"), { timeout: 1_000 });
 
-      expect(server.requestCount).toBe(1);
+      expect(server.requestCount).toBe(3);
       expect(server.requestUrl).toBe("/api/auth.test");
       expect(events).toContain("auth-settled");
       expect(events.indexOf("auth-settled")).toBeLessThan(events.indexOf("app-start"));
@@ -286,7 +286,7 @@ describe("auth.test boot call", () => {
       await monitor.run;
       await server.close();
     }
-  }, 20_000);
+  }, 40_000);
 
   it("preserves workspace startup when auth.test omits app_id", async () => {
     getSlackClient().auth.test.mockResolvedValueOnce({


### PR DESCRIPTION
## What Problem This Solves

Slack can establish its channel transport while its startup `auth.test` request fails. The Gateway then records degraded Slack identity for the lifetime of the process because the check is not retried. Without the authenticated bot user ID, channels that require an explicit mention fail closed: real `@bot` mentions are not recognized or handled correctly until the Gateway is restarted.

## Why This Change Was Made

Gateway startup can overlap Slack identity initialization with agent/plugin prewarm. Plugin prewarm performs synchronous plugin-registry loading on the Node.js main event loop, which can delay Slack Web API I/O and timers long enough for `auth.test` to hit a transient timeout.

The startup-only Slack Web API client now makes up to two immediate retries for transient transport or HTTP failures before committing to degraded identity. Each attempt retains the existing 10-second timeout. Rate-limit retries remain disabled, and permanent Slack API errors such as `invalid_auth` still fail after one request. A persistent outage can therefore extend this startup phase from 10 seconds to at most 30 seconds before the existing degraded-mode fallback.

## User Impact

After transient resource pressure during startup, Slack has additional chances to authenticate and publish the bot identity required for mention detection. Explicit `@bot` mentions continue to work instead of being ignored until restart. Persistent network failures still produce bounded degraded startup, while invalid or revoked credentials do not trigger redundant retries.

## Evidence

- `node_modules/.bin/oxfmt --check extensions/slack/src/client.ts extensions/slack/src/client.test.ts extensions/slack/src/client.web-api.test.ts` passed.
- `node scripts/run-vitest.mjs extensions/slack/src/client.test.ts extensions/slack/src/client.web-api.test.ts` passed: 42 tests.
- SDK-boundary coverage proves two transient request failures recover on the third total attempt, while a permanent `invalid_auth` response is attempted only once.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/provider.auth-test-token.test.ts -t 'settles and closes a real stalled startup auth request before degraded startup'` passed. The real stalled-HTTP-server test now verifies all three requests settle and close before degraded startup proceeds.
- A live staging startup under actual plugin/catalog warmup pressure reached normal Slack Socket Mode with no degraded-identity log or restart. A direct `auth.test` returned HTTP 200 with `ok: true`, and a fresh required `@bot` mention reached the Slack handler. The live run exercised startup contention but did not force the first request to fail; retry recovery is covered by the SDK-boundary test above.
- AI-assisted: yes. The retry policy, dependency behavior, failure handling, and live startup evidence were manually reviewed.
