### PR TITLE
refactor(gateway): simplify operator approval resolution

### DIFF
--- a/src/gateway/operator-approval-store.test.ts
+++ b/src/gateway/operator-approval-store.test.ts
@@ -23,7 +23,6 @@ import {
   expireDueOperatorApprovals,
   forceDenyOperatorApproval,
   getOperatorApprovalDetailed,
-  getOperatorApprovalDetailedByLocator,
   insertOperatorApproval,
   listPendingOperatorApprovals,
   listTerminalOperatorApprovals,
@@ -174,8 +173,9 @@ describe("operator approval store", () => {
       inserted.record,
     );
     expect(
-      getOperatorApprovalDetailedByLocator({
-        locator: inserted.record.resolutionRef,
+      getOperatorApprovalDetailed({
+        id: inserted.record.resolutionRef,
+        allowTransportRef: true,
         nowMs: 2_000,
         databaseOptions,
       }),
@@ -479,8 +479,9 @@ describe("operator approval store", () => {
       }),
     ).toEqual({ outcome: "conflict" });
     expect(
-      getOperatorApprovalDetailedByLocator({
-        locator: inserted.record.resolutionRef,
+      getOperatorApprovalDetailed({
+        id: inserted.record.resolutionRef,
+        allowTransportRef: true,
         nowMs: 2_000,
         databaseOptions,
       }),

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -705,41 +705,16 @@ export function insertOperatorApproval(params: {
 
 export function getOperatorApprovalDetailed(params: {
   id: string;
+  allowTransportRef?: boolean;
   nowMs?: number;
   databaseOptions?: OpenClawStateDatabaseOptions;
 }): GetOperatorApprovalResult {
-  const id = requireApprovalId(params.id);
+  const locator = requireApprovalId(params.id);
   return runOpenClawStateWriteTransaction((database) => {
     const nowMs = params.nowMs ?? Date.now();
-    let row = selectOperatorApprovalRow(database, id);
-    if (!row) {
-      return { outcome: "not-found" };
-    }
-    if (row.status === "pending" && row.expires_at_ms <= nowMs) {
-      row = expirePendingRow({ database, id, nowMs, createdAtMs: row.created_at_ms });
-      if (!row) {
-        return { outcome: "not-found" };
-      }
-    }
-    const record = decodeOperatorApprovalRow(row);
-    if (record) {
-      return { outcome: "found", record };
-    }
-    denyCorruptPendingRow({ database, id, nowMs, createdAtMs: row.created_at_ms });
-    return { outcome: "corrupt" };
-  }, params.databaseOptions);
-}
-
-/** Resolve either the canonical id or its fixed-size transport reference. */
-export function getOperatorApprovalDetailedByLocator(params: {
-  locator: string;
-  nowMs?: number;
-  databaseOptions?: OpenClawStateDatabaseOptions;
-}): GetOperatorApprovalResult {
-  const locator = requireApprovalId(params.locator);
-  return runOpenClawStateWriteTransaction((database) => {
-    const nowMs = params.nowMs ?? Date.now();
-    let row = selectOperatorApprovalRowByLocator(database, locator);
+    let row = params.allowTransportRef
+      ? selectOperatorApprovalRowByLocator(database, locator)
+      : selectOperatorApprovalRow(database, locator);
     if (!row) {
       return { outcome: "not-found" };
     }
@@ -755,7 +730,7 @@ export function getOperatorApprovalDetailedByLocator(params: {
       return { outcome: "found", record };
     }
     denyCorruptPendingRow({ database, id, nowMs, createdAtMs: row.created_at_ms });
-    return { outcome: "corrupt", id };
+    return params.allowTransportRef ? { outcome: "corrupt", id } : { outcome: "corrupt" };
   }, params.databaseOptions);
 }
 

--- a/src/gateway/server-methods/approval-publication.ts
+++ b/src/gateway/server-methods/approval-publication.ts
@@ -1,5 +1,4 @@
 // Best-effort legacy approval resolution events after durable CAS wins.
-import type { ApprovalDecision } from "../../../packages/gateway-protocol/src/index.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import type {
   ExecApprovalRequestPayload,
@@ -12,21 +11,13 @@ import type {
 import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
 import type { ExecApprovalRecord } from "../exec-approval-manager.js";
 import type { OperatorApprovalRecord } from "../operator-approval-store.js";
-import { resolveApprovalRequestRecipientConnIds } from "./approval-shared.js";
+import { broadcastApprovalResolvedEvent } from "./approval-shared.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ApprovalRequest =
   | ExecApprovalRequestPayload
   | PluginApprovalRequestPayload
   | SystemAgentApprovalRequestPayload;
-
-type SystemAgentApprovalResolved = {
-  id: string;
-  decision: ApprovalDecision;
-  resolvedBy?: string | null;
-  ts: number;
-  request: SystemAgentApprovalRequestPayload;
-};
 
 export type ExecApprovalIosPushDelivery = {
   handleResolved?: (resolved: ExecApprovalResolved) => Promise<void>;
@@ -35,37 +26,6 @@ export type ExecApprovalIosPushDelivery = {
 export type PluginApprovalIosPushDelivery = {
   handleResolved?: (resolved: PluginApprovalResolved) => Promise<void>;
 };
-
-function broadcastResolvedEvent(params: {
-  approvalKind: "exec" | "plugin" | "system-agent";
-  context: GatewayRequestContext;
-  eventName: "exec.approval.resolved" | "plugin.approval.resolved" | "openclaw.approval.resolved";
-  event: ExecApprovalResolved | PluginApprovalResolved | SystemAgentApprovalResolved;
-  liveRecord: ExecApprovalRecord<ApprovalRequest>;
-}): void {
-  const recipientConnIds = resolveApprovalRequestRecipientConnIds({
-    approvalKind: params.approvalKind,
-    context: params.context,
-    record: {
-      id: params.liveRecord.id,
-      request: params.liveRecord.request,
-      createdAtMs: params.liveRecord.createdAtMs,
-      expiresAtMs: params.liveRecord.expiresAtMs,
-      requestedByConnId: params.liveRecord.requestedByConnId,
-      requestedByDeviceId: params.liveRecord.requestedByDeviceId,
-      requestedByClientId: params.liveRecord.requestedByClientId,
-      requestedByDeviceTokenAuth: params.liveRecord.requestedByDeviceTokenAuth,
-      approvalReviewerDeviceIds: params.liveRecord.approvalReviewerDeviceIds,
-    },
-  });
-  if (recipientConnIds) {
-    params.context.broadcastToConnIds(params.eventName, params.event, recipientConnIds, {
-      dropIfSlow: true,
-    });
-    return;
-  }
-  params.context.broadcast(params.eventName, params.event, { dropIfSlow: true });
-}
 
 async function runSideEffect(params: {
   context: GatewayRequestContext;
@@ -107,30 +67,23 @@ export async function publishAppliedApprovalResolution(params: {
   const decision = params.record.decision ?? "deny";
   const resolvedBy = params.liveRecord.resolvedBy ?? null;
   const ts = params.record.resolvedAtMs ?? Date.now();
-  const eventName =
-    params.record.kind === "exec"
-      ? "exec.approval.resolved"
-      : params.record.kind === "plugin"
-        ? "plugin.approval.resolved"
-        : "openclaw.approval.resolved";
   const event = {
     id: params.record.id,
     decision,
     resolvedBy,
     ts,
     request: params.liveRecord.request,
-  } as ExecApprovalResolved | PluginApprovalResolved | SystemAgentApprovalResolved;
+  };
   await runSideEffect({
     context: params.context,
     approvalKind: params.record.kind,
     effect: "broadcast",
     run: () =>
-      broadcastResolvedEvent({
+      broadcastApprovalResolvedEvent({
         approvalKind: params.record.kind,
         context: params.context,
-        eventName,
         event,
-        liveRecord: params.liveRecord,
+        record: params.liveRecord,
       }),
   });
   const nativeApprovalKind = params.record.kind;

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -1165,12 +1165,6 @@ describe("handlePendingApprovalRequest", () => {
         clientId: "client-owner",
         scopes: ["operator.approvals"],
       }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
-      }),
     });
 
     expect(respond).toHaveBeenCalledWith(
@@ -1418,12 +1412,6 @@ describe("handlePendingApprovalRequest", () => {
         clientId: GATEWAY_CLIENT_IDS.IOS_APP,
         scopes: ["operator.approvals"],
       }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
-      }),
     });
 
     expect(respond).toHaveBeenCalledWith(
@@ -1476,12 +1464,6 @@ describe("handlePendingApprovalRequest", () => {
         connId: "conn-mobile-approval",
         clientId: GATEWAY_CLIENT_IDS.IOS_APP,
         scopes: ["operator.approvals"],
-      }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
       }),
     });
 
@@ -1539,12 +1521,6 @@ describe("handlePendingApprovalRequest", () => {
         deviceId: "device-mobile",
         scopes: ["operator.approvals"],
       }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
-      }),
     });
 
     expect(respond).toHaveBeenCalledWith(
@@ -1601,12 +1577,6 @@ describe("handlePendingApprovalRequest", () => {
         scopes: ["operator.approvals"],
         approvalRuntime: true,
       }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
-      }),
     });
 
     expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
@@ -1657,12 +1627,6 @@ describe("handlePendingApprovalRequest", () => {
         connId: "conn-owner-approval",
         clientId: "client-owner",
         deviceId: "device-owner",
-      }),
-      resolvedEventName: "exec.approval.resolved",
-      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-        id: approvalId,
-        decision,
-        request: snapshot.request,
       }),
     });
 
@@ -1800,12 +1764,6 @@ describe("handlePendingApprovalRequest", () => {
           logGateway: { error: logError },
         } as unknown as GatewayRequestContext,
         client: null,
-        resolvedEventName: "exec.approval.resolved",
-        buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
-          id: approvalId,
-          decision,
-          request: snapshot.request,
-        }),
       });
 
       expect(respond).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -49,6 +49,14 @@ type RequestedApprovalEvent<TPayload extends ApprovalTurnSourceFields> = {
   expiresAtMs: number;
 };
 
+type ResolvedApprovalEvent<TPayload> = {
+  id: string;
+  decision: ExecApprovalDecision;
+  resolvedBy: string | null;
+  ts: number;
+  request: TPayload;
+};
+
 type PendingApprovalListEntry<TPayload> = {
   id: string;
   request: TPayload;
@@ -216,10 +224,10 @@ export function bindApprovalReviewerDeviceIds<TPayload>(params: {
   }
 }
 
-function respondApprovalStorageUnavailable(params: {
+export function respondApprovalStorageUnavailable(params: {
   context: GatewayRequestContext;
   respond: RespondFn;
-  operation: "request" | "resolve";
+  operation: "request" | "resolve" | "history" | "lookup";
   error: unknown;
 }): void {
   params.context.logGateway?.error?.(
@@ -282,7 +290,7 @@ export function resolveApprovalDecisionParams<TParams extends ApprovalResolvePar
 }
 
 /** Resolves the approval clients that should receive request or resolution events. */
-export function resolveApprovalRequestRecipientConnIds<TPayload>(params: {
+function resolveApprovalRequestRecipientConnIds<TPayload>(params: {
   approvalKind: "exec" | "plugin" | "system-agent";
   context: GatewayRequestContext;
   record: ExecApprovalRecord<TPayload>;
@@ -300,6 +308,31 @@ export function resolveApprovalRequestRecipientConnIds<TPayload>(params: {
         }),
     }) ?? null
   );
+}
+
+/** Sends a resolved approval only to clients authorized for its live binding. */
+export function broadcastApprovalResolvedEvent<TPayload>(params: {
+  approvalKind: "exec" | "plugin" | "system-agent";
+  context: GatewayRequestContext;
+  record: ExecApprovalRecord<TPayload>;
+  event: ResolvedApprovalEvent<TPayload>;
+}): void {
+  const eventName =
+    params.approvalKind === "system-agent"
+      ? "openclaw.approval.resolved"
+      : `${params.approvalKind}.approval.resolved`;
+  const recipientConnIds = resolveApprovalRequestRecipientConnIds({
+    approvalKind: params.approvalKind,
+    context: params.context,
+    record: params.record,
+  });
+  if (recipientConnIds) {
+    params.context.broadcastToConnIds(eventName, params.event, recipientConnIds, {
+      dropIfSlow: true,
+    });
+    return;
+  }
+  params.context.broadcast(eventName, params.event, { dropIfSlow: true });
 }
 
 /** Finds a pending approval by full id or prefix after applying client visibility rules. */
@@ -575,8 +608,28 @@ export async function handlePendingApprovalRequest<
   }
 }
 
+function respondRepeatedApprovalResolution<TPayload>(
+  record: ExecApprovalRecord<TPayload>,
+  decision: ExecApprovalDecision,
+  respond: RespondFn,
+): void {
+  // Identical retries are idempotent; a conflicting retry must never replace
+  // or obscure the first durable operator decision.
+  if (resolveRecordedApprovalDecision(record) === decision) {
+    respond(true, { ok: true }, undefined);
+    return;
+  }
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
+      details: APPROVAL_ALREADY_RESOLVED_DETAILS,
+    }),
+  );
+}
+
 /** Resolves a pending approval and broadcasts the final decision exactly once. */
-export async function handleApprovalResolve<TPayload, TResolvedEvent extends object>(params: {
+export async function handleApprovalResolve<TPayload>(params: {
   approvalKind: "exec" | "plugin";
   manager: ExecApprovalManager<TPayload>;
   inputId: string;
@@ -598,18 +651,10 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
     resolvedBy: string | null;
     snapshot: ExecApprovalRecord<TPayload>;
   }) => boolean;
-  resolvedEventName: string;
-  buildResolvedEvent: (params: {
-    approvalId: string;
-    decision: ExecApprovalDecision;
-    resolvedBy: string | null;
-    snapshot: ExecApprovalRecord<TPayload>;
-    nowMs: number;
-  }) => TResolvedEvent;
-  forwardResolved?: (event: TResolvedEvent) => Promise<void> | void;
+  forwardResolved?: (event: ResolvedApprovalEvent<TPayload>) => Promise<void> | void;
   forwardResolvedErrorLabel?: string;
   extraResolvedHandlers?: Array<{
-    run: (event: TResolvedEvent) => Promise<void> | void;
+    run: (event: ResolvedApprovalEvent<TPayload>) => Promise<void> | void;
     errorLabel: string;
   }>;
 }): Promise<void> {
@@ -639,19 +684,7 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
       return;
     }
     if (resolvedRepeat.ok) {
-      // Treat repeated identical resolves as successful retries; a conflicting
-      // retry is rejected so stale operators cannot overwrite the first choice.
-      if (resolveRecordedApprovalDecision(resolvedRepeat.snapshot) === params.decision) {
-        params.respond(true, { ok: true }, undefined);
-        return;
-      }
-      params.respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
-          details: APPROVAL_ALREADY_RESOLVED_DETAILS,
-        }),
-      );
+      respondRepeatedApprovalResolution(resolvedRepeat.snapshot, params.decision, params.respond);
       return;
     }
     respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
@@ -693,51 +726,27 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
     // resolve; report the recorded conflict, not a missing approval.
     const raced = params.manager.getSnapshot(resolved.approvalId);
     if (raced && raced.resolvedAtMs !== undefined) {
-      if (resolveRecordedApprovalDecision(raced) === params.decision) {
-        params.respond(true, { ok: true }, undefined);
-        return;
-      }
-      params.respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
-          details: APPROVAL_ALREADY_RESOLVED_DETAILS,
-        }),
-      );
+      respondRepeatedApprovalResolution(raced, params.decision, params.respond);
       return;
     }
     respondUnknownOrExpiredApproval(params.respond);
     return;
   }
 
-  const resolvedEvent = params.buildResolvedEvent({
-    approvalId: resolved.approvalId,
+  const resolvedEvent: ResolvedApprovalEvent<TPayload> = {
+    id: resolved.approvalId,
     decision: params.decision,
     resolvedBy,
-    snapshot: resolved.snapshot,
-    nowMs: Date.now(),
-  });
-  const resolvedEventConnIds = resolveApprovalRequestRecipientConnIds({
+    ts: Date.now(),
+    request: resolved.snapshot.request,
+  };
+  broadcastApprovalResolvedEvent({
     approvalKind: params.approvalKind,
     context: params.context,
     record: resolved.snapshot,
+    event: resolvedEvent,
   });
-  if (resolvedEventConnIds) {
-    params.context.broadcastToConnIds(
-      params.resolvedEventName,
-      resolvedEvent,
-      resolvedEventConnIds,
-      {
-        dropIfSlow: true,
-      },
-    );
-  } else {
-    params.context.broadcast(params.resolvedEventName, resolvedEvent, { dropIfSlow: true });
-  }
-  params.context.approvalEvents?.publishResolved(
-    params.approvalKind ?? (params.resolvedEventName.startsWith("plugin.") ? "plugin" : "exec"),
-    resolvedEvent as never,
-  );
+  params.context.approvalEvents?.publishResolved(params.approvalKind, resolvedEvent as never);
 
   const followUps = [
     params.forwardResolved
@@ -750,8 +759,10 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
   ].filter(
     (
       entry,
-    ): entry is { run: (event: TResolvedEvent) => Promise<void> | void; errorLabel: string } =>
-      Boolean(entry),
+    ): entry is {
+      run: (event: ResolvedApprovalEvent<TPayload>) => Promise<void> | void;
+      errorLabel: string;
+    } => Boolean(entry),
   );
 
   // Resolution has already been recorded and broadcast; follow-up hooks are

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -31,7 +31,6 @@ import {
 } from "../operator-approval-authorization.js";
 import {
   getOperatorApprovalDetailed,
-  getOperatorApprovalDetailedByLocator,
   listTerminalOperatorApprovals,
   OperatorApprovalHistoryCursorError,
   type OperatorApprovalRecord,
@@ -42,12 +41,8 @@ import {
   type ExecApprovalIosPushDelivery,
   type PluginApprovalIosPushDelivery,
 } from "./approval-publication.js";
-import type {
-  GatewayClient,
-  GatewayRequestContext,
-  GatewayRequestHandlers,
-  RespondFn,
-} from "./types.js";
+import { respondApprovalStorageUnavailable } from "./approval-shared.js";
+import type { GatewayClient, GatewayRequestHandlers, RespondFn } from "./types.js";
 
 type CreateApprovalHandlersParams = {
   execApprovalManager: ExecApprovalManager;
@@ -133,22 +128,6 @@ function respondApprovalNotFound(respond: RespondFn): void {
   );
 }
 
-function respondApprovalUnavailable(params: {
-  context: GatewayRequestContext;
-  respond: RespondFn;
-  operation: "history" | "lookup" | "resolve";
-  error: unknown;
-}): void {
-  params.context.logGateway?.error?.(
-    `approval ${params.operation} storage failure: ${String(params.error)}`,
-  );
-  params.respond(
-    false,
-    undefined,
-    errorShape(ErrorCodes.UNAVAILABLE, `approval ${params.operation} unavailable`),
-  );
-}
-
 function readExactApprovalId(params: unknown): string | null {
   if (!isRecord(params) || typeof params.id !== "string") {
     return null;
@@ -191,15 +170,11 @@ function loadVisibleApproval(params: {
   }
   let lookup: ReturnType<typeof getOperatorApprovalDetailed>;
   try {
-    lookup = params.allowTransportRef
-      ? getOperatorApprovalDetailedByLocator({
-          locator: params.id,
-          databaseOptions: params.databaseOptions,
-        })
-      : getOperatorApprovalDetailed({
-          id: params.id,
-          databaseOptions: params.databaseOptions,
-        });
+    lookup = getOperatorApprovalDetailed({
+      id: params.id,
+      allowTransportRef: params.allowTransportRef,
+      databaseOptions: params.databaseOptions,
+    });
   } catch (error) {
     const corrupt = { outcome: "corrupt", id: params.id } as const;
     params.execApprovalManager.reconcileDurableLookup(corrupt);
@@ -254,49 +229,6 @@ function resolveLiveRecord<TPayload>(params: {
   return params.liveRecord ?? params.manager.getLiveSnapshot(params.id) ?? undefined;
 }
 
-function applyForcedDeny<TPayload>(params: {
-  manager: ExecApprovalManager<TPayload>;
-  id: string;
-  resolver: OperatorApprovalResolver;
-  localResolvedBy: string | null;
-}): ApplyApprovalDecisionResult<TPayload> {
-  const result = params.manager.forceDenyDetailed(
-    params.id,
-    "malformed-verdict",
-    params.resolver,
-    "denied",
-    undefined,
-    false,
-    params.localResolvedBy,
-  );
-  switch (result.outcome) {
-    case "denied":
-      return {
-        ok: true,
-        applied: true,
-        record: result.record,
-        liveRecord: resolveLiveRecord({
-          manager: params.manager,
-          id: params.id,
-          liveRecord: result.liveRecord,
-        }),
-      };
-    case "expired":
-    case "already-terminal":
-    case "not-due":
-      return {
-        ok: true,
-        applied: false,
-        record: result.record,
-        liveRecord: result.liveRecord,
-      };
-    case "not-found":
-    case "corrupt":
-      return { ok: false };
-  }
-  return result satisfies never;
-}
-
 function applyApprovalDecision<TPayload>(params: {
   manager: ExecApprovalManager<TPayload>;
   id: string;
@@ -305,43 +237,37 @@ function applyApprovalDecision<TPayload>(params: {
   resolver: OperatorApprovalResolver;
   localResolvedBy: string | null;
 }): ApplyApprovalDecisionResult<TPayload> {
-  if (params.forceMalformedDeny) {
-    return applyForcedDeny(params);
+  const result = params.forceMalformedDeny
+    ? params.manager.forceDenyDetailed(
+        params.id,
+        "malformed-verdict",
+        params.resolver,
+        "denied",
+        undefined,
+        false,
+        params.localResolvedBy,
+      )
+    : params.manager.resolveDetailed(
+        params.id,
+        params.decision as ExecApprovalDecision,
+        params.resolver,
+        params.localResolvedBy,
+      );
+  if (result.outcome === "decision-not-allowed") {
+    return applyApprovalDecision({ ...params, forceMalformedDeny: true });
   }
-
-  const result = params.manager.resolveDetailed(
-    params.id,
-    params.decision as ExecApprovalDecision,
-    params.resolver,
-    params.localResolvedBy,
-  );
-  switch (result.outcome) {
-    case "resolved":
-      return {
-        ok: true,
-        applied: true,
-        record: result.record,
-        liveRecord: resolveLiveRecord({
-          manager: params.manager,
-          id: params.id,
-          liveRecord: result.liveRecord,
-        }),
-      };
-    case "expired":
-    case "already-resolved":
-      return {
-        ok: true,
-        applied: false,
-        record: result.record,
-        liveRecord: result.liveRecord,
-      };
-    case "decision-not-allowed":
-      return applyForcedDeny(params);
-    case "not-found":
-    case "corrupt":
-      return { ok: false };
+  if (result.outcome === "not-found" || result.outcome === "corrupt") {
+    return { ok: false };
   }
-  return result satisfies never;
+  const applied = result.outcome === "resolved" || result.outcome === "denied";
+  return {
+    ok: true,
+    applied,
+    record: result.record,
+    liveRecord: applied
+      ? resolveLiveRecord({ manager: params.manager, id: params.id, liveRecord: result.liveRecord })
+      : result.liveRecord,
+  };
 }
 
 /** Creates kind-agnostic approval lookup and resolution handlers. */
@@ -376,7 +302,7 @@ export function createApprovalHandlers(
           );
           return;
         }
-        respondApprovalUnavailable({ context, respond, operation: "history", error });
+        respondApprovalStorageUnavailable({ context, respond, operation: "history", error });
         return;
       }
       const controlUiBasePath = normalizeControlUiBasePath(
@@ -416,7 +342,7 @@ export function createApprovalHandlers(
             })
           : null;
       } catch (error) {
-        respondApprovalUnavailable({ context, respond, operation: "lookup", error });
+        respondApprovalStorageUnavailable({ context, respond, operation: "lookup", error });
         return;
       }
       const controlUiBasePath = normalizeControlUiBasePath(
@@ -447,7 +373,7 @@ export function createApprovalHandlers(
             })
           : null;
       } catch (error) {
-        respondApprovalUnavailable({ context, respond, operation: "lookup", error });
+        respondApprovalStorageUnavailable({ context, respond, operation: "lookup", error });
         return;
       }
       if (!id || !record) {
@@ -514,7 +440,7 @@ export function createApprovalHandlers(
                   localResolvedBy,
                 });
       } catch (error) {
-        respondApprovalUnavailable({ context, respond, operation: "resolve", error });
+        respondApprovalStorageUnavailable({ context, respond, operation: "resolve", error });
         return;
       }
       if (!resolution.ok) {

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -485,21 +485,6 @@ export function createExecApprovalHandlers(
           autoReviewResolution
             ? manager.resolveAutoReview(approvalId, resolvedBy)
             : manager.resolve(approvalId, decisionLocal, resolvedBy),
-        resolvedEventName: "exec.approval.resolved",
-        buildResolvedEvent: ({
-          approvalId,
-          decision: decisionLocal,
-          resolvedBy,
-          snapshot,
-          nowMs,
-        }) =>
-          ({
-            id: approvalId,
-            decision: decisionLocal,
-            resolvedBy,
-            ts: nowMs,
-            request: snapshot.request,
-          }) satisfies ExecApprovalResolved,
         forwardResolved: (resolvedEvent) => opts?.forwarder?.handleResolved(resolvedEvent),
         forwardResolvedErrorLabel: "exec approvals: forward resolve failed",
         extraResolvedHandlers: opts?.iosPushDelivery?.handleResolved

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -208,21 +208,6 @@ export function createPluginApprovalHandlers(
                   ),
                 },
               },
-        resolvedEventName: "plugin.approval.resolved",
-        buildResolvedEvent: ({
-          approvalId,
-          decision: decisionLocal,
-          resolvedBy,
-          snapshot,
-          nowMs,
-        }) =>
-          ({
-            id: approvalId,
-            decision: decisionLocal,
-            resolvedBy,
-            ts: nowMs,
-            request: snapshot.request,
-          }) satisfies PluginApprovalResolved,
         forwardResolved: (resolvedEvent) =>
           opts?.forwarder?.handlePluginApprovalResolved?.(resolvedEvent),
         forwardResolvedErrorLabel: "plugin approvals: forward resolve failed",


### PR DESCRIPTION
## What Problem This Solves

Operator approvals maintained duplicate exact-ID and transport-reference lookups, parallel forced-denial adapters, and separate exec, plugin, and system-agent approval publication paths. Duplicating those security-sensitive flows makes reviewer visibility, first-answer-wins decisions, expiry, and visible approval outcomes harder to keep consistent.

## Why This Change Was Made

Move exact-ID and transport-reference lookup through one durable SQLite owner, normalize normal and forced-denial outcomes through one adapter, and construct targeted approval-resolution events through the existing shared gateway owner. Preserve every existing public Gateway RPC, approval kind, reviewer/device binding, durable first-answer-wins behavior, timeout, channel forwarder, and iOS push surface. No protocol, schema, or configuration changes.

Net reduction: 165 production lines and 41 test lines (206 total).

## User Impact

No intended user-visible behavior change. Existing CLI, Control UI, native apps, channel approvals, plugin approvals, and system-agent approvals retain their current authorization, resolution, expiry, and notification behavior.

## Evidence

- Blacksmith Testbox tbx_01kyx6bd29jx8ty95rp1xnjpfx: https://github.com/openclaw/openclaw/actions/runs/30671528411
- 224 tests passed across operator-approval-store, exec-approval-manager, unified approval methods, shared approval authorization, plugin approvals, delivery, and node-invoke plugin policy.
- Full remote pnpm check:changed passed: production and test typechecks, changed-file lint, format, dead-export scans, max-lines ratchet, database-first state guard, import cycles, pairing authorization, and plugin boundaries.
- Independent structured autoreview passed with no accepted/actionable findings (confidence 0.98).
- Testbox one-shot stopped after successful wrapper exitCode=0; the backing Actions keepalive may therefore appear cancelled even though the remote proof succeeded.

### Real Gateway approval RPC, native-event, and actor-visibility proof

- Additional Blacksmith Testbox tbx_01kyx8418h4ct182wzhr7e6pg5: https://github.com/openclaw/openclaw/actions/runs/30672981464 (wrapper exitCode=0). Two real Gateway end-to-end tests and 15 native approval-event/subscription tests passed.
- Starts the production Gateway server on loopback with isolated SQLite state, real independent requester, reviewer, and read-only device identities, authenticated WebSocket clients, and production approval RPC handlers. No mocked Gateway, approval store, device authority, or approval RPC.
- exec.approval.request creates a pending exec approval; the distinct authorized reviewer reads it through approval.get. A read-only third device is denied approval.get, approval.resolve, and approval.history with missing scope: operator.approvals.
- The requester resolves allow-once while the reviewer concurrently resolves deny. Exactly one approval.resolve returns applied=true; both connections receive the identical durable terminal decision. Replaying the winning decision returns applied=false; approval.get and approval.history independently return the same terminal record.
- The legacy exec.approval.resolve route accepts a generated local Gateway runtime authority but rejects an impersonated remote-loopback authority with APPROVAL_NOT_FOUND.
- Native approval-event proof confirms exact opted-in source/ancestor audiences, reviewer authorization, canonical agent/session audience keys, durable terminal-state agreement, authoritative sanitized pending snapshots, and exactly-once expiry/waiter settlement.
- Native subscription proof permits paired approval-authorized reviewers, rejects approval scopes without paired devices and paired devices without approval authority, and restores the prior subscription if replay cannot complete.
- Existing node-invoke plugin-policy coverage additionally proves requester device/client ownership and preservation of originating channel, destination, accountId, and threadId when delivering approval requests.