### PR TITLE
refactor(state): unify synchronous and asynchronous plugin storage

### DIFF
--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -117,6 +117,25 @@ describe("plugin state keyed store", () => {
     });
   });
 
+  it("shares sync and async state while preserving their error contracts", async () => {
+    await withPluginStateTestState(async () => {
+      const options = { namespace: "shared-sync-async", maxEntries: 10 };
+      const asyncStore = createPluginStateKeyedStore<{ count: number }>("discord", options);
+      const syncStore = createPluginStateSyncKeyedStore<{ count: number }>("discord", options);
+
+      syncStore.register("counter", { count: 1 });
+      await expect(asyncStore.lookup("counter")).resolves.toEqual({ count: 1 });
+
+      await expect(
+        asyncStore.update?.("counter", (current) => ({ count: (current?.count ?? 0) + 1 })),
+      ).resolves.toBe(true);
+      expect(syncStore.lookup("counter")).toEqual({ count: 2 });
+
+      expect(() => syncStore.lookup(" ")).toThrow(PluginStateStoreError);
+      await expect(asyncStore.lookup(" ")).rejects.toThrow(PluginStateStoreError);
+    });
+  });
+
   it("reads a bounded sortable key range without scanning sibling keys", async () => {
     await withPluginStateTestState(async () => {
       const store = createPluginStateSyncKeyedStore<{ count: number }>("memory-core", {

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -193,116 +193,25 @@ function createKeyedStoreForPluginId<T>(
   pluginId: string,
   options: OpenKeyedStoreOptions,
 ): PluginStateKeyedStore<T> {
-  const namespace = validateNamespace(options.namespace);
-  const maxEntries = validateMaxEntries(options.maxEntries);
-  const overflowPolicy = validateOverflowPolicy(options.overflowPolicy);
-  const defaultTtlMs = validateOptionalTtlMs(options.defaultTtlMs);
-  const env = options.env;
-  assertConsistentOptions(pluginId, namespace, { maxEntries, overflowPolicy, defaultTtlMs });
+  const store = createSyncKeyedStoreForPluginId<T>(pluginId, options);
 
   return {
-    async register(key, value, opts) {
-      const params = prepareRegisterParams(key, value, defaultTtlMs, opts);
-      pluginStateRegister({
-        pluginId,
-        namespace,
-        key: params.key,
-        valueJson: params.valueJson,
-        maxEntries,
-        overflowPolicy,
-        ...(env ? { env } : {}),
-        ...(params.ttlMs != null ? { ttlMs: params.ttlMs } : {}),
-      });
-    },
-    async registerIfAbsent(key, value, opts) {
-      const params = prepareRegisterParams(key, value, defaultTtlMs, opts);
-      return pluginStateRegisterIfAbsent({
-        pluginId,
-        namespace,
-        key: params.key,
-        valueJson: params.valueJson,
-        maxEntries,
-        overflowPolicy,
-        ...(env ? { env } : {}),
-        ...(params.ttlMs != null ? { ttlMs: params.ttlMs } : {}),
-      });
-    },
-    async update(key, updateValue, opts) {
-      const normalizedKey = validateKey(key, "register");
-      return pluginStateUpdate({
-        pluginId,
-        namespace,
-        key: normalizedKey,
-        maxEntries,
-        overflowPolicy,
-        updateValueJson: (current) => {
-          const next = updateValue(current as T | undefined);
-          if (next === undefined) {
-            return undefined;
-          }
-          const params = prepareRegisterParams(normalizedKey, next, defaultTtlMs, opts);
-          return {
-            valueJson: params.valueJson,
-            ...(params.ttlMs != null ? { ttlMs: params.ttlMs } : {}),
-          };
-        },
-        ...(env ? { env } : {}),
-      });
-    },
-    async deleteIf(key, predicate) {
-      const normalizedKey = validateKey(key, "delete");
-      return pluginStateDeleteIf({
-        pluginId,
-        namespace,
-        key: normalizedKey,
-        predicate: (current) => predicate(current as T),
-        ...(env ? { env } : {}),
-      });
-    },
-    async lookup(key) {
-      const normalizedKey = validateKey(key, "lookup");
-      return pluginStateLookup({
-        pluginId,
-        namespace,
-        key: normalizedKey,
-        ...(env ? { env } : {}),
-      }) as T | undefined;
-    },
-    async consume(key) {
-      const normalizedKey = validateKey(key, "consume");
-      return pluginStateConsume({
-        pluginId,
-        namespace,
-        key: normalizedKey,
-        ...(env ? { env } : {}),
-      }) as T | undefined;
-    },
-    async delete(key) {
-      const normalizedKey = validateKey(key, "delete");
-      return pluginStateDelete({
-        pluginId,
-        namespace,
-        key: normalizedKey,
-        ...(env ? { env } : {}),
-      });
-    },
-    async entries() {
-      return pluginStateEntries({
-        pluginId,
-        namespace,
-        ...(env ? { env } : {}),
-      }) as PluginStateEntry<T>[];
-    },
-    async clear() {
-      pluginStateClear({ pluginId, namespace, ...(env ? { env } : {}) });
-    },
+    register: async (...args) => store.register(...args),
+    registerIfAbsent: async (...args) => store.registerIfAbsent(...args),
+    update: async (...args) => store.update(...args),
+    deleteIf: async (...args) => store.deleteIf(...args),
+    lookup: async (...args) => store.lookup(...args),
+    consume: async (...args) => store.consume(...args),
+    delete: async (...args) => store.delete(...args),
+    entries: async () => store.entries(),
+    clear: async () => store.clear(),
   };
 }
 
 function createSyncKeyedStoreForPluginId<T>(
   pluginId: string,
   options: OpenKeyedStoreOptions,
-): PluginStateSyncKeyedStore<T> {
+): Required<PluginStateSyncKeyedStore<T>> {
   const namespace = validateNamespace(options.namespace);
   const maxEntries = validateMaxEntries(options.maxEntries);
   const overflowPolicy = validateOverflowPolicy(options.overflowPolicy);


### PR DESCRIPTION
## What Problem This Solves

Plugin authors and maintainers rely on synchronous and Promise-based keyed state behaving identically, but separate implementations duplicate validation, namespace isolation, TTL handling, and write policy, creating unnecessary maintenance and behavior-drift risk.

## Why This Change Was Made

Make the existing synchronous SQLite-backed keyed store the single implementation and project the existing asynchronous public API through Promise-returning methods. Preserve public plugin SDK signatures, synchronous transaction callbacks, isolation, TTL and overflow behavior, and rejected-Promise error handling without changing the storage schema.

## User Impact

No user-visible behavior change. Plugin storage keeps the same synchronous and asynchronous contracts while removing 91 production lines and making both interfaces share identical behavior.

## Evidence

- Blacksmith Testbox tbx_01kyx4mp8abtdkkd1pgyfzxhdr: 60 passing tests across plugin-state unit, plugin-runtime, and persisted-storage E2E coverage.
- Focused command: pnpm test src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.runtime.test.ts src/plugin-state/plugin-state-store.e2e.test.ts
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/30670019258
- Added direct regression covering shared sync/async visibility and synchronous throws versus rejected Promises.
- Targeted oxfmt check, git diff --check, and fresh independent autoreview all passed.
- AI-assisted; autoreview reported no actionable findings.