### PR TITLE
perf(gateway): cache disk reads on agent-list and skill expansion hot paths

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -383,6 +383,10 @@ export class AgentSession {
   private turnIndex = 0;
 
   private sessionResourceLoader: ResourceLoader;
+  // Skill file content is static for the lifetime of a session, but /skill:name
+  // messages can arrive repeatedly (including via steering); avoid a blocking
+  // readFileSync per message once a skill has been read once.
+  private skillContentCache: Map<string, string> = new Map();
   private customTools: ToolDefinition[];
   private baseToolDefinitions: Map<string, ToolDefinition> = new Map();
   private cwd: string;
@@ -1345,7 +1349,11 @@ export class AgentSession {
     } // Unknown skill, pass through
 
     try {
-      const content = readFileSync(skill.filePath, "utf-8");
+      let content = this.skillContentCache.get(skill.filePath);
+      if (content === undefined) {
+        content = readFileSync(skill.filePath, "utf-8");
+        this.skillContentCache.set(skill.filePath, content);
+      }
       const body = stripFrontmatter(content).trim();
       const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
       return args ? `${skillBlock}\n\n${args}` : skillBlock;

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -14,18 +14,34 @@ type GatewayAgentListRow = {
   name?: string;
 };
 
+// Short TTL: this is a hot path called from multiple RPCs per request, but the
+// on-disk agent directory set changes rarely (only on agent create/delete).
+const DISK_AGENT_IDS_TTL_MS = 2_000;
+let diskAgentIdsCache: { ids: string[]; agentsDir: string; time: number } | null = null;
+
 function listExistingAgentIdsFromDisk(): string[] {
   const root = resolveStateDir();
   const agentsDir = path.join(root, "agents");
+  const now = Date.now();
+  if (
+    diskAgentIdsCache &&
+    diskAgentIdsCache.agentsDir === agentsDir &&
+    now - diskAgentIdsCache.time < DISK_AGENT_IDS_TTL_MS
+  ) {
+    return diskAgentIdsCache.ids;
+  }
+  let ids: string[];
   try {
     const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
-    return entries
+    ids = entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => normalizeAgentId(entry.name))
       .filter(Boolean);
   } catch {
-    return [];
+    ids = [];
   }
+  diskAgentIdsCache = { ids, agentsDir, time: now };
+  return ids;
 }
 
 export function listGatewayAgentIds(cfg: OpenClawConfig): string[] {


### PR DESCRIPTION
## Summary
- `listExistingAgentIdsFromDisk()` ran a synchronous `readdirSync` on every `listGatewayAgentIds`/`listGatewayAgentsBasic` call even though the on-disk agent directory set rarely changes; adds a 2s TTL cache.
- `expandSkillCommand()` re-read the skill file from disk on every `/skill:name` message in a session even though skill content is static for the session's lifetime; caches per session after first read.
- Both block the Node event loop for all concurrent gateway connections while the sync read completes, so avoiding repeat reads on these hot paths reduces tail latency under load.

## Not included
- A rate-limited prune fix for `native-hook-relay.ts` was attempted but reverted: it broke 8 tests that pin pruning as deterministic per-registration behavior, not just an optimization.
- A lazy-import refactor for `message-handler.ts` (2641 lines, ~64 eager imports) was identified but skipped here as too large/risky for this focused perf pass; better suited to a dedicated change.

## Test plan
- [x] `vitest run src/gateway/agent-list.test.ts src/agents/harness/native-hook-relay.test.ts src/gateway/server-methods/native-hook-relay.test.ts src/agents/sessions/agent-session.context-usage.test.ts` — 184 passed
- [x] `tsc -p tsconfig.core.json --noEmit` — no new errors (pre-existing unrelated error in src/secrets/config-io.ts confirmed present on main too)

https://claude.ai/code/session_01KYDVt9CwiARCyPcba16K5V