### PR TITLE
refactor(doctor): share state migration ownership lifecycle

### DIFF
--- a/src/infra/state-migrations.apns.ts
+++ b/src/infra/state-migrations.apns.ts
@@ -8,8 +8,6 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -25,6 +23,7 @@ import {
   normalizeCanonicalApnsRegistration,
   type ApnsRegistration,
 } from "./push-apns-store.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceOrClaimMayExist,
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
@@ -36,8 +35,6 @@ import type { LegacyStateDetection, MigrationMessages } from "./state-migrations
 const LEGACY_APNS_REGISTRATION_PATH = "push/apns-registrations.json";
 const APNS_DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const MIGRATION_KIND = "legacy-apns-registrations-json";
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 // Legacy values are wall-clock timestamps. Bounding them to ECMAScript Date's
 // finite range rejects hostile counters with ~367 trillion successor values left.
 const MAX_LEGACY_APNS_UPDATED_AT_MS = 8_640_000_000_000_000;
@@ -557,60 +554,22 @@ export async function migrateLegacyApnsRegistrations(params: {
     return { changes: [], warnings: [] };
   }
 
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy APNs state: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy APNs state: exclusive state ownership unavailable."],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy APNs state",
+    releaseLabel: "APNs",
+    errorLabel: "Failed reading legacy APNs state",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({
+      return await migrateWithExclusiveStateOwnership({
         ...params,
         env,
         stateRoot,
       });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy APNs state: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(`APNs migration lock release failed: ${formatErrorMessage(releaseError)}`);
-  }
-  return result;
+    },
+  });
 }

--- a/src/infra/state-migrations.device-auth.ts
+++ b/src/infra/state-migrations.device-auth.ts
@@ -7,13 +7,12 @@ import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "../shared/de
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resetLegacyDeviceAuthPresenceCache } from "./device-auth-store.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_PATH = "identity/device-auth.json";
@@ -169,51 +168,12 @@ export async function migrateLegacyDeviceAuth(params: {
   if (!params.detected.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: 25,
-      role: "sqlite-maintenance",
-      timeoutMs: 250,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy device auth: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy device auth: exclusive state ownership unavailable."],
-    };
-  }
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    result = await importLegacyStore({ ...params, env });
-  } catch (error) {
-    result.warnings.push(`Failed migrating legacy device auth: ${String(error)}`);
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Device-auth migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy device auth",
+    releaseLabel: "Device-auth",
+    errorLabel: "Failed migrating legacy device auth",
+    run: async (env) => await importLegacyStore({ ...params, env }),
+  });
 }

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -19,7 +19,6 @@ import {
 } from "./device-identity-store.js";
 import { deriveEd25519PrivateKeyRaw, deriveEd25519PublicKeyRaw } from "./ed25519-signature.js";
 import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -30,6 +29,7 @@ import {
   repairInvalidCanonicalIdentity,
 } from "./state-migrations.device-identity-repair.js";
 import type { LegacyDeviceIdentityDetection } from "./state-migrations.device-identity.types.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
   readLegacyMigrationSourceSnapshot,
@@ -40,8 +40,6 @@ import type { MigrationMessages } from "./state-migrations.types.js";
 
 const IDENTITY_KEY = "primary";
 const MIGRATION_KIND = "legacy-device-identity-json";
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const MAX_LEGACY_IDENTITY_BYTES = 128 * 1024;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
@@ -584,81 +582,38 @@ export async function migrateLegacyDeviceIdentity(params: {
   if (params.doctorOnlyStateMigrations !== true) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy device identity: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy device identity: exclusive state ownership unavailable."],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
   let identityCoordinator: ReturnType<typeof acquireDeviceIdentityCoordinator> | undefined;
-  try {
-    try {
-      identityCoordinator = acquireDeviceIdentityCoordinator({
-        databasePath: resolveDeviceIdentityStore({ env, identityKey: IDENTITY_KEY }).databasePath,
-      });
-    } catch (error) {
-      result.warnings.push(
-        `Failed migrating legacy device identity: identity state is busy (${formatErrorMessage(error)}).`,
-      );
-    }
-    if (identityCoordinator) {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy device identity",
+    releaseLabel: "Device identity",
+    errorLabel: "Failed reading legacy device identity state",
+    beforeRelease: () => identityCoordinator?.release(),
+    run: async (env) => {
       try {
-        const hasLegacyNow = hasLegacyDeviceIdentityPath(params.detected);
-        if (hasLegacyNow) {
-          const stateRoot = await root(params.stateDir, {
-            hardlinks: "reject",
-            maxBytes: MAX_LEGACY_IDENTITY_BYTES,
-            symlinks: "reject",
-          });
-          result = await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
-        } else if (params.detected.hasInvalidCanonical) {
-          result = repairInvalidCanonicalIdentity(env);
-        }
+        identityCoordinator = acquireDeviceIdentityCoordinator({
+          databasePath: resolveDeviceIdentityStore({ env, identityKey: IDENTITY_KEY }).databasePath,
+        });
       } catch (error) {
-        result.warnings.push(`Failed reading legacy device identity state: ${String(error)}`);
+        return {
+          changes: [],
+          warnings: [
+            `Failed migrating legacy device identity: identity state is busy (${formatErrorMessage(error)}).`,
+          ],
+        };
       }
-    }
-  } finally {
-    try {
-      identityCoordinator?.release();
-    } catch (error) {
-      releaseError = error;
-    }
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError ??= error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Device identity migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+      if (hasLegacyDeviceIdentityPath(params.detected)) {
+        const stateRoot = await root(params.stateDir, {
+          hardlinks: "reject",
+          maxBytes: MAX_LEGACY_IDENTITY_BYTES,
+          symlinks: "reject",
+        });
+        return await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
+      }
+      return params.detected.hasInvalidCanonical
+        ? repairInvalidCanonicalIdentity(env)
+        : { changes: [], warnings: [] };
+    },
+  });
 }

--- a/src/infra/state-migrations.exec-approvals.ts
+++ b/src/infra/state-migrations.exec-approvals.ts
@@ -5,7 +5,6 @@ import { isDeepStrictEqual } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
 import {
   resolveExecApprovalsPath,
   tryParsePersistedExecApprovals,
@@ -16,13 +15,13 @@ import {
   serializeExecApprovals,
   writeExecApprovalsConfigRow,
 } from "./exec-approvals-sqlite.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import type { LegacyExecApprovalsDetection } from "./state-migrations.exec-approvals.types.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceOrClaimMayExist,
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
@@ -36,8 +35,6 @@ const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const MAX_LEGACY_EXEC_APPROVALS_BYTES = 4 * 1024 * 1024;
 const MIGRATION_KIND = "legacy-exec-approvals-json";
 const TARGET_TABLE = "exec_approvals_config";
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 type ExecApprovalsMigrationDatabase = Pick<
@@ -468,64 +465,25 @@ export async function migrateLegacyExecApprovals(params: {
   if (!detected?.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy exec approvals: ${detail}. Stop the Gateway, then run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy exec approvals: exclusive state ownership unavailable."],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy exec approvals",
+    releaseLabel: "Exec approvals",
+    errorLabel: "Failed reading legacy exec approvals",
+    retryGuidance: "Stop the Gateway, then run `openclaw doctor --fix` again.",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: MAX_LEGACY_EXEC_APPROVALS_BYTES,
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({
+      return await migrateWithExclusiveStateOwnership({
         ...params,
         detected,
         env,
         stateRoot,
       });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy exec approvals: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Exec approvals migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+    },
+  });
 }

--- a/src/infra/state-migrations.lock.test.ts
+++ b/src/infra/state-migrations.lock.test.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { acquireGatewayLock } from "./gateway-lock.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
+
+describe("legacy state migration ownership", () => {
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      closeOpenClawStateDatabaseForTest();
+      cleanup();
+    });
+  });
+
+  function migrationOptions() {
+    const stateDir = tempDirs.make("openclaw-state-migration-lock-");
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    return {
+      env,
+      stateDir,
+      label: "legacy example state",
+      releaseLabel: "Example",
+    };
+  }
+
+  async function expectStateOwnershipReleased(env: NodeJS.ProcessEnv) {
+    const lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      pollIntervalMs: 10,
+      role: "sqlite-maintenance",
+      timeoutMs: 100,
+    });
+    expect(lock).not.toBeNull();
+    await lock?.release();
+  }
+
+  it("keeps nested cleanup inside exclusive ownership and forwards canonical state env", async () => {
+    const options = migrationOptions();
+    const events: string[] = [];
+    const result = await withLegacyMigrationStateLock({
+      ...options,
+      beforeRelease: () => {
+        events.push("nested-release");
+      },
+      run: async (env) => {
+        events.push("migrate");
+        expect(env.OPENCLAW_STATE_DIR).toBe(options.stateDir);
+        return { changes: ["imported"], warnings: [], notices: ["verified"] };
+      },
+    });
+
+    expect(result).toEqual({ changes: ["imported"], warnings: [], notices: ["verified"] });
+    expect(events).toEqual(["migrate", "nested-release"]);
+    await expectStateOwnershipReleased(options.env);
+  });
+
+  it("reports migration failures without retaining exclusive ownership", async () => {
+    const options = migrationOptions();
+    const result = await withLegacyMigrationStateLock({
+      ...options,
+      errorLabel: "Failed reading legacy example state",
+      run: async () => {
+        throw new Error("unsafe source");
+      },
+    });
+
+    expect(result).toEqual({
+      changes: [],
+      warnings: ["Failed reading legacy example state: Error: unsafe source"],
+    });
+    await expectStateOwnershipReleased(options.env);
+  });
+
+  it("preserves thrown owner failures when the caller does not request conversion", async () => {
+    const options = migrationOptions();
+    await expect(
+      withLegacyMigrationStateLock({
+        ...options,
+        run: async () => {
+          throw new Error("unexpected owner failure");
+        },
+      }),
+    ).rejects.toThrow("unexpected owner failure");
+    await expectStateOwnershipReleased(options.env);
+  });
+
+  it("reports nested cleanup failures after releasing the Gateway lock", async () => {
+    const options = migrationOptions();
+    const result = await withLegacyMigrationStateLock({
+      ...options,
+      beforeRelease: () => {
+        throw new Error("nested release failed");
+      },
+      run: async () => ({ changes: ["imported"], warnings: [] }),
+    });
+
+    expect(result).toEqual({
+      changes: ["imported"],
+      warnings: ["Example migration lock release failed: nested release failed"],
+    });
+    await expectStateOwnershipReleased(options.env);
+  });
+
+  it("refuses active Gateway ownership without touching the migration source", async () => {
+    const options = migrationOptions();
+    const owner = await acquireGatewayLock({
+      allowInTests: true,
+      env: options.env,
+      pollIntervalMs: 10,
+      port: 18_796,
+      timeoutMs: 100,
+    });
+    if (!owner) {
+      throw new Error("expected Gateway lock");
+    }
+    const run = vi.fn(async () => ({ changes: [], warnings: [] }));
+    try {
+      const result = await withLegacyMigrationStateLock({
+        ...options,
+        retryGuidance: "Stop the Gateway and node host, then retry.",
+        run,
+      });
+
+      expect(result.warnings).toEqual([
+        "Failed migrating legacy example state: the Gateway or another SQLite maintenance command owns this state directory. Stop the Gateway and node host, then retry.",
+      ]);
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      await owner.release();
+    }
+  });
+});

--- a/src/infra/state-migrations.lock.ts
+++ b/src/infra/state-migrations.lock.ts
@@ -1,0 +1,79 @@
+import { formatErrorMessage } from "./errors.js";
+import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import type { MigrationMessages } from "./state-migrations.types.js";
+
+type LegacyMigrationStateLockOptions = {
+  stateDir: string;
+  env?: NodeJS.ProcessEnv;
+  label: string;
+  releaseLabel: string;
+  errorLabel?: string;
+  retryGuidance?: string;
+  formatAcquireError?: (error: unknown) => string;
+  beforeRelease?: () => void | Promise<void>;
+  run: (env: NodeJS.ProcessEnv) => Promise<MigrationMessages>;
+};
+
+/** Keep old Gateway writers excluded through migration, verification, and cleanup. */
+export async function withLegacyMigrationStateLock(
+  options: LegacyMigrationStateLockOptions,
+): Promise<MigrationMessages> {
+  const env = { ...(options.env ?? process.env), OPENCLAW_STATE_DIR: options.stateDir };
+  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
+  try {
+    lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      pollIntervalMs: 25,
+      role: "sqlite-maintenance",
+      timeoutMs: 250,
+    });
+  } catch (error) {
+    const detail =
+      error instanceof GatewayLockError
+        ? "the Gateway or another SQLite maintenance command owns this state directory"
+        : (options.formatAcquireError?.(error) ?? String(error));
+    const guidance =
+      options.retryGuidance ?? "Stop the Gateway and run `openclaw doctor --fix` again.";
+    return {
+      changes: [],
+      warnings: [`Failed migrating ${options.label}: ${detail}. ${guidance}`],
+    };
+  }
+  if (!lock) {
+    return {
+      changes: [],
+      warnings: [`Failed migrating ${options.label}: exclusive state ownership unavailable.`],
+    };
+  }
+
+  let result: MigrationMessages = { changes: [], warnings: [] };
+  let releaseError: unknown;
+  try {
+    try {
+      result = await options.run(env);
+    } catch (error) {
+      if (!options.errorLabel) {
+        throw error;
+      }
+      result.warnings.push(`${options.errorLabel}: ${String(error)}`);
+    }
+  } finally {
+    try {
+      await options.beforeRelease?.();
+    } catch (error) {
+      releaseError = error;
+    }
+    try {
+      await lock.release();
+    } catch (error) {
+      releaseError ??= error;
+    }
+  }
+  if (releaseError) {
+    result.warnings.push(
+      `${options.releaseLabel} migration lock release failed: ${formatErrorMessage(releaseError)}`,
+    );
+  }
+  return result;
+}

--- a/src/infra/state-migrations.mcp-oauth.ts
+++ b/src/infra/state-migrations.mcp-oauth.ts
@@ -9,13 +9,12 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import { parseLegacyMcpOAuthStore } from "./state-migrations.mcp-oauth-format.js";
 import { withRootBoundedLegacyFileLock } from "./state-migrations.mcp-oauth-lock.js";
 import type { LegacyMcpOAuthDetection } from "./state-migrations.mcp-oauth.types.js";
@@ -30,8 +29,6 @@ import type { MigrationMessages } from "./state-migrations.types.js";
 const LEGACY_MCP_OAUTH_DIR = "mcp-oauth";
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const MIGRATION_KIND = "legacy-mcp-oauth-json";
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const MAX_LEGACY_STORE_BYTES = 4 * 1024 * 1024;
 const LEGACY_STORE_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,29}-[0-9a-f]{16}\.json$/u;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
@@ -534,61 +531,19 @@ export async function migrateLegacyMcpOAuthStores(params: {
   if (!params.detected.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy MCP OAuth stores: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: [
-        "Failed migrating legacy MCP OAuth stores: exclusive state ownership unavailable.",
-      ],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy MCP OAuth stores",
+    releaseLabel: "MCP OAuth",
+    errorLabel: "Failed reading legacy MCP OAuth state",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: MAX_LEGACY_STORE_BYTES,
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy MCP OAuth state: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `MCP OAuth migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+      return await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
+    },
+  });
 }

--- a/src/infra/state-migrations.node-host.ts
+++ b/src/infra/state-migrations.node-host.ts
@@ -11,13 +11,12 @@ import {
 } from "../node-host/config.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceContentMatches as contentSnapshotsMatch,
   legacyMigrationSourceOrClaimMayExist,
@@ -29,8 +28,6 @@ import {
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_NODE_HOST_MAX_BYTES = 64 * 1024;
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const CONFIG_KEYS = new Set(["version", "nodeId", "token", "displayName", "gateway"]);
 const GATEWAY_KEYS = new Set(["host", "port", "tls", "tlsFingerprint", "contextPath"]);
 
@@ -487,63 +484,24 @@ export async function migrateLegacyNodeHostConfig(params: {
   if (!params.detected.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy node-host state: ${detail}. Stop the Gateway and node host, then run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy node-host state: exclusive state ownership unavailable."],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy node-host state",
+    releaseLabel: "Node-host",
+    errorLabel: "Failed reading legacy node-host state",
+    retryGuidance: "Stop the Gateway and node host, then run `openclaw doctor --fix` again.",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: LEGACY_NODE_HOST_MAX_BYTES,
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({
+      return await migrateWithExclusiveStateOwnership({
         ...params,
         env,
         stateRoot,
       });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy node-host state: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Node-host migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+    },
+  });
 }

--- a/src/infra/state-migrations.restart-sentinel.ts
+++ b/src/infra/state-migrations.restart-sentinel.ts
@@ -8,8 +8,6 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -21,6 +19,7 @@ import {
   writeRestartSentinelRowSync,
   type RestartSentinelEnvelope,
 } from "./restart-sentinel-store.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import type { LegacyRestartSentinelDetection } from "./state-migrations.restart-sentinel.types.js";
 import {
   legacyMigrationSourceOrClaimMayExist,
@@ -35,8 +34,6 @@ const LEGACY_RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const MAX_LEGACY_RESTART_SENTINEL_BYTES = 4 * 1024 * 1024;
 const MIGRATION_KIND = "legacy-restart-sentinel-json";
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 type RestartSentinelMigrationDatabase = Pick<
@@ -430,66 +427,25 @@ export async function migrateLegacyRestartSentinel(params: {
   if (!detected?.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating the legacy restart sentinel: ${detail}. Stop the Gateway, then run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: [
-        "Failed migrating the legacy restart sentinel: exclusive state ownership unavailable.",
-      ],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "the legacy restart sentinel",
+    releaseLabel: "Restart sentinel",
+    errorLabel: "Failed reading the legacy restart sentinel",
+    retryGuidance: "Stop the Gateway, then run `openclaw doctor --fix` again.",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: MAX_LEGACY_RESTART_SENTINEL_BYTES,
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({
+      return await migrateWithExclusiveStateOwnership({
         ...params,
         detected,
         env,
         stateRoot,
       });
-    } catch (error) {
-      result.warnings.push(`Failed reading the legacy restart sentinel: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Restart sentinel migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+    },
+  });
 }

--- a/src/infra/state-migrations.subagent-registry.ts
+++ b/src/infra/state-migrations.subagent-registry.ts
@@ -1,8 +1,7 @@
 // Doctor-only removal for the retired subagent run registry JSON store.
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
   legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
@@ -17,8 +16,6 @@ import {
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_SUBAGENT_REGISTRY_MAX_BYTES = 16 * 1024 * 1024;
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 
 function resolveLegacySubagentRegistryPath(stateDir: string): string {
@@ -233,61 +230,20 @@ export async function migrateLegacySubagentRegistry(params: {
   if (!params.detected.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy subagent registry: ${detail}. Stop the Gateway, then run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: [
-        "Failed migrating legacy subagent registry: exclusive state ownership unavailable.",
-      ],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy subagent registry",
+    releaseLabel: "Subagent registry",
+    errorLabel: "Failed reading legacy subagent registry",
+    retryGuidance: "Stop the Gateway, then run `openclaw doctor --fix` again.",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: LEGACY_SUBAGENT_REGISTRY_MAX_BYTES,
         symlinks: "reject",
       });
-      result = await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy subagent registry: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Subagent registry migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+      return await migrateWithExclusiveStateOwnership({ ...params, env, stateRoot });
+    },
+  });
 }

--- a/src/infra/state-migrations.web-push.ts
+++ b/src/infra/state-migrations.web-push.ts
@@ -2,8 +2,6 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { root, type Root } from "@openclaw/fs-safe";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -20,6 +18,7 @@ import {
   type WebPushDatabase,
   type WebPushSubscription,
 } from "./push-web-store.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationSourceContentMatches as contentSnapshotsMatch,
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
@@ -36,8 +35,6 @@ import {
 
 const LEGACY_SUBSCRIPTIONS_MAX_BYTES = 4 * 1024 * 1024;
 const LEGACY_VAPID_KEYS_MAX_BYTES = 64 * 1024;
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 
 type ParsedLegacyState = {
@@ -530,63 +527,23 @@ export async function migrateLegacyWebPush(params: {
     return { changes: [], warnings: [] };
   }
 
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : String(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy Web Push state: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy Web Push state: exclusive state ownership unavailable."],
-    };
-  }
-
-  let result: MigrationMessages = { changes: [], warnings: [] };
-  let releaseError: unknown;
-  try {
-    try {
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy Web Push state",
+    releaseLabel: "Web Push",
+    errorLabel: "Failed reading legacy Web Push state",
+    run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
         maxBytes: LEGACY_SUBSCRIPTIONS_MAX_BYTES,
         symlinks: "reject",
       });
-      result = await migrateLegacyWebPushWithExclusiveStateOwnership({
+      return await migrateLegacyWebPushWithExclusiveStateOwnership({
         ...params,
         env,
         stateRoot,
       });
-    } catch (error) {
-      result.warnings.push(`Failed reading legacy Web Push state: ${String(error)}`);
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    result.warnings.push(
-      `Web Push migration lock release failed: ${formatErrorMessage(releaseError)}`,
-    );
-  }
-  return result;
+    },
+  });
 }

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -18,7 +18,7 @@ import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.j
 import { resolveLegacyStateDirs } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "./errors.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   legacyMigrationPathMayExist as pathMayExist,
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
@@ -45,8 +45,6 @@ import type {
 
 const SETUP_MAX_BYTES = 64 * 1024;
 const CLAIM_SUFFIX = WORKSPACE_DOCTOR_CLAIM_SUFFIX;
-const MIGRATION_LOCK_TIMEOUT_MS = 250;
-const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 async function readBoundedRegularFile(params: {
@@ -652,63 +650,32 @@ export async function migrateLegacyWorkspaceState(params: {
   beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
 }): Promise<MigrationMessages> {
-  if (!params.detected?.hasLegacy) {
+  const detected = params.detected;
+  if (!detected?.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      env,
-      pollIntervalMs: MIGRATION_LOCK_POLL_INTERVAL_MS,
-      role: "sqlite-maintenance",
-      timeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const detail =
-      error instanceof GatewayLockError
-        ? "the Gateway or another SQLite maintenance command owns this state directory"
-        : formatErrorMessage(error);
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy workspace state: ${detail}. Stop the Gateway and run \`openclaw doctor --fix\` again.`,
-      ],
-    };
-  }
-  if (!lock) {
-    return {
-      changes: [],
-      warnings: ["Failed migrating legacy workspace state: exclusive state ownership unavailable."],
-    };
-  }
-
-  const changes: string[] = [];
-  const warnings: string[] = [];
-  const notices: string[] = [];
-  let releaseError: unknown;
-  try {
-    for (const source of params.detected.sources) {
-      const result = await migrateOneSource({
-        source,
-        env,
-        ...(params.beforeClaim ? { beforeClaim: params.beforeClaim } : {}),
-        ...(params.removeSource ? { removeSource: params.removeSource } : {}),
-      });
-      changes.push(...result.changes);
-      warnings.push(...result.warnings);
-      notices.push(...(result.notices ?? []));
-    }
-  } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      releaseError = error;
-    }
-  }
-  if (releaseError) {
-    warnings.push(`Workspace migration lock release failed: ${formatErrorMessage(releaseError)}`);
-  }
-  return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+  return await withLegacyMigrationStateLock({
+    stateDir: params.stateDir,
+    env: params.env,
+    label: "legacy workspace state",
+    releaseLabel: "Workspace",
+    formatAcquireError: formatErrorMessage,
+    run: async (env) => {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      const notices: string[] = [];
+      for (const source of detected.sources) {
+        const result = await migrateOneSource({
+          source,
+          env,
+          ...(params.beforeClaim ? { beforeClaim: params.beforeClaim } : {}),
+          ...(params.removeSource ? { removeSource: params.removeSource } : {}),
+        });
+        changes.push(...result.changes);
+        warnings.push(...result.warnings);
+        notices.push(...(result.notices ?? []));
+      }
+      return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+    },
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Doctor-owned legacy state imports repeated the same exclusive Gateway and SQLite maintenance lock lifecycle in ten separate migration owners, increasing the chance that lock acquisition, cleanup ordering, or operator recovery guidance diverges during upgrades.

## Why This Change Was Made

Use one private state-migration ownership executor for APNs, device auth, device identity, exec approvals, MCP OAuth, node-host config, restart sentinels, subagent state, Web Push, and workspace state. Preserve every existing migration algorithm, source safety policy, SQLite transaction, domain-specific warning, retry guidance, and nested identity-coordinator release order. No SQLite schema or public API changes.

## User Impact

No intended visible behavior change. Existing published-version upgrade paths retain the same exclusive ownership and recovery behavior while production source shrinks by 340 lines; the complete change including five new regression tests shrinks by 202 lines.

## Evidence

- Blacksmith Testbox tbx_01kyx60csqcv57hv1rjcaa4zk0: 275 tests passed across all 11 affected infra migration suites plus the full doctor-state-migrations integration suite.
- Added focused ownership tests covering canonical state-directory propagation, Gateway contention, cleanup ordering, expected error conversion, propagated owner failures, and released ownership after failures.
- Independent structured autoreview completed clean with no actionable findings.
- Hosted remote proof: https://github.com/openclaw/openclaw/actions/runs/30671233730
- git diff --check clean; production LOC +227/-567; test LOC +138/-0.