### PR TITLE
fix(terminal): keep Unicode cron columns aligned

### DIFF
--- a/packages/terminal-core/package.json
+++ b/packages/terminal-core/package.json
@@ -103,6 +103,7 @@
   "dependencies": {
     "@clack/prompts": "1.7.0",
     "@openclaw/normalization-core": "workspace:*",
-    "chalk": "6.0.0"
+    "chalk": "6.0.0",
+    "string-width": "8.2.2"
   }
 }

--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -193,6 +193,59 @@ describe("terminal ansi helpers", () => {
     expect(visibleWidth("a\u001B[31\u0001mb")).toBe(2);
   });
 
+  it.each([
+    ["halfwidth voiced kana", "ﾊﾞ", 2],
+    ["halfwidth semi-voiced kana", "ﾊﾟ", 2],
+    ["halfwidth kana with a prolonged sound", "ｳﾞｰ", 3],
+    ["zero-width space", "\u200B", 0],
+    ["zero-width non-joiner", "\u200C", 0],
+    ["word joiner", "\u2060", 0],
+    ["function application", "\u2061", 0],
+    ["soft hyphen", "\u00AD", 0],
+    ["zero-width no-break space", "\uFEFF", 0],
+    ["Hindi spacing mark", "का", 2],
+    ["repeated leading Hangul jamo", "ᄀᄀ", 4],
+    ["repeated Hangul jamo with a vowel", "ᄀ가", 4],
+    ["Hangul leading filler", "\u115F", 2],
+    ["Hangul vowel filler", "\u1160", 0],
+    ["Hangul compatibility filler", "\u3164", 2],
+    ["halfwidth Hangul filler", "\uFFA0", 1],
+    ["Hangul filler with a vowel", "\u115F\u1161", 2],
+    ["Hangul leading and vowel fillers", "\u115F\u1160", 2],
+    ["Hangul compatibility filler with a combining mark", "\u3164\u0301", 2],
+    ["halfwidth Hangul filler with a voiced mark", "\uFFA0\uFF9E", 2],
+    ["lone high surrogate", "\uD800", 1],
+    ["lone low surrogate", "\uDC00", 1],
+    ["well-formed emoji surrogate pair", "\uD83D\uDE00", 2],
+  ])("measures %s with Unicode terminal-width rules", (_label, text, width) => {
+    expect(visibleWidth(text)).toBe(width);
+  });
+
+  it("measures malformed UTF-16 by Node's rendered replacement cells", () => {
+    for (const input of ["\uD800", "\uDC00", "表\uD800\t", "\u001B[31m\uDC00\u001B[0m"]) {
+      const rendered = Buffer.from(input, "utf8").toString("utf8");
+      expect(visibleWidth(input)).toBe(visibleWidth(rendered));
+    }
+  });
+
+  it("preserves the executed width of tabs", () => {
+    expect(visibleWidth("\t")).toBe(1);
+    expect(visibleWidth("a\tb")).toBe(3);
+    expect(visibleWidth("a\u001B[31\tmb")).toBe(3);
+    expect(visibleWidth("a\u009B31\tmb")).toBe(3);
+  });
+
+  it("keeps malformed ANSI ownership with OpenClaw's canonical scanner", () => {
+    expect(visibleWidth("\u001B")).toBe(0);
+    expect(visibleWidth("\u009B")).toBe(0);
+    expect(visibleWidth("\u009D")).toBe(0);
+    expect(visibleWidth("\u001B[")).toBe(0);
+    expect(visibleWidth("\u001B]visible")).toBe("]visible".length);
+    expect(visibleWidth("\u009Dvisible")).toBe("visible".length);
+    // Removing CSI must not let another ANSI grammar reinterpret joined bytes as OSC.
+    expect(visibleWidth("\u001B\u001B[0m]visible\u0007after")).toBe("]visibleafter".length);
+  });
+
   it("keeps emoji zwj sequences as single graphemes", () => {
     expect(splitGraphemes("👨‍👩‍👧‍👦")).toEqual(["👨‍👩‍👧‍👦"]);
     expect(visibleWidth("👨‍👩‍👧‍👦")).toBe(2);
@@ -229,7 +282,30 @@ describe("terminal ansi helpers", () => {
     // never emitted half-width, so the result never exceeds the budget.
     expect(truncateToVisibleWidth("表文", 2)).toBe("表");
     expect(truncateToVisibleWidth("表", 1)).toBe("");
+    expect(truncateToVisibleWidth("ﾊﾞ", 1)).toBe("");
+    expect(truncateToVisibleWidth("ﾊﾞ", 2)).toBe("ﾊﾞ");
+    expect(truncateToVisibleWidth("का", 1)).toBe("");
+    expect(truncateToVisibleWidth("ᄀᄀ", 3)).toBe("");
+    expect(truncateToVisibleWidth("👨‍👩‍👧‍👦", 1)).toBe("");
+    expect(truncateToVisibleWidth("🇬🇧", 1)).toBe("");
+    expect(truncateToVisibleWidth("\u200B表", 1)).toBe("\u200B");
+    expect(truncateToVisibleWidth("a\tb", 2)).toBe("a\t");
+    expect(truncateToVisibleWidth("\u115F\u1161", 1)).toBe("");
+    expect(truncateToVisibleWidth("\u3164".repeat(30), 1)).toBe("");
+    expect(truncateToVisibleWidth("\u3164".repeat(30), 2)).toBe("\u3164");
+    expect(truncateToVisibleWidth("\uFFA0\uFF9E", 1)).toBe("");
+    expect(truncateToVisibleWidth("\uD800".repeat(30), 5)).toBe("\uD800".repeat(5));
+    expect(truncateToVisibleWidth("表\uDC00\t", 3)).toBe("表\uDC00");
     expect(visibleWidth(truncateToVisibleWidth("📸📸", 1))).toBeLessThanOrEqual(1);
+  });
+
+  it("keeps complete graphemes and zero-width prefixes at either truncation edge", () => {
+    expect(truncateToVisibleWidth("abcd", 3)).toBe("abc");
+    expect(truncateToVisibleWidth("表文字", 5)).toBe("表文");
+    expect(truncateToVisibleWidth("👨‍👩‍👧‍👦📸", 3)).toBe("👨‍👩‍👧‍👦");
+    expect(truncateToVisibleWidth("a\u200Bb", 1)).toBe("a\u200B");
+    expect(truncateToVisibleWidth("abc\u200B", 2)).toBe("ab");
+    expect(truncateToVisibleWidth("\u200Babc", 2)).toBe("\u200Bab");
   });
 
   it("preserves ANSI sequences when truncating styled text", () => {

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -1,3 +1,4 @@
+import stringWidth from "string-width";
 import {
   ANSI_COMPAT_CONTROL_SEQUENCE_PATTERN,
   ANSI_OSC_INTRODUCER_PATTERN,
@@ -179,102 +180,27 @@ export function sanitizeForLog(v: string): string {
   return stripAnsi(v).replace(controlCharsRegex, "");
 }
 
-function isZeroWidthCodePoint(codePoint: number): boolean {
-  return (
-    (codePoint <= 0x1f && codePoint !== 0x09) ||
-    (codePoint >= 0x7f && codePoint <= 0x9f) ||
-    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
-    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
-    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
-    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
-    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
-    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
-    codePoint === 0x200d
-  );
-}
-
-function isFullWidthCodePoint(codePoint: number): boolean {
-  if (codePoint < 0x1100) {
-    return false;
+function textWidth(text: string): number {
+  // POSIX renders these default-ignorable Hangul fillers as wide/halfwidth cells;
+  // same-shaping representatives and well-formed surrogates preserve terminal output.
+  const printable = /[\u115F\u3164\uFFA0\uD800-\uDFFF]/u.test(text)
+    ? text
+        .replace(/[\uD800-\uDFFF]/gu, "\uFFFD")
+        .replaceAll("\u115F", "\u1100")
+        .replaceAll("\u3164", "\u3131")
+        .replaceAll("\uFFA0", "\uFF8A")
+    : text;
+  // OpenClaw owns ANSI parsing; upstream must not reinterpret malformed sequences.
+  let width = stringWidth(printable, { countAnsiEscapeCodes: true });
+  // Tabs execute inside CSI too; string-width intentionally treats them as zero-width.
+  for (let index = text.indexOf("\t"); index !== -1; index = text.indexOf("\t", index + 1)) {
+    width += 1;
   }
-  return (
-    codePoint <= 0x115f ||
-    codePoint === 0x2329 ||
-    codePoint === 0x232a ||
-    (codePoint >= 0x2e80 && codePoint <= 0x3247 && codePoint !== 0x303f) ||
-    (codePoint >= 0x3250 && codePoint <= 0x4dbf) ||
-    (codePoint >= 0x4e00 && codePoint <= 0xa4c6) ||
-    (codePoint >= 0xa960 && codePoint <= 0xa97c) ||
-    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
-    (codePoint >= 0xfe30 && codePoint <= 0xfe6b) ||
-    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
-    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
-    (codePoint >= 0x1aff0 && codePoint <= 0x1aff3) ||
-    (codePoint >= 0x1aff5 && codePoint <= 0x1affb) ||
-    (codePoint >= 0x1affd && codePoint <= 0x1affe) ||
-    (codePoint >= 0x1b000 && codePoint <= 0x1b2ff) ||
-    (codePoint >= 0x1f200 && codePoint <= 0x1f251) ||
-    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
-  );
-}
-
-const rgiEmojiPattern = new RegExp("^\\p{RGI_Emoji}$", "v");
-const emojiPresentationPattern = /\p{Emoji_Presentation}/u;
-const regionalIndicatorPattern = /\p{Regional_Indicator}/u;
-const unqualifiedKeycapPattern = /^[#*0-9]\u20E3$/u;
-const extendedPictographicPattern = /\p{Extended_Pictographic}/gu;
-
-function isWideEmojiGrapheme(grapheme: string): boolean {
-  const isRgiEmoji = rgiEmojiPattern.test(grapheme);
-  // RGI recognizes paired flags while keeping a lone regional indicator narrow.
-  if (regionalIndicatorPattern.test(grapheme)) {
-    return isRgiEmoji;
-  }
-  if (
-    emojiPresentationPattern.test(grapheme) ||
-    isRgiEmoji ||
-    unqualifiedKeycapPattern.test(grapheme)
-  ) {
-    return true;
-  }
-  // Minimally qualified ZWJ sequences still shape as one wide emoji in terminals.
-  return (
-    grapheme.includes("\u200D") && (grapheme.match(extendedPictographicPattern)?.length ?? 0) >= 2
-  );
-}
-
-function graphemeWidth(grapheme: string): number {
-  if (!grapheme) {
-    return 0;
-  }
-  if (isWideEmojiGrapheme(grapheme)) {
-    return 2;
-  }
-
-  let sawPrintable = false;
-  for (const char of grapheme) {
-    const codePoint = char.codePointAt(0);
-    if (codePoint == null) {
-      continue;
-    }
-    if (isZeroWidthCodePoint(codePoint)) {
-      continue;
-    }
-    if (isFullWidthCodePoint(codePoint)) {
-      return 2;
-    }
-    sawPrintable = true;
-  }
-  return sawPrintable ? 1 : 0;
+  return width;
 }
 
 export function visibleWidth(input: string): number {
-  return splitGraphemes(stripAnsi(input)).reduce(
-    (sum, grapheme) => sum + graphemeWidth(grapheme),
-    0,
-  );
+  return textWidth(stripAnsi(input));
 }
 
 /**
@@ -288,7 +214,9 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
   if (maxWidth <= 0) {
     return "";
   }
-  if (visibleWidth(input) <= maxWidth) {
+  const plainInput = stripAnsi(input);
+  const inputWidth = textWidth(plainInput);
+  if (inputWidth <= maxWidth) {
     return input;
   }
   let out = "";
@@ -301,20 +229,89 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
     if (budgetSpent) {
       return;
     }
-    for (const grapheme of splitGraphemes(segment)) {
-      const width = graphemeWidth(grapheme);
-      if (used + width > maxWidth) {
-        budgetSpent = true;
-        return;
-      }
-      out += grapheme;
+    const remaining = maxWidth - used;
+    const width = segment === plainInput ? inputWidth : textWidth(segment);
+    if (width <= remaining) {
+      out += segment;
       used += width;
+      return;
     }
+
+    const graphemes = splitGraphemes(segment);
+    let offset = 0;
+    const offsets = [offset];
+    for (const grapheme of graphemes) {
+      offset += grapheme.length;
+      offsets.push(offset);
+    }
+    let start = 0;
+    let fittedWidth = 0;
+    if (remaining <= width / 2) {
+      let end = Math.max(
+        1,
+        Math.min(graphemes.length - 1, Math.floor((remaining * graphemes.length) / width)),
+      );
+      let stride = 1;
+      // Estimate the cell boundary first; gallop handles uneven/zero-width clusters.
+      while (end < graphemes.length) {
+        const candidateWidth = textWidth(segment.slice(0, offsets[end]));
+        if (candidateWidth > remaining) {
+          break;
+        }
+        start = end;
+        fittedWidth = candidateWidth;
+        end = Math.min(graphemes.length, end + stride);
+        stride *= 2;
+      }
+      while (start + 1 < end) {
+        const middle = Math.floor((start + end) / 2);
+        const candidateWidth = textWidth(segment.slice(0, offsets[middle]));
+        if (candidateWidth <= remaining) {
+          start = middle;
+          fittedWidth = candidateWidth;
+        } else {
+          end = middle;
+        }
+      }
+    } else {
+      const overflow = width - remaining;
+      let tooShort = 0;
+      let removed = Math.min(graphemes.length, 1);
+      let removedWidth = width;
+      // Near-end cuts search short complete-grapheme suffixes, not repeated full prefixes.
+      while (removed < graphemes.length) {
+        removedWidth = textWidth(segment.slice(offsets[graphemes.length - removed]));
+        if (removedWidth >= overflow) {
+          break;
+        }
+        tooShort = removed;
+        removed = Math.min(graphemes.length, removed * 2);
+      }
+      if (removed === graphemes.length) {
+        removedWidth = width;
+      }
+      while (tooShort + 1 < removed) {
+        const middle = Math.floor((tooShort + removed) / 2);
+        const candidateWidth = textWidth(segment.slice(offsets[graphemes.length - middle]));
+        if (candidateWidth >= overflow) {
+          removed = middle;
+          removedWidth = candidateWidth;
+        } else {
+          tooShort = middle;
+        }
+      }
+      start = graphemes.length - removed;
+      fittedWidth = width - removedWidth;
+    }
+    out += segment.slice(0, offsets[start]);
+    used += fittedWidth;
+    budgetSpent = true;
   };
   for (const segment of splitAnsiSegments(input)) {
     if (segment.kind === "ansi") {
-      const widthControls = segment.controls.filter((control) => graphemeWidth(control) > 0);
-      const controlWidth = widthControls.reduce((sum, control) => sum + graphemeWidth(control), 0);
+      // CSI retains only C0/DEL controls; TAB is the sole visible-width member.
+      const widthControls = segment.controls.filter((control) => control === "\t");
+      const controlWidth = widthControls.length;
       if (!budgetSpent && used + controlWidth <= maxWidth) {
         out += segment.value;
         used += controlWidth;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2328,6 +2328,9 @@ importers:
       chalk:
         specifier: 6.0.0
         version: 6.0.0
+      string-width:
+        specifier: 8.2.2
+        version: 8.2.2
 
   packages/tool-call-repair:
     dependencies:

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -129,6 +129,33 @@ describe("printCronList", () => {
     expect(output).not.toContain(injectedMarker);
   });
 
+  it.each([
+    ["halfwidth voiced kana", `${"x".repeat(23)}ﾊﾞ`, `${"x".repeat(21)}...`],
+    ["halfwidth semi-voiced kana", `${"x".repeat(23)}ﾊﾟ`, `${"x".repeat(21)}...`],
+    ["zero-width space", `${"x".repeat(23)}\u200B`, `${"x".repeat(23)}\u200B `],
+    ["word joiner", `${"x".repeat(23)}\u2060`, `${"x".repeat(23)}\u2060 `],
+    ["zero-width no-break space", `${"x".repeat(23)}\uFEFF`, `${"x".repeat(23)}\uFEFF `],
+    ["leading zero-width non-joiner", `\u200C${"x".repeat(23)}`, `\u200C${"x".repeat(23)} `],
+    ["Hindi spacing mark", `${"x".repeat(23)}का`, `${"x".repeat(21)}...`],
+    ["repeated Hangul jamo", `${"x".repeat(22)}ᄀ가`, `${"x".repeat(21)}...`],
+    ["Hangul leading filler", `${"x".repeat(23)}\u115F`, `${"x".repeat(21)}...`],
+    ["Hangul compatibility filler", `${"x".repeat(23)}\u3164`, `${"x".repeat(21)}...`],
+    ["halfwidth Hangul filler", `${"x".repeat(23)}\uFFA0`, `${"x".repeat(23)}\uFFA0`],
+    ["zero-width Hangul vowel filler", `${"x".repeat(23)}\u1160`, `${"x".repeat(23)}\u1160 `],
+    ["lone high surrogate", `${"x".repeat(23)}\uD800`, `${"x".repeat(23)}\uD800`],
+    ["lone low surrogate", `${"x".repeat(23)}\uDC00`, `${"x".repeat(23)}\uDC00`],
+  ])("aligns the %s name cell without relying on its width helper", (_label, name, expected) => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    printCronList([createBaseJob({ name })], runtime);
+
+    const [header = "", row = ""] = logs;
+    const nameColumn = header.indexOf("Name");
+    const scheduleColumn = row.indexOf("at ");
+    expect(nameColumn).toBeGreaterThan(-1);
+    expect(scheduleColumn).toBeGreaterThan(nameColumn);
+    expect(row.slice(nameColumn, scheduleColumn - 1)).toBe(expected);
+  });
+
   it("sanitizes and bounds named-session targets", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const injectedMarker = "cron-target-injection";


### PR DESCRIPTION
Refs #103896

## What Problem This Solves

Users listing automations can see the Schedule column drift or unbounded names when job labels contain voiced halfwidth kana, Hindi spacing marks, invisible controls, repeated Hangul Jamo, rendered Hangul fillers, or malformed UTF-16.

## Why This Change Was Made

Move Unicode display measurement to the existing pinned `string-width@8.2.2` dependency at its terminal-core owner. Preserve OpenClaw's existing ANSI/TAB scanner and grapheme-safe truncation while correcting the three POSIX-visible Hangul fillers and replacing only lone UTF-16 surrogate halves for measurement; valid astral emoji and the original rendered text remain intact.

`string-width@8.2.2` was already present in the frozen lock graph: this adds the existing exact version only to the terminal-core importer, with no new dependency nodes, tsconfig changes, public APIs, providers, or compatibility shims. Terminal production ownership shrinks by **3 lines**.

## User Impact

Automation names and every other terminal-table consumer now use consistent visible-cell widths, retain styling and whole graphemes, correctly render valid emoji, and keep columns aligned across zero-width controls, CJK, kana, Hangul filler edge cases, and malformed user input.

## Evidence

- Immutable affected owner: **16/69** terminal checks and **9/52** real cron-rendering checks fail.
- Independently rejected upstream-only intermediate: **11/69** owner checks and **5/52** cron checks fail on the visible Hangul fillers and lone surrogates.
- Corrected implementation: **69/69** terminal-owner tests and **52/52** cron-output tests pass.
- Real rebuilt, token-authenticated production Gateway: **19 actual `openclaw cron add` / `cron list` jobs**, including all three visible fillers, invisible vowel filler, composed forms, voiced kana, Hindi, Jamo, valid astral/ZWJ emoji, and both real UTF-8 replacement cases; every independently measured Schedule column is exactly **87**.
- Complete production build: **9/9** unified builds, regenerated terminal package JavaScript and declarations, full CLI/plugin artifacts, and Vite **2,983 modules / 1,338 assets**.
- **30,000** independent shipped-artifact Unicode/truncation oracle cases plus **11,168** additional independent reviewer-generated fuzz cases: **41,168 randomized cases, zero failures**.
- Full strict changed gate: **734.8 seconds**, all-project ES2023 TypeScript build, 90 package-lock checks, formatting/dead-code/boundary guards, and core, plugin, and scripts linters each with **0 warnings / 0 errors**.
- Focused ES2023 terminal-owner typecheck confirms no newer JavaScript library contract is needed.
- Independent baseline comparison: ASCII width **0.01x** / truncation **0.41x**; emoji width **1.00x**; rare filler truncation **1.73x**, bounded and isolated.
- Two fresh independent source/proof approvals and a separate high-effort read-only deep review found **no actionable regressions**.
- The signed local secret scanner is unavailable; the maintainer explicitly waived that local preflight for this change. Normal hosted secret-scanning/security checks and security-owner/CODEOWNERS requirements remain required; nothing is bypassed.

## Maintainer verification: actual shipped terminal and dependency contract

Verified the immutable PR head `6b59aeea19c8bc7bf110919f073ff4ac92065f09` using a clean, frozen package-manager install and an actual rebuilt production/UI artifact. The actual token-authenticated Gateway persisted 21 cron jobs: 19 Unicode proof jobs and two automatically provisioned jobs. The complete, unmodified terminal output below was synchronously persisted **before** parsing or assertions. Credentials were never printed.

### Actual authenticated `openclaw cron list` terminal stdout

```text
ID                                   Declaration              Name                     Schedule                         Next       Last       Status       Target    Delivery                                                         Agent ID   Owner                    Model               
3469ad38-6823-4336-8948-8c3a46e81627 heartbeat:main           Heartbeat (main)         every 30m                        in 28m     -          idle         main      not requested (not requested)                                    main       -                        -
0a1e3613-552b-43c2-b216-e755d5258605 -                        01-ascii-abcdefghijkl... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
0a0b53bc-3b63-48c8-b795-4823e3f7d5c8 -                        02-计划任务漢字漢字漢字  every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
9b1fb904-908f-4537-aff9-33961005c0dd -                        03-ﾊﾞﾋﾞﾌﾞﾍﾞ              every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
b5c7d177-f4e9-4862-af5f-c314b0440fe0 -                        04-हिन्दीकार्यक्रम             every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
1fe6b8dd-592b-49fd-8455-5b9ac0180c01 -                        05-가나다                every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
8a114007-913e-4f2b-bddd-cbe2e32219ce -                        06-xxxxxxxxxxxxxxxxxx... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
5dbce1a6-0648-4f2a-86a6-3ecc114f000b -                        07-xxxxxxxxxxxxxxxxxx... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
f8dbdfb6-0a4c-4760-9149-39613d51f3d5 -                        08-xxxxxxxxxxxxxxxxxx... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
4c95ea3a-c364-409b-a91f-810d99becdd9 -                        09-xxxxxxxxxxxxxxxxxx... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
6d4e2eea-7b9c-4a21-a7d0-47b2d898df36 -                        10-caféresumécomposé     every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
2e7ab18a-8bf2-4de6-90ae-82b4f55d8036 -                        11-café-résumé-élève     every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
820c4468-103d-46d0-8360-dd3333a1d780 -                        12-🚀12-🚀12-🚀12-🚀1... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
91b765ad-9ad3-4f50-9a83-5297ef142979 -                        13-👨‍👩‍👧‍👦                    every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
9f322d3f-854a-4237-b171-bfe4c93439d9 -                        14-🏳️‍🌈                    every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
2306426d-47b4-4b07-96c5-80ee695485a2 -                        15-漢字🚀नमस्तेﾊﾞ           every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
fd4aeb89-fa1b-4349-a7ad-ffc5d3abfb49 -                        16-safe-controlred       every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
9a344d54-32bc-4b57-ac4c-aad678de1425 -                        17-ㅤㅤㅤㅤㅤㅤㅤㅤㅤ... every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
017f6753-a1d4-4fb9-be16-fbaabb6d4b34 -                        18-high-�-replacement    every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
7bccbb35-b2af-4f64-8fb8-748eb7351906 -                        19-low-�-replacement     every 1h                         in 60m     -          idle         main      not requested (not requested)                                    -          -                        -
980ea654-9f4a-4429-ad58-ee16853c9b87 memory-core:memory-dr... Memory Dreaming Promo... cron 0 3 * * * (exact)           in 4h      -          idle         isolated  not requested (not requested)                                    -          -                        -
```

### Independent terminal-column verdict and directly inspected dependency

The verifier uses `Intl.Segmenter`, Unicode properties, and East Asian Width; it does **not** call `string-width` to compute the expected result. Header schedule column and all 19 tracked Unicode proof-job schedule columns are 87, including Devanagari clusters, family/rainbow ZWJ emoji, visible and neutral Hangul fillers, mixed CJK, and malformed UTF-16 rendered as U+FFFD. Source and declaration types were inspected from the package-local pinned `string-width@8.2.2` installation; the frozen lockfile SHA256 is `542fe107a51090dffef05b59ec32dd7b37d8f5e3ed988ea23138aaac3da84ca7`.

```json
{
  "DEPENDENCY_RESOLUTION_JSON": {
    "importer": "packages/terminal-core/package.json",
    "importerVersion": "8.2.2",
    "resolvedEntry": "/home/runner/_work/openclaw/openclaw/packages/terminal-core/node_modules/string-width/index.js",
    "typesPath": "/home/runner/_work/openclaw/openclaw/packages/terminal-core/node_modules/string-width/index.d.ts",
    "version": "8.2.2",
    "engines": {
      "node": ">=20"
    },
    "lockSha256": "542fe107a51090dffef05b59ec32dd7b37d8f5e3ed988ea23138aaac3da84ca7",
    "sourceLines": [
      "1: import stripAnsi from 'strip-ansi';",
      "2: import {eastAsianWidth} from 'get-east-asian-width';",
      "3: ",
      "4: /**",
      "5: Logic:",
      "6: - Segment graphemes to match how terminals render clusters.",
      "7: - Width rules:",
      "8: \t1. Skip non-printing clusters (Default_Ignorable, Control, pure nonspacing/enclosing Mark, lone Surrogates). Tabs are ignored by design.",
      "9: \t2. RGI emoji clusters (\\p{RGI_Emoji}) are double-width.",
      "10: \t3. Minimally-qualified/unqualified emoji clusters (ZWJ sequences with 2+ Extended_Pictographic, or keycap sequences) are double-width.",
      "11: \t4. Hangul jamo collapse each standard modern Hangul L+V or L+V+T syllable piece to width 2.",
      "12: \t   Unmatched repeated leading/vowel/trailing jamo stay additive because that matches how the terminals we target render them.",
      "13: \t5. Otherwise use East Asian Width of the cluster's first visible code point, and add widths for trailing spacing marks and Halfwidth/Fullwidth Forms within the same cluster (e.g., dakuten/handakuten/prolonged sound mark).",
      "14: */",
      "15: ",
      "16: const segmenter = new Intl.Segmenter();",
      "17: ",
      "18: // Whole-cluster zero-width",
      "23: const spacingMarkRegex = /\\p{Spacing_Mark}/v;",
      "24: ",
      "25: // RGI emoji sequences",
      "26: const rgiEmojiRegex = /^\\p{RGI_Emoji}$/v;",
      "27: ",
      "40: \t}",
      "41: ",
      "42: \t// ZWJ sequences with 2+ Extended_Pictographic",
      "43: \tif (segment.includes('\\u200D')) {",
      "44: \t\tconst pictographics = segment.match(extendedPictographicRegex);",
      "78: }",
      "79: ",
      "80: function hangulClusterWidth(visibleSegment, eastAsianWidthOptions) {",
      "81: \tconst codePoints = [];",
      "82: ",
      "104: \t\t\t// Mixed cluster (e.g., L + precomposed syllable): use EAW for non-jamo remainder",
      "105: \t\t\tfor (let remaining = index; remaining < codePoints.length; remaining++) {",
      "106: \t\t\t\twidth += eastAsianWidth(codePoints[remaining], eastAsianWidthOptions);",
      "107: \t\t\t}",
      "108: "
    ],
    "typeLines": [
      "1: export type Options = {",
      "2: \t/**",
      "3: \tCount [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide width (count of 2).",
      "8: \t> - http://www.unicode.org/reports/tr11/",
      "9: \t*/",
      "10: \treadonly ambiguousIsNarrow?: boolean;",
      "11: ",
      "12: \t/**",
      "15: \t@default false",
      "16: \t*/",
      "17: \treadonly countAnsiEscapeCodes?: boolean;",
      "18: };",
      "19: ",
      "37: ```",
      "38: */",
      "39: export default function stringWidth(string: string, options?: Options): number;",
      "40: "
    ]
  },
  "PERSISTED_CRON_COUNTS_JSON": {
    "total": 21,
    "target": 19,
    "autoProvisioned": 2
  },
  "INDEPENDENT_GRAPHEME_ORACLE_JSON": {
    "implementation": "Intl.Segmenter + Unicode property escapes + get-east-asian-width",
    "eawEntry": "/home/runner/_work/openclaw/openclaw/node_modules/get-east-asian-width/index.js",
    "headerWidth": 87,
    "columns": [
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87
    ]
  },
  "PHYSICAL_COLUMN_VERDICT_JSON": {
    "head": "6b59aeea19c8bc7bf110919f073ff4ac92065f09",
    "persistedJobsTotal": 21,
    "targetPersistedJobs": 19,
    "printedTargetRows": 19,
    "headerScheduleColumn": 87,
    "physicalScheduleColumns": [
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87,
      87
    ],
    "oracle": "Intl.Segmenter + Unicode properties + East Asian Width",
    "unicodeCases": [
      "ascii",
      "cjk",
      "kana",
      "hindi",
      "jamo",
      "leading-filler",
      "compatibility-filler",
      "halfwidth-filler",
      "vowel-filler",
      "combining",
      "precomposed",
      "emoji",
      "family-zwj",
      "flag-zwj",
      "mixed-cjk",
      "controls",
      "repeated-fillers",
      "lone-high",
      "lone-low"
    ],
    "gatewayAuthenticated": true,
    "success": true
  },
  "RAW_CRON_LIST_SAVED_JSON": {
    "path": "/tmp/openclaw-pr117062-gateway-pyYHWw/cron-list-raw.txt",
    "bytes": 6079,
    "auth": "ephemeral-redacted"
  }
}
```

Full proof: rebuilt production + UI succeeded; the actual authenticated Gateway run succeeded; all 19 tracked jobs physically aligned; earlier owner/full-repo typecheck and core/extensions/scripts lint all passed. The previously missing local signed secret scanner was explicitly waived by the maintainer; hosted secret/security and normal `openclaw-secops` CODEOWNER review remain required.
