### PR TITLE
fix(outbound): preserve fenced tool call examples

### DIFF
--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -4,6 +4,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
+  findCodeRegions,
 } from "openclaw/plugin-sdk/text-chunking";
 import { stripPlainTextToolCallBlocks } from "openclaw/plugin-sdk/tool-payload";
 
@@ -58,9 +59,13 @@ function stripDiscordInternalChannelLines(text: string): string {
 }
 
 function sanitizeDiscordFrontChannelText(text: string): string {
-  const withoutToolCallBlocks = stripPlainTextToolCallBlocks(text);
+  const withoutToolCallBlocks = stripPlainTextToolCallBlocks(text, {
+    resolveProtectedRanges: findCodeRegions,
+  });
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(withoutToolCallBlocks);
-  const withoutResidualToolCallBlocks = stripPlainTextToolCallBlocks(withoutAssistantScaffolding);
+  const withoutResidualToolCallBlocks = stripPlainTextToolCallBlocks(withoutAssistantScaffolding, {
+    resolveProtectedRanges: findCodeRegions,
+  });
   const withoutChannelLines = stripDiscordInternalChannelLines(withoutResidualToolCallBlocks);
   return collapseExcessBlankLines(withoutChannelLines).trim();
 }

--- a/packages/tool-call-repair/src/contracts.ts
+++ b/packages/tool-call-repair/src/contracts.ts
@@ -1,0 +1,27 @@
+/** Parser limits and allowlist options for plain-text tool-call repair. */
+export type PlainTextToolCallParseOptions = {
+  /** Optional allowlist of tool names that may be repaired. */
+  allowedToolNames?: Iterable<string>;
+  /** Maximum serialized payload size accepted for one repaired call. */
+  maxPayloadBytes?: number;
+};
+
+export type PlainTextToolCallNameMatcher = {
+  hasExactName(name: string): boolean;
+  hasNamePrefix(prefix: string): boolean;
+};
+
+/** Source range that must remain literal user-visible text. */
+export type PlainTextToolCallProtectedRange = { end: number; start: number };
+
+/** Resolves protected ranges against the exact text about to be scanned. */
+export type PlainTextToolCallProtectedRangeResolver = (
+  text: string,
+) => readonly PlainTextToolCallProtectedRange[];
+
+export function isOffsetInProtectedRanges(
+  offset: number,
+  ranges: readonly PlainTextToolCallProtectedRange[],
+): boolean {
+  return ranges.some((range) => offset >= range.start && offset < range.end);
+}

--- a/packages/tool-call-repair/src/index.ts
+++ b/packages/tool-call-repair/src/index.ts
@@ -3,13 +3,17 @@ export {
   parseStandalonePlainTextToolCallBlocks,
   stripPlainTextToolCallBlocks,
   type PlainTextToolCallBlock,
-  type PlainTextToolCallParseOptions,
 } from "./payload.js";
+export {
+  type PlainTextToolCallNameMatcher,
+  type PlainTextToolCallParseOptions,
+  type PlainTextToolCallProtectedRange,
+  type PlainTextToolCallProtectedRangeResolver,
+} from "./contracts.js";
 export {
   normalizePlainTextToolCallStreamEvents,
   projectScrubbedPlainTextToolCallMessage,
   type PlainTextToolCallMessageNormalization,
-  type PlainTextToolCallNameMatcher,
   type PlainTextToolCallStreamNormalizerOptions,
 } from "./stream-normalizer.js";
 export {

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -146,6 +146,32 @@ describe("scanPlainTextJsonToolCall", () => {
 });
 
 describe("stripPlainTextToolCallBlocks", () => {
+  it("preserves protected candidates while stripping adjacent unprotected calls", () => {
+    const protectedCall = '[read]\n{"path":"example.txt"}\n[/read]';
+    const unprotectedCall = '[read]\n{"path":"secret.txt"}\n[/read]';
+    const raw = [protectedCall, unprotectedCall].join("\n");
+
+    expect(
+      stripPlainTextToolCallBlocks(raw, {
+        resolveProtectedRanges: () => [{ start: 0, end: protectedCall.length }],
+      }),
+    ).toBe(`${protectedCall}\n`);
+    expect(stripPlainTextToolCallBlocks(raw)).toBe("");
+  });
+
+  it("checks protection for every adjacent candidate", () => {
+    const first = '[read]\n{"path":"secret.txt"}\n[/read]';
+    const second = '[server]\n{"host":"example.test"}\n[/server]';
+    const raw = `${first}\n${second}`;
+    const secondStart = raw.indexOf(second);
+
+    expect(
+      stripPlainTextToolCallBlocks(raw, {
+        resolveProtectedRanges: () => [{ start: secondStart, end: raw.length }],
+      }),
+    ).toBe(second);
+  });
+
   it("preserves a balanced tool block whose JSON is invalid", () => {
     const raw = '[read]\n{"path":}\n[/read]';
 

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -1,3 +1,9 @@
+import {
+  isOffsetInProtectedRanges,
+  type PlainTextToolCallNameMatcher,
+  type PlainTextToolCallParseOptions,
+  type PlainTextToolCallProtectedRangeResolver,
+} from "./contracts.js";
 // Tool Call Repair module implements payload behavior.
 import {
   consumeLineBreak,
@@ -27,14 +33,6 @@ export type PlainTextToolCallBlock = {
   raw: string;
   /** Inclusive start offset of the parsed block. */
   start: number;
-};
-
-/** Parser limits and allowlist options for plain-text tool-call repair. */
-export type PlainTextToolCallParseOptions = {
-  /** Optional allowlist of tool names that may be repaired. */
-  allowedToolNames?: Iterable<string>;
-  /** Maximum serialized payload size accepted for one repaired call. */
-  maxPayloadBytes?: number;
 };
 
 type NormalizedPlainTextToolCallParseOptions = Omit<
@@ -69,11 +67,6 @@ export type PlainTextJsonToolCallScan =
       nameComplete: true;
       payload: PlainTextJsonToolCallSpan;
     });
-
-export type PlainTextToolCallNameMatcher = {
-  hasExactName(name: string): boolean;
-  hasNamePrefix(prefix: string): boolean;
-};
 
 type PlainTextToolCallScanBranches = {
   json: PlainTextJsonToolCallScan;
@@ -681,7 +674,10 @@ export function parseStandalonePlainTextToolCallBlocks(
 }
 
 /** Removes full-line standalone plain-text tool-call blocks from user-visible text. */
-export function stripPlainTextToolCallBlocks(text: string): string {
+export function stripPlainTextToolCallBlocks(
+  text: string,
+  options: { resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver } = {},
+): string {
   if (
     !text ||
     (!/\[(?:tool:)?[A-Za-z0-9_-]+\]/.test(text) &&
@@ -692,6 +688,7 @@ export function stripPlainTextToolCallBlocks(text: string): string {
   ) {
     return text;
   }
+  const protectedRanges = options.resolveProtectedRanges?.(text) ?? [];
   let result = "";
   let cursor = 0;
   let index = 0;
@@ -702,6 +699,10 @@ export function stripPlainTextToolCallBlocks(text: string): string {
       continue;
     }
     const blockStart = skipLineIndentation(text, index);
+    if (isOffsetInProtectedRanges(blockStart, protectedRanges)) {
+      index += 1;
+      continue;
+    }
     const scan = scanPlainTextToolCall(text, blockStart);
     if (scan.kind === "prefix" && scan.completeEnd === undefined) {
       return result + text.slice(cursor);
@@ -719,6 +720,9 @@ export function stripPlainTextToolCallBlocks(text: string): string {
     result += text.slice(cursor, index);
     while (true) {
       const adjacentStart = skipLineIndentation(text, blockEnd);
+      if (isOffsetInProtectedRanges(adjacentStart, protectedRanges)) {
+        break;
+      }
       const adjacent = scanPlainTextToolCall(text, adjacentStart);
       const adjacentEnd =
         adjacent.kind === "complete"

--- a/packages/tool-call-repair/src/promote.ts
+++ b/packages/tool-call-repair/src/promote.ts
@@ -1,3 +1,4 @@
+import type { PlainTextToolCallProtectedRangeResolver } from "./contracts.js";
 // Tool Call Repair module implements promote behavior.
 import { parseStandalonePlainTextToolCallBlocks, type PlainTextToolCallBlock } from "./payload.js";
 
@@ -21,6 +22,7 @@ export type PlainTextToolCallPromotionOptions = {
   isRetainableNonTextBlock?: (block: Record<string, unknown>) => boolean;
   message: unknown;
   requireAssistantRole?: boolean;
+  resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver;
   resolveToolName?: ToolCallRepairNameResolver;
 };
 
@@ -87,6 +89,14 @@ function createPromotedToolCallBlocks(
   if (!parsedBlocks) {
     return undefined;
   }
+  const protectedRanges = options.resolveProtectedRanges?.(text) ?? [];
+  if (
+    parsedBlocks.some((block) =>
+      protectedRanges.some((range) => block.start >= range.start && block.start < range.end),
+    )
+  ) {
+    return undefined;
+  }
 
   const resolveToolName = options.resolveToolName ?? resolveExactToolName;
   const toolCalls: Record<string, unknown>[] = [];
@@ -137,7 +147,7 @@ export function projectStandalonePlainTextToolCallMessage(
 
   const originalContent = messageRecord.content;
   if (typeof originalContent === "string") {
-    const toolCalls = createPromotedToolCallBlocks(originalContent.trim(), options);
+    const toolCalls = createPromotedToolCallBlocks(originalContent, options);
     if (!toolCalls) {
       return undefined;
     }

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -14,6 +14,25 @@ const matcher: PlainTextToolCallNameMatcher = {
 
 type Terminal = "done" | "eof" | "error";
 
+function resolveTestFenceRanges(text: string): Array<{ end: number; start: number }> {
+  const ranges: Array<{ end: number; start: number }> = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const backtick = text.indexOf("```", cursor);
+    const tilde = text.indexOf("~~~", cursor);
+    const start = backtick === -1 ? tilde : tilde === -1 ? backtick : Math.min(backtick, tilde);
+    if (start === -1) {
+      break;
+    }
+    const marker = text.slice(start, start + 3);
+    const close = text.indexOf(marker, start + marker.length);
+    const end = close === -1 ? text.length : close + marker.length;
+    ranges.push({ start, end });
+    cursor = end;
+  }
+  return ranges;
+}
+
 function parseSplitCall(parts: readonly string[]) {
   let offset = 0;
   const lineBreakOffsets = new Set(
@@ -40,16 +59,20 @@ function textDelta(delta: string, snapshot: string) {
   };
 }
 
-async function normalize(events: readonly unknown[]): Promise<Record<string, unknown>[]> {
+async function normalize(
+  events: readonly unknown[],
+  options: { protectFences?: boolean } = {},
+): Promise<Record<string, unknown>[]> {
   async function* source() {
     yield* events;
   }
   const normalized: Record<string, unknown>[] = [];
-  const scrubMessage = (message: unknown, options?: { preserveEmptyTextBlocks?: boolean }) =>
+  const scrubMessage = (message: unknown, scrubOptions?: { preserveEmptyTextBlocks?: boolean }) =>
     projectScrubbedPlainTextToolCallMessage({
       matcher,
       message,
-      preserveEmptyTextBlocks: options?.preserveEmptyTextBlocks,
+      preserveEmptyTextBlocks: scrubOptions?.preserveEmptyTextBlocks,
+      resolveProtectedRanges: options.protectFences ? resolveTestFenceRanges : undefined,
     });
   for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
     matcher,
@@ -61,6 +84,7 @@ async function normalize(events: readonly unknown[]): Promise<Record<string, unk
       const scrubbed = scrubMessage(message, { preserveEmptyTextBlocks });
       return scrubbed ? { kind: "scrubbed", ...scrubbed } : undefined;
     },
+    resolveProtectedRanges: options.protectFences ? resolveTestFenceRanges : undefined,
   })) {
     if (event && typeof event === "object") {
       normalized.push(event as Record<string, unknown>);
@@ -618,6 +642,186 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(projectScrubbedPlainTextToolCallMessage({ matcher, message })?.message).toEqual({
       ...message,
       content: "Visible answer\n",
+    });
+  });
+
+  it("preserves a fenced call in terminal projections", () => {
+    const text = ["```json", "[read]", '{"path":"example.txt"}', "[/read]", "```"].join("\n");
+    const message = { role: "assistant", content: text };
+
+    expect(
+      projectScrubbedPlainTextToolCallMessage({
+        matcher,
+        message,
+        resolveProtectedRanges: resolveTestFenceRanges,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves fenced calls when the opener and call are split across live deltas", async () => {
+    const parts = ["`", "``json\n", "[re", 'ad]\n{"path":"example.txt"}\n[/read]\n', "```"];
+    const text = parts.join("");
+    const events = await normalize(
+      [
+        ...parts.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+        {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content: textContent(text), stopReason: "stop" },
+        },
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events).join("")).toBe(text);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      message: { content: textContent(text), stopReason: "stop" },
+    });
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+  });
+
+  it("preserves fence ownership across adjacent text content blocks", async () => {
+    const first = "```json\n";
+    const second = ["[read]", '{"path":"example.txt"}', "[/read]", "```"].join("\n");
+    const content = [
+      { type: "text", text: first },
+      { type: "text", text: second },
+    ];
+    const events = await normalize(
+      [
+        { type: "text_delta", contentIndex: 0, delta: first },
+        { type: "text_end", contentIndex: 0, content: first },
+        { type: "text_delta", contentIndex: 1, delta: second },
+        { type: "text_end", contentIndex: 1, content: second },
+        {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content, stopReason: "stop" },
+        },
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events).join("")).toBe(first + second);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      message: { content, stopReason: "stop" },
+    });
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+  });
+
+  it("uses cumulative partials when earlier fenced blocks were not streamed", async () => {
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]", "```"].join("\n");
+    const content = [
+      { type: "text", text: "```json\n" },
+      { type: "text", text: candidate },
+    ];
+    const events = await normalize(
+      [
+        {
+          type: "text_delta",
+          contentIndex: 1,
+          delta: candidate,
+          partial: { role: "assistant", content },
+        },
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events)).toEqual([candidate]);
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+  });
+
+  it("preserves candidate bytes after bounded protection history overflows", async () => {
+    const opening = `\`\`\`text\n${"x".repeat(1_000_000)}`;
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");
+    const events = await normalize(
+      [
+        { type: "text_delta", contentIndex: 0, delta: opening },
+        { type: "text_delta", contentIndex: 0, delta: candidate },
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events).join("")).toBe(opening + candidate);
+  });
+
+  it("does not resolve Markdown protection for ordinary streamed text", async () => {
+    let resolverCalls = 0;
+    const visibleChunks = Array.from({ length: 1_000 }, () => "ordinary prose\n");
+
+    async function* source() {
+      for (const delta of visibleChunks) {
+        yield { type: "text_delta", contentIndex: 0, delta };
+      }
+    }
+
+    const events: Record<string, unknown>[] = [];
+    for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+      matcher,
+      createPromotedToolCallEvents: () => [],
+      normalizeTerminalMessage: () => undefined,
+      resolveProtectedRanges: () => {
+        resolverCalls += 1;
+        return [];
+      },
+    })) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect(resolverCalls).toBe(0);
+    expect(textDeltas(events).join("")).toBe(visibleChunks.join(""));
+  });
+
+  it("materializes accumulated Markdown only after a candidate-shaped delta", async () => {
+    const resolvedLengths: number[] = [];
+    const visibleChunks = Array.from({ length: 1_000 }, () => "ordinary prose\n");
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");
+
+    async function* source() {
+      for (const delta of visibleChunks) {
+        yield { type: "text_delta", contentIndex: 0, delta };
+      }
+      yield { type: "text_delta", contentIndex: 0, delta: candidate };
+    }
+
+    const events: Record<string, unknown>[] = [];
+    for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+      matcher,
+      createPromotedToolCallEvents: () => [],
+      normalizeTerminalMessage: () => undefined,
+      resolveProtectedRanges: (text) => {
+        resolvedLengths.push(text.length);
+        return [];
+      },
+    })) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect(resolvedLengths).toContain(visibleChunks.join("").length + candidate.length);
+    expect(resolvedLengths.length).toBeLessThanOrEqual(3);
+    expect(textDeltas(events).join("")).toBe(visibleChunks.join(""));
+  });
+
+  it("still scrubs an unfenced call from live deltas and the terminal message", async () => {
+    const text = ["[read]", '{"path":"secret.txt"}', "[/read]"].join("\n");
+    const events = await normalize(
+      [
+        { type: "text_delta", contentIndex: 0, delta: text },
+        {
+          type: "done",
+          reason: "length",
+          message: { role: "assistant", content: textContent(text), stopReason: "length" },
+        },
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events)).toEqual([]);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      message: { content: [{ type: "text", text: "" }], stopReason: "length" },
     });
   });
 

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1,4 +1,10 @@
 import {
+  isOffsetInProtectedRanges,
+  type PlainTextToolCallNameMatcher,
+  type PlainTextToolCallProtectedRange,
+  type PlainTextToolCallProtectedRangeResolver,
+} from "./contracts.js";
+import {
   consumeLineBreak,
   END_TOOL_REQUEST,
   HARMONY_CALL_MARKER,
@@ -11,14 +17,10 @@ import {
   type StructuralLineBreakOptions,
   utf8ByteLengthWithinLimit,
 } from "./grammar.js";
-import {
-  scanPlainTextToolCall,
-  type PlainTextToolCallNameMatcher,
-  type PlainTextToolCallScan,
-} from "./payload.js";
+import { scanPlainTextToolCall, type PlainTextToolCallScan } from "./payload.js";
 import type { PlainTextToolCallMessageProjection } from "./promote.js";
 
-export type { PlainTextToolCallNameMatcher } from "./payload.js";
+export type { PlainTextToolCallNameMatcher } from "./contracts.js";
 
 /** Result of repairing the final message carried by a provider stream `done` event. */
 export type PlainTextToolCallMessageNormalization =
@@ -31,6 +33,8 @@ export type PlainTextToolCallStreamNormalizerOptions = {
   createPromotedToolCallEvents(message: Record<string, unknown>): Iterable<unknown>;
   /** Tool-name matcher scoped to the exact request being normalized. */
   matcher: PlainTextToolCallNameMatcher;
+  /** Resolves source ranges that must remain literal user-visible text. */
+  resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver;
   /** Promotes an eligible terminal snapshot or scrubs every recognized candidate. */
   normalizeTerminalMessage(params: {
     allowPromotion: boolean;
@@ -44,6 +48,8 @@ export type PlainTextToolCallStreamNormalizerOptions = {
 
 const MAX_PAYLOAD_BYTES = 256_000;
 const MAX_PENDING_EVENTS = 256;
+// Retain bounded visible history only for split Markdown ownership; terminal snapshots stay canonical.
+const MAX_PROTECTION_CONTEXT_CHARS = 1_000_000;
 const MAX_TOOL_NAME_CHARS = 120;
 
 type TextRange = { end: number; start: number };
@@ -200,6 +206,7 @@ function findCallSequences(
   matcher: PlainTextToolCallNameMatcher,
   structuralBoundaries: readonly number[] = [],
   structuralLineBreaks?: StructuralLineBreakOptions,
+  protectedRanges: readonly PlainTextToolCallProtectedRange[] = [],
 ): ScannedCallSequence[] {
   const sequences: ScannedCallSequence[] = [];
   const structuralBoundarySet = new Set(structuralBoundaries);
@@ -217,6 +224,10 @@ function findCallSequences(
     }
     const sequenceStart = index;
     let callStart = skipLineIndentation(text, index);
+    if (isOffsetInProtectedRanges(callStart, protectedRanges)) {
+      index += 1;
+      continue;
+    }
     let sequenceEnd = callStart;
     let hasOverCap = false;
     let activeStart: number | undefined;
@@ -274,6 +285,9 @@ function findCallSequences(
       if (nextStart >= text.length) {
         break;
       }
+      if (isOffsetInProtectedRanges(nextStart, protectedRanges)) {
+        break;
+      }
       const nextScan = scanPlainTextToolCall(text, nextStart, {
         matcher,
         maxPayloadBytes: MAX_PAYLOAD_BYTES,
@@ -321,9 +335,16 @@ function createCandidateScanView(candidate: StandalonePlainTextToolCallCandidate
 function findCandidateCallSequences(
   candidate: StandalonePlainTextToolCallCandidate,
   matcher: PlainTextToolCallNameMatcher,
+  resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver,
 ): ScannedCallSequence[] {
   const view = createCandidateScanView(candidate);
-  return findCallSequences(view.text, matcher, view.boundaries, view.structuralLineBreaks);
+  return findCallSequences(
+    view.text,
+    matcher,
+    view.boundaries,
+    view.structuralLineBreaks,
+    resolveProtectedRanges?.(view.text),
+  );
 }
 
 function createRangeRemover(ranges: readonly TextRange[]) {
@@ -398,6 +419,7 @@ export function projectScrubbedPlainTextToolCallMessage(params: {
   matcher: PlainTextToolCallNameMatcher;
   message: unknown;
   preserveEmptyTextBlocks?: boolean;
+  resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver;
   requireAssistantRole?: boolean;
 }): PlainTextToolCallMessageProjection | undefined {
   const record = asRecord(params.message);
@@ -408,7 +430,11 @@ export function projectScrubbedPlainTextToolCallMessage(params: {
   if (!record || !candidate) {
     return undefined;
   }
-  const sequences = findCandidateCallSequences(candidate, params.matcher);
+  const sequences = findCandidateCallSequences(
+    candidate,
+    params.matcher,
+    params.resolveProtectedRanges,
+  );
   const visibleOutsideCalls = Boolean(createRangeRemover(sequences)(candidate.text).trim());
   const ranges = sequences.filter(
     (sequence) =>
@@ -426,6 +452,7 @@ function findPotentialCallStart(
   text: string,
   atLineStart: boolean,
   matcher: PlainTextToolCallNameMatcher,
+  isProtected?: (offset: number) => boolean,
 ): number | null {
   for (let index = 0; index < text.length;) {
     const lineStart =
@@ -435,6 +462,10 @@ function findPotentialCallStart(
       continue;
     }
     const start = skipLineIndentation(text, index);
+    if (isProtected?.(start)) {
+      index += 1;
+      continue;
+    }
     const scan = scanPlainTextToolCall(text, start, {
       matcher,
       maxPayloadBytes: MAX_PAYLOAD_BYTES,
@@ -445,6 +476,48 @@ function findPotentialCallStart(
     index = Math.max(index + 1, scan.next);
   }
   return null;
+}
+
+function resolvePartialProtectionCheck(params: {
+  authoritative: boolean;
+  contentIndex: number;
+  incoming: string;
+  partial: unknown;
+  resolveProtectedRanges: PlainTextToolCallProtectedRangeResolver;
+}): ((offset: number) => boolean) | undefined {
+  const candidate = extractStandaloneCandidate(params.partial);
+  const record = asRecord(params.partial);
+  if (!candidate || !record) {
+    return undefined;
+  }
+  let blockStart = 0;
+  let blockText: string | undefined;
+  if (typeof record.content === "string") {
+    if (params.contentIndex !== 0) {
+      return undefined;
+    }
+    blockText = record.content;
+  } else {
+    const part = candidate.parts.find((entry) => entry.contentIndex === params.contentIndex);
+    const block = Array.isArray(record.content)
+      ? asRecord(record.content[params.contentIndex])
+      : undefined;
+    if (!part || block?.type !== "text" || typeof block.text !== "string") {
+      return undefined;
+    }
+    blockStart = part.start;
+    blockText = block.text;
+  }
+  const incomingStart = params.authoritative ? 0 : blockText.length - params.incoming.length;
+  if (
+    incomingStart < 0 ||
+    (params.authoritative ? blockText !== params.incoming : !blockText.endsWith(params.incoming))
+  ) {
+    return undefined;
+  }
+  const protectedRanges = params.resolveProtectedRanges(candidate.text);
+  return (offset) =>
+    isOffsetInProtectedRanges(blockStart + incomingStart + offset, protectedRanges);
 }
 
 function nextAtLineStart(previous: boolean, text: string): boolean {
@@ -756,6 +829,7 @@ function createOverCapSuppressor(
 function classifyPending(
   pending: CandidatePendingState,
   matcher: PlainTextToolCallNameMatcher,
+  resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver,
   finalize = false,
 ): PendingClassification {
   const candidate = { text: pending.buffer, parts: pending.parts };
@@ -766,7 +840,7 @@ function classifyPending(
     structuralLineBreaks: view.structuralLineBreaks,
   });
   const hasNamedCandidate = scanHasNamedCandidate(terminalScan);
-  const sequences = findCandidateCallSequences(candidate, matcher);
+  const sequences = findCandidateCallSequences(candidate, matcher, resolveProtectedRanges);
   const overCapRanges = sequences.filter(({ overCap }) => overCap);
   const leading = sequences[0]?.start === 0 ? sequences[0] : undefined;
   if (leading?.activeStart !== undefined && (pending.sequenceOverCap || overCapRanges.length > 0)) {
@@ -1039,6 +1113,61 @@ export async function* normalizePlainTextToolCallStreamEvents(
   const heldTextStarts = new Map<string, Record<string, unknown>>();
   const lineStarts = new Map<string, boolean>();
   const emittedTextUnits = new Map<string, number>();
+  const protectionChunks: string[] = [];
+  let protectionContextLength = 0;
+  let protectionContextOverflow = false;
+  let protectionBlockContentIndex: number | undefined;
+  let protectionBlockStart = 0;
+
+  const beginProtectionBlock = (contentIndex: number) => {
+    if (protectionBlockContentIndex === contentIndex) {
+      return;
+    }
+    protectionBlockContentIndex = contentIndex;
+    protectionBlockStart = protectionContextLength;
+  };
+  const truncateProtectionContext = (length: number) => {
+    while (protectionContextLength > length) {
+      const tail = protectionChunks.at(-1);
+      if (tail === undefined) {
+        protectionContextLength = 0;
+        return;
+      }
+      const retainedLength = tail.length - (protectionContextLength - length);
+      if (retainedLength > 0) {
+        protectionChunks[protectionChunks.length - 1] = tail.slice(0, retainedLength);
+        protectionContextLength = length;
+        return;
+      }
+      protectionChunks.pop();
+      protectionContextLength -= tail.length;
+    }
+  };
+  const advanceProtectionContext = (text: string, resetActiveBlock = false) => {
+    if (!options.resolveProtectedRanges || protectionContextOverflow) {
+      return;
+    }
+    if (resetActiveBlock) {
+      truncateProtectionContext(protectionBlockStart);
+    }
+    if (protectionContextLength + text.length > MAX_PROTECTION_CONTEXT_CHARS) {
+      protectionChunks.length = 0;
+      protectionContextLength = 0;
+      protectionContextOverflow = true;
+      return;
+    }
+    if (text) {
+      protectionChunks.push(text);
+    }
+    protectionContextLength += text.length;
+  };
+  const materializeProtectionPrefix = (authoritative: boolean): string => {
+    if (protectionContextOverflow) {
+      return "";
+    }
+    const context = protectionChunks.join("");
+    return authoritative ? context.slice(0, protectionBlockStart) : context;
+  };
 
   const scrubSnapshot = (
     value: unknown,
@@ -1051,6 +1180,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
           matcher: options.matcher,
           message: value,
           preserveEmptyTextBlocks,
+          resolveProtectedRanges: options.resolveProtectedRanges,
         })
       : undefined;
     if (forced) {
@@ -1153,6 +1283,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
         const closesText = type === "text_end";
         let authoritative = closesText;
         let sequenceOverCap = false;
+        beginProtectionBlock(eventContentIndex(record));
         while (true) {
           if (pending?.kind === "suppressing") {
             if (closesText) {
@@ -1208,7 +1339,41 @@ export async function* normalizePlainTextToolCallStreamEvents(
               sequenceOverCap ||
               overCapSequenceOpen ||
               (lineStarts.get(key) ?? true);
-            const callStart = findPotentialCallStart(incoming, atLineStart, options.matcher);
+            let callStart = findPotentialCallStart(incoming, atLineStart, options.matcher);
+            if (callStart !== null && options.resolveProtectedRanges) {
+              if (protectionContextOverflow) {
+                // Bounded live history no longer proves ownership. Preserve bytes and let the
+                // authoritative terminal snapshot decide instead of deleting literal content.
+                callStart = null;
+              } else {
+                const partialProtection = resolvePartialProtectionCheck({
+                  authoritative,
+                  contentIndex: eventContentIndex(incomingRecord),
+                  incoming,
+                  partial: incomingRecord.partial,
+                  resolveProtectedRanges: options.resolveProtectedRanges,
+                });
+                // Candidate-shaped text is rare. Materialize prior visible text only when the
+                // provider did not supply an authoritative cumulative partial.
+                const protectionPrefix = partialProtection
+                  ? ""
+                  : materializeProtectionPrefix(authoritative);
+                const protectedRanges = partialProtection
+                  ? undefined
+                  : options.resolveProtectedRanges(`${protectionPrefix}${incoming}`);
+                callStart = findPotentialCallStart(
+                  incoming,
+                  atLineStart,
+                  options.matcher,
+                  partialProtection ??
+                    ((offset) =>
+                      isOffsetInProtectedRanges(
+                        protectionPrefix.length + offset,
+                        protectedRanges ?? [],
+                      )),
+                );
+              }
+            }
             if (callStart === null) {
               const held = heldTextStarts.get(key);
               if (held) {
@@ -1224,9 +1389,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
                   (sequenceOverCap || continuesScrubbedSequence) && contentIndex > 0;
               }
               lineStarts.set(key, nextAtLineStart(atLineStart, incoming));
+              advanceProtectionContext(incoming, authoritative);
               break;
             }
             const visiblePrefix = incoming.slice(0, callStart);
+            advanceProtectionContext(visiblePrefix, authoritative);
             const emittedUnits = emittedTextUnits.get(key) ?? 0;
             const emittedPrefixUnits = authoritative ? emittedUnits : 0;
             const novelVisiblePrefix = visiblePrefix.slice(emittedPrefixUnits);
@@ -1332,7 +1499,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
           if (!shouldClassify) {
             break;
           }
-          const classification = classifyPending(pending, options.matcher);
+          const classification = classifyPending(
+            pending,
+            options.matcher,
+            options.resolveProtectedRanges,
+          );
           pending.nextScanChars = Math.max(pending.buffer.length + 1, pending.nextScanChars * 2);
           if (classification.kind === "complete" || classification.kind === "incomplete") {
             break;
@@ -1373,10 +1544,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
           if (classification.kind === "false-positive") {
             yield* replayFalsePositiveCandidate(pending);
             const replayText = pending.buffer;
+            const replayedCandidate = pending;
             pending = undefined;
             if (replayText) {
               overCapSequenceOpen = false;
               lineStarts.set(key, nextAtLineStart(lineStarts.get(key) ?? true, replayText));
+              advanceProtectionContext(replayedCandidate.buffer);
             }
             break;
           }
@@ -1419,11 +1592,14 @@ export async function* normalizePlainTextToolCallStreamEvents(
             yield createSyntheticTextDelta(pending.template, novelText, partial);
           }
           lineStarts.set(key, nextAtLineStart(lineStarts.get(key) ?? true, sanitizedText));
+          advanceProtectionContext(sanitizedText);
           pending = undefined;
           break;
         }
         if (closesText) {
           emittedTextUnits.delete(key);
+          protectionBlockContentIndex = undefined;
+          protectionBlockStart = protectionContextLength;
         }
         continue;
       }
@@ -1444,9 +1620,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
           : extractStandaloneCandidate(record.message, false);
         const terminalHasIncompleteCandidate =
           terminalCandidate &&
-          findCandidateCallSequences(terminalCandidate, options.matcher).some(
-            (sequence) => sequence.activeStart !== undefined,
-          );
+          findCandidateCallSequences(
+            terminalCandidate,
+            options.matcher,
+            options.resolveProtectedRanges,
+          ).some((sequence) => sequence.activeStart !== undefined);
         const terminalCandidateProjection = terminalHasIncompleteCandidate
           ? scrubSnapshot(record.message, preserveTerminalContentIndexes, true)
           : undefined;
@@ -1470,7 +1648,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
           yield { ...record, reason: "toolUse", message: normalized.message };
         } else if (normalized?.kind === "scrubbed") {
           if (pending?.kind === "candidate") {
-            const classification = classifyPending(pending, options.matcher, true);
+            const classification = classifyPending(
+              pending,
+              options.matcher,
+              options.resolveProtectedRanges,
+              true,
+            );
             if (classification.kind === "stripped" && classification.text) {
               const template = projectEventIndex(pending.template, normalized);
               if (template) {
@@ -1491,7 +1674,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
         } else {
           let message = record.message;
           if (pending?.kind === "candidate") {
-            const classification = classifyPending(pending, options.matcher, true);
+            const classification = classifyPending(
+              pending,
+              options.matcher,
+              options.resolveProtectedRanges,
+              true,
+            );
             if (classification.kind === "false-positive") {
               yield* replayFalsePositiveCandidate(pending);
             } else {
@@ -1510,6 +1698,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
         forceScrubTerminal = false;
         heldTextStarts.clear();
         emittedTextUnits.clear();
+        protectionChunks.length = 0;
+        protectionContextLength = 0;
+        protectionContextOverflow = false;
+        protectionBlockContentIndex = undefined;
+        protectionBlockStart = 0;
         if (options.stopAfterDone) {
           return;
         }
@@ -1520,7 +1713,8 @@ export async function* normalizePlainTextToolCallStreamEvents(
         const knownCandidate =
           pending?.kind === "suppressing" ||
           (pending?.kind === "candidate" &&
-            classifyPending(pending, options.matcher, true).kind !== "false-positive");
+            classifyPending(pending, options.matcher, options.resolveProtectedRanges, true).kind !==
+              "false-positive");
         if (pending?.kind === "candidate" && !knownCandidate) {
           yield* replayFalsePositiveCandidate(pending);
         }
@@ -1573,7 +1767,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
         }
         queuePendingEvent(pending, record);
         if (pendingQueueOverCap(pending)) {
-          const classification = classifyPending(pending, options.matcher);
+          const classification = classifyPending(
+            pending,
+            options.matcher,
+            options.resolveProtectedRanges,
+          );
           if (classification.kind === "false-positive") {
             yield* replayFalsePositiveCandidate(pending);
             pending = undefined;
@@ -1606,7 +1804,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
     }
 
     if (pending?.kind === "candidate") {
-      const classification = classifyPending(pending, options.matcher, true);
+      const classification = classifyPending(
+        pending,
+        options.matcher,
+        options.resolveProtectedRanges,
+        true,
+      );
       if (classification.kind === "false-positive") {
         yield* replayFalsePositiveCandidate(pending);
       } else {

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -23,6 +23,7 @@ import {
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
+import { findCodeRegions } from "../../shared/text/code-regions.js";
 import { stripFinalTags } from "../../shared/text/final-tags.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
@@ -453,6 +454,7 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     : withoutPlaceholder;
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
     stripLegacyBracketToolCallBlocks(withoutInternalTraceLines),
+    { resolveProtectedRanges: findCodeRegions },
   );
   const trimmed = withoutToolCallBlocks.trim();
   if (!trimmed) {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
@@ -96,6 +96,122 @@ function toolResultSummary(message: AgentMessage | undefined) {
 }
 
 describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
+  it("preserves a fenced allowed-tool example in live and terminal output", async () => {
+    const parts = ["`", "``json\n", "[re", 'ad]\n{"path":"example.txt"}\n[/read]\n', "```"];
+    const rawText = parts.join("");
+    const createMessage = () => ({
+      role: "assistant",
+      content: [{ type: "text", text: rawText }],
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          ...parts.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+          { type: "text_end", contentIndex: 0, content: rawText },
+          { type: "done", reason: "stop", message: createMessage() },
+        ],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["read"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const events = (await collectStreamEvents(stream)).map((event) =>
+      requireRecord(event, "event"),
+    );
+    const result = requireRecord(await stream.result(), "result message");
+
+    expect(
+      events
+        .filter((event) => event.type === "text_delta")
+        .map((event) => event.delta)
+        .join(""),
+    ).toBe(rawText);
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+    expect(requireRecord(events.at(-1)?.message, "done message").content).toEqual([
+      { type: "text", text: rawText },
+    ]);
+    expect(result.content).toEqual([{ type: "text", text: rawText }]);
+  });
+
+  it("preserves a fenced example split across adjacent text blocks", async () => {
+    const textParts = [
+      "```json\n",
+      ["[read]", '{"path":"example.txt"}', "[/read]", "\n"].join("\n"),
+      "```",
+    ];
+    const content = textParts.map((text) => ({ type: "text", text }));
+    const createMessage = () => ({
+      role: "assistant",
+      content,
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          ...textParts.flatMap((text, contentIndex) => [
+            { type: "text_delta", contentIndex, delta: text },
+            { type: "text_end", contentIndex, content: text },
+          ]),
+          { type: "done", reason: "stop", message: createMessage() },
+        ],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["read"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const events = (await collectStreamEvents(stream)).map((event) =>
+      requireRecord(event, "event"),
+    );
+    const result = requireRecord(await stream.result(), "result message");
+
+    expect(
+      events
+        .filter((event) => event.type === "text_delta")
+        .map((event) => event.delta)
+        .join(""),
+    ).toBe(textParts.join(""));
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+    expect(requireRecord(events.at(-1)?.message, "done message").content).toEqual(content);
+    expect(result.content).toEqual(content);
+  });
+
+  it("does not promote an indented code example from terminal output", async () => {
+    const rawText = ["    [read]", '    {"path":"example.txt"}', "    [/read]"].join("\n");
+    const createMessage = () => ({
+      role: "assistant",
+      content: [{ type: "text", text: rawText }],
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [{ type: "done", reason: "stop", message: createMessage() }],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["read"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const events = (await collectStreamEvents(stream)).map((event) =>
+      requireRecord(event, "event"),
+    );
+    const result = requireRecord(await stream.result(), "result message");
+
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+    expect(requireRecord(events.at(-1)?.message, "done message").content).toEqual([
+      { type: "text", text: rawText },
+    ]);
+    expect(result.content).toEqual([{ type: "text", text: rawText }]);
+  });
+
   it("promotes standalone serialized parameter XML text to structured tool calls", async () => {
     // Some providers emit tool calls as text blocks; promote only allowed tool
     // names into structured toolCall content.

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -14,6 +14,7 @@ import {
   type PlainTextToolCallNameMatcher,
 } from "../../../../packages/tool-call-repair/src/index.js";
 import { visitObjectContentBlocks } from "../../../shared/message-content-blocks.js";
+import { findCodeRegions } from "../../../shared/text/code-regions.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
@@ -901,6 +902,7 @@ function wrapStreamPromoteStandaloneTextToolCalls(
       matcher,
       message: params.message,
       preserveEmptyTextBlocks: params.preserveEmptyTextBlocks,
+      resolveProtectedRanges: findCodeRegions,
       requireAssistantRole: true,
     });
     if (scrubbed) {
@@ -936,6 +938,7 @@ function wrapStreamPromoteStandaloneTextToolCalls(
       isRetainableNonTextBlock: isRetainableNonVisibleBlock,
       message: params.message,
       requireAssistantRole: true,
+      resolveProtectedRanges: findCodeRegions,
       resolveToolName: resolveExactAllowedToolName,
     });
     return promoted ? { kind: "promoted", ...promoted } : undefined;
@@ -965,6 +968,7 @@ function wrapStreamPromoteStandaloneTextToolCalls(
       createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
       matcher,
       normalizeTerminalMessage,
+      resolveProtectedRanges: findCodeRegions,
     });
   };
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -57,6 +57,7 @@ import { resolvePollMaxSelections } from "../../polls.js";
 import { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
+import { findCodeRegions } from "../../shared/text/code-regions.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
@@ -1295,7 +1296,9 @@ async function buildSendPayloadParts(params: {
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
 
-  message = stripPlainTextToolCallBlocks(stripUnsupportedCitationControlMarkers(parsed.text));
+  message = stripPlainTextToolCallBlocks(stripUnsupportedCitationControlMarkers(parsed.text), {
+    resolveProtectedRanges: findCodeRegions,
+  });
   if (message || !hasPresentation) {
     actionParams.message = message;
   } else {

--- a/src/infra/outbound/protocol-scaffolding.ts
+++ b/src/infra/outbound/protocol-scaffolding.ts
@@ -5,6 +5,7 @@ import {
   stripInternalRuntimeContext,
 } from "../../agents/internal-runtime-context.js";
 import { escapeRegExp } from "../../shared/regexp.js";
+import { findCodeRegions } from "../../shared/text/code-regions.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
 const INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN = INTERNAL_RUNTIME_SCAFFOLDING_TAGS.join("|");
@@ -102,5 +103,5 @@ export function stripInternalRuntimeScaffolding(text: string): string {
   for (const marker of INTERNAL_RUNTIME_MARKER_LINES) {
     stripped = stripStandaloneMarkerLine(stripped, marker);
   }
-  return stripPlainTextToolCallBlocks(stripped);
+  return stripPlainTextToolCallBlocks(stripped, { resolveProtectedRanges: findCodeRegions });
 }

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -2,6 +2,7 @@
 // prompt-data wrappers, and conservative HTML markup.
 import { describe, expect, it } from "vitest";
 import { escapeInternalRuntimeContextDelimiters } from "../../agents/internal-runtime-context.js";
+import { stripInternalRuntimeScaffoldingFromPayload } from "./deliver-payload.js";
 import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 import { sanitizeForPlainText } from "./sanitize-text.js";
 
@@ -134,6 +135,56 @@ describe("sanitizeForPlainText", () => {
 });
 
 describe("stripInternalRuntimeScaffolding", () => {
+  it.each([
+    ["backtick fence", "```json", "```"],
+    ["tilde fence", "~~~json", "~~~"],
+    ["unterminated fence", "```json", ""],
+  ])("preserves plain-text tool-call examples inside a %s", (_name, open, close) => {
+    const example = [open, "[server]", '{"host":"example.test"}', "[/server]", close]
+      .filter(Boolean)
+      .join("\n");
+
+    expect(stripInternalRuntimeScaffolding(example)).toBe(example);
+  });
+
+  it("preserves indented plain-text tool-call examples", () => {
+    const example = ["    [read]", '    {"path":"example.txt"}', "    [/read]"].join("\n");
+
+    expect(stripInternalRuntimeScaffolding(example)).toBe(example);
+  });
+
+  it("still strips unfenced plain-text tool calls", () => {
+    expect(
+      stripInternalRuntimeScaffolding(
+        ["before", "[read]", '{"path":"secret.txt"}', "[/read]", "after"].join("\n"),
+      ),
+    ).toBe("before\nafter");
+  });
+
+  it("preserves fenced examples across nested outbound payload fields", () => {
+    const example = ["```json", "[read]", '{"path":"example.txt"}', "[/read]", "```"].join("\n");
+    const stripped = stripInternalRuntimeScaffoldingFromPayload({
+      text: example,
+      channelData: {
+        example,
+        leaked: ["[read]", '{"path":"secret.txt"}', "[/read]"].join("\n"),
+      },
+    });
+
+    expect(stripped).toMatchObject({
+      text: example,
+      channelData: { example, leaked: "" },
+    });
+  });
+
+  it("does not let Markdown fences bypass private runtime scaffolding removal", () => {
+    expect(
+      stripInternalRuntimeScaffolding(
+        ["```xml", "<system-reminder>private runtime data</system-reminder>", "```"].join("\n"),
+      ),
+    ).toBe(["```xml", "", "```"].join("\n"));
+  });
+
   it("removes closed, self-closing, and stray internal runtime tags", () => {
     expect(
       stripInternalRuntimeScaffolding(

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -21,6 +21,7 @@ import { mapThinkingLevelToReasoningEffort } from "../llm/providers/stream-wrapp
 import { streamWithPayloadPatch } from "../llm/providers/stream-wrappers/stream-payload-utils.js";
 import { streamSimple } from "../llm/stream.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import { findCodeRegions } from "../shared/text/code-regions.js";
 export { applyAnthropicRefusal } from "@openclaw/ai/internal/anthropic";
 export { createDeferredEventBuffer } from "@openclaw/ai/internal/runtime";
 export { notifyLlmRequestActivity, onLlmRequestActivity } from "@openclaw/ai/internal/runtime";
@@ -79,6 +80,7 @@ function promotePlainTextToolCalls(
     createToolCallBlock: createPromotedPlainTextToolCallBlock,
     isRetainableNonTextBlock: () => true,
     message,
+    resolveProtectedRanges: findCodeRegions,
   });
 }
 
@@ -127,6 +129,7 @@ function scrubProviderTerminalMessage(
     matcher,
     message,
     preserveEmptyTextBlocks,
+    resolveProtectedRanges: findCodeRegions,
   });
 }
 
@@ -165,6 +168,7 @@ function wrapPlainTextToolCallStream(
               matcher,
               preserveEmptyTextBlocks,
             ),
+          resolveProtectedRanges: findCodeRegions,
           stopAfterDone: true,
         },
       );

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -450,6 +450,17 @@ describe("stripPlainTextToolCallBlocks", () => {
     expect(stripPlainTextToolCallBlocks(text)).toBe(text);
   });
 
+  it("supports opt-in protected ranges without weakening strict defaults", () => {
+    const call = '[read]\n{"path":"example.txt"}\n[/read]';
+
+    expect(
+      stripPlainTextToolCallBlocks(call, {
+        resolveProtectedRanges: () => [{ start: 0, end: call.length }],
+      }),
+    ).toBe(call);
+    expect(stripPlainTextToolCallBlocks(call)).toBe("");
+  });
+
   it("strips legacy tool-prefixed XML parameter blocks without a function close", () => {
     expect(
       stripPlainTextToolCallBlocks(

--- a/src/plugin-sdk/tool-payload.ts
+++ b/src/plugin-sdk/tool-payload.ts
@@ -26,6 +26,12 @@ export type PlainTextToolCallParseOptions = {
   maxPayloadBytes?: number;
 };
 
+export type PlainTextToolCallProtectedRange = { end: number; start: number };
+export type PlainTextToolCallStripOptions = {
+  /** Resolves literal source ranges that must not be interpreted as tool calls. */
+  resolveProtectedRanges?: (text: string) => readonly PlainTextToolCallProtectedRange[];
+};
+
 /** Parses a message made only of standalone plain-text tool call blocks. */
 export function parseStandalonePlainTextToolCallBlocks(
   text: string,
@@ -35,8 +41,11 @@ export function parseStandalonePlainTextToolCallBlocks(
 }
 
 /** Removes full-line standalone plain-text tool call blocks from visible text. */
-export function stripPlainTextToolCallBlocks(text: string): string {
-  return stripRepairToolCallBlocks(text);
+export function stripPlainTextToolCallBlocks(
+  text: string,
+  options?: PlainTextToolCallStripOptions,
+): string {
+  return stripRepairToolCallBlocks(text, options);
 }
 
 type ToolPayloadTextBlock = {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -874,6 +874,19 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
+  it("preserves fenced serialized tool-call examples through delivery", () => {
+    const input = [
+      "Example:",
+      "```json",
+      "[read]",
+      '{"path":"example.txt"}',
+      "[/read]",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("strips minimax, tool XML, downgraded tool markers, and think tags in one pass", () => {
     const input = [
       '<invoke name="read">payload</invoke></minimax:tool_call>',

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -1058,7 +1058,7 @@ function applyAssistantVisibleTextStagePipeline(
       cleaned = stripAssistantInternalTraceLines(cleaned);
     }
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
-    cleaned = stripPlainTextToolCallBlocks(cleaned);
+    cleaned = stripPlainTextToolCallBlocks(cleaned, { resolveProtectedRanges: findCodeRegions });
     if (!options.preserveDowngradedToolText) {
       cleaned = stripDowngradedToolCallText(cleaned);
     }


### PR DESCRIPTION
Fixes #116941

Related: #116943

## What Problem This Solves

Fixes an issue where users receiving assistant replies would lose fenced tool-call examples when the example matched OpenClaw's plain-text tool-call fallback syntax. The shared outbound and streamed agent paths could silently remove those bytes without producing a tool call.

## Why This Change Was Made

The shared tool-call repair package now accepts an explicit source-relative protected-range resolver while preserving its strict default. User-visible OpenClaw callers supply the existing CommonMark code-region resolver, including streaming paths that must carry fence ownership across split deltas and adjacent text blocks.

This deliberately does not make Markdown fencing an authorization signal for private runtime tags. Fenced `<system-reminder>`, `<previous_response>`, and prompt-data scaffolding remain stripped; #116943 needs producer-owned provenance before those bytes can be preserved safely.

## User Impact

Fenced, indented, inline, tilde-fenced, unterminated-fence, and split-stream tool-call examples are delivered verbatim. Genuine standalone plain-text tool calls outside code remain scrubbed or promoted as before.

## Evidence

- 380 focused tests passed across tool-call repair, streamed agent normalization, shared outbound sanitization, assistant-visible text, and the plugin SDK facade.
- Real wrapper coverage proves byte-exact live deltas, terminal `done` messages, and `stream.result()` across adjacent text blocks.
- Adversarial coverage includes split fence openers, cumulative partial snapshots, more than 1 MB of bounded live history, protected and unprotected adjacent calls, and the private-runtime-tag security control.
- Exact-head changed gate passed all core, core-test, extension, and extension-test lanes on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30674126894
- Targeted Oxlint, Oxfmt, and `git diff --check` passed.
- Autoreview: clean, no actionable P0/P1 findings.

AI-assisted; the implementation and validation evidence were reviewed before submission.
