### PR TITLE
refactor(doctor): compact compatibility release inventory

### DIFF
--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -35,24 +35,31 @@ export type DoctorDeprecationCompatRecord<Code extends string = string> = {
 
 const TODAY = "2026-04-26";
 const MAX_REMOVE_AFTER = "2026-07-26";
+const DEFAULT_TESTS = ["src/commands/doctor/shared/legacy-config-migrate.test.ts"] as const;
 
 function deprecatedCompatRecord<Code extends string>(
+  code: Code,
   record: Omit<
     DoctorDeprecationCompatRecord<Code>,
-    "deprecated" | "warningStarts" | "removeAfter" | "status"
+    "code" | "introduced" | "deprecated" | "warningStarts" | "removeAfter" | "status" | "tests"
   > &
     Partial<
       Pick<
         DoctorDeprecationCompatRecord<Code>,
-        "deprecated" | "removeAfter" | "status" | "warningStarts"
+        "introduced" | "deprecated" | "removeAfter" | "status" | "warningStarts" | "tests"
       >
     >,
 ): DoctorDeprecationCompatRecord<Code> {
+  const introduced = record.introduced ?? TODAY;
+  const deprecated = record.deprecated ?? (record.removeAfter ? introduced : TODAY);
   return {
+    code,
     status: "deprecated",
-    deprecated: TODAY,
-    warningStarts: TODAY,
+    introduced,
+    deprecated,
+    warningStarts: deprecated,
     removeAfter: MAX_REMOVE_AFTER,
+    tests: DEFAULT_TESTS,
     ...record,
   };
 }
@@ -62,10 +69,7 @@ function deprecatedCompatRecord<Code extends string>(
 // doctor fixes, and replacement notes should be revalidated against the current
 // architecture because ownership and config footprint can shift during rollout.
 const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
-  deprecatedCompatRecord({
-    code: "doctor-cli-backends-plugin-registration",
-    deprecated: "2026-07-21",
-    warningStarts: "2026-07-21",
+  deprecatedCompatRecord("doctor-cli-backends-plugin-registration", {
     removeAfter: "2026-09-22",
     owner: "agent-runtime",
     introduced: "2026-07-21",
@@ -78,10 +82,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-model-compat-catalog-ownership",
-    deprecated: "2026-07-21",
-    warningStarts: "2026-07-21",
+  deprecatedCompatRecord("doctor-model-compat-catalog-ownership", {
     removeAfter: "2026-09-22",
     owner: "provider",
     introduced: "2026-07-21",
@@ -94,10 +95,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-tier-eval-tranche",
-    deprecated: "2026-07-20",
-    warningStarts: "2026-07-20",
+  deprecatedCompatRecord("doctor-tier-eval-tranche", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-20",
@@ -111,10 +109,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-final-layout-polish",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-final-layout-polish", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-19",
@@ -127,10 +122,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-phase4-product-config-retirements",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-phase4-product-config-retirements", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-19",
@@ -143,10 +135,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-media-models-consolidation",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-media-models-consolidation", {
     removeAfter: "2026-09-18",
     owner: "tools",
     introduced: "2026-07-19",
@@ -159,10 +148,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-runtime-tuning-knobs-purge",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-runtime-tuning-knobs-purge", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-19",
@@ -175,10 +161,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/config/dead-config-keys.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-phase2-channel-dm-aliases",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-phase2-channel-dm-aliases", {
     removeAfter: "2026-09-18",
     owner: "channel",
     introduced: "2026-07-18",
@@ -188,10 +171,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/cli/doctor",
     tests: ["src/config/channel-alias-migration.test.ts", "src/config/dead-config-keys.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-phase1-retired-runtime-config",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-phase1-retired-runtime-config", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-18",
@@ -203,10 +183,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/cli/doctor",
     tests: ["src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-root-default-model",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-root-default-model", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-18",
@@ -216,10 +193,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/gateway/doctor",
     tests: ["src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-session-prune-reset-aliases",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-session-prune-reset-aliases", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-18",
@@ -229,10 +203,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/gateway/configuration-reference",
     tests: ["src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-mcp-timeout-aliases",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-mcp-timeout-aliases", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-18",
@@ -242,10 +213,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/cli/mcp",
     tests: ["src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-cron-webhook-fallback",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-cron-webhook-fallback", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-18",
@@ -255,10 +223,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/automation/cron-jobs",
     tests: ["src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-canvas-host-root",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-canvas-host-root", {
     removeAfter: "2026-09-18",
     owner: "plugin",
     introduced: "2026-07-18",
@@ -268,10 +233,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/plugins",
     tests: ["src/plugins/setup-registry.migrations.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-phase1-channel-noops-aliases",
-    deprecated: "2026-07-18",
-    warningStarts: "2026-07-18",
+  deprecatedCompatRecord("doctor-phase1-channel-noops-aliases", {
     removeAfter: "2026-09-18",
     owner: "channel",
     introduced: "2026-07-18",
@@ -282,56 +244,44 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/channels/channel-routing",
     tests: ["src/config/dead-config-keys.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-agent-llm-timeout",
+  deprecatedCompatRecord("doctor-agent-llm-timeout", {
     owner: "agent-runtime",
     introduced: "2026-04-27",
     source: "agents.defaults.llm.idleTimeoutSeconds",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "models.providers.<id>.timeoutSeconds",
     docsPath: "/gateway/config-agents",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "The old agent-level idle timeout knob was collapsed into provider request timeout handling, bounded by the agent/run timeout ceiling.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-agent-runtime-embedded-harness",
+  deprecatedCompatRecord("doctor-agent-runtime-embedded-harness", {
     owner: "agent-runtime",
     introduced: "2026-04-25",
     source: "agents.defaults.embeddedHarness; agents.list[].embeddedHarness",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "models.providers.<provider>.agentRuntime or model-scoped agentRuntime",
     docsPath: "/plugins/sdk-agent-harness",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "Whole-agent runtime pins are retired; doctor preserves intent only when it can move the value to provider/model runtime policy.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-agent-embedded-pi-config",
+  deprecatedCompatRecord("doctor-agent-embedded-pi-config", {
     owner: "agent-runtime",
     introduced: "2026-05-21",
     source: "agents.defaults.embeddedPi; agents.list[].embeddedPi",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "agents.defaults.embeddedAgent; agents.list[].embeddedAgent",
     docsPath: "/gateway/config-agents",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "Runtime code no longer reads the legacy key; doctor keeps this migration only to preserve shipped configs during upgrade.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-agent-sandbox-persession",
+  deprecatedCompatRecord("doctor-agent-sandbox-persession", {
     owner: "agent-runtime",
-    introduced: "2026-04-26",
     source: "agents.defaults.sandbox.perSession; agents.list[].sandbox.perSession",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "agents.*.sandbox.scope",
     docsPath: "/cli/doctor",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-memory-search-owner-consolidation",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-memory-search-owner-consolidation", {
     removeAfter: "2026-09-18",
     owner: "config",
     introduced: "2026-07-19",
@@ -339,12 +289,8 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "memory.search; agents.list[].memory.search",
     docsPath: "/reference/memory-config",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-session-typing-mode-owner",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-session-typing-mode-owner", {
     removeAfter: "2026-09-18",
     owner: "agent-runtime",
     introduced: "2026-07-19",
@@ -352,84 +298,63 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "agents.defaults.typingMode or agents.list[].typingMode",
     docsPath: "/concepts/typing-indicators",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-top-level-heartbeat",
+  deprecatedCompatRecord("doctor-top-level-heartbeat", {
     owner: "config",
-    introduced: "2026-04-26",
     source: "heartbeat",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts",
     replacement: "agents.defaults.heartbeat and channels.defaults.heartbeat",
     docsPath: "/automation",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-mcp-server-type-alias",
+  deprecatedCompatRecord("doctor-mcp-server-type-alias", {
     owner: "config",
     introduced: "2026-04-27",
     source: "mcp.servers.*.type",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts",
     replacement: "mcp.servers.*.transport",
     docsPath: "/cli/mcp",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "OpenClaw stores transport names; CLI backends receive their own type fields through runtime adapters.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-gateway-bind-host-aliases",
+  deprecatedCompatRecord("doctor-gateway-bind-host-aliases", {
     owner: "gateway",
-    introduced: "2026-04-26",
     source: "gateway.bind host aliases such as 0.0.0.0 and localhost",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts",
     replacement: "gateway.bind.mode values such as lan, loopback, custom, tailnet, and auto",
     docsPath: "/gateway/configuration",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-audio-transcription-command",
+  deprecatedCompatRecord("doctor-audio-transcription-command", {
     owner: "audio",
-    introduced: "2026-04-26",
     source: "audio.transcription",
     migration: "src/commands/doctor/shared/legacy-config-migrations.audio.ts",
     replacement: "capability-tagged tools.media.models",
     docsPath: "/tools/media-overview",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-channel-thread-binding-ttl",
+  deprecatedCompatRecord("doctor-channel-thread-binding-ttl", {
     owner: "channel",
-    introduced: "2026-04-26",
     source: "threadBindings.ttlHours",
     migration: "src/commands/doctor/shared/legacy-config-migrations.channels.ts",
     replacement: "threadBindings.idleHours",
     docsPath: "/channels/channel-routing",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-message-queue-steering-modes",
+  deprecatedCompatRecord("doctor-message-queue-steering-modes", {
     owner: "config",
     introduced: "2026-05-04",
     source: "messages.queue.mode and messages.queue.byChannel retired queue modes",
     migration: "src/commands/doctor/shared/legacy-config-migrations.queue.ts",
     replacement: "steer, followup, collect, or interrupt queue modes",
     docsPath: "/concepts/queue",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-channel-dm-aliases",
+  deprecatedCompatRecord("doctor-channel-dm-aliases", {
     owner: "channel",
-    introduced: "2026-04-26",
     source: "channels.<id>.dm.policy and channels.<id>.dm.allowFrom",
     migration: "src/config/channel-compat-normalization.ts",
     replacement: "channels.<id>.dmPolicy and channels.<id>.allowFrom",
     docsPath: "/channels/channel-routing",
     tests: ["src/commands/doctor/shared/channel-legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-channel-streaming-aliases",
+  deprecatedCompatRecord("doctor-channel-streaming-aliases", {
     owner: "channel",
-    introduced: "2026-04-26",
     source: "streamMode, scalar streaming, chunkMode, blockStreaming, draftChunk, nativeStreaming",
     migration: "src/config/channel-compat-normalization.ts",
     replacement: "channels.<id>.streaming.*",
@@ -438,26 +363,20 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Runtime reads are nested-only; doctor keeps this migration to move shipped configs during upgrade.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-webchat-channel-config",
+  deprecatedCompatRecord("doctor-webchat-channel-config", {
     status: "removed",
     owner: "channel",
     introduced: "2026-05-18",
     deprecated: "2026-05-31",
-    warningStarts: "2026-05-31",
     removeAfter: "2026-08-31",
     source: "channels.webchat",
     migration: "src/commands/doctor/shared/legacy-config-migrations.channels.ts",
     replacement: "chat.history maxChars per-request override when a custom client needs it",
     docsPath: "/web/webchat",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "WebChat is an internal control surface, not a configurable outbound channel. Runtime ignores the retired channel key; doctor removes stale config.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-tts-top-level-owner",
-    deprecated: "2026-07-19",
-    warningStarts: "2026-07-19",
+  deprecatedCompatRecord("doctor-tts-top-level-owner", {
     removeAfter: "2026-09-18",
     owner: "tts",
     introduced: "2026-07-19",
@@ -467,18 +386,14 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-tts-provider-aliases",
+  deprecatedCompatRecord("doctor-tts-provider-aliases", {
     owner: "tts",
-    introduced: "2026-04-26",
     source: "messages.tts.openai/elevenlabs/edge and plugins.entries.voice-call.config.tts aliases",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.tts.ts",
     replacement: "tts.providers.<provider> and microsoft instead of edge",
     docsPath: "/tools/tts",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-tts-enabled-auto-mode",
+  deprecatedCompatRecord("doctor-tts-enabled-auto-mode", {
     owner: "tts",
     introduced: "2026-04-29",
     source:
@@ -489,8 +404,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-tts-speaker-selection-fields",
+  deprecatedCompatRecord("doctor-tts-speaker-selection-fields", {
     owner: "tts",
     introduced: "2026-05-28",
     source: "TTS provider speaker selection fields named voice, voiceName, and voiceId",
@@ -499,8 +413,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-plugin-install-config-ledger",
+  deprecatedCompatRecord("doctor-plugin-install-config-ledger", {
     owner: "plugin",
     introduced: "2026-04-25",
     source: "plugins.installs in authored config",
@@ -512,8 +425,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/commands/doctor/shared/plugin-registry-migration.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-bundled-plugin-load-paths",
+  deprecatedCompatRecord("doctor-bundled-plugin-load-paths", {
     owner: "plugin",
     introduced: "2026-04-25",
     source: "plugins.load.paths entries that point at bundled plugin source/dist locations",
@@ -522,37 +434,30 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/cli/plugins#registry",
     tests: ["src/commands/doctor/shared/bundled-plugin-load-paths.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-bundled-provider-discovery-allowlist",
+  deprecatedCompatRecord("doctor-bundled-provider-discovery-allowlist", {
     owner: "plugin",
     introduced: "2026-04-25",
     source: "plugins.allow configs created before bundled provider discovery was explicit",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts",
     replacement: "plugins.bundledDiscovery allowlist mode plus explicit plugin/provider entries",
     docsPath: "/cli/plugins#registry",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "Doctor preserves the shipped upgrade path only; runtime compatibility should stay behind explicit bundledDiscovery config.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-codex-supervisor-plugin-config",
+  deprecatedCompatRecord("doctor-codex-supervisor-plugin-config", {
     owner: "plugin",
     introduced: "2026-05-29",
     deprecated: "2026-07-09",
-    warningStarts: "2026-07-09",
     removeAfter: "2026-10-09",
     source: "plugins.entries.codex-supervisor and codex-supervisor plugin policy references",
     migration: "src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts",
     replacement: "plugins.entries.codex.config.supervision",
     docsPath: "/plugins/codex-supervision",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
       "The core bootstrap migration must remain available when the external Codex plugin is not installed yet.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-web-search-plugin-config",
+  deprecatedCompatRecord("doctor-web-search-plugin-config", {
     owner: "provider",
-    introduced: "2026-04-26",
     source: "tools.web.search.apiKey and tools.web.search.<provider>",
     migration: "src/commands/doctor/shared/legacy-web-search-migrate.ts",
     replacement: "plugins.entries.<plugin>.config.webSearch",
@@ -561,20 +466,16 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Provider/plugin ownership can move as bundled providers externalize; verify the current manifest owner before deleting migration support.",
   }),
-  deprecatedCompatRecord({
-    code: "doctor-web-fetch-plugin-config",
+  deprecatedCompatRecord("doctor-web-fetch-plugin-config", {
     owner: "provider",
-    introduced: "2026-04-26",
     source: "tools.web.fetch.firecrawl",
     migration: "src/commands/doctor/shared/legacy-web-fetch-migrate.ts",
     replacement: "plugins.entries.firecrawl.config.webFetch",
     docsPath: "/tools/web-fetch",
     tests: ["src/commands/doctor/shared/legacy-web-fetch-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-x-search-plugin-config",
+  deprecatedCompatRecord("doctor-x-search-plugin-config", {
     owner: "provider",
-    introduced: "2026-04-26",
     source: "tools.web.x_search.apiKey",
     migration: "src/commands/doctor/shared/legacy-x-search-migrate.ts",
     replacement: "plugins.entries.xai.config.webSearch.apiKey",
@@ -584,20 +485,15 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/commands/doctor/shared/legacy-config-migrate.test.ts",
     ],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-talk-provider-shape",
+  deprecatedCompatRecord("doctor-talk-provider-shape", {
     owner: "tts",
-    introduced: "2026-04-26",
     source: "legacy talk provider scalar fields and provider/provider ids",
     migration: "src/commands/doctor/shared/legacy-talk-config-normalizer.ts",
     replacement: "talk.providers.<provider>",
     docsPath: "/tools/tts",
-    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord({
-    code: "doctor-legacy-tools-by-sender",
+  deprecatedCompatRecord("doctor-legacy-tools-by-sender", {
     owner: "tools",
-    introduced: "2026-04-26",
     source: "untyped toolsBySender keys",
     migration: "src/commands/doctor/shared/legacy-tools-by-sender.ts",
     replacement: "typed id:, e164:, username:, or name: sender keys",

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -506,10 +506,9 @@ export type DoctorDeprecationCompatCode =
   (typeof DOCTOR_DEPRECATION_COMPAT_RECORDS)[number]["code"];
 export type KnownDoctorDeprecationCompatRecord = DoctorDeprecationCompatRecord;
 
-const doctorDeprecationCompatRecordByCode = new Map<
-  DoctorDeprecationCompatCode,
-  KnownDoctorDeprecationCompatRecord
->(DOCTOR_DEPRECATION_COMPAT_RECORDS.map((record) => [record.code, record]));
+const doctorDeprecationCompatRecordByCode = new Map<string, KnownDoctorDeprecationCompatRecord>(
+  DOCTOR_DEPRECATION_COMPAT_RECORDS.map((record) => [record.code, record]),
+);
 
 /** List every doctor compatibility record, including removed or still-active entries. */
 export function listDoctorDeprecationCompatRecords(): readonly KnownDoctorDeprecationCompatRecord[] {


### PR DESCRIPTION
## What Problem This Solves

The maintainer-owned doctor compatibility inventory repeats lifecycle dates, introduction dates, and common proof references across 43 release records, making the documented release-review source larger and harder to maintain.

## Why This Change Was Made

Keep the existing documented inventory, all public lookup APIs, and every release-policy record while deriving only genuinely redundant defaults in its existing record factory. Future removal dates, migration owners, replacement guidance, documentation references, and proof paths remain unchanged.

## User Impact

No user-visible behavior changes. Release maintainers retain the same 43 actionable compatibility records and all 20 future-dated removal windows with 105 fewer production lines.

## Evidence

- Focused Blacksmith Testbox changed gate: pnpm check:changed passed, including core production types, core test types, formatting, lint, boundaries, deadcode, and guards.
- Focused Blacksmith Testbox regression: pnpm test src/commands/doctor/shared/deprecation-compat.test.ts — 4 tests passed.
- Testbox: tbx_01kyx5jggwrfdvcf3qckgs0gkq; https://github.com/openclaw/openclaw/actions/runs/30670853139
- Direct baseline-to-worktree deep equality confirms all 43 complete record objects are unchanged, including all 20 future removal windows and every exported lookup API.
- Targeted oxfmt check and git diff --check passed.
- Fresh structured autoreview after the type-safe lookup correction: clean; no accepted/actionable findings.
- Production delta: +57/-162, net -105 lines; no test changes.