### PR TITLE
fix(browser): honor pinned nodes consistently across browser routes

### DIFF
--- a/extensions/browser/src/browser-node-routing.ts
+++ b/extensions/browser/src/browser-node-routing.ts
@@ -1,0 +1,69 @@
+/** Shared browser-node selection for agent tools and Gateway requests. */
+import { BROWSER_PROXY_COMMAND } from "./browser-node-commands.js";
+import { resolveNodeIdFromList } from "./sdk-setup-tools.js";
+
+type BrowserNodeCandidate = {
+  nodeId: string;
+  displayName?: string;
+  connected?: boolean;
+  caps?: string[];
+  commands?: string[];
+};
+
+type BrowserNodeRoutingPolicy = {
+  mode?: "off" | "auto" | "manual";
+  node?: string;
+};
+
+/** Select the same authorized browser-capable node on every request surface. */
+export function resolveBrowserNodeTarget<T extends BrowserNodeCandidate>(params: {
+  nodes: T[];
+  policy?: BrowserNodeRoutingPolicy;
+  requestedNode?: string;
+  explicitTarget?: boolean;
+  requireConnected?: boolean;
+}): T | null {
+  const mode = params.policy?.mode ?? "auto";
+  const explicit = params.explicitTarget || Boolean(params.requestedNode?.trim());
+  if (mode === "off") {
+    if (explicit) {
+      throw new Error("Node browser proxy is disabled (gateway.nodes.browser.mode=off).");
+    }
+    return null;
+  }
+
+  const requested = params.requestedNode?.trim() || params.policy?.node?.trim();
+  if (mode === "manual" && !explicit && !requested) {
+    return null;
+  }
+
+  const browserNodes = params.nodes.filter((node) => {
+    if (params.requireConnected && !node.connected) {
+      return false;
+    }
+    return node.caps?.includes("browser") || node.commands?.includes(BROWSER_PROXY_COMMAND);
+  });
+  if (browserNodes.length === 0) {
+    if (explicit || requested) {
+      throw new Error("No connected browser-capable nodes.");
+    }
+    return null;
+  }
+
+  if (requested) {
+    const nodeId = resolveNodeIdFromList(browserNodes, requested, false, {
+      allowCompactDisplayName: true,
+    });
+    return browserNodes.find((node) => node.nodeId === nodeId) ?? null;
+  }
+
+  if (browserNodes.length === 1) {
+    return browserNodes[0] ?? null;
+  }
+  if (explicit) {
+    throw new Error(
+      `Multiple browser-capable nodes connected (${browserNodes.length}). Set gateway.nodes.browser.node or pass node=<id>.`,
+    );
+  }
+  return null;
+}

--- a/extensions/browser/src/browser-tool.runtime.ts
+++ b/extensions/browser/src/browser-tool.runtime.ts
@@ -29,12 +29,10 @@ export {
   normalizeWhitespace,
   prepareSimpleCompletionModelForAgent,
   validateJsonSchemaValue,
-  resolveNodeIdFromList,
   saveMediaBuffer,
   sanitizeHtml,
-  selectDefaultNodeFromList,
 } from "./sdk-setup-tools.js";
-export type { AnyAgentTool, NodeListNode } from "./sdk-setup-tools.js";
+export type { AnyAgentTool } from "./sdk-setup-tools.js";
 export { wrapExternalContent } from "./sdk-security-runtime.js";
 export {
   normalizeOptionalString,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -159,7 +159,7 @@ const configMocks = vi.hoisted(() => ({
   loadConfig: vi.fn<
     () => {
       browser: Record<string, unknown>;
-      gateway?: { nodes?: { browser?: { node?: string } } };
+      gateway?: { nodes?: { browser?: { node?: string; mode?: "off" | "auto" | "manual" } } };
       agents?: { defaults?: { imageMaxDimensionPx?: number } };
     }
   >(() => ({ browser: {} })),
@@ -1961,6 +1961,33 @@ describe("browser tool snapshot maxChars", () => {
 
     expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to the host when a configured browser node is disconnected", async () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: {},
+      gateway: { nodes: { browser: { node: "node-1" } } },
+    });
+    const tool = createBrowserTool();
+
+    await expect(tool.execute?.("call-1", { action: "status" })).rejects.toThrow(
+      "No connected browser-capable nodes.",
+    );
+    expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("honors a configured browser node in manual routing mode", async () => {
+    mockSingleBrowserProxyNode();
+    configMocks.loadConfig.mockReturnValue({
+      browser: {},
+      gateway: { nodes: { browser: { mode: "manual", node: "node-1" } } },
+    });
+
+    await createBrowserTool().execute?.("call-1", { action: "status" });
+
+    expect(lastNodeInvokeCall().request.nodeId).toBe("node-1");
+    expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
   });
 
   it('allows profile="user" with target="node"', async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -1,4 +1,3 @@
-import { BROWSER_PROXY_COMMAND } from "./browser-node-commands.js";
 /**
  * Browser agent tool registration.
  *
@@ -6,6 +5,7 @@ import { BROWSER_PROXY_COMMAND } from "./browser-node-commands.js";
  * maps high-level actions onto browser control client calls.
  */
 import { createBrowserNodeProxyRequest } from "./browser-node-proxy.js";
+import { resolveBrowserNodeTarget } from "./browser-node-routing.js";
 import { applyBrowserTabToolBinding, parseBrowserTabToolBinding } from "./browser-tool-binding.js";
 import { describeBrowserTool } from "./browser-tool-description.js";
 import {
@@ -21,7 +21,6 @@ import {
 } from "./browser-tool.actions.js";
 import {
   type AnyAgentTool,
-  type NodeListNode,
   BrowserToolOutputSchema,
   BrowserToolSchema,
   browserAct,
@@ -59,11 +58,9 @@ import {
   resolveBrowserConfig,
   resolveExistingUploadPaths,
   resolveRuntimeImageSanitization,
-  resolveNodeIdFromList,
   resolveProfile,
   saveMediaBuffer,
   sanitizeHtml,
-  selectDefaultNodeFromList,
   stageBrowserScreenshotForSharing,
   touchSessionBrowserTab,
   trackSessionBrowserTab,
@@ -218,13 +215,7 @@ type BrowserNodeTarget = {
   pendingDeclaredCommands: string[];
 };
 
-function isBrowserNode(node: NodeListNode) {
-  const caps = Array.isArray(node.caps) ? node.caps : [];
-  const commands = Array.isArray(node.commands) ? node.commands : [];
-  return caps.includes("browser") || commands.includes(BROWSER_PROXY_COMMAND);
-}
-
-async function resolveBrowserNodeTarget(params: {
+async function resolveBrowserToolNodeTarget(params: {
   requestedNode?: string;
   target?: "sandbox" | "host" | "node";
   sandboxBridgeUrl?: string;
@@ -239,84 +230,36 @@ async function resolveBrowserNodeTarget(params: {
 
   const cfg = browserToolDeps.getRuntimeConfig();
   const policy = cfg.gateway?.nodes?.browser;
-  const mode = policy?.mode ?? "auto";
-  if (mode === "off") {
-    if (params.target === "node" || params.requestedNode) {
-      throw new Error("Node browser proxy is disabled (gateway.nodes.browser.mode=off).");
-    }
+  const explicitTarget = params.target === "node";
+  const requestedNode = params.requestedNode?.trim();
+  if (policy?.mode === "off") {
+    resolveBrowserNodeTarget({ nodes: [], policy, requestedNode, explicitTarget });
     return null;
   }
-  if (params.sandboxBridgeUrl?.trim() && params.target !== "node" && !params.requestedNode) {
+  if (params.sandboxBridgeUrl?.trim() && !explicitTarget && !requestedNode) {
     return null;
   }
-  if (params.target && params.target !== "node") {
+  if (params.target && !explicitTarget) {
     return null;
   }
-  if (mode === "manual" && params.target !== "node" && !params.requestedNode) {
+  if (policy?.mode === "manual" && !explicitTarget && !requestedNode && !policy.node?.trim()) {
     return null;
   }
-
-  const nodes = await browserToolDeps.listNodes({});
-  const browserNodes = nodes.filter((node) => node.connected && isBrowserNode(node));
-  if (browserNodes.length === 0) {
-    if (params.target === "node" || params.requestedNode) {
-      throw new Error("No connected browser-capable nodes.");
-    }
-    return null;
-  }
-
-  const requested = params.requestedNode?.trim() || policy?.node?.trim();
-  if (requested) {
-    const nodeId = resolveNodeIdFromList(browserNodes, requested, false, {
-      allowCompactDisplayName: true,
-    });
-    const node = browserNodes.find((entry) => entry.nodeId === nodeId);
-    return {
-      nodeId,
-      label: node?.displayName ?? node?.remoteIp ?? nodeId,
-      commands: Array.isArray(node?.commands) ? node.commands : [],
-      pendingDeclaredCommands: Array.isArray(node?.pendingDeclaredCommands)
-        ? node.pendingDeclaredCommands
-        : [],
-    };
-  }
-
-  const selected = selectDefaultNodeFromList(browserNodes, {
-    preferLocalMac: false,
-    fallback: "none",
+  const node = resolveBrowserNodeTarget({
+    nodes: await browserToolDeps.listNodes({}),
+    policy,
+    requestedNode,
+    explicitTarget,
+    requireConnected: true,
   });
-
-  if (params.target === "node") {
-    if (selected) {
-      return {
-        nodeId: selected.nodeId,
-        label: selected.displayName ?? selected.remoteIp ?? selected.nodeId,
-        commands: Array.isArray(selected.commands) ? selected.commands : [],
-        pendingDeclaredCommands: Array.isArray(selected.pendingDeclaredCommands)
-          ? selected.pendingDeclaredCommands
-          : [],
-      };
-    }
-    throw new Error(
-      `Multiple browser-capable nodes connected (${browserNodes.length}). Set gateway.nodes.browser.node or pass node=<id>.`,
-    );
-  }
-
-  if (mode === "manual") {
-    return null;
-  }
-
-  if (selected) {
-    return {
-      nodeId: selected.nodeId,
-      label: selected.displayName ?? selected.remoteIp ?? selected.nodeId,
-      commands: Array.isArray(selected.commands) ? selected.commands : [],
-      pendingDeclaredCommands: Array.isArray(selected.pendingDeclaredCommands)
-        ? selected.pendingDeclaredCommands
-        : [],
-    };
-  }
-  return null;
+  return node
+    ? {
+        nodeId: node.nodeId,
+        label: node.displayName ?? node.remoteIp ?? node.nodeId,
+        commands: node.commands ?? [],
+        pendingDeclaredCommands: node.pendingDeclaredCommands ?? [],
+      }
+    : null;
 }
 
 function resolveBrowserBaseUrl(params: {
@@ -505,7 +448,7 @@ export function createBrowserTool(opts?: {
 
       let nodeTarget: BrowserNodeTarget | null = null;
       try {
-        nodeTarget = await resolveBrowserNodeTarget({
+        nodeTarget = await resolveBrowserToolNodeTarget({
           requestedNode: requestedNode ?? undefined,
           target,
           sandboxBridgeUrl: opts?.sandboxBridgeUrl,
@@ -554,75 +497,55 @@ export function createBrowserTool(opts?: {
         isHostFallbackActive: proxyRequest?.isHostFallbackActive,
         registry: browserToolDeps,
       });
+      const readBrowserStatus = async () =>
+        proxyRequest
+          ? await proxyRequest({
+              method: "GET",
+              path: "/",
+              profile,
+              timeoutMs: toolTimeoutMs,
+            })
+          : await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs });
+      const executeTrackedTabRequest = async (
+        path: string,
+        body: Record<string, unknown>,
+        runLocal: () => Promise<unknown>,
+      ) => {
+        const result = proxyRequest
+          ? await proxyRequest({ method: "POST", path, profile, body })
+          : await runLocal();
+        sessionTabs.touch(
+          readStringValue((result as { targetId?: unknown }).targetId) ??
+            readStringValue(body.targetId),
+        );
+        return jsonResult(result);
+      };
 
       switch (action) {
         case "doctor":
-          if (proxyRequest) {
-            return jsonResult(
-              await proxyRequest({
-                method: "GET",
-                path: "/doctor",
-                profile,
-              }),
-            );
-          }
-          return jsonResult(await browserToolDeps.browserDoctor(baseUrl, { profile }));
+          return jsonResult(
+            proxyRequest
+              ? await proxyRequest({ method: "GET", path: "/doctor", profile })
+              : await browserToolDeps.browserDoctor(baseUrl, { profile }),
+          );
         case "status":
-          if (proxyRequest) {
-            return jsonResult(
-              await proxyRequest({
-                method: "GET",
-                path: "/",
-                profile,
-                timeoutMs: toolTimeoutMs,
-              }),
-            );
-          }
-          return jsonResult(
-            await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
-          );
+          return jsonResult(await readBrowserStatus());
         case "start":
+        case "stop": {
           if (proxyRequest) {
             await proxyRequest({
               method: "POST",
-              path: "/start",
+              path: `/${action}`,
               profile,
               timeoutMs: toolTimeoutMs,
             });
-            return jsonResult(
-              await proxyRequest({
-                method: "GET",
-                path: "/",
-                profile,
-                timeoutMs: toolTimeoutMs,
-              }),
-            );
+          } else {
+            const updateBrowser =
+              action === "start" ? browserToolDeps.browserStart : browserToolDeps.browserStop;
+            await updateBrowser(baseUrl, { profile, timeoutMs: toolTimeoutMs });
           }
-          await browserToolDeps.browserStart(baseUrl, { profile, timeoutMs: toolTimeoutMs });
-          return jsonResult(
-            await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
-          );
-        case "stop":
-          if (proxyRequest) {
-            await proxyRequest({
-              method: "POST",
-              path: "/stop",
-              profile,
-              timeoutMs: toolTimeoutMs,
-            });
-            return jsonResult(
-              await proxyRequest({
-                method: "GET",
-                path: "/",
-                profile,
-                timeoutMs: toolTimeoutMs,
-              }),
-            );
-          }
-          await browserToolDeps.browserStop(baseUrl, { profile, timeoutMs: toolTimeoutMs });
-          return jsonResult(
-            await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
-          );
+          return jsonResult(await readBrowserStatus());
+        }
         case "profiles": {
           // Importable system profiles are host-local (import runs on the host),
           // so read them from the host regardless of the profiles action target;
@@ -673,35 +596,33 @@ export function createBrowserTool(opts?: {
         case "open": {
           const targetUrl = readTargetUrlParam(params);
           const label = normalizeOptionalString(params.label);
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "POST",
-              path: "/tabs/open",
-              profile,
-              body: { url: targetUrl, ...(label ? { label } : {}) },
-              timeoutMs: toolTimeoutMs,
-            });
-            const closeOpenedTab = async (targetId: string, openedProfile?: string) => {
+          const opened = proxyRequest
+            ? await proxyRequest({
+                method: "POST",
+                path: "/tabs/open",
+                profile,
+                body: { url: targetUrl, ...(label ? { label } : {}) },
+                timeoutMs: toolTimeoutMs,
+              })
+            : await browserToolDeps.browserOpenTab(baseUrl, targetUrl, {
+                profile,
+                label,
+                timeoutMs: toolTimeoutMs,
+              });
+          const closeOpenedTab = async (targetId: string, openedProfile?: string) => {
+            if (proxyRequest) {
               await proxyRequest({
                 method: "DELETE",
                 path: `/tabs/${encodeURIComponent(targetId)}`,
                 profile: openedProfile,
                 timeoutMs: toolTimeoutMs,
               });
-            };
-            await sessionTabs.trackOpened(result, closeOpenedTab);
-            return jsonResult(stripBrowserOpenInternalMetadata(result));
-          }
-          const opened = await browserToolDeps.browserOpenTab(baseUrl, targetUrl, {
-            profile,
-            label,
-            timeoutMs: toolTimeoutMs,
-          });
-          const closeOpenedTab = async (targetId: string, openedProfile?: string) => {
-            await browserToolDeps.browserCloseTab(baseUrl, targetId, {
-              profile: openedProfile,
-              timeoutMs: toolTimeoutMs,
-            });
+            } else {
+              await browserToolDeps.browserCloseTab(baseUrl, targetId, {
+                profile: openedProfile,
+                timeoutMs: toolTimeoutMs,
+              });
+            }
           };
           await sessionTabs.trackOpened(opened, closeOpenedTab);
           return jsonResult(stripBrowserOpenInternalMetadata(opened));
@@ -710,23 +631,22 @@ export function createBrowserTool(opts?: {
           const targetId = readStringParam(params, "targetId", {
             required: true,
           });
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "POST",
-              path: "/tabs/focus",
-              profile,
-              body: { targetId },
-              timeoutMs: toolTimeoutMs,
-            });
-            sessionTabs.touch(targetId);
-            return jsonResult(result);
-          }
-          const result = await browserToolDeps.browserFocusTab(baseUrl, targetId, {
-            profile,
-            timeoutMs: toolTimeoutMs,
-          });
-          sessionTabs.touch(readStringValue(result.targetId) ?? targetId);
-          return jsonResult({ ok: true });
+          const result = proxyRequest
+            ? await proxyRequest({
+                method: "POST",
+                path: "/tabs/focus",
+                profile,
+                body: { targetId },
+                timeoutMs: toolTimeoutMs,
+              })
+            : await browserToolDeps.browserFocusTab(baseUrl, targetId, {
+                profile,
+                timeoutMs: toolTimeoutMs,
+              });
+          sessionTabs.touch(
+            readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
+          );
+          return jsonResult(proxyRequest ? result : { ok: true });
         }
         case "close": {
           const targetId = readStringParam(params, "targetId");
@@ -1004,74 +924,32 @@ export function createBrowserTool(opts?: {
           const inputRef = readStringParam(params, "inputRef");
           const element = readStringParam(params, "element");
           const { targetId, timeoutMs } = readOptionalTargetAndTimeout(params);
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "POST",
-              path: "/hooks/file-chooser",
-              profile,
-              body: {
-                paths: normalizedPaths,
-                ref,
-                inputRef,
-                element,
-                targetId,
-                timeoutMs,
-              },
-            });
-            sessionTabs.touch(
-              readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
-            );
-            return jsonResult(result);
-          }
-          const result = await browserToolDeps.browserArmFileChooser(baseUrl, {
+          const request = {
             paths: normalizedPaths,
             ref,
             inputRef,
             element,
             targetId,
             timeoutMs,
-            profile,
-          });
-          sessionTabs.touch(
-            readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
+          };
+          return await executeTrackedTabRequest(
+            "/hooks/file-chooser",
+            request,
+            async () =>
+              await browserToolDeps.browserArmFileChooser(baseUrl, { ...request, profile }),
           );
-          return jsonResult(result);
         }
         case "dialog": {
           const accept = Boolean(params.accept);
           const promptText = readStringValue(params.promptText);
           const dialogId = readStringValue(params.dialogId);
           const { targetId, timeoutMs } = readOptionalTargetAndTimeout(params);
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "POST",
-              path: "/hooks/dialog",
-              profile,
-              body: {
-                accept,
-                promptText,
-                dialogId,
-                targetId,
-                timeoutMs,
-              },
-            });
-            sessionTabs.touch(
-              readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
-            );
-            return jsonResult(result);
-          }
-          const result = await browserToolDeps.browserArmDialog(baseUrl, {
-            accept,
-            promptText,
-            dialogId,
-            targetId,
-            timeoutMs,
-            profile,
-          });
-          sessionTabs.touch(
-            readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
+          const request = { accept, promptText, dialogId, targetId, timeoutMs };
+          return await executeTrackedTabRequest(
+            "/hooks/dialog",
+            request,
+            async () => await browserToolDeps.browserArmDialog(baseUrl, { ...request, profile }),
           );
-          return jsonResult(result);
         }
         case "act": {
           const request = readActRequestParam(params);

--- a/extensions/browser/src/core-api.ts
+++ b/extensions/browser/src/core-api.ts
@@ -37,7 +37,6 @@ export {
   formatHelpExamples,
   inheritOptionFromParent,
   info,
-  resolveNodeIdFromList,
   theme,
 } from "./sdk-setup-tools.js";
 export { getRuntimeConfig, parseBooleanValue, shortenHomePath } from "./sdk-config.js";
@@ -54,5 +53,4 @@ export {
   safeParseJson,
   withTimeout,
 } from "./sdk-node-runtime.js";
-export type { OpenClawConfig } from "./sdk-config.js";
 export type { GatewayRequestHandlers, GatewayRpcOpts, NodeSession } from "./sdk-node-runtime.js";

--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -234,6 +234,17 @@ describe("browser.request profile selection", () => {
     expect(firstRespondCall(respond)[0]).toBe(true);
   });
 
+  it("honors a configured browser node in manual routing mode", async () => {
+    loadConfigMock.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "manual", node: "node-1" } } },
+    });
+
+    const { respond, nodeRegistry } = await runBrowserRequest({ method: "GET", path: "/" });
+
+    expect(invokeParams(nodeRegistry).nodeId).toBe("node-1");
+    expect(firstRespondCall(respond)[0]).toBe(true);
+  });
+
   it.each([
     {
       method: "POST",

--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -12,11 +12,11 @@ import {
   browserProxyUploadUnavailableMessage,
 } from "../browser-node-commands.js";
 import { isBrowserControlHostUnavailableError } from "../browser-node-fallback.js";
+import { resolveBrowserNodeTarget } from "../browser-node-routing.js";
 import {
   BROWSER_PROXY_ERROR_ENVELOPE,
   parseBrowserProxyFailure,
   type BrowserProxyEnvelope,
-  type BrowserProxyFile,
   type BrowserProxySuccess,
 } from "../browser-proxy-envelope.js";
 import {
@@ -35,7 +35,6 @@ import {
   isPersistentBrowserProfileMutation,
   persistBrowserProxyFiles,
   resolveNodeCommandAllowlist,
-  resolveNodeIdFromList,
   resolveRequestedBrowserProfile,
   respondUnavailableOnNodeInvokeError,
   safeParseJson,
@@ -43,7 +42,6 @@ import {
   withTimeout,
   type GatewayRequestHandlers,
   type NodeSession,
-  type OpenClawConfig,
 } from "../core-api.js";
 
 const logger = createSubsystemLogger("browser");
@@ -55,62 +53,6 @@ type BrowserRequestParams = {
   body?: unknown;
   timeoutMs?: number;
 };
-
-function isBrowserNode(node: NodeSession) {
-  const caps = Array.isArray(node.caps) ? node.caps : [];
-  const commands = Array.isArray(node.commands) ? node.commands : [];
-  return caps.includes("browser") || commands.includes(BROWSER_PROXY_COMMAND);
-}
-
-function resolveBrowserNode(nodes: NodeSession[], query: string): NodeSession | null {
-  const q = normalizeOptionalString(query) ?? "";
-  if (!q) {
-    return null;
-  }
-  const nodeId = resolveNodeIdFromList(nodes, q, false, { allowCompactDisplayName: true });
-  return nodes.find((node) => node.nodeId === nodeId) ?? null;
-}
-
-function resolveBrowserNodeTarget(params: {
-  cfg: OpenClawConfig;
-  nodes: NodeSession[];
-}): NodeSession | null {
-  const policy = params.cfg.gateway?.nodes?.browser;
-  const mode = policy?.mode ?? "auto";
-  if (mode === "off") {
-    return null;
-  }
-  const browserNodes = params.nodes.filter((node) => isBrowserNode(node));
-  if (browserNodes.length === 0) {
-    if (normalizeOptionalString(policy?.node)) {
-      throw new Error("No connected browser-capable nodes.");
-    }
-    return null;
-  }
-  const requested = normalizeOptionalString(policy?.node) ?? "";
-  if (requested) {
-    const resolved = resolveBrowserNode(browserNodes, requested);
-    if (!resolved) {
-      throw new Error(`Configured browser node not connected: ${requested}`);
-    }
-    return resolved;
-  }
-  if (mode === "manual") {
-    return null;
-  }
-  if (browserNodes.length === 1) {
-    return browserNodes[0] ?? null;
-  }
-  return null;
-}
-
-async function persistProxyFiles(files: BrowserProxyFile[] | undefined) {
-  return await persistBrowserProxyFiles(files);
-}
-
-function applyProxyPaths(result: unknown, mapping: Map<string, string>) {
-  applyBrowserProxyPaths(result, mapping);
-}
 
 /** Handles one browser.request gateway call and streams a success/error response. */
 export async function handleBrowserGatewayRequest({
@@ -151,8 +93,8 @@ export async function handleBrowserGatewayRequest({
   if (!forceHostLocal) {
     try {
       nodeTarget = resolveBrowserNodeTarget({
-        cfg,
         nodes: context.nodeRegistry.listConnected(),
+        policy: cfg.gateway?.nodes?.browser,
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
@@ -271,8 +213,8 @@ export async function handleBrowserGatewayRequest({
         return;
       }
       const success = proxy as BrowserProxySuccess;
-      const mapping = await persistProxyFiles(success.files);
-      applyProxyPaths(success.result, mapping);
+      const mapping = await persistBrowserProxyFiles(success.files);
+      applyBrowserProxyPaths(success.result, mapping);
       respond(true, success.result);
       return;
     }

--- a/extensions/browser/src/sdk-setup-tools.ts
+++ b/extensions/browser/src/sdk-setup-tools.ts
@@ -5,9 +5,8 @@ export {
   callGatewayTool,
   listNodes,
   resolveNodeIdFromList,
-  selectDefaultNodeFromList,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-export type { AnyAgentTool, NodeListNode } from "openclaw/plugin-sdk/agent-harness-runtime";
+export type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
 export {
   imageResultFromFile,
   jsonResult,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser requests with a configured node pin could silently run on the Gateway host when the pinned node disconnected, while manual-mode node pins were honored by Gateway requests but ignored by the agent browser tool.

## Why This Change Was Made

The browser tool and Gateway request handler now share one browser-node selection policy. Duplicate lifecycle and tab-action dispatch and seven obsolete private barrel exports are removed while preserving sandbox restrictions, host-only profile operations, remote upload authorization, nested watchdogs, cancellation isolation, and safe fallback boundaries. Production code decreases by 116 lines.

## User Impact

Configured browser node pins now consistently select the requested node in manual mode and fail visibly instead of unexpectedly controlling the Gateway host when the node is disconnected. Existing automatic browser routing and host fallback behavior are unchanged.

## Evidence

### Operator-visible routing proof

A fresh Blacksmith Testbox loaded and executed the actual production browser-node routing owner directly, with no mocked selector, using a configured manual pin followed by a disconnected pinned node. Observed terminal output:

```text
manual configured pin => selected browser node=node-1; Gateway-host dispatch=false
disconnected configured pin => ERROR: No connected browser-capable nodes. Gateway-host dispatch=false
```

Production runtime probe: https://github.com/openclaw/openclaw/actions/runs/30671740760 (Testbox tbx_01kyx6k8c6r9gq4p02c38j2d91; exit 0).

- Focused Blacksmith Testbox proof: 178 passing tests across browser tool, node proxy, Gateway profile routing, shared control state, and timeout suites, including both configured-manual-pin and disconnected-pin regressions.
- Full pnpm check:changed passed, including production and test typechecking, lint, formatting, plugin boundaries, dead-export scans, database-first storage guards, and zero runtime import cycles: https://github.com/openclaw/openclaw/actions/runs/30670832742 (Testbox tbx_01kyx5hq64gbqamszgb954gfbk; exit 0).
- Exact-head GitHub CI completed successfully with every relevant job green: https://github.com/openclaw/openclaw/actions/runs/30671248924.
- Fresh structured autoreview passed with no accepted or actionable findings.