### PR TITLE
fix(memory): compact SQLite sessions after newly appended content

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1894,7 +1894,6 @@ describe("runMemoryFlushIfNeeded", () => {
   it.each(["user", "auto"] as const)(
     "passes resolved context budget and $authProfileIdSource auth profile to preflight compaction",
     async (authProfileIdSource) => {
-      const sessionFile = path.join(rootDir, "budget-session.jsonl");
       const sessionEntry: SessionEntry = {
         sessionId: "session",
         updatedAt: Date.now(),

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -112,6 +112,24 @@ function loadMainSessionEntry(storePath: string): SessionEntry {
   return entry;
 }
 
+async function writeTestSessionTranscript(params: {
+  rootDir: string;
+  events: Parameters<typeof replaceSqliteTranscriptEvents>[1];
+  sessionKey?: string;
+  sessionId?: string;
+}): Promise<void> {
+  const sessionId = params.sessionId ?? "session";
+  const sessionKey = params.sessionKey ?? "main";
+  const scope = {
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    storePath: path.join(params.rootDir, "sessions.json"),
+  };
+  await upsertSessionEntry(scope, { sessionId, updatedAt: 10 });
+  await replaceSqliteTranscriptEvents(scope, params.events);
+}
+
 type RefreshQueuedFollowupSessionParams = {
   key?: string;
   previousSessionId?: string;
@@ -344,10 +362,6 @@ describe("runMemoryFlushIfNeeded", () => {
       incrementCompactionCount: incrementCompactionCountMock as never,
       registerAgentRunContext: registerAgentRunContextMock as never,
       emitAgentEvent: emitAgentEventMock as never,
-      resolveSessionLogPath: (
-        _sessionId: string | undefined,
-        entry: (SessionEntry & { transcriptPath?: string }) | undefined,
-      ) => entry?.transcriptPath,
       randomUUID: () => "00000000-0000-0000-0000-000000000001",
       now: () => 1_700_000_000_000,
     });
@@ -1541,7 +1555,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -1636,7 +1649,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -1684,7 +1696,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -1745,7 +1756,6 @@ describe("runMemoryFlushIfNeeded", () => {
       });
       const sessionEntry: SessionEntry = {
         sessionId: "session",
-        transcriptPath: sessionFile,
         updatedAt: Date.now(),
         totalTokens: 120,
         totalTokensFresh: true,
@@ -1798,7 +1808,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -1853,7 +1862,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -1889,7 +1897,6 @@ describe("runMemoryFlushIfNeeded", () => {
       const sessionFile = path.join(rootDir, "budget-session.jsonl");
       const sessionEntry: SessionEntry = {
         sessionId: "session",
-        transcriptPath: sessionFile,
         updatedAt: Date.now(),
         totalTokens: 245_000,
         totalTokensFresh: true,
@@ -2000,11 +2007,11 @@ describe("runMemoryFlushIfNeeded", () => {
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
-      "utf8",
-    );
+    await writeTestSessionTranscript({
+      rootDir,
+      sessionKey: "agent:main:main",
+      events: [{ type: "message", message: { role: "user", content: "x".repeat(5_000) } }],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 1,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2024,7 +2031,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2064,17 +2070,19 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("includes recent output tokens when deciding preflight compaction", async () => {
     const sessionFile = path.join(rootDir, "session-usage.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "large answer",
-          usage: { input: 90_000, output: 10_000 },
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "large answer",
+            usage: { input: 90_000, output: 10_000 },
+          },
         },
-      })}\n`,
-      "utf8",
-    );
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2085,7 +2093,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2111,26 +2118,27 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.currentTokenCount).toBeGreaterThanOrEqual(100_000);
   });
 
-  it("reuses the transcript tail scan stat when memory flush needs usage and byte size", async () => {
+  it("reads flush usage and byte size from SQLite without statting a retired transcript path", async () => {
     const sessionFile = path.join(rootDir, "memory-flush-usage-and-size.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "large answer",
-          usage: { input: 80_000, output: 4_000 },
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "large answer",
+            usage: { input: 80_000, output: 4_000 },
+          },
         },
-      })}\n`,
-      "utf8",
-    );
+      ],
+    });
     const originalStat = fsCore.promises.stat.bind(fsCore.promises);
     const statSpy = vi
       .spyOn(fsCore.promises, "stat")
       .mockImplementation(async (target, options) => originalStat(target, options));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2174,7 +2182,6 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: path.join(rootDir, "required-preflight-session.jsonl"),
       updatedAt: Date.now(),
       totalTokens: 180_499,
       totalTokensFresh: true,
@@ -2442,24 +2449,26 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("does not treat unavailable Anthropic context as transcript prompt usage", async () => {
     const sessionFile = path.join(rootDir, "unavailable-context-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "small answer",
-          usage: {
-            input: 12,
-            output: 15_104,
-            cacheRead: 819_661,
-            cacheWrite: 93_130,
-            contextUsage: { state: "unavailable" },
-            totalTokens: 927_907,
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "small answer",
+            usage: {
+              input: 12,
+              output: 15_104,
+              cacheRead: 819_661,
+              cacheWrite: 93_130,
+              contextUsage: { state: "unavailable" },
+              totalTokens: 927_907,
+            },
           },
         },
-      })}\n`,
-      "utf8",
-    );
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2470,7 +2479,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2497,25 +2505,26 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("keeps preflight compaction conservative for content appended after latest usage", async () => {
     const sessionFile = path.join(rootDir, "post-usage-tail-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
           message: {
             role: "assistant",
             content: "small answer",
             usage: { input: 40_000, output: 2_000 },
           },
-        }),
-        JSON.stringify({
+        },
+        {
+          type: "message",
           message: {
             role: "tool",
             content: `large interrupted tool output ${"x".repeat(450_000)}`,
           },
-        }),
-      ].join("\n"),
-      "utf8",
-    );
+        },
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2526,7 +2535,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2554,25 +2562,26 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("combines latest usage with post-usage tail pressure for preflight compaction", async () => {
     const sessionFile = path.join(rootDir, "combined-tail-pressure-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
           message: {
             role: "assistant",
             content: "small answer",
             usage: { input: 86_000, output: 2_000 },
           },
-        }),
-        JSON.stringify({
+        },
+        {
+          type: "message",
           message: {
             role: "tool",
             content: `moderate interrupted tool output ${"x".repeat(36_000)}`,
           },
-        }),
-      ].join("\n"),
-      "utf8",
-    );
+        },
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2583,7 +2592,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2611,23 +2619,19 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("does not count bytes from a large latest usage record as post-usage tail pressure", async () => {
     const sessionFile = path.join(rootDir, "large-usage-record-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "session",
-          id: "session",
-        }),
-        JSON.stringify({
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
           message: {
             role: "assistant",
             content: `large answer ${"x".repeat(300_000)}`,
             usage: { input: 40_000, output: 2_000 },
           },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
+        },
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2638,7 +2642,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2665,27 +2668,23 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("does not treat raw transcript metadata bytes as token pressure", async () => {
     const sessionFile = path.join(rootDir, "metadata-heavy-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "session",
-          id: "session",
-        }),
-        JSON.stringify({
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
           type: "custom",
           payload: "x".repeat(450_000),
-        }),
-        JSON.stringify({
+        },
+        {
+          type: "message",
           message: {
             role: "assistant",
             content: "small answer",
             usage: { input: 40_000, output: 2_000 },
           },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
+        },
+      ],
+    });
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
       forceFlushTranscriptBytes: 1_000_000_000,
@@ -2696,7 +2695,6 @@ describe("runMemoryFlushIfNeeded", () => {
     }));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
@@ -2747,14 +2745,12 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("triggers preflight compaction when the active transcript exceeds the configured byte threshold", async () => {
     const sessionFile = path.join(rootDir, "large-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({ message: { role: "user", content: "x".repeat(256) } })}\n`,
-      "utf8",
-    );
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [{ type: "message", message: { role: "user", content: "x".repeat(256) } }],
+    });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 10,
       totalTokensFresh: true,
@@ -2794,7 +2790,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sessionId).toBe("session");
     expect(compactCall.trigger).toBe("budget");
     expect(compactCall.currentTokenCount).toBe(12);
-    expect(compactCall.sessionFile).toContain("large-session.jsonl");
+    expect(compactCall.sessionFile).toBe("main");
   });
 
   it("byte-guards a Codex runtime session through SQLite semantic compaction", async () => {
@@ -3204,14 +3200,12 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("emits preflight compaction notices around a successful budget compaction", async () => {
     const sessionFile = path.join(rootDir, "notify-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
-      "utf8",
-    );
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [{ type: "message", message: { role: "user", content: "x".repeat(5_000) } }],
+    });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,
@@ -3252,15 +3246,13 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("emits an incomplete preflight compaction notice when post-compaction state update throws", async () => {
     const sessionFile = path.join(rootDir, "notify-failed-session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
-      "utf8",
-    );
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [{ type: "message", message: { role: "user", content: "x".repeat(5_000) } }],
+    });
     incrementCompactionCountMock.mockRejectedValueOnce(new Error("count update failed"));
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      transcriptPath: sessionFile,
       updatedAt: Date.now(),
       totalTokens: 120,
       totalTokensFresh: true,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -38,7 +38,6 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../../config/sessions.js";
-import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
@@ -167,7 +166,6 @@ const memoryDeps = {
   incrementCompactionCount,
   updateSessionEntry: updateSessionEntryDefault,
   emitAgentEvent,
-  resolveSessionLogPath,
   randomUUID: () => crypto.randomUUID(),
   now: () => Date.now(),
 };
@@ -184,7 +182,6 @@ function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): v
     incrementCompactionCount,
     updateSessionEntry: updateSessionEntryDefault,
     emitAgentEvent,
-    resolveSessionLogPath,
     randomUUID: () => crypto.randomUUID(),
     now: () => Date.now(),
     ...overrides,
@@ -365,41 +362,8 @@ type SessionTranscriptUsageSnapshot = {
 // Keep a generous near-threshold window so large assistant outputs still trigger
 // transcript reads in time to flip memory-flush gating when needed.
 const TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS = 8192;
-const TRANSCRIPT_TAIL_CHUNK_BYTES = 64 * 1024;
 const SQLITE_USAGE_TAIL_MAX_EVENTS = 512;
 const FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN = 4;
-
-function parseUsageFromTranscriptLine(line: string): ReturnType<typeof normalizeUsage> | undefined {
-  const trimmed = line.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(trimmed) as {
-      message?: { usage?: UsageLike };
-      usage?: UsageLike;
-    };
-    const usageRaw = parsed.message?.usage ?? parsed.usage;
-    const usage = normalizeUsage(usageRaw);
-    if (usage && hasNonzeroUsage(usage)) {
-      return usage;
-    }
-  } catch {
-    // ignore bad lines
-  }
-  return undefined;
-}
-
-function resolveSessionLogPath(
-  _sessionId?: string,
-  _sessionEntry?: SessionEntry,
-  _sessionKey?: string,
-  _opts?: { agentId?: string; storePath?: string },
-): string | undefined {
-  // Runtime session rows carry SQLite identity only. Tests may inject an artifact
-  // resolver to cover explicit exported JSONL inputs, but runtime never infers one.
-  return undefined;
-}
 
 function deriveTranscriptUsageSnapshot(
   snapshot:
@@ -434,10 +398,11 @@ function deriveTranscriptUsageSnapshot(
   };
 }
 
-function readLatestNonzeroUsageFromTranscriptEvents(
+function readLatestNonzeroUsageSnapshotFromTranscriptEvents(
   events: readonly unknown[],
-): ReturnType<typeof normalizeUsage> | undefined {
+): { usage: NonNullable<ReturnType<typeof normalizeUsage>>; trailingBytes: number } | undefined {
   const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
+  let trailingBytes = 0;
   for (const event of activeEvents.toReversed()) {
     if (!event || typeof event !== "object" || Array.isArray(event)) {
       continue;
@@ -452,7 +417,12 @@ function readLatestNonzeroUsageFromTranscriptEvents(
         : undefined;
     const usage = normalizeUsage(message?.usage ?? record.usage);
     if (usage && hasNonzeroUsage(usage)) {
-      return usage;
+      return { usage, trailingBytes };
+    }
+    if (message) {
+      // Count later conversation content, not session metadata, when projecting
+      // context growth since the most recent authoritative provider usage.
+      trailingBytes += Buffer.byteLength(JSON.stringify(message), "utf8") + 1;
     }
   }
   return undefined;
@@ -499,9 +469,9 @@ function readSqliteSessionLogSnapshot(
     if (options.includeUsage || options.includeTurnTaint) {
       const events = readRecentSessionTranscriptActiveEvents(scope, SQLITE_USAGE_TAIL_MAX_EVENTS);
       if (options.includeUsage) {
-        snapshot.usage = deriveTranscriptUsageSnapshot({
-          usage: readLatestNonzeroUsageFromTranscriptEvents(events),
-        });
+        snapshot.usage = deriveTranscriptUsageSnapshot(
+          readLatestNonzeroUsageSnapshotFromTranscriptEvents(events),
+        );
       }
       if (options.includeTurnTaint) {
         const scan = readActiveTurnTaintFromTranscriptEvents(events);
@@ -546,183 +516,28 @@ async function appendPostCompactionRefreshPrompt(params: {
     .join("\n\n");
 }
 
-async function readSessionLogSnapshot(params: {
+function readSessionLogSnapshot(params: {
   agentId?: string;
   sessionId?: string;
-  sessionEntry?: SessionEntry;
   sessionKey?: string;
-  opts?: { agentId?: string; storePath?: string };
+  storePath?: string;
   includeByteSize: boolean;
   includeTurnTaint?: boolean;
   includeUsage: boolean;
-}): Promise<SessionLogSnapshot> {
-  const logPath = memoryDeps.resolveSessionLogPath(
-    params.sessionId,
-    params.sessionEntry,
-    params.sessionKey,
-    params.opts,
-  );
-  const sqliteMarker = logPath ? parseSqliteSessionFileMarker(logPath) : undefined;
-  if (logPath && !sqliteMarker) {
-    return await readFileSessionLogSnapshot(logPath, params);
-  }
-  const agentId =
-    params.agentId ?? params.opts?.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
-  if (params.sessionId && params.opts?.storePath && agentId) {
+}): SessionLogSnapshot {
+  const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+  if (params.sessionId && params.storePath && agentId) {
     return readSqliteSessionLogSnapshot(
       {
         agentId,
         sessionId: params.sessionId,
         ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        storePath: params.opts.storePath,
+        storePath: params.storePath,
       },
       params,
     );
   }
-  if (sqliteMarker) {
-    return readSqliteSessionLogSnapshot(sqliteMarker, params);
-  }
   return params.includeTurnTaint ? { turnTainted: true } : {};
-}
-
-async function readFileSessionLogSnapshot(
-  logPath: string,
-  params: { includeByteSize: boolean; includeTurnTaint?: boolean; includeUsage: boolean },
-): Promise<SessionLogSnapshot> {
-  const snapshot: SessionLogSnapshot = {};
-  let usageScan: SessionLogUsageScan | undefined;
-
-  if (params.includeUsage) {
-    try {
-      usageScan = await readLastNonzeroUsageFromSessionLog(logPath);
-      snapshot.usage = deriveTranscriptUsageSnapshot(usageScan);
-    } catch {
-      snapshot.usage = undefined;
-    }
-  }
-
-  if (params.includeByteSize) {
-    const scannedSize = usageScan?.byteSize;
-    if (typeof scannedSize === "number" && Number.isFinite(scannedSize) && scannedSize >= 0) {
-      snapshot.byteSize = Math.floor(scannedSize);
-    } else {
-      snapshot.byteSize = await readSessionLogByteSize(logPath);
-    }
-  }
-
-  if (params.includeTurnTaint) {
-    snapshot.turnTainted = await readFileSessionTurnTaint(logPath);
-  }
-
-  return snapshot;
-}
-
-async function readFileSessionTurnTaint(logPath: string): Promise<boolean> {
-  const handle = await fs.promises.open(logPath, "r");
-  try {
-    const stat = await handle.stat();
-    const size = Math.min(TRANSCRIPT_TAIL_CHUNK_BYTES, stat.size);
-    const buffer = Buffer.allocUnsafe(size);
-    const { bytesRead } = await handle.read(buffer, 0, size, stat.size - size);
-    const lines = buffer.toString("utf8", 0, bytesRead).split(/\n+/u);
-    if (stat.size > size) {
-      lines.shift();
-    }
-    const events = lines.flatMap((line) => {
-      try {
-        return line.trim() ? [JSON.parse(line) as unknown] : [];
-      } catch {
-        return [];
-      }
-    });
-    const scan = readActiveTurnTaintFromTranscriptEvents(events);
-    return scan.tainted || (!scan.boundaryFound && stat.size > size);
-  } catch {
-    return true;
-  } finally {
-    await handle.close();
-  }
-}
-
-type SessionLogUsageScan = {
-  usage?: ReturnType<typeof normalizeUsage>;
-  trailingBytes?: number;
-  byteSize: number;
-};
-
-async function readSessionLogByteSize(logPath: string): Promise<number | undefined> {
-  let handle: fs.promises.FileHandle | undefined;
-  try {
-    handle = await fs.promises.open(logPath, "r");
-    const stat = await handle.stat();
-    const size = Math.floor(stat.size);
-    return Number.isFinite(size) && size >= 0 ? size : undefined;
-  } catch {
-    return undefined;
-  } finally {
-    await handle?.close();
-  }
-}
-
-async function readLastNonzeroUsageFromSessionLog(logPath: string): Promise<SessionLogUsageScan> {
-  const handle = await fs.promises.open(logPath, "r");
-  try {
-    const stat = await handle.stat();
-    let position = stat.size;
-    let leadingPartial = "";
-    while (position > 0) {
-      const chunkSize = Math.min(TRANSCRIPT_TAIL_CHUNK_BYTES, position);
-      const start = position - chunkSize;
-      const buffer = Buffer.allocUnsafe(chunkSize);
-      const { bytesRead } = await handle.read(buffer, 0, chunkSize, start);
-      if (bytesRead <= 0) {
-        break;
-      }
-      const chunk = buffer.toString("utf-8", 0, bytesRead);
-      const appendedPartialBytes = Buffer.byteLength(leadingPartial, "utf8");
-      const combined = `${chunk}${leadingPartial}`;
-      const lines = combined.split(/\n+/);
-      const firstLine = lines.shift() ?? "";
-      if (start > 0) {
-        leadingPartial = firstLine;
-      } else {
-        leadingPartial = "";
-        lines.unshift(firstLine);
-      }
-      const suffixBytesBeforeChunk = stat.size - position;
-      const suffixBytesOutsideCombined = Math.max(0, suffixBytesBeforeChunk - appendedPartialBytes);
-      for (let i = lines.length - 1; i >= 0; i -= 1) {
-        const usage = parseUsageFromTranscriptLine(lines[i] ?? "");
-        if (usage) {
-          const trailingLines = lines.slice(i + 1);
-          const trailingBytesInChunk = estimatePostUsageTrailingBytes(trailingLines);
-          return {
-            usage,
-            trailingBytes: suffixBytesOutsideCombined + trailingBytesInChunk,
-            byteSize: stat.size,
-          };
-        }
-      }
-      position = start;
-    }
-    const usage = parseUsageFromTranscriptLine(leadingPartial);
-    return usage
-      ? {
-          usage,
-          trailingBytes: Math.max(0, stat.size - Buffer.byteLength(leadingPartial, "utf8")),
-          byteSize: stat.size,
-        }
-      : { byteSize: stat.size };
-  } finally {
-    await handle.close();
-  }
-}
-
-function estimatePostUsageTrailingBytes(lines: string[]): number {
-  if (!lines.some((line) => line.trim())) {
-    return 0;
-  }
-  return Buffer.byteLength(lines.join("\n"), "utf8") + lines.length;
 }
 
 type TranscriptTokenEstimate = {
@@ -735,7 +550,6 @@ type TranscriptTokenEstimate = {
 async function estimatePromptTokensFromSessionTranscript(params: {
   agentId?: string;
   sessionId?: string;
-  sessionEntry?: SessionEntry;
   sessionKey?: string;
   storePath?: string;
 }): Promise<TranscriptTokenEstimate | undefined> {
@@ -744,12 +558,11 @@ async function estimatePromptTokensFromSessionTranscript(params: {
     return undefined;
   }
   try {
-    const snapshot = await readSessionLogSnapshot({
+    const snapshot = readSessionLogSnapshot({
       agentId: params.agentId,
       sessionId,
-      sessionEntry: params.sessionEntry,
       sessionKey: params.sessionKey,
-      opts: { agentId: params.agentId, storePath: params.storePath },
+      storePath: params.storePath,
       includeByteSize: true,
       includeUsage: true,
     });
@@ -933,18 +746,16 @@ export async function runPreflightCompactionIfNeeded(params: {
       : await estimatePromptTokensFromSessionTranscript({
           agentId: compactionAgentId,
           sessionId: entry.sessionId,
-          sessionEntry: entry,
           sessionKey: compactionSessionKey,
           storePath: compactionStorePath,
         });
   const transcriptSizeSnapshot =
     shouldCheckActiveTranscriptBytes && transcriptUsageTokens?.transcriptByteSize === undefined
-      ? await readSessionLogSnapshot({
+      ? readSessionLogSnapshot({
           agentId: compactionAgentId,
           sessionId: entry.sessionId,
-          sessionEntry: entry,
           sessionKey: compactionSessionKey,
-          opts: { agentId: compactionAgentId, storePath: compactionStorePath },
+          storePath: compactionStorePath,
           includeByteSize: true,
           includeUsage: false,
         })
@@ -1054,15 +865,6 @@ export async function runPreflightCompactionIfNeeded(params: {
   };
   try {
     await notifyStartCompaction();
-    const sessionFile =
-      memoryDeps.resolveSessionLogPath(entry.sessionId, entry, compactionSessionKey, {
-        agentId: compactionAgentId,
-        storePath: compactionStorePath,
-      }) ?? normalizeOptionalString(compactionSessionKey);
-    if (!sessionFile) {
-      await notifyTerminalCompaction("skipped");
-      return entry ?? params.sessionEntry;
-    }
     const result = await deps.compactEmbeddedAgentSession({
       sessionId: entry.sessionId,
       sessionKey: compactionSessionKey,
@@ -1084,7 +886,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       senderUsername: params.followupRun.run.senderUsername,
       senderE164: params.followupRun.run.senderE164,
       inputProvenance: params.followupRun.run.inputProvenance,
-      sessionFile,
+      sessionFile: compactionSessionKey,
       workspaceDir: params.followupRun.run.workspaceDir,
       cwd: params.followupRun.run.cwd,
       agentDir: params.followupRun.run.agentDir,
@@ -1304,11 +1106,11 @@ export async function runMemoryFlushIfNeeded(params: {
   const shouldReadSessionLog =
     shouldReadTranscript || shouldCheckTranscriptSizeForForcedFlush || shouldReadTurnTaint;
   const sessionLogSnapshot = shouldReadSessionLog
-    ? await readSessionLogSnapshot({
+    ? readSessionLogSnapshot({
+        agentId: params.followupRun.run.agentId,
         sessionId: params.followupRun.run.sessionId,
-        sessionEntry: entry,
         sessionKey: params.sessionKey ?? params.followupRun.run.sessionKey,
-        opts: { agentId: params.followupRun.run.agentId, storePath: params.storePath },
+        storePath: params.storePath,
         includeByteSize: shouldCheckTranscriptSizeForForcedFlush,
         includeTurnTaint: shouldReadTurnTaint,
         includeUsage: shouldReadTranscript,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where conversations with stale token totals could miss required memory flush or preflight compaction after additional tool or user content was appended to a SQLite-backed session.

## Why This Change Was Made

Read usage, byte pressure, and provenance directly from the authoritative SQLite transcript, account for message content appended after the latest provider usage, and remove the unreachable JSONL compatibility scanner and artificial test-only resolver.

## User Impact

Conversation maintenance reacts correctly to newly accumulated transcript content without relying on retired transcript files. Existing memory-flush provenance, byte limits, session rotation, and native runtime ownership remain covered.

## Evidence

- Exact reviewed head: 35c14b37c9e8aa50f63539f5d3fa35cc17f6645f.
- Blacksmith Testbox tbx_01kyx5fzr8wndhkebk112e1r9x: 67 of 67 focused tests passed across src/auto-reply/reply/agent-runner-memory.test.ts (61) and src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts (6).
- Canonical SQLite fixtures prove post-usage tool content triggers compaction, moderate appended content is added to provider usage, metadata is not mistaken for prompt pressure, byte-triggered flushes persist, and network-tainted writes stay untrusted.
- Exact-head hosted check-lint and required openclaw/ci-gate passed: https://github.com/openclaw/openclaw/actions/runs/30670912560/job/91289673471.
- Focused remote proof: https://github.com/openclaw/openclaw/actions/runs/30670783991.
- Fresh structured full-branch autoreview: no accepted or actionable findings.
- Production delta: +26/-224 (-198 lines); complete change: +145/-352 (-207 lines).
- Provenance: PR #113233 (4273ca9dbd9) retired file-era runtime transcripts and made the production resolver unconditionally return undefined while test-only injection retained the unreachable scanner; code author, PR author, and merger were @steipete.