### PR TITLE
refactor(sessions): simplify session manager delegation

### DIFF
--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -7,23 +7,11 @@
 import { loadTranscriptEventsSync } from "../../config/sessions/session-accessor.js";
 import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
-import type { ImageContent, Message, TextContent } from "../../llm/types.js";
+import type { Message } from "../../llm/types.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import { SessionManagerBranching } from "./session-manager-branching.js";
 import type { SessionManagerPersistenceTarget } from "./session-manager-core.js";
-import type {
-  AppendPersistenceOptions,
-  FileEntry,
-  NewSessionOptions,
-  PromptReleasedSessionEntry,
-  PromptReleasedSessionMergeResult,
-  ResetReason,
-  SessionContext,
-  SessionEntry,
-  SessionHeader,
-  SessionLeafControl,
-  SessionTreeNode,
-} from "./session-manager-types.js";
+import type { AppendPersistenceOptions, FileEntry } from "./session-manager-types.js";
 
 export { CURRENT_SESSION_VERSION };
 export {
@@ -66,197 +54,17 @@ export class SessionManager extends SessionManagerBranching {
     super(cwd, persistenceTarget, loadedEntries);
   }
 
-  override setSessionTarget(target: SessionManagerPersistenceTarget): void {
-    super.setSessionTarget(target);
-  }
-
-  override newSession(options?: NewSessionOptions): string | undefined {
-    return super.newSession(options);
-  }
-
-  override clearPreservedOpaqueFileEntries(): void {
-    super.clearPreservedOpaqueFileEntries();
-  }
-
-  override getPersistedEntries(): unknown[] {
-    return super.getPersistedEntries();
-  }
-
   /** Makes pending append-oriented persistence durable without rewriting committed entries. */
   override flushPendingPersistence(): void {
     super.flushPendingPersistence();
   }
 
-  override isPersisted(): boolean {
-    return super.isPersisted();
-  }
-
-  override getCwd(): string {
-    return super.getCwd();
-  }
-
-  override getSessionId(): string {
-    return super.getSessionId();
-  }
-
-  override getSessionTarget(): SessionManagerPersistenceTarget | undefined {
-    return super.getSessionTarget();
-  }
-
-  override removeTrailingEntries(
-    predicate: (entry: SessionEntry) => boolean,
-    options?: { preserveTrailing?: (entry: SessionEntry) => boolean },
-  ): number {
-    return super.removeTrailingEntries(predicate, options);
-  }
-
-  override persist(
-    entry: SessionEntry,
-    options?: AppendPersistenceOptions,
-  ): string | null | undefined {
-    return super.persist(entry, options);
-  }
-
-  override mergePromptReleasedSessionEntries(
-    entries: readonly PromptReleasedSessionEntry[],
-    options?: { persistLeaf?: boolean },
-  ): PromptReleasedSessionMergeResult | undefined {
-    return super.mergePromptReleasedSessionEntries(entries, options);
-  }
-
+  // Worker rollback instrumentation wraps the method on this public prototype.
   override appendMessage(
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
   ): string {
     return super.appendMessage(message, options);
-  }
-
-  override appendThinkingLevelChange(thinkingLevel: string): string {
-    return super.appendThinkingLevelChange(thinkingLevel);
-  }
-
-  override appendModelChange(provider: string, modelId: string): string {
-    return super.appendModelChange(provider, modelId);
-  }
-
-  override appendCompaction(
-    summary: string,
-    firstKeptEntryId: string,
-    tokensBefore: number,
-    details?: unknown,
-    fromHook?: boolean,
-  ): string {
-    return super.appendCompaction(summary, firstKeptEntryId, tokensBefore, details, fromHook);
-  }
-
-  override appendResetBoundary(reason: ResetReason, firstKeptEntryId?: string): string {
-    return super.appendResetBoundary(reason, firstKeptEntryId);
-  }
-
-  override appendCustomEntry(customType: string, data?: unknown): string {
-    return super.appendCustomEntry(customType, data);
-  }
-
-  override appendSessionInfo(name: string): string {
-    return super.appendSessionInfo(name);
-  }
-
-  override getSessionName(): string | undefined {
-    return super.getSessionName();
-  }
-
-  override appendCustomMessageEntry(
-    customType: string,
-    content: string | (TextContent | ImageContent)[],
-    display: boolean,
-    details?: unknown,
-  ): string {
-    return super.appendCustomMessageEntry(customType, content, display, details);
-  }
-
-  override getLeafId(): string | null {
-    return super.getLeafId();
-  }
-
-  override getAppendParentId(): string | null {
-    return super.getAppendParentId();
-  }
-
-  override getAppendMode(): "side" | undefined {
-    return super.getAppendMode();
-  }
-
-  override appendLeafControl(params: {
-    targetId: string | null;
-    appendParentId: string | null;
-    appendMode?: "side";
-  }): SessionLeafControl {
-    return super.appendLeafControl(params);
-  }
-
-  override getLeafEntry(): SessionEntry | undefined {
-    return super.getLeafEntry();
-  }
-
-  override getEntry(id: string): SessionEntry | undefined {
-    return super.getEntry(id);
-  }
-
-  override getChildren(parentId: string): SessionEntry[] {
-    return super.getChildren(parentId);
-  }
-
-  override getLabel(id: string): string | undefined {
-    return super.getLabel(id);
-  }
-
-  override appendLabelChange(targetId: string, label: string | undefined): string {
-    return super.appendLabelChange(targetId, label);
-  }
-
-  override getBranch(fromId?: string): SessionEntry[] {
-    return super.getBranch(fromId);
-  }
-
-  override buildSessionContext(): SessionContext {
-    return super.buildSessionContext();
-  }
-
-  override getBoundaryCount(): number {
-    return super.getBoundaryCount();
-  }
-
-  override getHeader(): SessionHeader | null {
-    return super.getHeader();
-  }
-
-  override getEntries(): SessionEntry[] {
-    return super.getEntries();
-  }
-
-  override getTree(): SessionTreeNode[] {
-    return super.getTree();
-  }
-
-  override branch(branchFromId: string): void {
-    super.branch(branchFromId);
-  }
-
-  override resetLeaf(): void {
-    super.resetLeaf();
-  }
-
-  override branchWithSummary(
-    branchFromId: string | null,
-    summary: string,
-    details?: unknown,
-    fromHook?: boolean,
-  ): string {
-    return super.branchWithSummary(branchFromId, summary, details, fromHook);
-  }
-
-  override createBranchedSession(leafId: string): string | undefined {
-    return super.createBranchedSession(leafId);
   }
 
   static open(target: SessionTranscriptRuntimeTarget, cwdOverride?: string): SessionManager {


### PR DESCRIPTION
## What Problem This Solves

The agent session manager facade repeated dozens of inherited method signatures solely to forward unchanged calls to their actual owners. This maintainer-requested cleanup removes duplication that obscured the session persistence and branching ownership boundaries.

## Why This Change Was Made

Inherit behavior-neutral session methods directly from the existing core, persistence, entries, and branching classes. Preserve the public flushPendingPersistence visibility contract and the prototype-owned appendMessage hook required by gateway worker rollback instrumentation; static factories and exported session types remain unchanged. AI-assisted maintainer-requested refactor.

## User Impact

No user-visible behavior changes. Session persistence, transcript branching, worker rollback, and public plugin session APIs continue to behave as before while removing 192 net production lines. No persistence shape or SQLite schema changes.

## Evidence

### Real after-fix SQLite session lifecycle

A clean Blacksmith Testbox ran the actual SessionManager against a real isolated SQLite-backed session store, appended two parent-linked user messages, flushed them, reopened the session, reread the persisted transcript, and verified the restored active leaf and public prototype contracts.

Exact command:

```bash
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- node --import tsx -e 'void (async () => { const [{ mkdtemp, realpath, rm }, { tmpdir }, { join }, { SessionManager }, { upsertSessionEntry, loadTranscriptEvents }] = await Promise.all([import("node:fs/promises"), import("node:os"), import("node:path"), import("./src/agents/sessions/session-manager.ts"), import("./src/config/sessions/session-accessor.ts")]); const proofRoot = await mkdtemp(join(await realpath(tmpdir()), "openclaw-session-manager-proof-")); try { const target = { agentId: "main", sessionId: "session-manager-inherited-lifecycle", sessionKey: "agent:main:session-manager-inherited-lifecycle", storePath: join(proofRoot, "sessions.json") }; await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: Date.now() }); const manager = SessionManager.open(target, proofRoot); const firstId = manager.appendMessage({ role: "user", content: "first persisted turn", timestamp: 1 }); const secondId = manager.appendMessage({ role: "user", content: "second persisted turn", timestamp: 2 }); manager.flushPendingPersistence(); const reopened = SessionManager.open(target, proofRoot); const entries = reopened.getEntries(); const persisted = await loadTranscriptEvents(target); if (entries.length !== 2 || entries[1]?.parentId !== firstId || reopened.getLeafId() !== secondId) throw new Error("session lifecycle proof failed"); console.log("SESSION_LIFECYCLE_PROOF=" + JSON.stringify({ storage: "sqlite", persistedEntryTypes: persisted.map(entry => entry.type), reopenedMessageCount: entries.length, parentLinked: entries[1]?.parentId === firstId, activeLeafRestored: reopened.getLeafId() === secondId, inheritedGetEntries: !Object.hasOwn(SessionManager.prototype, "getEntries"), appendPrototypeOwned: Object.hasOwn(SessionManager.prototype, "appendMessage"), publicFlushCallable: typeof manager.flushPendingPersistence === "function" })); } finally { await rm(proofRoot, { recursive: true, force: true }); } })().catch(error => { console.error(error); process.exitCode = 1; });'
```

Observed redacted terminal output:

```text
SESSION_LIFECYCLE_PROOF={"storage":"sqlite","persistedEntryTypes":["session","message","message"],"reopenedMessageCount":2,"parentLinked":true,"activeLeafRestored":true,"inheritedGetEntries":true,"appendPrototypeOwned":true,"publicFlushCallable":true}
```

- Real lifecycle Testbox: tbx_01kyx5mezm3454eby797tkjbtt; https://github.com/openclaw/openclaw/actions/runs/30670905377
- The persisted transcript contained one session header and two message rows; reopening recovered both messages, their parent link, and the active leaf.
- The same live probe confirmed getEntries is inherited, appendMessage remains owned by the public prototype, and flushPendingPersistence remains publicly callable.
- 22 session-manager SQLite persistence, branching, cursor, and session lifecycle regressions passed.
- 10 gateway worker transcript commit, replay, stale-branch, and transactional rollback regressions passed.
- Focused command: pnpm test src/agents/sessions/session-manager.test.ts src/gateway/worker-environments/transcript-commit.test.ts
- Path-scoped command: pnpm check:changed -- src/agents/sessions/session-manager.ts
- Scoped check passed the public Plugin SDK API contract, production and core-test TypeScript checks, formatting, lint, dead exports, architecture boundaries, schema guards, and runtime import cycles.
- Focused/scoped Testbox: tbx_01kyx46k69zd780v8cf858swst; https://github.com/openclaw/openclaw/actions/runs/30669604411
- Exact-head PR CI passed: https://github.com/openclaw/openclaw/actions/runs/30670369546
- Fresh structured autoreview passed with no accepted or actionable findings.
- Production change: +3 / -195 lines; no test files changed.