### PR TITLE
fix(gateway): reject sends on closing node sockets

### DIFF
--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -35,7 +35,10 @@ const NON_OPEN_NODE_SOCKET_STATES = [
   { state: "closed", readyState: WebSocket.CLOSED },
 ];
 
-function createTestNodeSocket(sent: string[] = [], readyState = WebSocket.OPEN): TestNodeSocket {
+function createTestNodeSocket(
+  sent: string[] = [],
+  readyState: TestNodeSocket["readyState"] = WebSocket.OPEN,
+): TestNodeSocket {
   return {
     readyState,
     bufferedAmount: 0,

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -88,9 +88,7 @@ function makeClient(
   return {
     connId,
     usesSharedGatewayAuth: false,
-    socket:
-      opts.socket ??
-      (createTestNodeSocket(sent) as unknown as GatewayWsClient["socket"]),
+    socket: opts.socket ?? (createTestNodeSocket(sent) as unknown as GatewayWsClient["socket"]),
     connect: {
       minProtocol: 1,
       maxProtocol: 1,

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
 } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { getCurrentActiveNodeContext, setActiveNodeContext } from "../infra/active-node-context.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
@@ -20,6 +21,32 @@ let testNodeHostCommands: NonNullable<
   ReturnType<typeof createEmptyPluginRegistry>["nodeHostCommands"]
 > = [];
 const activeTestRegistries = new Set<NodeRegistry>();
+
+type TestNodeSocket = {
+  readyState: number;
+  bufferedAmount: number;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const NON_OPEN_NODE_SOCKET_STATES = [
+  { state: "connecting", readyState: WebSocket.CONNECTING },
+  { state: "closing", readyState: WebSocket.CLOSING },
+  { state: "closed", readyState: WebSocket.CLOSED },
+];
+
+function createTestNodeSocket(sent: string[] = [], readyState = WebSocket.OPEN): TestNodeSocket {
+  return {
+    readyState,
+    bufferedAmount: 0,
+    send: vi.fn((frame: unknown) => {
+      if (typeof frame === "string") {
+        sent.push(frame);
+      }
+    }),
+    close: vi.fn(),
+  };
+}
 
 function createNodeRegistry(options?: ConstructorParameters<typeof NodeRegistry>[0]): NodeRegistry {
   const registry = new NodeRegistry(options);
@@ -63,13 +90,7 @@ function makeClient(
     usesSharedGatewayAuth: false,
     socket:
       opts.socket ??
-      ({
-        send(frame: unknown) {
-          if (typeof frame === "string") {
-            sent.push(frame);
-          }
-        },
-      } as unknown as GatewayWsClient["socket"]),
+      (createTestNodeSocket(sent) as unknown as GatewayWsClient["socket"]),
     connect: {
       minProtocol: 1,
       maxProtocol: 1,
@@ -106,6 +127,19 @@ function registerNodeSession(
 ) {
   const { pairingIdentity = "identity-a", ...registration } = opts;
   return registry.register(client, { ...registration, pairingIdentity });
+}
+
+function registerTestNodeSocket(
+  registry: NodeRegistry,
+  socket: TestNodeSocket,
+  sent: string[] = [],
+) {
+  return registerNodeSession(
+    registry,
+    makeClient("conn-1", "node-1", sent, {
+      socket: socket as unknown as GatewayWsClient["socket"],
+    }),
+  );
 }
 
 function registerDemoNodePluginTool(params: {
@@ -588,6 +622,44 @@ describe("gateway/node-registry", () => {
     expect(() => registry.sendInvokeInput("missing", { kind: "data", data: "x" })).toThrow(
       "node invoke is not pending",
     );
+
+    controller.abort();
+    await expect(invoke).resolves.toMatchObject({ ok: false, error: { code: "ABORTED" } });
+  });
+
+  it("does not advance streamed input sequence when the node websocket is closing", async () => {
+    const registry = createNodeRegistry();
+    const frames: string[] = [];
+    const socket = createTestNodeSocket(frames);
+    registerTestNodeSocket(registry, socket, frames);
+    const controller = new AbortController();
+    const invoke = registry.invoke({
+      nodeId: "node-1",
+      command: "codex.terminal.resume.v1",
+      timeoutMs: 0,
+      signal: controller.signal,
+      onProgress: () => {},
+    });
+    const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+    const invokeId = request.payload?.id ?? "";
+
+    socket.readyState = WebSocket.CLOSING;
+    expect(() => registry.sendInvokeInput(invokeId, { kind: "data", data: "lost" })).toThrow(
+      "failed to send node invoke input",
+    );
+    expect(frames).toHaveLength(1);
+
+    socket.readyState = WebSocket.OPEN;
+    registry.sendInvokeInput(invokeId, { kind: "data", data: "delivered" });
+    expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
+      event: "node.invoke.input",
+      payload: {
+        id: invokeId,
+        nodeId: "node-1",
+        seq: 0,
+        payloadJSON: JSON.stringify({ kind: "data", data: "delivered" }),
+      },
+    });
 
     controller.abort();
     await expect(invoke).resolves.toMatchObject({ ok: false, error: { code: "ABORTED" } });
@@ -1158,6 +1230,28 @@ describe("gateway/node-registry", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("returns unavailable without dispatching an invoke to a closing node websocket", async () => {
+    const registry = createNodeRegistry();
+    const frames: string[] = [];
+    const socket = createTestNodeSocket(frames, WebSocket.CLOSING);
+    registerTestNodeSocket(registry, socket, frames);
+    const onDispatchReady = vi.fn();
+
+    await expect(
+      registry.invoke({
+        nodeId: "node-1",
+        command: "debug.ping",
+        timeoutMs: 0,
+        onDispatchReady,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "failed to send invoke to node" },
+    });
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(onDispatchReady).not.toHaveBeenCalled();
   });
 
   it("forwards the agent session that owns a stateful node invoke", async () => {
@@ -1918,6 +2012,32 @@ describe("gateway/node-registry", () => {
     ]);
   });
 
+  it.each(NON_OPEN_NODE_SOCKET_STATES)(
+    "rejects normal event sends while the node websocket is $state",
+    ({ readyState }) => {
+      const registry = createTestNodeRegistry();
+      const socket = createTestNodeSocket([], readyState);
+      registerTestNodeSocket(registry, socket);
+
+      expect(registry.sendEvent("node-1", "node.test", { ok: true })).toBe(false);
+      expect(socket.send).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(NON_OPEN_NODE_SOCKET_STATES)(
+    "rejects raw event sends while the node websocket is $state",
+    ({ readyState }) => {
+      const registry = createTestNodeRegistry();
+      const socket = createTestNodeSocket([], readyState);
+      registerTestNodeSocket(registry, socket);
+
+      expect(
+        registry.sendEventRaw("node-1", "node.test", serializeEventPayload({ ok: true })),
+      ).toBe(false);
+      expect(socket.send).not.toHaveBeenCalled();
+    },
+  );
+
   it("drops a delayed voice-wake snapshot after persistent generation changes", async () => {
     let resolveCurrent!: (state: { identity: string; generation?: string } | undefined) => void;
     const currentPairingState = new Promise<{ identity: string; generation?: string } | undefined>(
@@ -1978,17 +2098,12 @@ describe("gateway/node-registry", () => {
     const stopDiagnostics = onDiagnosticEvent((event) => diagnosticEvents.push(event));
     const registry = createTestNodeRegistry();
     const socket = {
+      readyState: WebSocket.OPEN,
       bufferedAmount: MAX_BUFFERED_BYTES + 1,
       send: vi.fn(),
       close: vi.fn(),
     };
-    registerNodeSession(
-      registry,
-      makeClient("conn-1", "node-1", [], {
-        socket: socket as unknown as GatewayWsClient["socket"],
-      }),
-      {},
-    );
+    registerTestNodeSocket(registry, socket);
     const payload = serializeEventPayload({ foo: "bar" });
 
     try {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -158,7 +158,6 @@ export type NodeConnectivityResult =
 
 /** Minimal websocket ping/pong surface used by connectivity checks. */
 type PingableSocket = {
-  readyState?: number;
   ping?: (data?: Buffer, mask?: boolean, cb?: (err?: Error) => void) => void;
   once?: (event: "pong" | "close" | "error", listener: (...args: unknown[]) => void) => unknown;
   off?: (event: "pong" | "close" | "error", listener: (...args: unknown[]) => void) => unknown;
@@ -846,7 +845,7 @@ export class NodeRegistry {
       return currentConnectionResult(result);
     }
     const socket = node.client.socket as PingableSocket;
-    if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
+    if (!this.isNodeWebSocketOpen(node)) {
       return {
         ok: false,
         error: { code: "NOT_CONNECTED", message: "node socket not open" },
@@ -1473,6 +1472,9 @@ export class NodeRegistry {
     if (eventTransport) {
       return eventTransport.send(event, payload);
     }
+    if (!this.isNodeWebSocketOpen(node)) {
+      return false;
+    }
     if (this.rejectSlowNodeSocket(node)) {
       return false;
     }
@@ -1509,6 +1511,9 @@ export class NodeRegistry {
     if (eventTransport) {
       return eventTransport.sendRaw(event, payloadJSON);
     }
+    if (!this.isNodeWebSocketOpen(node)) {
+      return false;
+    }
     if (this.rejectSlowNodeSocket(node)) {
       return false;
     }
@@ -1525,6 +1530,12 @@ export class NodeRegistry {
 
   private sendEventToSession(node: NodeSession, event: string, payload: unknown): boolean {
     return this.sendEventInternal(node, event, payload);
+  }
+
+  private isNodeWebSocketOpen(node: NodeSession): boolean {
+    // ws.send() does not throw after entering CLOSING; it only accounts the
+    // unsent bytes. Keep the synchronous send-admission result truthful.
+    return node.client.socket.readyState === WEBSOCKET_OPEN_READY_STATE;
   }
 
   private rejectSlowNodeSocket(node: NodeSession): boolean {

--- a/src/gateway/node-registry.ws-lifecycle.test.ts
+++ b/src/gateway/node-registry.ws-lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { setActiveNodeContext } from "../infra/active-node-context.js";
+import { NodeRegistry } from "./node-registry.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+
+function createNodeClient(socket: WebSocket): GatewayWsClient {
+  return {
+    connId: "runtime-proof-conn",
+    usesSharedGatewayAuth: false,
+    socket,
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-runtime-proof",
+        version: "1.0.0",
+        platform: "linux",
+        mode: "node",
+      },
+      device: {
+        id: "runtime-proof-node",
+        publicKey: "runtime-proof-public-key",
+        signature: "runtime-proof-signature",
+        signedAt: 1,
+        nonce: "runtime-proof-nonce",
+      },
+      caps: [],
+      commands: [],
+    } as GatewayWsClient["connect"],
+  };
+}
+
+describe("NodeRegistry real WebSocket lifecycle", () => {
+  afterEach(() => {
+    setActiveNodeContext(null);
+  });
+
+  it("rejects event and invoke delivery after a real socket leaves OPEN", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const address = server.address() as AddressInfo;
+    const accepted = once(server, "connection");
+    const peer = new WebSocket(`ws://127.0.0.1:${address.port}`);
+    await once(peer, "open");
+    const [socket] = (await accepted) as [WebSocket];
+    const frames: string[] = [];
+    peer.on("message", (data) => frames.push(data.toString()));
+    const registry = new NodeRegistry();
+    registry.register(createNodeClient(socket), { pairingIdentity: "runtime-proof-pairing" });
+
+    try {
+      expect(socket.readyState).toBe(WebSocket.OPEN);
+      expect(registry.sendEvent("runtime-proof-node", "runtime.proof", { phase: "open" })).toBe(
+        true,
+      );
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+
+      socket.close(1000, "runtime proof");
+      const closingState = socket.readyState;
+      const frameCountAtClose = frames.length;
+      const normalAccepted = registry.sendEvent("runtime-proof-node", "runtime.proof", {
+        phase: "closing",
+      });
+      const rawAccepted = registry.sendEventRaw("runtime-proof-node", "runtime.raw", null);
+      const onDispatchReady = vi.fn();
+      const invoke = await registry.invoke({
+        nodeId: "runtime-proof-node",
+        command: "runtime.proof",
+        timeoutMs: 0,
+        onDispatchReady,
+      });
+      const invokeErrorCode = invoke.ok ? null : invoke.error?.code;
+
+      expect(closingState).toBe(WebSocket.CLOSING);
+      expect(normalAccepted).toBe(false);
+      expect(rawAccepted).toBe(false);
+      expect(invoke).toMatchObject({
+        ok: false,
+        error: { code: "UNAVAILABLE", message: "failed to send invoke to node" },
+      });
+      expect(onDispatchReady).not.toHaveBeenCalled();
+      expect(frames).toHaveLength(frameCountAtClose);
+
+      console.log(
+        "[behavior-evidence] node-ws-open-admission",
+        JSON.stringify({
+          openState: WebSocket.OPEN,
+          closingState,
+          openFrameCount: frameCountAtClose,
+          closingNormalAccepted: normalAccepted,
+          closingRawAccepted: rawAccepted,
+          invokeErrorCode,
+          invokeDispatchReady: onDispatchReady.mock.calls.length,
+          framesAfterClosingAttempts: frames.length - frameCountAtClose,
+        }),
+      );
+    } finally {
+      registry.unregister("runtime-proof-conn");
+      peer.terminate();
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/src/gateway/node-registry.ws-lifecycle.test.ts
+++ b/src/gateway/node-registry.ws-lifecycle.test.ts
@@ -1,8 +1,9 @@
 import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocket, WebSocketServer } from "ws";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { setActiveNodeContext } from "../infra/active-node-context.js";
+import { rawDataToString } from "../infra/ws.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
@@ -15,7 +16,7 @@ function createNodeClient(socket: WebSocket): GatewayWsClient {
       minProtocol: 1,
       maxProtocol: 1,
       client: {
-        id: "openclaw-runtime-proof",
+        id: "openclaw-linux",
         version: "1.0.0",
         platform: "linux",
         mode: "node",
@@ -47,7 +48,7 @@ describe("NodeRegistry real WebSocket lifecycle", () => {
     await once(peer, "open");
     const [socket] = (await accepted) as [WebSocket];
     const frames: string[] = [];
-    peer.on("message", (data) => frames.push(data.toString()));
+    peer.on("message", (data: RawData) => frames.push(rawDataToString(data)));
     const registry = new NodeRegistry();
     registry.register(createNodeClient(socket), { pairingIdentity: "runtime-proof-pairing" });
 

--- a/src/gateway/server-in-process-dispatch.abort.test.ts
+++ b/src/gateway/server-in-process-dispatch.abort.test.ts
@@ -1,5 +1,6 @@
 /** Proves in-process Gateway cancellation reaches real paired-node invocation state. */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { NodeRegistry } from "./node-registry.js";
 import { dispatchGatewayRequestInProcessRaw } from "./server-in-process-dispatch.js";
@@ -29,6 +30,7 @@ function registerPairedNode(): { registry: NodeRegistry; frames: string[] } {
       connId: "paired-node-connection",
       usesSharedGatewayAuth: false,
       socket: {
+        readyState: WebSocket.OPEN,
         send(frame: unknown) {
           if (typeof frame === "string") {
             frames.push(frame);

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -2,6 +2,7 @@
 // delivery metadata, pairing state, and outbound payload lifecycle events.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -266,6 +267,7 @@ function makeNodeClient(connId: string, nodeId: string, sent: string[] = []): Ga
     connId,
     usesSharedGatewayAuth: false,
     socket: {
+      readyState: WebSocket.OPEN,
       send(frame: unknown) {
         if (typeof frame === "string") {
           sent.push(frame);

--- a/src/gateway/server-node-session-runtime.test.ts
+++ b/src/gateway/server-node-session-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
 import {
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
@@ -7,6 +8,7 @@ import { createGatewayNodeSessionRuntime } from "./server-node-session-runtime.j
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 type TestSocket = {
+  readyState: number;
   bufferedAmount: number;
   send: (payload: string) => void;
   close: (code?: number, reason?: string) => void;
@@ -58,6 +60,7 @@ function registerNode(
   frames: string[],
 ) {
   const socket: TestSocket = {
+    readyState: WebSocket.OPEN,
     bufferedAmount: 0,
     send: vi.fn((payload: string) => frames.push(payload)),
     close: vi.fn(),
@@ -140,6 +143,7 @@ describe("gateway node session runtime", () => {
     });
     const frames: string[] = [];
     const socket: TestSocket = {
+      readyState: WebSocket.OPEN,
       bufferedAmount: 0,
       send: vi.fn((payload: string) => frames.push(payload)),
       close: vi.fn(),

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
@@ -1,7 +1,7 @@
 /** Verifies transport disconnect cancels only its own paired-node invocation. */
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { WebSocket } from "ws";
+import { WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -37,6 +37,7 @@ function createPairedNode() {
       connId: "paired-node-connection",
       usesSharedGatewayAuth: false,
       socket: {
+        readyState: WebSocket.OPEN,
         send(frame: unknown) {
           if (typeof frame === "string") {
             frames.push(frame);

--- a/src/gateway/terminal/node-relay.test.ts
+++ b/src/gateway/terminal/node-relay.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
 import { type NodeInvokeResult, NodeRegistry } from "../node-registry.js";
 import { createNodeRelayBackend } from "./node-relay.js";
@@ -24,6 +25,7 @@ describe("createNodeRelayBackend", () => {
         connId: "conn-validated",
         usesSharedGatewayAuth: false,
         socket: {
+          readyState: WebSocket.OPEN,
           send(frame: unknown) {
             if (typeof frame === "string") {
               frames.push(frame);


### PR DESCRIPTION
## What Problem This Solves

`NodeRegistry` treated `socket.send()` returning normally as proof that an event or invoke crossed the wire. In pinned `ws` 8.21.1, sends on CLOSING/CLOSED sockets without a callback do not throw; they only increase buffered-byte accounting and return. OpenClaw could therefore report dispatch readiness, create pending invokes, or advance streamed-input sequence numbers for frames that were never sent.

## Why This Change Was Made

The registry now owns one WebSocket admission check and requires `readyState === OPEN` before normal or raw sends. The alternate HTTP event-transport path remains unaffected. Every invoke, streamed input, cancel, and event caller inherits the same synchronous truth boundary.

## User Impact

Closing or closed node connections now report unavailable immediately instead of accepting unsent events/invokes. Failed streamed input does not consume its sequence number, so a later send on a healthy connection retains correct ordering.

## Evidence

- Exact reviewed head: `094835c7b1881134e969ed4c6dbc25dc44f5c89d`.
- Focused Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30667650419
  - 195/195 Gateway/node tests passed across registry, invoke abort, node events/session runtime, terminal relay, WebSocket dispatch, and HTTP watch transport.
- Test-type correction Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30669910101
  - `pnpm check:test-types` passed on the current candidate tree after correcting the fixture parameter's inferred literal type.
- Pre-proof-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/30670204874 (attempt 2)
  - Every required check passed, including `check:test-types`, the complete Node matrix, and `openclaw/ci-gate`.
  - Attempt 1 had one unrelated TUI PTY fixture failure before its mocked first prompt reached the model; rerunning that unchanged-head failed job passed the full 65-test PTY shard.
- Real WebSocket lifecycle proof: https://github.com/openclaw/openclaw/actions/runs/30673323776
  - A real local `ws` client/server pair sent one frame while OPEN, then the registered socket entered CLOSING.
  - Redacted runtime transcript: `{"openState":1,"closingState":2,"openFrameCount":1,"closingNormalAccepted":false,"closingRawAccepted":false,"invokeErrorCode":"UNAVAILABLE","invokeDispatchReady":0,"framesAfterClosingAttempts":0}`.
  - This proves non-OPEN sends produce no frame, no dispatch-ready signal, and an unavailable invoke result through the actual `ws` state machine.
- Proof-file static gates: https://github.com/openclaw/openclaw/actions/runs/30673992387
  - Targeted oxlint and the complete core-test `tsgo` project passed after aligning the real-socket fixture with the closed client-id and raw-data contracts.
- Direct pinned dependency inspection: the public npm tarball for `ws` 8.21.1 throws in CONNECTING, but CLOSING/CLOSED calls `sendAfterClose()` and returns; without a callback, that path reports no error and only updates buffered-byte counters.
- The earlier changed-gate follow-up was twice blocked before repository execution by delegated Testbox file-sync timeouts (runs 30667882111 and 30668309268). Neither failed sync produced a code/test failure.
- Regressions cover normal/raw CONNECTING, CLOSING, and CLOSED sends; invoke admission and dispatch callback suppression; streamed-input sequence preservation; and unchanged alternate event transport.
- Final whole-branch autoreview on the current head: clean, confidence 0.99.
- `git diff --check` and pinned local formatting: passed.

Release-note context: Gateway node sends now fail immediately after a WebSocket leaves OPEN instead of accepting unsent frames.
