### PR TITLE
fix(agents): honor bootstrap continuation skips for SQLite sessions

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   upsertSessionEntry,
   type SessionTranscriptRuntimeTarget,

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -5,10 +5,15 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  upsertSessionEntry,
+  type SessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
+import {
   clearInternalHooks,
   registerInternalHook,
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -24,6 +29,7 @@ import {
   resolveBootstrapFilesForRun,
   resolveContextInjectionMode,
 } from "./bootstrap-files.js";
+import { SessionManager } from "./sessions/session-manager.js";
 import { resetLegacyWorkspaceStateCheckForTest } from "./workspace-legacy-state.test-support.js";
 import { mergeWorkspaceSetupState } from "./workspace-state-store.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
@@ -477,199 +483,108 @@ describe("resolveBootstrapContextForRun", () => {
 
 describe("hasCompletedBootstrapTurn", () => {
   let tmpDir: string;
+  let sessionTarget: SessionTranscriptRuntimeTarget;
+  let sessionManager: SessionManager;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "openclaw-bootstrap-turn-"));
+    sessionTarget = {
+      agentId: "main",
+      sessionId: randomUUID(),
+      sessionKey: "agent:main:bootstrap-turn",
+      storePath: path.join(tmpDir, "sessions.json"),
+    };
+    await upsertSessionEntry(sessionTarget, {
+      sessionId: sessionTarget.sessionId,
+      updatedAt: Date.now(),
+    });
+    sessionManager = SessionManager.open(sessionTarget, tmpDir);
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
+    closeOpenClawAgentDatabasesForTest();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns false when session file does not exist", async () => {
-    expect(await hasCompletedBootstrapTurn(path.join(tmpDir, "missing.jsonl"))).toBe(false);
+  it("returns false without a complete SQLite transcript identity", async () => {
+    expect(await hasCompletedBootstrapTurn()).toBe(false);
+    expect(await hasCompletedBootstrapTurn({ ...sessionTarget, storePath: undefined })).toBe(false);
   });
 
-  it("returns false for SQLite transcript markers", async () => {
-    expect(
-      await hasCompletedBootstrapTurn("sqlite:main:session-1:/tmp/openclaw/sessions.json"),
-    ).toBe(false);
+  it("returns false when the SQLite session has no transcript", async () => {
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(false);
   });
 
-  it("returns false for empty session files", async () => {
-    const sessionFile = path.join(tmpDir, "empty.jsonl");
-    await fs.writeFile(sessionFile, "", "utf8");
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+  it("returns false when no full bootstrap marker has been recorded", async () => {
+    sessionManager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sessionManager.appendCustomEntry("openclaw:unrelated", { timestamp: 2 });
+
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(false);
   });
 
-  it("returns false for header-only session files", async () => {
-    const sessionFile = path.join(tmpDir, "header-only.jsonl");
-    await fs.writeFile(sessionFile, `${JSON.stringify({ type: "session", id: "s1" })}\n`, "utf8");
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+  it("reads a completion marker persisted by the SQLite session manager", async () => {
+    sessionManager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(true);
   });
 
-  it("returns false when no assistant turn has been flushed yet", async () => {
-    const sessionFile = path.join(tmpDir, "user-only.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({ type: "session", id: "s1" }),
-        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
-  });
-
-  it("returns false for assistant turns without a recorded full bootstrap marker", async () => {
-    const sessionFile = path.join(tmpDir, "assistant-no-marker.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({ type: "session", id: "s1" }),
-        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
-        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
-  });
-
-  it("returns true when a full bootstrap completion marker exists", async () => {
-    const sessionFile = path.join(tmpDir, "full-bootstrap.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 1 },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
-  });
-
-  it("returns false when compaction happened after the last assistant turn", async () => {
-    const sessionFile = path.join(tmpDir, "post-compaction.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 1 },
-        }),
-        JSON.stringify({ type: "compaction", summary: "trimmed" }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
-  });
-
-  it("returns true when a later full bootstrap marker happens after compaction", async () => {
-    const sessionFile = path.join(tmpDir, "assistant-after-compaction.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 1 },
-        }),
-        JSON.stringify({ type: "compaction", summary: "trimmed" }),
-        JSON.stringify({ type: "message", message: { role: "user", content: "new ask" } }),
-        JSON.stringify({ type: "message", message: { role: "assistant", content: "new reply" } }),
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 2 },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
-  });
-
-  it("ignores malformed JSON lines", async () => {
-    const sessionFile = path.join(tmpDir, "malformed.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      [
-        "{broken",
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 1 },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
-  });
-
-  it("finds a recent full bootstrap marker even when the scan starts mid-file", async () => {
-    const sessionFile = path.join(tmpDir, "large-prefix.jsonl");
-    const hugePrefix = "x".repeat(300 * 1024);
-    await fs.writeFile(
-      sessionFile,
-      [
-        JSON.stringify({ type: "message", message: { role: "user", content: hugePrefix } }),
-        JSON.stringify({
-          type: "custom",
-          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-          data: { timestamp: 1 },
-        }),
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
-  });
-
-  it("finds a recent full bootstrap marker when the tail read returns short", async () => {
-    const sessionFile = path.join(tmpDir, "short-read-tail.jsonl");
-    const lines = [
-      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
-      JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
-      JSON.stringify({
-        type: "custom",
-        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-        data: { timestamp: 1 },
-      }),
-    ];
-    await fs.writeFile(sessionFile, `${lines.join("\n")}\n`, "utf8");
-
-    const realOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-      const handle = await realOpen(...args);
-      const realRead = handle.read.bind(handle);
-      return new Proxy(handle, {
-        get(target, prop, receiver) {
-          if (prop === "read") {
-            return (buffer: Buffer, offset: number, length: number, position: number) =>
-              realRead(buffer, offset, Math.min(length, 16), position);
-          }
-          return Reflect.get(target, prop, receiver);
-        },
-      });
+  it("invalidates a completion marker after compaction", async () => {
+    const firstEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: 1,
     });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+    sessionManager.appendCompaction("trimmed", firstEntryId, 10);
 
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(false);
   });
 
-  it("returns false for symbolic links", async () => {
-    const realFile = path.join(tmpDir, "real.jsonl");
-    const linkFile = path.join(tmpDir, "link.jsonl");
-    await fs.writeFile(
-      realFile,
-      `${JSON.stringify({ type: "custom", customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, data: { timestamp: 1 } })}\n`,
-      "utf8",
-    );
-    await fs.symlink(realFile, linkFile);
-    expect(await hasCompletedBootstrapTurn(linkFile)).toBe(false);
+  it("accepts a newer full bootstrap marker after compaction", async () => {
+    const firstEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: 1,
+    });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+    sessionManager.appendCompaction("trimmed", firstEntryId, 10);
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 3 });
+
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(true);
+  });
+
+  it("invalidates a completion marker after a session reset", async () => {
+    sessionManager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+    sessionManager.appendResetBoundary("reset");
+
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(false);
+  });
+
+  it("accepts a newer full bootstrap marker after a session reset", async () => {
+    sessionManager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+    sessionManager.appendResetBoundary("reset");
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 3 });
+
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(true);
+  });
+
+  it("ignores completion markers on an inactive transcript branch", async () => {
+    const firstEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: 1,
+    });
+    sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(true);
+
+    sessionManager.appendLeafControl({
+      targetId: firstEntryId,
+      appendParentId: firstEntryId,
+    });
+    expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(false);
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -2,12 +2,11 @@
  * Resolves workspace bootstrap files for agent runs and converts them into
  * bounded context files.
  */
-import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { readRecentSessionTranscriptActiveEvents } from "../config/sessions/session-accessor.js";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readFileWindowFully } from "../infra/file-read.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
@@ -19,6 +18,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "./embedded-agent-helpers.js";
+import type { AgentRunSessionTarget } from "./run-session-target.js";
 import {
   DEFAULT_BOOTSTRAP_FILENAME,
   filterBootstrapFilesForSession,
@@ -29,7 +29,6 @@ import {
 
 export type BootstrapContextMode = "full" | "lightweight";
 
-const CONTINUATION_SCAN_MAX_TAIL_BYTES = 256 * 1024;
 const CONTINUATION_SCAN_MAX_RECORDS = 500;
 export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:full";
 const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
@@ -66,78 +65,30 @@ export function resolveContextInjectionMode(
   return config?.agents?.defaults?.contextInjection ?? "always";
 }
 
-/** Checks whether the session transcript still has a valid full-bootstrap marker. */
-export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<boolean> {
-  if (!path.isAbsolute(sessionFile) || !sessionFile.endsWith(".jsonl")) {
+/** Checks the active SQLite transcript branch for a valid full-bootstrap marker. */
+export async function hasCompletedBootstrapTurn(
+  sessionTarget?: AgentRunSessionTarget,
+): Promise<boolean> {
+  const { agentId, sessionId, sessionKey, storePath } = sessionTarget ?? {};
+  if (!agentId || !sessionId || !sessionKey || !storePath) {
     return false;
   }
   try {
-    const stat = await fs.lstat(sessionFile);
-    if (stat.isSymbolicLink()) {
-      return false;
-    }
-
-    const fh = await fs.open(sessionFile, "r");
-    try {
-      const bytesToRead = Math.min(stat.size, CONTINUATION_SCAN_MAX_TAIL_BYTES);
-      if (bytesToRead <= 0) {
+    const records = readRecentSessionTranscriptActiveEvents(
+      { agentId, sessionId, sessionKey, storePath },
+      CONTINUATION_SCAN_MAX_RECORDS,
+    );
+    for (const entry of records.toReversed()) {
+      const record = entry as { type?: string; customType?: string } | null | undefined;
+      // Context before compaction/reset is not reusable on the active branch.
+      if (record?.type === "compaction" || record?.type === "reset") {
         return false;
       }
-      const start = stat.size - bytesToRead;
-      const buffer = Buffer.allocUnsafe(bytesToRead);
-      const bytesRead = await readFileWindowFully(fh, buffer, start);
-      let text = buffer.toString("utf-8", 0, bytesRead);
-      if (start > 0) {
-        const firstNewline = text.indexOf("\n");
-        if (firstNewline === -1) {
-          return false;
-        }
-        text = text.slice(firstNewline + 1);
+      if (record?.type === "custom" && record.customType === FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE) {
+        return true;
       }
-
-      const records = text
-        .split(/\r?\n/u)
-        .filter((line) => line.trim().length > 0)
-        .slice(-CONTINUATION_SCAN_MAX_RECORDS);
-      let compactedAfterLatestAssistant = false;
-
-      for (let i = records.length - 1; i >= 0; i--) {
-        // Only the tail matters: compaction after the marker makes earlier
-        // bootstrap context unreliable for continuation prompts.
-        const line = records[i];
-        if (!line) {
-          continue;
-        }
-        let entry: unknown;
-        try {
-          entry = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        const record = entry as
-          | {
-              type?: string;
-              customType?: string;
-              message?: { role?: string };
-            }
-          | null
-          | undefined;
-        if (record?.type === "compaction" || record?.type === "reset") {
-          compactedAfterLatestAssistant = true;
-          continue;
-        }
-        if (
-          record?.type === "custom" &&
-          record.customType === FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE
-        ) {
-          return !compactedAfterLatestAssistant;
-        }
-      }
-
-      return false;
-    } finally {
-      await fh.close();
     }
+    return false;
   } catch {
     return false;
   }

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
@@ -51,8 +51,8 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     warn: (message) => log.warn(message),
   });
   let completedBootstrapTurn: boolean | undefined;
-  const hasCompletedBootstrapTurnForAttempt = async (sessionFile: string) => {
-    completedBootstrapTurn ??= await hasCompletedBootstrapTurn(sessionFile);
+  const hasCompletedBootstrapTurnForAttempt = async () => {
+    completedBootstrapTurn ??= await hasCompletedBootstrapTurn(attempt.sessionTarget);
     return completedBootstrapTurn;
   };
   const resolveBootstrapRouting = (bootstrapFiles?: readonly WorkspaceBootstrapFile[]) =>
@@ -72,7 +72,7 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     !suppressAmbientContext &&
     contextInjectionMode === "continuation-skip" &&
     !isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind) &&
-    (await hasCompletedBootstrapTurnForAttempt(attempt.sessionFile));
+    (await hasCompletedBootstrapTurnForAttempt());
   let preloadedBootstrapFiles: WorkspaceBootstrapFile[] | undefined;
   let bootstrapRouting =
     shouldProbeContinuationSkip || suppressAmbientContext || contextInjectionMode === "never"
@@ -108,7 +108,6 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     bootstrapContextMode: attempt.bootstrapContextMode,
     bootstrapContextRunKind: attempt.bootstrapContextRunKind ?? "default",
     bootstrapMode,
-    sessionFile: attempt.sessionFile,
     hasCompletedBootstrapTurn: hasCompletedBootstrapTurnForAttempt,
     resolveBootstrapContextForRun: async () => {
       const bootstrapFiles =

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -36,8 +36,7 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
   bootstrapContextMode?: string;
   bootstrapContextRunKind?: BootstrapContextRunKind;
   bootstrapMode?: BootstrapMode;
-  sessionFile: string;
-  hasCompletedBootstrapTurn: (sessionFile: string) => Promise<boolean>;
+  hasCompletedBootstrapTurn: () => Promise<boolean>;
   resolveBootstrapContextForRun: () => Promise<
     AttemptBootstrapContext<TBootstrapFile, TContextFile>
   >;
@@ -52,7 +51,7 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
     params.bootstrapMode !== "full" &&
     params.contextInjectionMode === "continuation-skip" &&
     !isHeartbeatLifecycleRun &&
-    (await params.hasCompletedBootstrapTurn(params.sessionFile));
+    (await params.hasCompletedBootstrapTurn());
   // Continuation-skip and explicit never both produce an empty injection set,
   // but only a clean full bootstrap later records a durable completion marker.
   const shouldSkipBootstrapInjection =

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -36,7 +36,6 @@ async function resolveBootstrapContext(params: {
     bootstrapContextMode: params.bootstrapContextMode ?? "full",
     bootstrapContextRunKind: params.bootstrapContextRunKind ?? "default",
     bootstrapMode: params.bootstrapMode ?? "none",
-    sessionFile: "/tmp/session.jsonl",
     hasCompletedBootstrapTurn,
     resolveBootstrapContextForRun,
   });
@@ -59,7 +58,7 @@ describe("embedded attempt context injection", () => {
     expect(result.isContinuationTurn).toBe(true);
     expect(result.bootstrapFiles).toStrictEqual([]);
     expect(result.contextFiles).toStrictEqual([]);
-    expect(hasCompletedBootstrapTurn).toHaveBeenCalledWith("/tmp/session.jsonl");
+    expect(hasCompletedBootstrapTurn).toHaveBeenCalledOnce();
     expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
   });
 
@@ -201,7 +200,7 @@ describe("embedded attempt context injection", () => {
       });
 
     expect(result.isContinuationTurn).toBe(true);
-    expect(hasCompletedBootstrapTurn).toHaveBeenCalledWith("/tmp/session.jsonl");
+    expect(hasCompletedBootstrapTurn).toHaveBeenCalledOnce();
     expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
     expect(result.shouldRecordCompletedBootstrapTurn).toBe(false);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling continuation-skip still paid for full workspace bootstrap context on every agent turn after session transcripts moved to SQLite.

## Why This Change Was Made

Before: run-orchestrator supplies the canonical SQLite session target, while the old completion helper accepted only an absolute .jsonl filename; the SQLite session key therefore always returned false and every continuation reinjected workspace context.

After: use the complete agentId/sessionId/sessionKey/storePath target to read the existing bounded active SQLite transcript projection, scan the completion marker written by the production SessionManager owner, and stop at compaction/reset boundaries. Delete the obsolete JSONL-only scanner and file-era helper arguments.

## User Impact

Configured continuation turns now actually skip repeated workspace bootstrap context, reducing prompt size and model token usage without changing defaults. Heartbeat turns, pending bootstrap, compaction recovery, session reset, and explicit never mode retain existing behavior.

## Real SQLite Runtime Proof

Blacksmith Testbox tbx_01kyx76ta1fz95f0422d45m6gx ran actual production SessionManager.open, upsertSessionEntry, SessionManager.appendCustomEntry, readRecentSessionTranscriptActiveEvents, and prepareEmbeddedAttemptBootstrap against real on-disk SQLite state plus real AGENTS.md/BOOTSTRAP.md workspace files. This is a direct runtime session, not Vitest, mocks, or a JSONL fixture. The producer writes FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE exactly as attempt-after-turn does; the consumer resolves the actual embedded-attempt bootstrap context.

Observed redacted runtime output:

~~~json
{"stage":"FIRST_FULL_TURN_BEFORE_MARKER","markerValidOnActiveBranch":false,"bootstrapMode":"full","injectedContextFiles":["AGENTS.md","SOUL.md","IDENTITY.md","BOOTSTRAP.md"],"shouldRecordCompletedBootstrapTurn":true,"activeEvents":["message"]}
{"stage":"NEXT_CONTINUATION_AFTER_PRODUCER_MARKER","markerValidOnActiveBranch":true,"bootstrapMode":"none","injectedContextFiles":[],"shouldRecordCompletedBootstrapTurn":false,"activeEvents":["message","openclaw:bootstrap-context:full"]}
{"stage":"AFTER_COMPACTION_RESTORES_BOOTSTRAP","markerValidOnActiveBranch":false,"bootstrapMode":"none","injectedContextFiles":["AGENTS.md","SOUL.md","IDENTITY.md"],"shouldRecordCompletedBootstrapTurn":false,"activeEvents":["message","openclaw:bootstrap-context:full","compaction"]}
{"stage":"NEW_MARKER_AFTER_COMPACTION_SKIPS_AGAIN","markerValidOnActiveBranch":true,"bootstrapMode":"none","injectedContextFiles":[],"shouldRecordCompletedBootstrapTurn":false,"activeEvents":["message","openclaw:bootstrap-context:full","compaction","openclaw:bootstrap-context:full"]}
{"stage":"AFTER_RESET_RESTORES_BOOTSTRAP","markerValidOnActiveBranch":false,"bootstrapMode":"none","injectedContextFiles":["AGENTS.md","SOUL.md","IDENTITY.md"],"shouldRecordCompletedBootstrapTurn":false,"activeEvents":["message","openclaw:bootstrap-context:full","compaction","openclaw:bootstrap-context:full","reset"]}
{"stage":"NEW_MARKER_AFTER_RESET_SKIPS_AGAIN","markerValidOnActiveBranch":true,"bootstrapMode":"none","injectedContextFiles":[],"shouldRecordCompletedBootstrapTurn":false,"activeEvents":["message","openclaw:bootstrap-context:full","compaction","openclaw:bootstrap-context:full","reset","openclaw:bootstrap-context:full"]}
REAL_SQLITE_RUNTIME_PROOF_PASS: first-turn bootstrap, continuation skip, compaction/reset renewal, active SQLite branch
~~~

Runtime proof artifact: https://github.com/openclaw/openclaw/actions/runs/30672244672

## Additional Verification

- Exact-head PR CI green: https://github.com/openclaw/openclaw/actions/runs/30671480358 for 280ca48a2790cacf461a24db1f167736ca8666b2.
- Blacksmith Testbox tbx_01kyx63072cp6sagthsbg5zq3n passed all 123 focused tests and scoped type-aware core oxlint: https://github.com/openclaw/openclaw/actions/runs/30671306062.
- Focused test command: pnpm test src/agents/bootstrap-files.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts.
- SQLite regressions also cover incomplete identities and completion markers excluded from inactive transcript branches.
- Heartbeat, pending full-bootstrap, explicit never mode, marker renewal, and embedded-runner context-engine sibling paths passed.
- Independent autoreview returned clean with no accepted or actionable findings.
- Net deletion: 51 production lines and 86 test lines.
- AI-assisted implementation and review.
