### PR TITLE
fix(ui): preserve actionable Gateway opening timeout diagnostics

### DIFF
--- a/ui/src/api/gateway-browser-socket.test.ts
+++ b/ui/src/api/gateway-browser-socket.test.ts
@@ -76,7 +76,20 @@ describe("createBrowserGatewaySocket", () => {
     socket?.emit("error");
     socket?.emit("close", { code: 1006, reason: "" });
     expect(handlers.error).toHaveBeenCalledOnce();
-    expect(handlers.close).toHaveBeenCalledWith(1006, "");
+    expect(handlers.close).toHaveBeenCalledWith(
+      1006,
+      `gateway websocket opening timed out after ${DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS}ms`,
+    );
+  });
+
+  it("preserves a real close reason when an opening timeout also occurred", async () => {
+    const handlers = createHandlers();
+    createBrowserGatewaySocket("wss://gateway.example", handlers);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+    sockets[0]?.emit("close", { code: 1006, reason: "gateway supplied a close reason" });
+
+    expect(handlers.close).toHaveBeenCalledWith(1006, "gateway supplied a close reason");
   });
 
   it("clears the opening deadline after the socket opens", async () => {

--- a/ui/src/api/gateway-browser-socket.ts
+++ b/ui/src/api/gateway-browser-socket.ts
@@ -10,7 +10,7 @@ export function createBrowserGatewaySocket(
 ): GatewayProtocolSocket {
   const socket = new WebSocket(url);
   let opening = true;
-  let openingTimedOut = false;
+  let openingTimeoutReason: string | undefined;
   let openingTimer: ReturnType<typeof setTimeout> | undefined;
   const finishOpening = () => {
     opening = false;
@@ -27,11 +27,12 @@ export function createBrowserGatewaySocket(
   socket.addEventListener("message", (event) => handlers.message(String(event.data ?? "")));
   socket.addEventListener("close", (event) => {
     finishOpening();
-    handlers.close(event.code, event.reason ?? "");
+    // Browsers erase locally initiated close reasons before the handshake finishes.
+    handlers.close(event.code, event.reason || openingTimeoutReason || "");
   });
   socket.addEventListener("error", () => {
     finishOpening();
-    if (!openingTimedOut) {
+    if (!openingTimeoutReason) {
       handlers.error(new Error("websocket error"));
     }
   });
@@ -44,13 +45,9 @@ export function createBrowserGatewaySocket(
       return;
     }
     opening = false;
-    openingTimedOut = true;
+    openingTimeoutReason = `gateway websocket opening timed out after ${DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS}ms`;
     try {
-      handlers.error(
-        new Error(
-          `gateway websocket opening timed out after ${DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS}ms`,
-        ),
-      );
+      handlers.error(new Error(openingTimeoutReason));
     } finally {
       socket.close();
     }


### PR DESCRIPTION
## What Problem This Solves

When a Control UI WebSocket connection stalls before the opening handshake, the browser transport correctly creates the actionable error `gateway websocket opening timed out after 15000ms`. However, closing a browser WebSocket before it opens produces a native `1006` close event with an empty reason. The shared Gateway client and application store consume that close event, not the earlier transport error, so the operator-facing login gate incorrectly displays:

```text
disconnected (1006): no reason
```

This makes a reproducible network/handshake timeout indistinguishable from an unexplained disconnect. The failure is present on frozen parent `2a56ce9ad5489e0cef60c01644fd79e676f08803`; a new owner regression failed there before the production fix.

## Why This Change Was Made

Make the existing private browser WebSocket adapter the single owner of the opening-timeout fact:

- Replace its old duplicate `openingTimedOut` boolean with the already necessary concrete opening-timeout reason.
- Reuse that one recorded reason for the immediate error callback, suppression of the later generic native error, and the subsequent close callback.
- Preserve the real server-provided close reason whenever it is nonempty; synthesize a callback reason only for the browser's empty pre-handshake close.
- Keep native wire close semantics, retry policy and timing, healthy authentication/device handshake, constructor diagnostics, public SDK/API, configuration, and protocol unchanged.

This is an owner-boundary cleanup, not a store-level workaround: only the private browser socket adapter and its colocated tests change, and production code shrinks by **three lines**.

## User Impact

The existing Control UI login gate now displays the concrete timeout instead of an unexplained disconnect:

```diff
- disconnected (1006): no reason
+ disconnected (1006): gateway websocket opening timed out after 15000ms
```

Automatic reconnect remains enabled with the same real 800 ms initial delay. Genuine upstream close reasons, successful Gateway connections, browser device authentication, and constructor errors retain their existing behavior.

## Evidence

- Immutable candidate: `ced3c342341c5ab6adb8309fd4b7e3fab7cef1cc`.
- Exact frozen parent: `2a56ce9ad5489e0cef60c01644fd79e676f08803`.
- True baseline RED: the new owner regression expected `gateway websocket opening timed out after 15000ms` but received the existing empty close reason; 13 unchanged owner controls remained green.
- Exact candidate focused transport, browser client, Gateway store, and observer suites: **110/110 passed**:

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs \
    ui/src/api/gateway-browser-socket.test.ts \
    ui/src/api/gateway.node.test.ts \
    ui/src/app/gateway-store.test.ts \
    ui/src/app/gateway-store.observers.test.ts
  ```

- Standalone changed-owner suite: **14/14 passed**; real nonempty server reason explicitly wins after a timeout.
- Genuine type-aware `oxlint --type-aware --type-check`, targeted `oxfmt --check`, and `git diff --check`: clean.
- Independent actual **Google Chrome 150.0.7871.187** baseline-to-candidate matrix: **22/22 assertions passed** using five real localhost TCP connections whose WebSocket upgrades genuinely stalled. It exercised the production browser adapter, full `GatewayBrowserClient`, actual Gateway application store, login-gate diagnostic projection, two real automatic retry attempts, a genuine server `4007` close with a nonempty reason, a complete healthy WebSocket challenge/hello with browser device authentication, and constructor-failure diagnostics.
- Before the fix the real application store reported `disconnected (1006): no reason`; afterwards it reported `disconnected (1006): gateway websocket opening timed out after 15000ms`. In both revisions the actual native browser/wire close reason remained empty, proving the fix changes only the private application diagnostic.
- Independent full owner/caller/browser review: **zero actionable P0–P3 findings**, confidence **0.99**.
- Fresh official whole-branch Codex autoreview against the exact frozen parent through **P3**: **zero findings**, confidence **0.96**; genuine TruffleHog secret scan clean.

## Agent Transcript

Agent-created change developed in an isolated frozen-main worktree. No secrets, credentials, personal data, persistent operator state, public APIs, configuration, or authentication behavior were changed or included in the proof artifacts. A separate reviewer independently exercised genuine Chrome and real stalled TCP connections before the final fresh whole-branch review and secret scan.
