### PR TITLE
fix(gateway): preserve authenticated icon HEAD response metadata

### DIFF
--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -48,6 +48,14 @@ const PNG_BYTES = Buffer.from(
   "base64",
 );
 const NORMALIZED_PNG_BYTES = Buffer.from("normalized-png");
+const CATALOG_ICON_URL = "https://cdn.example.test/setup-tool.svg";
+const ICON_ROUTES = [
+  { label: "plugin", pathname: "/__openclaw__/plugin-icon/firecrawl" },
+  {
+    label: "catalog",
+    pathname: `/__openclaw__/catalog-icon/${encodeURIComponent(CATALOG_ICON_URL)}`,
+  },
+] as const;
 
 let port = 0;
 let server: ReturnType<typeof createServer>;
@@ -85,6 +93,7 @@ beforeEach(() => {
   clearPluginIconCacheForTest();
   vi.clearAllMocks();
   configForRequest = () => testConfig;
+  mocks.authorize.mockReset();
   mocks.authorize.mockResolvedValue({
     authMethod: "token",
     trustDeclaredOperatorScopes: false,
@@ -112,20 +121,68 @@ function request(pathname: string, options?: { token?: string; method?: string }
   });
 }
 
-describe("GET /__openclaw__/plugin-icon/:pluginId", () => {
-  it("requires gateway authentication before resolving plugin metadata", async () => {
-    mocks.authorize.mockImplementationOnce(async ({ res }) => {
-      res.statusCode = 401;
-      res.end();
-      return null;
-    });
+describe("Control UI plugin and catalog icon routes", () => {
+  it.each(
+    ICON_ROUTES.flatMap(({ label, pathname }) =>
+      (["GET", "HEAD"] as const).map((method) => ({ label, method, pathname })),
+    ),
+  )(
+    "authenticates $method $label icons before resolving their metadata",
+    async ({ method, pathname }) => {
+      mocks.authorize.mockImplementationOnce(async ({ res }) => {
+        res.statusCode = 401;
+        res.end();
+        return null;
+      });
 
-    const response = await request("/__openclaw__/plugin-icon/firecrawl", { token: "" });
+      const response = await request(pathname, { method, token: "" });
 
-    expect(response.status).toBe(401);
-    expect(mocks.resolveIconUrl).not.toHaveBeenCalled();
-    expect(mocks.readRemoteMediaBuffer).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(401);
+      expect(mocks.resolveIconUrl).not.toHaveBeenCalled();
+      expect(mocks.resolveCatalogIconUrl).not.toHaveBeenCalled();
+      expect(mocks.readRemoteMediaBuffer).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(
+    ICON_ROUTES.flatMap(({ label, pathname }) =>
+      (["image/png", "image/svg+xml"] as const).map((contentType) => ({
+        contentType,
+        label,
+        pathname,
+      })),
+    ),
+  )(
+    "preserves every $contentType $label GET header on a bodyless HEAD",
+    async ({ contentType, pathname }) => {
+      const svg = "<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+      if (contentType === "image/svg+xml") {
+        mocks.readRemoteMediaBuffer.mockResolvedValue({ buffer: Buffer.from(svg), contentType });
+      }
+
+      const get = await request(pathname);
+      const head = await request(pathname, { method: "HEAD" });
+
+      expect(get.status).toBe(200);
+      expect(head.status).toBe(200);
+      for (const name of [
+        "cache-control",
+        "content-disposition",
+        "content-length",
+        "content-security-policy",
+        "content-type",
+        "cross-origin-resource-policy",
+        "x-content-type-options",
+      ]) {
+        expect(head.headers.get(name), name).toBe(get.headers.get(name));
+      }
+      const expectedBody =
+        contentType === "image/svg+xml" ? Buffer.from(svg) : NORMALIZED_PNG_BYTES;
+      expect(Buffer.from(await get.arrayBuffer())).toEqual(expectedBody);
+      expect((await head.arrayBuffer()).byteLength).toBe(0);
+      expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("resolves by plugin identity and ignores arbitrary remote URL parameters", async () => {
     const response = await request(
@@ -167,7 +224,7 @@ describe("GET /__openclaw__/plugin-icon/:pluginId", () => {
   });
 
   it("resolves encoded catalog URLs through the server-owned allowlist", async () => {
-    const iconUrl = "https://cdn.example.test/setup-tool.svg";
+    const iconUrl = CATALOG_ICON_URL;
     const response = await request(`/__openclaw__/catalog-icon/${encodeURIComponent(iconUrl)}`);
 
     expect(response.status).toBe(200);
@@ -217,6 +274,53 @@ describe("GET /__openclaw__/plugin-icon/:pluginId", () => {
     expect(mocks.resolveIconUrl).toHaveBeenCalledTimes(2);
     expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledTimes(1);
   });
+
+  it.each(ICON_ROUTES)(
+    "shares one $label icon download across concurrent GET and HEAD",
+    async ({ pathname }) => {
+      const [get, head] = await Promise.all([
+        request(pathname),
+        request(pathname, { method: "HEAD" }),
+      ]);
+
+      expect(get.status).toBe(200);
+      expect(head.status).toBe(200);
+      expect((await head.arrayBuffer()).byteLength).toBe(0);
+      expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(ICON_ROUTES)(
+    "reuses a $label icon loaded by HEAD on a later GET",
+    async ({ pathname }) => {
+      const head = await request(pathname, { method: "HEAD" });
+      const get = await request(pathname);
+
+      expect(head.status).toBe(200);
+      expect(get.status).toBe(200);
+      expect(head.headers.get("content-length")).toBe(get.headers.get("content-length"));
+      expect((await head.arrayBuffer()).byteLength).toBe(0);
+      expect(Buffer.from(await get.arrayBuffer())).toEqual(NORMALIZED_PNG_BYTES);
+      expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(ICON_ROUTES)(
+    "returns a bodyless 404 for an unavailable $label icon HEAD",
+    async ({ label, pathname }) => {
+      if (label === "plugin") {
+        mocks.resolveIconUrl.mockResolvedValueOnce(undefined);
+      } else {
+        mocks.resolveCatalogIconUrl.mockReturnValueOnce(undefined);
+      }
+
+      const response = await request(pathname, { method: "HEAD" });
+
+      expect(response.status).toBe(404);
+      expect((await response.arrayBuffer()).byteLength).toBe(0);
+      expect(mocks.readRemoteMediaBuffer).not.toHaveBeenCalled();
+    },
+  );
 
   it("accepts one canonical scoped plugin id encoded as a single path segment", async () => {
     const response = await request(
@@ -279,13 +383,17 @@ describe("GET /__openclaw__/plugin-icon/:pluginId", () => {
     expect(failed.status).toBe(404);
   });
 
-  it("rejects non-GET methods without loading metadata", async () => {
-    const response = await request("/__openclaw__/plugin-icon/firecrawl", { method: "POST" });
+  it.each(ICON_ROUTES)(
+    "rejects non-read $label icon methods without loading metadata",
+    async ({ pathname }) => {
+      const response = await request(pathname, { method: "POST" });
 
-    expect(response.status).toBe(405);
-    expect(response.headers.get("allow")).toBe("GET");
-    expect(mocks.resolveIconUrl).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(405);
+      expect(response.headers.get("allow")).toBe("GET, HEAD");
+      expect(mocks.resolveIconUrl).not.toHaveBeenCalled();
+      expect(mocks.resolveCatalogIconUrl).not.toHaveBeenCalled();
+    },
+  );
 
   it("matches the configured Control UI base path", async () => {
     const handledServer = createServer((req, res) => {
@@ -306,11 +414,18 @@ describe("GET /__openclaw__/plugin-icon/:pluginId", () => {
     });
     try {
       const handledPort = (handledServer.address() as AddressInfo).port;
-      const response = await fetch(
-        `http://127.0.0.1:${handledPort}/openclaw/__openclaw__/plugin-icon/firecrawl`,
-        { headers: { Authorization: "Bearer test-token" } },
-      );
-      expect(response.status).toBe(200);
+      for (const { pathname } of ICON_ROUTES) {
+        for (const method of ["GET", "HEAD"]) {
+          const response = await fetch(`http://127.0.0.1:${handledPort}/openclaw${pathname}`, {
+            headers: { Authorization: "Bearer test-token" },
+            method,
+          });
+          expect(response.status).toBe(200);
+          if (method === "HEAD") {
+            expect((await response.arrayBuffer()).byteLength).toBe(0);
+          }
+        }
+      }
     } finally {
       await new Promise<void>((resolve, reject) => {
         handledServer.close((error) => (error ? reject(error) : resolve()));

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -269,8 +269,9 @@ export async function handlePluginIconHttpRequest(
   if (!pluginId && !catalogIconUrl) {
     return false;
   }
-  if (req.method !== "GET") {
-    sendMethodNotAllowed(res, "GET");
+  const method = req.method;
+  if (method !== "GET" && method !== "HEAD") {
+    sendMethodNotAllowed(res, "GET, HEAD");
     return true;
   }
   const requestAuth = await authorizeGatewayHttpRequestOrReply({
@@ -322,6 +323,7 @@ export async function handlePluginIconHttpRequest(
     "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; sandbox",
   );
   res.setHeader("content-disposition", 'attachment; filename="plugin-icon"');
-  res.end(icon.body);
+  // HEAD uses the same authenticated, cached representation; only its body is omitted.
+  res.end(method === "HEAD" ? undefined : icon.body);
   return true;
 }


### PR DESCRIPTION
## What Problem This Solves

The Gateway's authenticated plugin-icon and setup-catalog-icon routes serve normal `GET` image representations but rejected every `HEAD` request with `405 Method Not Allowed` and `Allow: GET`. Clients therefore could not inspect icon metadata without downloading the icon, and valid authenticated image probes lost `Content-Type`, `Content-Length`, cache policy, and the existing security headers.

## Root Cause and Fix

Both icon URLs already share one canonical Gateway HTTP owner. That owner admitted only `GET` before authentication and unconditionally wrote its cached image bytes. The fix admits `GET` and `HEAD` through the same existing authenticated, validated, cached representation path, advertises `Allow: GET, HEAD` for other methods, preserves every existing response header, and suppresses only the final `HEAD` response body.

This follows [RFC 9110 §9.3.2](https://www.rfc-editor.org/rfc/rfc9110.html#name-head): `HEAD` is identical to `GET` except that it has no response content, and the response should retain the same representation headers. [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) allows the same `Content-Length` when it equals the body that `GET` would have sent.

- One shared Gateway owner, covering both plugin IDs and server-allowlisted catalog icon URLs.
- Existing bearer authentication, catalog allowlisting, guarded remote fetches, image validation/normalization, bounded single-flight cache, sandbox CSP, same-origin resource policy, `nosniff`, attachment policy, and configured Control UI base paths remain unchanged.
- Missing or unauthorized `HEAD` requests retain their `404` or `401` status and never send a body.
- Non-read methods remain rejected and now accurately advertise `GET, HEAD`.
- No public protocol/SDK, configuration/default, persistent-state, provider, or channel changes.

## Regression-First Evidence

Frozen parent: `2a56ce9ad5489e0cef60c01644fd79e676f08803`.

Before the production fix, the new owner-local cases produced **10 failing assertions**: authenticated plugin/catalog `HEAD` requests returned `405` instead of `200`, unauthorized `HEAD` requests returned `405` instead of `401`, GET/HEAD image-header parity and cache/single-flight cases failed, and rejected methods advertised only `GET`.

Immutable candidate: `3cb27e9f561cef7971370640268011f9ae6af1f3`.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/plugin-icon-http.test.ts

Test Files  1 passed (1)
     Tests  25 passed (25)
```

The colocated real-loopback HTTP suite covers both icon routes, PNG and SVG representations, all seven representation/security headers, exact `Content-Length`, empty `HEAD` bodies, unauthorized `401`, unavailable `404`, GET→HEAD and HEAD→GET cache reuse, concurrent single-flight GET/HEAD, configured base paths, and `POST` rejection with `Allow: GET, HEAD`.

Type-aware focused oxlint (`--type-aware --type-check`), targeted oxfmt checking, and `git diff --check` all passed. The sole production file changes **+5/-3, net +2 lines**.

## Real Production HTTP and Official CDN Proof

The immutable production handler was exercised over actual bearer-authenticated loopback TCP and real HTTPS Simple Icons CDN responses for the bundled Telegram plugin and the Ollama and LM Studio setup-catalog icons, both root-mounted and under `/openclaw`.

```json
{"candidate":"3cb27e9f561cef7971370640268011f9ae6af1f3","realHttpAssertions":152,"variants":6,"plugin":"telegram","catalog":["ollama","lmstudio"],"basePaths":["/","/openclaw"],"headFirst":200,"get":200,"cachedHead":200,"unauthorizedHead":401,"unavailableHead":404,"post":405,"allow":"GET, HEAD","bodylessHead":true,"representationHeadersMatched":7}
```

Observed actual icon sizes: Telegram **757 bytes**, Ollama **4,784 bytes**, and LM Studio **550 bytes**. Every `HEAD` preserved the corresponding `GET` content type, exact content length, cache-control, sandbox CSP, same-origin resource policy, attachment policy, and `nosniff`, without transferring image bytes.

## Review

Genuine whole-branch `autoreview --mode branch --base 2a56ce9ad5489e0cef60c01644fd79e676f08803 --max-priority P3`: **zero P0/P1/P2/P3 findings**, TruffleHog clean, verdict **patch is correct**, confidence **0.94**.

A separate independent reviewer personally read the full owner, dispatch callers, browser loader, sibling image endpoints, official RFC semantics, security/cache boundaries, and the complete test suite; independently reran all **25 owner tests**; and reported **zero P0/P1/P2/P3 findings**, confidence **0.99**.
