### PR TITLE
fix(exec): preserve approved exec continuation output

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -96,7 +96,9 @@ function buildExecApprovalFollowupPrompt(resultText: string): string {
     "Only ask the user for help if you are actually blocked.",
     "",
     "Exact completion details:",
-    trimmed,
+    // Raw, not trimmed: trailing newlines, tabs, and indentation are part of the command
+    // output the agent has to work from.
+    trimmed ? resultText : "",
     "",
     "Continue the task if needed, then reply to the user in a helpful way.",
     "If it succeeded, share the relevant output.",
@@ -331,11 +333,14 @@ export async function sendExecApprovalFollowup(
   params: ExecApprovalFollowupParams,
 ): Promise<boolean> {
   const sessionKey = params.sessionKey?.trim();
-  const resultText = params.resultText.trim();
-  if (!resultText) {
+  // Trimmed text only classifies empty/denied results; the raw text is what reaches the
+  // agent so command whitespace survives the follow-up.
+  const trimmedResultText = params.resultText.trim();
+  if (!trimmedResultText) {
     return false;
   }
-  const isDenied = isExecDeniedResultText(resultText);
+  const resultText = params.resultText;
+  const isDenied = isExecDeniedResultText(trimmedResultText);
 
   const deliveryTarget = resolveExternalBestEffortDeliveryTarget({
     channel: params.turnSourceChannel,

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
+
+// Pinned so a budget change is a deliberate edit rather than a silent drift.
+const MAX_UTF16_UNITS = 16_000;
+const MARKER =
+  "[... truncated to fit the continuation budget; more output may have been dropped when it was captured ...]";
+
+describe("formatExecApprovalContinuationOutput", () => {
+  it("returns empty output when no stream carries content", () => {
+    expect(formatExecApprovalContinuationOutput([])).toBe("");
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "" },
+        { label: "stderr", value: undefined },
+        { label: "error", value: null },
+      ]),
+    ).toBe("");
+  });
+
+  it("leaves a single stream verbatim and unlabelled", () => {
+    const value = "line one\nline two\n";
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value },
+        { label: "stderr", value: "" },
+      ]),
+    ).toBe(value);
+  });
+
+  it("preserves LF, CRLF, tabs, indentation, blank lines and trailing whitespace", () => {
+    const value = "first\r\n\tindented\n\n  spaced  \ttrailing\t\n   ";
+    expect(formatExecApprovalContinuationOutput([{ label: "stdout", value }])).toBe(value);
+  });
+
+  it("does not collapse whitespace the way the compact notify formatter does", () => {
+    const value = "a\n\n\nb    c";
+    const formatted = formatExecApprovalContinuationOutput([{ label: "stdout", value }]);
+    expect(formatted).toBe(value);
+    expect(formatted).not.toBe(value.replace(/\s+/g, " ").trim());
+  });
+
+  it("labels streams in deterministic order when several carry content", () => {
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "out\n" },
+        { label: "stderr", value: "err\n" },
+        { label: "error", value: "boom" },
+      ]),
+    ).toBe("[stdout]\nout\n\n[stderr]\nerr\n\n[error]\nboom");
+  });
+
+  it("keeps error-only output unlabelled", () => {
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "" },
+        { label: "stderr", value: "" },
+        { label: "error", value: "spawn failed" },
+      ]),
+    ).toBe("spawn failed");
+  });
+
+  it("is byte-identical at and below the cap", () => {
+    const exact = "x".repeat(MAX_UTF16_UNITS);
+    expect(formatExecApprovalContinuationOutput([{ label: "stdout", value: exact }])).toBe(exact);
+    const under = "y".repeat(MAX_UTF16_UNITS - 1);
+    expect(formatExecApprovalContinuationOutput([{ label: "stdout", value: under }])).toBe(under);
+  });
+
+  it("keeps head and tail within the cap and marks the cut once", () => {
+    const value = `${"a".repeat(30_000)}\n${"b".repeat(30_000)}`;
+    const formatted = formatExecApprovalContinuationOutput([{ label: "stdout", value }]);
+    expect(formatted.length).toBeLessThanOrEqual(MAX_UTF16_UNITS);
+    expect(formatted.split(MARKER)).toHaveLength(2);
+    expect(formatted.startsWith("a")).toBe(true);
+    expect(formatted.endsWith("b")).toBe(true);
+  });
+
+  it("does not claim an exact omission count", () => {
+    const formatted = formatExecApprovalContinuationOutput([
+      { label: "stdout", value: "z".repeat(50_000) },
+    ]);
+    // Source-side capture can already have dropped output without a marker, so the
+    // continuation must not imply this cut is the whole story.
+    expect(formatted).toContain("may have been dropped when it was captured");
+    expect(formatted).not.toMatch(/\d+\s+(characters|units|chars)\s+omitted/);
+  });
+
+  it("never splits a surrogate pair at either cut", () => {
+    const value = "😀".repeat(20_000);
+    const formatted = formatExecApprovalContinuationOutput([{ label: "stdout", value }]);
+    expect(formatted.length).toBeLessThanOrEqual(MAX_UTF16_UNITS);
+    for (const part of formatted.split(MARKER)) {
+      expect(part).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+      expect(part).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    }
+  });
+
+  it("never emits a partial generated stream header", () => {
+    // Sized so both the head cut and the tail cut land inside the "[stderr]" header.
+    const headBudget = Math.floor((MAX_UTF16_UNITS - MARKER.length - 2) * 0.75);
+    const formatted = formatExecApprovalContinuationOutput([
+      { label: "stdout", value: "s".repeat(headBudget - 3) },
+      { label: "stderr", value: "e".repeat(MAX_UTF16_UNITS) },
+    ]);
+    expect(formatted.length).toBeLessThanOrEqual(MAX_UTF16_UNITS);
+    for (const partial of ["[st\n", "[std\n", "[stde", "[stder", "[stderr\n"]) {
+      expect(formatted).not.toContain(partial);
+    }
+  });
+
+  it("keeps a source-side truncation marker visible when it fits", () => {
+    const value = "head output\n... (truncated)\ntail output";
+    expect(formatExecApprovalContinuationOutput([{ label: "stdout", value }])).toContain(
+      "... (truncated)",
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -1,0 +1,71 @@
+// Formats command output for the model continuation sent after an approved async exec
+// completes. This is deliberately separate from the compact background `notifyOnExit`
+// notification path: a notification is a glance, a continuation is what the agent must
+// work from, so it keeps whitespace and stays large enough to be useful.
+
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
+// The continuation re-enters the run as a user follow-up, so it bypasses the live
+// tool-result guard in attempt-context-guards. Bound it here at the same order of
+// magnitude as DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS so one long-running command cannot
+// flood the resumed context.
+const MAX_UTF16_UNITS = 16_000;
+
+// Command output usually opens with context and closes with the result or error, so keep
+// both ends rather than a single window.
+const HEAD_SHARE = 0.75;
+
+// Intentionally reports no omission count. Output can already be capped at capture time
+// (bash-process-registry `trimWithCap` drops the head at DEFAULT_MAX_OUTPUT and leaves no
+// marker), so an exact number here would describe only this cut while reading as though
+// nothing else was lost. "may" is the strongest honest claim available at this boundary.
+const TRUNCATION_MARKER =
+  "[... truncated to fit the continuation budget; more output may have been dropped when it was captured ...]";
+
+/** Backs a cut off to a line break so a generated stream header is never split. */
+function alignHeadToLineBreak(text: string): string {
+  const lastBreak = text.lastIndexOf("\n");
+  return lastBreak > text.length / 2 ? text.slice(0, lastBreak) : text;
+}
+
+/** Advances a cut past a line break so a generated stream header is never split. */
+function alignTailToLineBreak(text: string): string {
+  const firstBreak = text.indexOf("\n");
+  return firstBreak >= 0 && firstBreak < text.length / 2 ? text.slice(firstBreak + 1) : text;
+}
+
+function capContinuationOutput(text: string): string {
+  if (text.length <= MAX_UTF16_UNITS) {
+    return text;
+  }
+  // The marker and its two surrounding newlines are spent from the same budget so the
+  // rendered result never exceeds the cap.
+  const cutBudget = MAX_UTF16_UNITS - TRUNCATION_MARKER.length - 2;
+  const headBudget = Math.floor(cutBudget * HEAD_SHARE);
+  const head = alignHeadToLineBreak(truncateUtf16Safe(text, headBudget));
+  const tail = alignTailToLineBreak(sliceUtf16Safe(text, text.length - (cutBudget - headBudget)));
+  return `${head}\n${TRUNCATION_MARKER}\n${tail}`;
+}
+
+/**
+ * Renders approved exec output for the agent continuation, preserving whitespace exactly.
+ *
+ * Streams are emitted in the given order and labelled only when more than one carries
+ * content, so the common single-stream case stays byte-identical to the command output.
+ * The node payload supplies separate fields, so this order is not a claim about
+ * chronological stdout/stderr interleaving.
+ */
+export function formatExecApprovalContinuationOutput(
+  streams: readonly { label: string; value?: string | null }[],
+): string {
+  const present = streams.filter((stream) => (stream.value ?? "") !== "");
+  const [only] = present;
+  if (!only) {
+    return "";
+  }
+  const rendered =
+    present.length === 1
+      ? (only.value ?? "")
+      : present.map((stream) => `[${stream.label}]\n${stream.value ?? ""}`).join("\n");
+  return capContinuationOutput(rendered);
+}

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -239,7 +239,6 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
 }));
 
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1000,
   createApprovalSlug: vi.fn(() => "slug"),
   normalizeNotifyOutput: vi.fn((value) => value),
   runExecProcess: runExecProcessMock,
@@ -2078,6 +2077,49 @@ EOF`,
     });
     expect(requireSentFollowupTarget(0)?.direct).toBe(false);
     expect(requireSentFollowupText(0)).toContain("done");
+  });
+
+  it("keeps multiline gateway approval follow-up output intact", async () => {
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    const aggregated = "first line\r\n\tindented\n\nlast line  \t\n";
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        aggregated,
+      }),
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "openclaw sessions export-trajectory --json",
+      approvalFollowupMode: "agent",
+      sessionId: "approval-session",
+      sessionStore: "/tmp/openclaw-sessions.json",
+      turnSourceChannel: "webchat",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
+    });
+    const text = requireSentFollowupText(0);
+    expect(text).toContain(aggregated);
+    // The compact notify formatter would have collapsed every run of whitespace.
+    expect(text).not.toContain("first line indented last line");
   });
 
   it("fails closed when detached approval metadata cannot be persisted", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -48,6 +48,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -69,7 +70,6 @@ import {
 } from "./bash-tools.exec-host-shared.js";
 import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   normalizeNotifyOutput,
   runExecProcess,
@@ -404,9 +404,9 @@ function buildGatewayExecApprovalFollowupSummary(params: {
     const body = [diagnosticsText, followupText].filter(Boolean).join("\n\n");
     summary = `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
   } else {
-    const output = normalizeNotifyOutput(
-      tail(params.outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
-    );
+    const output = formatExecApprovalContinuationOutput([
+      { label: "output", value: params.outcome.aggregated },
+    ]);
     summary = output
       ? `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${output}`
       : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -88,9 +88,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
 vi.mock("./bash-process-registry.js", () => ({ tail: vi.fn((text: string) => text) }));
 
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1_000,
   createApprovalSlug: vi.fn(() => "approval"),
-  normalizeNotifyOutput: vi.fn((text: string) => text),
 }));
 
 vi.mock("./embedded-agent-runner/run/abortable.js", () => ({

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -291,9 +291,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
 }));
 
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1000,
   createApprovalSlug: vi.fn(() => "slug"),
-  normalizeNotifyOutput: vi.fn((value: string) => value),
 }));
 
 vi.mock("./tools/gateway.js", () => ({
@@ -1495,7 +1493,56 @@ describe("executeNodeHostCommand", () => {
     const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
     expect(message).not.toMatch(loneSurrogate);
     expect(message).not.toContain("�");
-    expect(message).toContain(`Exec finished (node=node-1 id=approval-1, code 0)\n${tailHead}`);
+    // Under the continuation budget the payload survives whole, so the leading `prefix`
+    // is no longer dropped by the old compact tail.
+    expect(message).toContain(`Exec finished (node=node-1 id=approval-1, code 0)\n${stdout}`);
+    expect(message).toContain(prefix);
+    expect(message).toContain(tailHead);
+  });
+
+  it("keeps multiline async node approval follow-up output intact", async () => {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    const stdout = "first line\r\n\tindented\n\nlast line  \t\n";
+    const stderr = "warning: something\n";
+    callGatewayToolMock.mockImplementation(
+      async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
+        if (method === "exec.approvals.node.get") {
+          return { file: { version: 1, agents: {} } };
+        }
+        if (method !== "node.invoke") {
+          throw new Error(`unexpected gateway method: ${method}`);
+        }
+        if (params?.command === "system.run.prepare") {
+          return { payload: { plan: preparedPlan } };
+        }
+        if (params?.command === "system.run") {
+          return {
+            payload: { success: true, stdout, stderr, exitCode: 0, timedOut: false },
+          };
+        }
+        throw new Error(`unexpected node invoke command: ${String(params?.command)}`);
+      },
+    );
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({}));
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalled();
+    });
+    const message = sendExecApprovalFollowupResultMock.mock.calls[0]?.[1];
+    if (typeof message !== "string") {
+      throw new Error("expected follow-up message");
+    }
+    expect(message).toContain(`[stdout]\n${stdout}`);
+    expect(message).toContain(`[stderr]\n${stderr}`);
+    // The compact notify formatter would have collapsed every run of whitespace.
+    expect(message).not.toContain("first line indented last line");
   });
 
   it("does not build a human approval prompt for node auto-review allows", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -18,7 +18,7 @@ import {
   defaultExecAutoReviewer,
   resolveExecAutoReviewDecision,
 } from "../infra/exec-auto-review.js";
-import { tail } from "./bash-process-registry.js";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -36,11 +36,7 @@ import {
 } from "./bash-tools.exec-host-node-phases.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
-import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
-  createApprovalSlug,
-  normalizeNotifyOutput,
-} from "./bash-tools.exec-runtime.js";
+import { createApprovalSlug } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -614,10 +610,11 @@ export async function executeNodeHostCommand(
                     timedOut?: boolean;
                   })
                 : {};
-            const combined = [payload.stdout, payload.stderr, payload.error]
-              .filter(Boolean)
-              .join("\n");
-            const output = normalizeNotifyOutput(tail(combined, DEFAULT_NOTIFY_TAIL_CHARS));
+            const output = formatExecApprovalContinuationOutput([
+              { label: "stdout", value: payload.stdout },
+              { label: "stderr", value: payload.stderr },
+              { label: "error", value: payload.error },
+            ]);
             const exitLabel = payload.timedOut ? "timeout" : `code ${payload.exitCode ?? "?"}`;
             const summary = output
               ? `Exec finished (node=${target.nodeId} id=${approvalId}, ${exitLabel})\n${output}`

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -102,7 +102,7 @@ export const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
 export const DEFAULT_PATH =
   process.env.PATH ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 /** Tail length used in background completion notifications. */
-export const DEFAULT_NOTIFY_TAIL_CHARS = 400;
+const DEFAULT_NOTIFY_TAIL_CHARS = 400;
 const DEFAULT_NOTIFY_SNIPPET_CHARS = 180;
 /** Default time an approval can remain pending. */
 export const DEFAULT_APPROVAL_TIMEOUT_MS = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;


### PR DESCRIPTION
## What Problem This Solves

Closes #41152.

When an approval-required async exec completes, both exec hosts resumed the agent using the compact **background notification** formatter instead of a continuation formatter:

- `src/agents/bash-tools.exec-host-node.ts` — `normalizeNotifyOutput(tail(combined, DEFAULT_NOTIFY_TAIL_CHARS))`
- `src/agents/bash-tools.exec-host-gateway.ts` — the same shape in `buildGatewayExecApprovalFollowupSummary`

`DEFAULT_NOTIFY_TAIL_CHARS` is 400 and `normalizeNotifyOutput` is `value.replace(/\s+/g, " ").trim()`. The agent therefore resumed from the last 400 characters of its own command output, with every newline, tab, and indent collapsed into single spaces, the head silently dropped, and no signal that anything was missing.

`buildExecApprovalFollowupPrompt` then trimmed the result again, so trailing newlines and indentation that survived the cap died at the prompt boundary.

## Why This Change Was Made

This was accidental policy reuse, not a deliberate continuation limit.

`07a3db153dc` ("feat: notify on exec exit") introduced `DEFAULT_NOTIFY_TAIL_CHARS` and `normalizeNotifyOutput` **for compact background exit notifications**, where a one-line glance is the right product decision. #37233 (merged as `de49a8b72c1`) later wired the approval continuation path through those same helpers. `git log -L 620,620:src/agents/bash-tools.exec-host-node.ts` bottoms out at that commit.

A notification is something a human glances at. A continuation is what the model has to work from. They should not share a formatter.

Prior art, credited and not resurrected: #41170 and #92185 both proposed gateway-only fixes and were closed unmerged. #98721 made the existing cut UTF-16 safe while explicitly preserving the caps; this PR builds on top of it and reuses its shared `sliceUtf16Safe` / `truncateUtf16Safe` contract from `@openclaw/normalization-core/utf16-slice` rather than hand-rolling Unicode cuts.

## User Impact

Approved async exec output now reaches the agent intact. A build log, test run, or `git diff` resumes as the command actually printed it, instead of a single collapsed line of its last 400 characters.

Both hosts share one formatter (`src/agents/bash-tools.exec-approval-output.ts`):

- whitespace is preserved exactly — LF, CRLF, tabs, indentation, blank lines, trailing whitespace;
- streams render in deterministic order and are labelled only when more than one carries content, so the common single-stream case is byte-identical to the command output. The node payload supplies separate `stdout`/`stderr`/`error` fields, so this order is **not** a claim of chronological interleaving;
- cuts are surrogate-safe and land on line breaks, so a generated stream header is never split;
- over-limit output keeps a head and a tail with a single marker, and the marker plus its newlines are spent from the same budget so the result never exceeds the cap.

**Budget: 16,000 UTF-16 units.** This continuation re-enters the run as a *user follow-up*, so it bypasses the live tool-result guard in `attempt-context-guards.ts`. 16,000 is anchored to `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS` (`src/agents/tool-result-limits.ts:5`) so the continuation is bounded at the same order of magnitude as a tool result the model would otherwise receive. It is deliberately much larger than the 400-char notification budget, because the two surfaces answer different questions, and deliberately smaller than `DEFAULT_MAX_OUTPUT` (200,000) used for exec aggregate storage, because storage is not context. No new config knob: the repo bar on config surface is high and no user-visible need for tuning has been shown.

**The marker reports no exact omission count, on purpose.** Output can already be capped at capture time — `trimWithCap` (`src/agents/bash-process-registry.ts:384-386`) is `tail(text, max)` against `DEFAULT_MAX_OUTPUT`, which drops the *head* and leaves no marker. An exact count here would describe only this formatter's cut while reading as though it were the whole story. `"more output may have been dropped when it was captured"` is the strongest honest claim available at this boundary.

**Truncation here is a context budget, not a sanitization or prompt-injection boundary.** Command output remains untrusted and attacker-influenceable before and after this change, and nothing in this PR should be relied on as a trust boundary.

Unchanged: compact `notifyOnExit` notifications, poll/retained output, the gateway `diagnostics` trigger branch (`formatDiagnosticsExportFailure`, 4,000-char tail), and direct/detached execution. `DEFAULT_NOTIFY_TAIL_CHARS` keeps its value and is now module-local since no other module needs it.

## Evidence

Production diff is **+92/−19** across four files; the rest is test coverage.

**Targeted tests** — `node scripts/run-vitest.mjs` across `bash-tools.exec-approval-output.test.ts`, `bash-tools.exec-host-node.test.ts`, `bash-tools.exec-host-node.cancellation.test.ts`, `bash-tools.exec-host-gateway.test.ts`, `bash-tools.exec-approval-followup.test.ts`, `bash-tools.exec.approval-id.test.ts`, `bash-tools.exec-runtime.test.ts` → **264 passed**.

New coverage pins: empty/blank classification, single-stream verbatim output, LF/CRLF/tabs/indentation/trailing whitespace, explicit non-collapse versus the notify formatter, deterministic multi-stream order, error-only output, byte-identity at and below the cap, head/tail retention within the cap with exactly one marker, absence of any exact-count claim, surrogate-pair safety at both cuts, no partial generated header when either cut lands inside one, and survival of a source-side truncation marker. Host-level tests assert multiline output survives end to end for **both** `host=node` and `host=gateway`.

**Two pre-existing failures**, not caused by this change: `processGatewayAllowlist > reviews and executes the same PATH-resolved executable` and `> does not bind current policy to redundant exact-command trust`. Both expect `cd .` and receive `/usr/bin/cd .`, a local macOS PATH-resolution artifact. Proven by stashing this branch's changes and re-running the same suite on pristine `main`: identical two failures (`2 failed | 87 passed`), versus `2 failed | 88 passed` with this change applied — same two names, plus the one test this PR adds.

**Static gates** — `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean; `-p test/tsconfig/tsconfig.core.test.json` clean; `node scripts/run-oxlint.mjs` clean; `oxfmt` applied; `node scripts/check-deadcode-exports.mjs` → production, full-tree, and script unused-export scans all 0 entries.

**Autoreview** — `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`, engine `codex`, model `gpt-5.6-sol`, thinking `high`, TruffleHog clean. Result: `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.98)`.
