### PR TITLE
refactor(telegram): unify outbound media delivery

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements delivery.replies behavior.
-import { type Bot, GrammyError, InputFile } from "grammy";
+import { type Bot, GrammyError } from "grammy";
 import type { Message } from "grammy/types";
 import {
   createOutboundPayloadPlan,
@@ -19,8 +19,6 @@ import type { ReplyPayloadDelivery } from "openclaw/plugin-sdk/interactive-runti
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   buildOutboundMediaLoadOptions,
-  isGifMedia,
-  kindFromMime,
   probeVideoDimensions,
 } from "openclaw/plugin-sdk/media-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
@@ -31,11 +29,9 @@ import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "../button-types.js";
-import { resolveTelegramPlainCaption, splitTelegramCaption } from "../caption.js";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
-  renderTelegramHtmlText,
   splitTelegramHtmlChunks,
   telegramHtmlToPlainTextFallback,
   wrapFileReferencesInHtml,
@@ -44,7 +40,13 @@ import {
   canonicalizeTelegramPresentationPayload,
   resolveTelegramInteractiveTextFallback,
 } from "../interactive-fallback.js";
-import { resolveTelegramOutboundMediaFilename } from "../outbound-media.js";
+import {
+  prepareTelegramOutboundMedia,
+  resolveTelegramOutboundMediaSenders,
+  sendTelegramCaptionedMediaWithFallback,
+  sendTelegramOutboundMediaWithPhotoFallback,
+  type TelegramOutboundMediaSender,
+} from "../outbound-media.js";
 import type { TelegramPromptContextProjectionSequence } from "../prompt-context-projection.js";
 import type { TelegramRichBlocksDegradationReason } from "../rich-block-model.js";
 import {
@@ -53,11 +55,9 @@ import {
   TELEGRAM_RICH_TEXT_LIMIT,
   type TelegramInputRichMessage,
 } from "../rich-message.js";
-import { isTelegramHtmlParseError } from "../rich-plain-fallback.js";
 import { isTelegramPhotoLimitError } from "../send-error-predicates.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { resolveTelegramTargetChatType } from "../targets.js";
-import { resolveTelegramVoiceSend } from "../voice.js";
 import {
   buildTelegramSendParams,
   sendTelegramText,
@@ -320,63 +320,6 @@ function resolveVoiceFallbackText(reply: ReplyPayload): string | undefined {
   return undefined;
 }
 
-function buildPlainCaptionParams(
-  mediaParams: Record<string, unknown>,
-  plainCaption: string,
-): Record<string, unknown> {
-  const nextParams: Record<string, unknown> = { ...mediaParams, caption: plainCaption };
-  delete nextParams.parse_mode;
-  return nextParams;
-}
-
-async function sendTelegramCaptionedMediaWithFallback<T>(params: {
-  operation: string;
-  runtime: RuntimeEnv;
-  thread?: TelegramThreadSpec | null;
-  requestParams: Record<string, unknown>;
-  plainCaption?: string;
-  shouldLog?: (err: unknown) => boolean;
-  send: (effectiveParams: Record<string, unknown>) => Promise<T>;
-}): Promise<T> {
-  const sendMedia = (
-    requestParams: Record<string, unknown>,
-    shouldLog?: (err: unknown) => boolean,
-  ) =>
-    sendTelegramWithThreadFallback({
-      operation: params.operation,
-      runtime: params.runtime,
-      thread: params.thread,
-      requestParams,
-      ...(shouldLog ? { shouldLog } : {}),
-      send: params.send,
-    });
-  if (!params.plainCaption) {
-    return await sendMedia(params.requestParams, params.shouldLog);
-  }
-  try {
-    return await sendMedia(
-      params.requestParams,
-      (err: unknown) =>
-        !isTelegramHtmlParseError(err) && (params.shouldLog ? params.shouldLog(err) : true),
-    );
-  } catch (err) {
-    if (!isTelegramHtmlParseError(err)) {
-      throw err;
-    }
-    // Caption fallback mirrors text sends: Telegram HTML parse failures retry
-    // once with plain caption so media replies are not dropped.
-    logVerbose(
-      `telegram ${params.operation} caption HTML rejected; retrying as plain caption: ${formatErrorMessage(
-        err,
-      )}`,
-    );
-    return await sendMedia(
-      buildPlainCaptionParams(params.requestParams, params.plainCaption),
-      params.shouldLog,
-    );
-  }
-}
-
 async function deliverMediaReply(params: {
   reply: ReplyPayload;
   mediaList: string[];
@@ -416,17 +359,25 @@ async function deliverMediaReply(params: {
     await params.progress.promptContext?.accept(promptContextMessage);
   };
   const deliverAcceptedMedia = async (options: {
-    operation: string;
+    sender: TelegramOutboundMediaSender<Message>;
     requestParams: Record<string, unknown>;
     plainCaption?: string;
     text?: string;
     shouldLog?: (err: unknown) => boolean;
-    send: (effectiveParams: Record<string, unknown>) => Promise<Message>;
   }) => {
     const message = await sendTelegramCaptionedMediaWithFallback({
-      ...options,
-      runtime: params.runtime,
-      thread: params.thread,
+      operation: options.sender.operation,
+      requestParams: options.requestParams,
+      plainCaption: options.plainCaption,
+      shouldLog: options.shouldLog,
+      send: (requestParams, shouldLog) =>
+        sendTelegramWithThreadFallback({
+          operation: options.sender.operation,
+          runtime: params.runtime,
+          requestParams,
+          ...(shouldLog ? { shouldLog } : {}),
+          send: options.sender.send,
+        }),
     });
     firstDeliveredMessageId ??= message.message_id;
     await recordPromptContextMessage(message, options.text);
@@ -447,31 +398,21 @@ async function deliverMediaReply(params: {
         maxBytes: params.mediaMaxBytes,
       }),
     );
-    const kind = kindFromMime(media.contentType ?? undefined);
-    const isGif = isGifMedia({
-      contentType: media.contentType,
-      fileName: media.fileName,
+    const mediaPlan = prepareTelegramOutboundMedia({
+      media,
+      text: isFirstMedia ? (params.reply.text ?? undefined) : undefined,
+      textMode: params.textMode,
+      tableMode: params.tableMode,
+      preparedHtml: true,
     });
-    const fileName = resolveTelegramOutboundMediaFilename({
-      fileName: media.fileName,
-      contentType: media.contentType,
-      kind,
-      isGif,
+    const { sender: mediaSender, documentSender } = resolveTelegramOutboundMediaSenders<Message>({
+      api: params.bot.api,
+      chatId: params.chatId,
+      media,
+      plan: mediaPlan,
+      asVoice: params.reply.audioAsVoice,
     });
-    const file = new InputFile(media.buffer, fileName);
-    const captionText = isFirstMedia ? (params.reply.text ?? undefined) : undefined;
-    const trimmedCaption = captionText?.trim();
-    const renderedCaption = trimmedCaption
-      ? params.textMode === "html"
-        ? trimmedCaption
-        : renderTelegramHtmlText(trimmedCaption, { tableMode: params.tableMode })
-      : undefined;
-    const { caption, followUpText } = splitTelegramCaption(captionText, renderedCaption);
-    const htmlCaption = caption ? renderedCaption : undefined;
-    const plainCaption = resolveTelegramPlainCaption(
-      caption && params.textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption,
-      htmlCaption,
-    );
+    const { htmlCaption, plainCaption, followUpText } = mediaPlan;
     if (followUpText) {
       pendingFollowUpText = followUpText;
     }
@@ -482,7 +423,8 @@ async function deliverMediaReply(params: {
       progress: params.progress,
     });
     const shouldAttachButtonsToMedia = isFirstMedia && params.replyMarkup && !followUpText;
-    const videoDimensions = kind === "video" ? await probeVideoDimensions(media.buffer) : undefined;
+    const videoDimensions =
+      mediaPlan.kind === "video" ? await probeVideoDimensions(media.buffer) : undefined;
     const mediaParams: Record<string, unknown> = {
       caption: htmlCaption,
       ...(htmlCaption ? { parse_mode: "HTML" } : {}),
@@ -498,174 +440,109 @@ async function deliverMediaReply(params: {
         silent: params.silent,
       }),
     };
-    if (isGif) {
-      await deliverAcceptedMedia({
-        operation: "sendAnimation",
-        requestParams: mediaParams,
-        plainCaption,
-        text: plainCaption,
-        send: (effectiveParams) =>
-          params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
-      });
-    } else if (kind === "image") {
+    if (mediaSender.label === "voice") {
+      const sendVoiceMedia = async (
+        requestParams: typeof mediaParams,
+        shouldLog?: (err: unknown) => boolean,
+      ) => {
+        const hasCaption = typeof requestParams.caption === "string";
+        await deliverAcceptedMedia({
+          sender: mediaSender,
+          requestParams,
+          plainCaption: hasCaption ? plainCaption : undefined,
+          text: hasCaption ? plainCaption : undefined,
+          shouldLog,
+        });
+      };
+      const sendVoiceFallbackText = async (
+        text: string,
+        options: { replyToId?: number; includeQuote?: boolean; replyToMode?: ReplyToMode } = {},
+      ) =>
+        await deliverTextReply({
+          bot: params.bot,
+          chatId: params.chatId,
+          runtime: params.runtime,
+          text,
+          chunkText: params.chunkText,
+          replyToId: options.replyToId,
+          ...(options.includeQuote
+            ? {
+                replyQuoteMessageId: params.replyQuoteMessageId,
+                replyQuotePosition: params.replyQuotePosition,
+                replyQuoteEntities: params.replyQuoteEntities,
+                replyQuoteText: params.replyQuoteText,
+              }
+            : {}),
+          thread: params.thread,
+          richMessages: params.richMessages,
+          tableMode: params.tableMode,
+          linkPreview: params.linkPreview,
+          silent: params.silent,
+          replyMarkup: params.replyMarkup,
+          replyToMode: options.replyToMode ?? params.replyToMode,
+          progress: createVoiceFallbackProgress(),
+          quoteOnlyOnFirstChunk: true,
+        });
+
+      await params.onVoiceRecording?.();
       try {
-        await deliverAcceptedMedia({
-          operation: "sendPhoto",
-          requestParams: mediaParams,
-          plainCaption,
-          text: plainCaption,
-          shouldLog: (error) => !isTelegramPhotoLimitError(error),
-          send: (effectiveParams) =>
-            params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
-        });
-      } catch (error) {
-        if (!isTelegramPhotoLimitError(error)) {
-          throw error;
-        }
-        // Let Telegram validate photo limits without decoding image buffers;
-        // retry the same accepted caption, topic, quote, and markup as a file.
-        logVerbose(
-          `telegram sendPhoto exceeded photo limits; retrying as document: ${formatErrorMessage(error)}`,
-        );
-        await deliverAcceptedMedia({
-          operation: "sendDocument",
-          requestParams: mediaParams,
-          plainCaption,
-          text: plainCaption,
-          send: (effectiveParams) =>
-            params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
-        });
-      }
-    } else if (kind === "video") {
-      await deliverAcceptedMedia({
-        operation: "sendVideo",
-        requestParams: mediaParams,
-        plainCaption,
-        text: plainCaption,
-        send: (effectiveParams) =>
-          params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams }),
-      });
-    } else if (kind === "audio") {
-      const { useVoice } = resolveTelegramVoiceSend({
-        wantsVoice: params.reply.audioAsVoice === true,
-        contentType: media.contentType,
-        fileName,
-        logFallback: logVerbose,
-      });
-      if (useVoice) {
-        const sendVoiceMedia = async (
-          requestParams: typeof mediaParams,
-          shouldLog?: (err: unknown) => boolean,
-        ) => {
-          const hasCaption = typeof requestParams.caption === "string";
-          await deliverAcceptedMedia({
-            operation: "sendVoice",
-            requestParams,
-            plainCaption: hasCaption ? plainCaption : undefined,
-            text: hasCaption ? plainCaption : undefined,
-            shouldLog,
-            send: (effectiveParams) =>
-              params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
+        await sendVoiceMedia(mediaParams, (err) => !isVoiceMessagesForbidden(err));
+      } catch (voiceErr) {
+        if (isVoiceMessagesForbidden(voiceErr)) {
+          const fallbackText = resolveVoiceFallbackText(params.reply);
+          if (!fallbackText || !fallbackText.trim()) {
+            throw voiceErr;
+          }
+          logVerbose(
+            "telegram sendVoice forbidden (recipient has voice messages blocked in privacy settings); falling back to text",
+          );
+          const voiceFallbackReplyTo = resolveReplyToForSend({
+            replyToId: params.replyToId,
+            replyToMode: params.replyToMode,
+            progress: params.progress,
           });
-        };
-        await params.onVoiceRecording?.();
-        try {
-          await sendVoiceMedia(mediaParams, (err) => !isVoiceMessagesForbidden(err));
-        } catch (voiceErr) {
-          if (isVoiceMessagesForbidden(voiceErr)) {
-            const fallbackText = resolveVoiceFallbackText(params.reply);
-            if (!fallbackText || !fallbackText.trim()) {
-              throw voiceErr;
-            }
-            logVerbose(
-              "telegram sendVoice forbidden (recipient has voice messages blocked in privacy settings); falling back to text",
-            );
-            const voiceFallbackReplyTo = resolveReplyToForSend({
-              replyToId: params.replyToId,
-              replyToMode: params.replyToMode,
-              progress: params.progress,
-            });
-            const fallbackMessageId = await deliverTextReply({
-              bot: params.bot,
-              chatId: params.chatId,
-              runtime: params.runtime,
-              text: fallbackText,
-              chunkText: params.chunkText,
-              replyToId: voiceFallbackReplyTo,
-              replyQuoteMessageId: params.replyQuoteMessageId,
-              replyQuotePosition: params.replyQuotePosition,
-              replyQuoteEntities: params.replyQuoteEntities,
-              thread: params.thread,
-              richMessages: params.richMessages,
-              tableMode: params.tableMode,
-              linkPreview: params.linkPreview,
-              silent: params.silent,
-              replyMarkup: params.replyMarkup,
-              replyQuoteText: params.replyQuoteText,
-              replyToMode: params.replyToMode,
-              progress: createVoiceFallbackProgress(),
-              quoteOnlyOnFirstChunk: true,
-            });
-            if (firstDeliveredMessageId == null) {
-              firstDeliveredMessageId = fallbackMessageId;
-            }
-            visibleFallbackText = fallbackText;
-            markReplyApplied(params.progress, voiceFallbackReplyTo);
-            markDelivered(params.progress);
-            continue;
-          }
-          if (isCaptionTooLong(voiceErr)) {
-            logVerbose(
-              "telegram sendVoice caption too long; resending voice without caption + text separately",
-            );
-            const noCaptionParams = { ...mediaParams };
-            delete noCaptionParams.caption;
-            delete noCaptionParams.parse_mode;
-            await sendVoiceMedia(noCaptionParams);
-            const fallbackText = resolveVoiceFallbackText(params.reply);
-            if (fallbackText?.trim()) {
-              await deliverTextReply({
-                bot: params.bot,
-                chatId: params.chatId,
-                runtime: params.runtime,
-                text: fallbackText,
-                chunkText: params.chunkText,
-                replyToId: undefined,
-                thread: params.thread,
-                richMessages: params.richMessages,
-                tableMode: params.tableMode,
-                linkPreview: params.linkPreview,
-                silent: params.silent,
-                replyMarkup: params.replyMarkup,
-                replyToMode: "first",
-                progress: createVoiceFallbackProgress(),
-                quoteOnlyOnFirstChunk: true,
-              });
-              visibleFallbackText = fallbackText;
-            }
-            markReplyApplied(params.progress, replyToMessageId);
-            continue;
-          }
-          throw voiceErr;
+          const fallbackMessageId = await sendVoiceFallbackText(fallbackText, {
+            replyToId: voiceFallbackReplyTo,
+            includeQuote: true,
+          });
+          firstDeliveredMessageId ??= fallbackMessageId;
+          visibleFallbackText = fallbackText;
+          markReplyApplied(params.progress, voiceFallbackReplyTo);
+          markDelivered(params.progress);
+          continue;
         }
-      } else {
-        await deliverAcceptedMedia({
-          operation: "sendAudio",
-          requestParams: mediaParams,
-          plainCaption,
-          text: plainCaption,
-          send: (effectiveParams) =>
-            params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams }),
-        });
+        if (isCaptionTooLong(voiceErr)) {
+          logVerbose(
+            "telegram sendVoice caption too long; resending voice without caption + text separately",
+          );
+          const noCaptionParams = { ...mediaParams };
+          delete noCaptionParams.caption;
+          delete noCaptionParams.parse_mode;
+          await sendVoiceMedia(noCaptionParams);
+          const fallbackText = resolveVoiceFallbackText(params.reply);
+          if (fallbackText?.trim()) {
+            await sendVoiceFallbackText(fallbackText, { replyToMode: "first" });
+            visibleFallbackText = fallbackText;
+          }
+          markReplyApplied(params.progress, replyToMessageId);
+          continue;
+        }
+        throw voiceErr;
       }
     } else {
-      await deliverAcceptedMedia({
-        operation: "sendDocument",
-        requestParams: mediaParams,
-        plainCaption,
-        text: plainCaption,
-        send: (effectiveParams) =>
-          params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
+      await sendTelegramOutboundMediaWithPhotoFallback({
+        sender: mediaSender,
+        documentSender,
+        send: (sender) =>
+          deliverAcceptedMedia({
+            sender,
+            requestParams: mediaParams,
+            plainCaption,
+            text: plainCaption,
+            ...(sender.label === "photo"
+              ? { shouldLog: (error: unknown) => !isTelegramPhotoLimitError(error) }
+              : {}),
+          }),
       });
     }
     markReplyApplied(params.progress, replyToMessageId);

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -11,7 +11,6 @@ import {
   buildTelegramSendParams,
   getTelegramNativeQuoteReplyMessageId,
   isTelegramQuoteParamError,
-  removeTelegramNativeQuoteParam,
 } from "../reply-parameters.js";
 import { TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS } from "../retry-after.js";
 import type { TelegramRichBlocksDegradationReason } from "../rich-block-model.js";
@@ -28,6 +27,7 @@ import {
   isTelegramHtmlParseError,
   warnTelegramRichBlocksDegradations,
 } from "../rich-plain-fallback.js";
+import { withTelegramNativeQuoteFallback } from "../send-context.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
@@ -45,48 +45,29 @@ function createTelegramDeliverySendRetry() {
 export async function sendTelegramWithThreadFallback<T>(params: {
   operation: string;
   runtime: RuntimeEnv;
-  thread?: TelegramThreadSpec | null;
   requestParams: Record<string, unknown>;
   send: (effectiveParams: Record<string, unknown>) => Promise<T>;
   removeNativeQuoteParam?: (requestParams: Record<string, unknown>) => Record<string, unknown>;
   shouldLog?: (err: unknown) => boolean;
 }): Promise<T> {
-  const hasNativeQuote = getTelegramNativeQuoteReplyMessageId(params.requestParams) != null;
-  const shouldSuppressFirstErrorLog = (err: unknown) =>
-    hasNativeQuote && isTelegramQuoteParamError(err);
-  const mergedShouldLog = params.shouldLog
-    ? (err: unknown) => params.shouldLog!(err) && !shouldSuppressFirstErrorLog(err)
-    : (err: unknown) => !shouldSuppressFirstErrorLog(err);
   const requestWithRetry = createTelegramDeliverySendRetry();
-  const runLoggedSend = (
-    operation: string,
-    requestParams: Record<string, unknown>,
-    shouldLog?: (err: unknown) => boolean,
-  ) =>
-    withTelegramApiErrorLogging({
-      operation,
-      runtime: params.runtime,
-      ...(shouldLog ? { shouldLog } : {}),
-      fn: () => requestWithRetry(() => params.send(requestParams), operation),
-    });
-
-  try {
-    return await runLoggedSend(params.operation, params.requestParams, mergedShouldLog);
-  } catch (err) {
-    if (hasNativeQuote && isTelegramQuoteParamError(err)) {
-      params.runtime.log?.(
-        `telegram ${params.operation}: native quote rejected; retrying with legacy reply_to_message_id`,
-      );
-      return await sendTelegramWithThreadFallback({
-        ...params,
-        operation: `${params.operation} (legacy reply retry)`,
-        requestParams: (params.removeNativeQuoteParam ?? removeTelegramNativeQuoteParam)(
-          params.requestParams,
-        ),
-      });
-    }
-    throw err;
-  }
+  const { result } = await withTelegramNativeQuoteFallback({
+    label: params.operation,
+    requestParams: params.requestParams,
+    removeNativeQuoteParam: params.removeNativeQuoteParam,
+    request: (requestParams, operation) =>
+      withTelegramApiErrorLogging({
+        operation,
+        runtime: params.runtime,
+        shouldLog: (error) =>
+          (params.shouldLog?.(error) ?? true) &&
+          !(
+            getTelegramNativeQuoteReplyMessageId(requestParams) && isTelegramQuoteParamError(error)
+          ),
+        fn: () => requestWithRetry(() => params.send(requestParams), operation),
+      }),
+  });
+  return result;
 }
 
 export async function sendTelegramText(
@@ -132,7 +113,6 @@ export async function sendTelegramText(
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,
-      thread: opts?.thread,
       requestParams: baseParams,
       send: (effectiveParams) =>
         bot.api.sendMessage(chatId, plainText, {
@@ -176,7 +156,6 @@ export async function sendTelegramText(
       const res = await sendTelegramWithThreadFallback({
         operation: "sendRichMessage",
         runtime,
-        thread: opts.thread,
         requestParams: toTelegramRichMessageContextParams(baseParams),
         removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
         send: (effectiveParams) =>
@@ -214,7 +193,6 @@ export async function sendTelegramText(
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,
-      thread: opts?.thread,
       requestParams: baseParams,
       shouldLog: (err) => {
         const errText = formatErrorMessage(err);

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -1,6 +1,49 @@
+import { InputFile } from "grammy";
+import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
+import { isGifMedia, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import type { loadWebMedia } from "openclaw/plugin-sdk/web-media";
+import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
+import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
+import type { TelegramOutboundPromptContextMessage } from "./outbound-message-context.js";
+import { isTelegramHtmlParseError } from "./rich-plain-fallback.js";
+import type { TelegramApi } from "./send-context.js";
+import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
+import { resolveTelegramVoiceSend } from "./voice.js";
 
-export function resolveTelegramOutboundMediaFilename(params: {
+type TelegramLoadedMedia = Awaited<ReturnType<typeof loadWebMedia>>;
+
+type TelegramOutboundMediaKind =
+  | "animation"
+  | "photo"
+  | "video"
+  | "video_note"
+  | "voice"
+  | "audio"
+  | "document";
+
+type TelegramOutboundMediaPlan = {
+  kind: MediaKind | undefined;
+  deliveryKind: MediaKind | undefined;
+  isGif: boolean;
+  isVideoNote: boolean;
+  fileName: string;
+  file: InputFile;
+  caption?: string;
+  htmlCaption?: string;
+  plainCaption?: string;
+  followUpText?: string;
+};
+
+export type TelegramOutboundMediaSender<T = TelegramOutboundPromptContextMessage> = {
+  label: TelegramOutboundMediaKind;
+  operation: string;
+  send: (effectiveParams: Record<string, unknown>) => Promise<T>;
+};
+
+function resolveTelegramOutboundMediaFilename(params: {
   fileName?: string;
   contentType?: string;
   kind?: MediaKind;
@@ -28,4 +71,180 @@ export function resolveTelegramOutboundMediaFilename(params: {
           ? ".ogg"
           : ".bin";
   return `${basename}${extensionForMime(params.contentType) ?? defaultExtension}`;
+}
+
+export function prepareTelegramOutboundMedia(params: {
+  media: TelegramLoadedMedia;
+  text?: string;
+  textMode?: "markdown" | "html";
+  tableMode?: MarkdownTableMode;
+  forceDocument?: boolean;
+  asVideoNote?: boolean;
+  preparedHtml?: boolean;
+}): TelegramOutboundMediaPlan {
+  const kind = kindFromMime(params.media.contentType ?? undefined);
+  const isGif = isGifMedia({
+    contentType: params.media.contentType,
+    fileName: params.media.fileName,
+  });
+  const deliveryKind =
+    params.forceDocument === true && (kind === "image" || kind === "video") ? "document" : kind;
+  if (params.asVideoNote === true && deliveryKind !== "video") {
+    throw new Error("Telegram video notes require video media.");
+  }
+  const isVideoNote = deliveryKind === "video" && params.asVideoNote === true;
+  const fileName = resolveTelegramOutboundMediaFilename({
+    fileName: params.media.fileName,
+    contentType: params.media.contentType,
+    kind,
+    isGif,
+  });
+  const text = params.text;
+  const trimmedText = text?.trim();
+  const renderedCaption =
+    !isVideoNote && trimmedText
+      ? params.preparedHtml === true && params.textMode === "html"
+        ? trimmedText
+        : renderTelegramHtmlText(trimmedText, {
+            textMode: params.textMode ?? "markdown",
+            tableMode: params.tableMode,
+          })
+      : undefined;
+  const { caption, followUpText } = isVideoNote
+    ? { caption: undefined, followUpText: trimmedText ? text : undefined }
+    : splitTelegramCaption(text, renderedCaption);
+  const htmlCaption = caption ? renderedCaption : undefined;
+
+  return {
+    kind,
+    deliveryKind,
+    isGif,
+    isVideoNote,
+    fileName,
+    file: new InputFile(params.media.buffer, fileName),
+    caption,
+    htmlCaption,
+    plainCaption: resolveTelegramPlainCaption(
+      caption && params.textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption,
+      htmlCaption,
+    ),
+    followUpText,
+  };
+}
+
+export function resolveTelegramOutboundMediaSenders<
+  T = TelegramOutboundPromptContextMessage,
+>(params: {
+  api: TelegramApi;
+  chatId: string;
+  media: TelegramLoadedMedia;
+  plan: TelegramOutboundMediaPlan;
+  forceDocument?: boolean;
+  asVoice?: boolean;
+  sendImageAsPhoto?: boolean;
+}): { sender: TelegramOutboundMediaSender<T>; documentSender: TelegramOutboundMediaSender<T> } {
+  const createSender = (label: TelegramOutboundMediaKind): TelegramOutboundMediaSender<T> => {
+    const operation = `send${label
+      .split("_")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join("")}`;
+    const method = params.api[operation as keyof TelegramApi] as unknown as (
+      chatId: string,
+      file: InputFile,
+      options: Record<string, unknown>,
+    ) => Promise<T>;
+    return {
+      label,
+      operation,
+      send: (effectiveParams) =>
+        method.call(
+          params.api,
+          params.chatId,
+          params.plan.file,
+          label === "document" && params.forceDocument
+            ? { ...effectiveParams, disable_content_type_detection: true }
+            : effectiveParams,
+        ),
+    };
+  };
+  const documentSender = createSender("document");
+  let label: TelegramOutboundMediaKind = "document";
+  if (params.plan.isGif && params.plan.deliveryKind !== "document") {
+    label = "animation";
+  } else if (
+    params.plan.deliveryKind === "image" &&
+    !params.plan.isGif &&
+    params.sendImageAsPhoto !== false
+  ) {
+    label = "photo";
+  } else if (params.plan.deliveryKind === "video") {
+    label = params.plan.isVideoNote ? "video_note" : "video";
+  } else if (params.plan.kind === "audio") {
+    const { useVoice } = resolveTelegramVoiceSend({
+      wantsVoice: params.asVoice === true,
+      contentType: params.media.contentType,
+      fileName: params.plan.fileName,
+      logFallback: logVerbose,
+    });
+    label = useVoice ? "voice" : "audio";
+  }
+  return { sender: label === "document" ? documentSender : createSender(label), documentSender };
+}
+
+export async function sendTelegramCaptionedMediaWithFallback<T>(params: {
+  operation: string;
+  requestParams: Record<string, unknown>;
+  plainCaption?: string;
+  shouldLog?: (err: unknown) => boolean;
+  send: (
+    requestParams: Record<string, unknown>,
+    shouldLog?: (err: unknown) => boolean,
+  ) => Promise<T>;
+}): Promise<T> {
+  if (!params.plainCaption) {
+    return await params.send(params.requestParams, params.shouldLog);
+  }
+  try {
+    return await params.send(
+      params.requestParams,
+      (err) => !isTelegramHtmlParseError(err) && (params.shouldLog?.(err) ?? true),
+    );
+  } catch (err) {
+    if (!isTelegramHtmlParseError(err)) {
+      throw err;
+    }
+    // Captions share the text-send contract: retain visible content after an
+    // HTML parse failure without disturbing the topic, quote, or keyboard.
+    logVerbose(
+      `telegram ${params.operation} caption HTML rejected; retrying as plain caption: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+    const plainParams: Record<string, unknown> = {
+      ...params.requestParams,
+      caption: params.plainCaption,
+    };
+    delete plainParams.parse_mode;
+    return await params.send(plainParams, params.shouldLog);
+  }
+}
+
+export async function sendTelegramOutboundMediaWithPhotoFallback<T, TMessage>(params: {
+  sender: TelegramOutboundMediaSender<TMessage>;
+  documentSender: TelegramOutboundMediaSender<TMessage>;
+  send: (sender: TelegramOutboundMediaSender<TMessage>) => Promise<T>;
+}): Promise<{ result: T; sender: TelegramOutboundMediaSender<TMessage> }> {
+  try {
+    return { result: await params.send(params.sender), sender: params.sender };
+  } catch (error) {
+    if (params.sender.label !== "photo" || !isTelegramPhotoLimitError(error)) {
+      throw error;
+    }
+    // Telegram is authoritative for photo limits; preserve the same bytes and
+    // accepted caption/topic/quote/keyboard when retrying as a document.
+    logVerbose(
+      `telegram sendPhoto exceeded photo limits; retrying as document: ${formatErrorMessage(error)}`,
+    );
+    return { result: await params.send(params.documentSender), sender: params.documentSender };
+  }
 }

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -214,17 +214,85 @@ export function createTelegramTextSender(config: {
       : undefined;
   };
 
+  const createTextDelivery = (context: string) => {
+    let lastMessageId = "";
+    let lastChatId = chatId;
+    let lastAcceptedParams:
+      | TelegramThreadScopedParams
+      | TelegramRichMessageContextParams
+      | undefined;
+    let acceptedReplyToMessageId: number | undefined;
+    const messageIds: string[] = [];
+    let sentChunkCount = 0;
+
+    const record = async (params: {
+      result: TelegramMessageLike;
+      acceptedParams?: TelegramThreadScopedParams | TelegramRichMessageContextParams;
+      plainText: string;
+      finalPart: boolean;
+      hasInlineKeyboard: boolean;
+    }) => {
+      const messageId = resolveTelegramMessageIdOrThrow(params.result, context);
+      recordSentMessage(chatId, messageId, cfg);
+      await reportDelivery(messageId, params.result?.chat?.id ?? chatId, {
+        telegramDeliveredText: params.plainText,
+        telegramHasInlineKeyboard: params.hasInlineKeyboard,
+      });
+      await recordDeliveredPromptContext(
+        {
+          message: params.result,
+          messageId,
+          text: params.plainText,
+          ...(params.acceptedParams?.message_thread_id !== undefined
+            ? { messageThreadId: params.acceptedParams.message_thread_id }
+            : {}),
+        },
+        params.finalPart,
+      );
+      lastMessageId = String(messageId);
+      lastChatId = String(params.result?.chat?.id ?? chatId);
+      lastAcceptedParams = params.acceptedParams;
+      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(params.acceptedParams);
+      messageIds.push(lastMessageId);
+      sentChunkCount += 1;
+    };
+
+    const finish = (operation: string): TelegramSendResult => {
+      if (lastMessageId) {
+        logTelegramOutboundSendOk({
+          accountId: account.accountId,
+          chatId: lastChatId,
+          messageId: lastMessageId,
+          operation,
+          deliveryKind: "text",
+          messageThreadId: lastAcceptedParams?.message_thread_id,
+          replyToMessageId: opts.replyToMessageId,
+          silent: opts.silent,
+          chunkCount: sentChunkCount,
+        });
+      }
+      const receipt = buildTelegramTextSendReceipt({
+        messageIds,
+        chatId: lastChatId,
+        messageThreadId: lastAcceptedParams?.message_thread_id,
+        replyToMessageId: acceptedReplyToMessageId,
+      });
+      return {
+        messageId: lastMessageId,
+        chatId: lastChatId,
+        ...(receipt ? { receipt } : {}),
+      };
+    };
+
+    return { record, finish };
+  };
+
   const sendTelegramTextChunks = async (
     chunks: TelegramTextChunk[],
     context: string,
     options: { replyToAlreadyUsed?: boolean } = {},
   ): Promise<TelegramSendResult> => {
-    let lastMessageId = "";
-    let lastChatId = chatId;
-    let lastAcceptedParams: TelegramThreadScopedParams | undefined;
-    let acceptedReplyToMessageId: number | undefined;
-    const messageIds: string[] = [];
-    let sentChunkCount = 0;
+    const delivery = createTextDelivery(context);
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index];
       if (!chunk) {
@@ -239,54 +307,16 @@ export function createTelegramTextSender(config: {
           options.replyToAlreadyUsed === true,
         ),
       );
-      const messageId = resolveTelegramMessageIdOrThrow(res, context);
-      recordSentMessage(chatId, messageId, cfg);
-      await reportDelivery(messageId, res?.chat?.id ?? chatId, {
-        telegramDeliveredText: chunk.plainText,
-        telegramHasInlineKeyboard: index === chunks.length - 1 && Boolean(replyMarkup),
-      });
-      await recordDeliveredPromptContext(
-        {
-          message: res,
-          messageId,
-          text: chunk.plainText,
-          ...(acceptedParams?.message_thread_id !== undefined
-            ? { messageThreadId: acceptedParams.message_thread_id }
-            : {}),
-        },
-        index === chunks.length - 1,
-      );
-      lastMessageId = String(messageId);
-      lastChatId = String(res?.chat?.id ?? chatId);
-      lastAcceptedParams = acceptedParams;
-      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(acceptedParams);
-      messageIds.push(lastMessageId);
-      sentChunkCount += 1;
-    }
-    if (lastMessageId) {
-      logTelegramOutboundSendOk({
-        accountId: account.accountId,
-        chatId: lastChatId,
-        messageId: lastMessageId,
-        operation: "sendMessage",
-        deliveryKind: "text",
-        messageThreadId: lastAcceptedParams?.message_thread_id,
-        replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
-        chunkCount: sentChunkCount,
+      const finalPart = index === chunks.length - 1;
+      await delivery.record({
+        result: res,
+        acceptedParams,
+        plainText: chunk.plainText,
+        finalPart,
+        hasInlineKeyboard: finalPart && Boolean(replyMarkup),
       });
     }
-    const receipt = buildTelegramTextSendReceipt({
-      messageIds,
-      chatId: lastChatId,
-      messageThreadId: lastAcceptedParams?.message_thread_id,
-      replyToMessageId: acceptedReplyToMessageId,
-    });
-    return {
-      messageId: lastMessageId,
-      chatId: lastChatId,
-      ...(receipt ? { receipt } : {}),
-    };
+    return delivery.finish("sendMessage");
   };
 
   const buildChunkedTextPlan = (rawText: string, context: string): TelegramTextChunk[] => {
@@ -360,15 +390,7 @@ export function createTelegramTextSender(config: {
     options: { replyToAlreadyUsed?: boolean } = {},
   ): Promise<TelegramSendResult> => {
     const richRawApi = getTelegramRichRawApi(api);
-    let lastMessageId = "";
-    let lastChatId = chatId;
-    let lastAcceptedParams:
-      | TelegramThreadScopedParams
-      | TelegramRichMessageContextParams
-      | undefined;
-    let acceptedReplyToMessageId: number | undefined;
-    const messageIds: string[] = [];
-    let sentChunkCount = 0;
+    const delivery = createTextDelivery(context);
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index];
       if (!chunk) {
@@ -437,83 +459,28 @@ export function createTelegramTextSender(config: {
             { plainText: fallbackText },
             fallbackParams,
           );
-          const fallbackMessageId = resolveTelegramMessageIdOrThrow(plainResult.result, context);
-          recordSentMessage(chatId, fallbackMessageId, cfg);
-          await reportDelivery(fallbackMessageId, plainResult.result?.chat?.id ?? chatId, {
-            telegramDeliveredText: fallbackText,
-            telegramHasInlineKeyboard:
-              index === chunks.length - 1 &&
-              fallbackIndex === fallbackChunks.length - 1 &&
-              Boolean(replyMarkup),
+          const finalPart =
+            index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
+          await delivery.record({
+            result: plainResult.result,
+            acceptedParams: plainResult.acceptedParams,
+            plainText: fallbackText,
+            finalPart,
+            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
           });
-          await recordDeliveredPromptContext(
-            {
-              message: plainResult.result,
-              messageId: fallbackMessageId,
-              text: fallbackText,
-              ...(plainResult.acceptedParams?.message_thread_id !== undefined
-                ? { messageThreadId: plainResult.acceptedParams.message_thread_id }
-                : {}),
-            },
-            index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
-          );
-          lastMessageId = String(fallbackMessageId);
-          lastChatId = String(plainResult.result?.chat?.id ?? chatId);
-          lastAcceptedParams = plainResult.acceptedParams;
-          acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(plainResult.acceptedParams);
-          messageIds.push(lastMessageId);
-          sentChunkCount += 1;
         }
         continue;
       }
-      const messageId = resolveTelegramMessageIdOrThrow(result, context);
-      recordSentMessage(chatId, messageId, cfg);
-      await reportDelivery(messageId, result?.chat?.id ?? chatId, {
-        telegramDeliveredText: chunk.plainText,
-        telegramHasInlineKeyboard: index === chunks.length - 1 && Boolean(replyMarkup),
-      });
-      await recordDeliveredPromptContext(
-        {
-          message: result,
-          messageId,
-          text: chunk.plainText,
-          ...(recordedParams?.message_thread_id !== undefined
-            ? { messageThreadId: recordedParams.message_thread_id }
-            : {}),
-        },
-        index === chunks.length - 1,
-      );
-      lastMessageId = String(messageId);
-      lastChatId = String(result?.chat?.id ?? chatId);
-      lastAcceptedParams = recordedParams;
-      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(recordedParams);
-      messageIds.push(lastMessageId);
-      sentChunkCount += 1;
-    }
-    if (lastMessageId) {
-      logTelegramOutboundSendOk({
-        accountId: account.accountId,
-        chatId: lastChatId,
-        messageId: lastMessageId,
-        operation: "sendRichMessage",
-        deliveryKind: "text",
-        messageThreadId: lastAcceptedParams?.message_thread_id,
-        replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
-        chunkCount: sentChunkCount,
+      const finalPart = index === chunks.length - 1;
+      await delivery.record({
+        result,
+        acceptedParams: recordedParams,
+        plainText: chunk.plainText,
+        finalPart,
+        hasInlineKeyboard: finalPart && Boolean(replyMarkup),
       });
     }
-    const receipt = buildTelegramTextSendReceipt({
-      messageIds,
-      chatId: lastChatId,
-      messageThreadId: lastAcceptedParams?.message_thread_id,
-      replyToMessageId: acceptedReplyToMessageId,
-    });
-    return {
-      messageId: lastMessageId,
-      chatId: lastChatId,
-      ...(receipt ? { receipt } : {}),
-    };
+    return delivery.finish("sendRichMessage");
   };
 
   return { sendChunkedText };

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -1,12 +1,14 @@
-import * as grammy from "grammy";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
-import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
-import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
+import { renderTelegramHtmlText } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
-import { resolveTelegramOutboundMediaFilename } from "./outbound-media.js";
+import {
+  prepareTelegramOutboundMedia,
+  resolveTelegramOutboundMediaSenders,
+  sendTelegramCaptionedMediaWithFallback,
+  sendTelegramOutboundMediaWithPhotoFallback,
+} from "./outbound-media.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from "./outbound-message-context.js";
 import {
@@ -24,10 +26,8 @@ import {
   sendLogger,
   toAcceptedThreadScopedParams,
   withTelegramApiContextLease,
-  withTelegramHtmlParseFallback,
   withTelegramNativeQuoteFallback,
   type TelegramApiContext,
-  type TelegramThreadScopedParams,
 } from "./send-context.js";
 import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
@@ -35,8 +35,6 @@ import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
-  isGifMedia,
-  kindFromMime,
   loadWebMedia,
   probeVideoDimensions,
   resolveMarkdownTableMode,
@@ -44,9 +42,7 @@ import {
 import { recordSentMessage } from "./sent-message-cache.js";
 import { parseTelegramTarget } from "./targets.js";
 import { resolveTelegramBotUserIdFromToken } from "./token.js";
-import { resolveTelegramVoiceSend } from "./voice.js";
 
-const InputFileCtor = grammy.InputFile;
 const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
 const MAX_TELEGRAM_PHOTO_ASPECT_RATIO = 20;
 
@@ -232,48 +228,28 @@ async function sendMessageTelegramWithContext(
         optimizeImages: opts.forceDocument ? false : undefined,
       }),
     );
-    const kind = kindFromMime(media.contentType ?? undefined);
-    const isGif = isGifMedia({
-      contentType: media.contentType,
-      fileName: media.fileName,
+    const mediaPlan = prepareTelegramOutboundMedia({
+      media,
+      text,
+      textMode,
+      tableMode,
+      forceDocument: opts.forceDocument,
+      asVideoNote: opts.asVideoNote,
     });
-
-    let sendImageAsPhoto = true;
-    const deliveryKind =
-      opts.forceDocument === true && (kind === "image" || kind === "video") ? "document" : kind;
-    if (opts.asVideoNote === true && deliveryKind !== "video") {
-      throw new Error("Telegram video notes require video media.");
-    }
-    if (deliveryKind === "image" && !isGif) {
-      sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
-    }
-    const isVideoNote = deliveryKind === "video" && opts.asVideoNote === true;
-    const fileName = resolveTelegramOutboundMediaFilename({
-      fileName: media.fileName,
-      contentType: media.contentType,
-      kind,
-      isGif,
+    const sendImageAsPhoto =
+      mediaPlan.deliveryKind !== "image" ||
+      mediaPlan.isGif ||
+      (await shouldSendTelegramImageAsPhoto(media.buffer));
+    const { sender: mediaSender, documentSender } = resolveTelegramOutboundMediaSenders({
+      api,
+      chatId,
+      media,
+      plan: mediaPlan,
+      forceDocument: opts.forceDocument,
+      asVoice: opts.asVoice,
+      sendImageAsPhoto,
     });
-    const file = new InputFileCtor(media.buffer, fileName);
-    let caption: string | undefined;
-    let htmlCaption: string | undefined;
-    let followUpText: string | undefined;
-
-    if (isVideoNote) {
-      caption = undefined;
-      followUpText = text.trim() ? text : undefined;
-    } else {
-      const trimmedText = text.trim();
-      const renderedCaption = trimmedText ? renderHtmlText(trimmedText) : undefined;
-      const split = splitTelegramCaption(text, renderedCaption);
-      caption = split.caption;
-      followUpText = split.followUpText;
-      htmlCaption = caption ? renderedCaption : undefined;
-    }
-    const plainCaption = resolveTelegramPlainCaption(
-      caption && textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption,
-      htmlCaption,
-    );
+    const { caption, htmlCaption, plainCaption, followUpText } = mediaPlan;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);
@@ -286,7 +262,7 @@ async function sendMessageTelegramWithContext(
       ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
     };
     const videoDimensions =
-      deliveryKind === "video" && !isVideoNote
+      mediaPlan.deliveryKind === "video" && !mediaPlan.isVideoNote
         ? await probeVideoDimensions(media.buffer)
         : undefined;
     const mediaParams = {
@@ -295,148 +271,41 @@ async function sendMessageTelegramWithContext(
       ...(opts.silent === true ? { disable_notification: true } : {}),
       ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
     };
-    const plainMediaParams = {
-      ...(plainCaption ? { caption: plainCaption } : {}),
-      ...baseMediaParams,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
-      ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
-    };
     const sendMedia = async (
       label: string,
-      sender: (
-        effectiveParams: TelegramThreadScopedParams | undefined,
-      ) => Promise<TelegramMessageLike>,
+      sender: (effectiveParams: Record<string, unknown>) => Promise<TelegramMessageLike>,
     ) => {
-      const requestMedia = (requestParams: TelegramThreadScopedParams, retryLabel: string) =>
-        withTelegramNativeQuoteFallback({
-          label: retryLabel,
-          requestParams,
-          request: (effectiveParams, effectiveLabel) =>
-            requestWithChatNotFound(
-              () => sender(effectiveParams as TelegramThreadScopedParams),
-              effectiveLabel,
-              label === "photo"
-                ? { shouldLog: (error) => !isTelegramPhotoLimitError(error) }
-                : undefined,
-            ),
-        });
-      if (!htmlCaption || !plainCaption) {
-        return await requestMedia(mediaParams, label);
-      }
-      // Same contract as text sends: Telegram HTML parse failures retry once
-      // with the already visible plain caption so final media replies survive.
-      return await withTelegramHtmlParseFallback({
-        label,
-        verbose: opts.verbose,
-        requestHtml: (retryLabel) => requestMedia(mediaParams, retryLabel),
-        requestPlain: (retryLabel) => requestMedia(plainMediaParams, retryLabel),
+      return await sendTelegramCaptionedMediaWithFallback({
+        operation: label,
+        requestParams: mediaParams,
+        plainCaption: htmlCaption ? plainCaption : undefined,
+        ...(label === "photo"
+          ? { shouldLog: (error: unknown) => !isTelegramPhotoLimitError(error) }
+          : {}),
+        send: (requestParams, shouldLog) =>
+          withTelegramNativeQuoteFallback({
+            label,
+            requestParams,
+            request: (effectiveParams, effectiveLabel) =>
+              requestWithChatNotFound(
+                () => sender(effectiveParams),
+                effectiveLabel,
+                shouldLog ? { shouldLog } : undefined,
+              ),
+          }),
       });
     };
 
-    const documentSender = {
-      label: "document",
-      sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-        api.sendDocument(
-          chatId,
-          file,
-          (opts.forceDocument
-            ? { ...effectiveParams, disable_content_type_detection: true }
-            : effectiveParams) as Parameters<typeof api.sendDocument>[2],
-        ) as Promise<TelegramMessageLike>,
-    };
-    const mediaSender = (() => {
-      if (isGif && deliveryKind !== "document") {
-        return {
-          label: "animation",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-            api.sendAnimation(
-              chatId,
-              file,
-              effectiveParams as Parameters<typeof api.sendAnimation>[2],
-            ) as Promise<TelegramMessageLike>,
-        };
-      }
-      if (deliveryKind === "image" && !isGif && sendImageAsPhoto) {
-        return {
-          label: "photo",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-            api.sendPhoto(
-              chatId,
-              file,
-              effectiveParams as Parameters<typeof api.sendPhoto>[2],
-            ) as Promise<TelegramMessageLike>,
-        };
-      }
-      if (deliveryKind === "video") {
-        if (isVideoNote) {
-          return {
-            label: "video_note",
-            sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-              api.sendVideoNote(
-                chatId,
-                file,
-                effectiveParams as Parameters<typeof api.sendVideoNote>[2],
-              ) as Promise<TelegramMessageLike>,
-          };
-        }
-        return {
-          label: "video",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-            api.sendVideo(
-              chatId,
-              file,
-              effectiveParams as Parameters<typeof api.sendVideo>[2],
-            ) as Promise<TelegramMessageLike>,
-        };
-      }
-      if (kind === "audio") {
-        const { useVoice } = resolveTelegramVoiceSend({
-          wantsVoice: opts.asVoice === true, // default false (backward compatible)
-          contentType: media.contentType,
-          fileName,
-          logFallback: logVerbose,
-        });
-        if (useVoice) {
-          return {
-            label: "voice",
-            sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-              api.sendVoice(
-                chatId,
-                file,
-                effectiveParams as Parameters<typeof api.sendVoice>[2],
-              ) as Promise<TelegramMessageLike>,
-          };
-        }
-        return {
-          label: "audio",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
-            api.sendAudio(
-              chatId,
-              file,
-              effectiveParams as Parameters<typeof api.sendAudio>[2],
-            ) as Promise<TelegramMessageLike>,
-        };
-      }
-      return documentSender;
-    })();
-
-    let deliveredMediaSender = mediaSender;
     let mediaDelivery: Awaited<ReturnType<typeof sendMedia>>;
+    let deliveredMediaSender: typeof mediaSender;
     try {
-      try {
-        mediaDelivery = await sendMedia(mediaSender.label, mediaSender.sender);
-      } catch (error) {
-        if (mediaSender.label !== "photo" || !isTelegramPhotoLimitError(error)) {
-          throw error;
-        }
-        // The provider is authoritative for photo size/dimensions; keep the
-        // same bytes, caption, quote, keyboard, and topic when retrying as a file.
-        logVerbose(
-          `telegram sendPhoto exceeded photo limits; retrying as document: ${formatErrorMessage(error)}`,
-        );
-        deliveredMediaSender = documentSender;
-        mediaDelivery = await sendMedia(documentSender.label, documentSender.sender);
-      }
+      const delivery = await sendTelegramOutboundMediaWithPhotoFallback({
+        sender: mediaSender,
+        documentSender,
+        send: (sender) => sendMedia(sender.label, sender.send),
+      });
+      mediaDelivery = delivery.result;
+      deliveredMediaSender = delivery.sender;
     } catch (error) {
       opts.promptContextProjectionPlan?.cursor.invalidate();
       throw error;
@@ -465,10 +334,7 @@ async function sendMessageTelegramWithContext(
       accountId: account.accountId,
       chatId: resolvedChatId,
       messageId: String(mediaMessageId),
-      operation: `send${deliveredMediaSender.label
-        .split("_")
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-        .join("")}`,
+      operation: deliveredMediaSender.operation,
       deliveryKind: deliveredMediaSender.label,
       messageThreadId: acceptedMediaParams?.message_thread_id,
       replyToMessageId: opts.replyToMessageId,

--- a/extensions/telegram/src/send.runtime.ts
+++ b/extensions/telegram/src/send.runtime.ts
@@ -6,8 +6,6 @@ export type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 export {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
-  isGifMedia,
-  kindFromMime,
   normalizePollInput,
   probeVideoDimensions,
 } from "openclaw/plugin-sdk/media-runtime";

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -2,8 +2,6 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   buildOutboundMediaLoadOptions,
-  isGifMedia,
-  kindFromMime,
   normalizePollInput,
 } from "openclaw/plugin-sdk/media-runtime";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -193,8 +191,6 @@ vi.mock("openclaw/plugin-sdk/plugin-config-runtime", async () => {
 vi.mock("./send.runtime.js", () => ({
   buildOutboundMediaLoadOptions,
   getImageMetadata: vi.fn(async () => ({ ...imageMetadata })),
-  isGifMedia,
-  kindFromMime,
   loadConfig,
   loadWebMedia,
   normalizePollInput,


### PR DESCRIPTION
## What Problem This Solves

Telegram agent replies and explicit outbound sends maintained separate media classification, caption rendering, quote recovery, and photo fallback paths. The duplicate paths made normal Telegram behavior harder to keep consistent across both delivery surfaces.

## Why This Change Was Made

Move MIME-aware media preparation, sender selection, HTML-caption fallback, and Telegram photo-to-document fallback into the existing Telegram-owned outbound media helper. Reuse the canonical native-quote recovery owner and share rich/plain text receipt and prompt-context accounting. Remove the now-dead runtime exports and test mocks.

## User Impact

No intended user-visible behavior changes. Text, rich messages, captions, voice privacy fallbacks, inline keyboards, reply quotes, forum topics, DM topics, media filenames, delivery receipts, and retry behavior remain covered on both Telegram send surfaces.

## Evidence

### Real Telegram transport / ephemeral gateway proof

The real Telegram plugin ran against the existing Crabline mock Telegram Bot API, a mock OpenAI provider, and an ephemeral OpenClaw gateway on the exact reviewed head.

Command:

```text
OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario channel-message-flows --channel-driver crabline --channel telegram
```

Observed execution:

```text
[qa-suite] run start: scenarios=1 concurrency=1 transport=qa-channel channelDriver=crabline channel=telegram
[qa-suite] lab ready: http://127.0.0.1:44969
[qa-suite] provider start: mock-openai
[qa-suite] provider ready: http://127.0.0.1:44073
[qa-suite] gateway ready: http://127.0.0.1:34845
[qa-suite] scenario start (1/1): channel-message-flows
[qa-suite] scenario pass (1/1): channel-message-flows
[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
```

Verdict:

```json
{"verdict":"pass","head":"9fb7f05061b70d01930b9f17a1f01cb0856c0cb7","channel":"telegram","driver":"crabline","provider":"mock-openai","gateway":"ephemeral","scenario":"channel-message-flows","passed":1,"failed":0,"minimumPreviewEvents":1,"expectedFinalMarker":"QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890"}
```

Remote proof run: https://github.com/openclaw/openclaw/actions/runs/30672962017

### Additional validation

- Exact-head required GitHub CI passed: https://github.com/openclaw/openclaw/actions/runs/30672473469
- Focused remote Telegram proof: 280/280 tests passed across durable send and streaming reply delivery: https://github.com/openclaw/openclaw/actions/runs/30672106188
- Full remote changed gate passed, including production and test TypeScript, formatting, lint, dead exports, plugin boundaries, database-first guards, and import cycles: https://github.com/openclaw/openclaw/actions/runs/30672105896
- Structured autoreview: clean, no accepted or actionable findings.
- Production delta: +523/-618 (-95 LOC); test-support delta: -4 LOC; total: +523/-622 (-99 LOC).
- grammY 1.45.1 API ownership verified directly against the upstream sendMessage/sendPhoto/sendDocument/sendVideo/sendVoice/sendAudio/sendAnimation implementations.