### PR TITLE
fix(ui): prevent stale sidebar sessions after switching filters

### DIFF
--- a/ui/src/components/session-data-controller-pagination.ts
+++ b/ui/src/components/session-data-controller-pagination.ts
@@ -1,6 +1,7 @@
 import type { SessionsListResult } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
+import { appendSessionResults } from "../lib/sessions/reconcile.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import {
   SIDEBAR_AGENT_SESSION_LIST_LIMIT,
@@ -54,34 +55,6 @@ function publishSidebarSessionResult(
     }
   }
   owner.requestSessionDataUpdate();
-}
-
-function appendSidebarSessionResults(
-  previous: SessionsListResult,
-  page: SessionsListResult,
-): SessionsListResult {
-  const seen = new Set<string>();
-  const sessions = [...previous.sessions, ...page.sessions].filter((row) => {
-    if (!row.key || seen.has(row.key)) {
-      return false;
-    }
-    seen.add(row.key);
-    return true;
-  });
-  const totalCount = page.totalCount ?? previous.totalCount;
-  const hasMore =
-    page.hasMore ??
-    (typeof totalCount === "number" && Number.isFinite(totalCount)
-      ? sessions.length < totalCount
-      : false);
-  return {
-    ...page,
-    count: sessions.length,
-    totalCount,
-    hasMore,
-    nextOffset: page.nextOffset ?? (hasMore ? sessions.length : null),
-    sessions,
-  };
 }
 
 export async function refreshSidebarSessions(
@@ -228,7 +201,7 @@ export async function loadMoreSidebarSessions(
       publishSidebarSessionResult(
         owner,
         agentId,
-        appendSidebarSessionResults(previous, page),
+        appendSessionResults(previous, page),
         archivedFilter,
         generation,
       );

--- a/ui/src/components/session-data-controller.event-refresh.test.ts
+++ b/ui/src/components/session-data-controller.event-refresh.test.ts
@@ -230,6 +230,39 @@ describe("filtered sidebar session event refresh", () => {
     controller.hostDisconnected();
   });
 
+  it("retires an in-flight child snapshot when the status filter changes", async () => {
+    const { controller, list, selectStatusFilter } = createFilteredSessionController("archived");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    let resolveChildPage!: (value: Awaited<ReturnType<typeof list>>) => void;
+    const childPage = new Promise<Awaited<ReturnType<typeof list>>>((resolve) => {
+      resolveChildPage = resolve;
+    });
+    list.mockImplementationOnce(async () => await childPage);
+
+    const pendingChildren = controller.loadChildSessions("agent:main:parent");
+    expect(controller.loadingChildSessionKeys.has("agent:main:parent")).toBe(true);
+
+    selectStatusFilter("all");
+    resolveChildPage({
+      ts: 2,
+      path: "",
+      count: 1,
+      totalCount: 1,
+      nextOffset: null,
+      hasMore: false,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:stale-child", kind: "direct", updatedAt: 2 }],
+    });
+    await pendingChildren;
+
+    expect(controller.childSessionRowsByParent).toEqual({});
+    expect(controller.loadedChildSessionKeys.has("agent:main:parent")).toBe(false);
+    expect(controller.loadingChildSessionKeys.has("agent:main:parent")).toBe(false);
+    controller.hostDisconnected();
+  });
+
   it("bounds refresh latency while same-agent events continue arriving", async () => {
     vi.useFakeTimers();
     const { controller, list, publishSessionChanged } = createFilteredSessionController("all");

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -399,24 +399,28 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     }
   }
 
+  private resetChildSessionState(): void {
+    this.childSessionGeneration += 1;
+    this.childSessionRowsByParent = {};
+    this.loadedChildSessionKeys = new Set();
+    this.failedChildSessionKeys = new Set();
+    this.loadingChildSessionKeys = new Set();
+    this.activeSessionLineageRoot = null;
+    this.activeSessionLineageRouteKey = null;
+    this.activeSessionLineageLoaded = false;
+    this.activeSessionLineageRequestToken = null;
+    if (this.activeSessionLineageRetryTimer) {
+      globalThis.clearTimeout(this.activeSessionLineageRetryTimer);
+      this.activeSessionLineageRetryTimer = null;
+    }
+  }
+
   private readonly updateSessions = (sessions: SessionCapability) => {
     if (this.childSessionCanonicalListRevision !== sessions.canonicalListRevision) {
       this.childSessionCanonicalListRevision = sessions.canonicalListRevision;
       // The canonical root list advances after session events, but excludes hidden children.
       // Drop child snapshots so expanded parents refetch live terminal state.
-      this.childSessionGeneration += 1;
-      this.childSessionRowsByParent = {};
-      this.loadedChildSessionKeys = new Set();
-      this.failedChildSessionKeys = new Set();
-      this.loadingChildSessionKeys = new Set();
-      this.activeSessionLineageRoot = null;
-      this.activeSessionLineageRouteKey = null;
-      this.activeSessionLineageLoaded = false;
-      this.activeSessionLineageRequestToken = null;
-      if (this.activeSessionLineageRetryTimer) {
-        globalThis.clearTimeout(this.activeSessionLineageRetryTimer);
-        this.activeSessionLineageRetryTimer = null;
-      }
+      this.resetChildSessionState();
       this.notify();
     }
     const snapshot = sessions.state;
@@ -512,24 +516,12 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   }
 
   private clearSessionCache(): void {
-    this.childSessionGeneration += 1;
     this.childSessionCanonicalListRevision = null;
     this.reconnectListRevision = null;
     this.sessionsResult = null;
     this.sessionsAgentId = null;
     this.sessionRowsByAgent = {};
-    this.childSessionRowsByParent = {};
-    this.loadedChildSessionKeys = new Set();
-    this.failedChildSessionKeys = new Set();
-    this.loadingChildSessionKeys = new Set();
-    this.activeSessionLineageRoot = null;
-    this.activeSessionLineageRouteKey = null;
-    this.activeSessionLineageLoaded = false;
-    this.activeSessionLineageRequestToken = null;
-    if (this.activeSessionLineageRetryTimer) {
-      globalThis.clearTimeout(this.activeSessionLineageRetryTimer);
-      this.activeSessionLineageRetryTimer = null;
-    }
+    this.resetChildSessionState();
     this.sessionCreatedOrder.clear();
     this.visibleSessionLimits.clear();
     this.notify();
@@ -680,10 +672,9 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.sidebarSessionPaginationState.loadedScope = undefined;
     this.sessionsLoading = false;
     this.visibleSessionLimits.clear();
-    this.childSessionRowsByParent = {};
-    this.loadedChildSessionKeys = new Set();
-    this.failedChildSessionKeys = new Set();
-    this.loadingChildSessionKeys = new Set();
+    // A filter transition owns a new child/lineage generation; otherwise a
+    // pending request from the retired view can repopulate its cleared rows.
+    this.resetChildSessionState();
     this.sessionRowsByAgent = {};
     if (statusFilter === "active" && this.context) {
       this.sessionsResult = this.context.sessions.state.result;

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -41,6 +41,35 @@ export type SessionRunTerminal = {
   endedAt: number;
 };
 
+/** Merge canonical and filtered pages with the same cursor/deduplication contract. */
+export function appendSessionResults(
+  previous: SessionsListResult,
+  page: SessionsListResult,
+): SessionsListResult {
+  const seen = new Set<string>();
+  const sessions = [...previous.sessions, ...page.sessions].filter((row) => {
+    if (!row.key || seen.has(row.key)) {
+      return false;
+    }
+    seen.add(row.key);
+    return true;
+  });
+  const totalCount = page.totalCount ?? previous.totalCount;
+  const hasMore =
+    page.hasMore ??
+    (typeof totalCount === "number" && Number.isFinite(totalCount)
+      ? sessions.length < totalCount
+      : false);
+  return {
+    ...page,
+    count: sessions.length,
+    totalCount,
+    hasMore,
+    nextOffset: page.nextOffset ?? (hasMore ? sessions.length : null),
+    sessions,
+  };
+}
+
 type SessionChangedEventInfo = {
   key: string;
   agentId: string | null;

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,5 +1,6 @@
 import type { SessionsListResult } from "../../api/types.ts";
 import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
+import { appendSessionResults } from "./reconcile.ts";
 import type {
   SessionConnectionOwner,
   SessionGateway,
@@ -25,34 +26,6 @@ type SessionRosterRefreshHost = {
   decorate: (result: SessionsListResult | null) => SessionsListResult | null;
   onCanonicalList: (result: SessionsListResult | null) => void;
 };
-
-function appendSessionResults(
-  previous: SessionsListResult,
-  page: SessionsListResult,
-): SessionsListResult {
-  const seen = new Set<string>();
-  const sessions = [...previous.sessions, ...page.sessions].filter((row) => {
-    if (!row.key || seen.has(row.key)) {
-      return false;
-    }
-    seen.add(row.key);
-    return true;
-  });
-  const totalCount = page.totalCount ?? previous.totalCount;
-  const hasMore =
-    page.hasMore ??
-    (typeof totalCount === "number" && Number.isFinite(totalCount)
-      ? sessions.length < totalCount
-      : false);
-  return {
-    ...page,
-    count: sessions.length,
-    totalCount,
-    hasMore,
-    nextOffset: page.nextOffset ?? (hasMore ? sessions.length : null),
-    sessions,
-  };
-}
 
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let inFlight: Promise<void> | null = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where switching the Control UI session sidebar between status filters could allow an obsolete in-flight child-session response to repopulate the newly selected view.

## Why This Change Was Made

A concurrent main change (#117103) replaced the previous monolithic session capability with lifecycle-owned reconnect, navigation, roster, mutation, group, and scoped-operation modules. This PR was rebased onto that architecture and preserves it intact: `ui/src/lib/sessions/index.ts` and all seven new owners remain unchanged except for removing the roster owner's duplicate page-merger implementation.

The remaining uncovered invariant belongs to `SessionDataController`: every root-list reset, disconnect, and sidebar filter switch must retire the same child/lineage generation before old requests can publish. Both the canonical session roster and sidebar-specific archived/all pagination now call one identical cursor/deduplication merger.

## User Impact

Changing sidebar filters cannot revive stale child sessions. Existing reconnect/navigation ownership and the selected-session observer behavior from #117103 are preserved. Honest rebased delta: **production -34 LOC, regression tests +33 LOC, overall -1 LOC across five files**.

## Real behavior proof: running Control UI in Chromium

After-fix operator-visible proof reran against the rebased reviewed commit `ad3d4e60e2b0ffd8fb75038b3ce008896e1bbd55` on Blacksmith Testbox `tbx_01kyx94f71r7fjzat9er612a4p`, using the real running Vite-served production Control UI, Chromium 144.0.7559.0, actual sidebar/menu clicks, and browser Gateway WebSocket frames with a deterministically delayed `sessions.list` response.

1. Open `/chat/main/active-project` with the default visible **Active** sidebar filter.
2. Expand **Visible project** and hold its child `sessions.list` request in flight.
3. Open the actual **Sort threads** menu and select **All**. An **Archived reference** row becomes visible; the retained expanded parent legitimately issues a fresh current-generation request returning no children.
4. Deliver the retired Active-filter response containing `agent:main:stale-child` only after All is rendered. Real Chromium confirms zero stale rows in both the operator-visible sidebar DOM and the controller cache.
5. In the same real-browser run, execute #117103's existing **retains the selected session and one observer while reconnecting across route changes** scenario; it also passes, independently proving the concurrent reconnect/navigation fix was preserved.

Redacted, inspectable live browser trace:

```json
{
  "browser": "Chromium 144.0.7559.0",
  "route": "/chat/main/active-project",
  "childRequest": {
    "includeGlobal": false,
    "includeUnknown": false,
    "configuredAgentsOnly": true,
    "limit": 100,
    "spawnedBy": "agent:main:visible-parent"
  },
  "beforeSwitch": {
    "filter": "active",
    "childPending": true,
    "childLoaded": false,
    "childCacheRows": 0,
    "visibleChildRows": 0
  },
  "afterOperatorFilterSwitch": {
    "filter": "all",
    "childPending": false,
    "childLoaded": true,
    "childCacheRows": 0,
    "visibleChildRows": 0
  },
  "afterStaleGatewayResponse": {
    "filter": "all",
    "childPending": false,
    "childLoaded": true,
    "childCacheRows": 0,
    "visibleChildRows": 0
  },
  "result": "PASS: stale child never appears in the visible sidebar or controller cache"
}
```

`childLoaded: true` after switching is intentional: the new generation completes a legitimate empty child request. The delayed obsolete response cannot overwrite that current snapshot.

```text
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/session-filter-race.proof.e2e.test.ts \
  ui/src/e2e/session-management.sidebar.e2e.test.ts \
  -t 'drops a delayed child response|retains the selected session and one observer'

✓ retains the selected session and one observer while reconnecting across route changes
✓ drops a delayed child response after an operator switches the sidebar from Active to All
Test Files  2 passed (2)
Tests       2 passed (2)
Testbox wrapper exitCode=0
```

The race E2E was temporary proof-only input and was removed afterward; no generated screenshots or temporary validation files are in the commit. Real-browser Testbox run: https://github.com/openclaw/openclaw/actions/runs/30673781008 (wrapper exit 0; delegated leases can show cancelled after intentional cleanup).

## Exact-head validation and maintainer handling

- Reviewed/rebased head: `ad3d4e60e2b0ffd8fb75038b3ce008896e1bbd55`.
- Rebase parent: `83e0be6efee6cde3a4f450817858d4245e552204`, including the overlapping #117103 session/reconnect/navigation architecture.
- Full relevant remote changed gate: **PASS, exit 0** — core-test typecheck, UI typecheck, changed-file lint (**0 warnings, 0 errors**), formatting, dead exports, i18n, max-lines ratchet, dependency pins, wildcard guards, duplicate coverage, and repository guards. https://github.com/openclaw/openclaw/actions/runs/30674000995
- Full sidebar/session/chat focused suite: **369 tests passed across 8 files**, including 223 complete sidebar cases. Additional reconnect, gateway lifecycle, route resolution, agent ownership, event refresh, and chat-pane suites: **176 tests passed across 13 files**. https://github.com/openclaw/openclaw/actions/runs/30673581538
- Fresh independent autoreview: **CLEAN**, `gpt-5.6-sol/high`, correctness confidence **0.99**, no findings.
- Conflict-free merge against later main `aae474ab97df0abb0d8418f3927780cf1a241fee`: `git merge-tree --write-tree HEAD <main>` produced tree `2a03b5e0cd567c9288eb62d4af7b4cc393721b28` with exit 0. Main advances concurrently; maintainer-native landing must freshly prepare the exact current merge immediately before landing.
- The `maintainer` label is handled explicitly by the maintainer-authorized orchestration flow.
- No persisted data model, SQLite schema, migration, public configuration, or Gateway protocol changes: all modified state is process-local child/lineage cache or page reconciliation.
- Exact-new-head GitHub required CI was retriggered by the necessary conflict-resolution force push and is being monitored before landing. Complete five-file diff: https://github.com/openclaw/openclaw/pull/117090/files