### PR TITLE
refactor(memory): unify embedding provider adaptation

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -12,21 +12,50 @@ const mockEmbeddingRegistry = vi.hoisted(() => ({
   acquireLocalService: vi.fn(async () => undefined),
 }));
 
-vi.mock("openclaw/plugin-sdk/embedding-providers", () => ({
-  getEmbeddingProvider: (id: string, config?: OpenClawConfig) => {
-    mockEmbeddingRegistry.genericLookupConfigs.push(config);
-    return mockEmbeddingRegistry.genericAdapters.find((adapter) => adapter.id === id);
-  },
-  listEmbeddingProviders: () => [...mockEmbeddingRegistry.genericAdapters],
-}));
-
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
   DEFAULT_LOCAL_MODEL: "nomic-embed-text",
   createLocalEmbeddingProvider: async () => {
     throw new Error("local embedding provider is not used by these tests");
   },
-  getMemoryEmbeddingProvider: (id: string) =>
-    mockEmbeddingRegistry.adapters.find((adapter) => adapter.id === id),
+  getMemoryEmbeddingProvider: (id: string, config?: OpenClawConfig) => {
+    const memoryAdapter = mockEmbeddingRegistry.adapters.find((adapter) => adapter.id === id);
+    if (memoryAdapter) {
+      return memoryAdapter;
+    }
+    mockEmbeddingRegistry.genericLookupConfigs.push(config);
+    const genericAdapter = mockEmbeddingRegistry.genericAdapters.find(
+      (adapter) => adapter.id === id,
+    );
+    if (!genericAdapter) {
+      return undefined;
+    }
+    return {
+      ...genericAdapter,
+      create: async (options) => {
+        const result = await genericAdapter.create({
+          ...options,
+          ...(typeof options.outputDimensionality === "number"
+            ? { dimensions: options.outputDimensionality }
+            : {}),
+        });
+        const provider = result.provider;
+        if (!provider) {
+          return { ...result, provider: null };
+        }
+        return {
+          ...result,
+          provider: {
+            ...provider,
+            embedQuery: (text, callOptions) =>
+              provider.embed(text, { ...callOptions, inputType: "query" }),
+            embedBatch: (texts, callOptions) =>
+              provider.embedBatch(texts, { ...callOptions, inputType: "document" }),
+            ...(provider.close ? { close: () => provider.close?.() } : {}),
+          },
+        };
+      },
+    } satisfies MemoryEmbeddingProviderAdapter;
+  },
   listMemoryEmbeddingProviders: () => [...mockEmbeddingRegistry.adapters],
   listRegisteredMemoryEmbeddingProviderAdapters: () => [...mockEmbeddingRegistry.adapters],
   listRegisteredMemoryEmbeddingProviders: () =>

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -1,12 +1,6 @@
 // Memory Core plugin module implements embeddings behavior.
 import {
-  getEmbeddingProvider,
-  type EmbeddingProviderAdapter,
-  type EmbeddingProvider as GenericEmbeddingProvider,
-  type EmbeddingProviderRuntime as GenericEmbeddingProviderRuntime,
-} from "openclaw/plugin-sdk/embedding-providers";
-import {
-  getMemoryEmbeddingProvider as getLegacyMemoryEmbeddingProvider,
+  getMemoryEmbeddingProvider,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderAdapter,
   type MemoryEmbeddingProviderCreateOptions,
@@ -38,7 +32,6 @@ type CreateEmbeddingProviderOptions = MemoryEmbeddingProviderCreateOptions & {
 
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 const LOCAL_LLAMA_CPP_PROVIDER_ID = "local";
-const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 
 function createMissingLlamaCppProviderError(): Error {
   return new Error(
@@ -51,99 +44,6 @@ function createMissingLlamaCppProviderError(): Error {
   );
 }
 
-function adaptGenericEmbeddingProvider(
-  provider: GenericEmbeddingProvider,
-): MemoryEmbeddingProvider {
-  const adapted: MemoryEmbeddingProvider = {
-    id: provider.id,
-    model: provider.model,
-    ...(typeof provider.maxInputTokens === "number"
-      ? { maxInputTokens: provider.maxInputTokens }
-      : {}),
-    embedQuery: async (text, options) =>
-      await provider.embed(text, {
-        ...options,
-        inputType: "query",
-      }),
-    embedBatch: async (texts, options) =>
-      await provider.embedBatch(texts, {
-        ...options,
-        inputType: "document",
-      }),
-    embedBatchInputs: async (inputs, options) =>
-      await provider.embedBatch(inputs, {
-        ...options,
-        inputType: "document",
-      }),
-    ...(provider.close ? { close: async () => await provider.close?.() } : {}),
-  };
-  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
-  if (typeof getRuntimeFacts === "function") {
-    Object.defineProperty(adapted, LOCAL_EMBEDDING_RUNTIME_FACTS, {
-      enumerable: false,
-      value: getRuntimeFacts,
-    });
-  }
-  return adapted;
-}
-
-function adaptGenericRuntime(
-  runtime: GenericEmbeddingProviderRuntime | undefined,
-): MemoryEmbeddingProviderRuntime | undefined {
-  if (!runtime) {
-    return undefined;
-  }
-  return {
-    id: runtime.id,
-    ...(runtime.cacheKeyData ? { cacheKeyData: runtime.cacheKeyData } : {}),
-    ...(runtime.indexIdentityAliases?.length
-      ? { indexIdentityAliases: runtime.indexIdentityAliases }
-      : {}),
-    ...(typeof runtime.inlineQueryTimeoutMs === "number"
-      ? { inlineQueryTimeoutMs: runtime.inlineQueryTimeoutMs }
-      : {}),
-    ...(typeof runtime.inlineBatchTimeoutMs === "number"
-      ? { inlineBatchTimeoutMs: runtime.inlineBatchTimeoutMs }
-      : {}),
-  };
-}
-
-function adaptGenericEmbeddingAdapter(
-  adapter: EmbeddingProviderAdapter,
-): MemoryEmbeddingProviderAdapter {
-  const resolveIndexIdentity = adapter.resolveIndexIdentity;
-  return {
-    id: adapter.id,
-    ...(adapter.defaultModel ? { defaultModel: adapter.defaultModel } : {}),
-    ...(adapter.transport ? { transport: adapter.transport } : {}),
-    ...(adapter.authProviderId ? { authProviderId: adapter.authProviderId } : {}),
-    ...(adapter.formatSetupError ? { formatSetupError: adapter.formatSetupError } : {}),
-    ...(resolveIndexIdentity
-      ? {
-          resolveIndexIdentity: (options: MemoryEmbeddingProviderCreateOptions) =>
-            resolveIndexIdentity({
-              ...options,
-              ...(typeof options.outputDimensionality === "number"
-                ? { dimensions: options.outputDimensionality }
-                : {}),
-            }),
-        }
-      : {}),
-    create: async (options) => {
-      const result = await adapter.create({
-        ...options,
-        ...(typeof options.outputDimensionality === "number"
-          ? { dimensions: options.outputDimensionality }
-          : {}),
-      });
-      return {
-        provider: result.provider ? adaptGenericEmbeddingProvider(result.provider) : null,
-        runtime: adaptGenericRuntime(result.runtime),
-      };
-    },
-  };
-}
-
 function formatProviderError(adapter: MemoryEmbeddingProviderAdapter, err: unknown): string {
   return adapter.formatSetupError?.(err) ?? formatErrorMessage(err);
 }
@@ -152,13 +52,9 @@ function getAdapter(
   id: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
 ): MemoryEmbeddingProviderAdapter {
-  const adapter = getLegacyMemoryEmbeddingProvider(id, config);
+  const adapter = getMemoryEmbeddingProvider(id, config);
   if (adapter) {
     return adapter;
-  }
-  const genericAdapter = getEmbeddingProvider(id, config);
-  if (genericAdapter) {
-    return adaptGenericEmbeddingAdapter(genericAdapter);
   }
   if (id === LOCAL_LLAMA_CPP_PROVIDER_ID) {
     throw createMissingLlamaCppProviderError();
@@ -182,9 +78,7 @@ export function resolveEmbeddingProviderFallbackModel(
   fallbackSourceModel: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
 ): string {
-  const adapter =
-    getLegacyMemoryEmbeddingProvider(providerId, config) ??
-    getEmbeddingProvider(providerId, config);
+  const adapter = getMemoryEmbeddingProvider(providerId, config);
   return adapter?.defaultModel ?? fallbackSourceModel;
 }
 

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -1,10 +1,7 @@
 /**
  * Resolves memory-search source, sync, and ranking configuration.
  */
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   MAX_TIMER_TIMEOUT_MS,
   resolvePositiveTimerTimeoutMs,
@@ -21,8 +18,7 @@ import {
   normalizeMemoryMultimodalSettings,
   type MemoryMultimodalSettings,
 } from "../memory-host-sdk/multimodal.js";
-import { getEmbeddingProvider } from "../plugins/embedding-provider-runtime.js";
-import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
+import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-provider-runtime.js";
 import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
 import { runtimeMemorySecretOwnerId } from "../secrets/runtime-memory-secret-owner.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
@@ -198,25 +194,7 @@ function getConfiguredMemoryEmbeddingProvider(
   if (normalizeProviderId(providerId) === "none") {
     return undefined;
   }
-  const directAdapter = getMemoryEmbeddingProvider(providerId);
-  if (directAdapter) {
-    return directAdapter;
-  }
-  const genericAdapter = getEmbeddingProvider(providerId, cfg);
-  if (genericAdapter) {
-    return genericAdapter;
-  }
-  const providerConfig = findNormalizedProviderValue(cfg.models?.providers, providerId);
-  const ownerApi = providerConfig?.api?.trim();
-  if (!ownerApi) {
-    return undefined;
-  }
-  const normalizedProvider = normalizeProviderId(providerId);
-  const normalizedOwner = normalizeProviderId(ownerApi);
-  if (!normalizedOwner || normalizedOwner === normalizedProvider) {
-    return undefined;
-  }
-  return getMemoryEmbeddingProvider(normalizedOwner);
+  return getMemoryEmbeddingProvider(providerId, cfg);
 }
 
 function mergeConfig(
@@ -462,9 +440,8 @@ export function resolveMemorySearchConfig(
   if (
     !isFtsOnly &&
     multimodalActive &&
-    ((multimodalProvider &&
-      !(multimodalProvider.supportsMultimodalEmbeddings?.({ model: resolved.model }) ?? false)) ||
-      (!multimodalProvider && getEmbeddingProvider(resolved.provider, cfg)))
+    multimodalProvider &&
+    !(multimodalProvider.supportsMultimodalEmbeddings?.({ model: resolved.model }) ?? false)
   ) {
     throw new Error(
       "memory.search.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.",

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -13,16 +13,8 @@ import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
-import {
-  getEmbeddingProvider as getGenericEmbeddingProvider,
-  type EmbeddingProvider as GenericEmbeddingProvider,
-  type EmbeddingProviderAdapter as GenericEmbeddingProviderAdapter,
-} from "../plugins/embedding-provider-runtime.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-provider-runtime.js";
-import type {
-  MemoryEmbeddingProvider,
-  MemoryEmbeddingProviderAdapter,
-} from "../plugins/memory-embedding-providers.js";
+import type { MemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, sendMissingScopeForbidden, watchClientDisconnect } from "./http-common.js";
@@ -240,10 +232,7 @@ function isLocalEmbeddingProvider(params: {
 }): boolean {
   const providerId =
     params.provider === "auto" ? DEFAULT_MEMORY_EMBEDDING_PROVIDER : params.provider;
-  return (
-    getMemoryEmbeddingProvider(providerId, params.cfg)?.transport === "local" ||
-    getGenericEmbeddingProvider(providerId, params.cfg)?.transport === "local"
-  );
+  return getMemoryEmbeddingProvider(providerId, params.cfg)?.transport === "local";
 }
 
 async function createConfiguredEmbeddingProvider(params: {
@@ -256,83 +245,28 @@ async function createConfiguredEmbeddingProvider(params: {
   const acquireLocalService = createConfiguredProviderLocalServiceAcquirer(() => params.cfg);
   const providerId =
     params.provider === "auto" ? DEFAULT_MEMORY_EMBEDDING_PROVIDER : params.provider;
-  // Prefer memory-specific adapters because they understand query/document
-  // input types; generic embedding adapters are adapted only as a fallback.
-  const createWithAdapter = async (adapter: MemoryEmbeddingProviderAdapter) => {
-    const createOptions = {
-      config: params.cfg,
-      agentDir: params.agentDir,
-      provider: providerId,
-      model: params.model || adapter.defaultModel || "",
-      local: params.memorySearch?.local,
-      remote: resolveEmbeddingProviderRemoteConfig(params.memorySearch?.remote),
-      outputDimensionality: params.memorySearch?.outputDimensionality,
-      acquireLocalService,
-    };
-    const result = await adapter.create(createOptions);
-    return result.provider;
-  };
-  const createWithGenericAdapter = async (adapter: GenericEmbeddingProviderAdapter) => {
-    const createOptions = {
-      config: params.cfg,
-      agentDir: params.agentDir,
-      provider: providerId,
-      model: params.model || adapter.defaultModel || "",
-      local: params.memorySearch?.local,
-      remote: resolveEmbeddingProviderRemoteConfig(params.memorySearch?.remote),
-      dimensions: params.memorySearch?.outputDimensionality,
-      inputType: params.memorySearch?.inputType,
-      queryInputType: params.memorySearch?.queryInputType,
-      documentInputType: params.memorySearch?.documentInputType,
-      acquireLocalService,
-    };
-    const result = await adapter.create(createOptions);
-    return result.provider ? adaptGenericEmbeddingProvider(result.provider) : null;
-  };
-
   const adapter = getMemoryEmbeddingProvider(providerId, params.cfg);
-  if (adapter) {
-    const provider = await createWithAdapter(adapter);
-    if (!provider) {
-      throw new Error(`Memory embedding provider ${providerId} is unavailable.`);
-    }
-    return provider;
-  }
-
-  const genericAdapter = getGenericEmbeddingProvider(providerId, params.cfg);
-  if (!genericAdapter) {
+  if (!adapter) {
     throw new Error(`Unknown memory embedding provider: ${providerId}`);
   }
-  const provider = await createWithGenericAdapter(genericAdapter);
+  const createOptions = {
+    config: params.cfg,
+    agentDir: params.agentDir,
+    provider: providerId,
+    model: params.model || adapter.defaultModel || "",
+    local: params.memorySearch?.local,
+    remote: resolveEmbeddingProviderRemoteConfig(params.memorySearch?.remote),
+    inputType: params.memorySearch?.inputType,
+    queryInputType: params.memorySearch?.queryInputType,
+    documentInputType: params.memorySearch?.documentInputType,
+    outputDimensionality: params.memorySearch?.outputDimensionality,
+    acquireLocalService,
+  };
+  const { provider } = await adapter.create(createOptions);
   if (!provider) {
-    throw new Error(`Embedding provider ${providerId} is unavailable.`);
+    throw new Error(`Memory embedding provider ${providerId} is unavailable.`);
   }
   return provider;
-}
-
-// Generic embedding providers expose one embed API; memory search expects
-// query/document methods so the HTTP endpoint can batch document-style inputs.
-function adaptGenericEmbeddingProvider(
-  provider: GenericEmbeddingProvider,
-): MemoryEmbeddingProvider {
-  return {
-    id: provider.id,
-    model: provider.model,
-    ...(typeof provider.maxInputTokens === "number"
-      ? { maxInputTokens: provider.maxInputTokens }
-      : {}),
-    embedQuery: async (text, options) =>
-      await provider.embed(text, {
-        ...options,
-        inputType: "query",
-      }),
-    embedBatch: async (texts, options) =>
-      await provider.embedBatch(texts, {
-        ...options,
-        inputType: "document",
-      }),
-    ...(provider.close ? { close: async () => await provider.close?.() } : {}),
-  };
 }
 
 // Request model overrides are constrained to the configured memory provider so

--- a/src/plugins/embedding-provider-runtime.ts
+++ b/src/plugins/embedding-provider-runtime.ts
@@ -53,5 +53,3 @@ export function getEmbeddingProvider(
     getRegisteredProvider: getRegisteredEmbeddingProvider,
   });
 }
-
-export type { EmbeddingProvider, EmbeddingProviderAdapter } from "./embedding-providers.js";

--- a/src/plugins/embedding-providers.ts
+++ b/src/plugins/embedding-providers.ts
@@ -1,4 +1,5 @@
 /** Registry for plugin-contributed embedding providers. */
+import { resolveGlobalMap } from "../shared/global-singleton.js";
 import type {
   EmbeddingProviderAdapter,
   RegisteredEmbeddingProvider,
@@ -27,14 +28,7 @@ const CORE_EMBEDDING_PROVIDERS: RegisteredEmbeddingProvider[] = [
 
 function getEmbeddingProviders(): Map<string, RegisteredEmbeddingProvider> {
   // The registry is global so tests and lazy-loaded plugin modules share one provider table.
-  const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[EMBEDDING_PROVIDERS_KEY];
-  if (existing instanceof Map) {
-    return existing as Map<string, RegisteredEmbeddingProvider>;
-  }
-  const created = new Map<string, RegisteredEmbeddingProvider>();
-  globalStore[EMBEDDING_PROVIDERS_KEY] = created;
-  return created;
+  return resolveGlobalMap(EMBEDDING_PROVIDERS_KEY);
 }
 
 function getCoreEmbeddingProvider(id: string): RegisteredEmbeddingProvider | undefined {

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./loader.js";
 import { makeTempDir, resetPluginLoaderTestStateForTest } from "./loader.test-fixtures.js";
 import {
-  getMemoryEmbeddingProvider,
+  getRegisteredMemoryEmbeddingProvider,
   registerMemoryEmbeddingProvider,
 } from "./memory-embedding-providers.js";
 import { buildMemoryPromptSection, registerMemoryCapability } from "./memory-state.js";
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 function requireMemoryEmbeddingProvider(providerId: string) {
-  const provider = getMemoryEmbeddingProvider(providerId);
+  const provider = getRegisteredMemoryEmbeddingProvider(providerId)?.adapter;
   if (!provider) {
     throw new Error(`expected ${providerId} memory embedding provider`);
   }

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -1,5 +1,6 @@
 // Covers memory embedding provider runtime hooks from plugins.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearEmbeddingProviders, registerEmbeddingProvider } from "./embedding-providers.js";
 import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
@@ -30,6 +31,7 @@ function createCapabilityAdapter(id: string): MemoryEmbeddingProviderAdapter {
 }
 
 beforeEach(async () => {
+  clearEmbeddingProviders();
   clearMemoryEmbeddingProviders();
   mocks.resolvePluginCapabilityProviders.mockReset();
   mocks.resolvePluginCapabilityProviders.mockReturnValue([]);
@@ -39,6 +41,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  clearEmbeddingProviders();
   clearMemoryEmbeddingProviders();
 });
 
@@ -145,5 +148,71 @@ describe("memory embedding provider runtime resolution", () => {
       "openai",
     ]);
     expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("adapts generic providers once without adding them to memory auto-selection", async () => {
+    const close = vi.fn();
+    const embed = vi.fn(async () => [1, 2]);
+    const embedBatch = vi.fn(async (inputs: unknown[]) => inputs.map(() => [3, 4]));
+    const runtime = { id: "generic", inlineQueryTimeoutMs: 1234 };
+    const runtimeFactsKey = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
+    const provider = {
+      id: "generic",
+      model: "generic-model",
+      maxInputTokens: 2048,
+      embed,
+      embedBatch,
+      close,
+    };
+    const runtimeFacts = () => ({ model: "generic-model" });
+    Object.defineProperty(provider, runtimeFactsKey, { value: runtimeFacts });
+    const create = vi.fn(async () => ({ provider, runtime }));
+    registerEmbeddingProvider({
+      id: "generic",
+      defaultModel: "generic-default",
+      transport: "local",
+      resolveIndexIdentity: (options) => ({
+        model: options.model,
+        cacheKeyData: { dimensions: options.dimensions },
+      }),
+      create,
+    });
+
+    const adapter = runtimeModule.getMemoryEmbeddingProvider("generic");
+    expect(adapter).toMatchObject({
+      id: "generic",
+      defaultModel: "generic-default",
+      transport: "local",
+    });
+    expect(runtimeModule.listMemoryEmbeddingProviders()).toEqual([]);
+    const options = { config: {}, model: "generic-model", outputDimensionality: 7 };
+    expect(adapter?.resolveIndexIdentity?.(options)).toEqual({
+      model: "generic-model",
+      cacheKeyData: { dimensions: 7 },
+    });
+
+    const result = await adapter?.create(options);
+    expect(create).toHaveBeenCalledWith({ ...options, dimensions: 7 });
+    expect(result?.runtime).toBe(runtime);
+    expect(result?.provider?.maxInputTokens).toBe(2048);
+    await result?.provider?.embedQuery("query", { signal: undefined });
+    await result?.provider?.embedBatch(["document"]);
+    await result?.provider?.embedBatchInputs?.([{ text: "structured" }]);
+    expect(embed).toHaveBeenCalledWith("query", { signal: undefined, inputType: "query" });
+    expect(embedBatch).toHaveBeenNthCalledWith(1, ["document"], { inputType: "document" });
+    expect(embedBatch).toHaveBeenNthCalledWith(2, [{ text: "structured" }], {
+      inputType: "document",
+    });
+    expect(Reflect.get(result?.provider ?? {}, runtimeFactsKey)).toBe(runtimeFacts);
+    await result?.provider?.close?.();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps memory-specific adapters authoritative during dual registration", () => {
+    const memoryAdapter = createCapabilityAdapter("dual");
+    registerMemoryEmbeddingProvider(memoryAdapter);
+    registerEmbeddingProvider({ id: "dual", create: async () => ({ provider: null }) });
+
+    expect(runtimeModule.getMemoryEmbeddingProvider("dual")).toBe(memoryAdapter);
   });
 });

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -6,11 +6,21 @@ import {
   listRuntimeEmbeddingProviderAdapters,
   resolveRuntimeEmbeddingProviderLookupIds,
 } from "./embedding-provider-runtime-shared.js";
+import { getEmbeddingProvider } from "./embedding-provider-runtime.js";
+import type {
+  EmbeddingProvider,
+  EmbeddingProviderAdapter,
+  EmbeddingProviderCreateOptions,
+} from "./embedding-provider-types.js";
 import {
   getRegisteredMemoryEmbeddingProvider,
   listRegisteredMemoryEmbeddingProviders,
+  type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderAdapter,
+  type MemoryEmbeddingProviderCreateOptions,
 } from "./memory-embedding-providers.js";
+
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 
 export { listRegisteredMemoryEmbeddingProviders };
 
@@ -45,15 +55,73 @@ function resolveMemoryEmbeddingProviderLookupIds(id: string, cfg?: OpenClawConfi
   });
 }
 
+function adaptEmbeddingProvider(provider: EmbeddingProvider): MemoryEmbeddingProvider {
+  const adapted: MemoryEmbeddingProvider = {
+    ...provider,
+    embedQuery: (text, options) => provider.embed(text, { ...options, inputType: "query" }),
+    embedBatch: (texts, options) =>
+      provider.embedBatch(texts, { ...options, inputType: "document" }),
+    embedBatchInputs: (inputs, options) =>
+      provider.embedBatch(inputs, { ...options, inputType: "document" }),
+    ...(provider.close ? { close: () => provider.close?.() } : {}),
+  };
+  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  if (typeof getRuntimeFacts === "function") {
+    Object.defineProperty(adapted, LOCAL_EMBEDDING_RUNTIME_FACTS, {
+      enumerable: false,
+      value: getRuntimeFacts,
+    });
+  }
+  return adapted;
+}
+
+function adaptEmbeddingProviderAdapter(
+  adapter: EmbeddingProviderAdapter,
+): MemoryEmbeddingProviderAdapter {
+  const genericOptions = (
+    options: MemoryEmbeddingProviderCreateOptions,
+  ): EmbeddingProviderCreateOptions => ({
+    ...options,
+    ...(typeof options.outputDimensionality === "number"
+      ? { dimensions: options.outputDimensionality }
+      : {}),
+  });
+  const resolveIndexIdentity = adapter.resolveIndexIdentity;
+
+  return {
+    ...adapter,
+    ...(resolveIndexIdentity
+      ? {
+          resolveIndexIdentity: (options) => resolveIndexIdentity(genericOptions(options)),
+        }
+      : {}),
+    create: async (options) => {
+      const result = await adapter.create(genericOptions(options));
+      return {
+        ...result,
+        provider: result.provider ? adaptEmbeddingProvider(result.provider) : null,
+      };
+    },
+  };
+}
+
 /** Resolves one memory embedding provider by id, alias, or configured API owner. */
 export function getMemoryEmbeddingProvider(
   id: string,
   cfg?: OpenClawConfig,
 ): MemoryEmbeddingProviderAdapter | undefined {
-  return getRuntimeEmbeddingProviderAdapter({
+  const memoryAdapter = getRuntimeEmbeddingProviderAdapter({
     key: "memoryEmbeddingProviders",
     cfg,
     lookupIds: resolveMemoryEmbeddingProviderLookupIds(id, cfg),
     getRegisteredProvider: getRegisteredMemoryEmbeddingProvider,
   });
+  if (memoryAdapter) {
+    return memoryAdapter;
+  }
+
+  // Resolve the shipped generic provider contract at its registry owner so all
+  // memory consumers share one query/document and multimodal adaptation path.
+  const embeddingAdapter = getEmbeddingProvider(id, cfg);
+  return embeddingAdapter ? adaptEmbeddingProviderAdapter(embeddingAdapter) : undefined;
 }

--- a/src/plugins/memory-embedding-providers.test.ts
+++ b/src/plugins/memory-embedding-providers.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearMemoryEmbeddingProviders,
-  getMemoryEmbeddingProvider,
   getRegisteredMemoryEmbeddingProvider,
   listMemoryEmbeddingProviders,
   listRegisteredMemoryEmbeddingProviders,
@@ -62,7 +61,7 @@ function expectCurrentMemoryEmbeddingProvider(
   id: string,
   adapter: MemoryEmbeddingProviderAdapter | undefined,
 ) {
-  expect(getMemoryEmbeddingProvider(id)).toBe(adapter);
+  expect(getRegisteredMemoryEmbeddingProvider(id)?.adapter).toBe(adapter);
 }
 
 function expectMemoryEmbeddingProviderState(params: {

--- a/src/plugins/memory-embedding-providers.ts
+++ b/src/plugins/memory-embedding-providers.ts
@@ -1,7 +1,14 @@
 import type { EmbeddingInput } from "../../packages/memory-host-sdk/src/engine-embeddings.js";
 // Resolves plugin-provided memory embedding providers from config and registry.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { SecretInput } from "../config/types.secrets.js";
+import { resolveGlobalMap } from "../shared/global-singleton.js";
+import type {
+  EmbeddingProvider,
+  EmbeddingProviderAdapter,
+  EmbeddingProviderCallOptions,
+  EmbeddingProviderCreateOptions,
+  EmbeddingProviderIndexIdentity,
+  EmbeddingProviderRuntime,
+} from "./embedding-provider-types.js";
 
 /** Chunk submitted to memory embedding batch processing. */
 export type MemoryEmbeddingBatchChunk = {
@@ -21,40 +28,22 @@ export type MemoryEmbeddingBatchOptions = {
 };
 
 /** Per-call options for memory embedding providers. */
-export type MemoryEmbeddingProviderCallOptions = {
-  signal?: AbortSignal;
-};
+export type MemoryEmbeddingProviderCallOptions = Pick<EmbeddingProviderCallOptions, "signal">;
 
 /** Runtime metadata returned with memory embedding providers. */
-export type MemoryEmbeddingProviderRuntime = {
-  id: string;
-  cacheKeyData?: Record<string, unknown>;
-  /** Prior persisted model/cache identities that are equivalent to the current identity. */
-  indexIdentityAliases?: Array<{
-    model: string;
-    cacheKeyData: Record<string, unknown>;
-  }>;
-  inlineQueryTimeoutMs?: number;
-  inlineBatchTimeoutMs?: number;
+export type MemoryEmbeddingProviderRuntime = EmbeddingProviderRuntime & {
   sourceWideBatchEmbed?: boolean;
   batchEmbed?: (options: MemoryEmbeddingBatchOptions) => Promise<number[][] | null>;
 };
 
 /** Provider-owned canonical identity and exact aliases for persisted indexes. */
-export type MemoryEmbeddingProviderIndexIdentity = {
-  model: string;
-  cacheKeyData: Record<string, unknown>;
-  aliases?: Array<{
-    model: string;
-    cacheKeyData: Record<string, unknown>;
-  }>;
-};
+export type MemoryEmbeddingProviderIndexIdentity = EmbeddingProviderIndexIdentity;
 
 /** Created memory embedding provider instance. */
-export type MemoryEmbeddingProvider = {
-  id: string;
-  model: string;
-  maxInputTokens?: number;
+export type MemoryEmbeddingProvider = Pick<
+  EmbeddingProvider,
+  "id" | "model" | "maxInputTokens" | "close"
+> & {
   embedQuery: (text: string, options?: MemoryEmbeddingProviderCallOptions) => Promise<number[]>;
   embedBatch: (
     texts: string[],
@@ -64,24 +53,14 @@ export type MemoryEmbeddingProvider = {
     inputs: EmbeddingInput[],
     options?: MemoryEmbeddingProviderCallOptions,
   ) => Promise<number[][]>;
-  close?: () => Promise<void> | void;
 };
 
 /** Options passed to memory embedding provider adapters. */
-export type MemoryEmbeddingProviderCreateOptions = {
-  config: OpenClawConfig;
-  agentDir?: string;
-  provider?: string;
+export type MemoryEmbeddingProviderCreateOptions = Omit<
+  EmbeddingProviderCreateOptions,
+  "dimensions" | "local" | "taskType"
+> & {
   fallback?: string;
-  remote?: {
-    baseUrl?: string;
-    apiKey?: SecretInput;
-    headers?: Record<string, string>;
-  };
-  model: string;
-  inputType?: string;
-  queryInputType?: string;
-  documentInputType?: string;
   local?: {
     modelPath?: string;
     modelCacheDir?: string;
@@ -105,11 +84,10 @@ export type MemoryEmbeddingProviderCreateResult = {
 };
 
 /** Adapter contract for registered memory embedding providers. */
-export type MemoryEmbeddingProviderAdapter = {
-  id: string;
-  defaultModel?: string;
-  transport?: "local" | "remote";
-  authProviderId?: string;
+export type MemoryEmbeddingProviderAdapter = Omit<
+  EmbeddingProviderAdapter,
+  "create" | "resolveIndexIdentity"
+> & {
   autoSelectPriority?: number;
   allowExplicitWhenConfiguredAuto?: boolean;
   supportsMultimodalEmbeddings?: (params: { model: string }) => boolean;
@@ -119,7 +97,6 @@ export type MemoryEmbeddingProviderAdapter = {
   create: (
     options: MemoryEmbeddingProviderCreateOptions,
   ) => Promise<MemoryEmbeddingProviderCreateResult>;
-  formatSetupError?: (err: unknown) => string;
   shouldContinueAutoSelection?: (err: unknown) => boolean;
 };
 
@@ -132,14 +109,7 @@ export type RegisteredMemoryEmbeddingProvider = {
 const MEMORY_EMBEDDING_PROVIDERS_KEY = Symbol.for("openclaw.memoryEmbeddingProviders");
 
 function getMemoryEmbeddingProviders(): Map<string, RegisteredMemoryEmbeddingProvider> {
-  const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[MEMORY_EMBEDDING_PROVIDERS_KEY];
-  if (existing instanceof Map) {
-    return existing as Map<string, RegisteredMemoryEmbeddingProvider>;
-  }
-  const created = new Map<string, RegisteredMemoryEmbeddingProvider>();
-  globalStore[MEMORY_EMBEDDING_PROVIDERS_KEY] = created;
-  return created;
+  return resolveGlobalMap(MEMORY_EMBEDDING_PROVIDERS_KEY);
 }
 
 /** Registers a memory embedding provider adapter for the current process. */
@@ -158,11 +128,6 @@ export function getRegisteredMemoryEmbeddingProvider(
   id: string,
 ): RegisteredMemoryEmbeddingProvider | undefined {
   return getMemoryEmbeddingProviders().get(id);
-}
-
-/** Returns only the memory embedding provider adapter. */
-export function getMemoryEmbeddingProvider(id: string): MemoryEmbeddingProviderAdapter | undefined {
-  return getMemoryEmbeddingProviders().get(id)?.adapter;
 }
 
 /** Lists registered memory embedding provider entries. */


### PR DESCRIPTION
## What Problem This Solves

Memory indexing, memory-search configuration, and the Gateway /v1/embeddings endpoint maintained independent generic-to-memory provider adapters and fallback rules. The duplication made provider dimension handling, lifecycle cleanup, and multimodal behavior vulnerable to drift while retaining obsolete internal registry exports.

## Why This Change Was Made

Resolve generic providers and adapt them once in the memory embedding registry owner. Preserve both shipped plugin registration APIs, configured provider aliases, query/document input kinds, structured embedding inputs, local runtime facts, provider cleanup, and provider-owned batch metadata. Derive legacy contract types from the canonical generic contract and reuse the shared process-global map owner.

## User Impact

Existing provider configuration and public plugin APIs remain unchanged. Generic embedding providers now use the same behavior across memory search, memory indexing, and Gateway embedding requests. Removes 170 lines of production code; strengthens regression coverage for compatibility, precedence, dimensions, multimodal inputs, and lifecycle cleanup. There are no storage, SQLite schema, persisted-data, or migration changes.

## Evidence

- Blacksmith Testbox tbx_01kyx64129497qp92hghm2jpx0: 135 focused tests passing across 12 files and five Vitest shards, including 25 Gateway HTTP cases and DeepInfra/llama.cpp provider coverage.
- Full changed-file gate passed: core and plugin production/test typechecks, lint, zero-unused-export scans, public Plugin SDK API baseline, plugin boundaries, import cycles, and database-first storage guards.
- Independent autoreview passed with no accepted/actionable findings.
- Full exact-head GitHub CI passed: https://github.com/openclaw/openclaw/actions/runs/30671836237
- Remote Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30671333771

### Observed after-fix integration behavior

Both proofs use real ephemeral loopback HTTP servers; Gateway proof additionally starts an isolated Gateway. No production credentials are used.

```text
Blacksmith Testbox tbx_01kyx64129497qp92hghm2jpx0

✓ extension-memory extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts (2 tests) 85ms
✓ gateway-server ../../src/gateway/embeddings-http.test.ts (25 tests) 8836ms
[test] passed 5 Vitest shards

Memory generic-provider query:
POST /v1/embeddings {"model":"text-embedding-bge-m3","input":["hello"],"dimensions":3,"input_type":"query"}
=> [5,0.5,3]

Memory generic-provider document batch:
POST /v1/embeddings {"model":"text-embedding-bge-m3","input":["a","abcd"],"dimensions":3,"input_type":"document"}
=> [[1,0.5,3],[4,1.5,3]]

Gateway client request:
POST /v1/embeddings {"model":"openclaw/default","input":["a","b"]}
=> HTTP 200 {"data":[{"object":"embedding","index":0,"embedding":[9.1,9.2]},{"object":"embedding","index":1,"embedding":[10.1,9.2]}]}
=> configured generic provider receives model=nomic-embed-text dimensions=768 input_type=document

blacksmith run summary ... exit=0
```

The explicit generic-provider route and configured `tenant-embeddings` alias both pass the same Gateway behavior. Requested and authored by @steipete, repository admin and recent memory-provider owner.