### PR TITLE
fix(config): prevent recovery from stale or invalid backups

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -644,7 +644,6 @@ src/config/config-misc.test.ts
 src/config/config.plugin-validation.test.ts
 src/config/env-preserve.ts
 src/config/io.observe-recovery.test.ts
-src/config/io.observe-recovery.ts
 src/config/io.write-config.test.ts
 src/config/io.write-prepare.test.ts
 src/config/io.write-prepare.ts

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -727,6 +727,92 @@ describe("config observe recovery", () => {
     });
   });
 
+  it.each(["async", "sync"] as const)(
+    "%s recovery refuses a backup without gateway mode despite a stale healthy fingerprint",
+    async (mode) => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, auditPath } = makeDeps(home);
+        const snapshot = await makeSnapshot(configPath, recoverableTelegramConfig);
+        await promoteConfigSnapshotToLastKnownGood({ deps, snapshot, logger: deps.logger });
+        await fsp.writeFile(
+          `${configPath}.bak`,
+          `${JSON.stringify({ meta: { lastTouchedVersion: "2026.4.22" } })}\n`,
+          "utf-8",
+        );
+        const clobbered = await writeClobberedUpdateChannel(configPath);
+        const input = { deps, configPath, ...clobbered };
+
+        const recovered =
+          mode === "async"
+            ? await maybeRecoverSuspiciousConfigRead(input)
+            : maybeRecoverSuspiciousConfigReadSync(input);
+
+        expect(recovered).toEqual(clobbered);
+        await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+        await expect(readObserveEvents(auditPath)).resolves.toEqual([]);
+      });
+    },
+  );
+
+  it.each(["async", "sync"] as const)(
+    "%s recovery uses canonical metadata fingerprints",
+    async (mode) => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath } = makeDeps(home);
+        const backup = { meta: { authoredBy: "operator" }, gateway: { mode: "local" } };
+        await seedConfigBackup(configPath, backup);
+        const clobbered = await writeConfigRaw(configPath, { gateway: { mode: "local" } });
+        const input = { deps, configPath, ...clobbered };
+
+        const recovered =
+          mode === "async"
+            ? await maybeRecoverSuspiciousConfigRead(input)
+            : maybeRecoverSuspiciousConfigReadSync(input);
+
+        expect(recovered.parsed).toEqual(backup);
+      });
+    },
+  );
+
+  it.each(["async", "sync"] as const)(
+    "%s recovery tolerates an unreadable current config stat",
+    async (mode) => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath } = makeDeps(home);
+        await seedConfigBackup(configPath, recoverableTelegramConfig);
+        const clobbered = await writeClobberedUpdateChannel(configPath);
+        const statError = Object.assign(new Error("EACCES: stat denied"), { code: "EACCES" });
+        const statDeps: ObserveRecoveryDeps = {
+          ...deps,
+          fs: {
+            ...deps.fs,
+            promises: {
+              ...deps.fs.promises,
+              stat: ((target: fs.PathLike) =>
+                target === configPath
+                  ? Promise.reject(statError)
+                  : deps.fs.promises.stat(target)) as typeof fs.promises.stat,
+            },
+            statSync: ((target: fs.PathLike, options?: { throwIfNoEntry?: boolean }) => {
+              if (target === configPath) {
+                throw statError;
+              }
+              return deps.fs.statSync(target, options);
+            }) as typeof fs.statSync,
+          },
+        };
+        const input = { deps: statDeps, configPath, ...clobbered };
+
+        const recovered =
+          mode === "async"
+            ? await maybeRecoverSuspiciousConfigRead(input)
+            : maybeRecoverSuspiciousConfigReadSync(input);
+
+        expect((recovered.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      });
+    },
+  );
+
   it.each([
     {
       name: "records writeFile failure instead of falsely claiming restore succeeded",

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -1,12 +1,7 @@
 // Observes and recovers config files that appear missing, corrupt, or clobbered.
-import crypto from "node:crypto";
+import type fs from "node:fs";
 import { isRecord } from "../utils.js";
-import {
-  appendConfigAuditRecord,
-  appendConfigAuditRecordSync,
-  snapshotConfigAuditProcessInfo,
-  type ConfigObserveAuditRecord,
-} from "./io.audit.js";
+import { appendConfigAuditRecord, appendConfigAuditRecordSync } from "./io.audit.js";
 import {
   persistBoundedClobberedConfigSnapshot,
   persistBoundedClobberedConfigSnapshotSync,
@@ -16,9 +11,18 @@ import {
   writeConfigHealthStateToStore,
   type ConfigHealthEntry,
   type ConfigHealthFingerprint,
-  type ConfigHealthState,
 } from "./io.health-state.js";
+import {
+  createConfigHealthFingerprint,
+  createConfigObserveAuditRecord,
+  readConfigFingerprintForPath,
+  readConfigFingerprintForPathSync,
+  readConfigHealthEntry,
+  updateConfigHealthEntry,
+} from "./io.observe-state.js";
 import { resolveConfigObserveSuspiciousReasons } from "./io.observe-suspicious.js";
+import { hashConfigRaw, resolveConfigSnapshotHash } from "./io.read-helpers.js";
+import type { NormalizedConfigIoDeps } from "./io.types.js";
 import { formatConfigIssueSummary } from "./issue-format.js";
 import {
   isPluginLocalInvalidConfigSnapshot,
@@ -26,87 +30,9 @@ import {
 } from "./recovery-policy.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
-/** Dependencies injected into config recovery observation for testable filesystem behavior. */
-type ObserveRecoveryDeps = {
-  fs: {
-    promises: {
-      stat(path: string): Promise<{
-        mtimeMs?: number;
-        ctimeMs?: number;
-        dev?: number | bigint;
-        ino?: number | bigint;
-        mode?: number;
-        nlink?: number;
-        uid?: number;
-        gid?: number;
-      } | null>;
-      readFile(path: string, encoding: BufferEncoding): Promise<string>;
-      writeFile(
-        path: string,
-        data: string,
-        options?: { encoding?: BufferEncoding; mode?: number; flag?: string },
-      ): Promise<unknown>;
-      copyFile(src: string, dest: string): Promise<unknown>;
-      chmod?(path: string, mode: number): Promise<unknown>;
-      mkdir(path: string, options?: { recursive?: boolean; mode?: number }): Promise<unknown>;
-      readdir(path: string): Promise<string[]>;
-      rmdir(path: string): Promise<unknown>;
-      unlink(path: string): Promise<unknown>;
-      appendFile(
-        path: string,
-        data: string,
-        options?: { encoding?: BufferEncoding; mode?: number },
-      ): Promise<unknown>;
-    };
-    statSync(
-      path: string,
-      options?: { throwIfNoEntry?: boolean },
-    ): {
-      mtimeMs?: number;
-      ctimeMs?: number;
-      dev?: number | bigint;
-      ino?: number | bigint;
-      mode?: number;
-      nlink?: number;
-      uid?: number;
-      gid?: number;
-    } | null;
-    readFileSync(path: string, encoding: BufferEncoding): string;
-    writeFileSync(
-      path: string,
-      data: string,
-      options?: { encoding?: BufferEncoding; mode?: number; flag?: string },
-    ): unknown;
-    copyFileSync(src: string, dest: string): unknown;
-    chmodSync?(path: string, mode: number): unknown;
-    mkdirSync(path: string, options?: { recursive?: boolean; mode?: number }): unknown;
-    readdirSync(path: string): string[];
-    rmdirSync(path: string): unknown;
-    unlinkSync(path: string): unknown;
-    appendFileSync(
-      path: string,
-      data: string,
-      options?: { encoding?: BufferEncoding; mode?: number },
-    ): unknown;
-  };
-  json5: { parse(value: string): unknown };
-  env: NodeJS.ProcessEnv;
-  homedir: () => string;
+type ObserveRecoveryDeps = Pick<NormalizedConfigIoDeps, "fs" | "json5" | "env" | "homedir"> & {
   logger: Pick<typeof console, "warn">;
 };
-
-type ConfigStatMetadataSource =
-  | ({
-      mtimeMs?: number;
-      ctimeMs?: number;
-      dev?: number | bigint;
-      ino?: number | bigint;
-      mode?: number;
-      nlink?: number;
-      uid?: number;
-      gid?: number;
-    } & Record<string, unknown>)
-  | null;
 
 function formatConfigPermissionHardeningWarning(params: {
   configPath: string;
@@ -167,72 +93,6 @@ type ConfigReadRecoveryResult = {
   parsed: unknown;
 };
 
-function createConfigObserveAuditRecord(params: {
-  ts: string;
-  configPath: string;
-  valid: boolean;
-  current: ConfigHealthFingerprint;
-  suspicious: string[];
-  lastKnownGood: ConfigHealthFingerprint | undefined;
-  backup: ConfigHealthFingerprint | null | undefined;
-  clobberedPath: string | null;
-  restoredFromBackup: boolean;
-  restoredBackupPath: string | null;
-  restoreErrorCode?: string | null;
-  restoreErrorMessage?: string | null;
-}): ConfigObserveAuditRecord {
-  return {
-    ts: params.ts,
-    source: "config-io",
-    event: "config.observe",
-    phase: "read",
-    configPath: params.configPath,
-    ...snapshotConfigAuditProcessInfo(),
-    exists: true,
-    valid: params.valid,
-    hash: params.current.hash,
-    bytes: params.current.bytes,
-    mtimeMs: params.current.mtimeMs,
-    ctimeMs: params.current.ctimeMs,
-    dev: params.current.dev,
-    ino: params.current.ino,
-    mode: params.current.mode,
-    nlink: params.current.nlink,
-    uid: params.current.uid,
-    gid: params.current.gid,
-    hasMeta: params.current.hasMeta,
-    gatewayMode: params.current.gatewayMode,
-    suspicious: params.suspicious,
-    lastKnownGoodHash: params.lastKnownGood?.hash ?? null,
-    lastKnownGoodBytes: params.lastKnownGood?.bytes ?? null,
-    lastKnownGoodMtimeMs: params.lastKnownGood?.mtimeMs ?? null,
-    lastKnownGoodCtimeMs: params.lastKnownGood?.ctimeMs ?? null,
-    lastKnownGoodDev: params.lastKnownGood?.dev ?? null,
-    lastKnownGoodIno: params.lastKnownGood?.ino ?? null,
-    lastKnownGoodMode: params.lastKnownGood?.mode ?? null,
-    lastKnownGoodNlink: params.lastKnownGood?.nlink ?? null,
-    lastKnownGoodUid: params.lastKnownGood?.uid ?? null,
-    lastKnownGoodGid: params.lastKnownGood?.gid ?? null,
-    lastKnownGoodGatewayMode: params.lastKnownGood?.gatewayMode ?? null,
-    backupHash: params.backup?.hash ?? null,
-    backupBytes: params.backup?.bytes ?? null,
-    backupMtimeMs: params.backup?.mtimeMs ?? null,
-    backupCtimeMs: params.backup?.ctimeMs ?? null,
-    backupDev: params.backup?.dev ?? null,
-    backupIno: params.backup?.ino ?? null,
-    backupMode: params.backup?.mode ?? null,
-    backupNlink: params.backup?.nlink ?? null,
-    backupUid: params.backup?.uid ?? null,
-    backupGid: params.backup?.gid ?? null,
-    backupGatewayMode: params.backup?.gatewayMode ?? null,
-    clobberedPath: params.clobberedPath,
-    restoredFromBackup: params.restoredFromBackup,
-    restoredBackupPath: params.restoredBackupPath,
-    restoreErrorCode: params.restoreErrorCode ?? null,
-    restoreErrorMessage: params.restoreErrorMessage ?? null,
-  };
-}
-
 type ConfigObserveAuditRecordParams = Parameters<typeof createConfigObserveAuditRecord>[0];
 
 function createConfigObserveAuditAppendParams(
@@ -264,122 +124,8 @@ function extractRestoreErrorDetails(error: unknown): {
   return { code, message };
 }
 
-function hashConfigRaw(raw: string | null): string {
-  return crypto
-    .createHash("sha256")
-    .update(raw ?? "")
-    .digest("hex");
-}
-
-function resolveConfigSnapshotHash(snapshot: {
-  hash?: string;
-  raw?: string | null;
-}): string | null {
-  if (typeof snapshot.hash === "string") {
-    const trimmed = snapshot.hash.trim();
-    if (trimmed) {
-      return trimmed;
-    }
-  }
-  if (typeof snapshot.raw !== "string") {
-    return null;
-  }
-  return hashConfigRaw(snapshot.raw);
-}
-
-function hasConfigMeta(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    isRecord(value.meta) &&
-    (typeof value.meta.lastTouchedVersion === "string" ||
-      typeof value.meta.lastTouchedAt === "string")
-  );
-}
-
-function resolveGatewayMode(value: unknown): string | null {
-  if (!isRecord(value) || !isRecord(value.gateway)) {
-    return null;
-  }
-  return typeof value.gateway.mode === "string" ? value.gateway.mode : null;
-}
-
-function resolveConfigStatMetadata(stat: ConfigStatMetadataSource): {
-  dev: string | null;
-  ino: string | null;
-  mode: number | null;
-  nlink: number | null;
-  uid: number | null;
-  gid: number | null;
-} {
-  if (!stat) {
-    return {
-      dev: null,
-      ino: null,
-      mode: null,
-      nlink: null,
-      uid: null,
-      gid: null,
-    };
-  }
-  return {
-    dev: typeof stat.dev === "number" || typeof stat.dev === "bigint" ? String(stat.dev) : null,
-    ino: typeof stat.ino === "number" || typeof stat.ino === "bigint" ? String(stat.ino) : null,
-    mode: typeof stat.mode === "number" ? stat.mode : null,
-    nlink: typeof stat.nlink === "number" ? stat.nlink : null,
-    uid: typeof stat.uid === "number" ? stat.uid : null,
-    gid: typeof stat.gid === "number" ? stat.gid : null,
-  };
-}
-
-function createConfigHealthFingerprint(params: {
-  hash: string;
-  raw: string;
-  parsed: unknown;
-  gatewaySource: unknown;
-  stat: ConfigStatMetadataSource;
-  observedAt: string;
-}): ConfigHealthFingerprint {
-  return {
-    hash: params.hash,
-    bytes: Buffer.byteLength(params.raw, "utf-8"),
-    mtimeMs: params.stat?.mtimeMs ?? null,
-    ctimeMs: params.stat?.ctimeMs ?? null,
-    ...resolveConfigStatMetadata(params.stat),
-    hasMeta: hasConfigMeta(params.parsed),
-    gatewayMode: resolveGatewayMode(params.gatewaySource),
-    observedAt: params.observedAt,
-  };
-}
-
-function parseConfigRawOrEmpty(deps: ObserveRecoveryDeps, raw: string): unknown {
-  try {
-    return deps.json5.parse(raw);
-  } catch {
-    return {};
-  }
-}
-
 function returnOriginalConfigRead(params: ConfigReadRecoveryParams): ConfigReadRecoveryResult {
   return { raw: params.raw, parsed: params.parsed };
-}
-
-async function readConfigHealthState(deps: ObserveRecoveryDeps): Promise<ConfigHealthState> {
-  return readConfigHealthStateFromStore(deps);
-}
-
-function readConfigHealthStateSync(deps: ObserveRecoveryDeps): ConfigHealthState {
-  return readConfigHealthStateFromStore(deps);
-}
-
-async function writeConfigHealthState(
-  deps: ObserveRecoveryDeps,
-  state: ConfigHealthState,
-): Promise<void> {
-  writeConfigHealthStateToStore(deps, state);
-}
-
-function writeConfigHealthStateSync(deps: ObserveRecoveryDeps, state: ConfigHealthState): void {
-  writeConfigHealthStateToStore(deps, state);
 }
 
 function parseBackupConfigRaw(
@@ -391,52 +137,6 @@ function parseBackupConfigRaw(
   } catch {
     return null;
   }
-}
-
-function getConfigHealthEntry(state: ConfigHealthState, configPath: string): ConfigHealthEntry {
-  const entries = state.entries;
-  if (!entries || !isRecord(entries)) {
-    return {};
-  }
-  const entry = entries[configPath];
-  return entry && isRecord(entry) ? entry : {};
-}
-
-function setConfigHealthEntry(
-  state: ConfigHealthState,
-  configPath: string,
-  entry: ConfigHealthEntry,
-): ConfigHealthState {
-  return {
-    ...state,
-    entries: {
-      ...state.entries,
-      [configPath]: entry,
-    },
-  };
-}
-
-function createLastObservedSuspiciousEntry(
-  entry: ConfigHealthEntry,
-  suspiciousSignature: string,
-): ConfigHealthEntry {
-  return {
-    ...entry,
-    lastObservedSuspiciousSignature: suspiciousSignature,
-  };
-}
-
-function createRecoveredSuspiciousHealthState(params: {
-  healthState: ConfigHealthState;
-  configPath: string;
-  entry: ConfigHealthEntry;
-  suspiciousSignature: string;
-}): ConfigHealthState {
-  return setConfigHealthEntry(
-    params.healthState,
-    params.configPath,
-    createLastObservedSuspiciousEntry(params.entry, params.suspiciousSignature),
-  );
 }
 
 function logBackupRestoreResult(params: {
@@ -461,7 +161,6 @@ function logBackupRestoreResult(params: {
 
 function createBackupRestoreAuditAppendParams(params: {
   deps: ObserveRecoveryDeps;
-  now: string;
   configPath: string;
   restoredFromBackup: boolean;
   current: ConfigHealthFingerprint;
@@ -473,7 +172,6 @@ function createBackupRestoreAuditAppendParams(params: {
   restoreErrorDetails: { code: string | null; message: string | null };
 }) {
   return createConfigObserveAuditAppendParams(params.deps, {
-    ts: params.now,
     configPath: params.configPath,
     valid: params.restoredFromBackup,
     current: params.current,
@@ -527,48 +225,6 @@ function resolveConfigReadRecoveryContext(params: {
   return { suspicious, suspiciousSignature };
 }
 
-async function readConfigFingerprintForPath(
-  deps: ObserveRecoveryDeps,
-  targetPath: string,
-): Promise<ConfigHealthFingerprint | null> {
-  try {
-    const raw = await deps.fs.promises.readFile(targetPath, "utf-8");
-    const stat = await deps.fs.promises.stat(targetPath).catch(() => null);
-    const parsed = parseConfigRawOrEmpty(deps, raw);
-    return createConfigHealthFingerprint({
-      hash: hashConfigRaw(raw),
-      raw,
-      parsed,
-      gatewaySource: parsed,
-      stat: stat as ConfigStatMetadataSource,
-      observedAt: new Date().toISOString(),
-    });
-  } catch {
-    return null;
-  }
-}
-
-function readConfigFingerprintForPathSync(
-  deps: ObserveRecoveryDeps,
-  targetPath: string,
-): ConfigHealthFingerprint | null {
-  try {
-    const raw = deps.fs.readFileSync(targetPath, "utf-8");
-    const stat = deps.fs.statSync(targetPath, { throwIfNoEntry: false }) ?? null;
-    const parsed = parseConfigRawOrEmpty(deps, raw);
-    return createConfigHealthFingerprint({
-      hash: hashConfigRaw(raw),
-      raw,
-      parsed,
-      gatewaySource: parsed,
-      stat,
-      observedAt: new Date().toISOString(),
-    });
-  } catch {
-    return null;
-  }
-}
-
 function resolveLastKnownGoodConfigPath(configPath: string): string {
   return `${configPath}.last-good`;
 }
@@ -613,142 +269,95 @@ function collectPollutedSecretPlaceholders(
 export async function maybeRecoverSuspiciousConfigRead(
   params: ConfigReadRecoveryParams,
 ): Promise<ConfigReadRecoveryResult> {
-  const stat = await params.deps.fs.promises.stat(params.configPath).catch(() => null);
-  const now = new Date().toISOString();
-  const current = createConfigHealthFingerprint({
-    hash: hashConfigRaw(params.raw),
-    raw: params.raw,
-    parsed: params.parsed,
-    gatewaySource: params.parsed,
-    stat: stat as ConfigStatMetadataSource,
-    observedAt: now,
-  });
-
-  let healthState = await readConfigHealthState(params.deps);
-  const entry = getConfigHealthEntry(healthState, params.configPath);
-  const backupPath = `${params.configPath}.bak`;
-  const backupBaseline =
-    entry.lastKnownGood ??
-    (await readConfigFingerprintForPath(params.deps, backupPath)) ??
-    undefined;
-  const recoveryContext = resolveConfigReadRecoveryContext({
-    current,
-    parsed: params.parsed,
-    entry,
-    backupBaseline,
-  });
-  if (!recoveryContext) {
-    return returnOriginalConfigRead(params);
+  const recovery = recoverSuspiciousConfigRead(params);
+  let step = recovery.next();
+  while (!step.done) {
+    try {
+      step = recovery.next(await step.value.async());
+    } catch (error) {
+      step = recovery.throw(error);
+    }
   }
-  const { suspicious, suspiciousSignature } = recoveryContext;
-
-  const backupRaw = await params.deps.fs.promises.readFile(backupPath, "utf-8").catch(() => null);
-  if (!backupRaw) {
-    return returnOriginalConfigRead(params);
-  }
-  const backupParse = parseBackupConfigRaw(params.deps, backupRaw);
-  if (!backupParse) {
-    return returnOriginalConfigRead(params);
-  }
-  if (
-    params.validateBackup &&
-    !(await params.validateBackup({ raw: backupRaw, parsed: backupParse.parsed }))
-  ) {
-    return returnOriginalConfigRead(params);
-  }
-  const backup = backupBaseline ?? (await readConfigFingerprintForPath(params.deps, backupPath));
-  if (!backup?.gatewayMode) {
-    return returnOriginalConfigRead(params);
-  }
-  if (params.allowBackupRecovery && !(await params.allowBackupRecovery())) {
-    return returnOriginalConfigRead(params);
-  }
-
-  const clobberedPath = await persistBoundedClobberedConfigSnapshot({
-    deps: params.deps,
-    configPath: params.configPath,
-    raw: params.raw,
-    observedAt: now,
-  });
-
-  let restoredFromBackup = false;
-  let restoreError: unknown;
-  try {
-    await params.deps.fs.promises.writeFile(params.configPath, backupRaw, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-    await chmodConfigBestEffort({
-      deps: params.deps,
-      configPath: params.configPath,
-      context: "backup restore",
-    });
-    restoredFromBackup = true;
-  } catch (error) {
-    restoreError = error;
-  }
-
-  const restoreErrorDetails = restoredFromBackup
-    ? { code: null, message: null }
-    : extractRestoreErrorDetails(restoreError);
-
-  logBackupRestoreResult({
-    deps: params.deps,
-    configPath: params.configPath,
-    suspicious,
-    restoredFromBackup,
-    restoreErrorMessage: restoreErrorDetails.message,
-  });
-  await appendConfigAuditRecord(
-    createBackupRestoreAuditAppendParams({
-      deps: params.deps,
-      now,
-      configPath: params.configPath,
-      restoredFromBackup,
-      current,
-      suspicious,
-      entry,
-      backup,
-      clobberedPath,
-      backupPath,
-      restoreErrorDetails,
-    }),
-  );
-
-  if (restoredFromBackup) {
-    healthState = createRecoveredSuspiciousHealthState({
-      healthState,
-      configPath: params.configPath,
-      entry,
-      suspiciousSignature,
-    });
-    await writeConfigHealthState(params.deps, healthState);
-  }
-  return { raw: backupRaw, parsed: backupParse.parsed };
+  return step.value;
 }
 
 export function maybeRecoverSuspiciousConfigReadSync(
   params: ConfigReadRecoveryParams,
 ): ConfigReadRecoveryResult {
-  const stat = params.deps.fs.statSync(params.configPath, { throwIfNoEntry: false }) ?? null;
+  const recovery = recoverSuspiciousConfigRead(params);
+  let step = recovery.next();
+  while (!step.done) {
+    try {
+      step = recovery.next(step.value.sync());
+    } catch (error) {
+      step = recovery.throw(error);
+    }
+  }
+  return step.value;
+}
+
+type ConfigRecoveryEffect<T> = {
+  sync: () => T;
+  async: () => T | Promise<T>;
+};
+
+function createConfigRecoveryStatEffect(
+  deps: ObserveRecoveryDeps,
+  configPath: string,
+): ConfigRecoveryEffect<fs.Stats | null> {
+  return {
+    sync: () => {
+      try {
+        return deps.fs.statSync(configPath, { throwIfNoEntry: false }) ?? null;
+      } catch {
+        return null;
+      }
+    },
+    async: () => deps.fs.promises.stat(configPath).catch(() => null),
+  };
+}
+
+function createConfigBackupReadEffect(
+  deps: ObserveRecoveryDeps,
+  backupPath: string,
+): ConfigRecoveryEffect<string | null> {
+  return {
+    sync: () => {
+      try {
+        return deps.fs.readFileSync(backupPath, "utf-8");
+      } catch {
+        return null;
+      }
+    },
+    async: () => deps.fs.promises.readFile(backupPath, "utf-8").catch(() => null),
+  };
+}
+
+function* recoverSuspiciousConfigRead(
+  params: ConfigReadRecoveryParams,
+): Generator<ConfigRecoveryEffect<unknown>, ConfigReadRecoveryResult, unknown> {
+  const { deps, configPath, raw, parsed } = params;
+  const stat = (yield createConfigRecoveryStatEffect(deps, configPath)) as fs.Stats | null;
   const now = new Date().toISOString();
   const current = createConfigHealthFingerprint({
-    hash: hashConfigRaw(params.raw),
-    raw: params.raw,
-    parsed: params.parsed,
-    gatewaySource: params.parsed,
+    raw,
+    parsed,
     stat,
     observedAt: now,
   });
-
-  let healthState = readConfigHealthStateSync(params.deps);
-  const entry = getConfigHealthEntry(healthState, params.configPath);
-  const backupPath = `${params.configPath}.bak`;
+  const healthState = readConfigHealthStateFromStore(deps);
+  const entry = readConfigHealthEntry(healthState, configPath);
+  const backupPath = `${configPath}.bak`;
   const backupBaseline =
-    entry.lastKnownGood ?? readConfigFingerprintForPathSync(params.deps, backupPath) ?? undefined;
+    entry.lastKnownGood ??
+    ((yield {
+      sync: () => readConfigFingerprintForPathSync(deps, backupPath),
+      async: () => readConfigFingerprintForPath(deps, backupPath),
+    }) as ConfigHealthFingerprint | null) ??
+    undefined;
   const recoveryContext = resolveConfigReadRecoveryContext({
     current,
-    parsed: params.parsed,
+    parsed,
     entry,
     backupBaseline,
   });
@@ -756,89 +365,104 @@ export function maybeRecoverSuspiciousConfigReadSync(
     return returnOriginalConfigRead(params);
   }
   const { suspicious, suspiciousSignature } = recoveryContext;
-
-  let backupRaw: string;
-  try {
-    backupRaw = params.deps.fs.readFileSync(backupPath, "utf-8");
-  } catch {
+  const backupRaw = (yield createConfigBackupReadEffect(deps, backupPath)) as string | null;
+  if (!backupRaw) {
     return returnOriginalConfigRead(params);
   }
-  const backupParse = parseBackupConfigRaw(params.deps, backupRaw);
+  const backupParse = parseBackupConfigRaw(deps, backupRaw);
   if (!backupParse) {
     return returnOriginalConfigRead(params);
   }
-  if (
-    params.validateBackupSync &&
-    !params.validateBackupSync({ raw: backupRaw, parsed: backupParse.parsed })
-  ) {
+  const backupCandidate = { raw: backupRaw, parsed: backupParse.parsed };
+  const validBackup = (yield {
+    sync: () => params.validateBackupSync?.(backupCandidate) ?? true,
+    async: () => params.validateBackup?.(backupCandidate) ?? true,
+  }) as boolean;
+  if (!validBackup) {
     return returnOriginalConfigRead(params);
   }
-  const backup = backupBaseline ?? readConfigFingerprintForPathSync(params.deps, backupPath);
-  if (!backup?.gatewayMode) {
-    return returnOriginalConfigRead(params);
-  }
-
-  const clobberedPath = persistBoundedClobberedConfigSnapshotSync({
-    deps: params.deps,
-    configPath: params.configPath,
-    raw: params.raw,
-    observedAt: now,
+  // Eligibility must describe the approved backup bytes, never an older healthy config.
+  const backupStat = (yield createConfigRecoveryStatEffect(deps, backupPath)) as fs.Stats | null;
+  const backup = createConfigHealthFingerprint({
+    raw: backupRaw,
+    parsed: backupParse.parsed,
+    stat: backupStat,
   });
-
+  if (!backup.gatewayMode) {
+    return returnOriginalConfigRead(params);
+  }
+  if (params.allowBackupRecovery) {
+    const allowed = (yield {
+      sync: () => true,
+      async: () => params.allowBackupRecovery?.() ?? true,
+    }) as boolean;
+    if (!allowed) {
+      return returnOriginalConfigRead(params);
+    }
+  }
+  const snapshotParams = {
+    deps,
+    configPath,
+    raw,
+    observedAt: now,
+  };
+  const clobberedPath = (yield {
+    sync: () => persistBoundedClobberedConfigSnapshotSync(snapshotParams),
+    async: () => persistBoundedClobberedConfigSnapshot(snapshotParams),
+  }) as string | null;
   let restoredFromBackup = false;
   let restoreError: unknown;
   try {
-    params.deps.fs.writeFileSync(params.configPath, backupRaw, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-    chmodConfigBestEffortSync({
-      deps: params.deps,
-      configPath: params.configPath,
-      context: "backup restore",
-    });
+    const options = { encoding: "utf-8" as const, mode: 0o600 };
+    yield {
+      sync: () => deps.fs.writeFileSync(configPath, backupRaw, options),
+      async: () => deps.fs.promises.writeFile(configPath, backupRaw, options),
+    };
+    const chmodParams = { deps, configPath, context: "backup restore" };
+    yield {
+      sync: () => chmodConfigBestEffortSync(chmodParams),
+      async: () => chmodConfigBestEffort(chmodParams),
+    };
     restoredFromBackup = true;
   } catch (error) {
     restoreError = error;
   }
-
   const restoreErrorDetails = restoredFromBackup
     ? { code: null, message: null }
     : extractRestoreErrorDetails(restoreError);
-
   logBackupRestoreResult({
-    deps: params.deps,
-    configPath: params.configPath,
+    deps,
+    configPath,
     suspicious,
     restoredFromBackup,
     restoreErrorMessage: restoreErrorDetails.message,
   });
-  appendConfigAuditRecordSync(
-    createBackupRestoreAuditAppendParams({
-      deps: params.deps,
-      now,
-      configPath: params.configPath,
-      restoredFromBackup,
-      current,
-      suspicious,
-      entry,
-      backup,
-      clobberedPath,
-      backupPath,
-      restoreErrorDetails,
-    }),
-  );
-
+  const audit = createBackupRestoreAuditAppendParams({
+    deps,
+    configPath,
+    restoredFromBackup,
+    current,
+    suspicious,
+    entry,
+    backup,
+    clobberedPath,
+    backupPath,
+    restoreErrorDetails,
+  });
+  yield {
+    sync: () => appendConfigAuditRecordSync(audit),
+    async: () => appendConfigAuditRecord(audit),
+  };
   if (restoredFromBackup) {
-    healthState = createRecoveredSuspiciousHealthState({
-      healthState,
-      configPath: params.configPath,
-      entry,
-      suspiciousSignature,
-    });
-    writeConfigHealthStateSync(params.deps, healthState);
+    writeConfigHealthStateToStore(
+      deps,
+      updateConfigHealthEntry(healthState, configPath, {
+        ...entry,
+        lastObservedSuspiciousSignature: suspiciousSignature,
+      }),
+    );
   }
-  return { raw: backupRaw, parsed: backupParse.parsed };
+  return backupCandidate;
 }
 
 export async function promoteConfigSnapshotToLastKnownGood(params: {
@@ -860,11 +484,11 @@ export async function promoteConfigSnapshotToLastKnownGood(params: {
   const stat = await deps.fs.promises.stat(snapshot.path).catch(() => null);
   const now = new Date().toISOString();
   const current = createConfigHealthFingerprint({
-    hash: resolveConfigSnapshotHash(snapshot) ?? hashConfigRaw(snapshot.raw),
+    hash: resolveConfigSnapshotHash(snapshot) ?? undefined,
     raw: snapshot.raw,
     parsed: snapshot.parsed,
-    gatewaySource: snapshot.resolved,
-    stat: stat as ConfigStatMetadataSource,
+    resolved: snapshot.resolved,
+    stat,
     observedAt: now,
   });
   const lastGoodPath = resolveLastKnownGoodConfigPath(snapshot.path);
@@ -877,11 +501,11 @@ export async function promoteConfigSnapshotToLastKnownGood(params: {
     configPath: lastGoodPath,
     context: "last-known-good promotion",
   });
-  const healthState = await readConfigHealthState(deps);
-  const entry = getConfigHealthEntry(healthState, snapshot.path);
-  await writeConfigHealthState(
+  const healthState = readConfigHealthStateFromStore(deps);
+  const entry = readConfigHealthEntry(healthState, snapshot.path);
+  writeConfigHealthStateToStore(
     deps,
-    setConfigHealthEntry(healthState, snapshot.path, {
+    updateConfigHealthEntry(healthState, snapshot.path, {
       ...entry,
       lastKnownGood: current,
       lastPromotedGood: current,
@@ -908,8 +532,8 @@ export async function recoverConfigFromLastKnownGood(params: {
     }
     return false;
   }
-  const healthState = await readConfigHealthState(deps);
-  const entry = getConfigHealthEntry(healthState, snapshot.path);
+  const healthState = readConfigHealthStateFromStore(deps);
+  const entry = readConfigHealthEntry(healthState, snapshot.path);
   const promoted = entry.lastPromotedGood;
   if (!promoted?.hash) {
     return false;
@@ -935,11 +559,11 @@ export async function recoverConfigFromLastKnownGood(params: {
   const now = new Date().toISOString();
   const stat = await deps.fs.promises.stat(snapshot.path).catch(() => null);
   const current = createConfigHealthFingerprint({
-    hash: resolveConfigSnapshotHash(snapshot) ?? hashConfigRaw(snapshot.raw),
+    hash: resolveConfigSnapshotHash(snapshot) ?? undefined,
     raw: snapshot.raw,
     parsed: snapshot.parsed,
-    gatewaySource: snapshot.resolved,
-    stat: stat as ConfigStatMetadataSource,
+    resolved: snapshot.resolved,
+    stat,
     observedAt: now,
   });
   const clobberedPath = await preserveConfigSnapshotAsClobbered({
@@ -962,7 +586,6 @@ export async function recoverConfigFromLastKnownGood(params: {
   );
   await appendConfigAuditRecord(
     createConfigObserveAuditAppendParams(deps, {
-      ts: now,
       configPath: snapshot.path,
       valid: snapshot.valid,
       current,
@@ -974,9 +597,9 @@ export async function recoverConfigFromLastKnownGood(params: {
       restoredBackupPath: lastGoodPath,
     }),
   );
-  await writeConfigHealthState(
+  writeConfigHealthStateToStore(
     deps,
-    setConfigHealthEntry(healthState, snapshot.path, {
+    updateConfigHealthEntry(healthState, snapshot.path, {
       ...entry,
       lastKnownGood: promoted,
       lastPromotedGood: promoted,
@@ -1001,4 +624,3 @@ export async function preserveConfigSnapshotAsClobbered(params: {
     observedAt: params.observedAt ?? new Date().toISOString(),
   });
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/config/io.observe-state.ts
+++ b/src/config/io.observe-state.ts
@@ -1,0 +1,167 @@
+import type fs from "node:fs";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { snapshotConfigAuditProcessInfo, type ConfigObserveAuditRecord } from "./io.audit.js";
+import type {
+  ConfigHealthEntry,
+  ConfigHealthFingerprint,
+  ConfigHealthState,
+} from "./io.health-state.js";
+import {
+  hashConfigRaw,
+  hasConfigMeta,
+  parseConfigJson5,
+  resolveGatewayMode,
+} from "./io.read-helpers.js";
+import type { NormalizedConfigIoDeps } from "./io.types.js";
+import { resolveConfigStatMetadata } from "./io.write-safety.js";
+
+type ConfigFingerprintDeps = Pick<NormalizedConfigIoDeps, "fs" | "json5">;
+
+export function readConfigHealthEntry(
+  state: ConfigHealthState,
+  configPath: string,
+): ConfigHealthEntry {
+  const entry = state.entries?.[configPath];
+  return isRecord(entry) ? entry : {};
+}
+
+export function updateConfigHealthEntry(
+  state: ConfigHealthState,
+  configPath: string,
+  entry: ConfigHealthEntry,
+): ConfigHealthState {
+  return {
+    ...state,
+    entries: { ...state.entries, [configPath]: entry },
+  };
+}
+
+export function createConfigHealthFingerprint(params: {
+  raw: string;
+  parsed: unknown;
+  resolved?: unknown;
+  stat: fs.Stats | null;
+  hash?: string;
+  observedAt?: string;
+}): ConfigHealthFingerprint {
+  return {
+    hash: params.hash ?? hashConfigRaw(params.raw),
+    bytes: Buffer.byteLength(params.raw, "utf-8"),
+    mtimeMs: params.stat?.mtimeMs ?? null,
+    ctimeMs: params.stat?.ctimeMs ?? null,
+    ...resolveConfigStatMetadata(params.stat),
+    hasMeta: hasConfigMeta(params.parsed),
+    gatewayMode: resolveGatewayMode(params.resolved ?? params.parsed),
+    observedAt: params.observedAt ?? new Date().toISOString(),
+  };
+}
+
+function createConfigFingerprintFromRead(params: {
+  deps: ConfigFingerprintDeps;
+  raw: string;
+  stat: fs.Stats | null;
+}): ConfigHealthFingerprint {
+  const parsed = parseConfigJson5(params.raw, params.deps.json5);
+  return createConfigHealthFingerprint({
+    raw: params.raw,
+    parsed: parsed.ok ? parsed.parsed : {},
+    stat: params.stat,
+  });
+}
+
+export async function readConfigFingerprintForPath(
+  deps: ConfigFingerprintDeps,
+  configPath: string,
+): Promise<ConfigHealthFingerprint | null> {
+  try {
+    const raw = await deps.fs.promises.readFile(configPath, "utf-8");
+    const stat = await deps.fs.promises.stat(configPath).catch(() => null);
+    return createConfigFingerprintFromRead({ deps, raw, stat });
+  } catch {
+    return null;
+  }
+}
+
+export function readConfigFingerprintForPathSync(
+  deps: ConfigFingerprintDeps,
+  configPath: string,
+): ConfigHealthFingerprint | null {
+  try {
+    const raw = deps.fs.readFileSync(configPath, "utf-8");
+    let stat: fs.Stats | null = null;
+    try {
+      stat = deps.fs.statSync(configPath, { throwIfNoEntry: false }) ?? null;
+    } catch {
+      // Metadata is diagnostic only; readable backup bytes remain authoritative.
+    }
+    return createConfigFingerprintFromRead({ deps, raw, stat });
+  } catch {
+    return null;
+  }
+}
+
+export function createConfigObserveAuditRecord(params: {
+  configPath: string;
+  valid: boolean;
+  current: ConfigHealthFingerprint;
+  suspicious: string[];
+  lastKnownGood: ConfigHealthFingerprint | undefined;
+  backup: ConfigHealthFingerprint | null | undefined;
+  clobberedPath?: string | null;
+  restoredFromBackup?: boolean;
+  restoredBackupPath?: string | null;
+  restoreErrorCode?: string | null;
+  restoreErrorMessage?: string | null;
+}): ConfigObserveAuditRecord {
+  const { current, lastKnownGood, backup } = params;
+  return {
+    ts: current.observedAt,
+    source: "config-io",
+    event: "config.observe",
+    phase: "read",
+    configPath: params.configPath,
+    ...snapshotConfigAuditProcessInfo(),
+    exists: true,
+    valid: params.valid,
+    hash: current.hash,
+    bytes: current.bytes,
+    mtimeMs: current.mtimeMs,
+    ctimeMs: current.ctimeMs,
+    dev: current.dev,
+    ino: current.ino,
+    mode: current.mode,
+    nlink: current.nlink,
+    uid: current.uid,
+    gid: current.gid,
+    hasMeta: current.hasMeta,
+    gatewayMode: current.gatewayMode,
+    suspicious: params.suspicious,
+    lastKnownGoodHash: lastKnownGood?.hash ?? null,
+    lastKnownGoodBytes: lastKnownGood?.bytes ?? null,
+    lastKnownGoodMtimeMs: lastKnownGood?.mtimeMs ?? null,
+    lastKnownGoodCtimeMs: lastKnownGood?.ctimeMs ?? null,
+    lastKnownGoodDev: lastKnownGood?.dev ?? null,
+    lastKnownGoodIno: lastKnownGood?.ino ?? null,
+    lastKnownGoodMode: lastKnownGood?.mode ?? null,
+    lastKnownGoodNlink: lastKnownGood?.nlink ?? null,
+    lastKnownGoodUid: lastKnownGood?.uid ?? null,
+    lastKnownGoodGid: lastKnownGood?.gid ?? null,
+    lastKnownGoodGatewayMode: lastKnownGood?.gatewayMode ?? null,
+    backupHash: backup?.hash ?? null,
+    backupBytes: backup?.bytes ?? null,
+    backupMtimeMs: backup?.mtimeMs ?? null,
+    backupCtimeMs: backup?.ctimeMs ?? null,
+    backupDev: backup?.dev ?? null,
+    backupIno: backup?.ino ?? null,
+    backupMode: backup?.mode ?? null,
+    backupNlink: backup?.nlink ?? null,
+    backupUid: backup?.uid ?? null,
+    backupGid: backup?.gid ?? null,
+    backupGatewayMode: backup?.gatewayMode ?? null,
+    clobberedPath: params.clobberedPath ?? null,
+    restoredFromBackup: params.restoredFromBackup ?? false,
+    restoredBackupPath: params.restoredBackupPath ?? null,
+    restoreErrorCode: params.restoreErrorCode ?? null,
+    restoreErrorMessage: params.restoreErrorMessage ?? null,
+  };
+}

--- a/src/config/io.observe.ts
+++ b/src/config/io.observe.ts
@@ -1,11 +1,5 @@
 import type fs from "node:fs";
-import { isRecord } from "../utils.js";
-import {
-  appendConfigAuditRecord,
-  appendConfigAuditRecordSync,
-  snapshotConfigAuditProcessInfo,
-  type ConfigObserveAuditRecord,
-} from "./io.audit.js";
+import { appendConfigAuditRecord, appendConfigAuditRecordSync } from "./io.audit.js";
 import {
   readConfigHealthStateFromStore,
   writeConfigHealthStateToStore,
@@ -13,85 +7,18 @@ import {
   type ConfigHealthFingerprint,
   type ConfigHealthState,
 } from "./io.health-state.js";
-import { resolveConfigObserveSuspiciousReasons } from "./io.observe-suspicious.js";
 import {
-  hashConfigRaw,
-  hasConfigMeta,
-  parseConfigJson5,
-  resolveConfigSnapshotHash,
-  resolveGatewayMode,
-} from "./io.read-helpers.js";
+  createConfigHealthFingerprint,
+  createConfigObserveAuditRecord,
+  readConfigFingerprintForPath,
+  readConfigFingerprintForPathSync,
+  readConfigHealthEntry,
+  updateConfigHealthEntry,
+} from "./io.observe-state.js";
+import { resolveConfigObserveSuspiciousReasons } from "./io.observe-suspicious.js";
+import { resolveConfigSnapshotHash } from "./io.read-helpers.js";
 import type { NormalizedConfigIoDeps } from "./io.types.js";
-import { resolveConfigStatMetadata } from "./io.write-safety.js";
 import type { ConfigFileSnapshot } from "./types.js";
-
-function getConfigHealthEntry(state: ConfigHealthState, configPath: string): ConfigHealthEntry {
-  const entries = state.entries;
-  if (!entries || !isRecord(entries)) {
-    return {};
-  }
-  const entry = entries[configPath];
-  return entry && isRecord(entry) ? entry : {};
-}
-
-function setConfigHealthEntry(
-  state: ConfigHealthState,
-  configPath: string,
-  entry: ConfigHealthEntry,
-): ConfigHealthState {
-  return {
-    ...state,
-    entries: { ...state.entries, [configPath]: entry },
-  };
-}
-
-function fingerprintFromRaw(
-  raw: string,
-  stat: fs.Stats | null,
-  parsed: unknown,
-  resolved: unknown,
-): ConfigHealthFingerprint {
-  return {
-    hash: hashConfigRaw(raw),
-    bytes: Buffer.byteLength(raw, "utf-8"),
-    mtimeMs: stat?.mtimeMs ?? null,
-    ctimeMs: stat?.ctimeMs ?? null,
-    ...resolveConfigStatMetadata(stat),
-    hasMeta: hasConfigMeta(parsed),
-    gatewayMode: resolveGatewayMode(resolved),
-    observedAt: new Date().toISOString(),
-  };
-}
-
-async function readConfigFingerprintForPath(
-  deps: NormalizedConfigIoDeps,
-  targetPath: string,
-): Promise<ConfigHealthFingerprint | null> {
-  try {
-    const raw = await deps.fs.promises.readFile(targetPath, "utf-8");
-    const stat = await deps.fs.promises.stat(targetPath).catch(() => null);
-    const parsed = parseConfigJson5(raw, deps.json5);
-    const value = parsed.ok ? parsed.parsed : {};
-    return fingerprintFromRaw(raw, stat, value, value);
-  } catch {
-    return null;
-  }
-}
-
-function readConfigFingerprintForPathSync(
-  deps: NormalizedConfigIoDeps,
-  targetPath: string,
-): ConfigHealthFingerprint | null {
-  try {
-    const raw = deps.fs.readFileSync(targetPath, "utf-8");
-    const stat = deps.fs.statSync(targetPath, { throwIfNoEntry: false }) ?? null;
-    const parsed = parseConfigJson5(raw, deps.json5);
-    const value = parsed.ok ? parsed.parsed : {};
-    return fingerprintFromRaw(raw, stat, value, value);
-  } catch {
-    return null;
-  }
-}
 
 function sameFingerprint(
   left: ConfigHealthFingerprint | undefined,
@@ -118,70 +45,13 @@ function sameFingerprint(
 
 function createObservedFingerprint(snapshot: ConfigFileSnapshot, stat: fs.Stats | null) {
   const raw = snapshot.raw as string;
-  return {
-    ...fingerprintFromRaw(raw, stat, snapshot.parsed, snapshot.resolved),
-    hash: resolveConfigSnapshotHash(snapshot) ?? hashConfigRaw(raw),
-  };
-}
-
-function createObserveAuditRecord(params: {
-  snapshot: ConfigFileSnapshot;
-  current: ConfigHealthFingerprint;
-  suspicious: string[];
-  entry: ConfigHealthEntry;
-  backup: ConfigHealthFingerprint | null;
-}): ConfigObserveAuditRecord {
-  const { snapshot, current, suspicious, entry, backup } = params;
-  return {
-    ts: current.observedAt,
-    source: "config-io",
-    event: "config.observe",
-    phase: "read",
-    configPath: snapshot.path,
-    ...snapshotConfigAuditProcessInfo(),
-    exists: true,
-    valid: snapshot.valid,
-    hash: current.hash,
-    bytes: current.bytes,
-    mtimeMs: current.mtimeMs,
-    ctimeMs: current.ctimeMs,
-    dev: current.dev,
-    ino: current.ino,
-    mode: current.mode,
-    nlink: current.nlink,
-    uid: current.uid,
-    gid: current.gid,
-    hasMeta: current.hasMeta,
-    gatewayMode: current.gatewayMode,
-    suspicious,
-    lastKnownGoodHash: entry.lastKnownGood?.hash ?? null,
-    lastKnownGoodBytes: entry.lastKnownGood?.bytes ?? null,
-    lastKnownGoodMtimeMs: entry.lastKnownGood?.mtimeMs ?? null,
-    lastKnownGoodCtimeMs: entry.lastKnownGood?.ctimeMs ?? null,
-    lastKnownGoodDev: entry.lastKnownGood?.dev ?? null,
-    lastKnownGoodIno: entry.lastKnownGood?.ino ?? null,
-    lastKnownGoodMode: entry.lastKnownGood?.mode ?? null,
-    lastKnownGoodNlink: entry.lastKnownGood?.nlink ?? null,
-    lastKnownGoodUid: entry.lastKnownGood?.uid ?? null,
-    lastKnownGoodGid: entry.lastKnownGood?.gid ?? null,
-    lastKnownGoodGatewayMode: entry.lastKnownGood?.gatewayMode ?? null,
-    backupHash: backup?.hash ?? null,
-    backupBytes: backup?.bytes ?? null,
-    backupMtimeMs: backup?.mtimeMs ?? null,
-    backupCtimeMs: backup?.ctimeMs ?? null,
-    backupDev: backup?.dev ?? null,
-    backupIno: backup?.ino ?? null,
-    backupMode: backup?.mode ?? null,
-    backupNlink: backup?.nlink ?? null,
-    backupUid: backup?.uid ?? null,
-    backupGid: backup?.gid ?? null,
-    backupGatewayMode: backup?.gatewayMode ?? null,
-    clobberedPath: null,
-    restoredFromBackup: false,
-    restoredBackupPath: null,
-    restoreErrorCode: null,
-    restoreErrorMessage: null,
-  };
+  return createConfigHealthFingerprint({
+    raw,
+    parsed: snapshot.parsed,
+    resolved: snapshot.resolved,
+    stat,
+    hash: resolveConfigSnapshotHash(snapshot) ?? undefined,
+  });
 }
 
 function resolveObservation(params: {
@@ -190,7 +60,7 @@ function resolveObservation(params: {
   healthState: ConfigHealthState;
   backupBaseline?: ConfigHealthFingerprint;
 }) {
-  const entry = getConfigHealthEntry(params.healthState, params.snapshot.path);
+  const entry = readConfigHealthEntry(params.healthState, params.snapshot.path);
   const baseline = entry.lastKnownGood ?? params.backupBaseline;
   const suspicious = resolveConfigObserveSuspiciousReasons({
     bytes: params.current.bytes,
@@ -218,7 +88,7 @@ function updateHealthyObservation(params: {
   };
   return !sameFingerprint(params.entry.lastKnownGood, params.current) ||
     params.entry.lastObservedSuspiciousSignature !== null
-    ? setConfigHealthEntry(params.healthState, params.snapshot.path, nextEntry)
+    ? updateConfigHealthEntry(params.healthState, params.snapshot.path, nextEntry)
     : null;
 }
 
@@ -233,7 +103,7 @@ export async function observeConfigSnapshot(
   const current = createObservedFingerprint(snapshot, stat);
   let healthState = readConfigHealthStateFromStore(deps);
   const backupPath = `${snapshot.path}.bak`;
-  const initialEntry = getConfigHealthEntry(healthState, snapshot.path);
+  const initialEntry = readConfigHealthEntry(healthState, snapshot.path);
   const backupBaseline =
     initialEntry.lastKnownGood ??
     (await readConfigFingerprintForPath(deps, backupPath)) ??
@@ -261,9 +131,16 @@ export async function observeConfigSnapshot(
   await appendConfigAuditRecord({
     env: deps.env,
     homedir: deps.homedir,
-    record: createObserveAuditRecord({ snapshot, current, suspicious, entry, backup }),
+    record: createConfigObserveAuditRecord({
+      configPath: snapshot.path,
+      valid: snapshot.valid,
+      current,
+      suspicious,
+      lastKnownGood: entry.lastKnownGood,
+      backup,
+    }),
   });
-  healthState = setConfigHealthEntry(healthState, snapshot.path, {
+  healthState = updateConfigHealthEntry(healthState, snapshot.path, {
     ...entry,
     lastObservedSuspiciousSignature: signature,
   });
@@ -281,7 +158,7 @@ export function observeConfigSnapshotSync(
   const current = createObservedFingerprint(snapshot, stat);
   let healthState = readConfigHealthStateFromStore(deps);
   const backupPath = `${snapshot.path}.bak`;
-  const initialEntry = getConfigHealthEntry(healthState, snapshot.path);
+  const initialEntry = readConfigHealthEntry(healthState, snapshot.path);
   const backupBaseline =
     initialEntry.lastKnownGood ?? readConfigFingerprintForPathSync(deps, backupPath) ?? undefined;
   const { entry, baseline, suspicious } = resolveObservation({
@@ -307,9 +184,16 @@ export function observeConfigSnapshotSync(
   appendConfigAuditRecordSync({
     env: deps.env,
     homedir: deps.homedir,
-    record: createObserveAuditRecord({ snapshot, current, suspicious, entry, backup }),
+    record: createConfigObserveAuditRecord({
+      configPath: snapshot.path,
+      valid: snapshot.valid,
+      current,
+      suspicious,
+      lastKnownGood: entry.lastKnownGood,
+      backup,
+    }),
   });
-  healthState = setConfigHealthEntry(healthState, snapshot.path, {
+  healthState = updateConfigHealthEntry(healthState, snapshot.path, {
     ...entry,
     lastObservedSuspiciousSignature: signature,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could have their configuration restored from an invalid backup when a stale healthy fingerprint incorrectly authorized different backup bytes. Synchronous startup recovery could also fail on a metadata-only stat error, while asynchronous recovery continued.

## Why This Change Was Made

Canonicalize config observation fingerprints, audit records, and SQLite health ownership across synchronous startup and asynchronous snapshots. Evaluate restoration eligibility against the exact approved backup bytes, preserve backup-validation and caller-policy ordering, and remove duplicated sync/async policy.

## User Impact

Startup and snapshot recovery now refuse backups without a usable gateway mode, consistently recognize authored config metadata, preserve last-known-good doctor repair, and tolerate nonessential stat failures without weakening permission hardening or audit visibility. Production code shrinks by 327 lines and one grandfathered oversized-file suppression is removed.

## Evidence

Real runtime proof used actual temporary config files, actual backup files, and the shared SQLite config_health_entries store; filesystem/state storage were not replaced by mocks. The only injected fault was the targeted stat permission error.

Before the fix, Blacksmith Testbox reproduced five concrete failures:

1. Async stale-fingerprint recovery: SQLite contained a healthy promoted config with gateway.mode=local; the primary contained update.channel=beta; the actual backup contained only meta.lastTouchedVersion. Recovery incorrectly returned and restored the invalid backup instead of preserving the primary.
2. Sync stale-fingerprint recovery: the same on-disk primary/backup and SQLite fingerprint incorrectly restored the gateway-less backup during synchronous startup.
3. Async metadata recovery: the actual backup contained meta.authoredBy=operator and gateway.mode=local; the primary retained gateway.mode=local but dropped meta. Recovery incorrectly ignored the missing authored metadata and returned the truncated primary.
4. Sync metadata recovery: the same real backup/primary mismatch was incorrectly ignored during synchronous startup.
5. Sync stat recovery: a real recoverable primary and backup plus an EACCES fault only on the primary stat caused startup recovery to throw; the matching asynchronous path already recovered gateway.mode=local.

After the fix, the same fixtures prove both stale-backup modes preserve the exact original primary bytes and emit no restore audit, both metadata modes recover the authored backup payload, and both stat modes recover gateway.mode=local. Focused initial proof was 5 failed, 1 passed; final exact-head recovery proof was 44 passed.

Additional real-boundary coverage: 65 tests passed across recovery, ordinary config reads, and doctor repair, including actual last-known-good restoration, original clobber artifact preservation, rejected malformed-plugin handling, SQLite health updates, backup byte races, file permission hardening, env cleanup, and operator audit/warning output.

Full remote changed gate passed: production and test typechecks, all lint shards, formatting, dead-code scans, max-lines ratchet, database-first storage enforcement, and zero runtime import cycles. Fresh structured autoreview was clean. Exact-head hosted CI run 30672168417 completed successfully, including required openclaw/ci-gate. Blacksmith Testbox tbx_01kyx51xb2n4va3rksjp4y9dsg was stopped after validation.