### PR TITLE
refactor(discord): consolidate model picker navigation

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -87,7 +87,6 @@ extensions/discord/src/monitor/message-handler.preflight.test.ts
 extensions/discord/src/monitor/message-handler.preflight.ts
 extensions/discord/src/monitor/model-picker.test.ts
 extensions/discord/src/monitor/model-picker.view.ts
-extensions/discord/src/monitor/native-command-model-picker-interaction.ts
 extensions/discord/src/monitor/native-command.model-picker.test.ts
 extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
 extensions/discord/src/monitor/native-command.ts

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -14,9 +14,6 @@ const DISCORD_CUSTOM_ID_MAX_CHARS = 100;
 
 const DISCORD_COMPONENT_MAX_SELECT_OPTIONS = 25;
 
-const DISCORD_MODEL_PICKER_PROVIDER_PAGE_SIZE = DISCORD_COMPONENT_MAX_SELECT_OPTIONS;
-const DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE = DISCORD_COMPONENT_MAX_SELECT_OPTIONS;
-
 function compareBucketItems(left: string, right: string): number {
   const normalized = left.toLowerCase().localeCompare(right.toLowerCase());
   return normalized === 0 ? left.localeCompare(right) : normalized;
@@ -152,19 +149,24 @@ function parseRawPage(value: unknown): number {
   return 1;
 }
 
-function parseRawPositiveInt(value: unknown): number | undefined {
-  return parseStrictPositiveInteger(value);
-}
-
 function coerceString(value: unknown): string {
   return typeof value === "string" || typeof value === "number" ? String(value) : "";
 }
 
-function clampPageSize(rawPageSize: number | undefined, max: number, fallback: number): number {
+function clampPageSize(rawPageSize: number | undefined): number {
   if (!Number.isFinite(rawPageSize)) {
-    return fallback;
+    return DISCORD_COMPONENT_MAX_SELECT_OPTIONS;
   }
-  return Math.min(max, Math.max(1, Math.floor(rawPageSize ?? fallback)));
+  return Math.min(
+    DISCORD_COMPONENT_MAX_SELECT_OPTIONS,
+    Math.max(1, Math.floor(rawPageSize ?? DISCORD_COMPONENT_MAX_SELECT_OPTIONS)),
+  );
+}
+
+function normalizeOptionalModelPickerIndex(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(1, Math.floor(value))
+    : undefined;
 }
 
 function paginateItems<T>(params: {
@@ -219,19 +221,10 @@ export function buildDiscordModelPickerCustomId(params: {
   }
 
   const page = normalizeModelPickerPage(params.page);
-  const providerPage =
-    typeof params.providerPage === "number" && Number.isFinite(params.providerPage)
-      ? Math.max(1, Math.floor(params.providerPage))
-      : undefined;
+  const providerPage = normalizeOptionalModelPickerIndex(params.providerPage);
   const normalizedProvider = params.provider ? normalizeProviderId(params.provider) : undefined;
-  const modelIndex =
-    typeof params.modelIndex === "number" && Number.isFinite(params.modelIndex)
-      ? Math.max(1, Math.floor(params.modelIndex))
-      : undefined;
-  const recentSlot =
-    typeof params.recentSlot === "number" && Number.isFinite(params.recentSlot)
-      ? Math.max(1, Math.floor(params.recentSlot))
-      : undefined;
+  const modelIndex = normalizeOptionalModelPickerIndex(params.modelIndex);
+  const recentSlot = normalizeOptionalModelPickerIndex(params.recentSlot);
   const modelToken = params.modelToken?.trim();
   if (modelToken && !DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelToken)) {
     throw new Error("Discord model picker model token is invalid");
@@ -251,10 +244,7 @@ export function buildDiscordModelPickerCustomId(params: {
   if (runtime) {
     parts.push(`r=${encodeCustomIdComponent(runtime)}`);
   }
-  const runtimeIndex =
-    typeof params.runtimeIndex === "number" && Number.isFinite(params.runtimeIndex)
-      ? Math.max(1, Math.floor(params.runtimeIndex))
-      : undefined;
+  const runtimeIndex = normalizeOptionalModelPickerIndex(params.runtimeIndex);
   if (runtimeIndex) {
     parts.push(`ri=${String(runtimeIndex)}`);
   }
@@ -302,15 +292,15 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
   const userId = decodeCustomIdComponent(coerceString(data.u));
   const providerRaw = decodeCustomIdComponent(coerceString(data.p));
   const runtimeRaw = decodeCustomIdComponent(coerceString(data.r));
-  const runtimeIndex = parseRawPositiveInt(data.ri);
+  const runtimeIndex = parseStrictPositiveInteger(data.ri);
   const page = parseRawPage(data.g ?? data.pg);
-  const providerPage = parseRawPositiveInt(data.pp);
-  const modelIndex = parseRawPositiveInt(data.mi);
+  const providerPage = parseStrictPositiveInteger(data.pp);
+  const modelIndex = parseStrictPositiveInteger(data.mi);
   const modelTokenRaw = coerceString(data.m).trim();
   const modelToken = DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelTokenRaw)
     ? modelTokenRaw
     : undefined;
-  const recentSlot = parseRawPositiveInt(data.rs);
+  const recentSlot = parseStrictPositiveInteger(data.rs);
   const providerBucketRaw = decodeCustomIdComponent(coerceString(data.pb)).trim().toLowerCase();
   const modelBucketRaw = decodeCustomIdComponent(coerceString(data.mb)).trim().toLowerCase();
 
@@ -481,22 +471,10 @@ export function findProviderBucketLocation(
   data: ModelsProviderData,
   provider: string,
 ): { bucket?: string; page: number } | undefined {
-  const normalized = normalizeProviderId(provider);
-  const sorted = [...data.providers].toSorted();
-  const idx = sorted.indexOf(normalized);
-  if (idx < 0) {
-    return undefined;
-  }
-  const buckets = computeAlphaBuckets(sorted);
-  const containing = buckets.find((bucket) => idx >= bucket.start && idx < bucket.end);
-  if (!containing) {
-    return undefined;
-  }
-  const page = Math.floor((idx - containing.start) / DISCORD_MODEL_PICKER_PROVIDER_PAGE_SIZE) + 1;
-  return {
-    ...(containing.id !== "all" ? { bucket: containing.id } : {}),
-    page,
-  };
+  return findModelPickerBucketLocation(
+    [...data.providers].toSorted(),
+    normalizeProviderId(provider),
+  );
 }
 
 /**
@@ -511,28 +489,48 @@ export function findModelBucketId(
   model: string,
 ): string | undefined {
   const modelSet = data.byProvider.get(normalizeProviderId(provider));
-  if (!modelSet) {
-    return undefined;
-  }
-  const sorted = [...modelSet].toSorted(compareBucketItems);
-  const idx = sorted.indexOf(model);
-  if (idx < 0) {
-    return undefined;
-  }
-  const buckets = computeAlphaBuckets(sorted);
-  const containing = buckets.find((bucket) => idx >= bucket.start && idx < bucket.end);
-  return containing && containing.id !== "all" ? containing.id : undefined;
+  return modelSet
+    ? findModelPickerBucketLocation([...modelSet].toSorted(compareBucketItems), model)?.bucket
+    : undefined;
 }
 
-function buildDiscordModelPickerProviderItems(
-  data: ModelsProviderData,
-): DiscordModelPickerProviderItem[] {
-  // Sort lexicographically so the alpha-bucket boundaries are deterministic
-  // for any caller that derives buckets from `data.providers`.
-  return [...data.providers].toSorted().map((provider) => ({
-    id: provider,
-    count: data.byProvider.get(provider)?.size ?? 0,
-  }));
+function findModelPickerBucketLocation(
+  sortedItems: string[],
+  item: string,
+  pageSize = DISCORD_COMPONENT_MAX_SELECT_OPTIONS,
+): { bucket?: string; page: number } | undefined {
+  const index = sortedItems.indexOf(item);
+  const bucket =
+    index < 0
+      ? undefined
+      : computeAlphaBuckets(sortedItems).find((entry) => index >= entry.start && index < entry.end);
+  return bucket
+    ? {
+        ...(bucket.id === "all" ? {} : { bucket: bucket.id }),
+        page: Math.floor((index - bucket.start) / pageSize) + 1,
+      }
+    : undefined;
+}
+
+function paginateDiscordModelPickerBucket<T>(params: {
+  items: T[];
+  itemLabels: string[];
+  page?: number;
+  pageSize?: number;
+  bucket?: string;
+}): DiscordModelPickerPage<T> & {
+  bucket: DiscordModelPickerBucket | null;
+  buckets: DiscordModelPickerBucket[];
+} {
+  const buckets = computeAlphaBuckets(params.itemLabels);
+  const bucket = resolveBucket(buckets, params.bucket);
+  const items = bucket ? params.items.slice(bucket.start, bucket.end) : params.items;
+  const pageSize = clampPageSize(params.pageSize);
+  return {
+    ...paginateItems({ items, page: normalizeModelPickerPage(params.page), pageSize }),
+    bucket,
+    buckets,
+  };
 }
 
 export function getDiscordModelPickerProviderPage(params: {
@@ -544,22 +542,15 @@ export function getDiscordModelPickerProviderPage(params: {
   bucket: DiscordModelPickerBucket | null;
   buckets: DiscordModelPickerBucket[];
 } {
-  const allItems = buildDiscordModelPickerProviderItems(params.data);
-  const buckets = computeAlphaBuckets(allItems.map((item) => item.id));
-  const bucket = resolveBucket(buckets, params.bucket);
-  const bucketItems = bucket ? allItems.slice(bucket.start, bucket.end) : allItems;
-
-  const pageSize = clampPageSize(
-    params.pageSize,
-    DISCORD_MODEL_PICKER_PROVIDER_PAGE_SIZE,
-    DISCORD_MODEL_PICKER_PROVIDER_PAGE_SIZE,
-  );
-  const page = paginateItems({
-    items: bucketItems,
-    page: normalizeModelPickerPage(params.page),
-    pageSize,
+  const providers = [...params.data.providers].toSorted();
+  return paginateDiscordModelPickerBucket({
+    ...params,
+    itemLabels: providers,
+    items: providers.map((provider) => ({
+      id: provider,
+      count: params.data.byProvider.get(provider)?.size ?? 0,
+    })),
   });
-  return { ...page, bucket, buckets };
 }
 
 export function getDiscordModelPickerModelPage(params: {
@@ -581,26 +572,9 @@ export function getDiscordModelPickerModelPage(params: {
   }
 
   const allModels = [...modelSet].toSorted(compareBucketItems);
-  const buckets = computeAlphaBuckets(allModels);
-  const bucket = resolveBucket(buckets, params.bucket);
-  const bucketItems = bucket ? allModels.slice(bucket.start, bucket.end) : allModels;
-
-  const pageSize = clampPageSize(
-    params.pageSize,
-    DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE,
-    DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE,
-  );
-  const page = paginateItems({
-    items: bucketItems,
-    page: normalizeModelPickerPage(params.page),
-    pageSize,
-  });
-
   return {
-    ...page,
+    ...paginateDiscordModelPickerBucket({ ...params, items: allModels, itemLabels: allModels }),
     provider,
-    bucket,
-    buckets,
   };
 }
 
@@ -616,23 +590,6 @@ export function resolveDiscordModelPickerPageForModel(params: {
     return { page: 1 };
   }
   const sorted = [...modelSet].toSorted(compareBucketItems);
-  const index = sorted.indexOf(params.model);
-  if (index < 0) {
-    return { page: 1 };
-  }
-  const pageSize = clampPageSize(
-    params.pageSize,
-    DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE,
-    DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE,
-  );
-  const buckets = computeAlphaBuckets(sorted);
-  const containingBucket = buckets.find((bucket) => index >= bucket.start && index < bucket.end);
-  if (!containingBucket) {
-    return { page: Math.floor(index / pageSize) + 1 };
-  }
-  const offsetInBucket = index - containingBucket.start;
-  return {
-    page: Math.floor(offsetInBucket / pageSize) + 1,
-    bucket: containingBucket.id === "all" ? undefined : containingBucket.id,
-  };
+  const pageSize = clampPageSize(params.pageSize);
+  return findModelPickerBucketLocation(sorted, params.model, pageSize) ?? { page: 1 };
 }

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -376,53 +376,27 @@ function buildPaginationRow(params: {
   if (params.totalPages <= 1) {
     return null;
   }
-  const prevButton = createModelPickerButton({
-    label: "◀ Prev",
-    style: ButtonStyle.Secondary,
-    disabled: !params.hasPrev,
-    customId: buildDiscordModelPickerCustomId({
-      command: params.command,
-      action: "nav",
-      view: params.view,
-      provider: params.provider,
-      runtime: params.runtime,
-      runtimeIndex: params.runtimeIndex,
-      page: Math.max(1, params.page - 1),
-      providerPage: params.providerPage,
-      modelIndex: params.modelIndex,
-      modelToken: params.modelToken,
-      providerBucket: params.providerBucket,
-      modelBucket: params.modelBucket,
-      userId: params.userId,
-    }),
-  });
+  const { page, totalPages, hasPrev, hasNext, ...navigationState } = params;
+  const createNavigationButton = (label: string, targetPage: number, enabled: boolean) =>
+    createModelPickerButton({
+      label,
+      disabled: !enabled,
+      customId: buildDiscordModelPickerCustomId({
+        ...navigationState,
+        action: "nav",
+        page: targetPage,
+      }),
+    });
   const indicatorButton = createModelPickerButton({
-    label: `Page ${params.page}/${params.totalPages}`,
-    style: ButtonStyle.Secondary,
+    label: `Page ${page}/${totalPages}`,
     disabled: true,
     customId: DISCORD_MODEL_PICKER_PAGE_INDICATOR_CUSTOM_ID,
   });
-  const nextButton = createModelPickerButton({
-    label: "Next ▶",
-    style: ButtonStyle.Secondary,
-    disabled: !params.hasNext,
-    customId: buildDiscordModelPickerCustomId({
-      command: params.command,
-      action: "nav",
-      view: params.view,
-      provider: params.provider,
-      runtime: params.runtime,
-      runtimeIndex: params.runtimeIndex,
-      page: Math.min(params.totalPages, params.page + 1),
-      providerPage: params.providerPage,
-      modelIndex: params.modelIndex,
-      modelToken: params.modelToken,
-      providerBucket: params.providerBucket,
-      modelBucket: params.modelBucket,
-      userId: params.userId,
-    }),
-  });
-  return new Row([prevButton, indicatorButton, nextButton]);
+  return new Row([
+    createNavigationButton("◀ Prev", Math.max(1, page - 1), hasPrev),
+    indicatorButton,
+    createNavigationButton("Next ▶", Math.min(totalPages, page + 1), hasNext),
+  ]);
 }
 
 function buildModelRows(params: {
@@ -614,10 +588,17 @@ function buildModelRows(params: {
     typeof params.pendingModelIndex === "number" &&
     params.pendingModelIndex > 0;
 
+  const modelActionState = {
+    command: params.command,
+    provider: params.modelPage.provider,
+    ...compactRuntime,
+    page: params.modelPage.page,
+    providerPage: providerPage.page,
+    userId: params.userId,
+  };
   const buttonRowItems: Button[] = [
     createModelPickerButton({
       label: "Providers",
-      style: ButtonStyle.Secondary,
       customId: buildDiscordModelPickerCustomId({
         command: params.command,
         action: "back",
@@ -629,31 +610,19 @@ function buildModelRows(params: {
     }),
     createModelPickerButton({
       label: "Cancel",
-      style: ButtonStyle.Secondary,
       customId: buildDiscordModelPickerCustomId({
-        command: params.command,
+        ...modelActionState,
         action: "cancel",
         view: "models",
-        provider: params.modelPage.provider,
-        ...compactRuntime,
-        page: params.modelPage.page,
-        providerPage: providerPage.page,
-        userId: params.userId,
       }),
     }),
     createModelPickerButton({
       label: "Reset to default",
-      style: ButtonStyle.Secondary,
       disabled: shouldDisableReset,
       customId: buildDiscordModelPickerCustomId({
-        command: params.command,
+        ...modelActionState,
         action: "reset",
         view: "models",
-        provider: params.modelPage.provider,
-        ...compactRuntime,
-        page: params.modelPage.page,
-        providerPage: providerPage.page,
-        userId: params.userId,
       }),
     }),
   ];
@@ -662,17 +631,11 @@ function buildModelRows(params: {
     buttonRowItems.push(
       createModelPickerButton({
         label: "Recents",
-        style: ButtonStyle.Secondary,
         customId: buildDiscordModelPickerCustomId({
-          command: params.command,
+          ...modelActionState,
           action: "recents",
           view: "recents",
-          provider: params.modelPage.provider,
-          ...compactRuntime,
-          page: params.modelPage.page,
-          providerPage: providerPage.page,
           modelBucket: activeModelBucket,
-          userId: params.userId,
         }),
       }),
     );
@@ -684,16 +647,11 @@ function buildModelRows(params: {
       style: ButtonStyle.Primary,
       disabled: !hasPendingSelection,
       customId: buildDiscordModelPickerCustomId({
-        command: params.command,
+        ...modelActionState,
         action: "submit",
         view: "models",
-        provider: params.modelPage.provider,
-        ...compactRuntime,
-        page: params.modelPage.page,
-        providerPage: providerPage.page,
         modelIndex: params.pendingModelIndex,
         modelToken: pendingModelToken,
-        userId: params.userId,
       }),
     }),
   );
@@ -915,44 +873,20 @@ export function renderDiscordModelPickerRecentsView(
   const defaultModelRef = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
   const rows: DiscordModelPickerRow[] = [];
 
-  // Dedupe: filter recents that match the default model.
-  const dedupedQuickModels = params.quickModels.filter((modelRef) => modelRef !== defaultModelRef);
-
-  // Default model button — slot 1.
-  rows.push(
-    new Row([
-      createModelPickerButton({
-        label: formatRecentsButtonLabel(defaultModelRef, "(default)"),
-        style: ButtonStyle.Secondary,
-        customId: buildDiscordModelPickerCustomId({
-          command: params.command,
-          action: "submit",
-          view: "recents",
-          recentSlot: 1,
-          modelToken: createModelRefToken(defaultModelRef),
-          provider: params.provider,
-          runtime: params.runtime,
-          runtimeIndex: params.runtimeIndex,
-          page: params.page,
-          providerPage: params.providerPage,
-          userId: params.userId,
-        }),
-      }),
-    ]),
-  );
-
-  // Recent model buttons — slot 2+.
-  for (const [i, modelRef] of dedupedQuickModels.entries()) {
+  const recentModels = [
+    defaultModelRef,
+    ...params.quickModels.filter((modelRef) => modelRef !== defaultModelRef),
+  ];
+  for (const [index, modelRef] of recentModels.entries()) {
     rows.push(
       new Row([
         createModelPickerButton({
-          label: formatRecentsButtonLabel(modelRef),
-          style: ButtonStyle.Secondary,
+          label: formatRecentsButtonLabel(modelRef, index === 0 ? "(default)" : undefined),
           customId: buildDiscordModelPickerCustomId({
             command: params.command,
             action: "submit",
             view: "recents",
-            recentSlot: i + 2,
+            recentSlot: index + 1,
             modelToken: createModelRefToken(modelRef),
             provider: params.provider,
             runtime: params.runtime,
@@ -970,7 +904,6 @@ export function renderDiscordModelPickerRecentsView(
   const backRow: Row<Button> = new Row([
     createModelPickerButton({
       label: "Back",
-      style: ButtonStyle.Secondary,
       customId: buildDiscordModelPickerCustomId({
         command: params.command,
         action: "back",

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -373,6 +373,30 @@ async function handleDiscordModelPickerInteraction(params: {
     );
   const showNotice = async (message: string) =>
     await updatePicker(buildDiscordModelPickerNoticePayload(message));
+  const updateModelsView = async (
+    provider: string,
+    state: Omit<
+      Parameters<typeof renderDiscordModelPickerModelsView>[0],
+      "command" | "userId" | "data" | "provider" | "currentModel" | "currentRuntime" | "quickModels"
+    > = {},
+  ) => {
+    // Provider bucket is recoverable from durable catalog state, so compact
+    // custom IDs do not need to carry it through every interaction.
+    const rendered = renderDiscordModelPickerModelsView({
+      command: parsed.command,
+      userId: parsed.userId,
+      data: pickerData,
+      provider,
+      page: parsed.page,
+      providerPage: parsed.providerPage ?? 1,
+      providerBucket: parsed.providerBucket ?? findProviderBucketId(pickerData, provider),
+      currentModel: currentModelRef,
+      currentRuntime,
+      quickModels,
+      ...state,
+    });
+    return await updatePicker(toDiscordModelPickerMessagePayload(rendered));
+  };
 
   if (parsed.action === "recents") {
     const rendered = renderDiscordModelPickerRecentsView({
@@ -392,39 +416,17 @@ async function handleDiscordModelPickerInteraction(params: {
     return;
   }
 
-  if (parsed.action === "back" && parsed.view === "providers") {
+  if (
+    parsed.view === "providers" &&
+    (parsed.action === "back" || parsed.action === "nav" || parsed.action === "bucket")
+  ) {
+    const selectingBucket = parsed.action === "bucket";
     const rendered = renderDiscordModelPickerProvidersView({
       command: parsed.command,
       userId: parsed.userId,
       data: pickerData,
-      page: parsed.page,
-      providerBucket: parsed.providerBucket,
-      currentModel: currentModelRef,
-    });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
-    return;
-  }
-
-  if (parsed.action === "nav" && parsed.view === "providers") {
-    const rendered = renderDiscordModelPickerProvidersView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      page: parsed.page,
-      providerBucket: parsed.providerBucket,
-      currentModel: currentModelRef,
-    });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
-    return;
-  }
-
-  if (parsed.action === "bucket" && parsed.view === "providers") {
-    const rendered = renderDiscordModelPickerProvidersView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      page: 1,
-      providerBucket: resolveSelectedBucket(interaction),
+      page: selectingBucket ? 1 : parsed.page,
+      providerBucket: selectingBucket ? resolveSelectedBucket(interaction) : parsed.providerBucket,
       currentModel: currentModelRef,
     });
     await updatePicker(toDiscordModelPickerMessagePayload(rendered));
@@ -437,23 +439,11 @@ async function handleDiscordModelPickerInteraction(params: {
       currentModelRef,
       data: pickerData,
     });
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
+    await updateModelsView(provider, {
       page: 1,
-      providerPage: parsed.providerPage ?? 1,
-      // bucket-action customId omits providerBucket to stay under 100
-      // chars; derive from the picked provider on re-render.
-      providerBucket: parsed.providerBucket ?? findProviderBucketId(pickerData, provider),
       modelBucket: resolveSelectedBucket(interaction),
-      currentModel: currentModelRef,
-      currentRuntime,
       pendingRuntime: resolvePendingRuntime({ data: pickerData, provider, parsed }),
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -477,23 +467,12 @@ async function handleDiscordModelPickerInteraction(params: {
     const pendingModelIndex = pendingModel
       ? resolveDiscordModelPickerModelIndex({ data: pickerData, provider, model: pendingModel })
       : undefined;
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
-      page: parsed.page,
-      providerPage: parsed.providerPage ?? 1,
-      providerBucket: parsed.providerBucket ?? findProviderBucketId(pickerData, provider),
+    await updateModelsView(provider, {
       modelBucket: parsed.modelBucket,
-      currentModel: currentModelRef,
-      currentRuntime,
       ...(pendingModel ? { pendingModel: `${provider}/${pendingModel}` } : {}),
       pendingModelIndex: pendingModelIndex ?? undefined,
       pendingRuntime: resolvePendingRuntime({ data: pickerData, provider, parsed }),
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -503,21 +482,10 @@ async function handleDiscordModelPickerInteraction(params: {
       currentModelRef,
       data: pickerData,
     });
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
-      page: parsed.page ?? 1,
-      providerPage: parsed.providerPage ?? 1,
-      providerBucket: parsed.providerBucket ?? findProviderBucketId(pickerData, provider),
+    await updateModelsView(provider, {
       modelBucket: parsed.modelBucket,
-      currentModel: currentModelRef,
-      currentRuntime,
       pendingRuntime: resolvePendingRuntime({ data: pickerData, provider, parsed }),
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -527,22 +495,10 @@ async function handleDiscordModelPickerInteraction(params: {
       await showNotice("Sorry, that provider isn't available anymore.");
       return;
     }
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider: selectedProvider,
+    await updateModelsView(selectedProvider, {
       page: 1,
       providerPage: parsed.providerPage ?? parsed.page,
-      // Provider button customId no longer carries providerBucket;
-      // derive from the picked provider so the bucket select stays in
-      // sync on the next render.
-      providerBucket: parsed.providerBucket ?? findProviderBucketId(pickerData, selectedProvider),
-      currentModel: currentModelRef,
-      currentRuntime,
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -565,27 +521,14 @@ async function handleDiscordModelPickerInteraction(params: {
     const modelRef = `${provider}/${selectedModel}`;
     // The model select customId omits providerBucket/modelBucket to stay
     // under Discord's 100-char limit; derive both from the durable state.
-    const derivedProviderBucket =
-      parsed.providerBucket ?? findProviderBucketId(pickerData, provider);
     const derivedModelBucket =
       parsed.modelBucket ?? findModelBucketId(pickerData, provider, selectedModel);
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
-      page: parsed.page,
-      providerPage: parsed.providerPage ?? 1,
-      providerBucket: derivedProviderBucket,
+    await updateModelsView(provider, {
       modelBucket: derivedModelBucket,
-      currentModel: currentModelRef,
-      currentRuntime,
       pendingModel: modelRef,
       pendingModelIndex: modelIndex,
       pendingRuntime: resolvePendingRuntime({ data: pickerData, provider, parsed }),
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -617,8 +560,6 @@ async function handleDiscordModelPickerInteraction(params: {
     // fallback, derive from the user's current durable model so the
     // browse-bucket position survives a runtime change without anything
     // pending.
-    const derivedProviderBucket =
-      parsed.providerBucket ?? findProviderBucketId(pickerData, provider);
     const currentModelOnly = splitDiscordModelRef(currentModelRef ?? "");
     const derivedModelBucket =
       parsed.modelBucket ??
@@ -627,23 +568,12 @@ async function handleDiscordModelPickerInteraction(params: {
         : currentModelOnly && currentModelOnly.provider === provider
           ? findModelBucketId(pickerData, provider, currentModelOnly.model)
           : undefined);
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
-      page: parsed.page,
-      providerPage: parsed.providerPage ?? 1,
-      providerBucket: derivedProviderBucket,
+    await updateModelsView(provider, {
       modelBucket: derivedModelBucket,
-      currentModel: currentModelRef,
-      currentRuntime,
       ...(pendingModel ? { pendingModel } : {}),
       pendingModelIndex: pendingModelIndex ?? undefined,
       pendingRuntime: selectedRuntime,
-      quickModels,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
     return;
   }
 
@@ -780,4 +710,3 @@ export function createDiscordModelPickerFallbackSelect(
 ): StringSelectMenu {
   return new DiscordModelPickerFallbackSelect(params);
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/discord/src/monitor/native-command-model-picker-ui.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-ui.ts
@@ -84,13 +84,6 @@ export function shouldOpenDiscordModelPickerFromCommand(params: {
   return serializedArgs ? null : context;
 }
 
-function buildDiscordModelPickerCurrentModel(
-  defaultProvider: string,
-  defaultModel: string,
-): string {
-  return `${defaultProvider}/${defaultModel}`;
-}
-
 export function buildDiscordModelPickerAllowedModelRefs(
   data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>,
 ): Set<string> {
@@ -242,10 +235,7 @@ export function resolveDiscordModelPickerCurrentModel(params: {
   route: ResolvedAgentRoute;
   data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
 }): string {
-  const fallback = buildDiscordModelPickerCurrentModel(
-    params.data.resolvedDefault.provider,
-    params.data.resolvedDefault.model,
-  );
+  const fallback = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
   try {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.route.agentId,

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -361,6 +361,51 @@ describe("Discord model picker interactions", () => {
     expect(interaction.update).not.toHaveBeenCalled();
   });
 
+  it.each(["back", "nav", "bucket"] as const)(
+    "preserves the selected provider bucket for %s interactions",
+    async (action) => {
+      const context = createModelPickerContext();
+      const providers = Object.fromEntries(
+        Array.from({ length: 30 }, (_, index) => [
+          `provider-${String(index + 1).padStart(2, "0")}`,
+          ["model"],
+        ]),
+      );
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+        createModelsProviderData(providers),
+      );
+      const selectingBucket = action === "bucket";
+      const interaction = createInteraction({
+        userId: "owner",
+        ...(selectingBucket ? { values: ["21-30"] } : {}),
+      });
+      const data = {
+        cmd: "model",
+        act: action,
+        view: "providers",
+        u: "owner",
+        pg: "3",
+        pb: selectingBucket ? "1-20" : "21-30",
+      };
+
+      if (selectingBucket) {
+        await createModelPickerFallbackSelect(context).run(
+          interaction as unknown as PickerSelectInteraction,
+          data,
+        );
+      } else {
+        await createModelPickerFallbackButton(context).run(
+          interaction as unknown as PickerButtonInteraction,
+          data,
+        );
+      }
+
+      const rendered = JSON.stringify(firstMockArg(interaction.editReply, "interaction.editReply"));
+      expect(rendered).toContain('"value":"provider-21"');
+      expect(rendered).not.toContain('"value":"provider-01"');
+    },
+  );
+
   it("uses the hot-reloaded runtime config when old components reset to default", async () => {
     const context = createModelPickerContext();
     (context.cfg as { agents?: OpenClawConfig["agents"] }).agents = {


### PR DESCRIPTION
## What Problem This Solves

Discord model picker repeated provider/model bucket pagination, render-state reconstruction, navigation button construction, and recent-model rendering across independent paths. The duplication made authorization, hot reload, stable model selection, account scoping, and Discord component limits harder to maintain consistently.

## Why This Change Was Made

Reuse the existing canonical model-provider owner while sharing transport-only bucket pagination, picker rendering, provider navigation, and recent-model button construction. Remove the now-unnecessary oversized-file suppression and shrink its ratchet baseline.

## User Impact

No intentional user-visible behavior change. Discord keeps provider/model browsing, runtime selection, recent models, account/session authorization, Unicode bucket support, and the 100-character custom-ID constraint.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30671338938
- Focused Discord picker, interaction, preferences, and autocomplete suites: 4 files, 84 tests passed.
- Full changed gate passed: extension production/test typechecks, extension/tooling lint, max-lines ratchet, plugin boundaries, dead-export scans, database-first guard, and runtime import cycles.
- Independent structured autoreview clean, confidence 0.98.
- Production TypeScript: -191 lines. Regression tests: +45 lines. Oversized-file baseline: -1 entry. Overall: -147 lines.
### After-fix production Discord picker behavior

Executed the actual reviewed production Discord picker modules and serialized Discord V2 component payloads on Blacksmith Testbox tbx_01kyx7ve9ckfbjey4vs165ratw, then parsed and asserted the real rendered bucket selectors, provider/model menus, previous-page navigation, back navigation, authorized owner, stable selection token, enabled submit button, and Discord custom-ID length. Synthetic provider/model names keep the terminal output safe to publish; this is production component execution, not a live Discord account or gateway session.

Production terminal proof: https://github.com/openclaw/openclaw/actions/runs/30672764349

    {
      "head": "7f5d716eb1d213b773f60b9e06bfcca1ee40f170",
      "entry": "production Discord V2 component serialization",
      "providerCount": 30,
      "providerBuckets": [
        "1-20",
        "21-30"
      ],
      "selectedProviderBucket": "21-30",
      "visibleProviders": [
        "provider-21",
        "provider-22",
        "provider-23",
        "provider-24",
        "provider-25",
        "provider-26",
        "provider-27",
        "provider-28",
        "provider-29",
        "provider-30"
      ],
      "selectedProvider": "provider-21",
      "providerSelectionAction": "provider",
      "modelBuckets": [
        "m",
        "z"
      ],
      "modelPage": "2/2",
      "visibleModels": [
        "model-026",
        "model-027",
        "model-028",
        "model-029",
        "model-030"
      ],
      "previousAction": {
        "action": "nav",
        "page": 1,
        "bucket": "m",
        "enabled": true
      },
      "backAction": {
        "action": "back",
        "providerBucket": "21-30"
      },
      "selectedModel": "model-030",
      "submitAction": {
        "action": "submit",
        "stableTokenReplacesPositionalIndex": true,
        "modelTokenMatches": true,
        "enabled": true
      },
      "authorizedOwnerPreserved": true,
      "maxDiscordCustomIdLength": 90,
      "discordCustomIdLimit": 100,
      "storageConfigOrSchemaChanged": false,
      "verdict": "PASS"
    }

The existing passing production interaction-handler suite additionally executes provider back, nav, and bucket interactions through the actual handler, applies selected models through the canonical /model pipeline, rejects a different interaction owner, and proves catalog hot reload cannot retarget an existing stable model-selection token.

No stored session shape, SQLite schema, configuration surface, or migration changed. The full exact-head CI gate also passed: https://github.com/openclaw/openclaw/actions/runs/30671830764