### PR TITLE
fix(gateway): yield before post-ready background work

### DIFF
--- a/src/agents/main-session-restart-recovery-runtime.ts
+++ b/src/agents/main-session-restart-recovery-runtime.ts
@@ -333,6 +333,7 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
   maxRetries?: number;
   shouldContinue?: () => boolean;
   stateDir?: string;
+  waitForStart?: () => Promise<void>;
   gatewayRuntime: GatewayRecoveryRuntime;
 }): { stop: () => Promise<void> } {
   const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
@@ -343,12 +344,16 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let queuedAttempt: Promise<void> | undefined;
   let activeAttempt: Promise<void> | undefined;
+  let cancelStartWait: (() => void) | undefined;
+  const startWaitCancelled = new Promise<void>((resolve) => {
+    cancelStartWait = resolve;
+  });
   const shouldContinue = () =>
     !stopped &&
     params.shouldContinue?.() !== false &&
     isAgentEventLifecycleGenerationCurrent(lifecycleGeneration);
-  // Only reconcile rows that existed before this startup recovery was scheduled.
-  // Fresh runs started by this gateway are protected again by the active-run check.
+  // Capture the cutoff at registration, before any startup gate can release new
+  // work. Sessions created by this gateway must never become recovery candidates.
   const startupRecoveryCutoffMs = Date.now();
 
   const runRecoveryAttempt = (attempt: number, delay: number) => {
@@ -436,28 +441,36 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
     activeAttempt = trackedAttempt;
   };
 
+  const queueRecoveryAttempt = (attempt: number, delay: number) => {
+    const pendingStart = Promise.resolve().then(async () => {
+      if (attempt === 1 && params.waitForStart) {
+        // Shutdown must cancel an unresolved startup gate so failed startup and
+        // same-port replacement cannot hang while joining this lifetime owner.
+        await Promise.race([params.waitForStart(), startWaitCancelled]);
+      }
+      if (shouldContinue()) {
+        runRecoveryAttempt(attempt, delay);
+      }
+    });
+    const trackedStart = pendingStart.finally(() => {
+      if (queuedAttempt === trackedStart) {
+        queuedAttempt = undefined;
+      }
+    });
+    queuedAttempt = trackedStart;
+  };
+
   const scheduleAttempt = (attempt: number, delay: number) => {
     if (!shouldContinue()) {
       return;
     }
     if (delay <= 0) {
-      // Publish the cancellable handle before immediate startup can claim a session.
-      const pendingStart = Promise.resolve().then(() => {
-        if (shouldContinue()) {
-          runRecoveryAttempt(attempt, delay);
-        }
-      });
-      const trackedStart = pendingStart.finally(() => {
-        if (queuedAttempt === trackedStart) {
-          queuedAttempt = undefined;
-        }
-      });
-      queuedAttempt = trackedStart;
+      queueRecoveryAttempt(attempt, delay);
       return;
     }
     timer = setTimeout(() => {
       timer = undefined;
-      runRecoveryAttempt(attempt, delay);
+      queueRecoveryAttempt(attempt, delay);
     }, delay);
     timer.unref?.();
   };
@@ -468,6 +481,7 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
       // Restart recovery belongs to its startup generation; stale timers must
       // never claim a session after that gateway begins draining.
       stopped = true;
+      cancelStartWait?.();
       if (timer) {
         clearTimeout(timer);
         timer = undefined;

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -2387,6 +2387,87 @@ describe("main-session-restart-recovery", () => {
     });
   });
 
+  it("waits for startup release while preserving the registration cutoff", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const releaseStartup = createDeferred();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        ...runningSessionEntry("pre-start-session"),
+        updatedAt: 1,
+      },
+    });
+    await writeTranscript(sessionsDir, "pre-start-session", [
+      { role: "user", content: "resume the interrupted work" },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const recovery = scheduleRestartAbortedMainSessionRecovery({
+      cfg: {},
+      delayMs: 0,
+      stateDir: tmpDir,
+      waitForStart: () => releaseStartup.promise,
+    });
+    await Promise.resolve();
+    expect(callGateway).not.toHaveBeenCalled();
+
+    const postRegistrationUpdatedAt = Date.now() + 60_000;
+    await writeStore(sessionsDir, {
+      ...readStore(storePath),
+      "agent:main:fresh": {
+        ...runningSessionEntry("post-start-session"),
+        updatedAt: postRegistrationUpdatedAt,
+      },
+    });
+    await writeTranscript(sessionsDir, "post-start-session", [
+      { role: "user", content: "new work from this gateway" },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    releaseStartup.resolve();
+    await waitForFast(() => expect(callGateway).toHaveBeenCalledOnce());
+    await recovery.stop();
+
+    const store = readStore(storePath);
+    expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
+    expect(store["agent:main:fresh"]).toMatchObject({
+      sessionId: "post-start-session",
+      status: "running",
+    });
+    expect(store["agent:main:fresh"]?.abortedLastRun).toBeUndefined();
+  });
+
+  it("stops without waiting for an unresolved startup release", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const releaseStartup = createDeferred();
+    await writeMainSession({
+      sessionsDir,
+      pendingFinalDelivery: {
+        kind: "replayable",
+        text: "interrupted response",
+        createdAt: Date.now(),
+      },
+    });
+
+    const recovery = scheduleRestartAbortedMainSessionRecovery({
+      cfg: {},
+      delayMs: 0,
+      stateDir: tmpDir,
+      waitForStart: () => releaseStartup.promise,
+    });
+    await recovery.stop();
+    releaseStartup.resolve();
+    await Promise.resolve();
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
+      status: "running",
+      abortedLastRun: true,
+    });
+  });
+
   it("fences an in-flight startup recovery before its durable session claim", async () => {
     const sessionsDir = await makeSessionsDir();
     const storePath = path.join(sessionsDir, "sessions.json");

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -78,6 +78,7 @@ const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
 const logSecrets = log.child("secrets");
 const gatewayRuntime = runtimeForLogger(log);
+const POST_READY_WORK_START_DELAY_MS = 500;
 
 function formatRuntimeGatewayAuthTokenWarning(): string {
   const base =
@@ -101,6 +102,10 @@ export async function startGatewayServer(
   port = 18789,
   opts: GatewayServerOptions = {},
 ): Promise<GatewayServer> {
+  let releasePostReadyWork: () => void = () => {};
+  const postReadyWorkBarrier = new Promise<void>((resolve) => {
+    releasePostReadyWork = resolve;
+  });
   const bootstrap = await prepareGatewayServerBootstrap({
     port,
     opts,
@@ -168,11 +173,16 @@ export async function startGatewayServer(
       logReload,
       logTailscale,
       loadGatewayStartupPostAttachModule,
+      waitForPostReadyWork: () => postReadyWorkBarrier,
     });
   } catch (err) {
     await closeOnStartupFailure();
     throw err;
   }
+  // The public server is fully initialized now. Leave a short I/O window before
+  // background prewarms and cleanup imports compete for the startup CPU.
+  const postReadyWorkTimer = setTimeout(releasePostReadyWork, POST_READY_WORK_START_DELAY_MS);
+  postReadyWorkTimer.unref?.();
 
   const close = createCloseHandler();
 

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -30,8 +30,7 @@ import {
 type GatewayCoreRuntime = Awaited<ReturnType<typeof startGatewayCoreRuntime>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
 
-const POST_READY_MAINTENANCE_DELAY_MS = 250;
-const RETAINED_PLUGIN_CLEANUP_DELAY_MS = 30_000;
+const [POST_READY_MAINTENANCE_DELAY_MS, RETAINED_PLUGIN_CLEANUP_DELAY_MS] = [250, 30_000];
 
 export async function finishGatewayStartup(params: {
   coreRuntime: GatewayCoreRuntime;
@@ -48,6 +47,7 @@ export async function finishGatewayStartup(params: {
   loadGatewayStartupPostAttachModule: () => Promise<
     typeof import("./server-startup-post-attach.js")
   >;
+  waitForPostReadyWork: () => Promise<void>;
 }) {
   const {
     coreRuntime: runtime,
@@ -342,7 +342,6 @@ export async function finishGatewayStartup(params: {
         import("./server/plugins-http/route-capability.js"),
       ]),
   );
-  const pluginSurfaceScheme = gatewayTls.enabled ? "https" : "http";
   await startupTrace.measure("gateway.ws-attach", () =>
     attachGatewayWsHandlers({
       wss,
@@ -350,7 +349,7 @@ export async function finishGatewayStartup(params: {
       preauthConnectionBudget,
       port,
       gatewayHost: bindHost ?? undefined,
-      pluginSurfaceScheme,
+      pluginSurfaceScheme: gatewayTls.enabled ? "https" : "http",
       getPluginNodeCapabilities: () =>
         withCoreCanvasNodeCapability(
           listPluginNodeCapabilities(pluginRuntime.registry),
@@ -530,6 +529,7 @@ export async function finishGatewayStartup(params: {
           isClosing: () => lifecycle.closePreludeStarted,
           startupTrace,
           sidecarStartup,
+          waitForPostReadyWork: params.waitForPostReadyWork,
           providerAuthPrewarm: {
             getConfig: getRuntimeConfig,
           },

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -115,6 +115,53 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     sidecar.stop();
   });
 
+  it("waits for gateway readiness before warming handler data", async () => {
+    vi.useFakeTimers();
+    let releaseGatewayReady!: () => void;
+    const gatewayReady = new Promise<void>((resolve) => {
+      releaseGatewayReady = resolve;
+    });
+    const load = vi.fn(async () => {});
+
+    const sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: {} as never,
+      log: { warn: vi.fn() },
+      items: [{ name: "sessions", load }],
+      waitForPostReadyWork: () => gatewayReady,
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(load).not.toHaveBeenCalled();
+
+    releaseGatewayReady();
+    await vi.runAllTimersAsync();
+    expect(load).toHaveBeenCalledOnce();
+    sidecar.stop();
+  });
+
+  it("stays stopped when readiness arrives after shutdown", async () => {
+    vi.useFakeTimers();
+    let releaseGatewayReady!: () => void;
+    const gatewayReady = new Promise<void>((resolve) => {
+      releaseGatewayReady = resolve;
+    });
+    const load = vi.fn(async () => {});
+
+    const sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: {} as never,
+      log: { warn: vi.fn() },
+      items: [{ name: "sessions", load }],
+      waitForPostReadyWork: () => gatewayReady,
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+    sidecar.stop();
+    releaseGatewayReady();
+    await vi.runAllTimersAsync();
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
   it("logs failures and continues without changing later request behavior", async () => {
     vi.useFakeTimers();
     const warn = vi.fn();

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -77,12 +77,14 @@ export function scheduleGatewayHandlerPrewarm(params: {
   startupTrace?: StartupTrace;
   log: { warn: (msg: string) => void };
   items?: readonly GatewayHandlerPrewarmItem[];
+  waitForPostReadyWork?: () => Promise<void>;
 }): GatewayHandlerPrewarmHandle {
   // Frequent updater restarts make cold dashboard data the remaining slow tier.
   // Keep cheap session reads first, process-stable plugin data second, and provider catalogs last.
   const items = params.items ?? dashboardDataPrewarmItems(params.cfgAtStart);
   let stopped = false;
   let nextIndex = 0;
+  let currentItemName = "unknown";
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const scheduleNext = () => {
@@ -91,23 +93,27 @@ export function scheduleGatewayHandlerPrewarm(params: {
     }
     timer = setTimeout(() => {
       timer = undefined;
-      if (stopped) {
-        return;
-      }
-      const item = items[nextIndex++];
-      if (!item) {
-        return;
-      }
-      const load = () => item.load();
-      void runWithGatewayIndependentRootWorkAdmission(() =>
-        params.startupTrace
-          ? params.startupTrace.measure(`post-ready.gateway-data.${item.name}`, load)
-          : load(),
-      )
+      void (async () => {
+        await params.waitForPostReadyWork?.();
+        if (stopped) {
+          return;
+        }
+        const item = items[nextIndex++];
+        if (!item) {
+          return;
+        }
+        currentItemName = item.name;
+        const load = () => item.load();
+        await runWithGatewayIndependentRootWorkAdmission(() =>
+          params.startupTrace
+            ? params.startupTrace.measure(`post-ready.gateway-data.${item.name}`, load)
+            : load(),
+        );
+      })()
         .catch((err: unknown) => {
           // Prewarm only improves latency; readiness and request-time loaders remain authoritative.
           params.log.warn(
-            `post-ready gateway data prewarm failed for ${item.name}: ${String(err)}`,
+            `post-ready gateway data prewarm failed for ${currentItemName}: ${String(err)}`,
           );
         })
         .finally(scheduleNext);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1192,11 +1192,16 @@ describe("startGatewayPostAttachRuntime", () => {
   it("uses current config when agent runtime plugin prewarm runs", async () => {
     const startupConfig = { marker: "startup" } as never;
     const currentConfig = { marker: "current" } as never;
+    let releaseGatewayReady!: () => void;
+    const gatewayReady = new Promise<void>((resolve) => {
+      releaseGatewayReady = resolve;
+    });
 
     await startGatewayPostAttachRuntime({
       ...createPostAttachParams({
         gatewayPluginConfigAtStart: startupConfig,
       }),
+      waitForPostReadyWork: () => gatewayReady,
       providerAuthPrewarm: { enabled: false },
       agentRuntimePluginPrewarm: {
         enabled: true,
@@ -1205,6 +1210,12 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(hoisted.ensureRuntimePluginsLoaded).not.toHaveBeenCalled();
+
+    releaseGatewayReady();
     await waitForGatewayTestState(() => {
       expect(hoisted.ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
         config: currentConfig,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -426,6 +426,7 @@ describe("startGatewayPostAttachRuntime", () => {
       cfg: { hooks: { internal: { enabled: false } } },
       delayMs: 0,
       shouldContinue: expect.any(Function),
+      waitForStart: undefined,
       gatewayRuntime: expect.any(Object),
     });
     expect(hoisted.scheduleSubagentOrphanRecovery).toHaveBeenCalledWith();
@@ -459,6 +460,39 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(onGatewayLifetimeSidecars).toHaveBeenCalledWith(
       expect.arrayContaining([recoverySidecar]),
     );
+  });
+
+  it("gates main-session recovery behind post-ready work", async () => {
+    let releasePostReadyWork!: () => void;
+    const postReadyWork = new Promise<void>((resolve) => {
+      releasePostReadyWork = resolve;
+    });
+    let waitForStart: (() => Promise<void>) | undefined;
+    hoisted.scheduleRestartAbortedMainSessionRecovery.mockImplementationOnce(
+      (params: { waitForStart?: () => Promise<void> }) => {
+        waitForStart = params.waitForStart;
+        return { stop: vi.fn(async () => {}) };
+      },
+    );
+
+    await startGatewayPostAttachRuntime({
+      ...createPostAttachParams(),
+      waitForPostReadyWork: () => postReadyWork,
+    });
+
+    await waitForGatewayTestState(() => {
+      expect(waitForStart).toEqual(expect.any(Function));
+    });
+    let released = false;
+    const waiting = waitForStart?.().then(() => {
+      released = true;
+    });
+    await Promise.resolve();
+    expect(released).toBe(false);
+
+    releasePostReadyWork();
+    await waiting;
+    expect(released).toBe(true);
   });
 
   it("stops restart recovery with gateway-lifetime sidecars", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1290,6 +1290,7 @@ export async function startGatewayPostAttachRuntime(
                 cfg: params.cfgAtStart,
                 delayMs: 0,
                 shouldContinue: () => params.isClosing?.() !== true,
+                waitForStart: params.waitForPostReadyWork,
                 gatewayRuntime: params.recoveryRuntime,
               });
             }

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -304,6 +304,7 @@ function scheduleAgentRuntimePluginPrewarm(params: {
     warn: (msg: string) => void;
   };
   delayMs?: number;
+  waitForPostReadyWork?: () => Promise<void>;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -311,29 +312,39 @@ function scheduleAgentRuntimePluginPrewarm(params: {
   timer = setTimeout(
     () => {
       timer = undefined;
-      void runWithGatewayIndependentRootWorkAdmission(async () => {
-        await measureStartup(params.startupTrace, "post-ready.agent-runtime-plugins", async () => {
-          if (isStopped()) {
-            return;
-          }
-          const started = performance.now();
-          const { ensureRuntimePluginsLoaded } = await import("../agents/runtime-plugins.js");
-          const cfg = params.getConfig();
-          if (isStopped()) {
-            return;
-          }
-          ensureRuntimePluginsLoaded({
-            config: cfg,
-            workspaceDir: params.workspaceDir,
-            allowGatewaySubagentBinding: true,
-          });
-          if (!isStopped()) {
-            params.log.info(
-              `agent runtime plugins pre-warmed in ${(performance.now() - started).toFixed(0)}ms`,
-            );
-          }
+      void (async () => {
+        await params.waitForPostReadyWork?.();
+        if (isStopped()) {
+          return;
+        }
+        await runWithGatewayIndependentRootWorkAdmission(async () => {
+          await measureStartup(
+            params.startupTrace,
+            "post-ready.agent-runtime-plugins",
+            async () => {
+              if (isStopped()) {
+                return;
+              }
+              const started = performance.now();
+              const { ensureRuntimePluginsLoaded } = await import("../agents/runtime-plugins.js");
+              const cfg = params.getConfig();
+              if (isStopped()) {
+                return;
+              }
+              ensureRuntimePluginsLoaded({
+                config: cfg,
+                workspaceDir: params.workspaceDir,
+                allowGatewaySubagentBinding: true,
+              });
+              if (!isStopped()) {
+                params.log.info(
+                  `agent runtime plugins pre-warmed in ${(performance.now() - started).toFixed(0)}ms`,
+                );
+              }
+            },
+          );
         });
-      }).catch((err: unknown) => {
+      })().catch((err: unknown) => {
         params.log.warn(`agent runtime plugin pre-warm failed: ${String(err)}`);
       });
     },
@@ -357,19 +368,23 @@ function schedulePostReadySidecarTask(params: {
   log: { warn: (msg: string) => void };
   run: (isStopped: () => boolean, signal: AbortSignal) => Awaitable<void>;
   stop?: () => Awaitable<void>;
+  waitForPostReadyWork?: () => Promise<void>;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
   const abortController = new AbortController();
   const isStopped = () => stopped;
   const handle = setImmediate(() => {
-    if (isStopped()) {
-      return;
-    }
-    void runWithGatewayIndependentRootWorkAdmission(async () => {
-      await measureStartup(params.startupTrace, params.name, () =>
-        params.run(isStopped, abortController.signal),
-      );
-    }).catch((err: unknown) => {
+    void (async () => {
+      await params.waitForPostReadyWork?.();
+      if (isStopped()) {
+        return;
+      }
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        await measureStartup(params.startupTrace, params.name, () =>
+          params.run(isStopped, abortController.signal),
+        );
+      });
+    })().catch((err: unknown) => {
       params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
     });
   });
@@ -456,12 +471,14 @@ function scheduleTranscriptsAutoStartSidecar(params: {
   cfg: OpenClawConfig;
   startupTrace?: GatewayStartupTrace;
   log: { warn: (msg: string) => void };
+  waitForPostReadyWork?: () => Promise<void>;
 }): GatewayPostReadySidecarHandle {
   let stopTranscriptsAutoStart: (() => Promise<void>) | undefined;
   return schedulePostReadySidecarTask({
     startupTrace: params.startupTrace,
     name: "sidecars.transcripts-auto-start",
     log: params.log,
+    waitForPostReadyWork: params.waitForPostReadyWork,
     run: async (isStopped) => {
       const { createTranscriptsAutoStartService } =
         await import("../agents/tools/transcripts-tool.js");
@@ -619,6 +636,7 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   startupTrace?: GatewayStartupTrace;
   startupOutcomes?: GatewayStartupOutcomeRecorder;
+  waitForPostReadyWork?: () => Promise<void>;
 }) {
   const postReadySidecars: GatewayPostReadySidecarHandle[] = [];
 
@@ -793,6 +811,7 @@ export async function startGatewaySidecars(params: {
     startupTrace: params.startupTrace,
     name: "sidecars.session-locks",
     log: params.log,
+    waitForPostReadyWork: params.waitForPostReadyWork,
     run: async (isStopped) => {
       try {
         const [{ resolveAgentSessionDirs }, { cleanStaleLockFiles }] = await Promise.all([
@@ -818,6 +837,7 @@ export async function startGatewaySidecars(params: {
     startupTrace: params.startupTrace,
     name: "sidecars.restart-sentinel",
     log: params.log,
+    waitForPostReadyWork: params.waitForPostReadyWork,
     run: async () => {
       if (!shouldCheckRestartSentinel()) {
         return;
@@ -835,6 +855,7 @@ export async function startGatewaySidecars(params: {
         startupTrace: params.startupTrace,
         name: "sidecars.gmail-watch",
         log: params.log,
+        waitForPostReadyWork: params.waitForPostReadyWork,
         run: async (isStopped, signal) => {
           const { startGmailWatcherWithLogs } = await import("../hooks/gmail-watcher-lifecycle.js");
           if (isStopped()) {
@@ -857,6 +878,7 @@ export async function startGatewaySidecars(params: {
         startupTrace: params.startupTrace,
         name: "sidecars.gmail-model",
         log: params.log,
+        waitForPostReadyWork: params.waitForPostReadyWork,
         run: async (isStopped) => {
           const [
             { DEFAULT_MODEL, DEFAULT_PROVIDER },
@@ -948,6 +970,7 @@ function createDeferredGatewayUpdateCheck(params: {
   };
   isNixMode: boolean;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  waitForPostReadyWork?: () => Promise<void>;
 }): { start: () => void; stop: () => void } {
   let started = false;
   let stopped = false;
@@ -966,37 +989,47 @@ function createDeferredGatewayUpdateCheck(params: {
     started = true;
     // Update checks are intentionally post-attach so startup logging, sidecars,
     // and Tailscale exposure are not serialized behind network I/O.
-    setImmediate(() => {
+    void (async () => {
+      await params.waitForPostReadyWork?.();
       if (stopped) {
         return;
       }
-      void runWithGatewayIndependentRootWorkAdmission(
-        async () =>
-          await measureStartup(params.startupTrace, "post-attach.update-check", () =>
-            params.runtimeDeps.scheduleGatewayUpdateCheck({
-              cfg: params.cfg,
-              log: params.log,
-              isNixMode: params.isNixMode,
-              onUpdateAvailableChange: (updateAvailable) => {
-                const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
-                params.broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
-              },
-            }),
-          ),
-      )
-        .then((nextStop) => {
-          if (stopped) {
-            nextStop();
-            return;
-          }
-          stopUpdateCheck = nextStop;
-        })
-        .catch((err: unknown) => {
-          if (stopped) {
-            return;
-          }
-          params.log.warn(`gateway update check failed to start: ${String(err)}`);
-        });
+      setImmediate(() => {
+        if (stopped) {
+          return;
+        }
+        void runWithGatewayIndependentRootWorkAdmission(
+          async () =>
+            await measureStartup(params.startupTrace, "post-attach.update-check", () =>
+              params.runtimeDeps.scheduleGatewayUpdateCheck({
+                cfg: params.cfg,
+                log: params.log,
+                isNixMode: params.isNixMode,
+                onUpdateAvailableChange: (updateAvailable) => {
+                  const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
+                  params.broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
+                },
+              }),
+            ),
+        )
+          .then((nextStop) => {
+            if (stopped) {
+              nextStop();
+              return;
+            }
+            stopUpdateCheck = nextStop;
+          })
+          .catch((err: unknown) => {
+            if (stopped) {
+              return;
+            }
+            params.log.warn(`gateway update check failed to start: ${String(err)}`);
+          });
+      });
+    })().catch((err: unknown) => {
+      if (!stopped) {
+        params.log.warn(`gateway update check readiness wait failed: ${String(err)}`);
+      }
     });
   };
 
@@ -1076,6 +1109,7 @@ export async function startGatewayPostAttachRuntime(
       delayMs?: number;
       getConfig?: () => OpenClawConfig;
     };
+    waitForPostReadyWork?: () => Promise<void>;
   },
   runtimeDeps: GatewayPostAttachRuntimeDeps = defaultGatewayPostAttachRuntimeDeps,
 ) {
@@ -1157,6 +1191,7 @@ export async function startGatewayPostAttachRuntime(
         log: params.log,
         isNixMode: params.isNixMode,
         broadcast: params.broadcast,
+        waitForPostReadyWork: params.waitForPostReadyWork,
       });
 
   const tailscaleCleanupPromise = params.minimalTestGateway
@@ -1221,6 +1256,7 @@ export async function startGatewayPostAttachRuntime(
                 shouldStartPluginServices: () => params.isClosing?.() !== true,
                 broadcastPluginEvent: params.broadcastPluginEvent,
                 startupOutcomes,
+                waitForPostReadyWork: params.waitForPostReadyWork,
               }),
             );
           } catch (error) {
@@ -1295,6 +1331,7 @@ export async function startGatewayPostAttachRuntime(
               startupTrace: params.startupTrace,
               log: params.log,
               delayMs: params.agentRuntimePluginPrewarm?.delayMs,
+              waitForPostReadyWork: params.waitForPostReadyWork,
             }),
           );
         }
@@ -1314,6 +1351,7 @@ export async function startGatewayPostAttachRuntime(
               cfg: params.gatewayPluginConfigAtStart,
               startupTrace: params.startupTrace,
               log: params.log,
+              waitForPostReadyWork: params.waitForPostReadyWork,
             }),
           );
         }
@@ -1338,6 +1376,10 @@ export async function startGatewayPostAttachRuntime(
   void sidecarsPromise
     .then(async (sidecarsResult) => {
       if (params.minimalTestGateway) {
+        return;
+      }
+      await params.waitForPostReadyWork?.();
+      if (params.isClosing?.()) {
         return;
       }
       schedulePostAttachUpdateSentinelRefresh({


### PR DESCRIPTION
## Summary

- Hold profiled, readiness-neutral startup jobs behind one lifecycle-owned barrier.
- Release them 500 ms after public gateway startup returns, leaving an initial I/O window for probes and clients on constrained CPUs.
- Preserve authentication setup, readiness-critical sidecars and channels, plugin routes, WebSocket setup, shutdown registration, and same-port restart behavior.

## Root cause

Post-ready zero-delay jobs immediately enter synchronous plugin discovery, cleanup, and import work. On a one-core host the listener and readiness transition can be complete while the event loop remains unable to service probes before their timeout.

This is related to #116997, which delays only agent-runtime plugin prewarm for Slack. This change uses a shared startup boundary for every contributor observed in the startup profile, without adding a 10-second single-task delay.

## Contract

- Background jobs are still registered before startup completes, so shutdown owns and drains them.
- They re-check stop/closing state after the barrier opens.
- `/readyz` semantics are unchanged; no false liveness or weakened readiness is introduced.
- Authentication failures still install their hooks before the server is considered started.

## Validation

- Original Wilfred observation at `5332641ed3bab552d23fb16c67bc697a373ea9d7`: listener at 22.283 s; `/healthz` and `/readyz` at 25.470 s; a 10-second probe timed out.
- Exact current head `75dfe9bf32001154d21efa42bbba2731d947c178`, one CPU: first `/healthz` and `/readyz` completed at 6.832 s with channels skipped and 5.070 s with the default fixture, both below the real 10-second budget.
- Earlier six-run one-core matrix with the identical gateway diff: first `/healthz` and `/readyz` responses ranged from 4.650 to 5.335 s.
- Source-blind sustained probe with the identical gateway diff: 40 consecutive `200/200` health/readiness pairs after first success, with no gaps; worst busy-window latency was 4.829 s.
- Negative and adjacent behavior: unauthenticated tool invocation remained `401`; WebSocket probe passed; background prewarm completed; exact-PID shutdown released the port; same-port restart had one owner and healthy HTTP/WebSocket behavior.
- Exact current head: 65 focused startup lifecycle tests and 16 isolated HTTP probe tests passed.
- Exact current head: production `pnpm build` passed.
- Changed-file formatting, lint, type checks, max-lines, import-cycle, plugin-boundary, DB/sidecar, and dead-code gates passed.
- Exact current head autoreview reported no findings (correctness confidence 0.98).

Before the final push the branch was rebased onto fresh upstream `35be8ae6c293e53efe7766574d0d39ae4bc21d6d`, and the ancestry check passed. The last upstream movement touched Slack startup retry policy plus doctor/session/plugin-state refactors; it did not touch the barrier owners or the no-Slack benchmark fixture, so the already-clean lifecycle and constrained probe proofs were not invalidated.

## Non-goal

This does not split listener binding from readiness or introduce a pre-readiness health-only server. That broader design would require a separate authenticated bootstrap HTTP surface and ownership handoff. This PR addresses the measured timeout cause: post-ready event-loop starvation.