### PR TITLE
refactor(ui): make sessions and navigation reliable across reconnects

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -974,13 +974,11 @@ src/wizard/setup.test.ts
 src/worker/worker.runtime.test.ts
 ui/src/api/gateway.node.test.ts
 ui/src/api/types.ts
-ui/src/app/app-host.ts
 ui/src/lib/config/index.test.ts
 ui/src/lib/config/index.ts
 ui/src/lib/cron/index.test.ts
 ui/src/lib/cron/index.ts
 ui/src/lib/nodes/index.ts
-ui/src/lib/sessions/index.ts
 ui/src/lib/skills/index.test.ts
 ui/src/lib/workboard/index.test.ts
 ui/src/pages/agents/agents-page.ts

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1,144 +1,81 @@
-import { ContextProvider } from "@lit/context";
-import type { UiCommandParams } from "@openclaw/gateway-protocol";
-import { html, nothing } from "lit";
 import { property, query, state } from "lit/decorators.js";
-import {
-  type GatewayEventFrame,
-  hasStoredGatewayAuth,
-  type GatewayBrowserClient,
-} from "../api/gateway.ts";
-import type { GatewayAgentRow } from "../api/types.ts";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
 import "../components/app-topbar.ts";
-import "../components/gateway-url-confirmation.ts";
-import "../components/github-link-hovercard-registration.ts";
-import "../components/login-gate.ts";
 import "../components/macos-titlebar-controls.ts";
 import "../components/modal-dialog.ts";
-import {
-  formatDocumentTitle,
-  isSettingsNavigationRoute,
-  titleForRoute,
-} from "../app-navigation.ts";
+import { formatDocumentTitle, titleForRoute } from "../app-navigation.ts";
 import "../components/onboarding-memory-import.ts";
-import "../components/openclaw-mascot.ts";
 import "../components/resizable-divider.ts";
 import "../components/sidebar-update-card.ts";
-import "../components/tooltip.ts";
 import "../components/update-banner.ts";
-import { isSessionRouteId, workboardBoardIdFromPath } from "../app-route-paths.ts";
-import { APP_ROUTE_IDS, isRouteId, routeIdFromPath, type RouteId } from "../app-routes.ts";
+import { isSessionRouteId } from "../app-route-paths.ts";
+import { APP_ROUTE_IDS, type RouteId } from "../app-routes.ts";
 import {
   EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT,
   type SidebarWorkboardRenderers,
   type SidebarWorkboardRuntime,
   type SidebarWorkboardRuntimeFactory,
 } from "../components/app-sidebar-workboard.ts";
-import {
-  COMMAND_PALETTE_OPEN_EVENT,
-  COMMAND_PALETTE_TARGET_EVENT,
-  isCommandPaletteShortcut,
-  SHELL_NAV_DRAWER_TOGGLE_EVENT,
-  type CommandPaletteElement,
-  type CommandPaletteTargetDetail,
-  type ShellNavDrawerToggleDetail,
+import type {
+  CommandPaletteElement,
+  CommandPaletteTargetDetail,
 } from "../components/command-palette-contract.ts";
-import { icons } from "../components/icons.ts";
-import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
-import {
-  BROWSER_PANEL_TOGGLE_EVENT,
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
-  isTerminalPanelShortcut,
-  TERMINAL_PANEL_TOGGLE_EVENT,
-  UI_COMMAND_EVENT,
-  type PanelToggleElement,
-} from "../components/panel-toggle-contract.ts";
-import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
 import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
-import { i18n, isSupportedLocale, t } from "../i18n/index.ts";
+import { i18n, t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
-import { copyToClipboard } from "../lib/clipboard.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
-import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import {
-  findUiSessionRow,
-  resolveSessionPreferredFaceForKey,
-  resolveSessionNavigationAgentId,
-  sessionNavigationTarget,
-} from "../lib/sessions/route-navigation.ts";
-import {
-  buildAgentMainSessionKey,
   isUiGlobalSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiKnownSelectedGlobalAgentId,
-  uiSessionEventMatches,
 } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import type { ChatPage } from "../pages/chat/chat-page.ts";
-import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
-import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
-import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
-import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
-import { selectApplicationSession } from "./agent-selection.ts";
+import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectShellRouteState, type ShellRouteState } from "./app-host-route-state.ts";
-import { findInlineApproval } from "./approval-presentation.ts";
-import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
+import { OpenClawApp } from "./app-root.ts";
 import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationNavigationOptions,
-} from "./context.ts";
-import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
+  isBrowserPanelAvailable,
+  ShellChromeOwner,
+  type ShellChromeHost,
+} from "./app-shell-chrome.ts";
 import {
-  APPROVAL_PAGE_ELEMENT,
+  ShellGatewayOwner,
+  type OutboxStoreRuntime,
+  type ShellGatewayHost,
+  type StoredOutboxScopeHost,
+} from "./app-shell-gateway.ts";
+import { ShellNavigationOwner, type ShellNavigationHost } from "./app-shell-navigation.ts";
+import { renderApplicationShell, type ShellViewHost } from "./app-shell-view.ts";
+import { ShellWorkboardOwner, type ShellWorkboardHost } from "./app-shell-workboard.ts";
+import type { ApplicationRuntime } from "./bootstrap.ts";
+import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
+import {
   BROWSER_PANEL_ELEMENT,
   COMMAND_PALETTE_ELEMENT,
   CUSTODIAN_PANEL_ELEMENT,
   EXEC_APPROVAL_ELEMENT,
-  ensureOptionalElementForHost,
-  isOptionalElementDefined,
   preloadOptionalElement,
   TERMINAL_PANEL_ELEMENT,
-  type OptionalCustomElement,
 } from "./lazy-custom-element.ts";
-import { isMobileNavLayout, shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import { postNativeNavState, type NativeNavState } from "./native-nav-state.ts";
-import { considerRouteRestore, persistRoute } from "./native-route-memory.ts";
-import {
-  isNativeWebChromeHost,
-  NATIVE_HISTORY_STATE_EVENT,
-  readNativeHistoryState,
-  type NativeHistoryState,
-} from "./native-web-chrome.ts";
-import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
+import { readNativeHistoryState, type NativeHistoryState } from "./native-web-chrome.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
-import { hasOperatorAdminAccess, readGatewayOperatorAccess } from "./operator-access.ts";
-import { controlUiPublicAssetPath } from "./public-assets.ts";
 import {
-  applyServerUiPrefs,
   changedServerUiPrefs,
-  flushServerUiPrefs,
   isApplyingServerUiPrefs,
   pushServerUiPrefs,
-  resetServerUiPrefsSync,
-  resolveServerUiPrefState,
 } from "./server-prefs.ts";
-import {
-  NAV_WIDTH_MAX,
-  NAV_WIDTH_MIN,
-  loadSettings,
-  normalizeCatalogOpenTarget,
-  setSettingsChangeListener,
-} from "./settings.ts";
+import { setSettingsChangeListener } from "./settings.ts";
 import { isStaleChunkImportError, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
-import { resolveControlUiRefreshRequiredBanner } from "./update-overlay-helpers.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
@@ -147,11 +84,6 @@ type AppSidebarElement = HTMLElement & {
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
 const ROUTE_IDS_WITHOUT_WORKBOARD = APP_ROUTE_IDS.filter((routeId) => routeId !== "workboard");
-const AGENT_ROSTER_REFRESH_DEBOUNCE_MS = 100;
-const EMPTY_OUTBOX_COUNT_FOR_SESSION = () => 0;
-const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
-  ? "⌘K"
-  : "Ctrl K";
 
 i18n.setLocaleLoadRecovery({
   isUnrecoverableError: isStaleChunkImportError,
@@ -162,45 +94,6 @@ i18n.setLocaleLoadRecovery({
     void scheduleStaleChunkReload();
   },
 });
-
-type StoredOutboxScopeHost = {
-  settings: { gatewayUrl?: string | null };
-  assistantAgentId?: string | null;
-  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
-  hello?: { snapshot?: unknown } | null;
-};
-
-type OutboxStoreRuntime = {
-  summarizeStoredChatOutboxes: (state: StoredOutboxScopeHost) => {
-    countsByScope: ReadonlyMap<string, number>;
-    total: number;
-  };
-  resolveStoredChatOutboxScope: (
-    state: StoredOutboxScopeHost,
-    sessionKey: string,
-  ) => { sessionKey: string; agentId?: string };
-  storedChatOutboxScopeKey: (scope: { sessionKey: string; agentId?: string }) => string;
-  subscribeStoredChatOutboxChanges: (listener: () => void) => () => void;
-};
-
-function diffAgentRoster(
-  previous: readonly GatewayAgentRow[],
-  next: readonly GatewayAgentRow[],
-): { invalidatedIds: string[]; changedIds: string[] } {
-  const nextById = new Map(next.map((agent) => [agent.id, agent]));
-  const invalidatedIds: string[] = [];
-  const changedIds: string[] = [];
-  for (const agent of previous) {
-    const replacement = nextById.get(agent.id);
-    if (!replacement) {
-      invalidatedIds.push(agent.id);
-    } else if (JSON.stringify(replacement) !== JSON.stringify(agent)) {
-      invalidatedIds.push(agent.id);
-      changedIds.push(agent.id);
-    }
-  }
-  return { invalidatedIds, changedIds };
-}
 
 function equalShellRouteState(previous: ShellRouteState, next: ShellRouteState): boolean {
   return (
@@ -216,385 +109,88 @@ function equalShellRouteState(previous: ShellRouteState, next: ShellRouteState):
   );
 }
 
-/**
- * Terminal-only document mode (`?view=terminal`): the mobile apps embed the
- * terminal as a full-screen WebView page instead of the whole Control UI.
- * Fixed per document load — the apps construct the URL, users never toggle it.
- */
-function isTerminalOnlyView(): boolean {
-  return new URLSearchParams(globalThis.location?.search ?? "").get("view") === "terminal";
-}
-
-function resolveTerminalThemeMode(): "dark" | "light" {
-  return document.documentElement.dataset.themeMode === "light" ? "light" : "dark";
-}
-
-function renderConnectingSplash() {
-  return html`
-    <main class="connect-splash" role="status" aria-live="polite" aria-label=${t("common.loading")}>
-      <openclaw-mascot mood="thinking" .size=${120}></openclaw-mascot>
-    </main>
-  `;
-}
-
-function renderApprovalDocument(runtime: ApplicationRuntime) {
-  const documentMode = runtime.documentMode;
-  if (documentMode?.kind !== "approval") {
-    return nothing;
-  }
-  return html`
-    <openclaw-approval-page .approvalId=${documentMode.approvalId ?? ""}>
-      <main class="approval-page approval-page--booting" role="status" aria-live="polite">
-        <img
-          class="connect-splash__logo"
-          src=${controlUiPublicAssetPath("favicon.svg", runtime.context.basePath)}
-          alt=""
-        />
-        <span>${t("common.loading")}</span>
-      </main>
-    </openclaw-approval-page>
-  `;
-}
-
-function isBrowserPanelAvailable(snapshot: ApplicationContext["gateway"]["snapshot"]): boolean {
-  if (snapshot.phase !== "connected") {
-    return false;
-  }
-  return (
-    hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
-    isGatewayMethodAdvertised(snapshot, "browser.request") === true
-  );
-}
-
-class OpenClawApp extends OpenClawLightDomElement {
-  // Pinned while a connect submitted from the visible login gate is in
-  // flight, so a failed manual attempt cannot flash the shell in between.
-  @state() private loginGatePinned = false;
-  @state() private loginGatewayUrl = "";
-  @state() private loginToken = "";
-  @state() private loginPassword = "";
-  @state() private loginShowGatewayToken = false;
-  @state() private loginShowGatewayPassword = false;
-  @state() private pendingGatewayUrl: string | null = null;
-  @state() private onboarding = resolveOnboardingMode(globalThis.location?.search ?? "");
-
-  private readonly terminalOnly = isTerminalOnlyView();
-  // Fixed at page load: whether this browser held credentials (token,
-  // password, or stored device token) before the first connect attempt.
-  // Later manual gate submissions are covered by loginGatePinned instead.
-  private initialAuthPresent = false;
-  private runtime: ApplicationRuntime | undefined;
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-  private readonly subscriptions = new SubscriptionsController(this);
-  private loginGatewaySource: ApplicationContext["gateway"] | null = null;
-  private loginConnectionClient: GatewayBrowserClient | null = null;
-
-  private get context(): ApplicationContext<RouteId> | undefined {
-    return this.runtime?.context;
-  }
-
-  constructor() {
-    super();
-    this.subscriptions
-      .watch(
-        () => this.context?.gateway,
-        (gateway, notify) => gateway.subscribe(notify),
-        (gateway) => this.synchronizeGateway(gateway),
-      )
-      .watch(
-        () => (this.terminalOnly ? this.context?.config : undefined),
-        (config, notify) => config.subscribe(notify),
-      );
-  }
-
-  override connectedCallback() {
-    super.connectedCallback();
-    void import("../components/app-sidebar.ts");
-    this.resetLoginSensitivePresentation();
-    this.runtime = bootstrapApplication();
-    if (this.terminalOnly) {
-      preloadOptionalElement(this, TERMINAL_PANEL_ELEMENT);
-    }
-    if (this.runtime.documentMode?.kind === "approval") {
-      preloadOptionalElement(this, APPROVAL_PAGE_ELEMENT);
-    }
-    const context = this.runtime.context;
-    this.initialAuthPresent = hasStoredGatewayAuth(context.gateway.connection);
-    this.pendingGatewayUrl = this.runtime.pendingGatewayConnection?.gatewayUrl ?? null;
-    // Context identity changes only across a full app-tree connection epoch;
-    // descendants reconnect and rebuild their controller-owned state afterward.
-    this.contextProvider.setValue(context);
-    this.syncLoginConnection();
-    // The runtime is created after controller hostConnected hooks run. Ensure
-    // their lazy source getters bind on both the initial mount and reconnect.
-    this.requestUpdate();
-    void this.runtime.start().catch((error: unknown) => {
-      console.error("[openclaw] application start failed", error);
-    });
-  }
-
-  override disconnectedCallback() {
-    // Stop reactive subscriptions before disposing their application sources.
-    this.subscriptions.clear();
-    this.runtime?.stop();
-    this.runtime = undefined;
-    this.loginGatewaySource = null;
-    this.loginConnectionClient = null;
-    this.pendingGatewayUrl = null;
-    this.resetLoginSensitivePresentation();
-    super.disconnectedCallback();
-  }
-
-  private synchronizeGateway(gateway: ApplicationContext["gateway"]) {
-    const sourceChanged = gateway !== this.loginGatewaySource;
-    if (sourceChanged) {
-      this.loginGatewaySource = gateway;
-      this.loginConnectionClient = null;
-      this.resetLoginSensitivePresentation();
-    }
-    const snapshot = gateway.snapshot;
-    const clientChanged = snapshot.client !== this.loginConnectionClient;
-    if (clientChanged) {
-      this.loginConnectionClient = snapshot.client;
-      this.resetLoginSensitivePresentation();
-    }
-    if (sourceChanged || clientChanged) {
-      this.syncLoginConnection(gateway);
-    }
-    if (snapshot.phase === "connected") {
-      this.loginGatePinned = false;
-    }
-  }
-
-  private syncLoginConnection(gateway = this.context?.gateway) {
-    const connection = gateway?.connection;
-    if (!connection) {
-      return;
-    }
-    this.loginGatewayUrl = connection.gatewayUrl;
-    this.loginToken = connection.token;
-    this.loginPassword = connection.password;
-  }
-
-  private resetLoginSensitivePresentation() {
-    this.loginShowGatewayToken = false;
-    this.loginShowGatewayPassword = false;
-  }
-
-  override render() {
-    const context = this.context;
-    const runtime = this.runtime;
-    if (!context || !runtime) {
-      return html`<main class="app-shell app-shell--booting" aria-busy="true"></main>`;
-    }
-    const gatewaySnapshot = context.gateway.snapshot;
-    const gatewayConnected = gatewaySnapshot.phase === "connected";
-    const gatewayUrlConfirmation = this.pendingGatewayUrl
-      ? html`
-          <openclaw-gateway-url-confirmation
-            .props=${{
-              pendingGatewayUrl: this.pendingGatewayUrl,
-              onConfirm: () => {
-                runtime.confirmPendingGatewayConnection();
-                this.pendingGatewayUrl = null;
-              },
-              onCancel: () => {
-                runtime.cancelPendingGatewayConnection();
-                this.pendingGatewayUrl = null;
-              },
-            }}
-          ></openclaw-gateway-url-confirmation>
-        `
-      : nothing;
-    // Embedded mobile terminals own the whole document. Keep the generic login
-    // gate out of this path or a connecting native session exposes Web UI chrome.
-    if (this.terminalOnly) {
-      const terminalAvailable = isTerminalAvailable(
-        gatewaySnapshot,
-        context.config.current.terminalEnabled ?? false,
-      );
-      // Embedded clients query this host immediately; keep it stable while the chunk loads.
-      return html`
-        <openclaw-terminal-panel
-          .client=${gatewayConnected ? gatewaySnapshot.client : null}
-          .available=${terminalAvailable}
-          .themeMode=${resolveTerminalThemeMode()}
-          fullscreen
-        ></openclaw-terminal-panel>
-        ${!isOptionalElementDefined(TERMINAL_PANEL_ELEMENT) && terminalAvailable
-          ? renderConnectingSplash()
-          : nothing}
-        ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
-          ? html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`
-          : nothing}
-      `;
-    }
-    // Transport drops after an established session keep the shell mounted
-    // (offline presentation + client auto-retry); the login gate is reserved for
-    // credential-less first connects, credential rejections, and manual gate
-    // submissions. A first connect backed by stored credentials paints the
-    // connecting splash instead of flashing the login gate; the gate returns
-    // the moment the attempt fails (lastError set on every close).
-    const initialConnectPending =
-      this.initialAuthPresent &&
-      !gatewayConnected &&
-      gatewaySnapshot.phase !== "reconnecting" &&
-      !this.loginGatePinned &&
-      gatewaySnapshot.lastError === null &&
-      gatewaySnapshot.client !== null;
-    if (initialConnectPending) {
-      return html`
-        <openclaw-tooltip-provider>
-          ${renderConnectingSplash()} ${gatewayUrlConfirmation}
-        </openclaw-tooltip-provider>
-      `;
-    }
-    const showLoginGate =
-      !gatewayConnected && (this.loginGatePinned || gatewaySnapshot.phase !== "reconnecting");
-    if (showLoginGate) {
-      return html`
-        <openclaw-tooltip-provider>
-          <openclaw-login-gate
-            .props=${{
-              basePath: context.basePath,
-              connected: gatewayConnected,
-              lastError: gatewaySnapshot.lastError,
-              lastErrorCode: gatewaySnapshot.lastErrorCode,
-              hasToken: Boolean(this.loginToken.trim()),
-              hasPassword: Boolean(this.loginPassword.trim()),
-              gatewayUrl: this.loginGatewayUrl,
-              token: this.loginToken,
-              password: this.loginPassword,
-              showGatewayToken: this.loginShowGatewayToken,
-              showGatewayPassword: this.loginShowGatewayPassword,
-              onGatewayUrlChange: (value: string) => {
-                this.loginGatewayUrl = value;
-              },
-              onTokenChange: (value: string) => {
-                this.loginToken = value;
-              },
-              onPasswordChange: (value: string) => {
-                this.loginPassword = value;
-              },
-              onToggleGatewayToken: () => {
-                this.loginShowGatewayToken = !this.loginShowGatewayToken;
-              },
-              onToggleGatewayPassword: () => {
-                this.loginShowGatewayPassword = !this.loginShowGatewayPassword;
-              },
-              onConnect: () => {
-                this.loginGatePinned = true;
-                context.gateway.connect({
-                  gatewayUrl: this.loginGatewayUrl,
-                  token: this.loginToken,
-                  password: this.loginPassword,
-                });
-              },
-            }}
-          ></openclaw-login-gate>
-          ${gatewayUrlConfirmation}
-        </openclaw-tooltip-provider>
-      `;
-    }
-    if (runtime.documentMode?.kind === "approval") {
-      return html`
-        <openclaw-tooltip-provider>
-          ${gatewayUrlConfirmation} ${renderApprovalDocument(runtime)}
-        </openclaw-tooltip-provider>
-      `;
-    }
-    return html`
-      <openclaw-tooltip-provider>
-        <openclaw-github-link-hovercard-provider .client=${gatewaySnapshot.client}>
-          ${gatewayUrlConfirmation}
-          <openclaw-app-shell
-            .runtime=${runtime}
-            .onboarding=${this.onboarding}
-          ></openclaw-app-shell>
-        </openclaw-github-link-hovercard-provider>
-      </openclaw-tooltip-provider>
-    `;
-  }
-}
-
-class OpenClawShell extends OpenClawLightDomElement {
-  @property({ attribute: false }) runtime?: ApplicationRuntime;
+class OpenClawShell
+  extends OpenClawLightDomElement
+  implements
+    ShellChromeHost,
+    ShellGatewayHost,
+    ShellNavigationHost,
+    ShellViewHost,
+    ShellWorkboardHost
+{
+  @property({ attribute: false }) runtime: ApplicationRuntime | undefined;
   @property({ attribute: false }) onboarding = false;
 
-  @state() private navDrawerOpen = false;
-  @state() private desktopNavigationExpanded = false;
-  @state() private activeSessionKey = "";
-  @state() private settingsSearchQuery = "";
-  @state() private routeState: ShellRouteState = {};
-  @state() private nativeHistoryState: NativeHistoryState = readNativeHistoryState();
-  private readonly commandPaletteElement = COMMAND_PALETTE_ELEMENT;
-  private readonly terminalPanelElement = TERMINAL_PANEL_ELEMENT;
-  private readonly browserPanelElement = BROWSER_PANEL_ELEMENT;
-  private readonly custodianPanelElement = CUSTODIAN_PANEL_ELEMENT;
-  private readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
-  @query("openclaw-command-palette") private commandPalette?: CommandPaletteElement;
+  @state() navDrawerOpen = false;
+  @state() desktopNavigationExpanded = false;
+  @state() activeSessionKey = "";
+  @state() settingsSearchQuery = "";
+  @state() routeState: ShellRouteState = {};
+  @state() nativeHistoryState: NativeHistoryState = readNativeHistoryState();
+  readonly commandPaletteElement = COMMAND_PALETTE_ELEMENT;
+  readonly terminalPanelElement = TERMINAL_PANEL_ELEMENT;
+  readonly browserPanelElement = BROWSER_PANEL_ELEMENT;
+  readonly custodianPanelElement = CUSTODIAN_PANEL_ELEMENT;
+  readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
+  @query("openclaw-command-palette") commandPalette: CommandPaletteElement | undefined;
   @query("openclaw-exec-approval")
-  private approvalOverlay?: HTMLElement & { show(): void };
-  private commandPaletteTarget?: CommandPaletteTargetDetail;
-  private navDrawerTrigger: HTMLElement | null = null;
+  approvalOverlay: (HTMLElement & { show(): void }) | undefined;
+  commandPaletteTarget: CommandPaletteTargetDetail | undefined;
+  navDrawerTrigger: HTMLElement | null = null;
   // Desktop and modal navigation are two slots for the same live sidebar.
   // Moving its element preserves session controllers and the resident pet
   // instead of resetting their lifecycle at every responsive breakpoint.
-  private readonly navigationSidebar = document.createElement(
-    "openclaw-app-sidebar",
-  ) as AppSidebarElement;
+  readonly navigationSidebar = document.createElement("openclaw-app-sidebar") as AppSidebarElement;
   // Where "Back to app" / Escape leaves the settings takeover; falls back to
   // chat (the app default route) when settings was the entry point.
-  private lastWorkspaceLocation: { routeId: RouteId; pathname: string; search: string } | null =
-    null;
-  private custodianMinimizeRequestId = 0;
-  private lastConcreteRouteId: RouteId | undefined;
-  private agentsListClient: GatewayBrowserClient | null = null;
-  private agentsListSource: ApplicationContext["agents"] | null = null;
-  private sessionKeyClient: GatewayBrowserClient | null = null;
-  private runtimeConfigClient: GatewayBrowserClient | null = null;
-  private runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
-  private lastLocalePrefSignature: string | null = null;
-  private previousGatewayPhase: ApplicationContext["gateway"]["snapshot"]["phase"] | null = null;
-  private sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
-  private sidebarWorkboardRuntime: SidebarWorkboardRuntime | null = null;
-  private sidebarWorkboardHost: ApplicationContext["workboard"] | null = null;
-  private sidebarWorkboardRenderers: SidebarWorkboardRenderers | undefined;
-  private sidebarWorkboardRuntimeLoad: Promise<SidebarWorkboardRuntimeFactory> | null = null;
-  private sidebarWorkboardEpoch = 0;
-  private agentRosterRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  private outboxStoreRuntime: OutboxStoreRuntime | null = null;
+  lastWorkspaceLocation: { routeId: RouteId; pathname: string; search: string } | null = null;
+  custodianMinimizeRequestId = 0;
+  lastConcreteRouteId: RouteId | undefined;
+  agentsListClient: GatewayBrowserClient | null = null;
+  agentsListSource: ApplicationContext["agents"] | null = null;
+  sessionKeyClient: GatewayBrowserClient | null = null;
+  runtimeConfigClient: GatewayBrowserClient | null = null;
+  runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
+  lastLocalePrefSignature: string | null = null;
+  previousGatewayPhase: ApplicationContext["gateway"]["snapshot"]["phase"] | null = null;
+  sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
+  sidebarWorkboardRuntime: SidebarWorkboardRuntime | null = null;
+  sidebarWorkboardHost: ApplicationContext["workboard"] | null = null;
+  sidebarWorkboardRenderers: SidebarWorkboardRenderers | undefined;
+  sidebarWorkboardRuntimeLoad: Promise<SidebarWorkboardRuntimeFactory> | null = null;
+  sidebarWorkboardEpoch = 0;
+  agentRosterRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  outboxStoreRuntime: OutboxStoreRuntime | null = null;
   private outboxStoreUnsubscribe: (() => void) | null = null;
-  private readonly outboxStoreImport = createIdleImport(
+  readonly outboxStoreImport = createIdleImport(
     () => import("../lib/chat/outbox-store.ts").then((module): OutboxStoreRuntime => module),
     (runtime) => this.installOutboxStoreRuntime(runtime),
   );
   private lastNativeNavState: NativeNavState | undefined;
-  private didConsiderNativeRouteRestore = false;
-  private pendingNativeNewSession = false;
-  private readonly settingsPreloadTimers = new Map<
-    EventTarget,
-    ReturnType<typeof globalThis.setTimeout>
-  >();
+  didConsiderNativeRouteRestore = false;
+  pendingNativeNewSession = false;
+  readonly settingsPreloadTimers = new Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>();
   // Lazy: the critical-notice module stays out of the startup chunk (perf
   // budget); loaded on the first session.observer digest after boot.
-  private criticalNoticeRuntime: Promise<
+  criticalNoticeRuntime: Promise<
     typeof import("../pages/chat/critical-observer-notice.runtime.ts")
   > | null = null;
   private readonly subscriptions = new SubscriptionsController(this);
+  private readonly shellNavigation = new ShellNavigationOwner(this);
+  private readonly shellWorkboard = new ShellWorkboardOwner(this);
+  private readonly shellChrome = new ShellChromeOwner(this);
+  private readonly shellGateway = new ShellGatewayOwner(this);
 
-  private get context(): ApplicationContext<RouteId> | undefined {
+  get context(): ApplicationContext<RouteId> | undefined {
     return this.runtime?.context;
   }
 
-  private get onboardingMode(): boolean {
+  get onboardingMode(): boolean {
     const routeSearch = this.routeState.location?.search;
     return routeSearch === undefined ? this.onboarding : resolveOnboardingMode(routeSearch);
   }
 
-  private storedOutboxScopeHost(context: ApplicationContext<RouteId>): StoredOutboxScopeHost {
+  storedOutboxScopeHost(context: ApplicationContext<RouteId>): StoredOutboxScopeHost {
     const gatewaySnapshot = context.gateway.snapshot;
     return {
       settings: { gatewayUrl: context.gateway.connection.gatewayUrl },
@@ -714,32 +310,7 @@ class OpenClawShell extends OpenClawLightDomElement {
    * lands (connect, settings pages, reloads).
    */
   private reconcileServerUiPrefs(runtimeConfig: ApplicationContext["runtimeConfig"]) {
-    const snapshot = runtimeConfig.state.configSnapshot;
-    const context = this.context;
-    if (!snapshot?.config || !context || context.runtimeConfig !== runtimeConfig) {
-      return;
-    }
-    const scope = context.gateway.connection.gatewayUrl;
-    applyServerUiPrefs(snapshot.config, {
-      scope,
-      onApplied: (patch) => {
-        if (patch.sidebarEntries !== undefined) {
-          context.navigation.update({ sidebarEntries: patch.sidebarEntries });
-        }
-        context.theme.refresh();
-      },
-    });
-    const localePref = resolveServerUiPrefState(snapshot.config, "locale", scope);
-    const localePrefSignature = JSON.stringify([scope, localePref.overridden, localePref.value]);
-    if (localePrefSignature === this.lastLocalePrefSignature) {
-      return;
-    }
-    this.lastLocalePrefSignature = localePrefSignature;
-    if (localePref.overridden && isSupportedLocale(localePref.value)) {
-      void i18n.setLocale(localePref.value);
-    } else {
-      void i18n.useSystemLocale();
-    }
+    this.shellGateway.reconcileServerUiPrefs(runtimeConfig);
   }
 
   private reconcileCommittedServerUiPrefs(
@@ -747,17 +318,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     needsRefresh: boolean,
     retainedLocal = false,
   ) {
-    if (this.context?.runtimeConfig !== runtimeConfig) {
-      return;
-    }
-    if (needsRefresh) {
-      void runtimeConfig.refresh();
-      return;
-    }
-    this.reconcileServerUiPrefs(runtimeConfig);
-    if (retainedLocal) {
-      this.context?.theme.refresh();
-    }
+    this.shellGateway.reconcileCommittedServerUiPrefs(runtimeConfig, needsRefresh, retainedLocal);
   }
 
   override connectedCallback() {
@@ -766,26 +327,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       this.installOutboxStoreRuntime(this.outboxStoreRuntime);
     }
     this.outboxStoreImport.schedule();
-    this.nativeHistoryState = readNativeHistoryState();
-    this.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
-    window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
-    document.addEventListener("keydown", this.handleDocumentKeydown);
-    window.addEventListener("resize", this.handleWindowResize);
-    window.addEventListener("dragover", this.handleUnhandledFileDrag);
-    window.addEventListener("drop", this.handleUnhandledFileDrag);
-    window.addEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
-    // Shipped Mac app builds without web chrome still drive these events; the
-    // app's ⌘N menu item reuses native-new-session, while its ⌘K menu item
-    // uses native-toggle-search because the legacy open-search is open-only.
-    window.addEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
-    window.addEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
-    window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
-    window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
-    window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
-    window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
-    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+    this.shellChrome.connect();
     // Write-through of synced display prefs to config ui.prefs. Server-applied
     // deltas are suppressed so a reconcile never echoes back to the gateway.
     setSettingsChangeListener((previous, next) => {
@@ -804,22 +346,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
-    this.removeEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
-    window.removeEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
-    document.removeEventListener("keydown", this.handleDocumentKeydown);
-    window.removeEventListener("resize", this.handleWindowResize);
-    window.removeEventListener("dragover", this.handleUnhandledFileDrag);
-    window.removeEventListener("drop", this.handleUnhandledFileDrag);
-    window.removeEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
-    window.removeEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
-    window.removeEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
-    window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
-    window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
-    window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
-    window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
-    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+    this.shellChrome.disconnect();
     this.outboxStoreImport.dispose();
     this.outboxStoreUnsubscribe?.();
     this.outboxStoreUnsubscribe = null;
@@ -847,176 +374,24 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.navDrawerTrigger = null;
     this.lastWorkspaceLocation = null;
     this.activeSessionKey = "";
-    void this.criticalNoticeRuntime?.then((runtime) => runtime.resetCriticalObserverTracker());
     this.settingsSearchQuery = "";
     this.commandPaletteTarget = undefined;
-    this.agentsListClient = null;
-    this.agentsListSource = null;
-    this.sessionKeyClient = null;
-    this.runtimeConfigClient = null;
-    this.runtimeConfigSource = null;
-    this.previousGatewayPhase = null;
+    this.shellGateway.reset();
     this.disposeSidebarWorkboard();
-    if (this.agentRosterRefreshTimer !== null) {
-      globalThis.clearTimeout(this.agentRosterRefreshTimer);
-      this.agentRosterRefreshTimer = null;
-    }
-    resetServerUiPrefsSync();
     for (const timer of this.settingsPreloadTimers.values()) {
       globalThis.clearTimeout(timer);
     }
     this.settingsPreloadTimers.clear();
   }
 
-  private selectChatSession(sessionKey: string, agentId?: string | null) {
-    const context = this.context;
-    if (!context) {
-      return;
-    }
-    selectApplicationSession({
-      selection: context.agentSelection,
-      gateway: context.gateway,
-      sessionKey,
-      agentId,
-    });
-    const face = resolveSessionPreferredFaceForKey(context, sessionKey, agentId);
-    this.navigate(
-      face,
-      sessionNavigationTarget({
-        context,
-        face,
-        sessionKey,
-        ...(agentId ? { agentId } : {}),
-        preferenceDerivedFace: true,
-      }).options,
-    );
+  selectChatSession(sessionKey: string, agentId?: string | null) {
+    this.shellNavigation.selectChatSession(sessionKey, agentId);
   }
   private readonly handleGatewayEvent = (event: GatewayEventFrame) => {
-    this.sidebarWorkboardRuntime?.handleGatewayEvent(event.event);
-    if (event.event === "sessions.changed") {
-      const context = this.context;
-      if (context) {
-        this.recoverDeletedActiveSession(context.sessions.state);
-      }
-      return;
-    }
-    if (event.event === "session.observer") {
-      const context = this.context;
-      if (context) {
-        // All digests flow through (not just critical ones): the runtime
-        // tracker must see recovery transitions for its re-announce dedupe.
-        this.criticalNoticeRuntime ??= import("../pages/chat/critical-observer-notice.runtime.ts");
-        const payload = event.payload;
-        void this.criticalNoticeRuntime.then((runtime) =>
-          runtime.handleCriticalObserverDigest({
-            payload,
-            selectedSessionKey: this.activeSessionKey,
-            sessionHost: this.storedOutboxScopeHost(context),
-            sessions: context.sessions.state.result?.sessions ?? [],
-            onOpen: (sessionKey, agentId) => this.selectChatSession(sessionKey, agentId),
-          }),
-        );
-      }
-      return;
-    }
-    if (event.event === "config.changed") {
-      // Another writer (agent-approved config_set, other device, CLI) changed
-      // openclaw.json; refresh the snapshot so ui.prefs reconcile live. A
-      // dirty local settings draft wins — the autosave/conflict flow owns it.
-      const runtimeConfig = this.context?.runtimeConfig;
-      if (runtimeConfig && !runtimeConfig.state.configFormDirty) {
-        void runtimeConfig.refresh();
-      }
-      this.scheduleAgentRosterRefresh();
-      return;
-    }
-    if (event.event !== "ui.command" || !event.payload) {
-      return;
-    }
-    const context = this.context;
-    if (!context) {
-      return;
-    }
-    const commandParams = event.payload as UiCommandParams;
-    const { command } = commandParams;
-    if (!command) {
-      return;
-    }
-    if (command.kind === "sidebar") {
-      this.desktopNavigationExpanded = false;
-      context.navigation.update({ navCollapsed: !command.visible });
-      return;
-    }
-    if (command.kind === "panel") {
-      window.dispatchEvent(
-        new CustomEvent(
-          command.panel === "terminal" ? TERMINAL_PANEL_TOGGLE_EVENT : BROWSER_PANEL_TOGGLE_EVENT,
-          {
-            detail: {
-              open: command.open,
-              ...(command.dock ? { dock: command.dock } : {}),
-              ...(command.panel === "terminal" && command.terminalSessionId
-                ? { terminalSessionId: command.terminalSessionId }
-                : {}),
-            },
-          },
-        ),
-      );
-      return;
-    }
-
-    const handled = !window.dispatchEvent(
-      new CustomEvent(UI_COMMAND_EVENT, { detail: commandParams, cancelable: true }),
-    );
-    if (handled || (command.kind !== "navigate" && command.kind !== "split")) {
-      return;
-    }
-    this.selectChatSession(command.sessionKey);
+    this.shellGateway.handleGatewayEvent(event);
   };
 
-  private scheduleAgentRosterRefresh() {
-    // Persisted config writes can arrive as a tight sequence; roster state is
-    // snapshot-based, so only the final forced read in that burst is useful.
-    if (this.agentRosterRefreshTimer !== null) {
-      globalThis.clearTimeout(this.agentRosterRefreshTimer);
-    }
-    this.agentRosterRefreshTimer = globalThis.setTimeout(() => {
-      this.agentRosterRefreshTimer = null;
-      void this.refreshAgentRoster();
-    }, AGENT_ROSTER_REFRESH_DEBOUNCE_MS);
-  }
-
-  private async refreshAgentRoster() {
-    const context = this.context;
-    if (!context) {
-      return;
-    }
-    const previous = context.agents.state.agentsList;
-    const activeAgentId = context.agentSelection.state.selectedId;
-    const next = await context.agents.refreshList();
-    if (!next || this.context !== context) {
-      return;
-    }
-    const rosterDiff = diffAgentRoster(previous?.agents ?? [], next.agents);
-    if (rosterDiff.invalidatedIds.length > 0) {
-      context.agents.invalidateFiles(rosterDiff.invalidatedIds);
-      context.agentIdentity.invalidate(rosterDiff.invalidatedIds);
-    }
-    if (rosterDiff.changedIds.length > 0) {
-      void context.agentIdentity.ensure(rosterDiff.changedIds);
-    }
-    const nextIds = new Set(next.agents.map((agent) => agent.id));
-    if (
-      activeAgentId &&
-      context.agentSelection.state.selectedId === activeAgentId &&
-      next.agents.length > 0 &&
-      !nextIds.has(activeAgentId)
-    ) {
-      context.agentSelection.set(next.defaultId);
-    }
-  }
-
-  private readonly handleThemeChange = (event: CustomEvent<ThemeModeChangeDetail>) => {
+  readonly handleThemeChange = (event: CustomEvent<ThemeModeChangeDetail>) => {
     const context = this.context;
     if (!context) {
       return;
@@ -1024,7 +399,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     context.theme.setMode(event.detail.mode, event.detail.element);
   };
 
-  private async handleSettingsSearchQueryChange(nextQuery: string): Promise<void> {
+  async handleSettingsSearchQueryChange(nextQuery: string): Promise<void> {
     this.settingsSearchQuery = nextQuery;
     const runtimeConfig = this.context?.runtimeConfig;
     if (!runtimeConfig || !nextQuery.trim()) {
@@ -1040,547 +415,70 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
   }
 
-  private chatNavigationOptions(face: BoardFace, options?: ApplicationNavigationOptions) {
-    const sessionKey = this.activeSessionKey.trim();
-    const context = this.context;
-    return (
-      options ??
-      (sessionKey && context
-        ? sessionNavigationTarget({ context, face, sessionKey }).options
-        : undefined)
-    );
+  chatNavigationOptions(face: BoardFace, options?: ApplicationNavigationOptions) {
+    return this.shellNavigation.chatNavigationOptions(face, options);
   }
 
-  private navigate(routeId: string, options?: ApplicationNavigationOptions) {
-    const context = this.context;
-    if (!context || !isRouteId(routeId)) {
-      return;
-    }
-    this.closeNavDrawer({ restoreFocus: true });
-    context.navigate(
-      routeId,
-      isSessionRouteId(routeId) ? this.chatNavigationOptions(routeId, options) : options,
-    );
+  navigate(routeId: string, options?: ApplicationNavigationOptions) {
+    this.shellNavigation.navigate(routeId, options);
   }
 
-  private replaceChatWithCurrentSession() {
-    const context = this.context;
-    const sessionKey = this.activeSessionKey.trim();
-    if (
-      !context ||
-      (!parseAgentSessionKey(sessionKey) && context.gateway.snapshot.phase !== "connected")
-    ) {
-      return;
-    }
-    const face = this.routeState.routeId === "dashboard" ? "dashboard" : "chat";
-    const sessionWasDeleted = (context.sessions.state.deletedSessions ?? []).some(
-      ({ key, agentId }) =>
-        uiSessionEventMatches(
-          {
-            agentsList: context.agents.state.agentsList,
-            hello: context.gateway.snapshot.hello,
-            sessionKey,
-          },
-          key,
-          agentId,
-        ),
-    );
-    // Session lists are filtered and windowed. Only a failed route for this
-    // active key, or an authoritative deletion, proves it needs replacement.
-    const activeSessionRow = findUiSessionRow(context, sessionKey);
-    const attemptedPathname = this.routeState.location?.pathname;
-    const activeRouteFailed =
-      !attemptedPathname ||
-      attemptedPathname === sessionNavigationTarget({ context, face, sessionKey }).options.pathname;
-    const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
-    const knownAgents = context.agents.state.agentsList?.agents;
-    // A parseable retired agent is not a navigable owner; never turn its
-    // deleted session into another permanently unresolvable chat route.
-    const replacementAgentId =
-      parsedAgentId &&
-      (!knownAgents || knownAgents.some((agent) => normalizeAgentId(agent.id) === parsedAgentId))
-        ? parsedAgentId
-        : resolveSessionNavigationAgentId(context);
-    const replacementSessionKey =
-      !sessionWasDeleted && (activeSessionRow?.key || !activeRouteFailed)
-        ? sessionKey
-        : buildAgentMainSessionKey({
-            agentId: replacementAgentId,
-            mainKey: resolveUiConfiguredMainKey({
-              agentsList: context.agents.state.agentsList,
-              hello: context.gateway.snapshot.hello,
-            }),
-          });
-    // Gateway rejects deletion of a live main session. If an orphaned event
-    // still names that fallback, replacing the same route would retry forever.
-    if (sessionWasDeleted && replacementSessionKey === sessionKey) {
-      return;
-    }
-    if (replacementSessionKey !== sessionKey) {
-      // Commit the replacement to both selection owners before navigating;
-      // otherwise a stale Gateway snapshot restores the deleted key and loops.
-      this.activeSessionKey = replacementSessionKey;
-      selectApplicationSession({
-        selection: context.agentSelection,
-        gateway: context.gateway,
-        sessionKey: replacementSessionKey,
-      });
-    }
-    context.replace(
-      face,
-      sessionNavigationTarget({ context, face, sessionKey: replacementSessionKey }).options,
-    );
+  replaceChatWithCurrentSession() {
+    this.shellNavigation.replaceChatWithCurrentSession();
   }
 
-  private recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]) {
-    const context = this.context;
-    const routeId = this.routeState.routeId;
-    const sessionKey = this.activeSessionKey.trim();
-    if (!context || !routeId || !isSessionRouteId(routeId) || !sessionKey) {
-      return;
-    }
-    const selectedSessionDeleted = sessionState.deletedSessions.some(({ key, agentId }) =>
-      uiSessionEventMatches(
-        {
-          agentsList: context.agents.state.agentsList,
-          hello: context.gateway.snapshot.hello,
-          sessionKey,
-        },
-        key,
-        agentId,
-      ),
-    );
-    if (selectedSessionDeleted) {
-      this.replaceChatWithCurrentSession();
-    }
+  recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]) {
+    this.shellNavigation.recoverDeletedActiveSession(sessionState);
   }
 
-  private isSettingsTakeover(): boolean {
-    const routeId = this.routeState.routeId;
-    return routeId !== undefined && isSettingsNavigationRoute(routeId);
+  exitSettings() {
+    this.shellNavigation.exitSettings();
   }
 
-  private exitSettings() {
-    const previous = this.lastWorkspaceLocation;
-    if (previous) {
-      this.navigate(previous.routeId, {
-        pathname: previous.pathname,
-        ...(previous.search ? { search: previous.search } : {}),
-      });
-      return;
-    }
-    this.navigate("chat");
+  toggleNavigationSurface(trigger?: HTMLElement) {
+    this.shellChrome.toggleNavigationSurface(trigger);
   }
 
-  private toggleNavigationSurface(trigger?: HTMLElement) {
-    const context = this.context;
-    // Desktop settings takeover has no app nav to collapse; the mobile drawer
-    // hosts the settings sidebar and must keep toggling.
-    if (!context || this.onboardingMode || (this.isSettingsTakeover() && !isMobileNavLayout())) {
-      return;
-    }
-    if (isMobileNavLayout()) {
-      if (this.navDrawerOpen) {
-        this.closeNavDrawer({ restoreFocus: true });
-        return;
-      }
-      this.navDrawerTrigger = trigger ?? this.querySelector<HTMLElement>(".topbar-nav-toggle");
-      this.navDrawerOpen = true;
-      return;
-    }
-    // A responsive drawer handoff can expand this shell without rewriting the
-    // stored desktop preference; toggle the surface the user actually sees.
-    const nextNavCollapsed =
-      this.navDrawerOpen ||
-      !(context.navigation.snapshot.navCollapsed && !this.desktopNavigationExpanded);
-    this.desktopNavigationExpanded = false;
-    if (nextNavCollapsed) {
-      this.dismissSidebarTransientMenus();
-    }
-    this.closeNavDrawer();
-    context.navigation.update({
-      navCollapsed: nextNavCollapsed,
-    });
-    if (nextNavCollapsed) {
-      void this.updateComplete.then(() => {
-        this.restoreFocusTo(this.querySelector<HTMLElement>(".shell-chrome-controls__nav-toggle"));
-      });
-    }
+  closeNavDrawer(options: { restoreFocus?: boolean } = {}) {
+    this.shellChrome.closeNavDrawer(options);
   }
 
-  /** Focus a restoration target, falling back to the content anchor. Native
-   * Mac chrome hides the in-page toggles, so focus must not strand on the body
-   * or inside an offscreen drawer. */
-  private restoreFocusTo(target: HTMLElement | null | undefined) {
-    const resolved =
-      target?.isConnected && target.checkVisibility()
-        ? target
-        : this.querySelector<HTMLElement>(".content");
-    resolved?.focus();
+  resizeNavigation(splitRatio: number) {
+    this.shellChrome.resizeNavigation(splitRatio);
   }
 
-  private visibleNavDrawerToggle(): HTMLElement | undefined {
-    return [
-      ...this.querySelectorAll<HTMLElement>(".topbar-nav-toggle, .chat-pane__nav-toggle"),
-    ].find((candidate) => candidate.checkVisibility());
-  }
-
-  private closeNavDrawer(options: { restoreFocus?: boolean } = {}) {
-    if (this.navDrawerOpen) {
-      this.dismissSidebarTransientMenus();
-    }
-    const trigger = options.restoreFocus ? this.navDrawerTrigger : null;
-    const returnFocusTarget =
-      options.restoreFocus && trigger?.isConnected && trigger.checkVisibility()
-        ? trigger
-        : options.restoreFocus
-          ? this.querySelector<HTMLElement>(".content")
-          : null;
-    this.querySelector<OpenClawModalDialog>(
-      "openclaw-modal-dialog.nav-drawer",
-    )?.setReturnFocusTarget(returnFocusTarget ?? null);
-    this.navDrawerOpen = false;
-    this.navDrawerTrigger = null;
-    if (!options.restoreFocus) {
-      return;
-    }
-    requestAnimationFrame(() => {
-      this.restoreFocusTo(trigger instanceof HTMLElement ? trigger : null);
-    });
-  }
-
-  private resizeNavigation(splitRatio: number) {
-    const shell = this.querySelector<HTMLElement>(".shell");
-    const context = this.context;
-    if (!shell || !context) {
-      return;
-    }
-    const navWidth = Math.round(
-      Math.min(NAV_WIDTH_MAX, Math.max(NAV_WIDTH_MIN, splitRatio * shell.clientWidth)),
-    );
-    context.navigation.update({ navWidth });
-  }
-
-  private openNewSession(agentId: string, target?: NewSessionTarget) {
-    this.navigate("new-session", { search: newSessionSearch(agentId, target) });
+  openNewSession(agentId: string, target?: NewSessionTarget) {
+    this.shellNavigation.openNewSession(agentId, target);
   }
 
   // Shipped Mac app builds without web chrome still drive these handlers.
-  private readonly handleNativeToggleSidebar = () => {
-    this.toggleNavigationSurface();
-  };
+  readonly handleNativeToggleSidebar = () => this.shellChrome.handleNativeToggleSidebar();
+  readonly handleNativeOpenSearch = () => this.shellChrome.handleNativeOpenSearch();
+  readonly handleNativeToggleSearch = (event: Event) =>
+    this.shellChrome.handleNativeToggleSearch(event);
+  readonly handleNativeNewSession = () => this.shellChrome.handleNativeNewSession();
+  readonly handleNativeNavigate = (event: Event) => this.shellChrome.handleNativeNavigate(event);
+  readonly handleNativeHistoryState = (event: Event) =>
+    this.shellChrome.handleNativeHistoryState(event);
+  readonly handleWindowResize = () => this.shellChrome.handleWindowResize();
+  readonly handleDocumentKeydown = (event: KeyboardEvent) =>
+    this.shellChrome.handleDocumentKeydown(event);
+  readonly openPalette = () => this.shellChrome.openPalette();
+  readonly refreshControlUi = () => this.shellChrome.refreshControlUi();
+  readonly handleShellNavDrawerToggle = (event: Event) =>
+    this.shellChrome.handleShellNavDrawerToggle(event);
+  readonly openApprovals = () => this.shellChrome.openApprovals();
+  readonly handleDeferredTerminalToggle = (event: Event) =>
+    this.shellChrome.handleDeferredTerminalToggle(event);
+  readonly handleDeferredBrowserToggle = (event: Event) =>
+    this.shellChrome.handleDeferredBrowserToggle(event);
+  readonly handleDeferredCustodianToggle = (event: Event) =>
+    this.shellChrome.handleDeferredCustodianToggle(event);
+  readonly handleCommandPaletteSlashCommand = (command: string) =>
+    this.shellChrome.handleCommandPaletteSlashCommand(command);
 
-  private readonly handleNativeOpenSearch = () => {
-    this.openPalette();
-  };
-
-  private readonly handleNativeToggleSearch = (event: Event) => {
-    // The ⌘K menu item intercepts the key equivalent before page keydown, so
-    // closing must route through here; preventDefault acknowledges the event
-    // (the native dispatcher falls back to open-search when unhandled).
-    event.preventDefault();
-    this.togglePalette();
-  };
-
-  private readonly handleNativeNewSession = () => {
-    const context = this.context;
-    if (this.onboardingMode) {
-      return;
-    }
-    if (!context) {
-      // Native hosts flush queued commands at document-finish, which can beat
-      // runtime initialization; retain the request and replay once the
-      // context effect fires instead of silently dropping the ⌘N. A boolean is
-      // enough: the destination is idempotent, so repeated presses collapse.
-      this.pendingNativeNewSession = true;
-      return;
-    }
-    const agentId = context.agentSelection.state.selectedId ?? "";
-    this.openNewSession(agentId);
-  };
-
-  private readonly handleNativeNavigate = (event: Event) => {
-    const path = (event as CustomEvent<{ path?: unknown }>).detail?.path;
-    const schemeCandidate = typeof path === "string" ? path.slice(1) : "";
-    if (
-      typeof path !== "string" ||
-      !path.startsWith("/") ||
-      path.startsWith("//") ||
-      /^[a-z][a-z\d+.-]*:/i.test(schemeCandidate)
-    ) {
-      return;
-    }
-    const routeId = routeIdFromPath(path);
-    if (!routeId || !this.context) {
-      // Leave invalid or unavailable destinations unhandled so the native host can load its URL fallback.
-      return;
-    }
-    event.preventDefault();
-    this.navigate(routeId);
-  };
-
-  private readonly handleNativeHistoryState = (event: Event) => {
-    const detail = (event as CustomEvent<NativeHistoryState>).detail;
-    if (typeof detail?.canGoBack !== "boolean" || typeof detail.canGoForward !== "boolean") {
-      return;
-    }
-    this.nativeHistoryState = detail;
-  };
-
-  private readonly handleWindowResize = () => {
-    const mobileNavLayout = isMobileNavLayout();
-    // Clean up the old navigation surface before the shared sidebar moves;
-    // otherwise menus survive the breakpoint or the closed drawer reopens.
-    const dismissedSidebarMenus =
-      mobileNavLayout && !this.navDrawerOpen && this.dismissSidebarTransientMenus();
-    if (mobileNavLayout) {
-      this.desktopNavigationExpanded = false;
-    } else if (this.navDrawerOpen) {
-      this.closeNavDrawer({ restoreFocus: false });
-      // Keep the drawer visibly expanded in this shell without changing the
-      // user's persisted desktop-collapse preference.
-      this.desktopNavigationExpanded = this.context?.navigation.snapshot.navCollapsed ?? false;
-    }
-    this.requestUpdate();
-    void this.updateComplete.then(() => {
-      if (isMobileNavLayout() && !this.navDrawerOpen && dismissedSidebarMenus) {
-        requestAnimationFrame(() => {
-          this.restoreFocusTo(this.visibleNavDrawerToggle());
-        });
-      }
-    });
-  };
-
-  private readonly handleUnhandledFileDrag = (event: DragEvent) => {
-    // Bubble phase is intentional: explicit drop targets get first refusal by
-    // preventing the event, while only unaccepted file drags reach this fallback.
-    const nativeFileInput = event
-      .composedPath()
-      .some(
-        (target) =>
-          target instanceof HTMLInputElement && target.type === "file" && !target.disabled,
-      );
-    if (
-      event.defaultPrevented ||
-      nativeFileInput ||
-      !Array.from(event.dataTransfer?.types ?? []).includes("Files")
-    ) {
-      return;
-    }
-    event.preventDefault();
-    if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = "none";
-    }
-  };
-
-  private dismissSidebarTransientMenus(): boolean {
-    return (
-      this.querySelector<AppSidebarElement>("openclaw-app-sidebar")?.dismissTransientMenus() ??
-      false
-    );
-  }
-
-  private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
-    if (!this.commandPalette && isCommandPaletteShortcut(event)) {
-      event.preventDefault();
-      this.togglePalette();
-      return;
-    }
-    if (!isOptionalElementDefined(this.terminalPanelElement) && isTerminalPanelShortcut(event)) {
-      event.preventDefault();
-      this.handleDeferredTerminalToggle(new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT));
-      return;
-    }
-    if (event.defaultPrevented) {
-      return;
-    }
-    const plainKey = !event.altKey && !event.shiftKey && !event.metaKey && !event.ctrlKey;
-    if (plainKey && event.key === "Escape" && this.isSettingsTakeover()) {
-      if (this.navDrawerOpen) {
-        event.preventDefault();
-        this.closeNavDrawer({ restoreFocus: true });
-        return;
-      }
-      if (this.shouldIgnoreSettingsEscape(event)) {
-        return;
-      }
-      event.preventDefault();
-      this.exitSettings();
-      return;
-    }
-    const settingsModifier = event.metaKey !== event.ctrlKey && !event.altKey;
-    if (settingsModifier && event.shiftKey && event.code === "Comma") {
-      event.preventDefault();
-      this.navigate("appearance");
-      return;
-    }
-    const commandKey = event.metaKey && !event.ctrlKey && !event.altKey;
-    if (!commandKey || event.shiftKey || resolveAsciiShortcutKey(event) !== "b") {
-      return;
-    }
-    event.preventDefault();
-    this.toggleNavigationSurface();
-  };
-
-  /**
-   * Escape only exits settings when nothing else claims it: open dialogs,
-   * palette, menus, and text inputs keep their native dismiss/blur behavior.
-   */
-  private shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
-    const overlaySnapshot = this.context?.overlays.snapshot;
-    if (
-      this.commandPalette?.isOpen ||
-      overlaySnapshot?.devicePairSetupOpen ||
-      (overlaySnapshot?.approvalQueue.length ?? 0) > 0 ||
-      document.querySelector("dialog[open]")
-    ) {
-      return true;
-    }
-    const target = event.target;
-    return (
-      target instanceof Element &&
-      target.closest(
-        "input, textarea, select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
-      ) !== null
-    );
-  }
-
-  private runWithCommandPalette(action: (palette: CommandPaletteElement) => void): void {
-    const palette = this.commandPalette;
-    if (palette) {
-      action(palette);
-      return;
-    }
-    void ensureOptionalElementForHost(this, this.commandPaletteElement)
-      .then(async () => {
-        await this.updateComplete;
-        const loadedPalette = this.commandPalette;
-        if (loadedPalette) {
-          action(loadedPalette);
-        }
-      })
-      .catch(() => undefined);
-  }
-
-  private readonly openPalette = () => {
-    this.runWithCommandPalette((palette) => palette.openPalette());
-  };
-
-  private readonly refreshControlUi = () => {
-    globalThis.location.reload();
-  };
-
-  private readonly handleShellNavDrawerToggle = (event: Event) => {
-    const trigger = (event as CustomEvent<ShellNavDrawerToggleDetail>).detail?.trigger;
-    this.toggleNavigationSurface(trigger instanceof HTMLElement ? trigger : undefined);
-  };
-
-  private readonly togglePalette = () => {
-    this.runWithCommandPalette((palette) => palette.togglePalette());
-  };
-
-  private readonly openApprovals = () => {
-    const show = () => this.approvalOverlay?.show();
-    if (isOptionalElementDefined(this.execApprovalElement)) {
-      show();
-      return;
-    }
-    void ensureOptionalElementForHost(this, this.execApprovalElement)
-      .then(async () => {
-        await this.updateComplete;
-        show();
-      })
-      .catch(() => undefined);
-  };
-
-  private deliverPanelEventAfterLoad(element: OptionalCustomElement, event: Event): void {
-    void ensureOptionalElementForHost(this, element)
-      .then(async () => {
-        // Definition upgrades the mounted tag; one host update applies availability before delivery.
-        await this.updateComplete;
-        this.querySelector<PanelToggleElement>(element.tagName)?.handleToggleRequest(event);
-      })
-      .catch(() => undefined);
-  }
-
-  private readonly handleDeferredTerminalToggle = (event: Event) => {
-    if (isOptionalElementDefined(this.terminalPanelElement)) {
-      return;
-    }
-    const context = this.context;
-    const snapshot = context?.gateway?.snapshot;
-    if (
-      !snapshot ||
-      !isTerminalAvailable(snapshot, context.config?.current.terminalEnabled ?? false)
-    ) {
-      return;
-    }
-    this.deliverPanelEventAfterLoad(this.terminalPanelElement, event);
-  };
-
-  private readonly handleDeferredBrowserToggle = (event: Event) => {
-    if (isOptionalElementDefined(this.browserPanelElement)) {
-      return;
-    }
-    const snapshot = this.context?.gateway?.snapshot;
-    if (!snapshot || !isBrowserPanelAvailable(snapshot)) {
-      return;
-    }
-    this.deliverPanelEventAfterLoad(this.browserPanelElement, event);
-  };
-
-  private readonly handleDeferredCustodianToggle = (event: Event) => {
-    if (isOptionalElementDefined(this.custodianPanelElement)) {
-      return;
-    }
-    const snapshot = this.context?.gateway?.snapshot;
-    if (!snapshot || isGatewayMethodAdvertised(snapshot, "openclaw.chat") !== true) {
-      return;
-    }
-    this.deliverPanelEventAfterLoad(this.custodianPanelElement, event);
-  };
-
-  private readonly handleCommandPaletteSlashCommand = (command: string) => {
-    const chatHandler = this.commandPaletteTarget?.owner.isConnected
-      ? this.commandPaletteTarget.onSlashCommand
-      : null;
-    if (chatHandler) {
-      chatHandler(command);
-      return;
-    }
-    // Keep Chat's in-place draft path fast; other routes hand the draft through navigation.
-    const navigation = this.chatNavigationOptions("chat");
-    const search = new URLSearchParams(navigation?.search ?? "");
-    search.set("draft", command.endsWith(" ") ? command : `${command} `);
-    this.navigate("chat", { ...navigation, search: `?${search.toString()}` });
-  };
-
-  private readonly handleCommandPaletteTarget = (event: Event) => {
-    const detail = (event as CustomEvent<CommandPaletteTargetDetail>).detail;
-    if (!detail || !(detail.owner instanceof Element)) {
-      return;
-    }
-    if (detail.onSlashCommand) {
-      this.commandPaletteTarget = detail;
-    } else if (this.commandPaletteTarget?.owner === detail.owner) {
-      this.commandPaletteTarget = undefined;
-    }
-    this.requestUpdate();
-  };
-
-  /** Collapsed as seen by macOS titlebar chrome (native accessory on shipped
-   * apps, the web toolbar on current ones): drawer widths, settings takeover,
-   * and onboarding all hide the expanded rail. */
-  private nativeNavCollapsed(): boolean {
-    const mobileNavLayout = isMobileNavLayout();
-    return (
-      this.onboardingMode ||
-      mobileNavLayout ||
-      (this.isSettingsTakeover() && !mobileNavLayout) ||
-      (!this.navDrawerOpen &&
-        !this.desktopNavigationExpanded &&
-        (this.context?.navigation.snapshot.navCollapsed ?? false))
-    );
+  nativeNavCollapsed(): boolean {
+    return this.shellChrome.nativeNavCollapsed();
   }
 
   /** Keep the tab/window title on the active destination. Runs after every
@@ -1651,675 +549,48 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
-    const previousPhase = this.previousGatewayPhase;
-    this.previousGatewayPhase = snapshot.phase;
-    this.updateGatewaySessionKey(snapshot);
-    this.ensureAgentsList(snapshot);
-    this.ensureRuntimeConfig(snapshot);
-    if (previousPhase !== "connected" && snapshot.phase === "connected") {
-      i18n.retryPendingLocale();
-    }
-    this.syncSidebarWorkboard();
-    // Chunks are usually served by the gateway, so a failed idle load of the
-    // outbox module recovers on reconnect, not only on a browser online event.
-    if (snapshot.phase === "connected") {
-      void this.outboxStoreImport.load().catch(() => undefined);
-    }
+    this.shellGateway.synchronizeGateway(snapshot);
   }
 
-  private syncSidebarWorkboard() {
-    const context = this.context;
-    const snapshot = context?.gateway.snapshot;
-    const configSnapshot = context?.runtimeConfig.state.configSnapshot;
-    if (!context || !snapshot || !configSnapshot) {
-      return;
-    }
-    if (!isWorkboardEnabledInConfigSnapshot(configSnapshot)) {
-      this.disposeSidebarWorkboard();
-      return;
-    }
-    const runtime = this.sidebarWorkboardRuntime;
-    if (runtime) {
-      if (this.sidebarWorkboardHost !== context.workboard) {
-        this.disposeSidebarWorkboard();
-        this.syncSidebarWorkboard();
-        return;
-      }
-      runtime.sync(snapshot.client, snapshot.phase === "connected");
-      return;
-    }
-    if (this.sidebarWorkboardRuntimeLoad) {
-      return;
-    }
-    const epoch = this.sidebarWorkboardEpoch;
-    const load = import("../components/app-sidebar-workboard.runtime.ts");
-    this.sidebarWorkboardRuntimeLoad = load;
-    void load
-      .then((module) => {
-        if (this.sidebarWorkboardEpoch !== epoch || this.sidebarWorkboardRuntime) {
-          return;
-        }
-        const current = this.context;
-        if (!current) {
-          return;
-        }
-        const loadedRuntime = module.createSidebarWorkboardRuntime((nextSnapshot) => {
-          if (this.sidebarWorkboardRuntime === loadedRuntime) {
-            this.sidebarWorkboardSnapshot = nextSnapshot;
-            this.requestUpdate();
-          }
-        }, current.workboard);
-        this.sidebarWorkboardRuntime = loadedRuntime;
-        this.sidebarWorkboardHost = current.workboard;
-        this.sidebarWorkboardRenderers = {
-          renderEntry: module.renderSidebarWorkboardEntry,
-          renderCustomize: module.renderSidebarWorkboardCustomize,
-        };
-        const gateway = current?.gateway.snapshot;
-        if (
-          current &&
-          gateway &&
-          isWorkboardEnabledInConfigSnapshot(current.runtimeConfig.state.configSnapshot)
-        ) {
-          loadedRuntime.sync(gateway.client, gateway.phase === "connected");
-        }
-      })
-      .catch(() => {
-        if (this.sidebarWorkboardEpoch === epoch && this.sidebarWorkboardRuntimeLoad === load) {
-          this.sidebarWorkboardRuntimeLoad = null;
-        }
-      });
+  syncSidebarWorkboard() {
+    this.shellWorkboard.syncSidebarWorkboard();
   }
 
   private disposeSidebarWorkboard() {
-    this.sidebarWorkboardEpoch += 1;
-    const runtime = this.sidebarWorkboardRuntime;
-    runtime?.dispose();
-    if (!runtime) {
-      this.context?.workboard.clearBoards();
-    }
-    this.sidebarWorkboardRuntime = null;
-    this.sidebarWorkboardHost = null;
-    this.sidebarWorkboardRenderers = undefined;
-    this.sidebarWorkboardRuntimeLoad = null;
-    if (this.sidebarWorkboardSnapshot !== EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT) {
-      this.sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
-      this.requestUpdate();
-    }
+    this.shellWorkboard.disposeSidebarWorkboard();
   }
 
   private ensureRuntimeConfig(
     snapshot: ApplicationContext["gateway"]["snapshot"],
     runtimeConfig = this.context?.runtimeConfig,
   ) {
-    // The sidebar hides config-gated routes (Workboard), so the snapshot must
-    // load eagerly instead of waiting for a page that happens to fetch it.
-    if (snapshot.phase !== "connected" || !snapshot.client || !runtimeConfig) {
-      this.runtimeConfigClient = null;
-      return;
-    }
-    if (
-      this.runtimeConfigClient === snapshot.client &&
-      this.runtimeConfigSource === runtimeConfig
-    ) {
-      return;
-    }
-    this.runtimeConfigClient = snapshot.client;
-    this.runtimeConfigSource = runtimeConfig;
-    flushServerUiPrefs(runtimeConfig, {
-      afterCommit: ({ needsRefresh, retainedLocal }) =>
-        this.reconcileCommittedServerUiPrefs(runtimeConfig, needsRefresh, retainedLocal),
-    });
-    void runtimeConfig.ensureLoaded();
+    this.shellGateway.ensureRuntimeConfig(snapshot, runtimeConfig);
   }
 
-  private enabledRouteIds(): readonly RouteId[] {
+  enabledRouteIds(): readonly RouteId[] {
     return isWorkboardEnabledInConfigSnapshot(this.context?.runtimeConfig.state.configSnapshot)
       ? APP_ROUTE_IDS
       : ROUTE_IDS_WITHOUT_WORKBOARD;
   }
 
   /** Sidebar draft-row hint while the new-session page is open, keyed off its ?agent param. */
-  private draftSessionAgentId(): string {
-    if (this.routeState.routeId !== "new-session") {
-      return "";
-    }
-    return new URLSearchParams(this.routeState.location?.search ?? "").get("agent")?.trim() ?? "";
+  draftSessionAgentId(): string {
+    return this.shellNavigation.draftSessionAgentId();
   }
 
-  private ensureAgentsList(
+  ensureAgentsList(
     snapshot: ApplicationContext["gateway"]["snapshot"],
     agents = this.context?.agents,
   ) {
-    if (snapshot.phase !== "connected" || !snapshot.client) {
-      this.agentsListClient = null;
-      return;
-    }
-    const routeId = this.routeState.routeId;
-    if (!agents || !routeId || isSessionRouteId(routeId) || agents.state.agentsList) {
-      return;
-    }
-    if (this.agentsListClient === snapshot.client && this.agentsListSource === agents) {
-      return;
-    }
-    this.agentsListClient = snapshot.client;
-    this.agentsListSource = agents;
-    void agents.ensureList();
-  }
-
-  private updateGatewaySessionKey(snapshot: {
-    client: GatewayBrowserClient | null;
-    sessionKey: string;
-  }) {
-    const sessionKey = snapshot.sessionKey.trim();
-    if (snapshot.client === this.sessionKeyClient && sessionKey === this.activeSessionKey) {
-      return;
-    }
-    this.sessionKeyClient = snapshot.client;
-    if (sessionKey) {
-      this.activeSessionKey = sessionKey;
-    }
+    this.shellGateway.ensureAgentsList(snapshot, agents);
   }
 
   private updateRouteState(routeState: ShellRouteState) {
-    this.routeState = routeState;
-    if (routeState.routeId !== undefined) {
-      if (this.lastConcreteRouteId === "custodian" && routeState.routeId !== "custodian") {
-        this.custodianMinimizeRequestId += 1;
-      }
-      this.lastConcreteRouteId = routeState.routeId;
-    }
-    const committedRouteId = routeState.committedRouteId;
-    const committedPathname = routeState.committedLocation?.pathname ?? "";
-    const committedSearch = routeState.committedLocation?.search ?? "";
-    // Restoration and persistence both wait for a live context: consuming the
-    // one-shot restore without a router to call, or persisting the bootstrap
-    // route first, would clobber the stored route.
-    const routeContext = this.context;
-    if (committedRouteId && routeContext) {
-      // A rendered/pending match that differs from the committed route is an
-      // in-flight navigation: it wins over the one-shot restore, and the stale
-      // committed route must not be persisted over the remembered destination.
-      const pendingDiffers =
-        routeState.routeId !== committedRouteId ||
-        (routeState.location?.pathname ?? "") !== committedPathname ||
-        (routeState.location?.search ?? "") !== committedSearch;
-      if (!this.didConsiderNativeRouteRestore) {
-        this.didConsiderNativeRouteRestore = true;
-        const storedRoute = pendingDiffers
-          ? null
-          : considerRouteRestore(committedRouteId, committedPathname, committedSearch);
-        if (storedRoute) {
-          // Replace instead of push so a fresh window does not start with a
-          // Back entry pointing at the bootstrap chat route.
-          routeContext.replace(storedRoute.routeId, {
-            pathname: storedRoute.pathname,
-            search: storedRoute.search,
-          });
-          return;
-        }
-      }
-      if (!pendingDiffers) {
-        const committedSessionKey = routeState.committedSessionKey;
-        const committedSessionDeleted =
-          committedSessionKey !== undefined &&
-          (routeContext.sessions?.state.deletedSessions ?? []).some(({ key, agentId }) =>
-            uiSessionEventMatches(
-              {
-                agentsList: routeContext.agents.state.agentsList,
-                hello: routeContext.gateway.snapshot.hello,
-                sessionKey: committedSessionKey,
-              },
-              key,
-              agentId,
-            ),
-          );
-        if (committedSessionDeleted) {
-          // An older route can commit after deletion recovery has started.
-          // Never let it persist or reselect the session we just retired.
-          this.replaceChatWithCurrentSession();
-          return;
-        }
-        persistRoute(committedRouteId, committedPathname, committedSearch);
-        if (committedSessionKey) {
-          this.activeSessionKey = committedSessionKey;
-          selectApplicationSession({
-            selection: routeContext.agentSelection,
-            gateway: routeContext.gateway,
-            sessionKey: committedSessionKey,
-          });
-        }
-      }
-    }
-    const context = this.context;
-    if (context) {
-      this.ensureAgentsList(context.gateway.snapshot);
-    }
-    if (routeState.routeId && !isSettingsNavigationRoute(routeState.routeId)) {
-      this.settingsSearchQuery = "";
-      this.lastWorkspaceLocation = {
-        routeId: routeState.routeId,
-        pathname: routeState.location?.pathname ?? "",
-        search: routeState.location?.search ?? "",
-      };
-    }
+    this.shellNavigation.updateRouteState(routeState);
   }
 
   override render() {
-    const context = this.context;
-    const runtime = this.runtime;
-    if (!context || !runtime) {
-      return nothing;
-    }
-    const gatewaySnapshot = context.gateway.snapshot;
-    const gatewayConnected = gatewaySnapshot.phase === "connected";
-    const operatorAccess = readGatewayOperatorAccess(gatewaySnapshot);
-    const outboxScopeHost = this.storedOutboxScopeHost(context);
-    const outboxStoreRuntime = this.outboxStoreRuntime;
-    const storedOutboxes = outboxStoreRuntime
-      ? outboxStoreRuntime.summarizeStoredChatOutboxes(outboxScopeHost)
-      : null;
-    const outboxCountForSession = outboxStoreRuntime
-      ? (sessionKey: string) => {
-          const scope = outboxStoreRuntime.resolveStoredChatOutboxScope(
-            outboxScopeHost,
-            sessionKey,
-          );
-          return (
-            storedOutboxes?.countsByScope.get(outboxStoreRuntime.storedChatOutboxScopeKey(scope)) ??
-            0
-          );
-        }
-      : EMPTY_OUTBOX_COUNT_FOR_SESSION;
-    const navigationSnapshot = context.navigation.snapshot;
-    const overlaySnapshot = context.overlays.snapshot;
-    const terminalAvailable = isTerminalAvailable(
-      gatewaySnapshot,
-      context.config.current.terminalEnabled ?? false,
-    );
-    const browserPanelAvailable = isBrowserPanelAvailable(gatewaySnapshot);
-    const custodianPanelAvailable =
-      gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
-    const activeRoute = this.routeState.routeId ?? "chat";
-    // Plugin tabs share one route; the search picks the active item.
-    const activePluginRef =
-      activeRoute === "plugin"
-        ? pluginTabRefFromSearch(this.routeState.location?.search ?? "")
-        : null;
-    const activePluginTabId = activePluginRef ? pluginTabKey(activePluginRef) : "";
-    const settingsTakeover = isSettingsNavigationRoute(activeRoute);
-    const runtimeConfig = context.runtimeConfig.state;
-    const settingsSearchBlocks = findSettingsSearchBlocks({
-      query: this.settingsSearchQuery,
-      schema: runtimeConfig.configSchema,
-      value: runtimeConfig.configForm ?? runtimeConfig.configSnapshot?.config ?? null,
-      uiHints: runtimeConfig.configUiHints,
-      identityAvailable: Boolean(gatewaySnapshot.selfUser),
-      basePath: context.basePath,
-    });
-    const onboarding = this.onboardingMode;
-    const navDrawerOpen = this.navDrawerOpen && !onboarding;
-    const mobileNavLayout = isMobileNavLayout();
-    const mergedChatChrome = shouldMergeChatChrome({
-      mobileNavLayout,
-      routeId: activeRoute,
-      onboarding,
-    });
-    // Drawer navigation always opens expanded; the desktop collapse preference
-    // stays persisted for when the viewport returns to the desktop layout.
-    // The settings sidebar has a fixed width, so the collapse state pauses too.
-    const navCollapsed =
-      navigationSnapshot.navCollapsed &&
-      !this.desktopNavigationExpanded &&
-      !navDrawerOpen &&
-      !settingsTakeover;
-    const navigationSurfaceHidden = navigationSurfaceIsHidden({
-      navCollapsed,
-      navDrawerOpen,
-      mobileNavLayout,
-    });
-    const shellWidth = Math.max(globalThis.innerWidth || 0, NAV_WIDTH_MAX);
-    // Mirror the sidebar brand action: an open new-session draft wins over the
-    // persisted selection so the collapsed cluster "+" targets the same agent.
-    const selectedAgentId = normalizeAgentId(
-      this.draftSessionAgentId() ||
-        (context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId),
-    );
-    // One storage read per render; theme.refresh() re-renders on pref changes.
-    const uiSettings = loadSettings();
-    // The new-session draft shares the chat layout: full-height pane that owns
-    // its scrolling and pins the composer dock to the bottom.
-    const chatLikeRoute = isSessionRouteId(activeRoute) || activeRoute === "new-session";
-    const custodianRoute = activeRoute === "custodian";
-    const inlineApproval = isSessionRouteId(activeRoute)
-      ? findInlineApproval(overlaySnapshot.approvalQueue, this.activeSessionKey)
-      : null;
-    if (!settingsTakeover) {
-      Object.assign(this.navigationSidebar, {
-        basePath: context.basePath,
-        activeRouteId: activeRoute,
-        activePluginTabId,
-        enabledRouteIds: this.enabledRouteIds(),
-        activeWorkboardBoardId:
-          workboardBoardIdFromPath(this.routeState.location?.pathname ?? "", context.basePath) ??
-          "",
-        sessionKey: this.activeSessionKey,
-        connected: gatewayConnected,
-        offline: gatewaySnapshot.offlineStable,
-        outboxCountForSession,
-        terminalAvailable,
-        catalogOpenTarget: normalizeCatalogOpenTarget(uiSettings.catalogOpenTarget),
-        canPairDevice: gatewayConnected && (operatorAccess.canAdmin || operatorAccess.canPair),
-        sidebarEntries: navigationSnapshot.sidebarEntries,
-        workboardBoards: this.sidebarWorkboardSnapshot.boards,
-        workboardBoardsReady: this.sidebarWorkboardSnapshot.ready,
-        workboardRenderers: this.sidebarWorkboardRenderers,
-        sidebarLiveActivity: uiSettings.sidebarLiveActivity !== false,
-        pinnedAgentIds: navigationSnapshot.pinnedAgentIds,
-        themeMode: context.theme.mode,
-        lobsterPetVisits: uiSettings.lobsterPetVisits !== false,
-        lobsterPetSounds: uiSettings.lobsterPetSounds === true,
-        gatewayVersion:
-          context.config.current.serverVersion ?? gatewaySnapshot.hello?.server?.version ?? null,
-        devGitBranch: context.config.current.devGitBranch,
-        updateAvailable: navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable,
-        updateRunning: overlaySnapshot.updateRunning,
-        onUpdate: () => void context.overlays.runUpdate(),
-        onOpenApprovals: this.openApprovals,
-        onRetryConnect: () => context.gateway.connect(),
-        onOpenNewSession: (agentId: string, target?: NewSessionTarget) =>
-          this.openNewSession(agentId, target),
-        draftSessionAgentId: this.draftSessionAgentId(),
-        onUpdateSidebarEntries: (entries: string[]) =>
-          context.navigation.update({ sidebarEntries: entries }),
-        onPairMobile: () => void context.overlays.openDevicePairSetup(),
-        onNavigate: (routeId: string, options?: ApplicationNavigationOptions) =>
-          this.navigate(routeId, options),
-        onPreloadRoute: (routeId: string) =>
-          isRouteId(routeId) ? context.preload(routeId) : Promise.resolve(),
-      });
-    }
-    const navigationContent = settingsTakeover
-      ? renderSettingsSidebar({
-          basePath: context.basePath,
-          activeRouteId: activeRoute,
-          activePathname: this.routeState.location?.pathname ?? "",
-          activeSearch: this.routeState.location?.search ?? "",
-          activeHash: this.routeState.location?.hash ?? "",
-          offline: gatewaySnapshot.offlineStable,
-          queuedOutboxCount: storedOutboxes?.total ?? 0,
-          lastError: gatewaySnapshot.lastError,
-          gatewayVersion:
-            context.config.current.serverVersion ?? gatewaySnapshot.hello?.server?.version ?? "",
-          updateAvailable: navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable,
-          updateRunning: overlaySnapshot.updateRunning,
-          onUpdate: () => void context.overlays.runUpdate(),
-          searchQuery: this.settingsSearchQuery,
-          searchBlockMatches: settingsSearchBlocks,
-          onExit: () => this.exitSettings(),
-          onRetryConnect: () => context.gateway.connect(),
-          onNavigate: (routeId, options) => this.navigate(routeId, options),
-          onPreload: (routeId) => context.preload(routeId),
-          onSearchQueryChange: (nextQuery) => {
-            void this.handleSettingsSearchQueryChange(nextQuery);
-          },
-          preloadTimers: this.settingsPreloadTimers,
-          saveIndicator: {
-            status: runtimeConfig.configAutoSaveStatus,
-            lastError: runtimeConfig.lastError,
-            needsApply: runtimeConfig.configNeedsApply,
-            applying: runtimeConfig.configApplying,
-            applyDisabled:
-              runtimeConfig.configLoading ||
-              runtimeConfig.configSaving ||
-              (runtimeConfig.configFormDirty && runtimeConfig.configFormMode === "raw") ||
-              overlaySnapshot.updateRunning ||
-              overlaySnapshot.updateReconciliationPending,
-            onRetry: () => void context.runtimeConfig.save(),
-            onReload: () => void context.runtimeConfig.discardDraft(),
-            onApply: () => void context.runtimeConfig.apply(),
-          },
-        })
-      : this.navigationSidebar;
-    // Optional tags stay mounted before definition. Lit replays their properties on upgrade,
-    // and the upgraded panels catch the first toggle instead of dropping the event.
-    return html`
-      ${isOptionalElementDefined(this.commandPaletteElement)
-        ? html`<openclaw-command-palette
-            .onNavigate=${(routeId: RouteId) => this.navigate(routeId)}
-            .onSelectSession=${(sessionKey: string) => this.selectChatSession(sessionKey)}
-            .onSlashCommand=${this.handleCommandPaletteSlashCommand}
-          ></openclaw-command-palette>`
-        : nothing}
-      <div
-        class="shell ${chatLikeRoute ? "shell--chat" : ""} ${navCollapsed
-          ? "shell--nav-collapsed"
-          : ""} ${mobileNavLayout ? "shell--mobile-nav" : ""} ${mergedChatChrome
-          ? "shell--merged-chat-chrome"
-          : ""} ${navDrawerOpen ? "shell--nav-drawer-open" : ""} ${onboarding
-          ? "shell--onboarding"
-          : ""} ${settingsTakeover ? "shell--settings" : ""}"
-        style=${`--shell-nav-expanded-width: ${navigationSnapshot.navWidth}px`}
-        @theme-change=${this.handleThemeChange}
-      >
-        <a class="shell-skip-link" href="#control-ui-main"> ${t("common.skipToMainContent")} </a>
-        ${isNativeWebChromeHost() && !onboarding
-          ? html`
-              <openclaw-macos-titlebar-controls
-                .navCollapsed=${this.nativeNavCollapsed()}
-                .historyOnly=${settingsTakeover}
-                .canGoBack=${this.nativeHistoryState.canGoBack}
-                .canGoForward=${this.nativeHistoryState.canGoForward}
-                .onToggleSidebar=${() => this.toggleNavigationSurface()}
-                .onOpenPalette=${this.openPalette}
-                .onOpenNewSession=${this.handleNativeNewSession}
-              ></openclaw-macos-titlebar-controls>
-            `
-          : nothing}
-        <openclaw-app-topbar
-          .basePath=${context.basePath}
-          .searchDisabled=${false}
-          .navDrawerOpen=${navDrawerOpen}
-          .onboarding=${onboarding}
-          .onOpenPalette=${this.openPalette}
-          .onToggleDrawer=${(trigger: HTMLElement) => this.toggleNavigationSurface(trigger)}
-        ></openclaw-app-topbar>
-        ${!onboarding && !settingsTakeover && !mobileNavLayout
-          ? html`
-              <div class="shell-chrome-controls">
-                <openclaw-tooltip
-                  .content=${`${t(navCollapsed ? "nav.expand" : "nav.collapse")} (⌘B)`}
-                >
-                  <button
-                    type="button"
-                    class="shell-chrome-controls__button shell-chrome-controls__nav-toggle"
-                    aria-label=${t(navCollapsed ? "nav.expand" : "nav.collapse")}
-                    aria-expanded=${navCollapsed ? "false" : "true"}
-                    @click=${() => this.toggleNavigationSurface()}
-                  >
-                    ${navCollapsed ? icons.panelLeftOpen : icons.panelLeftClose}
-                  </button>
-                </openclaw-tooltip>
-                ${navCollapsed
-                  ? html`<openclaw-tooltip
-                      .content=${gatewaySnapshot.phase === "connected"
-                        ? t("chat.runControls.newSession")
-                        : t("chat.runControls.newSessionDisconnected")}
-                    >
-                      <button
-                        type="button"
-                        class="shell-chrome-controls__button shell-chrome-controls__new-thread"
-                        aria-label=${t("chat.runControls.newSession")}
-                        ?disabled=${gatewaySnapshot.phase !== "connected"}
-                        @click=${() => this.openNewSession(selectedAgentId)}
-                      >
-                        ${icons.plus}
-                      </button>
-                    </openclaw-tooltip>`
-                  : nothing}
-                <openclaw-tooltip
-                  .content=${`${t("chat.openCommandPalette")} (${PALETTE_SHORTCUT})`}
-                >
-                  <button
-                    type="button"
-                    class="shell-chrome-controls__button shell-chrome-controls__search"
-                    aria-label=${t("chat.openCommandPalette")}
-                    @click=${this.openPalette}
-                  >
-                    ${icons.search}
-                  </button>
-                </openclaw-tooltip>
-              </div>
-            `
-          : nothing}
-        <div class="shell-nav" ?inert=${navigationSurfaceHidden}>
-          ${mobileNavLayout
-            ? html`<openclaw-modal-dialog
-                class="drawer nav-drawer"
-                .open=${navDrawerOpen}
-                .label=${t("palette.categories.navigation")}
-                @modal-cancel=${() => this.closeNavDrawer({ restoreFocus: true })}
-              >
-                <div class="shell-nav-modal__content" tabindex="-1" autofocus>
-                  ${navigationContent}
-                </div>
-              </openclaw-modal-dialog>`
-            : navigationContent}
-        </div>
-        ${!navCollapsed && !onboarding && !settingsTakeover
-          ? html`
-              <resizable-divider
-                class="sidebar-resizer"
-                .label=${t("nav.resize")}
-                .splitRatio=${navigationSnapshot.navWidth / shellWidth}
-                .minRatio=${NAV_WIDTH_MIN / shellWidth}
-                .maxRatio=${NAV_WIDTH_MAX / shellWidth}
-                aria-valuetext=${`${navigationSnapshot.navWidth} pixels`}
-                title=${t("nav.resize")}
-                @resize=${(event: CustomEvent<{ splitRatio: number }>) =>
-                  this.resizeNavigation(event.detail.splitRatio)}
-              ></resizable-divider>
-            `
-          : nothing}
-        <main
-          id="control-ui-main"
-          class="content ${chatLikeRoute ? "content--chat" : ""} ${custodianRoute
-            ? "content--custodian"
-            : ""} ${activeRoute === "workboard" ? "content--workboard" : ""}"
-          .tabIndex=${-1}
-        >
-          ${gatewaySnapshot.hello?.deviceAuthMigration?.pending === true
-            ? customElements.get("openclaw-device-auth-migration-banner")
-              ? html`<openclaw-device-auth-migration-banner
-                  .props=${{
-                    state: overlaySnapshot.deviceAuthMigration,
-                    onSecure: () => void context.overlays.secureThisBrowser(),
-                  }}
-                ></openclaw-device-auth-migration-banner>`
-              : html`<openclaw-update-banner
-                  .props=${{
-                    statusBanner: {
-                      tone: overlaySnapshot.deviceAuthMigration.error ? "danger" : "warn",
-                      text:
-                        overlaySnapshot.deviceAuthMigration.error ??
-                        t("login.deviceAuthMigration.banner"),
-                    },
-                  }}
-                ></openclaw-update-banner>`
-            : html`<openclaw-update-banner
-                .props=${{
-                  statusBanner: overlaySnapshot.controlUiRefreshRequired
-                    ? resolveControlUiRefreshRequiredBanner()
-                    : null,
-                  action: overlaySnapshot.controlUiRefreshRequired
-                    ? { label: t("common.refresh"), onClick: this.refreshControlUi }
-                    : undefined,
-                }}
-              ></openclaw-update-banner>`}
-          <openclaw-update-banner
-            .props=${{
-              statusBanner: overlaySnapshot.updateStatusBanner,
-            }}
-          ></openclaw-update-banner>
-          ${renderFloatingUpdateCard({
-            navigationSurfaceHidden,
-            onboarding,
-            updateAvailable: overlaySnapshot.updateAvailable,
-            updateRunning: overlaySnapshot.updateRunning,
-            onUpdate: () => void context.overlays.runUpdate(),
-          })}
-          <openclaw-router-outlet
-            .router=${runtime.router}
-            .retryContext=${context}
-            .onNotFound=${() => this.replaceChatWithCurrentSession()}
-          ></openclaw-router-outlet>
-        </main>
-        <openclaw-terminal-panel
-          .client=${gatewayConnected ? gatewaySnapshot.client : null}
-          .available=${terminalAvailable}
-          .suppressed=${settingsTakeover}
-          .themeMode=${resolveTerminalThemeMode()}
-        ></openclaw-terminal-panel>
-        <openclaw-browser-panel
-          .client=${gatewayConnected ? gatewaySnapshot.client : null}
-          .available=${browserPanelAvailable}
-          .suppressed=${settingsTakeover}
-          .basePath=${context.basePath}
-          .authToken=${resolveControlUiAuthToken({
-            hello: gatewaySnapshot.hello,
-            settings: { token: context.gateway.connection.token },
-            password: context.gateway.connection.password,
-          })}
-        ></openclaw-browser-panel>
-        <openclaw-custodian-panel
-          .available=${custodianPanelAvailable}
-          .suppressed=${activeRoute === "custodian"}
-          .minimizeRequestId=${this.custodianMinimizeRequestId}
-        ></openclaw-custodian-panel>
-        ${isOptionalElementDefined(this.execApprovalElement)
-          ? html`<openclaw-exec-approval
-              .props=${{
-                queue: overlaySnapshot.approvalQueue,
-                busy: overlaySnapshot.approvalBusy,
-                errors: overlaySnapshot.approvalErrors,
-                nowMs: overlaySnapshot.approvalNowMs,
-                inlineApprovalId: inlineApproval?.id ?? null,
-                onDecision: (
-                  approvalId: string,
-                  decision: Parameters<typeof context.overlays.decideApproval>[0],
-                ) => context.overlays.decideApproval(decision, approvalId),
-              }}
-            ></openclaw-exec-approval>`
-          : nothing}
-        ${renderDevicePairSetup({
-          open: overlaySnapshot.devicePairSetupOpen,
-          loading: overlaySnapshot.devicePairSetupLoading,
-          error: overlaySnapshot.devicePairSetupError,
-          setup: overlaySnapshot.devicePairSetup,
-          access: overlaySnapshot.devicePairSetupAccess,
-          pendingCount: overlaySnapshot.devicePairPendingCount,
-          onRefresh: () => void context.overlays.refreshDevicePairSetup(),
-          onAccessChange: (access) => void context.overlays.setDevicePairSetupAccess(access),
-          onClose: () => context.overlays.closeDevicePairSetup(),
-          onCopy: (setupCode) => void copyToClipboard(setupCode),
-          onManageDevices: () => {
-            context.overlays.closeDevicePairSetup();
-            this.navigate("nodes");
-          },
-          onGetApps: () => {
-            context.overlays.closeDevicePairSetup();
-            this.navigate("apps");
-          },
-        })}
-        ${onboarding && activeRoute !== "custodian"
-          ? html`<openclaw-onboarding-memory-import
-              .active=${true}
-              .context=${context}
-            ></openclaw-onboarding-memory-import>`
-          : nothing}
-        <openclaw-toast-host></openclaw-toast-host>
-      </div>
-    `;
+    return renderApplicationShell(this);
   }
 }
 if (!customElements.get("openclaw-app")) {
@@ -2328,4 +599,3 @@ if (!customElements.get("openclaw-app")) {
 if (!customElements.get("openclaw-app-shell")) {
   customElements.define("openclaw-app-shell", OpenClawShell);
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -1,0 +1,317 @@
+import { ContextProvider } from "@lit/context";
+import { html, nothing } from "lit";
+import { state } from "lit/decorators.js";
+import { hasStoredGatewayAuth, type GatewayBrowserClient } from "../api/gateway.ts";
+import type { RouteId } from "../app-routes.ts";
+import "../components/gateway-url-confirmation.ts";
+import "../components/github-link-hovercard-registration.ts";
+import "../components/login-gate.ts";
+import "../components/openclaw-mascot.ts";
+import "../components/tooltip.ts";
+import { t } from "../i18n/index.ts";
+import { isTerminalAvailable } from "../lib/terminal-availability.ts";
+import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
+import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
+import { applicationContext, type ApplicationContext } from "./context.ts";
+import {
+  APPROVAL_PAGE_ELEMENT,
+  isOptionalElementDefined,
+  preloadOptionalElement,
+  TERMINAL_PANEL_ELEMENT,
+} from "./lazy-custom-element.ts";
+import { resolveOnboardingMode } from "./onboarding-mode.ts";
+import { controlUiPublicAssetPath } from "./public-assets.ts";
+
+/**
+ * Terminal-only document mode (`?view=terminal`): the mobile apps embed the
+ * terminal as a full-screen WebView page instead of the whole Control UI.
+ * Fixed per document load — the apps construct the URL, users never toggle it.
+ */
+function isTerminalOnlyView(): boolean {
+  return new URLSearchParams(globalThis.location?.search ?? "").get("view") === "terminal";
+}
+
+export function resolveTerminalThemeMode(): "dark" | "light" {
+  return document.documentElement.dataset.themeMode === "light" ? "light" : "dark";
+}
+
+function renderConnectingSplash() {
+  return html`
+    <main class="connect-splash" role="status" aria-live="polite" aria-label=${t("common.loading")}>
+      <openclaw-mascot mood="thinking" .size=${120}></openclaw-mascot>
+    </main>
+  `;
+}
+
+function renderApprovalDocument(runtime: ApplicationRuntime) {
+  const documentMode = runtime.documentMode;
+  if (documentMode?.kind !== "approval") {
+    return nothing;
+  }
+  return html`
+    <openclaw-approval-page .approvalId=${documentMode.approvalId ?? ""}>
+      <main class="approval-page approval-page--booting" role="status" aria-live="polite">
+        <img
+          class="connect-splash__logo"
+          src=${controlUiPublicAssetPath("favicon.svg", runtime.context.basePath)}
+          alt=""
+        />
+        <span>${t("common.loading")}</span>
+      </main>
+    </openclaw-approval-page>
+  `;
+}
+
+export class OpenClawApp extends OpenClawLightDomElement {
+  // Pinned while a connect submitted from the visible login gate is in
+  // flight, so a failed manual attempt cannot flash the shell in between.
+  @state() private loginGatePinned = false;
+  @state() private loginGatewayUrl = "";
+  @state() private loginToken = "";
+  @state() private loginPassword = "";
+  @state() private loginShowGatewayToken = false;
+  @state() private loginShowGatewayPassword = false;
+  @state() private pendingGatewayUrl: string | null = null;
+  @state() private onboarding = resolveOnboardingMode(globalThis.location?.search ?? "");
+
+  private readonly terminalOnly = isTerminalOnlyView();
+  // Fixed at page load: whether this browser held credentials (token,
+  // password, or stored device token) before the first connect attempt.
+  // Later manual gate submissions are covered by loginGatePinned instead.
+  private initialAuthPresent = false;
+  private runtime: ApplicationRuntime | undefined;
+  private readonly contextProvider = new ContextProvider(this, {
+    context: applicationContext,
+  });
+  private readonly subscriptions = new SubscriptionsController(this);
+  private loginGatewaySource: ApplicationContext["gateway"] | null = null;
+  private loginConnectionClient: GatewayBrowserClient | null = null;
+
+  private get context(): ApplicationContext<RouteId> | undefined {
+    return this.runtime?.context;
+  }
+
+  constructor() {
+    super();
+    this.subscriptions
+      .watch(
+        () => this.context?.gateway,
+        (gateway, notify) => gateway.subscribe(notify),
+        (gateway) => this.synchronizeGateway(gateway),
+      )
+      .watch(
+        () => (this.terminalOnly ? this.context?.config : undefined),
+        (config, notify) => config.subscribe(notify),
+      );
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    void import("../components/app-sidebar.ts");
+    this.resetLoginSensitivePresentation();
+    this.runtime = bootstrapApplication();
+    if (this.terminalOnly) {
+      preloadOptionalElement(this, TERMINAL_PANEL_ELEMENT);
+    }
+    if (this.runtime.documentMode?.kind === "approval") {
+      preloadOptionalElement(this, APPROVAL_PAGE_ELEMENT);
+    }
+    const context = this.runtime.context;
+    this.initialAuthPresent = hasStoredGatewayAuth(context.gateway.connection);
+    this.pendingGatewayUrl = this.runtime.pendingGatewayConnection?.gatewayUrl ?? null;
+    // Context identity changes only across a full app-tree connection epoch;
+    // descendants reconnect and rebuild their controller-owned state afterward.
+    this.contextProvider.setValue(context);
+    this.syncLoginConnection();
+    // The runtime is created after controller hostConnected hooks run. Ensure
+    // their lazy source getters bind on both the initial mount and reconnect.
+    this.requestUpdate();
+    void this.runtime.start().catch((error: unknown) => {
+      console.error("[openclaw] application start failed", error);
+    });
+  }
+
+  override disconnectedCallback() {
+    // Stop reactive subscriptions before disposing their application sources.
+    this.subscriptions.clear();
+    this.runtime?.stop();
+    this.runtime = undefined;
+    this.loginGatewaySource = null;
+    this.loginConnectionClient = null;
+    this.pendingGatewayUrl = null;
+    this.resetLoginSensitivePresentation();
+    super.disconnectedCallback();
+  }
+
+  private synchronizeGateway(gateway: ApplicationContext["gateway"]) {
+    const sourceChanged = gateway !== this.loginGatewaySource;
+    if (sourceChanged) {
+      this.loginGatewaySource = gateway;
+      this.loginConnectionClient = null;
+      this.resetLoginSensitivePresentation();
+    }
+    const snapshot = gateway.snapshot;
+    const clientChanged = snapshot.client !== this.loginConnectionClient;
+    if (clientChanged) {
+      this.loginConnectionClient = snapshot.client;
+      this.resetLoginSensitivePresentation();
+    }
+    if (sourceChanged || clientChanged) {
+      this.syncLoginConnection(gateway);
+    }
+    if (snapshot.phase === "connected") {
+      this.loginGatePinned = false;
+    }
+  }
+
+  private syncLoginConnection(gateway = this.context?.gateway) {
+    const connection = gateway?.connection;
+    if (!connection) {
+      return;
+    }
+    this.loginGatewayUrl = connection.gatewayUrl;
+    this.loginToken = connection.token;
+    this.loginPassword = connection.password;
+  }
+
+  private resetLoginSensitivePresentation() {
+    this.loginShowGatewayToken = false;
+    this.loginShowGatewayPassword = false;
+  }
+
+  override render() {
+    const context = this.context;
+    const runtime = this.runtime;
+    if (!context || !runtime) {
+      return html`<main class="app-shell app-shell--booting" aria-busy="true"></main>`;
+    }
+    const gatewaySnapshot = context.gateway.snapshot;
+    const gatewayConnected = gatewaySnapshot.phase === "connected";
+    const gatewayUrlConfirmation = this.pendingGatewayUrl
+      ? html`
+          <openclaw-gateway-url-confirmation
+            .props=${{
+              pendingGatewayUrl: this.pendingGatewayUrl,
+              onConfirm: () => {
+                runtime.confirmPendingGatewayConnection();
+                this.pendingGatewayUrl = null;
+              },
+              onCancel: () => {
+                runtime.cancelPendingGatewayConnection();
+                this.pendingGatewayUrl = null;
+              },
+            }}
+          ></openclaw-gateway-url-confirmation>
+        `
+      : nothing;
+    // Embedded mobile terminals own the whole document. Keep the generic login
+    // gate out of this path or a connecting native session exposes Web UI chrome.
+    if (this.terminalOnly) {
+      const terminalAvailable = isTerminalAvailable(
+        gatewaySnapshot,
+        context.config.current.terminalEnabled ?? false,
+      );
+      // Embedded clients query this host immediately; keep it stable while the chunk loads.
+      return html`
+        <openclaw-terminal-panel
+          .client=${gatewayConnected ? gatewaySnapshot.client : null}
+          .available=${terminalAvailable}
+          .themeMode=${resolveTerminalThemeMode()}
+          fullscreen
+        ></openclaw-terminal-panel>
+        ${!isOptionalElementDefined(TERMINAL_PANEL_ELEMENT) && terminalAvailable
+          ? renderConnectingSplash()
+          : nothing}
+        ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
+          ? html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`
+          : nothing}
+      `;
+    }
+    // Transport drops after an established session keep the shell mounted
+    // (offline presentation + client auto-retry); the login gate is reserved for
+    // credential-less first connects, credential rejections, and manual gate
+    // submissions. A first connect backed by stored credentials paints the
+    // connecting splash instead of flashing the login gate; the gate returns
+    // the moment the attempt fails (lastError set on every close).
+    const initialConnectPending =
+      this.initialAuthPresent &&
+      !gatewayConnected &&
+      gatewaySnapshot.phase !== "reconnecting" &&
+      !this.loginGatePinned &&
+      gatewaySnapshot.lastError === null &&
+      gatewaySnapshot.client !== null;
+    if (initialConnectPending) {
+      return html`
+        <openclaw-tooltip-provider>
+          ${renderConnectingSplash()} ${gatewayUrlConfirmation}
+        </openclaw-tooltip-provider>
+      `;
+    }
+    const showLoginGate =
+      !gatewayConnected && (this.loginGatePinned || gatewaySnapshot.phase !== "reconnecting");
+    if (showLoginGate) {
+      return html`
+        <openclaw-tooltip-provider>
+          <openclaw-login-gate
+            .props=${{
+              basePath: context.basePath,
+              connected: gatewayConnected,
+              lastError: gatewaySnapshot.lastError,
+              lastErrorCode: gatewaySnapshot.lastErrorCode,
+              hasToken: Boolean(this.loginToken.trim()),
+              hasPassword: Boolean(this.loginPassword.trim()),
+              gatewayUrl: this.loginGatewayUrl,
+              token: this.loginToken,
+              password: this.loginPassword,
+              showGatewayToken: this.loginShowGatewayToken,
+              showGatewayPassword: this.loginShowGatewayPassword,
+              onGatewayUrlChange: (value: string) => {
+                this.loginGatewayUrl = value;
+              },
+              onTokenChange: (value: string) => {
+                this.loginToken = value;
+              },
+              onPasswordChange: (value: string) => {
+                this.loginPassword = value;
+              },
+              onToggleGatewayToken: () => {
+                this.loginShowGatewayToken = !this.loginShowGatewayToken;
+              },
+              onToggleGatewayPassword: () => {
+                this.loginShowGatewayPassword = !this.loginShowGatewayPassword;
+              },
+              onConnect: () => {
+                this.loginGatePinned = true;
+                context.gateway.connect({
+                  gatewayUrl: this.loginGatewayUrl,
+                  token: this.loginToken,
+                  password: this.loginPassword,
+                });
+              },
+            }}
+          ></openclaw-login-gate>
+          ${gatewayUrlConfirmation}
+        </openclaw-tooltip-provider>
+      `;
+    }
+    if (runtime.documentMode?.kind === "approval") {
+      return html`
+        <openclaw-tooltip-provider>
+          ${gatewayUrlConfirmation} ${renderApprovalDocument(runtime)}
+        </openclaw-tooltip-provider>
+      `;
+    }
+    return html`
+      <openclaw-tooltip-provider>
+        <openclaw-github-link-hovercard-provider .client=${gatewaySnapshot.client}>
+          ${gatewayUrlConfirmation}
+          <openclaw-app-shell
+            .runtime=${runtime}
+            .onboarding=${this.onboarding}
+          ></openclaw-app-shell>
+        </openclaw-github-link-hovercard-provider>
+      </openclaw-tooltip-provider>
+    `;
+  }
+}

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -1,0 +1,530 @@
+import { isSettingsNavigationRoute } from "../app-navigation.ts";
+import { routeIdFromPath, type RouteId } from "../app-route-paths.ts";
+import {
+  COMMAND_PALETTE_OPEN_EVENT,
+  COMMAND_PALETTE_TARGET_EVENT,
+  isCommandPaletteShortcut,
+  SHELL_NAV_DRAWER_TOGGLE_EVENT,
+  type CommandPaletteElement,
+  type CommandPaletteTargetDetail,
+  type ShellNavDrawerToggleDetail,
+} from "../components/command-palette-contract.ts";
+import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
+import {
+  BROWSER_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
+  isTerminalPanelShortcut,
+  TERMINAL_PANEL_TOGGLE_EVENT,
+  type PanelToggleElement,
+} from "../components/panel-toggle-contract.ts";
+import type { BoardFace } from "../lib/board/settings.ts";
+import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
+import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
+import { isTerminalAvailable } from "../lib/terminal-availability.ts";
+import type { ShellRouteState } from "./app-host-route-state.ts";
+import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
+import {
+  ensureOptionalElementForHost,
+  isOptionalElementDefined,
+  type OptionalCustomElement,
+} from "./lazy-custom-element.ts";
+import { isMobileNavLayout } from "./mobile-nav-layout.ts";
+import {
+  NATIVE_HISTORY_STATE_EVENT,
+  readNativeHistoryState,
+  type NativeHistoryState,
+} from "./native-web-chrome.ts";
+import { hasOperatorAdminAccess } from "./operator-access.ts";
+import { NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
+
+type AppSidebarElement = HTMLElement & {
+  dismissTransientMenus: () => boolean;
+};
+
+export function isBrowserPanelAvailable(
+  snapshot: ApplicationContext["gateway"]["snapshot"],
+): boolean {
+  return (
+    snapshot.phase === "connected" &&
+    hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
+    isGatewayMethodAdvertised(snapshot, "browser.request") === true
+  );
+}
+
+export interface ShellChromeHost extends HTMLElement {
+  readonly context: ApplicationContext<RouteId> | undefined;
+  readonly onboardingMode: boolean;
+  readonly updateComplete: Promise<boolean>;
+  readonly commandPaletteElement: OptionalCustomElement;
+  readonly terminalPanelElement: OptionalCustomElement;
+  readonly browserPanelElement: OptionalCustomElement;
+  readonly custodianPanelElement: OptionalCustomElement;
+  readonly execApprovalElement: OptionalCustomElement;
+  readonly commandPalette: CommandPaletteElement | undefined;
+  readonly approvalOverlay: (HTMLElement & { show(): void }) | undefined;
+  routeState: ShellRouteState;
+  navDrawerOpen: boolean;
+  desktopNavigationExpanded: boolean;
+  navDrawerTrigger: HTMLElement | null;
+  nativeHistoryState: NativeHistoryState;
+  commandPaletteTarget: CommandPaletteTargetDetail | undefined;
+  pendingNativeNewSession: boolean;
+  requestUpdate(): void;
+  closeNavDrawer(options?: { restoreFocus?: boolean }): void;
+  exitSettings(): void;
+  navigate(routeId: string, options?: ApplicationNavigationOptions): void;
+  openNewSession(agentId: string): void;
+  chatNavigationOptions(
+    face: BoardFace,
+    options?: ApplicationNavigationOptions,
+  ): ApplicationNavigationOptions | undefined;
+}
+
+export class ShellChromeOwner {
+  constructor(private readonly host: ShellChromeHost) {}
+
+  connect(): void {
+    const host = this.host;
+    host.nativeHistoryState = readNativeHistoryState();
+    host.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
+    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
+    window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
+    document.addEventListener("keydown", this.handleDocumentKeydown);
+    window.addEventListener("resize", this.handleWindowResize);
+    window.addEventListener("dragover", this.handleUnhandledFileDrag);
+    window.addEventListener("drop", this.handleUnhandledFileDrag);
+    window.addEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
+    // Shipped Mac hosts use these same events even when native web chrome is absent.
+    window.addEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
+    window.addEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
+    window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
+    window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
+    window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
+    window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
+    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+  }
+
+  disconnect(): void {
+    const host = this.host;
+    host.removeEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
+    window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
+    window.removeEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
+    document.removeEventListener("keydown", this.handleDocumentKeydown);
+    window.removeEventListener("resize", this.handleWindowResize);
+    window.removeEventListener("dragover", this.handleUnhandledFileDrag);
+    window.removeEventListener("drop", this.handleUnhandledFileDrag);
+    window.removeEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
+    window.removeEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
+    window.removeEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
+    window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
+    window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
+    window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
+    window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
+    window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
+    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+  }
+
+  toggleNavigationSurface(trigger?: HTMLElement): void {
+    const host = this.host;
+    const context = host.context;
+    // Desktop settings takeover has no app nav; its mobile drawer still owns navigation.
+    if (!context || host.onboardingMode || (this.isSettingsTakeover() && !isMobileNavLayout())) {
+      return;
+    }
+    if (isMobileNavLayout()) {
+      if (host.navDrawerOpen) {
+        host.closeNavDrawer({ restoreFocus: true });
+        return;
+      }
+      host.navDrawerTrigger = trigger ?? host.querySelector<HTMLElement>(".topbar-nav-toggle");
+      host.navDrawerOpen = true;
+      return;
+    }
+    // A responsive handoff expands this shell without overwriting the desktop preference.
+    const nextNavCollapsed =
+      host.navDrawerOpen ||
+      !(context.navigation.snapshot.navCollapsed && !host.desktopNavigationExpanded);
+    host.desktopNavigationExpanded = false;
+    if (nextNavCollapsed) {
+      this.dismissSidebarTransientMenus();
+    }
+    host.closeNavDrawer();
+    context.navigation.update({ navCollapsed: nextNavCollapsed });
+    if (nextNavCollapsed) {
+      void host.updateComplete.then(() => {
+        this.restoreFocusTo(host.querySelector<HTMLElement>(".shell-chrome-controls__nav-toggle"));
+      });
+    }
+  }
+
+  /** Native Mac chrome hides in-page toggles, so restoration falls back to content. */
+  restoreFocusTo(target: HTMLElement | null | undefined): void {
+    const resolved =
+      target?.isConnected && target.checkVisibility()
+        ? target
+        : this.host.querySelector<HTMLElement>(".content");
+    resolved?.focus();
+  }
+
+  visibleNavDrawerToggle(): HTMLElement | undefined {
+    return [
+      ...this.host.querySelectorAll<HTMLElement>(".topbar-nav-toggle, .chat-pane__nav-toggle"),
+    ].find((candidate) => candidate.checkVisibility());
+  }
+
+  closeNavDrawer(options: { restoreFocus?: boolean } = {}): void {
+    const host = this.host;
+    if (host.navDrawerOpen) {
+      this.dismissSidebarTransientMenus();
+    }
+    const trigger = options.restoreFocus ? host.navDrawerTrigger : null;
+    const returnFocusTarget =
+      options.restoreFocus && trigger?.isConnected && trigger.checkVisibility()
+        ? trigger
+        : options.restoreFocus
+          ? host.querySelector<HTMLElement>(".content")
+          : null;
+    host
+      .querySelector<OpenClawModalDialog>("openclaw-modal-dialog.nav-drawer")
+      ?.setReturnFocusTarget(returnFocusTarget ?? null);
+    host.navDrawerOpen = false;
+    host.navDrawerTrigger = null;
+    if (options.restoreFocus) {
+      requestAnimationFrame(() => {
+        this.restoreFocusTo(trigger instanceof HTMLElement ? trigger : null);
+      });
+    }
+  }
+
+  resizeNavigation(splitRatio: number): void {
+    const host = this.host;
+    const shell = host.querySelector<HTMLElement>(".shell");
+    const context = host.context;
+    if (!shell || !context) {
+      return;
+    }
+    const navWidth = Math.round(
+      Math.min(NAV_WIDTH_MAX, Math.max(NAV_WIDTH_MIN, splitRatio * shell.clientWidth)),
+    );
+    context.navigation.update({ navWidth });
+  }
+
+  readonly handleNativeToggleSidebar = (): void => {
+    this.toggleNavigationSurface();
+  };
+
+  readonly handleNativeOpenSearch = (): void => {
+    this.openPalette();
+  };
+
+  readonly handleNativeToggleSearch = (event: Event): void => {
+    // Native menu dispatch falls back to open-only search unless the toggle acknowledges it.
+    event.preventDefault();
+    this.togglePalette();
+  };
+
+  readonly handleNativeNewSession = (): void => {
+    const host = this.host;
+    const context = host.context;
+    if (host.onboardingMode) {
+      return;
+    }
+    if (!context) {
+      // Native document-finish can beat runtime initialization; replay the idempotent request.
+      host.pendingNativeNewSession = true;
+      return;
+    }
+    host.openNewSession(context.agentSelection.state.selectedId ?? "");
+  };
+
+  readonly handleNativeNavigate = (event: Event): void => {
+    const path = (event as CustomEvent<{ path?: unknown }>).detail?.path;
+    const schemeCandidate = typeof path === "string" ? path.slice(1) : "";
+    if (
+      typeof path !== "string" ||
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      /^[a-z][a-z\d+.-]*:/i.test(schemeCandidate)
+    ) {
+      return;
+    }
+    const routeId = routeIdFromPath(path);
+    if (!routeId || !this.host.context) {
+      // Unhandled native routes remain eligible for the host's URL fallback.
+      return;
+    }
+    event.preventDefault();
+    this.host.navigate(routeId);
+  };
+
+  readonly handleNativeHistoryState = (event: Event): void => {
+    const detail = (event as CustomEvent<NativeHistoryState>).detail;
+    if (typeof detail?.canGoBack !== "boolean" || typeof detail.canGoForward !== "boolean") {
+      return;
+    }
+    this.host.nativeHistoryState = detail;
+  };
+
+  readonly handleWindowResize = (): void => {
+    const host = this.host;
+    const mobileNavLayout = isMobileNavLayout();
+    // Dismiss the old surface before moving the shared sidebar between breakpoints.
+    const dismissedSidebarMenus =
+      mobileNavLayout && !host.navDrawerOpen && this.dismissSidebarTransientMenus();
+    if (mobileNavLayout) {
+      host.desktopNavigationExpanded = false;
+    } else if (host.navDrawerOpen) {
+      host.closeNavDrawer({ restoreFocus: false });
+      // Preserve the stored preference while keeping the responsive handoff expanded.
+      host.desktopNavigationExpanded = host.context?.navigation.snapshot.navCollapsed ?? false;
+    }
+    host.requestUpdate();
+    void host.updateComplete.then(() => {
+      if (isMobileNavLayout() && !host.navDrawerOpen && dismissedSidebarMenus) {
+        requestAnimationFrame(() => {
+          this.restoreFocusTo(this.visibleNavDrawerToggle());
+        });
+      }
+    });
+  };
+
+  readonly handleUnhandledFileDrag = (event: DragEvent): void => {
+    // Bubble phase gives actual drop targets and native file inputs first refusal.
+    const nativeFileInput = event
+      .composedPath()
+      .some(
+        (target) =>
+          target instanceof HTMLInputElement && target.type === "file" && !target.disabled,
+      );
+    if (
+      event.defaultPrevented ||
+      nativeFileInput ||
+      !Array.from(event.dataTransfer?.types ?? []).includes("Files")
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "none";
+    }
+  };
+
+  dismissSidebarTransientMenus(): boolean {
+    return (
+      this.host.querySelector<AppSidebarElement>("openclaw-app-sidebar")?.dismissTransientMenus() ??
+      false
+    );
+  }
+
+  readonly handleDocumentKeydown = (event: KeyboardEvent): void => {
+    const host = this.host;
+    if (!host.commandPalette && isCommandPaletteShortcut(event)) {
+      event.preventDefault();
+      this.togglePalette();
+      return;
+    }
+    if (!isOptionalElementDefined(host.terminalPanelElement) && isTerminalPanelShortcut(event)) {
+      event.preventDefault();
+      this.handleDeferredTerminalToggle(new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT));
+      return;
+    }
+    if (event.defaultPrevented) {
+      return;
+    }
+    const plainKey = !event.altKey && !event.shiftKey && !event.metaKey && !event.ctrlKey;
+    if (plainKey && event.key === "Escape" && this.isSettingsTakeover()) {
+      if (host.navDrawerOpen) {
+        event.preventDefault();
+        host.closeNavDrawer({ restoreFocus: true });
+        return;
+      }
+      if (this.shouldIgnoreSettingsEscape(event)) {
+        return;
+      }
+      event.preventDefault();
+      host.exitSettings();
+      return;
+    }
+    const settingsModifier = event.metaKey !== event.ctrlKey && !event.altKey;
+    if (settingsModifier && event.shiftKey && event.code === "Comma") {
+      event.preventDefault();
+      host.navigate("appearance");
+      return;
+    }
+    const commandKey = event.metaKey && !event.ctrlKey && !event.altKey;
+    if (commandKey && !event.shiftKey && resolveAsciiShortcutKey(event) === "b") {
+      event.preventDefault();
+      this.toggleNavigationSurface();
+    }
+  };
+
+  /** Open overlays and editable controls own Escape before settings can exit. */
+  shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
+    const host = this.host;
+    const overlaySnapshot = host.context?.overlays.snapshot;
+    if (
+      host.commandPalette?.isOpen ||
+      overlaySnapshot?.devicePairSetupOpen ||
+      (overlaySnapshot?.approvalQueue.length ?? 0) > 0 ||
+      document.querySelector("dialog[open]")
+    ) {
+      return true;
+    }
+    const target = event.target;
+    return (
+      target instanceof Element &&
+      target.closest(
+        "input, textarea, select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
+      ) !== null
+    );
+  }
+
+  runWithCommandPalette(action: (palette: CommandPaletteElement) => void): void {
+    const host = this.host;
+    const palette = host.commandPalette;
+    if (palette) {
+      action(palette);
+      return;
+    }
+    void ensureOptionalElementForHost(host, host.commandPaletteElement)
+      .then(async () => {
+        await host.updateComplete;
+        const loadedPalette = host.commandPalette;
+        if (loadedPalette) {
+          action(loadedPalette);
+        }
+      })
+      .catch(() => undefined);
+  }
+
+  readonly openPalette = (): void => {
+    this.runWithCommandPalette((palette) => palette.openPalette());
+  };
+
+  readonly refreshControlUi = (): void => {
+    globalThis.location.reload();
+  };
+
+  readonly handleShellNavDrawerToggle = (event: Event): void => {
+    const trigger = (event as CustomEvent<ShellNavDrawerToggleDetail>).detail?.trigger;
+    this.toggleNavigationSurface(trigger instanceof HTMLElement ? trigger : undefined);
+  };
+
+  readonly togglePalette = (): void => {
+    this.runWithCommandPalette((palette) => palette.togglePalette());
+  };
+
+  readonly openApprovals = (): void => {
+    const host = this.host;
+    const show = () => host.approvalOverlay?.show();
+    if (isOptionalElementDefined(host.execApprovalElement)) {
+      show();
+      return;
+    }
+    void ensureOptionalElementForHost(host, host.execApprovalElement)
+      .then(async () => {
+        await host.updateComplete;
+        show();
+      })
+      .catch(() => undefined);
+  };
+
+  deliverPanelEventAfterLoad(element: OptionalCustomElement, event: Event): void {
+    const host = this.host;
+    void ensureOptionalElementForHost(host, element)
+      .then(async () => {
+        // Wait for the host to apply availability after defining the mounted tag.
+        await host.updateComplete;
+        host.querySelector<PanelToggleElement>(element.tagName)?.handleToggleRequest(event);
+      })
+      .catch(() => undefined);
+  }
+
+  readonly handleDeferredTerminalToggle = (event: Event): void => {
+    const host = this.host;
+    if (isOptionalElementDefined(host.terminalPanelElement)) {
+      return;
+    }
+    const context = host.context;
+    const snapshot = context?.gateway?.snapshot;
+    if (
+      !snapshot ||
+      !isTerminalAvailable(snapshot, context.config.current.terminalEnabled ?? false)
+    ) {
+      return;
+    }
+    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event);
+  };
+
+  readonly handleDeferredBrowserToggle = (event: Event): void => {
+    const host = this.host;
+    if (isOptionalElementDefined(host.browserPanelElement)) {
+      return;
+    }
+    const snapshot = host.context?.gateway?.snapshot;
+    if (snapshot && isBrowserPanelAvailable(snapshot)) {
+      this.deliverPanelEventAfterLoad(host.browserPanelElement, event);
+    }
+  };
+
+  readonly handleDeferredCustodianToggle = (event: Event): void => {
+    const host = this.host;
+    if (isOptionalElementDefined(host.custodianPanelElement)) {
+      return;
+    }
+    const snapshot = host.context?.gateway?.snapshot;
+    if (snapshot && isGatewayMethodAdvertised(snapshot, "openclaw.chat") === true) {
+      this.deliverPanelEventAfterLoad(host.custodianPanelElement, event);
+    }
+  };
+
+  readonly handleCommandPaletteSlashCommand = (command: string): void => {
+    const host = this.host;
+    const chatHandler = host.commandPaletteTarget?.owner.isConnected
+      ? host.commandPaletteTarget.onSlashCommand
+      : null;
+    if (chatHandler) {
+      chatHandler(command);
+      return;
+    }
+    // Chat can update its existing draft; other routes hand it through navigation.
+    const navigation = host.chatNavigationOptions("chat");
+    const search = new URLSearchParams(navigation?.search ?? "");
+    search.set("draft", command.endsWith(" ") ? command : `${command} `);
+    host.navigate("chat", { ...navigation, search: `?${search.toString()}` });
+  };
+
+  readonly handleCommandPaletteTarget = (event: Event): void => {
+    const host = this.host;
+    const detail = (event as CustomEvent<CommandPaletteTargetDetail>).detail;
+    if (!detail || !(detail.owner instanceof Element)) {
+      return;
+    }
+    if (detail.onSlashCommand) {
+      host.commandPaletteTarget = detail;
+    } else if (host.commandPaletteTarget?.owner === detail.owner) {
+      host.commandPaletteTarget = undefined;
+    }
+    host.requestUpdate();
+  };
+
+  /** Native titlebar chrome treats drawer, takeover, and onboarding layouts as collapsed. */
+  nativeNavCollapsed(): boolean {
+    const host = this.host;
+    const mobileNavLayout = isMobileNavLayout();
+    return (
+      host.onboardingMode ||
+      mobileNavLayout ||
+      (this.isSettingsTakeover() && !mobileNavLayout) ||
+      (!host.navDrawerOpen &&
+        !host.desktopNavigationExpanded &&
+        (host.context?.navigation.snapshot.navCollapsed ?? false))
+    );
+  }
+
+  private isSettingsTakeover(): boolean {
+    const routeId = this.host.routeState.routeId;
+    return routeId !== undefined && isSettingsNavigationRoute(routeId);
+  }
+}

--- a/ui/src/app/app-shell-gateway.ts
+++ b/ui/src/app/app-shell-gateway.ts
@@ -1,0 +1,355 @@
+import type { UiCommandParams } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
+import type { GatewayAgentRow } from "../api/types.ts";
+import { isSessionRouteId } from "../app-route-paths.ts";
+import type { RouteId } from "../app-routes.ts";
+import type { SidebarWorkboardRuntime } from "../components/app-sidebar-workboard.ts";
+import {
+  BROWSER_PANEL_TOGGLE_EVENT,
+  TERMINAL_PANEL_TOGGLE_EVENT,
+  UI_COMMAND_EVENT,
+} from "../components/panel-toggle-contract.ts";
+import { i18n, isSupportedLocale } from "../i18n/index.ts";
+import type { ShellRouteState } from "./app-host-route-state.ts";
+import type { ApplicationContext } from "./context.ts";
+import {
+  applyServerUiPrefs,
+  flushServerUiPrefs,
+  resetServerUiPrefsSync,
+  resolveServerUiPrefState,
+} from "./server-prefs.ts";
+
+const AGENT_ROSTER_REFRESH_DEBOUNCE_MS = 100;
+
+export type StoredOutboxScopeHost = {
+  settings: { gatewayUrl?: string | null };
+  assistantAgentId?: string | null;
+  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
+  hello?: { snapshot?: unknown } | null;
+};
+
+export type OutboxStoreRuntime = {
+  summarizeStoredChatOutboxes: (state: StoredOutboxScopeHost) => {
+    countsByScope: ReadonlyMap<string, number>;
+    total: number;
+  };
+  resolveStoredChatOutboxScope: (
+    state: StoredOutboxScopeHost,
+    sessionKey: string,
+  ) => { sessionKey: string; agentId?: string };
+  storedChatOutboxScopeKey: (scope: { sessionKey: string; agentId?: string }) => string;
+  subscribeStoredChatOutboxChanges: (listener: () => void) => () => void;
+};
+
+export interface ShellGatewayHost {
+  readonly context: ApplicationContext<RouteId> | undefined;
+  routeState: ShellRouteState;
+  activeSessionKey: string;
+  desktopNavigationExpanded: boolean;
+  agentsListClient: GatewayBrowserClient | null;
+  agentsListSource: ApplicationContext["agents"] | null;
+  sessionKeyClient: GatewayBrowserClient | null;
+  runtimeConfigClient: GatewayBrowserClient | null;
+  runtimeConfigSource: ApplicationContext["runtimeConfig"] | null;
+  lastLocalePrefSignature: string | null;
+  previousGatewayPhase: ApplicationContext["gateway"]["snapshot"]["phase"] | null;
+  agentRosterRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null;
+  criticalNoticeRuntime: Promise<
+    typeof import("../pages/chat/critical-observer-notice.runtime.ts")
+  > | null;
+  sidebarWorkboardRuntime: SidebarWorkboardRuntime | null;
+  readonly outboxStoreImport: { load: () => Promise<unknown> };
+  recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]): void;
+  selectChatSession(sessionKey: string, agentId?: string | null): void;
+  storedOutboxScopeHost(context: ApplicationContext<RouteId>): StoredOutboxScopeHost;
+  syncSidebarWorkboard(): void;
+  requestUpdate(): void;
+}
+
+function diffAgentRoster(
+  previous: readonly GatewayAgentRow[],
+  next: readonly GatewayAgentRow[],
+): { invalidatedIds: string[]; changedIds: string[] } {
+  const nextById = new Map(next.map((agent) => [agent.id, agent]));
+  const invalidatedIds: string[] = [];
+  const changedIds: string[] = [];
+  for (const agent of previous) {
+    const replacement = nextById.get(agent.id);
+    if (!replacement) {
+      invalidatedIds.push(agent.id);
+    } else if (JSON.stringify(replacement) !== JSON.stringify(agent)) {
+      invalidatedIds.push(agent.id);
+      changedIds.push(agent.id);
+    }
+  }
+  return { invalidatedIds, changedIds };
+}
+
+export class ShellGatewayOwner {
+  constructor(private readonly host: ShellGatewayHost) {}
+
+  reconcileServerUiPrefs(runtimeConfig: ApplicationContext["runtimeConfig"]): void {
+    const snapshot = runtimeConfig.state.configSnapshot;
+    const context = this.host.context;
+    if (!snapshot?.config || !context || context.runtimeConfig !== runtimeConfig) {
+      return;
+    }
+    const scope = context.gateway.connection.gatewayUrl;
+    applyServerUiPrefs(snapshot.config, {
+      scope,
+      onApplied: (patch) => {
+        if (patch.sidebarEntries !== undefined) {
+          context.navigation.update({ sidebarEntries: patch.sidebarEntries });
+        }
+        context.theme.refresh();
+      },
+    });
+    const localePref = resolveServerUiPrefState(snapshot.config, "locale", scope);
+    const localePrefSignature = JSON.stringify([scope, localePref.overridden, localePref.value]);
+    if (localePrefSignature === this.host.lastLocalePrefSignature) {
+      return;
+    }
+    this.host.lastLocalePrefSignature = localePrefSignature;
+    if (localePref.overridden && isSupportedLocale(localePref.value)) {
+      void i18n.setLocale(localePref.value);
+      return;
+    }
+    void i18n.useSystemLocale();
+  }
+
+  reconcileCommittedServerUiPrefs(
+    runtimeConfig: ApplicationContext["runtimeConfig"],
+    needsRefresh: boolean,
+    retainedLocal = false,
+  ): void {
+    if (this.host.context?.runtimeConfig !== runtimeConfig) {
+      return;
+    }
+    if (needsRefresh) {
+      void runtimeConfig.refresh();
+      return;
+    }
+    this.reconcileServerUiPrefs(runtimeConfig);
+    if (retainedLocal) {
+      this.host.context?.theme.refresh();
+    }
+  }
+
+  handleGatewayEvent(event: GatewayEventFrame): void {
+    this.host.sidebarWorkboardRuntime?.handleGatewayEvent(event.event);
+    if (event.event === "sessions.changed") {
+      const context = this.host.context;
+      if (context) {
+        this.host.recoverDeletedActiveSession(context.sessions.state);
+      }
+      return;
+    }
+    if (event.event === "session.observer") {
+      const context = this.host.context;
+      if (context) {
+        // Recovery digests share the tracker so stale critical notices can announce again.
+        this.host.criticalNoticeRuntime ??=
+          import("../pages/chat/critical-observer-notice.runtime.ts");
+        const payload = event.payload;
+        void this.host.criticalNoticeRuntime.then((runtime) =>
+          runtime.handleCriticalObserverDigest({
+            payload,
+            selectedSessionKey: this.host.activeSessionKey,
+            sessionHost: this.host.storedOutboxScopeHost(context),
+            sessions: context.sessions.state.result?.sessions ?? [],
+            onOpen: (sessionKey, agentId) => this.host.selectChatSession(sessionKey, agentId),
+          }),
+        );
+      }
+      return;
+    }
+    if (event.event === "config.changed") {
+      // A local settings draft owns config conflicts; external snapshots must not overwrite it.
+      const runtimeConfig = this.host.context?.runtimeConfig;
+      if (runtimeConfig && !runtimeConfig.state.configFormDirty) {
+        void runtimeConfig.refresh();
+      }
+      this.scheduleAgentRosterRefresh();
+      return;
+    }
+    if (event.event !== "ui.command" || !event.payload) {
+      return;
+    }
+    const context = this.host.context;
+    if (!context) {
+      return;
+    }
+    const commandParams = event.payload as UiCommandParams;
+    const { command } = commandParams;
+    if (!command) {
+      return;
+    }
+    if (command.kind === "sidebar") {
+      this.host.desktopNavigationExpanded = false;
+      context.navigation.update({ navCollapsed: !command.visible });
+      return;
+    }
+    if (command.kind === "panel") {
+      window.dispatchEvent(
+        new CustomEvent(
+          command.panel === "terminal" ? TERMINAL_PANEL_TOGGLE_EVENT : BROWSER_PANEL_TOGGLE_EVENT,
+          {
+            detail: {
+              open: command.open,
+              ...(command.dock ? { dock: command.dock } : {}),
+              ...(command.panel === "terminal" && command.terminalSessionId
+                ? { terminalSessionId: command.terminalSessionId }
+                : {}),
+            },
+          },
+        ),
+      );
+      return;
+    }
+
+    const handled = !window.dispatchEvent(
+      new CustomEvent(UI_COMMAND_EVENT, { detail: commandParams, cancelable: true }),
+    );
+    if (!handled && (command.kind === "navigate" || command.kind === "split")) {
+      this.host.selectChatSession(command.sessionKey);
+    }
+  }
+
+  scheduleAgentRosterRefresh(): void {
+    // Config writes arrive in bursts; only the final authoritative roster snapshot matters.
+    if (this.host.agentRosterRefreshTimer !== null) {
+      globalThis.clearTimeout(this.host.agentRosterRefreshTimer);
+    }
+    this.host.agentRosterRefreshTimer = globalThis.setTimeout(() => {
+      this.host.agentRosterRefreshTimer = null;
+      void this.refreshAgentRoster();
+    }, AGENT_ROSTER_REFRESH_DEBOUNCE_MS);
+  }
+
+  async refreshAgentRoster(): Promise<void> {
+    const context = this.host.context;
+    if (!context) {
+      return;
+    }
+    const previous = context.agents.state.agentsList;
+    const activeAgentId = context.agentSelection.state.selectedId;
+    const next = await context.agents.refreshList();
+    if (!next || this.host.context !== context) {
+      return;
+    }
+    const rosterDiff = diffAgentRoster(previous?.agents ?? [], next.agents);
+    if (rosterDiff.invalidatedIds.length > 0) {
+      context.agents.invalidateFiles(rosterDiff.invalidatedIds);
+      context.agentIdentity.invalidate(rosterDiff.invalidatedIds);
+    }
+    if (rosterDiff.changedIds.length > 0) {
+      void context.agentIdentity.ensure(rosterDiff.changedIds);
+    }
+    const nextIds = new Set(next.agents.map((agent) => agent.id));
+    if (
+      activeAgentId &&
+      context.agentSelection.state.selectedId === activeAgentId &&
+      next.agents.length > 0 &&
+      !nextIds.has(activeAgentId)
+    ) {
+      context.agentSelection.set(next.defaultId);
+    }
+  }
+
+  synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]): void {
+    const previousPhase = this.host.previousGatewayPhase;
+    this.host.previousGatewayPhase = snapshot.phase;
+    this.updateGatewaySessionKey(snapshot);
+    this.ensureAgentsList(snapshot);
+    this.ensureRuntimeConfig(snapshot);
+    if (previousPhase !== "connected" && snapshot.phase === "connected") {
+      i18n.retryPendingLocale();
+    }
+    this.host.syncSidebarWorkboard();
+    // Gateway-served chunks retry on reconnect after an earlier idle import failed.
+    if (snapshot.phase === "connected") {
+      void this.host.outboxStoreImport.load().catch(() => undefined);
+    }
+  }
+
+  ensureRuntimeConfig(
+    snapshot: ApplicationContext["gateway"]["snapshot"],
+    runtimeConfig = this.host.context?.runtimeConfig,
+  ): void {
+    // Config-gated sidebar routes require the snapshot before any settings page opens.
+    if (snapshot.phase !== "connected" || !snapshot.client || !runtimeConfig) {
+      this.host.runtimeConfigClient = null;
+      return;
+    }
+    if (
+      this.host.runtimeConfigClient === snapshot.client &&
+      this.host.runtimeConfigSource === runtimeConfig
+    ) {
+      return;
+    }
+    this.host.runtimeConfigClient = snapshot.client;
+    this.host.runtimeConfigSource = runtimeConfig;
+    flushServerUiPrefs(runtimeConfig, {
+      afterCommit: ({ needsRefresh, retainedLocal }) =>
+        this.reconcileCommittedServerUiPrefs(runtimeConfig, needsRefresh, retainedLocal),
+    });
+    void runtimeConfig.ensureLoaded();
+  }
+
+  ensureAgentsList(
+    snapshot: ApplicationContext["gateway"]["snapshot"],
+    agents = this.host.context?.agents,
+  ): void {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
+      this.host.agentsListClient = null;
+      return;
+    }
+    const routeId = this.host.routeState.routeId;
+    if (!agents || !routeId || isSessionRouteId(routeId) || agents.state.agentsList) {
+      return;
+    }
+    if (this.host.agentsListClient === snapshot.client && this.host.agentsListSource === agents) {
+      return;
+    }
+    this.host.agentsListClient = snapshot.client;
+    this.host.agentsListSource = agents;
+    void agents.ensureList();
+  }
+
+  updateGatewaySessionKey(snapshot: {
+    client: GatewayBrowserClient | null;
+    sessionKey: string;
+  }): void {
+    const sessionKey = snapshot.sessionKey.trim();
+    if (
+      snapshot.client === this.host.sessionKeyClient &&
+      sessionKey === this.host.activeSessionKey
+    ) {
+      return;
+    }
+    this.host.sessionKeyClient = snapshot.client;
+    if (sessionKey) {
+      this.host.activeSessionKey = sessionKey;
+    }
+  }
+
+  reset(): void {
+    void this.host.criticalNoticeRuntime?.then((runtime) => runtime.resetCriticalObserverTracker());
+    this.host.agentsListClient = null;
+    this.host.agentsListSource = null;
+    this.host.sessionKeyClient = null;
+    this.host.runtimeConfigClient = null;
+    this.host.runtimeConfigSource = null;
+    this.host.previousGatewayPhase = null;
+    if (this.host.agentRosterRefreshTimer !== null) {
+      globalThis.clearTimeout(this.host.agentRosterRefreshTimer);
+      this.host.agentRosterRefreshTimer = null;
+    }
+    resetServerUiPrefsSync();
+  }
+
+  dispose(): void {
+    this.host.lastLocalePrefSignature = null;
+    this.reset();
+  }
+}

--- a/ui/src/app/app-shell-navigation.ts
+++ b/ui/src/app/app-shell-navigation.ts
@@ -1,0 +1,291 @@
+import { isSettingsNavigationRoute } from "../app-navigation.ts";
+import { isSessionRouteId } from "../app-route-paths.ts";
+import { isRouteId, type RouteId } from "../app-routes.ts";
+import type { BoardFace } from "../lib/board/settings.ts";
+import {
+  findUiSessionRow,
+  resolveSessionNavigationAgentId,
+  resolveSessionPreferredFaceForKey,
+  sessionNavigationTarget,
+} from "../lib/sessions/route-navigation.ts";
+import {
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+  uiSessionEventMatches,
+} from "../lib/sessions/session-key.ts";
+import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
+import { selectApplicationSession } from "./agent-selection.ts";
+import type { ShellRouteState } from "./app-host-route-state.ts";
+import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
+import { considerRouteRestore, persistRoute } from "./native-route-memory.ts";
+
+export interface ShellNavigationHost {
+  readonly context: ApplicationContext<RouteId> | undefined;
+  activeSessionKey: string;
+  routeState: ShellRouteState;
+  lastWorkspaceLocation: { routeId: RouteId; pathname: string; search: string } | null;
+  custodianMinimizeRequestId: number;
+  lastConcreteRouteId: RouteId | undefined;
+  didConsiderNativeRouteRestore: boolean;
+  settingsSearchQuery: string;
+  closeNavDrawer(options?: { restoreFocus?: boolean }): void;
+  ensureAgentsList(
+    snapshot: ApplicationContext["gateway"]["snapshot"],
+    agents?: ApplicationContext["agents"],
+  ): void;
+}
+
+export class ShellNavigationOwner {
+  constructor(private readonly host: ShellNavigationHost) {}
+
+  selectChatSession(sessionKey: string, agentId?: string | null): void {
+    const context = this.host.context;
+    if (!context) {
+      return;
+    }
+    selectApplicationSession({
+      selection: context.agentSelection,
+      gateway: context.gateway,
+      sessionKey,
+      agentId,
+    });
+    const face = resolveSessionPreferredFaceForKey(context, sessionKey, agentId);
+    this.navigate(
+      face,
+      sessionNavigationTarget({
+        context,
+        face,
+        sessionKey,
+        ...(agentId ? { agentId } : {}),
+        preferenceDerivedFace: true,
+      }).options,
+    );
+  }
+
+  chatNavigationOptions(face: BoardFace, options?: ApplicationNavigationOptions) {
+    const sessionKey = this.host.activeSessionKey.trim();
+    const context = this.host.context;
+    return (
+      options ??
+      (sessionKey && context
+        ? sessionNavigationTarget({ context, face, sessionKey }).options
+        : undefined)
+    );
+  }
+
+  navigate(routeId: string, options?: ApplicationNavigationOptions): void {
+    const context = this.host.context;
+    if (!context || !isRouteId(routeId)) {
+      return;
+    }
+    this.host.closeNavDrawer({ restoreFocus: true });
+    context.navigate(
+      routeId,
+      isSessionRouteId(routeId) ? this.chatNavigationOptions(routeId, options) : options,
+    );
+  }
+
+  replaceChatWithCurrentSession(): void {
+    const context = this.host.context;
+    const sessionKey = this.host.activeSessionKey.trim();
+    if (
+      !context ||
+      (!parseAgentSessionKey(sessionKey) && context.gateway.snapshot.phase !== "connected")
+    ) {
+      return;
+    }
+    const face = this.host.routeState.routeId === "dashboard" ? "dashboard" : "chat";
+    const sessionWasDeleted = (context.sessions.state.deletedSessions ?? []).some(
+      ({ key, agentId }) =>
+        uiSessionEventMatches(
+          {
+            agentsList: context.agents.state.agentsList,
+            hello: context.gateway.snapshot.hello,
+            sessionKey,
+          },
+          key,
+          agentId,
+        ),
+    );
+    // Session lists are filtered and windowed. Only a failed route for this
+    // active key, or an authoritative deletion, proves it needs replacement.
+    const activeSessionRow = findUiSessionRow(context, sessionKey);
+    const attemptedPathname = this.host.routeState.location?.pathname;
+    const activeRouteFailed =
+      !attemptedPathname ||
+      attemptedPathname === sessionNavigationTarget({ context, face, sessionKey }).options.pathname;
+    const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+    const knownAgents = context.agents.state.agentsList?.agents;
+    // A parseable retired agent is not a navigable owner; never turn its
+    // deleted session into another permanently unresolvable chat route.
+    const replacementAgentId =
+      parsedAgentId &&
+      (!knownAgents || knownAgents.some((agent) => normalizeAgentId(agent.id) === parsedAgentId))
+        ? parsedAgentId
+        : resolveSessionNavigationAgentId(context);
+    const replacementSessionKey =
+      !sessionWasDeleted && (activeSessionRow?.key || !activeRouteFailed)
+        ? sessionKey
+        : buildAgentMainSessionKey({
+            agentId: replacementAgentId,
+            mainKey: resolveUiConfiguredMainKey({
+              agentsList: context.agents.state.agentsList,
+              hello: context.gateway.snapshot.hello,
+            }),
+          });
+    // Gateway rejects deletion of a live main session. If an orphaned event
+    // still names that fallback, replacing the same route would retry forever.
+    if (sessionWasDeleted && replacementSessionKey === sessionKey) {
+      return;
+    }
+    if (replacementSessionKey !== sessionKey) {
+      // Commit the replacement to both selection owners before navigating;
+      // otherwise a stale Gateway snapshot restores the deleted key and loops.
+      this.host.activeSessionKey = replacementSessionKey;
+      selectApplicationSession({
+        selection: context.agentSelection,
+        gateway: context.gateway,
+        sessionKey: replacementSessionKey,
+      });
+    }
+    context.replace(
+      face,
+      sessionNavigationTarget({ context, face, sessionKey: replacementSessionKey }).options,
+    );
+  }
+
+  recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]): void {
+    const context = this.host.context;
+    const routeId = this.host.routeState.routeId;
+    const sessionKey = this.host.activeSessionKey.trim();
+    if (!context || !routeId || !isSessionRouteId(routeId) || !sessionKey) {
+      return;
+    }
+    const selectedSessionDeleted = sessionState.deletedSessions.some(({ key, agentId }) =>
+      uiSessionEventMatches(
+        {
+          agentsList: context.agents.state.agentsList,
+          hello: context.gateway.snapshot.hello,
+          sessionKey,
+        },
+        key,
+        agentId,
+      ),
+    );
+    if (selectedSessionDeleted) {
+      this.replaceChatWithCurrentSession();
+    }
+  }
+
+  updateRouteState(routeState: ShellRouteState): void {
+    this.host.routeState = routeState;
+    if (routeState.routeId !== undefined) {
+      if (this.host.lastConcreteRouteId === "custodian" && routeState.routeId !== "custodian") {
+        this.host.custodianMinimizeRequestId += 1;
+      }
+      this.host.lastConcreteRouteId = routeState.routeId;
+    }
+    const committedRouteId = routeState.committedRouteId;
+    const committedPathname = routeState.committedLocation?.pathname ?? "";
+    const committedSearch = routeState.committedLocation?.search ?? "";
+    // Restoration and persistence both wait for a live context: consuming the
+    // one-shot restore without a router to call, or persisting the bootstrap
+    // route first, would clobber the stored route.
+    const routeContext = this.host.context;
+    if (committedRouteId && routeContext) {
+      // A rendered/pending match that differs from the committed route is an
+      // in-flight navigation: it wins over the one-shot restore, and the stale
+      // committed route must not be persisted over the remembered destination.
+      const pendingDiffers =
+        routeState.routeId !== committedRouteId ||
+        (routeState.location?.pathname ?? "") !== committedPathname ||
+        (routeState.location?.search ?? "") !== committedSearch;
+      if (!this.host.didConsiderNativeRouteRestore) {
+        this.host.didConsiderNativeRouteRestore = true;
+        const storedRoute = pendingDiffers
+          ? null
+          : considerRouteRestore(committedRouteId, committedPathname, committedSearch);
+        if (storedRoute) {
+          // Replace instead of push so a fresh window does not start with a
+          // Back entry pointing at the bootstrap chat route.
+          routeContext.replace(storedRoute.routeId, {
+            pathname: storedRoute.pathname,
+            search: storedRoute.search,
+          });
+          return;
+        }
+      }
+      if (!pendingDiffers) {
+        const committedSessionKey = routeState.committedSessionKey;
+        const committedSessionDeleted =
+          committedSessionKey !== undefined &&
+          (routeContext.sessions?.state.deletedSessions ?? []).some(({ key, agentId }) =>
+            uiSessionEventMatches(
+              {
+                agentsList: routeContext.agents.state.agentsList,
+                hello: routeContext.gateway.snapshot.hello,
+                sessionKey: committedSessionKey,
+              },
+              key,
+              agentId,
+            ),
+          );
+        if (committedSessionDeleted) {
+          // An older route can commit after deletion recovery has started.
+          // Never let it persist or reselect the session we just retired.
+          this.replaceChatWithCurrentSession();
+          return;
+        }
+        persistRoute(committedRouteId, committedPathname, committedSearch);
+        if (committedSessionKey) {
+          this.host.activeSessionKey = committedSessionKey;
+          selectApplicationSession({
+            selection: routeContext.agentSelection,
+            gateway: routeContext.gateway,
+            sessionKey: committedSessionKey,
+          });
+        }
+      }
+    }
+    const context = this.host.context;
+    if (context) {
+      this.host.ensureAgentsList(context.gateway.snapshot);
+    }
+    if (routeState.routeId && !isSettingsNavigationRoute(routeState.routeId)) {
+      this.host.settingsSearchQuery = "";
+      this.host.lastWorkspaceLocation = {
+        routeId: routeState.routeId,
+        pathname: routeState.location?.pathname ?? "",
+        search: routeState.location?.search ?? "",
+      };
+    }
+  }
+
+  /** Sidebar draft-row hint while the new-session page is open, keyed off its ?agent param. */
+  draftSessionAgentId(): string {
+    if (this.host.routeState.routeId !== "new-session") {
+      return "";
+    }
+    return (
+      new URLSearchParams(this.host.routeState.location?.search ?? "").get("agent")?.trim() ?? ""
+    );
+  }
+
+  openNewSession(agentId: string, target?: NewSessionTarget): void {
+    this.navigate("new-session", { search: newSessionSearch(agentId, target) });
+  }
+
+  exitSettings(): void {
+    const previous = this.host.lastWorkspaceLocation;
+    if (previous) {
+      this.navigate(previous.routeId, {
+        pathname: previous.pathname,
+        ...(previous.search ? { search: previous.search } : {}),
+      });
+      return;
+    }
+    this.navigate("chat");
+  }
+}

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -1,0 +1,495 @@
+import { html, nothing } from "lit";
+import { isSettingsNavigationRoute } from "../app-navigation.ts";
+import { isSessionRouteId, workboardBoardIdFromPath } from "../app-route-paths.ts";
+import { isRouteId, type RouteId } from "../app-routes.ts";
+import type {
+  SidebarWorkboardRenderers,
+  SidebarWorkboardSnapshot,
+} from "../components/app-sidebar-workboard.ts";
+import { icons } from "../components/icons.ts";
+import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
+import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
+import { t } from "../i18n/index.ts";
+import { copyToClipboard } from "../lib/clipboard.ts";
+import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
+import { normalizeAgentId } from "../lib/sessions/session-key.ts";
+import { isTerminalAvailable } from "../lib/terminal-availability.ts";
+import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
+import type { NewSessionTarget } from "../pages/new-session/location.ts";
+import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
+import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
+import type { ShellRouteState } from "./app-host-route-state.ts";
+import { resolveTerminalThemeMode } from "./app-root.ts";
+import { isBrowserPanelAvailable } from "./app-shell-chrome.ts";
+import type { OutboxStoreRuntime, StoredOutboxScopeHost } from "./app-shell-gateway.ts";
+import { findInlineApproval } from "./approval-presentation.ts";
+import type { ApplicationRuntime } from "./bootstrap.ts";
+import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
+import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
+import { isOptionalElementDefined, type OptionalCustomElement } from "./lazy-custom-element.ts";
+import { isMobileNavLayout, shouldMergeChatChrome } from "./mobile-nav-layout.ts";
+import type { NativeHistoryState } from "./native-web-chrome.ts";
+import { isNativeWebChromeHost } from "./native-web-chrome.ts";
+import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
+import { readGatewayOperatorAccess } from "./operator-access.ts";
+import {
+  NAV_WIDTH_MAX,
+  NAV_WIDTH_MIN,
+  loadSettings,
+  normalizeCatalogOpenTarget,
+} from "./settings.ts";
+import { resolveControlUiRefreshRequiredBanner } from "./update-overlay-helpers.ts";
+
+const EMPTY_OUTBOX_COUNT_FOR_SESSION = () => 0;
+const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
+  ? "⌘K"
+  : "Ctrl K";
+
+export interface ShellViewHost {
+  readonly context: ApplicationContext<RouteId> | undefined;
+  readonly runtime: ApplicationRuntime | undefined;
+  readonly activeSessionKey: string;
+  readonly commandPaletteElement: OptionalCustomElement;
+  readonly custodianMinimizeRequestId: number;
+  readonly desktopNavigationExpanded: boolean;
+  readonly execApprovalElement: OptionalCustomElement;
+  readonly nativeHistoryState: NativeHistoryState;
+  readonly navDrawerOpen: boolean;
+  readonly navigationSidebar: HTMLElement;
+  readonly onboardingMode: boolean;
+  readonly outboxStoreRuntime: OutboxStoreRuntime | null;
+  readonly routeState: ShellRouteState;
+  readonly settingsPreloadTimers: Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>;
+  readonly settingsSearchQuery: string;
+  readonly sidebarWorkboardRenderers: SidebarWorkboardRenderers | undefined;
+  readonly sidebarWorkboardSnapshot: SidebarWorkboardSnapshot;
+  closeNavDrawer(options?: { restoreFocus?: boolean }): void;
+  draftSessionAgentId(): string;
+  enabledRouteIds(): readonly RouteId[];
+  exitSettings(): void;
+  handleCommandPaletteSlashCommand(command: string): void;
+  handleNativeNewSession(): void;
+  handleSettingsSearchQueryChange(query: string): Promise<void>;
+  handleThemeChange(event: CustomEvent<ThemeModeChangeDetail>): void;
+  nativeNavCollapsed(): boolean;
+  navigate(routeId: string, options?: ApplicationNavigationOptions): void;
+  openApprovals(): void;
+  openNewSession(agentId: string, target?: NewSessionTarget): void;
+  openPalette(): void;
+  refreshControlUi(): void;
+  replaceChatWithCurrentSession(): void;
+  resizeNavigation(splitRatio: number): void;
+  selectChatSession(sessionKey: string, agentId?: string | null): void;
+  storedOutboxScopeHost(context: ApplicationContext<RouteId>): StoredOutboxScopeHost;
+  toggleNavigationSurface(trigger?: HTMLElement): void;
+}
+
+export function renderApplicationShell(host: ShellViewHost) {
+  const context = host.context;
+  const runtime = host.runtime;
+  if (!context || !runtime) {
+    return nothing;
+  }
+  const gatewaySnapshot = context.gateway.snapshot;
+  const gatewayConnected = gatewaySnapshot.phase === "connected";
+  const operatorAccess = readGatewayOperatorAccess(gatewaySnapshot);
+  const outboxScopeHost = host.storedOutboxScopeHost(context);
+  const outboxStoreRuntime = host.outboxStoreRuntime;
+  const storedOutboxes = outboxStoreRuntime
+    ? outboxStoreRuntime.summarizeStoredChatOutboxes(outboxScopeHost)
+    : null;
+  const outboxCountForSession = outboxStoreRuntime
+    ? (sessionKey: string) => {
+        const scope = outboxStoreRuntime.resolveStoredChatOutboxScope(outboxScopeHost, sessionKey);
+        return (
+          storedOutboxes?.countsByScope.get(outboxStoreRuntime.storedChatOutboxScopeKey(scope)) ?? 0
+        );
+      }
+    : EMPTY_OUTBOX_COUNT_FOR_SESSION;
+  const navigationSnapshot = context.navigation.snapshot;
+  const overlaySnapshot = context.overlays.snapshot;
+  const terminalAvailable = isTerminalAvailable(
+    gatewaySnapshot,
+    context.config.current.terminalEnabled ?? false,
+  );
+  const browserPanelAvailable = isBrowserPanelAvailable(gatewaySnapshot);
+  const custodianPanelAvailable =
+    gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
+  const activeRoute = host.routeState.routeId ?? "chat";
+  // Plugin tabs share one route; the search picks the active item.
+  const activePluginRef =
+    activeRoute === "plugin"
+      ? pluginTabRefFromSearch(host.routeState.location?.search ?? "")
+      : null;
+  const activePluginTabId = activePluginRef ? pluginTabKey(activePluginRef) : "";
+  const settingsTakeover = isSettingsNavigationRoute(activeRoute);
+  const runtimeConfig = context.runtimeConfig.state;
+  const settingsSearchBlocks = findSettingsSearchBlocks({
+    query: host.settingsSearchQuery,
+    schema: runtimeConfig.configSchema,
+    value: runtimeConfig.configForm ?? runtimeConfig.configSnapshot?.config ?? null,
+    uiHints: runtimeConfig.configUiHints,
+    identityAvailable: Boolean(gatewaySnapshot.selfUser),
+    basePath: context.basePath,
+  });
+  const onboarding = host.onboardingMode;
+  const navDrawerOpen = host.navDrawerOpen && !onboarding;
+  const mobileNavLayout = isMobileNavLayout();
+  const mergedChatChrome = shouldMergeChatChrome({
+    mobileNavLayout,
+    routeId: activeRoute,
+    onboarding,
+  });
+  // Drawer navigation always opens expanded; the desktop collapse preference
+  // stays persisted for when the viewport returns to the desktop layout.
+  // The settings sidebar has a fixed width, so the collapse state pauses too.
+  const navCollapsed =
+    navigationSnapshot.navCollapsed &&
+    !host.desktopNavigationExpanded &&
+    !navDrawerOpen &&
+    !settingsTakeover;
+  const navigationSurfaceHidden = navigationSurfaceIsHidden({
+    navCollapsed,
+    navDrawerOpen,
+    mobileNavLayout,
+  });
+  const shellWidth = Math.max(globalThis.innerWidth || 0, NAV_WIDTH_MAX);
+  // Mirror the sidebar brand action: an open new-session draft wins over the
+  // persisted selection so the collapsed cluster "+" targets the same agent.
+  const selectedAgentId = normalizeAgentId(
+    host.draftSessionAgentId() ||
+      (context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId),
+  );
+  // One storage read per render; theme.refresh() re-renders on pref changes.
+  const uiSettings = loadSettings();
+  // The new-session draft shares the chat layout: full-height pane that owns
+  // its scrolling and pins the composer dock to the bottom.
+  const chatLikeRoute = isSessionRouteId(activeRoute) || activeRoute === "new-session";
+  const custodianRoute = activeRoute === "custodian";
+  const inlineApproval = isSessionRouteId(activeRoute)
+    ? findInlineApproval(overlaySnapshot.approvalQueue, host.activeSessionKey)
+    : null;
+  if (!settingsTakeover) {
+    Object.assign(host.navigationSidebar, {
+      basePath: context.basePath,
+      activeRouteId: activeRoute,
+      activePluginTabId,
+      enabledRouteIds: host.enabledRouteIds(),
+      activeWorkboardBoardId:
+        workboardBoardIdFromPath(host.routeState.location?.pathname ?? "", context.basePath) ?? "",
+      sessionKey: host.activeSessionKey,
+      connected: gatewayConnected,
+      offline: gatewaySnapshot.offlineStable,
+      outboxCountForSession,
+      terminalAvailable,
+      catalogOpenTarget: normalizeCatalogOpenTarget(uiSettings.catalogOpenTarget),
+      canPairDevice: gatewayConnected && (operatorAccess.canAdmin || operatorAccess.canPair),
+      sidebarEntries: navigationSnapshot.sidebarEntries,
+      workboardBoards: host.sidebarWorkboardSnapshot.boards,
+      workboardBoardsReady: host.sidebarWorkboardSnapshot.ready,
+      workboardRenderers: host.sidebarWorkboardRenderers,
+      sidebarLiveActivity: uiSettings.sidebarLiveActivity !== false,
+      pinnedAgentIds: navigationSnapshot.pinnedAgentIds,
+      themeMode: context.theme.mode,
+      lobsterPetVisits: uiSettings.lobsterPetVisits !== false,
+      lobsterPetSounds: uiSettings.lobsterPetSounds === true,
+      gatewayVersion:
+        context.config.current.serverVersion ?? gatewaySnapshot.hello?.server?.version ?? null,
+      devGitBranch: context.config.current.devGitBranch,
+      updateAvailable: navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable,
+      updateRunning: overlaySnapshot.updateRunning,
+      onUpdate: () => void context.overlays.runUpdate(),
+      onOpenApprovals: () => host.openApprovals(),
+      onRetryConnect: () => context.gateway.connect(),
+      onOpenNewSession: (agentId: string, target?: NewSessionTarget) =>
+        host.openNewSession(agentId, target),
+      draftSessionAgentId: host.draftSessionAgentId(),
+      onUpdateSidebarEntries: (entries: string[]) =>
+        context.navigation.update({ sidebarEntries: entries }),
+      onPairMobile: () => void context.overlays.openDevicePairSetup(),
+      onNavigate: (routeId: string, options?: ApplicationNavigationOptions) =>
+        host.navigate(routeId, options),
+      onPreloadRoute: (routeId: string) =>
+        isRouteId(routeId) ? context.preload(routeId) : Promise.resolve(),
+    });
+  }
+  const navigationContent = settingsTakeover
+    ? renderSettingsSidebar({
+        basePath: context.basePath,
+        activeRouteId: activeRoute,
+        activePathname: host.routeState.location?.pathname ?? "",
+        activeSearch: host.routeState.location?.search ?? "",
+        activeHash: host.routeState.location?.hash ?? "",
+        offline: gatewaySnapshot.offlineStable,
+        queuedOutboxCount: storedOutboxes?.total ?? 0,
+        lastError: gatewaySnapshot.lastError,
+        gatewayVersion:
+          context.config.current.serverVersion ?? gatewaySnapshot.hello?.server?.version ?? "",
+        updateAvailable: navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable,
+        updateRunning: overlaySnapshot.updateRunning,
+        onUpdate: () => void context.overlays.runUpdate(),
+        searchQuery: host.settingsSearchQuery,
+        searchBlockMatches: settingsSearchBlocks,
+        onExit: () => host.exitSettings(),
+        onRetryConnect: () => context.gateway.connect(),
+        onNavigate: (routeId, options) => host.navigate(routeId, options),
+        onPreload: (routeId) => context.preload(routeId),
+        onSearchQueryChange: (nextQuery) => {
+          void host.handleSettingsSearchQueryChange(nextQuery);
+        },
+        preloadTimers: host.settingsPreloadTimers,
+        saveIndicator: {
+          status: runtimeConfig.configAutoSaveStatus,
+          lastError: runtimeConfig.lastError,
+          needsApply: runtimeConfig.configNeedsApply,
+          applying: runtimeConfig.configApplying,
+          applyDisabled:
+            runtimeConfig.configLoading ||
+            runtimeConfig.configSaving ||
+            (runtimeConfig.configFormDirty && runtimeConfig.configFormMode === "raw") ||
+            overlaySnapshot.updateRunning ||
+            overlaySnapshot.updateReconciliationPending,
+          onRetry: () => void context.runtimeConfig.save(),
+          onReload: () => void context.runtimeConfig.discardDraft(),
+          onApply: () => void context.runtimeConfig.apply(),
+        },
+      })
+    : host.navigationSidebar;
+  // Optional tags stay mounted before definition. Lit replays their properties on upgrade,
+  // and the upgraded panels catch the first toggle instead of dropping the event.
+  return html`
+    ${isOptionalElementDefined(host.commandPaletteElement)
+      ? html`<openclaw-command-palette
+          .onNavigate=${(routeId: RouteId) => host.navigate(routeId)}
+          .onSelectSession=${(sessionKey: string) => host.selectChatSession(sessionKey)}
+          .onSlashCommand=${(command: string) => host.handleCommandPaletteSlashCommand(command)}
+        ></openclaw-command-palette>`
+      : nothing}
+    <div
+      class="shell ${chatLikeRoute ? "shell--chat" : ""} ${navCollapsed
+        ? "shell--nav-collapsed"
+        : ""} ${mobileNavLayout ? "shell--mobile-nav" : ""} ${mergedChatChrome
+        ? "shell--merged-chat-chrome"
+        : ""} ${navDrawerOpen ? "shell--nav-drawer-open" : ""} ${onboarding
+        ? "shell--onboarding"
+        : ""} ${settingsTakeover ? "shell--settings" : ""}"
+      style=${`--shell-nav-expanded-width: ${navigationSnapshot.navWidth}px`}
+      @theme-change=${(event: CustomEvent<ThemeModeChangeDetail>) => host.handleThemeChange(event)}
+    >
+      <a class="shell-skip-link" href="#control-ui-main"> ${t("common.skipToMainContent")} </a>
+      ${isNativeWebChromeHost() && !onboarding
+        ? html`
+            <openclaw-macos-titlebar-controls
+              .navCollapsed=${host.nativeNavCollapsed()}
+              .historyOnly=${settingsTakeover}
+              .canGoBack=${host.nativeHistoryState.canGoBack}
+              .canGoForward=${host.nativeHistoryState.canGoForward}
+              .onToggleSidebar=${() => host.toggleNavigationSurface()}
+              .onOpenPalette=${() => host.openPalette()}
+              .onOpenNewSession=${() => host.handleNativeNewSession()}
+            ></openclaw-macos-titlebar-controls>
+          `
+        : nothing}
+      <openclaw-app-topbar
+        .basePath=${context.basePath}
+        .searchDisabled=${false}
+        .navDrawerOpen=${navDrawerOpen}
+        .onboarding=${onboarding}
+        .onOpenPalette=${() => host.openPalette()}
+        .onToggleDrawer=${(trigger: HTMLElement) => host.toggleNavigationSurface(trigger)}
+      ></openclaw-app-topbar>
+      ${!onboarding && !settingsTakeover && !mobileNavLayout
+        ? html`
+            <div class="shell-chrome-controls">
+              <openclaw-tooltip
+                .content=${`${t(navCollapsed ? "nav.expand" : "nav.collapse")} (⌘B)`}
+              >
+                <button
+                  type="button"
+                  class="shell-chrome-controls__button shell-chrome-controls__nav-toggle"
+                  aria-label=${t(navCollapsed ? "nav.expand" : "nav.collapse")}
+                  aria-expanded=${navCollapsed ? "false" : "true"}
+                  @click=${() => host.toggleNavigationSurface()}
+                >
+                  ${navCollapsed ? icons.panelLeftOpen : icons.panelLeftClose}
+                </button>
+              </openclaw-tooltip>
+              ${navCollapsed
+                ? html`<openclaw-tooltip
+                    .content=${gatewaySnapshot.phase === "connected"
+                      ? t("chat.runControls.newSession")
+                      : t("chat.runControls.newSessionDisconnected")}
+                  >
+                    <button
+                      type="button"
+                      class="shell-chrome-controls__button shell-chrome-controls__new-thread"
+                      aria-label=${t("chat.runControls.newSession")}
+                      ?disabled=${gatewaySnapshot.phase !== "connected"}
+                      @click=${() => host.openNewSession(selectedAgentId)}
+                    >
+                      ${icons.plus}
+                    </button>
+                  </openclaw-tooltip>`
+                : nothing}
+              <openclaw-tooltip .content=${`${t("chat.openCommandPalette")} (${PALETTE_SHORTCUT})`}>
+                <button
+                  type="button"
+                  class="shell-chrome-controls__button shell-chrome-controls__search"
+                  aria-label=${t("chat.openCommandPalette")}
+                  @click=${() => host.openPalette()}
+                >
+                  ${icons.search}
+                </button>
+              </openclaw-tooltip>
+            </div>
+          `
+        : nothing}
+      <div class="shell-nav" ?inert=${navigationSurfaceHidden}>
+        ${mobileNavLayout
+          ? html`<openclaw-modal-dialog
+              class="drawer nav-drawer"
+              .open=${navDrawerOpen}
+              .label=${t("palette.categories.navigation")}
+              @modal-cancel=${() => host.closeNavDrawer({ restoreFocus: true })}
+            >
+              <div class="shell-nav-modal__content" tabindex="-1" autofocus>
+                ${navigationContent}
+              </div>
+            </openclaw-modal-dialog>`
+          : navigationContent}
+      </div>
+      ${!navCollapsed && !onboarding && !settingsTakeover
+        ? html`
+            <resizable-divider
+              class="sidebar-resizer"
+              .label=${t("nav.resize")}
+              .splitRatio=${navigationSnapshot.navWidth / shellWidth}
+              .minRatio=${NAV_WIDTH_MIN / shellWidth}
+              .maxRatio=${NAV_WIDTH_MAX / shellWidth}
+              aria-valuetext=${`${navigationSnapshot.navWidth} pixels`}
+              title=${t("nav.resize")}
+              @resize=${(event: CustomEvent<{ splitRatio: number }>) =>
+                host.resizeNavigation(event.detail.splitRatio)}
+            ></resizable-divider>
+          `
+        : nothing}
+      <main
+        id="control-ui-main"
+        class="content ${chatLikeRoute ? "content--chat" : ""} ${custodianRoute
+          ? "content--custodian"
+          : ""} ${activeRoute === "workboard" ? "content--workboard" : ""}"
+        .tabIndex=${-1}
+      >
+        ${gatewaySnapshot.hello?.deviceAuthMigration?.pending === true
+          ? customElements.get("openclaw-device-auth-migration-banner")
+            ? html`<openclaw-device-auth-migration-banner
+                .props=${{
+                  state: overlaySnapshot.deviceAuthMigration,
+                  onSecure: () => void context.overlays.secureThisBrowser(),
+                }}
+              ></openclaw-device-auth-migration-banner>`
+            : html`<openclaw-update-banner
+                .props=${{
+                  statusBanner: {
+                    tone: overlaySnapshot.deviceAuthMigration.error ? "danger" : "warn",
+                    text:
+                      overlaySnapshot.deviceAuthMigration.error ??
+                      t("login.deviceAuthMigration.banner"),
+                  },
+                }}
+              ></openclaw-update-banner>`
+          : html`<openclaw-update-banner
+              .props=${{
+                statusBanner: overlaySnapshot.controlUiRefreshRequired
+                  ? resolveControlUiRefreshRequiredBanner()
+                  : null,
+                action: overlaySnapshot.controlUiRefreshRequired
+                  ? { label: t("common.refresh"), onClick: () => host.refreshControlUi() }
+                  : undefined,
+              }}
+            ></openclaw-update-banner>`}
+        <openclaw-update-banner
+          .props=${{
+            statusBanner: overlaySnapshot.updateStatusBanner,
+          }}
+        ></openclaw-update-banner>
+        ${renderFloatingUpdateCard({
+          navigationSurfaceHidden,
+          onboarding,
+          updateAvailable: overlaySnapshot.updateAvailable,
+          updateRunning: overlaySnapshot.updateRunning,
+          onUpdate: () => void context.overlays.runUpdate(),
+        })}
+        <openclaw-router-outlet
+          .router=${runtime.router}
+          .retryContext=${context}
+          .onNotFound=${() => host.replaceChatWithCurrentSession()}
+        ></openclaw-router-outlet>
+      </main>
+      <openclaw-terminal-panel
+        .client=${gatewayConnected ? gatewaySnapshot.client : null}
+        .available=${terminalAvailable}
+        .suppressed=${settingsTakeover}
+        .themeMode=${resolveTerminalThemeMode()}
+      ></openclaw-terminal-panel>
+      <openclaw-browser-panel
+        .client=${gatewayConnected ? gatewaySnapshot.client : null}
+        .available=${browserPanelAvailable}
+        .suppressed=${settingsTakeover}
+        .basePath=${context.basePath}
+        .authToken=${resolveControlUiAuthToken({
+          hello: gatewaySnapshot.hello,
+          settings: { token: context.gateway.connection.token },
+          password: context.gateway.connection.password,
+        })}
+      ></openclaw-browser-panel>
+      <openclaw-custodian-panel
+        .available=${custodianPanelAvailable}
+        .suppressed=${activeRoute === "custodian"}
+        .minimizeRequestId=${host.custodianMinimizeRequestId}
+      ></openclaw-custodian-panel>
+      ${isOptionalElementDefined(host.execApprovalElement)
+        ? html`<openclaw-exec-approval
+            .props=${{
+              queue: overlaySnapshot.approvalQueue,
+              busy: overlaySnapshot.approvalBusy,
+              errors: overlaySnapshot.approvalErrors,
+              nowMs: overlaySnapshot.approvalNowMs,
+              inlineApprovalId: inlineApproval?.id ?? null,
+              onDecision: (
+                approvalId: string,
+                decision: Parameters<typeof context.overlays.decideApproval>[0],
+              ) => context.overlays.decideApproval(decision, approvalId),
+            }}
+          ></openclaw-exec-approval>`
+        : nothing}
+      ${renderDevicePairSetup({
+        open: overlaySnapshot.devicePairSetupOpen,
+        loading: overlaySnapshot.devicePairSetupLoading,
+        error: overlaySnapshot.devicePairSetupError,
+        setup: overlaySnapshot.devicePairSetup,
+        access: overlaySnapshot.devicePairSetupAccess,
+        pendingCount: overlaySnapshot.devicePairPendingCount,
+        onRefresh: () => void context.overlays.refreshDevicePairSetup(),
+        onAccessChange: (access) => void context.overlays.setDevicePairSetupAccess(access),
+        onClose: () => context.overlays.closeDevicePairSetup(),
+        onCopy: (setupCode) => void copyToClipboard(setupCode),
+        onManageDevices: () => {
+          context.overlays.closeDevicePairSetup();
+          host.navigate("nodes");
+        },
+        onGetApps: () => {
+          context.overlays.closeDevicePairSetup();
+          host.navigate("apps");
+        },
+      })}
+      ${onboarding && activeRoute !== "custodian"
+        ? html`<openclaw-onboarding-memory-import
+            .active=${true}
+            .context=${context}
+          ></openclaw-onboarding-memory-import>`
+        : nothing}
+      <openclaw-toast-host></openclaw-toast-host>
+    </div>
+  `;
+}

--- a/ui/src/app/app-shell-workboard.ts
+++ b/ui/src/app/app-shell-workboard.ts
@@ -1,0 +1,110 @@
+import type { RouteId } from "../app-routes.ts";
+import {
+  EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT,
+  type SidebarWorkboardRenderers,
+  type SidebarWorkboardRuntime,
+  type SidebarWorkboardRuntimeFactory,
+  type SidebarWorkboardSnapshot,
+} from "../components/app-sidebar-workboard.ts";
+import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
+import type { ApplicationContext } from "./context.ts";
+
+export interface ShellWorkboardHost {
+  readonly context: ApplicationContext<RouteId> | undefined;
+  sidebarWorkboardSnapshot: SidebarWorkboardSnapshot;
+  sidebarWorkboardRuntime: SidebarWorkboardRuntime | null;
+  sidebarWorkboardHost: ApplicationContext["workboard"] | null;
+  sidebarWorkboardRenderers: SidebarWorkboardRenderers | undefined;
+  sidebarWorkboardRuntimeLoad: Promise<SidebarWorkboardRuntimeFactory> | null;
+  sidebarWorkboardEpoch: number;
+  requestUpdate(): void;
+}
+
+export class ShellWorkboardOwner {
+  constructor(private readonly host: ShellWorkboardHost) {}
+
+  syncSidebarWorkboard(): void {
+    const host = this.host;
+    const context = host.context;
+    const snapshot = context?.gateway.snapshot;
+    const configSnapshot = context?.runtimeConfig.state.configSnapshot;
+    if (!context || !snapshot || !configSnapshot) {
+      return;
+    }
+    if (!isWorkboardEnabledInConfigSnapshot(configSnapshot)) {
+      this.disposeSidebarWorkboard();
+      return;
+    }
+    const runtime = host.sidebarWorkboardRuntime;
+    if (runtime) {
+      if (host.sidebarWorkboardHost !== context.workboard) {
+        this.disposeSidebarWorkboard();
+        this.syncSidebarWorkboard();
+        return;
+      }
+      runtime.sync(snapshot.client, snapshot.phase === "connected");
+      return;
+    }
+    if (host.sidebarWorkboardRuntimeLoad) {
+      return;
+    }
+    // Disposal advances the epoch so a stale lazy import cannot revive its retired owner.
+    const epoch = host.sidebarWorkboardEpoch;
+    const load = import("../components/app-sidebar-workboard.runtime.ts");
+    host.sidebarWorkboardRuntimeLoad = load;
+    void load
+      .then((module) => {
+        if (host.sidebarWorkboardEpoch !== epoch || host.sidebarWorkboardRuntime) {
+          return;
+        }
+        const current = host.context;
+        if (!current) {
+          return;
+        }
+        const loadedRuntime = module.createSidebarWorkboardRuntime((nextSnapshot) => {
+          if (host.sidebarWorkboardRuntime === loadedRuntime) {
+            host.sidebarWorkboardSnapshot = nextSnapshot;
+            host.requestUpdate();
+          }
+        }, current.workboard);
+        host.sidebarWorkboardRuntime = loadedRuntime;
+        host.sidebarWorkboardHost = current.workboard;
+        host.sidebarWorkboardRenderers = {
+          renderEntry: module.renderSidebarWorkboardEntry,
+          renderCustomize: module.renderSidebarWorkboardCustomize,
+        };
+        const gateway = current?.gateway.snapshot;
+        if (
+          current &&
+          gateway &&
+          isWorkboardEnabledInConfigSnapshot(current.runtimeConfig.state.configSnapshot)
+        ) {
+          loadedRuntime.sync(gateway.client, gateway.phase === "connected");
+        }
+      })
+      .catch(() => {
+        if (host.sidebarWorkboardEpoch === epoch && host.sidebarWorkboardRuntimeLoad === load) {
+          host.sidebarWorkboardRuntimeLoad = null;
+        }
+      });
+  }
+
+  disposeSidebarWorkboard(): void {
+    const host = this.host;
+    host.sidebarWorkboardEpoch += 1;
+    const runtime = host.sidebarWorkboardRuntime;
+    runtime?.dispose();
+    if (!runtime) {
+      // The capability can retain boards before its lazy runtime has materialized.
+      host.context?.workboard.clearBoards();
+    }
+    host.sidebarWorkboardRuntime = null;
+    host.sidebarWorkboardHost = null;
+    host.sidebarWorkboardRenderers = undefined;
+    host.sidebarWorkboardRuntimeLoad = null;
+    if (host.sidebarWorkboardSnapshot !== EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT) {
+      host.sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
+      host.requestUpdate();
+    }
+  }
+}

--- a/ui/src/components/web-awesome-migration.node.test.ts
+++ b/ui/src/components/web-awesome-migration.node.test.ts
@@ -58,7 +58,7 @@ describe("Web Awesome control ownership", () => {
     // Web Awesome split panel owns exactly two panes; these layouts coordinate
     // sidebar, inspector, and responsive dock state across more than two panes.
     expect(await matchingFiles(/<resizable-divider\b/u)).toEqual([
-      "app/app-host.ts",
+      "app/app-shell-view.ts",
       "pages/chat/chat-page.ts",
       "pages/chat/components/chat-resizable-divider.ts",
     ]);

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -317,6 +317,87 @@ suite.define(() => {
     }
   });
 
+  it("retains the selected session and one observer while reconnecting across route changes", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const firstKey = "agent:main:reconnect-first";
+    const selectedKey = "agent:main:reconnect-selected";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(firstKey, "First session", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(selectedKey, "Selected session", Date.parse("2026-07-01T15:59:00.000Z")),
+        ]),
+      },
+      sessionKey: firstKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstKey));
+      const firstRow = page.locator(`.sidebar-recent-session[data-session-key="${firstKey}"]`);
+      const selectedRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${selectedKey}"]`,
+      );
+      await firstRow.waitFor({ state: "visible", timeout: 10_000 });
+      await selectedRow.waitFor({ state: "visible" });
+      await gateway.waitForRequest("sessions.subscribe");
+
+      await selectedRow.getByRole("link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedKey));
+      await expect.poll(() => selectedRow.getAttribute("class")).toContain("--active");
+      const initialObserverCount = (await gateway.getRequests("sessions.subscribe")).length;
+      const initialListCount = (await gateway.getRequests("sessions.list")).length;
+
+      await gateway.deferNext("sessions.subscribe");
+      await gateway.deferNext("sessions.list");
+      await gateway.closeLatest(1006, "session route reconnect");
+      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBeGreaterThan(1);
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.subscribe")).length, {
+          timeout: 15_000,
+        })
+        .toBe(initialObserverCount + 1);
+
+      await firstRow.getByRole("link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(firstKey));
+      await selectedRow.getByRole("link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedKey));
+      expect(await gateway.getRequests("sessions.subscribe")).toHaveLength(
+        initialObserverCount + 1,
+      );
+
+      await gateway.resolveDeferred("sessions.subscribe", { subscribed: true });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 15_000 })
+        .toBeGreaterThan(initialListCount);
+      await gateway.resolveDeferred(
+        "sessions.list",
+        sessionsListResponse([
+          sessionRow(firstKey, "First session", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(
+            selectedKey,
+            "Selected session recovered",
+            Date.parse("2026-07-01T16:01:00.000Z"),
+          ),
+        ]),
+      );
+      await expect.poll(() => selectedRow.textContent()).toContain("Selected session recovered");
+      await expect.poll(() => selectedRow.getAttribute("class")).toContain("--active");
+      await expect.poll(() => page.locator(".sidebar-recent-session--active").count()).toBe(1);
+      expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedKey));
+      expect(await gateway.getRequests("sessions.subscribe")).toHaveLength(
+        initialObserverCount + 1,
+      );
+      await captureUiProof(page, "sidebar-selected-session-route-reconnect.png");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("does not duplicate the active chat when its only session is pinned", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -189,6 +189,54 @@ describe("createAgentCapability lifecycle", () => {
     agents.dispose();
   });
 
+  it("retires existing file loading state before dropping disconnected owners", async () => {
+    const pending = deferred<unknown>();
+    const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const harness = createGatewayHarness(client);
+    const agents = createAgentCapability(harness.gateway);
+
+    const load = agents.refreshFiles("main");
+    const status = agents.files("main");
+    expect(status.loading).toBe(true);
+
+    harness.publish(false);
+
+    expect(status.loading).toBe(false);
+    expect(agents.files("main").loading).toBe(false);
+
+    pending.resolve({ agentId: "main", workspace: "stale", files: [] });
+    await load;
+    agents.dispose();
+  });
+
+  it("keeps a replacement list request owned while its predecessor completes", async () => {
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    const request = vi
+      .fn<TestRequest>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const harness = createGatewayHarness(client);
+    const agents = createAgentCapability(harness.gateway);
+
+    const staleLoad = agents.refreshList();
+    const currentLoad = agents.refreshList();
+
+    first.resolve({ defaultId: "old", agents: [{ id: "old" }] });
+    await staleLoad;
+    expect(agents.state.agentsList).toBeNull();
+    expect(agents.state.agentsLoading).toBe(true);
+
+    const current = { defaultId: "main", agents: [{ id: "main" }] };
+    second.resolve(current);
+    await currentLoad;
+    expect(agents.state.agentsList).toEqual(current);
+    expect(agents.state.agentsLoading).toBe(false);
+    agents.dispose();
+  });
+
   it("invalidates cached and in-flight file lists for changed agents", async () => {
     const pending = deferred<unknown>();
     const request = vi

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -7,7 +7,10 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
-import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
+import {
+  createGatewayConnectionLifecycle,
+  type GatewayConnectionSnapshot,
+} from "../gateway-connection-lifecycle.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -53,14 +56,9 @@ type AgentsConfigCapability = {
   stageDefaultAgent: (agentId: string) => boolean;
 };
 
-type AgentGatewaySnapshot = {
-  client: GatewayBrowserClient | null;
-  phase: ApplicationGatewayPhase;
-};
-
 type AgentGateway = {
-  readonly snapshot: AgentGatewaySnapshot;
-  subscribe: (listener: (snapshot: AgentGatewaySnapshot) => void) => () => void;
+  readonly snapshot: GatewayConnectionSnapshot;
+  subscribe: (listener: (snapshot: GatewayConnectionSnapshot) => void) => () => void;
 };
 
 type AgentFilesStatus = {
@@ -229,6 +227,7 @@ function normalizeAgentId(agentId: string | null | undefined): string | null {
 }
 
 export function createAgentCapability(gateway: AgentGateway): AgentCapability {
+  const lifecycle = createGatewayConnectionLifecycle(gateway.snapshot);
   const state: AgentCapabilityState = {
     client: gateway.snapshot.client,
     connected: gateway.snapshot.phase === "connected",
@@ -241,9 +240,6 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const fileRequestOwners = new Map<string, symbol>();
   const listeners = new Set<(state: AgentCapabilityState) => void>();
   let disposed = false;
-  // Transport reconnects reuse the client object, so identity alone cannot
-  // stop pre-disconnect completions from repopulating capability state.
-  let requestGeneration = 0;
   let agentsRequest: Promise<AgentsListResult | null> | null = null;
   let agentsRequestOwner: symbol | null = null;
 
@@ -255,9 +251,6 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
       listener(state);
     }
   };
-  const isCurrentRequest = (client: GatewayBrowserClient, generation: number) =>
-    !disposed && state.connected && state.client === client && requestGeneration === generation;
-
   const fileStatus = (agentId: string): AgentFilesStatus => {
     const existing = files.get(agentId);
     if (existing) {
@@ -269,8 +262,8 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   };
 
   const loadList = async (force: boolean): Promise<AgentsListResult | null> => {
-    const client = state.client;
-    if (!client || !state.connected) {
+    const scope = lifecycle.capture();
+    if (!scope) {
       return state.agentsList;
     }
     if (agentsRequest && !force) {
@@ -279,12 +272,11 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     state.agentsLoading = true;
     state.agentsError = null;
     publish();
-    const generation = requestGeneration;
     const owner = Symbol();
     agentsRequestOwner = owner;
-    const request = loadAgentsList(client)
+    const request = loadAgentsList(scope.client)
       .then((result) => {
-        const current = isCurrentRequest(client, generation) && agentsRequestOwner === owner;
+        const current = lifecycle.isCurrent(scope) && agentsRequestOwner === owner;
         if (current) {
           state.agentsList = result;
           state.agentsError = null;
@@ -292,7 +284,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return current ? result : null;
       })
       .catch((err: unknown) => {
-        if (isCurrentRequest(client, generation) && agentsRequestOwner === owner) {
+        if (lifecycle.isCurrent(scope) && agentsRequestOwner === owner) {
           state.agentsError = isMissingOperatorReadScopeError(err)
             ? formatMissingOperatorReadScopeMessage("agent list")
             : String(err);
@@ -305,7 +297,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
           agentsRequest = null;
           agentsRequestOwner = null;
         }
-        if (currentRequest && isCurrentRequest(client, generation)) {
+        if (currentRequest && lifecycle.isCurrent(scope)) {
           state.agentsLoading = false;
           publish();
         }
@@ -319,8 +311,8 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     force: boolean,
   ): Promise<AgentsFilesListResult | null> => {
     const agentId = normalizeAgentId(rawAgentId);
-    const client = state.client;
-    if (!agentId || !client || !state.connected) {
+    const scope = lifecycle.capture();
+    if (!agentId || !scope) {
       return agentId ? (files.get(agentId)?.list ?? null) : null;
     }
     const status = fileStatus(agentId);
@@ -334,13 +326,11 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     status.loading = true;
     status.error = null;
     publish();
-    const generation = requestGeneration;
     const owner = Symbol();
     fileRequestOwners.set(agentId, owner);
-    const request = loadAgentFilesList(client, agentId)
+    const request = loadAgentFilesList(scope.client, agentId)
       .then((result) => {
-        const current =
-          isCurrentRequest(client, generation) && fileRequestOwners.get(agentId) === owner;
+        const current = lifecycle.isCurrent(scope) && fileRequestOwners.get(agentId) === owner;
         if (current && result) {
           status.list = result;
           status.error = null;
@@ -348,7 +338,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return current ? status.list : null;
       })
       .catch((err: unknown) => {
-        if (isCurrentRequest(client, generation) && fileRequestOwners.get(agentId) === owner) {
+        if (lifecycle.isCurrent(scope) && fileRequestOwners.get(agentId) === owner) {
           status.error = String(err);
         }
         return null;
@@ -359,7 +349,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
           fileRequests.delete(agentId);
           fileRequestOwners.delete(agentId);
         }
-        if (currentRequest && isCurrentRequest(client, generation)) {
+        if (currentRequest && lifecycle.isCurrent(scope)) {
           status.loading = false;
           publish();
         }
@@ -371,25 +361,21 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const stopGateway = gateway.subscribe((snapshot) => {
     const clientChanged = state.client !== snapshot.client;
     const connected = snapshot.phase === "connected";
+    lifecycle.transition(snapshot);
     state.client = snapshot.client;
     state.connected = connected;
     if (clientChanged || !connected) {
-      requestGeneration += 1;
       agentsRequest = null;
       agentsRequestOwner = null;
       fileRequests.clear();
       fileRequestOwners.clear();
-    }
-    if (clientChanged || !connected) {
-      files.clear();
-      state.agentsList = null;
-      state.agentsError = null;
-    }
-    if (clientChanged || !connected) {
-      state.agentsLoading = false;
       for (const status of files.values()) {
         status.loading = false;
       }
+      files.clear();
+      state.agentsList = null;
+      state.agentsError = null;
+      state.agentsLoading = false;
     }
     publish();
   });
@@ -436,7 +422,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     },
     dispose() {
       disposed = true;
-      requestGeneration += 1;
+      lifecycle.dispose();
       stopGateway();
       listeners.clear();
       fileRequests.clear();

--- a/ui/src/lib/gateway-connection-lifecycle.test.ts
+++ b/ui/src/lib/gateway-connection-lifecycle.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle.ts";
+
+describe("gateway connection lifecycle", () => {
+  it("captures connected clients and preserves scopes across unchanged snapshots", () => {
+    const client = {} as GatewayBrowserClient;
+    const lifecycle = createGatewayConnectionLifecycle({ client, phase: "connected" });
+    const scope = lifecycle.capture();
+
+    expect(scope).toEqual({ client, epoch: 0 });
+    expect(lifecycle.transition({ client, phase: "connected" })).toBe(false);
+    expect(scope && lifecycle.isCurrent(scope)).toBe(true);
+  });
+
+  it.each(["connecting", "reconnecting", "offline", "stopped"] as const)(
+    "does not capture a %s connection",
+    (phase) => {
+      const lifecycle = createGatewayConnectionLifecycle({
+        client: {} as GatewayBrowserClient,
+        phase,
+      });
+
+      expect(lifecycle.capture()).toBeNull();
+    },
+  );
+
+  it("retires old requests across a reconnect that reuses the same client", () => {
+    const client = {} as GatewayBrowserClient;
+    const lifecycle = createGatewayConnectionLifecycle({ client, phase: "connected" });
+    const first = lifecycle.capture();
+
+    expect(first).not.toBeNull();
+    expect(lifecycle.transition({ client, phase: "reconnecting" })).toBe(true);
+    expect(first && lifecycle.isCurrent(first)).toBe(false);
+    expect(lifecycle.capture()).toBeNull();
+    expect(lifecycle.transition({ client, phase: "connected" })).toBe(true);
+
+    const second = lifecycle.capture();
+    expect(second).toEqual({ client, epoch: 2 });
+    expect(first && lifecycle.isCurrent(first)).toBe(false);
+    expect(second && lifecycle.isCurrent(second)).toBe(true);
+  });
+
+  it("retires old requests when the connected gateway client is replaced", () => {
+    const previous = {} as GatewayBrowserClient;
+    const replacement = {} as GatewayBrowserClient;
+    const lifecycle = createGatewayConnectionLifecycle({
+      client: previous,
+      phase: "connected",
+    });
+    const stale = lifecycle.capture();
+
+    expect(lifecycle.transition({ client: replacement, phase: "connected" })).toBe(true);
+    expect(stale && lifecycle.isCurrent(stale)).toBe(false);
+    expect(lifecycle.capture()).toEqual({ client: replacement, epoch: 1 });
+  });
+
+  it("retires a connection scope without changing its client or connection phase", () => {
+    const client = {} as GatewayBrowserClient;
+    const lifecycle = createGatewayConnectionLifecycle({ client, phase: "connected" });
+    const stale = lifecycle.capture();
+
+    lifecycle.invalidate();
+
+    expect(lifecycle.epoch).toBe(1);
+    expect(stale && lifecycle.isCurrent(stale)).toBe(false);
+    expect(lifecycle.capture()).toEqual({ client, epoch: 1 });
+  });
+
+  it("retires all scopes when disposed and cannot be reactivated", () => {
+    const client = {} as GatewayBrowserClient;
+    const lifecycle = createGatewayConnectionLifecycle({ client, phase: "connected" });
+    const stale = lifecycle.capture();
+
+    lifecycle.dispose();
+    lifecycle.dispose();
+    lifecycle.invalidate();
+
+    expect(lifecycle.epoch).toBe(1);
+    expect(stale && lifecycle.isCurrent(stale)).toBe(false);
+    expect(lifecycle.capture()).toBeNull();
+    expect(lifecycle.transition({ client, phase: "connected" })).toBe(false);
+  });
+});

--- a/ui/src/lib/gateway-connection-lifecycle.ts
+++ b/ui/src/lib/gateway-connection-lifecycle.ts
@@ -1,0 +1,63 @@
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
+
+export type GatewayConnectionSnapshot = Pick<ApplicationGatewaySnapshot, "client" | "phase">;
+
+export type GatewayConnectionScope = {
+  readonly client: GatewayBrowserClient;
+  readonly epoch: number;
+};
+
+type GatewayConnectionLifecycle = {
+  readonly epoch: number;
+  capture: () => GatewayConnectionScope | null;
+  isCurrent: (scope: GatewayConnectionScope) => boolean;
+  invalidate: () => void;
+  transition: (snapshot: GatewayConnectionSnapshot) => boolean;
+  dispose: () => void;
+};
+
+export function createGatewayConnectionLifecycle(
+  snapshot: GatewayConnectionSnapshot,
+): GatewayConnectionLifecycle {
+  let client = snapshot.client;
+  let connected = snapshot.phase === "connected";
+  let epoch = 0;
+  let disposed = false;
+
+  return {
+    get epoch() {
+      return epoch;
+    },
+    capture() {
+      return !disposed && connected && client ? { client, epoch } : null;
+    },
+    isCurrent(scope) {
+      return !disposed && connected && client === scope.client && epoch === scope.epoch;
+    },
+    invalidate() {
+      if (!disposed) {
+        epoch += 1;
+      }
+    },
+    transition(next) {
+      if (disposed) {
+        return false;
+      }
+      const nextConnected = next.phase === "connected";
+      const changed = client !== next.client || connected !== nextConnected;
+      if (changed) {
+        epoch += 1;
+      }
+      client = next.client;
+      connected = nextConnected;
+      return changed;
+    },
+    dispose() {
+      if (!disposed) {
+        disposed = true;
+        epoch += 1;
+      }
+    },
+  };
+}

--- a/ui/src/lib/gateway-retry.test.ts
+++ b/ui/src/lib/gateway-retry.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGatewayRetryOwner } from "./gateway-retry.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("gateway retry owner", () => {
+  it("backs off from 30 seconds and caps retries at five minutes", () => {
+    vi.useFakeTimers();
+    const owner = createGatewayRetryOwner();
+    const retry = vi.fn();
+
+    for (const delayMs of [30_000, 60_000, 120_000, 240_000, 300_000, 300_000]) {
+      const completed = retry.mock.calls.length;
+      owner.schedule(retry);
+      vi.advanceTimersByTime(delayMs - 1);
+      expect(retry).toHaveBeenCalledTimes(completed);
+      vi.advanceTimersByTime(1);
+      expect(retry).toHaveBeenCalledTimes(completed + 1);
+    }
+  });
+
+  it("cancels stale timers without resetting the current backoff", () => {
+    vi.useFakeTimers();
+    const owner = createGatewayRetryOwner();
+    const staleRetry = vi.fn();
+    const currentRetry = vi.fn();
+
+    owner.schedule(staleRetry);
+    owner.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+
+    owner.schedule(currentRetry);
+    vi.advanceTimersByTime(59_999);
+    expect(staleRetry).not.toHaveBeenCalled();
+    expect(currentRetry).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(currentRetry).toHaveBeenCalledOnce();
+  });
+
+  it("resets active timers and restarts the initial delay", () => {
+    vi.useFakeTimers();
+    const owner = createGatewayRetryOwner();
+    const staleRetry = vi.fn();
+    const currentRetry = vi.fn();
+
+    owner.schedule(staleRetry);
+    vi.advanceTimersByTime(10_000);
+    owner.reset();
+    expect(vi.getTimerCount()).toBe(0);
+
+    owner.schedule(currentRetry);
+    vi.advanceTimersByTime(29_999);
+    expect(staleRetry).not.toHaveBeenCalled();
+    expect(currentRetry).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(currentRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/lib/gateway-retry.ts
+++ b/ui/src/lib/gateway-retry.ts
@@ -1,0 +1,32 @@
+const GATEWAY_RETRY_INITIAL_DELAY_MS = 30_000;
+const GATEWAY_RETRY_MAX_DELAY_MS = 5 * 60_000;
+
+/** Owns one reconnect-safe retry timer and its bounded exponential backoff. */
+export function createGatewayRetryOwner() {
+  let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let nextDelayMs = GATEWAY_RETRY_INITIAL_DELAY_MS;
+
+  const cancel = () => {
+    if (timer !== null) {
+      globalThis.clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return {
+    cancel,
+    reset() {
+      cancel();
+      nextDelayMs = GATEWAY_RETRY_INITIAL_DELAY_MS;
+    },
+    schedule(retry: () => void) {
+      cancel();
+      const delayMs = nextDelayMs;
+      nextDelayMs = Math.min(nextDelayMs * 2, GATEWAY_RETRY_MAX_DELAY_MS);
+      timer = globalThis.setTimeout(() => {
+        timer = null;
+        retry();
+      }, delayMs);
+    },
+  };
+}

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -8,12 +8,10 @@ import {
 } from "../../../src/gateway/control-ui-contract.js";
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
+import { createGatewayRetryOwner } from "./gateway-retry.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "./sessions/session-key.ts";
 
 export const SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD = "controlUi.sessionPullRequests.subscribe";
-
-const SUBSCRIPTION_RETRY_BASE_MS = 30_000;
-const SUBSCRIPTION_RETRY_MAX_MS = 5 * 60_000;
 
 export type SessionPullRequestSnapshotStore = {
   watch: (
@@ -63,11 +61,10 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     Set<(snapshot: ControlUiSessionPullRequestSnapshot | undefined) => void>
   >();
   const pendingRefreshKeys = new Set<string>();
+  const retry = createGatewayRetryOwner();
   let knownClient = gateway.snapshot.client;
   let lastHello: object | null = null;
   let lastSignature: string | null = null;
-  let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  let retryDelayMs = SUBSCRIPTION_RETRY_BASE_MS;
   let syncRequestGeneration = 0;
   let syncScheduled = false;
   let syncScheduleGeneration = 0;
@@ -75,16 +72,6 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
   let stopGatewaySnapshots: (() => void) | null = null;
   let stopGatewayEvents: (() => void) | null = null;
   let visibilityDocument: Document | null = null;
-
-  const clearRetry = (resetDelay: boolean) => {
-    if (retryTimer !== null) {
-      globalThis.clearTimeout(retryTimer);
-      retryTimer = null;
-    }
-    if (resetDelay) {
-      retryDelayMs = SUBSCRIPTION_RETRY_BASE_MS;
-    }
-  };
 
   const notify = () => {
     for (const listener of Array.from(listeners)) {
@@ -142,7 +129,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
 
   const handleGatewaySnapshot = (snapshot: ApplicationGateway["snapshot"]) => {
     if (snapshot.client !== knownClient || snapshot.hello !== lastHello) {
-      clearRetry(true);
+      retry.reset();
       scheduleSync();
     }
   };
@@ -182,7 +169,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
   };
 
   const handleVisibilityChange = () => {
-    clearRetry(true);
+    retry.reset();
     scheduleSync();
   };
 
@@ -215,7 +202,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     stopGatewayEvents = null;
     visibilityDocument?.removeEventListener("visibilitychange", handleVisibilityChange);
     visibilityDocument = null;
-    clearRetry(true);
+    retry.reset();
     syncRequestGeneration += 1;
     syncScheduleGeneration += 1;
     syncScheduled = false;
@@ -232,7 +219,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     const snapshot = gateway.snapshot;
     const client = snapshot.client;
     if (snapshot.client !== knownClient) {
-      clearRetry(true);
+      retry.reset();
       knownClient = snapshot.client;
       lastHello = null;
       lastSignature = null;
@@ -279,7 +266,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       requestGeneration === syncRequestGeneration &&
       snapshot.hello === lastHello &&
       signature === lastSignature;
-    clearRetry(false);
+    retry.cancel();
     const request = client.request(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
       sessionKeys,
       ...(refreshSessionKeys.length > 0 ? { refreshSessionKeys } : {}),
@@ -293,20 +280,17 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
           for (const key of refreshSessionKeys) {
             pendingRefreshKeys.delete(key);
           }
-          retryDelayMs = SUBSCRIPTION_RETRY_BASE_MS;
+          retry.reset();
         }
       })
       .catch(() => {
         if (isCurrentRequest()) {
           lastSignature = null;
-          const delayMs = retryDelayMs;
-          retryDelayMs = Math.min(retryDelayMs * 2, SUBSCRIPTION_RETRY_MAX_MS);
-          retryTimer = globalThis.setTimeout(() => {
-            retryTimer = null;
+          retry.schedule(() => {
             if (attached && isActive()) {
               scheduleSync();
             }
-          }, delayMs);
+          });
           for (const key of sessionKeys) {
             settle(key);
           }
@@ -349,7 +333,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     } else {
       watchedByOwner.set(owner, { keys: next, foreground: options.foreground === true });
     }
-    clearRetry(true);
+    retry.reset();
     pruneUnwatched();
     if (isActive()) {
       if (!wasActive) {
@@ -415,7 +399,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
         return;
       }
       pendingRefreshKeys.add(key);
-      clearRetry(true);
+      retry.reset();
       scheduleSync();
     },
     get: (sessionKey) => snapshots.get(sessionKey),

--- a/ui/src/lib/session-viewer-presence.ts
+++ b/ui/src/lib/session-viewer-presence.ts
@@ -1,12 +1,10 @@
 import { SESSION_VIEWER_PRESENCE_MAX_KEYS } from "../../../packages/gateway-protocol/src/schema/sessions-viewer-presence.js";
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
+import { createGatewayRetryOwner } from "./gateway-retry.ts";
 import { resolveSessionKey } from "./sessions/index.ts";
 
 const SESSION_VIEWERS_SET_METHOD = "sessions.viewers.set";
-
-const RETRY_BASE_MS = 30_000;
-const RETRY_MAX_MS = 5 * 60_000;
 
 type SessionViewerPresenceStore = {
   watch: (owner: object, sessionKeys: readonly string[]) => void;
@@ -17,13 +15,12 @@ const stores = new WeakMap<ApplicationGateway, SessionViewerPresenceStore>();
 
 function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   const watchedByOwner = new Map<object, Set<string>>();
+  const retry = createGatewayRetryOwner();
   let knownClient = gateway.snapshot.client;
   let lastHello: object | null = null;
   let lastSignature: string | null = null;
   let acknowledgedSignature: string | null = null;
   let acknowledgedGeneration = 0;
-  let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  let retryDelayMs = RETRY_BASE_MS;
   let requestGeneration = 0;
   let syncScheduled = false;
   let scheduleGeneration = 0;
@@ -32,16 +29,6 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   let visibilityDocument: Document | null = null;
 
   const isActive = () => watchedByOwner.size > 0;
-
-  const clearRetry = (resetDelay: boolean) => {
-    if (retryTimer !== null) {
-      globalThis.clearTimeout(retryTimer);
-      retryTimer = null;
-    }
-    if (resetDelay) {
-      retryDelayMs = RETRY_BASE_MS;
-    }
-  };
 
   const visibleSessionKeys = (): string[] => {
     const hello = gateway.snapshot.hello;
@@ -59,7 +46,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
 
   const handleGatewaySnapshot = () => scheduleSync();
   const handleVisibilityChange = () => {
-    clearRetry(true);
+    retry.reset();
     scheduleSync();
   };
 
@@ -89,7 +76,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     stopGatewaySnapshots = null;
     visibilityDocument?.removeEventListener("visibilitychange", handleVisibilityChange);
     visibilityDocument = null;
-    clearRetry(true);
+    retry.reset();
     requestGeneration += 1;
     scheduleGeneration += 1;
     syncScheduled = false;
@@ -107,7 +94,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     const snapshot = gateway.snapshot;
     const client = snapshot.client;
     if (client !== knownClient) {
-      clearRetry(true);
+      retry.reset();
       knownClient = client;
       lastHello = null;
       lastSignature = null;
@@ -152,14 +139,14 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
       currentGeneration === requestGeneration &&
       snapshot.hello === lastHello &&
       signature === lastSignature;
-    clearRetry(false);
+    retry.cancel();
     const request = client.request(SESSION_VIEWERS_SET_METHOD, { sessionKeys });
     void request
       .then(() => {
         if (isCurrentRequest()) {
           acknowledgedSignature = signature;
           acknowledgedGeneration = currentGeneration;
-          retryDelayMs = RETRY_BASE_MS;
+          retry.reset();
           if (!isActive()) {
             detach();
           }
@@ -170,14 +157,11 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
           return;
         }
         lastSignature = null;
-        const delayMs = retryDelayMs;
-        retryDelayMs = Math.min(retryDelayMs * 2, RETRY_MAX_MS);
-        retryTimer = globalThis.setTimeout(() => {
-          retryTimer = null;
+        retry.schedule(() => {
           if (attached) {
             scheduleSync();
           }
-        }, delayMs);
+        });
       });
   }
 
@@ -209,7 +193,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     } else {
       watchedByOwner.set(owner, next);
     }
-    clearRetry(true);
+    retry.reset();
     if (isActive()) {
       attach();
       scheduleSync();

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -10,13 +10,9 @@ import {
   reconcileSessionRunTerminal,
   type SessionChangedResult,
   type SessionReconcileOptions,
+  type SessionRunTerminal,
 } from "./reconcile.ts";
-import type {
-  SessionCapability,
-  SessionGateway,
-  SessionRunTerminal,
-  SessionState,
-} from "./session-capability.ts";
+import type { SessionCapability, SessionGateway, SessionState } from "./session-capability.ts";
 import { createSessionEventSubscriptionOwner } from "./session-event-subscription.ts";
 import { createSessionGroupCatalog } from "./session-group-catalog.ts";
 import {
@@ -40,11 +36,10 @@ export type {
   SessionCapability,
   SessionListOptions,
   SessionMessageSubscription,
-  SessionRunTerminal,
 } from "./session-capability.ts";
 export type { SessionPatch } from "./patch.ts";
 export { DEFAULT_SESSION_LIST_QUERY } from "./session-requests.ts";
-export { reconcileSessionRunTerminal } from "./reconcile.ts";
+export { reconcileSessionRunTerminal, type SessionRunTerminal } from "./reconcile.ts";
 export { requestSessionCreate } from "./create.ts";
 export { resolveSessionKey } from "./navigation.ts";
 export {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1,311 +1,50 @@
-import {
-  getGatewaySessionMessageSubscriptionCoordinator,
-  releaseGatewaySessionMessageSubscription,
-  resetGatewaySessionMessageSubscriptionCoordinator,
-  type GatewaySessionMessageSubscription,
-} from "@openclaw/gateway-client/browser";
 import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/schema/sessions-catalog.js";
-import {
-  GatewayRequestError,
-  type GatewayBrowserClient,
-  type GatewayEventFrame,
-  type GatewayHelloOk,
-} from "../../api/gateway.ts";
-import type {
-  GatewaySessionRow,
-  SessionBranch,
-  SessionCompactionCheckpoint,
-  SessionRunStatus,
-  SessionsCompactionBranchResult,
-  SessionsCompactionListResult,
-  SessionsCompactionRestoreResult,
-  SessionsForkResult,
-  SessionsBranchesListResult,
-  SessionsBranchesSwitchResult,
-  SessionsListResult,
-  SessionsPatchResult,
-  SessionsRewindResult,
-  SessionWorkspaceGetResult,
-  SessionWorkspaceListResult,
-  SessionWorkspaceSetResult,
-} from "../../api/types.ts";
-import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
-import { getSafeLocalStorage } from "../../local-storage.ts";
-import { isGatewayMethodAdvertised } from "../gateway-methods.ts";
-import { isSessionRunActive } from "../session-run-state.ts";
-import {
-  requestSessionCreate,
-  resolveSessionCreateParams,
-  type SessionCreateOutcome,
-  type SessionCreateParams,
-} from "./create.ts";
-import { readSessionCustomGroupNames, readSidebarSectionOrder } from "./custom-groups.ts";
-import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
-import { scopedAgentListParamsForSession, type SessionArchivedFilter } from "./navigation.ts";
-import type { SessionPatch, SessionPatchOptions, SessionPatchRoute } from "./patch.ts";
+import { GatewayRequestError, type GatewayEventFrame } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { createGatewayConnectionLifecycle } from "../gateway-connection-lifecycle.ts";
+import { scopedAgentListParamsForSession } from "./navigation.ts";
 import {
   readSessionChangedEvent,
   reconcileSessionChanged,
   reconcileSessionHistory,
+  reconcileSessionRunTerminal,
   type SessionChangedResult,
   type SessionReconcileOptions,
 } from "./reconcile.ts";
+import type {
+  SessionCapability,
+  SessionGateway,
+  SessionRunTerminal,
+  SessionState,
+} from "./session-capability.ts";
 import { createSessionEventSubscriptionOwner } from "./session-event-subscription.ts";
+import { createSessionGroupCatalog } from "./session-group-catalog.ts";
 import {
-  areUiSessionKeysEquivalent,
-  isUiGlobalSessionKey,
   normalizeAgentId,
-  parseAgentSessionKey,
   resolveUiSelectedGlobalAgentId,
   uiSessionEventMatches,
-  uiSessionRowMatchesSelectedChat,
 } from "./session-key.ts";
+import { createSessionMutations } from "./session-mutations.ts";
+import { createSessionRosterRefresh } from "./session-roster-refresh.ts";
+import { createSessionScopedOperations } from "./session-scoped-operations.ts";
 import { SwarmActivityTracker } from "./swarm-activity.ts";
+
 export {
   buildSessionUsageDateParams,
   requestSessionUsage,
   requestSessionUsageLogs,
   requestSessionUsageTimeSeries,
 } from "./usage.ts";
-
-type SessionState = {
-  result: SessionsListResult | null;
-  agentId: string | null;
-  modelOverrides: Readonly<Record<string, string | null>>;
-  loading: boolean;
-  error: string | null;
-  deletedSessions: readonly SessionDeleteTarget[];
-  /** Gateway-owned custom group catalog in display order. */
-  groups: readonly string[];
-  /** Gateway-owned sidebar section order; pinned is intentionally absent. */
-  sectionOrder: readonly string[];
-};
-
-type SessionGroupMutationResult = "completed" | "stale";
-
 export type { SessionArchivedFilter } from "./navigation.ts";
-
-export type SessionListOptions = {
-  agentId?: string;
-  spawnedBy?: string;
-  boardFace?: "chat" | "dashboard";
-  activeMinutes?: number;
-  search?: string;
-  creatorId?: string;
-  offset?: number;
-  limit?: number;
-  includeGlobal?: boolean;
-  includeUnknown?: boolean;
-  configuredAgentsOnly?: boolean;
-  includeDerivedTitles?: boolean;
-  archivedFilter?: SessionArchivedFilter;
-  append?: boolean;
-};
-
-/** Gateway rosters omit recency so Chat and Settings agree.
- * The explicit cap keeps list work bounded. */
-export const DEFAULT_SESSION_LIST_QUERY = {
-  limit: 50,
-} as const satisfies SessionListOptions;
-
-type SessionRefreshOptions = SessionListOptions & {
-  force?: boolean;
-  // Sidebar startup hydration must not block session creation or drop the open session.
-  backgroundHydrate?: boolean;
-};
-
-export type SessionRunTerminal = {
-  sessionKeys: readonly string[];
-  runId?: string | null;
-  /** Latest session status after this owned model run leaves the active registry. */
-  status: SessionRunStatus;
-  endedAt: number;
-};
-
+export type {
+  SessionCapability,
+  SessionListOptions,
+  SessionMessageSubscription,
+  SessionRunTerminal,
+} from "./session-capability.ts";
 export type { SessionPatch } from "./patch.ts";
-
-type SessionDeleteOptions = {
-  agentId?: string;
-  deleteTranscript?: boolean;
-  archivedOnly?: boolean;
-};
-
-type SessionDeleteTarget = {
-  key: string;
-  agentId?: string;
-  deleteTranscript?: boolean;
-  archivedOnly?: boolean;
-};
-
-/** Dirty/unpushed checkouts survive session deletion; callers surface them. */
-type SessionDeleteOutcome = {
-  deleted: boolean;
-  worktreePreserved?: { id: string; branch: string; path: string };
-};
-
-type SessionDeleteBatchResult = {
-  deleted: string[];
-  errors: string[];
-  /** Dirty/unpushed checkouts kept by the gateway during this batch. */
-  preservedWorktrees: Array<{ id: string; branch: string; path: string }>;
-};
-
-type SessionCompactResult = {
-  ok?: boolean;
-  compacted?: boolean;
-  reason?: string;
-  result?: { tokensBefore?: number; tokensAfter?: number };
-};
-
-type SessionSteerResult = {
-  runId?: string;
-  status?: unknown;
-};
-
-type SessionResetOptions = {
-  agentId?: string | null;
-};
-
-type SessionResetResult = "completed" | "not-started" | "uncertain";
-
-type SessionGateway = {
-  readonly snapshot: {
-    client: GatewayBrowserClient | null;
-    phase: ApplicationGatewayPhase;
-    hello: GatewayHelloOk | null;
-    assistantAgentId?: string | null;
-    sessionKey?: string;
-  };
-  subscribe: (listener: (snapshot: SessionGateway["snapshot"]) => void) => () => void;
-  subscribeEvents: (listener: (event: GatewayEventFrame) => void) => () => void;
-};
-
-type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
-
-type SessionDeleteResponse = {
-  deleted: boolean;
-  worktreePreserved?: SessionDeleteOutcome["worktreePreserved"];
-};
-
-type SessionConnectionScope = {
-  client: GatewayBrowserClient;
-  epoch: number;
-};
-
-type SessionCreateReconciliation = "blocking" | "background";
-
-export type SessionMessageSubscription = GatewaySessionMessageSubscription;
-
-export type SessionCapability = {
-  readonly state: SessionState;
-  /** Advances only when a canonical sessions.list result is published. */
-  readonly canonicalListRevision: number;
-  list: (options?: SessionListOptions) => Promise<SessionsListResult | null>;
-  setCreatorFilter: (creatorId: string | null) => Promise<void>;
-  reconcile: (
-    row: GatewaySessionRow | undefined,
-    defaults?: SessionsListResult["defaults"],
-    options?: SessionReconcileOptions,
-  ) => boolean;
-  reconcileChanged: (payload: unknown, options?: SessionReconcileOptions) => SessionChangedResult;
-  reconcileRunTerminal: (terminal: SessionRunTerminal) => boolean;
-  refresh: (options?: SessionRefreshOptions) => Promise<void>;
-  refreshReplacement: (agentId?: string | null) => Promise<void>;
-  createResult: (
-    params?: SessionCreateParams,
-    options?: { reconciliation?: SessionCreateReconciliation },
-  ) => Promise<SessionCreateOutcome | null>;
-  create: (params?: SessionCreateParams) => Promise<string | null>;
-  patch: SessionPatchRoute;
-  setModelOverride: (key: string, value: string | null | undefined) => void;
-  /** Applies optimistic row fields to the published snapshot so mid-flight
-   * publishes (e.g. a refresh's loading flip) cannot revert them before the
-   * post-mutation canonical list lands. */
-  patchRowLocal: (key: string, patch: Partial<GatewaySessionRow>) => void;
-  /** True while a just-created work session is waiting for its canonical placement row. */
-  isPreparedWorkSession: (key: string) => boolean;
-  pullRequestSummary: (key: string) => SessionCatalogPullRequestSummary | undefined;
-  capturePullRequestEpoch: (key: string) => symbol;
-  setPullRequestSummary: (
-    key: string,
-    summary: SessionCatalogPullRequestSummary | undefined,
-    epoch?: symbol,
-  ) => void;
-  delete: (key: string, options?: SessionDeleteOptions) => Promise<SessionDeleteOutcome>;
-  deleteMany: (targets: readonly SessionDeleteTarget[]) => Promise<SessionDeleteBatchResult>;
-  reset: (key: string, options?: SessionResetOptions) => Promise<SessionResetResult>;
-  compact: (key: string, options?: { agentId?: string | null }) => Promise<SessionCompactResult>;
-  steer: (
-    key: string,
-    message: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionSteerResult>;
-  listFiles: (
-    key: string,
-    options?: { agentId?: string | null; path?: string; search?: string },
-  ) => Promise<SessionWorkspaceListResult | null>;
-  getFile: (
-    key: string,
-    path: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionWorkspaceGetResult | null>;
-  setFile: (
-    key: string,
-    path: string,
-    content: string,
-    options: { agentId?: string | null; expectedHash: string },
-  ) => Promise<SessionWorkspaceSetResult | null>;
-  subscribeMessages: (
-    key: string,
-    options?: { agentId?: string | null; includeApprovals?: boolean },
-  ) => Promise<SessionMessageSubscription>;
-  unsubscribeMessages: (subscription: SessionMessageSubscription) => Promise<void>;
-  listCheckpoints: (
-    key: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionCompactionCheckpoint[]>;
-  branchCheckpoint: (
-    key: string,
-    checkpointId: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionsCompactionBranchResult>;
-  restoreCheckpoint: (
-    key: string,
-    checkpointId: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionsCompactionRestoreResult>;
-  rewind: (
-    key: string,
-    entryId: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionsRewindResult>;
-  forkAtMessage: (
-    key: string,
-    entryId: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionsForkResult>;
-  listBranches: (key: string, options?: { agentId?: string | null }) => Promise<SessionBranch[]>;
-  switchBranch: (
-    key: string,
-    leafEntryId: string,
-    options?: { agentId?: string | null },
-  ) => Promise<SessionsBranchesSwitchResult>;
-  /** Loads the gateway-owned group catalog, coalescing successful connection attempts. */
-  groupsLoad: () => Promise<void>;
-  /** Replaces the group catalog; stale means the initiating connection retired. */
-  groupsPut: (
-    names: readonly string[],
-    sectionOrder?: readonly string[],
-  ) => Promise<SessionGroupMutationResult>;
-  /** Renames a group; stale means the initiating connection retired before reconciliation. */
-  groupsRename: (from: string, to: string) => Promise<SessionGroupMutationResult>;
-  /** Deletes a group; stale means the initiating connection retired before reconciliation. */
-  groupsDelete: (name: string) => Promise<SessionGroupMutationResult>;
-  subscribeCreated: (listener: (key: string) => void) => () => void;
-  subscribe: (listener: (state: SessionState) => void) => () => void;
-  dispose: () => void;
-};
-
+export { DEFAULT_SESSION_LIST_QUERY } from "./session-requests.ts";
+export { reconcileSessionRunTerminal } from "./reconcile.ts";
 export { requestSessionCreate } from "./create.ts";
 export { resolveSessionKey } from "./navigation.ts";
 export {
@@ -327,391 +66,23 @@ export type {
   SessionScopeHostWithKey,
 } from "./navigation.ts";
 
-const SESSION_LIST_PARAMS = {
-  includeGlobal: true,
-  includeUnknown: true,
-  configuredAgentsOnly: true,
-} as const;
+const SESSION_RETRY_DEFAULT_MS = 500;
+const SESSION_RETRY_MIN_MS = 100;
+const SESSION_RETRY_MAX_MS = 30_000;
 
-function buildSessionRequestParams(
-  key: string,
-  agentId?: string | null,
-): { key: string; agentId?: string } {
-  const normalizedKey = key.trim();
-  const normalizedAgentId = agentId?.trim();
-  return {
-    key: normalizedKey,
-    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
-  };
-}
-
-function buildTranscriptMutationParams(
-  sessionKey: string,
-  agentId?: string | null,
-): { sessionKey: string; agentId?: string } {
-  const normalizedSessionKey = sessionKey.trim();
-  const normalizedAgentId = agentId?.trim();
-  return {
-    sessionKey: normalizedSessionKey,
-    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
-  };
-}
-
-function buildSessionListParams(options: SessionListOptions = {}): Record<string, unknown> {
-  const params: Record<string, unknown> = {
-    ...SESSION_LIST_PARAMS,
-  };
-  if (options.limit === undefined) {
-    params.limit = DEFAULT_SESSION_LIST_QUERY.limit;
-  } else if (options.limit > 0) {
-    params.limit = Math.floor(options.limit);
+function sessionRetryDelayMs(error: unknown): number | null {
+  if (!(error instanceof GatewayRequestError) || !error.retryable) {
+    return null;
   }
-  if (options.includeGlobal !== undefined) {
-    params.includeGlobal = options.includeGlobal;
-  }
-  if (options.includeUnknown !== undefined) {
-    params.includeUnknown = options.includeUnknown;
-  }
-  if (options.configuredAgentsOnly !== undefined) {
-    params.configuredAgentsOnly = options.configuredAgentsOnly;
-  }
-  if (options.includeDerivedTitles === true) {
-    params.includeDerivedTitles = true;
-  }
-  if (options.archivedFilter === "archived") {
-    params.archived = true;
-  } else if (options.archivedFilter === "all") {
-    params.archived = "all";
-  }
-  const activeMinutes =
-    options.archivedFilter === "archived" || options.archivedFilter === "all"
-      ? 0
-      : typeof options.activeMinutes === "number" && options.activeMinutes > 0
-        ? Math.floor(options.activeMinutes)
-        : 0;
-  if (activeMinutes > 0) {
-    params.activeMinutes = activeMinutes;
-  }
-  const agentId = options.agentId?.trim();
-  const spawnedBy = options.spawnedBy?.trim();
-  const search = options.search?.trim();
-  const creatorId = options.creatorId?.trim();
-  if (options.boardFace) {
-    params.boardFace = options.boardFace;
-  }
-  if (agentId) {
-    params.agentId = agentId;
-  }
-  if (spawnedBy) {
-    params.spawnedBy = spawnedBy;
-  }
-  if (search) {
-    params.search = search;
-  }
-  if (creatorId) {
-    params.creatorId = creatorId;
-  }
-  if (typeof options.offset === "number" && options.offset > 0) {
-    params.offset = Math.floor(options.offset);
-  }
-  return params;
-}
-
-async function requestSessionList(
-  client: SessionRequestClient,
-  options: SessionListOptions = {},
-): Promise<SessionsListResult | null> {
-  const result = await client.request<SessionsListResult | undefined>(
-    "sessions.list",
-    buildSessionListParams(options),
-  );
-  return result ?? null;
-}
-
-function requestSessionPatch(
-  client: SessionRequestClient,
-  key: string,
-  patch: SessionPatch,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsPatchResult> {
-  return client.request<SessionsPatchResult>("sessions.patch", {
-    ...buildSessionRequestParams(key, options.agentId),
-    ...patch,
-  });
-}
-
-function requestSessionDelete(
-  client: SessionRequestClient,
-  key: string,
-  options: SessionDeleteOptions = {},
-): Promise<SessionDeleteResponse> {
-  return client.request<SessionDeleteResponse>("sessions.delete", {
-    ...buildSessionRequestParams(key, options.agentId),
-    deleteTranscript: options.deleteTranscript ?? true,
-    ...(options.archivedOnly === true ? { archivedOnly: true } : {}),
-  });
-}
-
-function confirmsSessionDeletion(response: SessionDeleteResponse): boolean {
-  // A successful RPC can still be a lifecycle no-op. Only the canonical result
-  // may drive optimistic removal, navigation, and model-override cleanup.
-  return response.deleted;
-}
-
-function requestSessionReset(
-  client: SessionRequestClient,
-  key: string,
-  options: SessionResetOptions = {},
-): Promise<void> {
-  return client
-    .request("sessions.reset", {
-      ...buildSessionRequestParams(key, options.agentId),
-    })
-    .then(() => undefined);
-}
-
-function requestSessionCompact(
-  client: SessionRequestClient,
-  key: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionCompactResult> {
-  return client.request<SessionCompactResult>("sessions.compact", {
-    ...buildSessionRequestParams(key, options.agentId),
-  });
-}
-
-function requestSessionSteer(
-  client: SessionRequestClient,
-  key: string,
-  message: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionSteerResult> {
-  return client.request<SessionSteerResult>("sessions.steer", {
-    ...buildSessionRequestParams(key, options.agentId),
-    message,
-  });
-}
-
-function requestSessionFilesList(
-  client: SessionRequestClient,
-  key: string,
-  options: { agentId?: string | null; path?: string; search?: string } = {},
-): Promise<SessionWorkspaceListResult | null> {
-  return client.request<SessionWorkspaceListResult | null>("sessions.files.list", {
-    sessionKey: key,
-    path: options.path ?? "",
-    search: options.search ?? "",
-    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
-  });
-}
-
-function requestSessionFile(
-  client: SessionRequestClient,
-  key: string,
-  path: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionWorkspaceGetResult | null> {
-  return client.request<SessionWorkspaceGetResult | null>("sessions.files.get", {
-    sessionKey: key,
-    path,
-    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
-  });
-}
-
-function requestSessionFileSet(
-  client: SessionRequestClient,
-  key: string,
-  path: string,
-  content: string,
-  options: { agentId?: string | null; expectedHash: string },
-): Promise<SessionWorkspaceSetResult | null> {
-  return client.request<SessionWorkspaceSetResult | null>("sessions.files.set", {
-    sessionKey: key,
-    path,
-    content,
-    expectedHash: options.expectedHash,
-    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
-  });
-}
-
-async function listSessionCheckpoints(
-  client: SessionRequestClient,
-  key: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsCompactionListResult> {
-  return client.request<SessionsCompactionListResult>(
-    "sessions.compaction.list",
-    buildSessionRequestParams(key, options.agentId),
-  );
-}
-
-function branchSessionCheckpoint(
-  client: SessionRequestClient,
-  key: string,
-  checkpointId: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsCompactionBranchResult> {
-  return client.request<SessionsCompactionBranchResult>("sessions.compaction.branch", {
-    ...buildSessionRequestParams(key, options.agentId),
-    checkpointId,
-  });
-}
-
-function restoreSessionCheckpoint(
-  client: SessionRequestClient,
-  key: string,
-  checkpointId: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsCompactionRestoreResult> {
-  return client.request<SessionsCompactionRestoreResult>("sessions.compaction.restore", {
-    ...buildSessionRequestParams(key, options.agentId),
-    checkpointId,
-  });
-}
-
-function rewindSessionAtMessage(
-  client: SessionRequestClient,
-  key: string,
-  entryId: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsRewindResult> {
-  return client.request<SessionsRewindResult>("sessions.rewind", {
-    ...buildTranscriptMutationParams(key, options.agentId),
-    entryId,
-  });
-}
-
-function forkSessionAtMessage(
-  client: SessionRequestClient,
-  key: string,
-  entryId: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsForkResult> {
-  return client.request<SessionsForkResult>("sessions.fork", {
-    ...buildTranscriptMutationParams(key, options.agentId),
-    entryId,
-  });
-}
-
-function listSessionBranches(
-  client: SessionRequestClient,
-  key: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsBranchesListResult> {
-  return client.request<SessionsBranchesListResult>(
-    "sessions.branches.list",
-    buildTranscriptMutationParams(key, options.agentId),
-  );
-}
-
-function switchSessionBranch(
-  client: SessionRequestClient,
-  key: string,
-  leafEntryId: string,
-  options: { agentId?: string | null } = {},
-): Promise<SessionsBranchesSwitchResult> {
-  return client.request<SessionsBranchesSwitchResult>("sessions.branches.switch", {
-    ...buildTranscriptMutationParams(key, options.agentId),
-    leafEntryId,
-  });
-}
-
-function appendSessionResults(
-  previous: SessionsListResult,
-  page: SessionsListResult,
-): SessionsListResult {
-  const seen = new Set<string>();
-  const sessions = [...previous.sessions, ...page.sessions].filter((row) => {
-    if (!row.key || seen.has(row.key)) {
-      return false;
-    }
-    seen.add(row.key);
-    return true;
-  });
-  const totalCount = page.totalCount ?? previous.totalCount;
-  const hasMore =
-    page.hasMore ??
-    (typeof totalCount === "number" && Number.isFinite(totalCount)
-      ? sessions.length < totalCount
-      : false);
-  return {
-    ...page,
-    count: sessions.length,
-    totalCount,
-    hasMore,
-    nextOffset: page.nextOffset ?? (hasMore ? sessions.length : null),
-    sessions,
-  };
+  const requested =
+    typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
+      ? error.retryAfterMs
+      : SESSION_RETRY_DEFAULT_MS;
+  return Math.min(Math.max(requested, SESSION_RETRY_MIN_MS), SESSION_RETRY_MAX_MS);
 }
 
 function isSessionStateEvent(event: GatewayEventFrame): boolean {
   return event.event === "sessions.changed" || event.event === "session.message";
-}
-
-export function reconcileSessionRunTerminal(
-  result: SessionsListResult | null,
-  terminal: SessionRunTerminal,
-): SessionsListResult | null {
-  const keys = terminal.sessionKeys.map((key) => key.trim()).filter(Boolean);
-  if (!result || keys.length === 0) {
-    return result;
-  }
-  const runId = terminal.runId?.trim() || null;
-  let changed = false;
-  const sessions = result.sessions.map((row): GatewaySessionRow => {
-    if (!keys.some((key) => areUiSessionKeysEquivalent(row.key, key))) {
-      return row;
-    }
-    if (row.hasActiveRun === true || isSessionRunActive(row)) {
-      // Active rows without matching identity may describe a newer or embedded
-      // run. Only terminalize an active row when this event owns its run ID.
-      if (!runId || !row.activeRunIds?.includes(runId)) {
-        return row;
-      }
-    }
-    const remainingRunIds = runId ? row.activeRunIds?.filter((id) => id !== runId) : [];
-    if (remainingRunIds?.length) {
-      // Settling one owned model turn must not retire overlapping active runs.
-      changed = true;
-      return {
-        ...row,
-        activeRunIds: remainingRunIds,
-        hasActiveRun: true,
-        status: "running" as const,
-      };
-    }
-    const endedAt = row.endedAt ?? terminal.endedAt;
-    const runtimeMs =
-      typeof row.startedAt === "number" ? Math.max(0, endedAt - row.startedAt) : row.runtimeMs;
-    const activeRunIds = row.activeRunIds?.length ? [] : row.activeRunIds;
-    const abortedLastRun =
-      terminal.status === "killed"
-        ? true
-        : terminal.status === "running"
-          ? false
-          : row.abortedLastRun;
-    if (
-      row.hasActiveRun === false &&
-      row.status === terminal.status &&
-      row.endedAt === endedAt &&
-      row.runtimeMs === runtimeMs &&
-      row.activeRunIds === activeRunIds &&
-      row.abortedLastRun === abortedLastRun
-    ) {
-      return row;
-    }
-    changed = true;
-    return {
-      ...row,
-      activeRunIds,
-      hasActiveRun: false,
-      status: terminal.status,
-      endedAt,
-      runtimeMs,
-      abortedLastRun,
-    };
-  });
-  return changed ? { ...result, sessions } : result;
 }
 
 export function createSessionCapability(gateway: SessionGateway): SessionCapability {
@@ -725,59 +96,17 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     groups: [],
     sectionOrder: [],
   };
-  let inFlight: Promise<void> | null = null;
-  let queuedExplicitRefresh: SessionRefreshOptions | null = null;
-  let eventRefreshQueued = false;
-  let canonicalListRevision = 0;
-  let disposed = false;
-  let connectionEpoch = 0;
-  let connectionClient = gateway.snapshot.client;
-  let connectionConnected = gateway.snapshot.phase === "connected";
-  const pendingModelPatches = new Map<
-    string,
-    { token: symbol; previous: string | null | undefined }
-  >();
-  const preparedWorkSessionKeys = new Set<string>();
+  const connection = createGatewayConnectionLifecycle(gateway.snapshot);
   const swarmActivity = new SwarmActivityTracker();
   const pullRequestSummaries = new Map<string, SessionCatalogPullRequestSummary>();
   const pullRequestEpochs = new Map<string, symbol>();
-  let hydratedClient: GatewayBrowserClient | null = null;
-  let sessionEventSubscriptionError: string | null = null;
-  let publishedErrorSource: "session-observer" | "operation" | null = null;
-  let lastListOptions: SessionListOptions = {};
-  let hasForegroundListOptions = false;
-  let hasSeededListOptions = false;
   const listeners = new Set<(next: SessionState) => void>();
   const createdListeners = new Set<(key: string) => void>();
-  const ownedMessageSubscriptions = new Set<SessionMessageSubscription>();
-
-  const captureConnection = (): SessionConnectionScope | null => {
-    const snapshot = gateway.snapshot;
-    return !disposed && snapshot.phase === "connected" && snapshot.client
-      ? { client: snapshot.client, epoch: connectionEpoch }
-      : null;
-  };
-
-  const isCurrentConnection = (scope: SessionConnectionScope): boolean => {
-    const snapshot = gateway.snapshot;
-    return (
-      !disposed &&
-      connectionEpoch === scope.epoch &&
-      snapshot.phase === "connected" &&
-      snapshot.client === scope.client
-    );
-  };
-
-  const requestList = async (
-    options: SessionListOptions = {},
-  ): Promise<SessionsListResult | null> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    const result = await requestSessionList(scope.client, options);
-    return isCurrentConnection(scope) ? swarmActivity.decorate(result ?? null) : null;
-  };
+  let canonicalListRevision = 0;
+  let hydratedClient: SessionGateway["snapshot"]["client"] = null;
+  let connectionClient = gateway.snapshot.client;
+  let sessionEventSubscriptionError: string | null = null;
+  let publishedErrorSource: "session-observer" | "operation" | null = null;
 
   const publish = (next: SessionState, errorSource?: "session-observer" | "operation") => {
     if (next.error === null) {
@@ -791,11 +120,30 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
+  const retirePullRequestSummary = (key: string) => {
+    const normalizedKey = key.trim();
+    pullRequestEpochs.delete(normalizedKey);
+    pullRequestSummaries.delete(normalizedKey);
+  };
+
+  const roster = createSessionRosterRefresh({
+    connection,
+    snapshot: () => gateway.snapshot,
+    readState: () => state,
+    publish,
+    observerError: () => sessionEventSubscriptionError,
+    decorate: (result) => swarmActivity.decorate(result),
+    onCanonicalList(result) {
+      mutations.settlePrepared(result);
+      canonicalListRevision += 1;
+    },
+  });
+
   const sessionEventSubscription = createSessionEventSubscriptionOwner({
-    isCurrent: isCurrentConnection,
-    retryDelayMs: (error) => sessionRetryDelayMs(error),
+    isCurrent: (scope) => connection.isCurrent(scope),
+    retryDelayMs: sessionRetryDelayMs,
     onError: (scope, error) => {
-      if (!isCurrentConnection(scope)) {
+      if (!connection.isCurrent(scope)) {
         return;
       }
       const previousError = sessionEventSubscriptionError;
@@ -807,33 +155,47 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         publish({ ...state, error: null });
       }
       if (previousError !== null && error === null) {
-        // Events lost while the observer was unavailable are not replayed;
-        // one canonical catch-up list closes that reconnect visibility gap.
-        void refresh({ ...lastListOptions, backgroundHydrate: true, force: true });
+        // Observer outages do not replay events; one canonical list closes the gap.
+        void roster.refresh({ ...roster.lastOptions(), backgroundHydrate: true, force: true });
       }
     },
   });
 
-  const pullRequestSummary = (key: string): SessionCatalogPullRequestSummary | undefined =>
-    pullRequestSummaries.get(key.trim());
+  const groups = createSessionGroupCatalog({
+    connection,
+    snapshot: () => gateway.snapshot,
+    readState: () => state,
+    publish,
+    refreshRows: () => roster.refresh({ ...roster.lastOptions(), force: true }),
+    retryDelayMs: sessionRetryDelayMs,
+  });
+
+  const mutations = createSessionMutations({
+    connection,
+    readState: () => state,
+    publish,
+    refreshReplacement: (agentId) => roster.refreshReplacement(agentId),
+    notifyCreated(key) {
+      for (const listener of createdListeners) {
+        listener(key);
+      }
+    },
+    retirePullRequestSummary,
+  });
+
+  const operations = createSessionScopedOperations({
+    connection,
+    agentId: () => state.agentId,
+    refreshReplacement: (agentId) => roster.refreshReplacement(agentId),
+  });
+
+  const pullRequestSummary = (key: string) => pullRequestSummaries.get(key.trim());
 
   const capturePullRequestEpoch = (key: string): symbol => {
     const normalizedKey = key.trim();
     const epoch = Symbol(normalizedKey);
     pullRequestEpochs.set(normalizedKey, epoch);
     return epoch;
-  };
-
-  const retirePullRequestSummary = (key: string) => {
-    const normalizedKey = key.trim();
-    pullRequestEpochs.delete(normalizedKey);
-    pullRequestSummaries.delete(normalizedKey);
-  };
-
-  // A deleted key stays reusable for a later ordinary thread, so a leftover
-  // prepared entry would keep classifying that new session as Coding forever.
-  const retirePreparedWorkSession = (key: string) => {
-    preparedWorkSessionKeys.delete(key.trim());
   };
 
   const setPullRequestSummary = (
@@ -861,628 +223,6 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     publish({ ...state });
   };
 
-  const setModelOverride = (key: string, value: string | null | undefined) => {
-    const normalizedKey = key.trim();
-    if (!normalizedKey) {
-      return;
-    }
-    const modelOverrides = { ...state.modelOverrides };
-    if (value === undefined) {
-      if (!Object.hasOwn(state.modelOverrides, normalizedKey)) {
-        return;
-      }
-      delete modelOverrides[normalizedKey];
-    } else {
-      const normalizedValue = value === null ? null : value.trim();
-      if (
-        modelOverrides[normalizedKey] === normalizedValue &&
-        Object.hasOwn(modelOverrides, normalizedKey)
-      ) {
-        return;
-      }
-      modelOverrides[normalizedKey] = normalizedValue;
-    }
-    publish({ ...state, modelOverrides });
-  };
-
-  // Optimistic session-settings patches (thinking level, speed) must live in
-  // the published capability snapshot, not only in consumer copies: every
-  // publish replaces consumer state wholesale, so a copy-only patch reverts on
-  // the next loading flip until the post-patch canonical list arrives. The
-  // revert window loses keyboard commits on the reasoning slider (flaky UI).
-  const patchRowLocal = (key: string, patch: Partial<GatewaySessionRow>) => {
-    const result = state.result;
-    const normalizedKey = key.trim();
-    if (!result || !normalizedKey) {
-      return;
-    }
-    let changed = false;
-    const sessions = result.sessions.map((row) => {
-      if (row.key !== normalizedKey) {
-        return row;
-      }
-      changed = true;
-      return { ...row, ...patch };
-    });
-    if (!changed) {
-      return;
-    }
-    publish({ ...state, result: { ...result, sessions } });
-  };
-
-  const rollbackPendingModelPatches = () => {
-    const pending = [...pendingModelPatches];
-    pendingModelPatches.clear();
-    for (const [key, operation] of pending) {
-      setModelOverride(key, operation.previous);
-    }
-  };
-
-  const load = async (options: SessionRefreshOptions) => {
-    const scope = captureConnection();
-    if (!scope) {
-      return;
-    }
-    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
-    const durableListOptions: SessionListOptions = { ...requestOptions };
-    // Pagination is request-local. Replacement refreshes restart at page one
-    // while retaining the filters and response enrichments that shape the list.
-    delete durableListOptions.offset;
-    // Foreground options become authoritative before I/O so a concurrent
-    // mutation cannot queue a replacement refresh with stale filters.
-    if (!backgroundHydrate) {
-      lastListOptions = durableListOptions;
-      hasForegroundListOptions = true;
-    } else if (!hasForegroundListOptions && !hasSeededListOptions) {
-      lastListOptions = durableListOptions;
-      hasSeededListOptions = true;
-    }
-    if (!backgroundHydrate) {
-      publish(
-        {
-          ...state,
-          loading: true,
-          error: sessionEventSubscriptionError,
-          deletedSessions: [],
-        },
-        sessionEventSubscriptionError ? "session-observer" : undefined,
-      );
-    }
-    try {
-      const result = await requestSessionList(scope.client, requestOptions);
-      if (!isCurrentConnection(scope)) {
-        return;
-      }
-      let nextResult =
-        result && append && requestOptions.offset && state.result
-          ? appendSessionResults(state.result, result)
-          : result;
-      if (append && nextResult && !backgroundHydrate) {
-        // Event replacements restart at page one, so retain the visible page
-        // depth instead of silently dropping every previously appended row.
-        lastListOptions = {
-          ...durableListOptions,
-          limit: Math.max(
-            durableListOptions.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
-            nextResult.sessions.length,
-          ),
-        };
-      }
-      if (backgroundHydrate && nextResult) {
-        const currentKey = gateway.snapshot.sessionKey?.trim();
-        if (currentKey) {
-          const currentAgentId = normalizeAgentId(
-            parseAgentSessionKey(currentKey)?.agentId ??
-              resolveUiSelectedGlobalAgentId(gateway.snapshot),
-          );
-          const previousCurrentRow =
-            state.result?.sessions.find((row) => areUiSessionKeysEquivalent(row.key, currentKey)) ??
-            (state.agentId === currentAgentId
-              ? state.result?.sessions.find((row) =>
-                  uiSessionRowMatchesSelectedChat(gateway.snapshot, row.key, currentKey),
-                )
-              : undefined);
-          if (
-            previousCurrentRow &&
-            !nextResult.sessions.some((row) =>
-              uiSessionRowMatchesSelectedChat(gateway.snapshot, row.key, currentKey),
-            )
-          ) {
-            const sessions = [...nextResult.sessions, previousCurrentRow];
-            nextResult = { ...nextResult, count: sessions.length, sessions };
-          }
-        }
-      }
-      nextResult = swarmActivity.decorate(nextResult);
-      for (const row of nextResult?.sessions ?? []) {
-        if (row.worktree || row.execNode) {
-          preparedWorkSessionKeys.delete(row.key);
-        }
-      }
-      canonicalListRevision += 1;
-      publish(
-        {
-          result: nextResult,
-          agentId: requestOptions.agentId?.trim() ? normalizeAgentId(requestOptions.agentId) : null,
-          modelOverrides: state.modelOverrides,
-          loading: backgroundHydrate ? state.loading : false,
-          error: sessionEventSubscriptionError,
-          deletedSessions: [],
-          groups: state.groups,
-          sectionOrder: state.sectionOrder,
-        },
-        sessionEventSubscriptionError ? "session-observer" : undefined,
-      );
-    } catch (error) {
-      if (isCurrentConnection(scope)) {
-        publish(
-          {
-            ...state,
-            loading: backgroundHydrate ? state.loading : false,
-            error: String(error),
-            deletedSessions: [],
-          },
-          "operation",
-        );
-      }
-    }
-  };
-
-  const absorbPendingEventRefresh = () => {
-    eventRefreshCoordinator.absorb();
-    eventRefreshQueued = false;
-  };
-
-  const takeNextQueuedRefresh = (): SessionRefreshOptions | null => {
-    const explicitRefresh = queuedExplicitRefresh;
-    queuedExplicitRefresh = null;
-    if (explicitRefresh) {
-      // A replacement that has not started yet observes every earlier event.
-      // Appends still need a canonical replacement after their requested page.
-      if (explicitRefresh.append !== true) {
-        absorbPendingEventRefresh();
-      }
-      return explicitRefresh;
-    }
-    if (!eventRefreshQueued) {
-      return null;
-    }
-    eventRefreshQueued = false;
-    return { ...lastListOptions, force: true };
-  };
-
-  const drainRefreshQueue = async (options: SessionRefreshOptions) => {
-    const epoch = connectionEpoch;
-    let next: SessionRefreshOptions | null = options;
-    while (next) {
-      await load(next);
-      if (disposed || connectionEpoch !== epoch) {
-        return;
-      }
-      next = takeNextQueuedRefresh();
-    }
-  };
-
-  const startRefresh = (options: SessionRefreshOptions) => {
-    const request = drainRefreshQueue(options).finally(() => {
-      if (inFlight === request) {
-        inFlight = null;
-      }
-    });
-    inFlight = request;
-    return request;
-  };
-
-  const refresh = (options: SessionRefreshOptions = {}) => {
-    if (gateway.snapshot.phase !== "connected" || !gateway.snapshot.client || disposed) {
-      return Promise.resolve();
-    }
-    if (inFlight) {
-      // Keep event invalidation pending until the queued request actually
-      // starts: a later explicit call can still replace this request.
-      queuedExplicitRefresh = options;
-      return inFlight;
-    }
-    const hasListOverrides = Object.entries(options).some(
-      ([key, value]) => key !== "force" && key !== "backgroundHydrate" && value !== undefined,
-    );
-    if (state.result && !options.force && !hasListOverrides) {
-      return Promise.resolve();
-    }
-    if (options.append !== true) {
-      absorbPendingEventRefresh();
-    }
-    return startRefresh(options);
-  };
-
-  const refreshFromEvent = () => {
-    if (gateway.snapshot.phase !== "connected" || !gateway.snapshot.client || disposed) {
-      return Promise.resolve();
-    }
-    if (inFlight) {
-      eventRefreshQueued = true;
-      return inFlight;
-    }
-    return startRefresh({ ...lastListOptions, force: true });
-  };
-
-  const eventRefreshCoordinator = createSessionEventRefreshCoordinator({
-    canRefresh: () =>
-      gateway.snapshot.phase === "connected" && gateway.snapshot.client !== null && !disposed,
-    refresh: refreshFromEvent,
-  });
-  const flushEventRefresh = () => eventRefreshCoordinator.flush();
-
-  const handleVisibilityChange = () => {
-    if (document.visibilityState === "hidden") {
-      flushEventRefresh();
-    }
-  };
-  const observesPageLifecycle =
-    typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
-  if (observesPageLifecycle) {
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    globalThis.addEventListener("pagehide", flushEventRefresh);
-  }
-
-  const refreshReplacement = (agentId?: string | null) => {
-    // Mutation refreshes replace the visible sidebar rows. A foreground probe
-    // that omitted derived titles must not turn readable names back into ids.
-    const options = {
-      ...lastListOptions,
-      includeDerivedTitles: lastListOptions.includeDerivedTitles ?? true,
-    };
-    const normalizedAgentId = agentId?.trim();
-    if (normalizedAgentId) {
-      options.agentId = normalizedAgentId;
-    }
-    return refresh({ ...options, force: true });
-  };
-
-  const setCreatorFilter = (creatorId: string | null) => {
-    const options = { ...lastListOptions, creatorId: creatorId?.trim() || undefined };
-    delete options.offset;
-    return refresh({ ...options, force: true });
-  };
-
-  const createResult = async (
-    params: SessionCreateParams = {},
-    options: { reconciliation?: SessionCreateReconciliation } = {},
-  ) => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    try {
-      const { currentSessionKey, ...requestParams } = params;
-      const result = await requestSessionCreate(scope.client, {
-        ...requestParams,
-        ...resolveSessionCreateParams(currentSessionKey, params.agentId),
-      });
-      if (!isCurrentConnection(scope)) {
-        return null;
-      }
-      // The create response precedes list reconciliation. Carry submitted facts
-      // across that gap so a partial history row cannot briefly lose its zone/model.
-      if (requestParams.worktree === true || Boolean(requestParams.execNode?.trim())) {
-        preparedWorkSessionKeys.add(result.key.trim());
-      }
-      if (requestParams.model?.trim()) {
-        setModelOverride(result.key, requestParams.model);
-      } else if (preparedWorkSessionKeys.has(result.key)) {
-        publish({ ...state });
-      }
-      const reconcileCreatedSession = async () => {
-        await refreshReplacement(params.agentId);
-        if (!isCurrentConnection(scope)) {
-          return;
-        }
-        // Creation may overlap read-only list loading. Notify presentation owners
-        // after its queued refresh so they never guess from stale list churn.
-        for (const listener of createdListeners) {
-          listener(result.key);
-        }
-      };
-      if (options.reconciliation === "background") {
-        void reconcileCreatedSession().catch((error: unknown) => {
-          if (isCurrentConnection(scope)) {
-            publish({ ...state, error: String(error) }, "operation");
-          }
-        });
-      } else {
-        await reconcileCreatedSession();
-        if (!isCurrentConnection(scope)) {
-          return null;
-        }
-      }
-      return result;
-    } catch (error) {
-      if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) }, "operation");
-      }
-      return null;
-    }
-  };
-
-  const create = async (params: SessionCreateParams = {}) =>
-    (await createResult(params))?.key ?? null;
-
-  const LEGACY_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
-  const GROUPS_LIST_METHOD = "sessions.groups.list";
-  const SESSION_RETRY_DEFAULT_MS = 500;
-  const SESSION_RETRY_MIN_MS = 100;
-  const SESSION_RETRY_MAX_MS = 30_000;
-  let groupsLoadedEpoch = -1;
-  let groupsLoadGeneration = 0;
-  let groupsRetryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-
-  const clearGroupsRetry = () => {
-    if (groupsRetryTimer !== null) {
-      globalThis.clearTimeout(groupsRetryTimer);
-      groupsRetryTimer = null;
-    }
-  };
-
-  const invalidateGroupsLoad = () => {
-    groupsLoadedEpoch = -1;
-    groupsLoadGeneration += 1;
-    clearGroupsRetry();
-  };
-
-  const sessionRetryDelayMs = (error: unknown): number | null => {
-    if (!(error instanceof GatewayRequestError) || !error.retryable) {
-      return null;
-    }
-    const requested =
-      typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
-        ? error.retryAfterMs
-        : SESSION_RETRY_DEFAULT_MS;
-    return Math.min(Math.max(requested, SESSION_RETRY_MIN_MS), SESSION_RETRY_MAX_MS);
-  };
-
-  const publishGroupCatalog = (groups: readonly string[], sectionOrder: readonly string[]) => {
-    const groupsUnchanged =
-      groups.length === state.groups.length &&
-      groups.every((group, i) => group === state.groups[i]);
-    const orderUnchanged =
-      sectionOrder.length === state.sectionOrder.length &&
-      sectionOrder.every((sectionId, i) => sectionId === state.sectionOrder[i]);
-    if (groupsUnchanged && orderUnchanged) {
-      return;
-    }
-    publish({ ...state, groups: [...groups], sectionOrder: [...sectionOrder] });
-  };
-
-  const finishGroupMutationFailure = (
-    current: boolean,
-    error: unknown,
-  ): SessionGroupMutationResult => {
-    if (!current) {
-      return "stale";
-    }
-    publish({ ...state, error: String(error) }, "operation");
-    throw error;
-  };
-
-  const readLegacyStoredGroups = (): string[] => {
-    try {
-      const raw = getSafeLocalStorage()?.getItem(LEGACY_GROUPS_STORAGE_KEY);
-      const parsed: unknown = raw ? JSON.parse(raw) : [];
-      return Array.isArray(parsed)
-        ? [
-            ...new Set(
-              parsed.flatMap((name) => {
-                const normalized = typeof name === "string" ? name.trim() : "";
-                return normalized ? [normalized] : [];
-              }),
-            ),
-          ]
-        : [];
-    } catch {
-      return [];
-    }
-  };
-
-  const loadGroups = async (
-    scope: SessionConnectionScope,
-    generation: number,
-    advertised: boolean | null,
-  ) => {
-    try {
-      const listed = await scope.client.request(GROUPS_LIST_METHOD, {});
-      if (!isCurrentConnection(scope) || generation !== groupsLoadGeneration) {
-        return;
-      }
-      let names = readSessionCustomGroupNames(listed);
-      let sectionOrder = readSidebarSectionOrder(listed);
-      // One-time migration: browser-local catalogs predate the gateway store.
-      const legacy = readLegacyStoredGroups();
-      if (names.length === 0 && legacy.length > 0) {
-        const put = await scope.client.request("sessions.groups.put", { names: legacy });
-        if (!isCurrentConnection(scope) || generation !== groupsLoadGeneration) {
-          return;
-        }
-        names = readSessionCustomGroupNames(put);
-        sectionOrder = readSidebarSectionOrder(put);
-      }
-      if (legacy.length > 0) {
-        try {
-          getSafeLocalStorage()?.removeItem(LEGACY_GROUPS_STORAGE_KEY);
-        } catch {
-          // The gateway catalog is canonical either way.
-        }
-      }
-      publishGroupCatalog(names, sectionOrder);
-    } catch (error) {
-      if (
-        !isCurrentConnection(scope) ||
-        generation !== groupsLoadGeneration ||
-        advertised !== true
-      ) {
-        // Gateways without feature metadata retain the legacy one-shot probe.
-        return;
-      }
-      groupsLoadedEpoch = -1;
-      const retryDelayMs = sessionRetryDelayMs(error);
-      if (retryDelayMs === null) {
-        return;
-      }
-      // The attempt token prevents an older rejection from reviving a retry
-      // after a newer event-driven catalog load has already succeeded.
-      groupsRetryTimer = globalThis.setTimeout(() => {
-        groupsRetryTimer = null;
-        if (isCurrentConnection(scope) && generation === groupsLoadGeneration) {
-          void groupsLoad();
-        }
-      }, retryDelayMs);
-    }
-  };
-
-  /** Idempotent per connection; list consumers call it when groups become visible. */
-  const groupsLoad = async () => {
-    const scope = captureConnection();
-    if (!scope || groupsLoadedEpoch === scope.epoch) {
-      return;
-    }
-    const advertised = isGatewayMethodAdvertised(gateway.snapshot, GROUPS_LIST_METHOD);
-    clearGroupsRetry();
-    const generation = ++groupsLoadGeneration;
-    groupsLoadedEpoch = scope.epoch;
-    if (advertised === false) {
-      publishGroupCatalog([], []);
-      return;
-    }
-    await loadGroups(scope, generation, advertised);
-  };
-
-  const groupsPut = async (
-    names: readonly string[],
-    sectionOrder?: readonly string[],
-  ): Promise<SessionGroupMutationResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return "stale";
-    }
-    try {
-      const result = await scope.client.request("sessions.groups.put", {
-        names: [...names],
-        ...(sectionOrder === undefined ? {} : { sectionOrder: [...sectionOrder] }),
-      });
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publishGroupCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
-      return "completed";
-    } catch (error) {
-      return finishGroupMutationFailure(isCurrentConnection(scope), error);
-    }
-  };
-
-  const groupsRename = async (from: string, to: string): Promise<SessionGroupMutationResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return "stale";
-    }
-    try {
-      const result = await scope.client.request("sessions.groups.rename", { name: from, to });
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publishGroupCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
-      // The mutation response is the commit point. Reconcile member rows in
-      // the background so a later disconnect cannot downgrade confirmed work.
-      void refresh({ ...lastListOptions, force: true });
-      return "completed";
-    } catch (error) {
-      return finishGroupMutationFailure(isCurrentConnection(scope), error);
-    }
-  };
-
-  const groupsDelete = async (name: string): Promise<SessionGroupMutationResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return "stale";
-    }
-    try {
-      const result = await scope.client.request("sessions.groups.delete", { name });
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publishGroupCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
-      // See groupsRename: collapsed-state consumers must observe confirmed
-      // completion before an unrelated refresh can outlive the connection.
-      void refresh({ ...lastListOptions, force: true });
-      return "completed";
-    } catch (error) {
-      return finishGroupMutationFailure(isCurrentConnection(scope), error);
-    }
-  };
-
-  const patch = async (
-    key: string,
-    patchParams: SessionPatch,
-    options: SessionPatchOptions = {},
-  ): Promise<SessionsPatchResult | null> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    const hasModelPatch = Object.hasOwn(patchParams, "model");
-    const normalizedKey = key.trim();
-    const pendingModelPatch = pendingModelPatches.get(normalizedKey);
-    const previousModelOverride = pendingModelPatch
-      ? pendingModelPatch.previous
-      : state.modelOverrides[normalizedKey];
-    const modelPatchToken = Symbol();
-    if (hasModelPatch) {
-      pendingModelPatches.set(normalizedKey, {
-        token: modelPatchToken,
-        previous: previousModelOverride,
-      });
-      setModelOverride(key, patchParams.model);
-    }
-    const restoreModelOverride = () => {
-      if (pendingModelPatches.get(normalizedKey)?.token !== modelPatchToken) {
-        return;
-      }
-      pendingModelPatches.delete(normalizedKey);
-      setModelOverride(key, previousModelOverride);
-    };
-    try {
-      if (options.waitFor) {
-        await options.waitFor;
-        if (!isCurrentConnection(scope)) {
-          restoreModelOverride();
-          return null;
-        }
-      }
-      const result = await requestSessionPatch(scope.client, key, patchParams, options);
-      if (!isCurrentConnection(scope)) {
-        restoreModelOverride();
-        return null;
-      }
-      if (!options.deferListRefresh) {
-        await refreshReplacement(options.agentId);
-        if (!isCurrentConnection(scope)) {
-          restoreModelOverride();
-          return null;
-        }
-      }
-      if (pendingModelPatches.get(normalizedKey)?.token === modelPatchToken) {
-        pendingModelPatches.delete(normalizedKey);
-        setModelOverride(key, patchParams.model);
-      }
-      return result;
-    } catch (error) {
-      restoreModelOverride();
-      if (!isCurrentConnection(scope)) {
-        return null;
-      }
-      publish({ ...state, error: String(error) }, "operation");
-      throw error;
-    }
-  };
-
   const reconcile = (
     row: GatewaySessionRow | undefined,
     defaults?: SessionsListResult["defaults"],
@@ -1504,9 +244,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return true;
   };
 
-  const publishReconciledSessionState = (next: SessionState) => {
-    // Targeted events can outlive a failed broad observer; preserve its outage
-    // unless a newer operation already owns the visible failure.
+  const publishReconciledState = (next: SessionState) => {
     const operationOwnsError = publishedErrorSource === "operation";
     const error = operationOwnsError ? state.error : sessionEventSubscriptionError;
     publish(
@@ -1533,7 +271,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       retirePullRequestSummary(reconciled.deletedKey);
     }
     if (reconciled.applied && (reconciled.result !== state.result || reconciled.deletedKey)) {
-      publishReconciledSessionState({
+      publishReconciledState({
         ...state,
         result: reconciled.result,
         agentId: options?.resultAgentId?.trim()
@@ -1552,357 +290,27 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (result === state.result) {
       return false;
     }
-    publishReconciledSessionState({ ...state, result });
+    publishReconciledState({ ...state, result });
     return true;
-  };
-
-  const remove = async (
-    key: string,
-    options: SessionDeleteOptions = {},
-  ): Promise<SessionDeleteOutcome> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return { deleted: false };
-    }
-    try {
-      const response = await requestSessionDelete(scope.client, key, options);
-      if (!isCurrentConnection(scope)) {
-        return { deleted: false };
-      }
-      if (!confirmsSessionDeletion(response)) {
-        return { deleted: false };
-      }
-      retirePullRequestSummary(key);
-      retirePreparedWorkSession(key);
-      publish({ ...state, deletedSessions: [{ key, agentId: options.agentId }] });
-      setModelOverride(key, undefined);
-      await refreshReplacement(options.agentId);
-      return {
-        deleted: isCurrentConnection(scope),
-        ...(response.worktreePreserved ? { worktreePreserved: response.worktreePreserved } : {}),
-      };
-    } catch (error) {
-      if (!isCurrentConnection(scope)) {
-        return { deleted: false };
-      }
-      publish({ ...state, error: String(error) }, "operation");
-      throw error;
-    }
-  };
-
-  const removeMany = async (
-    targets: readonly SessionDeleteTarget[],
-  ): Promise<SessionDeleteBatchResult> => {
-    const scope = captureConnection();
-    if (!scope || targets.length === 0) {
-      return { deleted: [], errors: [], preservedWorktrees: [] };
-    }
-    const deleted: string[] = [];
-    const errors: string[] = [];
-    const preservedWorktrees: SessionDeleteBatchResult["preservedWorktrees"] = [];
-    for (const target of targets) {
-      if (!isCurrentConnection(scope)) {
-        break;
-      }
-      try {
-        const response = await requestSessionDelete(scope.client, target.key, target);
-        if (!isCurrentConnection(scope)) {
-          break;
-        }
-        if (!confirmsSessionDeletion(response)) {
-          continue;
-        }
-        deleted.push(target.key);
-        if (response.worktreePreserved) {
-          preservedWorktrees.push(response.worktreePreserved);
-        }
-      } catch (error) {
-        errors.push(String(error));
-      }
-    }
-    if (deleted.length > 0 && isCurrentConnection(scope)) {
-      for (const key of deleted) {
-        retirePullRequestSummary(key);
-        retirePreparedWorkSession(key);
-      }
-      publish({
-        ...state,
-        deletedSessions: targets.filter((target) => deleted.includes(target.key)),
-      });
-      for (const key of deleted) {
-        setModelOverride(key, undefined);
-      }
-      await refreshReplacement();
-    }
-    return isCurrentConnection(scope)
-      ? { deleted, errors, preservedWorktrees }
-      : { deleted: [], errors: [], preservedWorktrees: [] };
-  };
-
-  const reset = async (
-    key: string,
-    options: SessionResetOptions = {},
-  ): Promise<SessionResetResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return "not-started";
-    }
-    try {
-      await requestSessionReset(scope.client, key, options);
-      return isCurrentConnection(scope) ? "completed" : "uncertain";
-    } catch (error) {
-      if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) }, "operation");
-      }
-      // The gateway commits the new session identity before every awaited
-      // post-reset lifecycle step finishes. Once requested, even a rejection
-      // on the same connection cannot prove that the destructive reset did not
-      // commit, so callers must never retry it automatically.
-      return "uncertain";
-    }
-  };
-
-  const compact = async (
-    key: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionCompactResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session compaction requires an active Gateway connection");
-    }
-    const result = await requestSessionCompact(scope.client, key, options);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session compaction completed on a replaced Gateway connection");
-    }
-    return result;
-  };
-
-  const steer = async (
-    key: string,
-    message: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionSteerResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session steering requires an active Gateway connection");
-    }
-    const result = await requestSessionSteer(scope.client, key, message, options);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session steering completed on a replaced Gateway connection");
-    }
-    return result;
-  };
-
-  const listFiles = async (
-    key: string,
-    options: { agentId?: string | null; path?: string; search?: string } = {},
-  ): Promise<SessionWorkspaceListResult | null> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    const result = await requestSessionFilesList(scope.client, key, options);
-    return isCurrentConnection(scope) ? result : null;
-  };
-
-  const getFile = async (
-    key: string,
-    path: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionWorkspaceGetResult | null> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    const result = await requestSessionFile(scope.client, key, path, options);
-    return isCurrentConnection(scope) ? result : null;
-  };
-
-  const setFile = async (
-    key: string,
-    path: string,
-    content: string,
-    options: { agentId?: string | null; expectedHash: string },
-  ): Promise<SessionWorkspaceSetResult | null> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return null;
-    }
-    const result = await requestSessionFileSet(scope.client, key, path, content, options);
-    return isCurrentConnection(scope) ? result : null;
-  };
-
-  const unsubscribeMessages = async (subscription: SessionMessageSubscription): Promise<void> => {
-    await releaseGatewaySessionMessageSubscription(subscription);
-    ownedMessageSubscriptions.delete(subscription);
-  };
-
-  const subscribeMessages = async (
-    key: string,
-    options: { agentId?: string | null; includeApprovals?: boolean } = {},
-  ): Promise<SessionMessageSubscription> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session message subscription requires an active Gateway connection");
-    }
-    const normalizedKey = key.trim();
-    const agentId =
-      isUiGlobalSessionKey(normalizedKey) && options.agentId?.trim()
-        ? normalizeAgentId(options.agentId)
-        : null;
-    const subscription = await getGatewaySessionMessageSubscriptionCoordinator(scope.client, {
-      keysEquivalent: areUiSessionKeysEquivalent,
-    }).acquire(normalizedKey, {
-      agentId,
-      ...(options.includeApprovals ? { includeApprovals: true } : {}),
-    });
-    ownedMessageSubscriptions.add(subscription);
-    if (!isCurrentConnection(scope)) {
-      await unsubscribeMessages(subscription).catch(() => undefined);
-      throw new Error("Session message subscription completed on a replaced Gateway connection");
-    }
-    return subscription;
-  };
-
-  const listCheckpoints = async (
-    key: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionCompactionCheckpoint[]> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return [];
-    }
-    const result = await listSessionCheckpoints(scope.client, key, options);
-    return isCurrentConnection(scope) ? (result.checkpoints ?? []) : [];
-  };
-
-  const branchCheckpoint = async (
-    key: string,
-    checkpointId: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionsCompactionBranchResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session checkpoint operation requires an active Gateway connection");
-    }
-    const result = await branchSessionCheckpoint(scope.client, key, checkpointId, options);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
-    }
-    await refreshReplacement(options.agentId ?? state.agentId ?? undefined);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
-    }
-    return result;
-  };
-
-  const restoreCheckpoint = async (
-    key: string,
-    checkpointId: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionsCompactionRestoreResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session checkpoint operation requires an active Gateway connection");
-    }
-    const result = await restoreSessionCheckpoint(scope.client, key, checkpointId, options);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
-    }
-    await refreshReplacement(options.agentId ?? state.agentId ?? undefined);
-    if (!isCurrentConnection(scope)) {
-      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
-    }
-    return result;
-  };
-
-  const rewind = async (
-    key: string,
-    entryId: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionsRewindResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session rewind requires an active Gateway connection");
-    }
-    const result = await rewindSessionAtMessage(scope.client, key, entryId, options);
-    if (isCurrentConnection(scope)) {
-      await refreshReplacement(options.agentId ?? state.agentId ?? undefined).catch(() => {});
-    }
-    return result;
-  };
-
-  const forkAtMessage = async (
-    key: string,
-    entryId: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionsForkResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session fork requires an active Gateway connection");
-    }
-    const result = await forkSessionAtMessage(scope.client, key, entryId, options);
-    if (isCurrentConnection(scope)) {
-      await refreshReplacement(options.agentId ?? state.agentId ?? undefined).catch(() => {});
-    }
-    return result;
-  };
-
-  const listBranches = async (
-    key: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionBranch[]> => {
-    const scope = captureConnection();
-    if (!scope) {
-      return [];
-    }
-    const result = await listSessionBranches(scope.client, key, options);
-    return isCurrentConnection(scope) ? result.branches : [];
-  };
-
-  const switchBranch = async (
-    key: string,
-    leafEntryId: string,
-    options: { agentId?: string | null } = {},
-  ): Promise<SessionsBranchesSwitchResult> => {
-    const scope = captureConnection();
-    if (!scope) {
-      throw new Error("Session branch switch requires an active Gateway connection");
-    }
-    const result = await switchSessionBranch(scope.client, key, leafEntryId, options);
-    if (isCurrentConnection(scope)) {
-      await refreshReplacement(options.agentId ?? state.agentId ?? undefined).catch(() => {});
-    }
-    return result;
   };
 
   const stopGateway = gateway.subscribe((next) => {
     const previousClient = connectionClient;
     const connected = next.phase === "connected";
-    const connectionChanged = next.client !== connectionClient || connected !== connectionConnected;
+    const connectionChanged = connection.transition(next);
     connectionClient = next.client;
-    connectionConnected = connected;
     if (connectionChanged) {
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
-      eventRefreshCoordinator.reset();
-      connectionEpoch += 1;
+      roster.reset();
       sessionEventSubscription.reset();
       sessionEventSubscriptionError = null;
-      if (previousClient) {
-        resetGatewaySessionMessageSubscriptionCoordinator(previousClient);
-      }
-      ownedMessageSubscriptions.clear();
-      invalidateGroupsLoad();
+      operations.retireConnection(previousClient);
+      groups.invalidate();
       swarmActivity.clear();
-      inFlight = null;
-      queuedExplicitRefresh = null;
-      eventRefreshQueued = false;
-      rollbackPendingModelPatches();
-      preparedWorkSessionKeys.clear();
+      mutations.retireConnection();
       pullRequestSummaries.clear();
       pullRequestEpochs.clear();
-      // A connected client replacement needs its own invalidation publish;
-      // disconnects publish the cleared state in the branch immediately below.
+      // Client replacement needs a publish; disconnect publishes cleared state below.
       if (hadPullRequestSummaries && connected && next.client) {
         publish({ ...state });
       }
@@ -1922,19 +330,19 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return;
     }
     if (hydratedClient !== next.client) {
-      const scope = captureConnection();
+      const scope = connection.capture();
       if (!scope) {
         return;
       }
       hydratedClient = scope.client;
       void (async () => {
         await sessionEventSubscription.ensure(scope);
-        if (isCurrentConnection(scope)) {
+        if (connection.isCurrent(scope)) {
           const sessionKey = gateway.snapshot.sessionKey?.trim();
           const agentScope = sessionKey
             ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
             : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
-          await refresh({
+          await roster.refresh({
             ...agentScope,
             includeDerivedTitles: true,
             backgroundHydrate: true,
@@ -1943,72 +351,59 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         }
       })();
     }
-    // Gateway snapshots also change for recovery scope, presence, and canvas metadata.
-    // Only a connection transition owns list hydration; refreshing here duplicates startup work.
   });
+
   const stopEvents = gateway.subscribeEvents((event) => {
-    if (isSessionStateEvent(event)) {
-      swarmActivity.observe(event.payload);
-      // Preserve canonical list filtering: decorate rows already admitted here,
-      // then let the refresh below admit new children before applying cached notes.
-      const decoratedResult = swarmActivity.decorate(state.result);
-      if (decoratedResult !== state.result) {
-        publish({ ...state, result: decoratedResult });
-      }
-      const reconciled = reconcileSessionChanged(state.result, event.payload, {
-        resultAgentId: state.agentId,
-        archivedFilter: lastListOptions.archivedFilter,
-      });
-      const eventInfo = readSessionChangedEvent(event.payload);
-      // Catalog mutations from other clients invalidate the per-connection
-      // groups snapshot. Groups events carry no session key, so read the
-      // reason straight off the payload instead of the parsed row info.
-      const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
-      if (eventReason === "groups") {
-        invalidateGroupsLoad();
-        void groupsLoad();
-      }
-      const hasActiveRun = reconciled.hasActiveRun ?? eventInfo?.hasActiveRun;
-      const status = reconciled.status ?? eventInfo?.status;
-      const runEnded =
-        hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
-      if (event.event === "session.message" && !runEnded) {
-        return;
-      }
-      if (reconciled.deletedKey) {
-        retirePullRequestSummary(reconciled.deletedKey);
-        // Preserve remote-deletion navigation before the canonical refresh
-        // clears transient event state.
-        publish({
-          ...state,
-          deletedSessions: [
-            { key: reconciled.deletedKey, agentId: reconciled.agentId ?? undefined },
-          ],
-        });
-      } else if ((eventReason === "create" || eventReason === "new") && eventInfo) {
-        const remainingDeletedSessions = state.deletedSessions.filter(
-          ({ key, agentId }) =>
-            !uiSessionEventMatches(
-              {
-                assistantAgentId: agentId ?? gateway.snapshot.assistantAgentId,
-                hello: gateway.snapshot.hello,
-                sessionKey: key,
-              },
-              eventInfo.key,
-              eventInfo.agentId,
-            ),
-        );
-        if (remainingDeletedSessions.length !== state.deletedSessions.length) {
-          // Gateway create events are ordered after the prior deletion. Retire
-          // only that generation's marker before the debounced list refresh.
-          publish({ ...state, deletedSessions: remainingDeletedSessions });
-        }
-      }
-      // Gateway lists are filtered and windowed. Events cannot preserve server
-      // membership or ordering, so the coalesced refresh remains canonical. Only
-      // events debounce, with a max wait; explicit refreshes and page exit flush it.
-      eventRefreshCoordinator.schedule();
+    if (!isSessionStateEvent(event)) {
+      return;
     }
+    swarmActivity.observe(event.payload);
+    const decoratedResult = swarmActivity.decorate(state.result);
+    if (decoratedResult !== state.result) {
+      publish({ ...state, result: decoratedResult });
+    }
+    const reconciled = reconcileSessionChanged(state.result, event.payload, {
+      resultAgentId: state.agentId,
+      archivedFilter: roster.lastOptions().archivedFilter,
+    });
+    const eventInfo = readSessionChangedEvent(event.payload);
+    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
+    if (eventReason === "groups") {
+      groups.invalidate();
+      void groups.load();
+    }
+    const hasActiveRun = reconciled.hasActiveRun ?? eventInfo?.hasActiveRun;
+    const status = reconciled.status ?? eventInfo?.status;
+    const runEnded =
+      hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
+    if (event.event === "session.message" && !runEnded) {
+      return;
+    }
+    if (reconciled.deletedKey) {
+      retirePullRequestSummary(reconciled.deletedKey);
+      publish({
+        ...state,
+        deletedSessions: [{ key: reconciled.deletedKey, agentId: reconciled.agentId ?? undefined }],
+      });
+    } else if ((eventReason === "create" || eventReason === "new") && eventInfo) {
+      const remainingDeletedSessions = state.deletedSessions.filter(
+        ({ key, agentId }) =>
+          !uiSessionEventMatches(
+            {
+              assistantAgentId: agentId ?? gateway.snapshot.assistantAgentId,
+              hello: gateway.snapshot.hello,
+              sessionKey: key,
+            },
+            eventInfo.key,
+            eventInfo.agentId,
+          ),
+      );
+      if (remainingDeletedSessions.length !== state.deletedSessions.length) {
+        publish({ ...state, deletedSessions: remainingDeletedSessions });
+      }
+    }
+    // Gateway lists own filtering/order; events coalesce into one canonical refresh.
+    roster.scheduleEvent();
   });
 
   return {
@@ -2018,45 +413,43 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     get canonicalListRevision() {
       return canonicalListRevision;
     },
-    list: requestList,
-    setCreatorFilter,
+    list: roster.list,
+    setCreatorFilter: (creatorId) => roster.setCreatorFilter(creatorId),
     reconcile,
     reconcileChanged,
     reconcileRunTerminal,
-    refresh,
-    refreshReplacement,
-    createResult,
-    create,
-    patch,
-    setModelOverride,
-    patchRowLocal,
-    isPreparedWorkSession(key) {
-      return preparedWorkSessionKeys.has(key.trim());
-    },
+    refresh: roster.refresh,
+    refreshReplacement: roster.refreshReplacement,
+    createResult: mutations.createResult,
+    create: mutations.create,
+    patch: mutations.patch,
+    setModelOverride: mutations.setModelOverride,
+    patchRowLocal: mutations.patchRowLocal,
+    isPreparedWorkSession: mutations.isPreparedWorkSession,
     pullRequestSummary,
     capturePullRequestEpoch,
     setPullRequestSummary,
-    delete: remove,
-    deleteMany: removeMany,
-    reset,
-    compact,
-    steer,
-    listFiles,
-    getFile,
-    setFile,
-    subscribeMessages,
-    unsubscribeMessages,
-    listCheckpoints,
-    branchCheckpoint,
-    restoreCheckpoint,
-    rewind,
-    forkAtMessage,
-    listBranches,
-    switchBranch,
-    groupsLoad,
-    groupsPut,
-    groupsRename,
-    groupsDelete,
+    delete: mutations.delete,
+    deleteMany: mutations.deleteMany,
+    reset: mutations.reset,
+    compact: operations.compact,
+    steer: operations.steer,
+    listFiles: operations.listFiles,
+    getFile: operations.getFile,
+    setFile: operations.setFile,
+    subscribeMessages: operations.subscribeMessages,
+    unsubscribeMessages: operations.unsubscribeMessages,
+    listCheckpoints: operations.listCheckpoints,
+    branchCheckpoint: operations.branchCheckpoint,
+    restoreCheckpoint: operations.restoreCheckpoint,
+    rewind: operations.rewind,
+    forkAtMessage: operations.forkAtMessage,
+    listBranches: operations.listBranches,
+    switchBranch: operations.switchBranch,
+    groupsLoad: groups.load,
+    groupsPut: groups.put,
+    groupsRename: groups.rename,
+    groupsDelete: groups.delete,
     subscribeCreated(listener) {
       createdListeners.add(listener);
       return () => createdListeners.delete(listener);
@@ -2066,27 +459,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return () => listeners.delete(listener);
     },
     dispose() {
-      // Page teardown must start the trailing refresh synchronously before the
-      // disposed guard makes the capability inert.
-      flushEventRefresh();
-      eventRefreshCoordinator.dispose();
-      if (observesPageLifecycle) {
-        document.removeEventListener("visibilitychange", handleVisibilityChange);
-        globalThis.removeEventListener("pagehide", flushEventRefresh);
-      }
-      for (const subscription of ownedMessageSubscriptions) {
-        void unsubscribeMessages(subscription).catch(() => undefined);
-      }
-      disposed = true;
-      connectionEpoch += 1;
-      invalidateGroupsLoad();
-      connectionConnected = false;
-      inFlight = null;
-      queuedExplicitRefresh = null;
-      eventRefreshQueued = false;
+      roster.dispose();
+      operations.dispose();
+      connection.dispose();
+      groups.dispose();
       hydratedClient = null;
-      pendingModelPatches.clear();
-      preparedWorkSessionKeys.clear();
+      mutations.dispose();
       swarmActivity.clear();
       pullRequestSummaries.clear();
       pullRequestEpochs.clear();
@@ -2098,4 +476,3 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/lib/sessions/navigation-handoff.ts
+++ b/ui/src/lib/sessions/navigation-handoff.ts
@@ -1,17 +1,30 @@
 type SessionNavigationHandoff = {
   pathname: string;
   sessionKey: string;
+  client: object | null;
+  hello: object | null;
+};
+
+type SessionNavigationHandoffOwner = {
+  readonly snapshot: {
+    readonly client: object | null;
+    readonly hello: object | null;
+  };
 };
 
 const SESSION_NAVIGATION_HANDOFF_TTL_MS = 2_000;
-const sessionNavigationHandoffs = new WeakMap<object, SessionNavigationHandoff>();
+const sessionNavigationHandoffs = new WeakMap<
+  SessionNavigationHandoffOwner,
+  SessionNavigationHandoff
+>();
 
 export function prepareSessionNavigationHandoff(
-  owner: object,
+  owner: SessionNavigationHandoffOwner,
   pathname: string,
   sessionKey: string,
 ): void {
-  const handoff = { pathname, sessionKey };
+  const { client, hello } = owner.snapshot;
+  const handoff = { pathname, sessionKey, client, hello };
   sessionNavigationHandoffs.set(owner, handoff);
   globalThis.setTimeout(() => {
     if (sessionNavigationHandoffs.get(owner) === handoff) {
@@ -21,7 +34,7 @@ export function prepareSessionNavigationHandoff(
 }
 
 export function consumeSessionNavigationHandoff(
-  owner: object,
+  owner: SessionNavigationHandoffOwner,
   pathname: string,
 ): string | undefined {
   const handoff = sessionNavigationHandoffs.get(owner);
@@ -29,5 +42,11 @@ export function consumeSessionNavigationHandoff(
     return undefined;
   }
   sessionNavigationHandoffs.delete(owner);
+  // Browser clients survive transport reconnects, so hello identity must also
+  // match before an old connection can bypass authoritative route resolution.
+  const { client, hello } = owner.snapshot;
+  if (handoff.client !== client || handoff.hello !== hello) {
+    return undefined;
+  }
   return handoff.sessionKey;
 }

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -6,7 +6,6 @@ import {
   sessionMatchesArchivedFilter,
   type SessionArchivedFilter,
 } from "./navigation.ts";
-import type { SessionRunTerminal } from "./session-capability.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
@@ -32,6 +31,14 @@ export type SessionChangedResult = {
   row?: GatewaySessionRow;
   deletedKey?: string;
   result: SessionsListResult | null;
+};
+
+export type SessionRunTerminal = {
+  sessionKeys: readonly string[];
+  runId?: string | null;
+  /** Latest session status after this owned model run leaves the active registry. */
+  status: SessionRunStatus;
+  endedAt: number;
 };
 
 type SessionChangedEventInfo = {

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -6,6 +6,7 @@ import {
   sessionMatchesArchivedFilter,
   type SessionArchivedFilter,
 } from "./navigation.ts";
+import type { SessionRunTerminal } from "./session-capability.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
@@ -504,4 +505,63 @@ export function reconcileSessionHistory(
     count: sessions.length,
     sessions,
   };
+}
+
+export function reconcileSessionRunTerminal(
+  result: SessionsListResult | null,
+  terminal: SessionRunTerminal,
+): SessionsListResult | null {
+  const keys = terminal.sessionKeys.map((key) => key.trim()).filter(Boolean);
+  if (!result || keys.length === 0) {
+    return result;
+  }
+  const runId = terminal.runId?.trim() || null;
+  let changed = false;
+  const sessions = result.sessions.map((row): GatewaySessionRow => {
+    if (!keys.some((key) => areUiSessionKeysEquivalent(row.key, key))) {
+      return row;
+    }
+    if (row.hasActiveRun === true || isSessionRunActive(row)) {
+      // Active identity belongs to the originating model run, not a newer overlap.
+      if (!runId || !row.activeRunIds?.includes(runId)) {
+        return row;
+      }
+    }
+    const remainingRunIds = runId ? row.activeRunIds?.filter((id) => id !== runId) : [];
+    if (remainingRunIds?.length) {
+      changed = true;
+      return { ...row, activeRunIds: remainingRunIds, hasActiveRun: true, status: "running" };
+    }
+    const endedAt = row.endedAt ?? terminal.endedAt;
+    const runtimeMs =
+      typeof row.startedAt === "number" ? Math.max(0, endedAt - row.startedAt) : row.runtimeMs;
+    const activeRunIds = row.activeRunIds?.length ? [] : row.activeRunIds;
+    const abortedLastRun =
+      terminal.status === "killed"
+        ? true
+        : terminal.status === "running"
+          ? false
+          : row.abortedLastRun;
+    if (
+      row.hasActiveRun === false &&
+      row.status === terminal.status &&
+      row.endedAt === endedAt &&
+      row.runtimeMs === runtimeMs &&
+      row.activeRunIds === activeRunIds &&
+      row.abortedLastRun === abortedLastRun
+    ) {
+      return row;
+    }
+    changed = true;
+    return {
+      ...row,
+      activeRunIds,
+      hasActiveRun: false,
+      status: terminal.status,
+      endedAt,
+      runtimeMs,
+      abortedLastRun,
+    };
+  });
+  return changed ? { ...result, sessions } : result;
 }

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -1,0 +1,252 @@
+import type { GatewaySessionMessageSubscription } from "@openclaw/gateway-client/browser";
+import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/schema/sessions-catalog.js";
+import type { GatewayBrowserClient, GatewayEventFrame, GatewayHelloOk } from "../../api/gateway.ts";
+import type {
+  GatewaySessionRow,
+  SessionBranch,
+  SessionCompactionCheckpoint,
+  SessionRunStatus,
+  SessionsBranchesSwitchResult,
+  SessionsCompactionBranchResult,
+  SessionsCompactionRestoreResult,
+  SessionsForkResult,
+  SessionsListResult,
+  SessionsRewindResult,
+  SessionWorkspaceGetResult,
+  SessionWorkspaceListResult,
+  SessionWorkspaceSetResult,
+} from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
+import type { GatewayConnectionScope } from "../gateway-connection-lifecycle.ts";
+import type { SessionCreateOutcome, SessionCreateParams } from "./create.ts";
+import type { SessionArchivedFilter } from "./navigation.ts";
+import type { SessionPatchRoute } from "./patch.ts";
+import type { SessionChangedResult, SessionReconcileOptions } from "./reconcile.ts";
+
+export type SessionState = {
+  result: SessionsListResult | null;
+  agentId: string | null;
+  modelOverrides: Readonly<Record<string, string | null>>;
+  loading: boolean;
+  error: string | null;
+  deletedSessions: readonly SessionDeleteTarget[];
+  /** Gateway-owned custom group catalog in display order. */
+  groups: readonly string[];
+  /** Gateway-owned sidebar section order; pinned is intentionally absent. */
+  sectionOrder: readonly string[];
+};
+
+export type SessionGroupMutationResult = "completed" | "stale";
+
+export type SessionListOptions = {
+  agentId?: string;
+  spawnedBy?: string;
+  boardFace?: "chat" | "dashboard";
+  activeMinutes?: number;
+  search?: string;
+  creatorId?: string;
+  offset?: number;
+  limit?: number;
+  includeGlobal?: boolean;
+  includeUnknown?: boolean;
+  configuredAgentsOnly?: boolean;
+  includeDerivedTitles?: boolean;
+  archivedFilter?: SessionArchivedFilter;
+  append?: boolean;
+};
+
+export type SessionRefreshOptions = SessionListOptions & {
+  force?: boolean;
+  // Sidebar startup hydration must not block session creation or drop the open session.
+  backgroundHydrate?: boolean;
+};
+
+export type SessionRunTerminal = {
+  sessionKeys: readonly string[];
+  runId?: string | null;
+  /** Latest session status after this owned model run leaves the active registry. */
+  status: SessionRunStatus;
+  endedAt: number;
+};
+
+export type SessionDeleteOptions = {
+  agentId?: string;
+  deleteTranscript?: boolean;
+  archivedOnly?: boolean;
+};
+
+export type SessionDeleteTarget = {
+  key: string;
+  agentId?: string;
+  deleteTranscript?: boolean;
+  archivedOnly?: boolean;
+};
+
+/** Dirty/unpushed checkouts survive session deletion; callers surface them. */
+export type SessionDeleteOutcome = {
+  deleted: boolean;
+  worktreePreserved?: { id: string; branch: string; path: string };
+};
+
+export type SessionDeleteBatchResult = {
+  deleted: string[];
+  errors: string[];
+  /** Dirty/unpushed checkouts kept by the gateway during this batch. */
+  preservedWorktrees: Array<{ id: string; branch: string; path: string }>;
+};
+
+export type SessionCompactResult = {
+  ok?: boolean;
+  compacted?: boolean;
+  reason?: string;
+  result?: { tokensBefore?: number; tokensAfter?: number };
+};
+
+export type SessionSteerResult = {
+  runId?: string;
+  status?: unknown;
+};
+
+export type SessionResetOptions = {
+  agentId?: string | null;
+};
+
+export type SessionResetResult = "completed" | "not-started" | "uncertain";
+
+export type SessionGateway = {
+  readonly snapshot: {
+    client: GatewayBrowserClient | null;
+    phase: ApplicationGatewayPhase;
+    hello: GatewayHelloOk | null;
+    assistantAgentId?: string | null;
+    sessionKey?: string;
+  };
+  subscribe: (listener: (snapshot: SessionGateway["snapshot"]) => void) => () => void;
+  subscribeEvents: (listener: (event: GatewayEventFrame) => void) => () => void;
+};
+
+export type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
+
+export type SessionDeleteResponse = {
+  deleted: boolean;
+  worktreePreserved?: SessionDeleteOutcome["worktreePreserved"];
+};
+
+export type SessionConnectionScope = GatewayConnectionScope;
+
+export type SessionConnectionOwner = {
+  capture: () => SessionConnectionScope | null;
+  isCurrent: (scope: SessionConnectionScope) => boolean;
+};
+
+export type SessionCreateReconciliation = "blocking" | "background";
+
+export type SessionMessageSubscription = GatewaySessionMessageSubscription;
+
+export type SessionCapability = {
+  readonly state: SessionState;
+  /** Advances only when a canonical sessions.list result is published. */
+  readonly canonicalListRevision: number;
+  list: (options?: SessionListOptions) => Promise<SessionsListResult | null>;
+  setCreatorFilter: (creatorId: string | null) => Promise<void>;
+  reconcile: (
+    row: GatewaySessionRow | undefined,
+    defaults?: SessionsListResult["defaults"],
+    options?: SessionReconcileOptions,
+  ) => boolean;
+  reconcileChanged: (payload: unknown, options?: SessionReconcileOptions) => SessionChangedResult;
+  reconcileRunTerminal: (terminal: SessionRunTerminal) => boolean;
+  refresh: (options?: SessionRefreshOptions) => Promise<void>;
+  refreshReplacement: (agentId?: string | null) => Promise<void>;
+  createResult: (
+    params?: SessionCreateParams,
+    options?: { reconciliation?: SessionCreateReconciliation },
+  ) => Promise<SessionCreateOutcome | null>;
+  create: (params?: SessionCreateParams) => Promise<string | null>;
+  patch: SessionPatchRoute;
+  setModelOverride: (key: string, value: string | null | undefined) => void;
+  /** Keep optimistic row changes in the published snapshot through later publishes. */
+  patchRowLocal: (key: string, patch: Partial<GatewaySessionRow>) => void;
+  /** True while a just-created work session awaits its canonical placement row. */
+  isPreparedWorkSession: (key: string) => boolean;
+  pullRequestSummary: (key: string) => SessionCatalogPullRequestSummary | undefined;
+  capturePullRequestEpoch: (key: string) => symbol;
+  setPullRequestSummary: (
+    key: string,
+    summary: SessionCatalogPullRequestSummary | undefined,
+    epoch?: symbol,
+  ) => void;
+  delete: (key: string, options?: SessionDeleteOptions) => Promise<SessionDeleteOutcome>;
+  deleteMany: (targets: readonly SessionDeleteTarget[]) => Promise<SessionDeleteBatchResult>;
+  reset: (key: string, options?: SessionResetOptions) => Promise<SessionResetResult>;
+  compact: (key: string, options?: { agentId?: string | null }) => Promise<SessionCompactResult>;
+  steer: (
+    key: string,
+    message: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionSteerResult>;
+  listFiles: (
+    key: string,
+    options?: { agentId?: string | null; path?: string; search?: string },
+  ) => Promise<SessionWorkspaceListResult | null>;
+  getFile: (
+    key: string,
+    path: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionWorkspaceGetResult | null>;
+  setFile: (
+    key: string,
+    path: string,
+    content: string,
+    options: { agentId?: string | null; expectedHash: string },
+  ) => Promise<SessionWorkspaceSetResult | null>;
+  subscribeMessages: (
+    key: string,
+    options?: { agentId?: string | null; includeApprovals?: boolean },
+  ) => Promise<SessionMessageSubscription>;
+  unsubscribeMessages: (subscription: SessionMessageSubscription) => Promise<void>;
+  listCheckpoints: (
+    key: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionCompactionCheckpoint[]>;
+  branchCheckpoint: (
+    key: string,
+    checkpointId: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionsCompactionBranchResult>;
+  restoreCheckpoint: (
+    key: string,
+    checkpointId: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionsCompactionRestoreResult>;
+  rewind: (
+    key: string,
+    entryId: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionsRewindResult>;
+  forkAtMessage: (
+    key: string,
+    entryId: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionsForkResult>;
+  listBranches: (key: string, options?: { agentId?: string | null }) => Promise<SessionBranch[]>;
+  switchBranch: (
+    key: string,
+    leafEntryId: string,
+    options?: { agentId?: string | null },
+  ) => Promise<SessionsBranchesSwitchResult>;
+  /** Loads the gateway-owned group catalog, coalescing successful connection attempts. */
+  groupsLoad: () => Promise<void>;
+  /** Replaces the group catalog; stale means the initiating connection retired. */
+  groupsPut: (
+    names: readonly string[],
+    sectionOrder?: readonly string[],
+  ) => Promise<SessionGroupMutationResult>;
+  /** Renames a group; stale means the initiating connection retired before reconciliation. */
+  groupsRename: (from: string, to: string) => Promise<SessionGroupMutationResult>;
+  /** Deletes a group; stale means the initiating connection retired before reconciliation. */
+  groupsDelete: (name: string) => Promise<SessionGroupMutationResult>;
+  subscribeCreated: (listener: (key: string) => void) => () => void;
+  subscribe: (listener: (state: SessionState) => void) => () => void;
+  dispose: () => void;
+};

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -5,7 +5,6 @@ import type {
   GatewaySessionRow,
   SessionBranch,
   SessionCompactionCheckpoint,
-  SessionRunStatus,
   SessionsBranchesSwitchResult,
   SessionsCompactionBranchResult,
   SessionsCompactionRestoreResult,
@@ -21,7 +20,11 @@ import type { GatewayConnectionScope } from "../gateway-connection-lifecycle.ts"
 import type { SessionCreateOutcome, SessionCreateParams } from "./create.ts";
 import type { SessionArchivedFilter } from "./navigation.ts";
 import type { SessionPatchRoute } from "./patch.ts";
-import type { SessionChangedResult, SessionReconcileOptions } from "./reconcile.ts";
+import type {
+  SessionChangedResult,
+  SessionReconcileOptions,
+  SessionRunTerminal,
+} from "./reconcile.ts";
 
 export type SessionState = {
   result: SessionsListResult | null;
@@ -59,14 +62,6 @@ export type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
   // Sidebar startup hydration must not block session creation or drop the open session.
   backgroundHydrate?: boolean;
-};
-
-export type SessionRunTerminal = {
-  sessionKeys: readonly string[];
-  runId?: string | null;
-  /** Latest session status after this owned model run leaves the active registry. */
-  status: SessionRunStatus;
-  endedAt: number;
 };
 
 export type SessionDeleteOptions = {

--- a/ui/src/lib/sessions/session-group-catalog.ts
+++ b/ui/src/lib/sessions/session-group-catalog.ts
@@ -1,0 +1,214 @@
+import { getSafeLocalStorage } from "../../local-storage.ts";
+import { isGatewayMethodAdvertised } from "../gateway-methods.ts";
+import { readSessionCustomGroupNames, readSidebarSectionOrder } from "./custom-groups.ts";
+import type {
+  SessionConnectionOwner,
+  SessionConnectionScope,
+  SessionGateway,
+  SessionGroupMutationResult,
+  SessionState,
+} from "./session-capability.ts";
+
+type SessionGroupCatalogHost = {
+  connection: SessionConnectionOwner;
+  snapshot: () => SessionGateway["snapshot"];
+  readState: () => SessionState;
+  publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
+  refreshRows: () => Promise<void>;
+  retryDelayMs: (error: unknown) => number | null;
+};
+
+const LEGACY_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
+const GROUPS_LIST_METHOD = "sessions.groups.list";
+
+function readLegacyStoredGroups(): string[] {
+  try {
+    const raw = getSafeLocalStorage()?.getItem(LEGACY_GROUPS_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? [
+          ...new Set(
+            parsed.flatMap((name) => {
+              const normalized = typeof name === "string" ? name.trim() : "";
+              return normalized ? [normalized] : [];
+            }),
+          ),
+        ]
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function createSessionGroupCatalog(host: SessionGroupCatalogHost) {
+  let loadedEpoch = -1;
+  let loadGeneration = 0;
+  let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  const clearRetry = () => {
+    if (retryTimer !== null) {
+      globalThis.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const invalidate = () => {
+    loadedEpoch = -1;
+    loadGeneration += 1;
+    clearRetry();
+  };
+
+  const publishCatalog = (groups: readonly string[], sectionOrder: readonly string[]) => {
+    const state = host.readState();
+    const groupsUnchanged =
+      groups.length === state.groups.length &&
+      groups.every((group, i) => group === state.groups[i]);
+    const orderUnchanged =
+      sectionOrder.length === state.sectionOrder.length &&
+      sectionOrder.every((sectionId, i) => sectionId === state.sectionOrder[i]);
+    if (!groupsUnchanged || !orderUnchanged) {
+      host.publish({ ...state, groups: [...groups], sectionOrder: [...sectionOrder] });
+    }
+  };
+
+  const finishMutationFailure = (current: boolean, error: unknown): SessionGroupMutationResult => {
+    if (!current) {
+      return "stale";
+    }
+    host.publish({ ...host.readState(), error: String(error) }, "operation");
+    throw error;
+  };
+
+  const loadAttempt = async (
+    scope: SessionConnectionScope,
+    generation: number,
+    advertised: boolean | null,
+  ) => {
+    try {
+      const listed = await scope.client.request(GROUPS_LIST_METHOD, {});
+      if (!host.connection.isCurrent(scope) || generation !== loadGeneration) {
+        return;
+      }
+      let names = readSessionCustomGroupNames(listed);
+      let sectionOrder = readSidebarSectionOrder(listed);
+      // Browser-local catalogs predate the gateway store and migrate exactly once.
+      const legacy = readLegacyStoredGroups();
+      if (names.length === 0 && legacy.length > 0) {
+        const put = await scope.client.request("sessions.groups.put", { names: legacy });
+        if (!host.connection.isCurrent(scope) || generation !== loadGeneration) {
+          return;
+        }
+        names = readSessionCustomGroupNames(put);
+        sectionOrder = readSidebarSectionOrder(put);
+      }
+      if (legacy.length > 0) {
+        try {
+          getSafeLocalStorage()?.removeItem(LEGACY_GROUPS_STORAGE_KEY);
+        } catch {
+          // The gateway catalog is canonical even when browser cleanup fails.
+        }
+      }
+      publishCatalog(names, sectionOrder);
+    } catch (error) {
+      if (
+        !host.connection.isCurrent(scope) ||
+        generation !== loadGeneration ||
+        advertised !== true
+      ) {
+        // Gateways without feature metadata retain the legacy one-shot probe.
+        return;
+      }
+      loadedEpoch = -1;
+      const delay = host.retryDelayMs(error);
+      if (delay === null) {
+        return;
+      }
+      // An older rejection cannot revive retries after a newer catalog load wins.
+      retryTimer = globalThis.setTimeout(() => {
+        retryTimer = null;
+        if (host.connection.isCurrent(scope) && generation === loadGeneration) {
+          void load();
+        }
+      }, delay);
+    }
+  };
+
+  /** Group consumers may probe once per connection; explicitly absent features never probe. */
+  const load = async () => {
+    const scope = host.connection.capture();
+    if (!scope || loadedEpoch === scope.epoch) {
+      return;
+    }
+    const advertised = isGatewayMethodAdvertised(host.snapshot(), GROUPS_LIST_METHOD);
+    clearRetry();
+    const generation = ++loadGeneration;
+    loadedEpoch = scope.epoch;
+    if (advertised === false) {
+      publishCatalog([], []);
+      return;
+    }
+    await loadAttempt(scope, generation, advertised);
+  };
+
+  const put = async (
+    names: readonly string[],
+    sectionOrder?: readonly string[],
+  ): Promise<SessionGroupMutationResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return "stale";
+    }
+    try {
+      const result = await scope.client.request("sessions.groups.put", {
+        names: [...names],
+        ...(sectionOrder === undefined ? {} : { sectionOrder: [...sectionOrder] }),
+      });
+      if (!host.connection.isCurrent(scope)) {
+        return "stale";
+      }
+      publishCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
+      return "completed";
+    } catch (error) {
+      return finishMutationFailure(host.connection.isCurrent(scope), error);
+    }
+  };
+
+  const rename = async (from: string, to: string): Promise<SessionGroupMutationResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return "stale";
+    }
+    try {
+      const result = await scope.client.request("sessions.groups.rename", { name: from, to });
+      if (!host.connection.isCurrent(scope)) {
+        return "stale";
+      }
+      publishCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
+      // Mutation response commits before a background member-row reconciliation.
+      void host.refreshRows();
+      return "completed";
+    } catch (error) {
+      return finishMutationFailure(host.connection.isCurrent(scope), error);
+    }
+  };
+
+  const remove = async (name: string): Promise<SessionGroupMutationResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return "stale";
+    }
+    try {
+      const result = await scope.client.request("sessions.groups.delete", { name });
+      if (!host.connection.isCurrent(scope)) {
+        return "stale";
+      }
+      publishCatalog(readSessionCustomGroupNames(result), readSidebarSectionOrder(result));
+      void host.refreshRows();
+      return "completed";
+    } catch (error) {
+      return finishMutationFailure(host.connection.isCurrent(scope), error);
+    }
+  };
+
+  return { delete: remove, dispose: invalidate, invalidate, load, put, rename };
+}

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -1,0 +1,343 @@
+import type {
+  GatewaySessionRow,
+  SessionsListResult,
+  SessionsPatchResult,
+} from "../../api/types.ts";
+import {
+  requestSessionCreate,
+  resolveSessionCreateParams,
+  type SessionCreateParams,
+} from "./create.ts";
+import type { SessionPatch, SessionPatchOptions } from "./patch.ts";
+import type {
+  SessionConnectionOwner,
+  SessionCreateReconciliation,
+  SessionDeleteBatchResult,
+  SessionDeleteOptions,
+  SessionDeleteOutcome,
+  SessionDeleteTarget,
+  SessionResetOptions,
+  SessionResetResult,
+  SessionState,
+} from "./session-capability.ts";
+import {
+  confirmsSessionDeletion,
+  requestSessionDelete,
+  requestSessionPatch,
+  requestSessionReset,
+} from "./session-requests.ts";
+
+type SessionMutationsHost = {
+  connection: SessionConnectionOwner;
+  readState: () => SessionState;
+  publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
+  refreshReplacement: (agentId?: string | null) => Promise<void>;
+  notifyCreated: (key: string) => void;
+  retirePullRequestSummary: (key: string) => void;
+};
+
+export function createSessionMutations(host: SessionMutationsHost) {
+  const pendingModelPatches = new Map<
+    string,
+    { token: symbol; previous: string | null | undefined }
+  >();
+  const preparedWorkSessionKeys = new Set<string>();
+
+  const setModelOverride = (key: string, value: string | null | undefined) => {
+    const normalizedKey = key.trim();
+    if (!normalizedKey) {
+      return;
+    }
+    const state = host.readState();
+    const modelOverrides = { ...state.modelOverrides };
+    if (value === undefined) {
+      if (!Object.hasOwn(state.modelOverrides, normalizedKey)) {
+        return;
+      }
+      delete modelOverrides[normalizedKey];
+    } else {
+      const normalizedValue = value === null ? null : value.trim();
+      if (
+        modelOverrides[normalizedKey] === normalizedValue &&
+        Object.hasOwn(modelOverrides, normalizedKey)
+      ) {
+        return;
+      }
+      modelOverrides[normalizedKey] = normalizedValue;
+    }
+    host.publish({ ...state, modelOverrides });
+  };
+
+  const patchRowLocal = (key: string, patch: Partial<GatewaySessionRow>) => {
+    const state = host.readState();
+    const normalizedKey = key.trim();
+    if (!state.result || !normalizedKey) {
+      return;
+    }
+    let changed = false;
+    const sessions = state.result.sessions.map((row) => {
+      if (row.key !== normalizedKey) {
+        return row;
+      }
+      changed = true;
+      return { ...row, ...patch };
+    });
+    if (changed) {
+      host.publish({ ...state, result: { ...state.result, sessions } });
+    }
+  };
+
+  const rollback = () => {
+    const pending = [...pendingModelPatches];
+    pendingModelPatches.clear();
+    for (const [key, operation] of pending) {
+      setModelOverride(key, operation.previous);
+    }
+  };
+
+  const createResult = async (
+    params: SessionCreateParams = {},
+    options: { reconciliation?: SessionCreateReconciliation } = {},
+  ) => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    try {
+      const { currentSessionKey, ...requestParams } = params;
+      const result = await requestSessionCreate(scope.client, {
+        ...requestParams,
+        ...resolveSessionCreateParams(currentSessionKey, params.agentId),
+      });
+      if (!host.connection.isCurrent(scope)) {
+        return null;
+      }
+      // Creation precedes canonical rows; carry placement/model until list hydration.
+      if (requestParams.worktree === true || Boolean(requestParams.execNode?.trim())) {
+        preparedWorkSessionKeys.add(result.key.trim());
+      }
+      if (requestParams.model?.trim()) {
+        setModelOverride(result.key, requestParams.model);
+      } else if (preparedWorkSessionKeys.has(result.key)) {
+        host.publish({ ...host.readState() });
+      }
+      const reconcileCreatedSession = async () => {
+        await host.refreshReplacement(params.agentId);
+        if (host.connection.isCurrent(scope)) {
+          host.notifyCreated(result.key);
+        }
+      };
+      if (options.reconciliation === "background") {
+        void reconcileCreatedSession().catch((error: unknown) => {
+          if (host.connection.isCurrent(scope)) {
+            host.publish({ ...host.readState(), error: String(error) }, "operation");
+          }
+        });
+      } else {
+        await reconcileCreatedSession();
+        if (!host.connection.isCurrent(scope)) {
+          return null;
+        }
+      }
+      return result;
+    } catch (error) {
+      if (host.connection.isCurrent(scope)) {
+        host.publish({ ...host.readState(), error: String(error) }, "operation");
+      }
+      return null;
+    }
+  };
+
+  const create = async (params: SessionCreateParams = {}) =>
+    (await createResult(params))?.key ?? null;
+
+  const patch = async (
+    key: string,
+    patchParams: SessionPatch,
+    options: SessionPatchOptions = {},
+  ): Promise<SessionsPatchResult | null> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    const hasModelPatch = Object.hasOwn(patchParams, "model");
+    const normalizedKey = key.trim();
+    const pendingModelPatch = pendingModelPatches.get(normalizedKey);
+    const previousModelOverride = pendingModelPatch
+      ? pendingModelPatch.previous
+      : host.readState().modelOverrides[normalizedKey];
+    const modelPatchToken = Symbol();
+    if (hasModelPatch) {
+      pendingModelPatches.set(normalizedKey, {
+        token: modelPatchToken,
+        previous: previousModelOverride,
+      });
+      setModelOverride(key, patchParams.model);
+    }
+    const restoreModelOverride = () => {
+      if (pendingModelPatches.get(normalizedKey)?.token === modelPatchToken) {
+        pendingModelPatches.delete(normalizedKey);
+        setModelOverride(key, previousModelOverride);
+      }
+    };
+    try {
+      if (options.waitFor) {
+        await options.waitFor;
+        if (!host.connection.isCurrent(scope)) {
+          restoreModelOverride();
+          return null;
+        }
+      }
+      const result = await requestSessionPatch(scope.client, key, patchParams, options);
+      if (!host.connection.isCurrent(scope)) {
+        restoreModelOverride();
+        return null;
+      }
+      if (!options.deferListRefresh) {
+        await host.refreshReplacement(options.agentId);
+        if (!host.connection.isCurrent(scope)) {
+          restoreModelOverride();
+          return null;
+        }
+      }
+      if (pendingModelPatches.get(normalizedKey)?.token === modelPatchToken) {
+        pendingModelPatches.delete(normalizedKey);
+        setModelOverride(key, patchParams.model);
+      }
+      return result;
+    } catch (error) {
+      restoreModelOverride();
+      if (!host.connection.isCurrent(scope)) {
+        return null;
+      }
+      host.publish({ ...host.readState(), error: String(error) }, "operation");
+      throw error;
+    }
+  };
+
+  const remove = async (
+    key: string,
+    options: SessionDeleteOptions = {},
+  ): Promise<SessionDeleteOutcome> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return { deleted: false };
+    }
+    try {
+      const response = await requestSessionDelete(scope.client, key, options);
+      if (!host.connection.isCurrent(scope) || !confirmsSessionDeletion(response)) {
+        return { deleted: false };
+      }
+      host.retirePullRequestSummary(key);
+      preparedWorkSessionKeys.delete(key.trim());
+      host.publish({ ...host.readState(), deletedSessions: [{ key, agentId: options.agentId }] });
+      setModelOverride(key, undefined);
+      await host.refreshReplacement(options.agentId);
+      return {
+        deleted: host.connection.isCurrent(scope),
+        ...(response.worktreePreserved ? { worktreePreserved: response.worktreePreserved } : {}),
+      };
+    } catch (error) {
+      if (!host.connection.isCurrent(scope)) {
+        return { deleted: false };
+      }
+      host.publish({ ...host.readState(), error: String(error) }, "operation");
+      throw error;
+    }
+  };
+
+  const removeMany = async (
+    targets: readonly SessionDeleteTarget[],
+  ): Promise<SessionDeleteBatchResult> => {
+    const scope = host.connection.capture();
+    if (!scope || targets.length === 0) {
+      return { deleted: [], errors: [], preservedWorktrees: [] };
+    }
+    const deleted: string[] = [];
+    const errors: string[] = [];
+    const preservedWorktrees: SessionDeleteBatchResult["preservedWorktrees"] = [];
+    for (const target of targets) {
+      if (!host.connection.isCurrent(scope)) {
+        break;
+      }
+      try {
+        const response = await requestSessionDelete(scope.client, target.key, target);
+        if (!host.connection.isCurrent(scope)) {
+          break;
+        }
+        if (confirmsSessionDeletion(response)) {
+          deleted.push(target.key);
+          if (response.worktreePreserved) {
+            preservedWorktrees.push(response.worktreePreserved);
+          }
+        }
+      } catch (error) {
+        errors.push(String(error));
+      }
+    }
+    if (deleted.length > 0 && host.connection.isCurrent(scope)) {
+      for (const key of deleted) {
+        host.retirePullRequestSummary(key);
+        preparedWorkSessionKeys.delete(key.trim());
+      }
+      host.publish({
+        ...host.readState(),
+        deletedSessions: targets.filter((target) => deleted.includes(target.key)),
+      });
+      for (const key of deleted) {
+        setModelOverride(key, undefined);
+      }
+      await host.refreshReplacement();
+    }
+    return host.connection.isCurrent(scope)
+      ? { deleted, errors, preservedWorktrees }
+      : { deleted: [], errors: [], preservedWorktrees: [] };
+  };
+
+  const reset = async (
+    key: string,
+    options: SessionResetOptions = {},
+  ): Promise<SessionResetResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return "not-started";
+    }
+    try {
+      await requestSessionReset(scope.client, key, options);
+      return host.connection.isCurrent(scope) ? "completed" : "uncertain";
+    } catch (error) {
+      if (host.connection.isCurrent(scope)) {
+        host.publish({ ...host.readState(), error: String(error) }, "operation");
+      }
+      // Reset can commit before awaited lifecycle work rejects; never infer safe retry.
+      return "uncertain";
+    }
+  };
+
+  return {
+    create,
+    createResult,
+    delete: remove,
+    deleteMany: removeMany,
+    patch,
+    patchRowLocal,
+    reset,
+    setModelOverride,
+    isPreparedWorkSession: (key: string) => preparedWorkSessionKeys.has(key.trim()),
+    settlePrepared(result: SessionsListResult | null) {
+      for (const row of result?.sessions ?? []) {
+        if (row.worktree || row.execNode) {
+          preparedWorkSessionKeys.delete(row.key);
+        }
+      }
+    },
+    retireConnection() {
+      rollback();
+      preparedWorkSessionKeys.clear();
+    },
+    dispose() {
+      pendingModelPatches.clear();
+      preparedWorkSessionKeys.clear();
+    },
+  };
+}

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -1,0 +1,316 @@
+import type {
+  SessionBranch,
+  SessionsBranchesListResult,
+  SessionsBranchesSwitchResult,
+  SessionsCompactionBranchResult,
+  SessionsCompactionListResult,
+  SessionsCompactionRestoreResult,
+  SessionsForkResult,
+  SessionsListResult,
+  SessionsPatchResult,
+  SessionsRewindResult,
+  SessionWorkspaceGetResult,
+  SessionWorkspaceListResult,
+  SessionWorkspaceSetResult,
+} from "../../api/types.ts";
+import type { SessionPatch } from "./patch.ts";
+import type {
+  SessionCompactResult,
+  SessionDeleteOptions,
+  SessionDeleteResponse,
+  SessionListOptions,
+  SessionRequestClient,
+  SessionResetOptions,
+  SessionSteerResult,
+} from "./session-capability.ts";
+
+/** Gateway rosters omit recency so Chat and Settings agree; the cap bounds list work. */
+export const DEFAULT_SESSION_LIST_QUERY = {
+  limit: 50,
+} as const satisfies SessionListOptions;
+
+const SESSION_LIST_PARAMS = {
+  includeGlobal: true,
+  includeUnknown: true,
+  configuredAgentsOnly: true,
+} as const;
+
+function buildSessionRequestParams(
+  key: string,
+  agentId?: string | null,
+): { key: string; agentId?: string } {
+  const normalizedKey = key.trim();
+  const normalizedAgentId = agentId?.trim();
+  return {
+    key: normalizedKey,
+    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
+  };
+}
+
+function buildTranscriptMutationParams(
+  sessionKey: string,
+  agentId?: string | null,
+): { sessionKey: string; agentId?: string } {
+  const normalizedSessionKey = sessionKey.trim();
+  const normalizedAgentId = agentId?.trim();
+  return {
+    sessionKey: normalizedSessionKey,
+    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
+  };
+}
+
+function buildSessionListParams(options: SessionListOptions = {}): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...SESSION_LIST_PARAMS };
+  if (options.limit === undefined) {
+    params.limit = DEFAULT_SESSION_LIST_QUERY.limit;
+  } else if (options.limit > 0) {
+    params.limit = Math.floor(options.limit);
+  }
+  if (options.includeGlobal !== undefined) {
+    params.includeGlobal = options.includeGlobal;
+  }
+  if (options.includeUnknown !== undefined) {
+    params.includeUnknown = options.includeUnknown;
+  }
+  if (options.configuredAgentsOnly !== undefined) {
+    params.configuredAgentsOnly = options.configuredAgentsOnly;
+  }
+  if (options.includeDerivedTitles === true) {
+    params.includeDerivedTitles = true;
+  }
+  if (options.archivedFilter === "archived") {
+    params.archived = true;
+  } else if (options.archivedFilter === "all") {
+    params.archived = "all";
+  }
+  const activeMinutes =
+    options.archivedFilter === "archived" || options.archivedFilter === "all"
+      ? 0
+      : typeof options.activeMinutes === "number" && options.activeMinutes > 0
+        ? Math.floor(options.activeMinutes)
+        : 0;
+  if (activeMinutes > 0) {
+    params.activeMinutes = activeMinutes;
+  }
+  const agentId = options.agentId?.trim();
+  const spawnedBy = options.spawnedBy?.trim();
+  const search = options.search?.trim();
+  const creatorId = options.creatorId?.trim();
+  if (options.boardFace) {
+    params.boardFace = options.boardFace;
+  }
+  if (agentId) {
+    params.agentId = agentId;
+  }
+  if (spawnedBy) {
+    params.spawnedBy = spawnedBy;
+  }
+  if (search) {
+    params.search = search;
+  }
+  if (creatorId) {
+    params.creatorId = creatorId;
+  }
+  if (typeof options.offset === "number" && options.offset > 0) {
+    params.offset = Math.floor(options.offset);
+  }
+  return params;
+}
+
+export async function requestSessionList(
+  client: SessionRequestClient,
+  options: SessionListOptions = {},
+): Promise<SessionsListResult | null> {
+  const result = await client.request<SessionsListResult | undefined>(
+    "sessions.list",
+    buildSessionListParams(options),
+  );
+  return result ?? null;
+}
+
+export function requestSessionPatch(
+  client: SessionRequestClient,
+  key: string,
+  patch: SessionPatch,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsPatchResult> {
+  return client.request<SessionsPatchResult>("sessions.patch", {
+    ...buildSessionRequestParams(key, options.agentId),
+    ...patch,
+  });
+}
+
+export function requestSessionDelete(
+  client: SessionRequestClient,
+  key: string,
+  options: SessionDeleteOptions = {},
+): Promise<SessionDeleteResponse> {
+  return client.request<SessionDeleteResponse>("sessions.delete", {
+    ...buildSessionRequestParams(key, options.agentId),
+    deleteTranscript: options.deleteTranscript ?? true,
+    ...(options.archivedOnly === true ? { archivedOnly: true } : {}),
+  });
+}
+
+export function confirmsSessionDeletion(response: SessionDeleteResponse): boolean {
+  // A successful RPC may be a lifecycle no-op; only confirmed deletion removes state.
+  return response.deleted;
+}
+
+export function requestSessionReset(
+  client: SessionRequestClient,
+  key: string,
+  options: SessionResetOptions = {},
+): Promise<void> {
+  return client
+    .request("sessions.reset", buildSessionRequestParams(key, options.agentId))
+    .then(() => undefined);
+}
+
+export function requestSessionCompact(
+  client: SessionRequestClient,
+  key: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionCompactResult> {
+  return client.request<SessionCompactResult>(
+    "sessions.compact",
+    buildSessionRequestParams(key, options.agentId),
+  );
+}
+
+export function requestSessionSteer(
+  client: SessionRequestClient,
+  key: string,
+  message: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionSteerResult> {
+  return client.request<SessionSteerResult>("sessions.steer", {
+    ...buildSessionRequestParams(key, options.agentId),
+    message,
+  });
+}
+
+export function requestSessionFilesList(
+  client: SessionRequestClient,
+  key: string,
+  options: { agentId?: string | null; path?: string; search?: string } = {},
+): Promise<SessionWorkspaceListResult | null> {
+  return client.request<SessionWorkspaceListResult | null>("sessions.files.list", {
+    sessionKey: key,
+    path: options.path ?? "",
+    search: options.search ?? "",
+    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
+  });
+}
+
+export function requestSessionFile(
+  client: SessionRequestClient,
+  key: string,
+  path: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionWorkspaceGetResult | null> {
+  return client.request<SessionWorkspaceGetResult | null>("sessions.files.get", {
+    sessionKey: key,
+    path,
+    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
+  });
+}
+
+export function requestSessionFileSet(
+  client: SessionRequestClient,
+  key: string,
+  path: string,
+  content: string,
+  options: { agentId?: string | null; expectedHash: string },
+): Promise<SessionWorkspaceSetResult | null> {
+  return client.request<SessionWorkspaceSetResult | null>("sessions.files.set", {
+    sessionKey: key,
+    path,
+    content,
+    expectedHash: options.expectedHash,
+    ...(options.agentId?.trim() ? { agentId: options.agentId.trim() } : {}),
+  });
+}
+
+export function requestSessionCheckpoints(
+  client: SessionRequestClient,
+  key: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsCompactionListResult> {
+  return client.request<SessionsCompactionListResult>(
+    "sessions.compaction.list",
+    buildSessionRequestParams(key, options.agentId),
+  );
+}
+
+export function requestSessionCheckpointBranch(
+  client: SessionRequestClient,
+  key: string,
+  checkpointId: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsCompactionBranchResult> {
+  return client.request<SessionsCompactionBranchResult>("sessions.compaction.branch", {
+    ...buildSessionRequestParams(key, options.agentId),
+    checkpointId,
+  });
+}
+
+export function requestSessionCheckpointRestore(
+  client: SessionRequestClient,
+  key: string,
+  checkpointId: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsCompactionRestoreResult> {
+  return client.request<SessionsCompactionRestoreResult>("sessions.compaction.restore", {
+    ...buildSessionRequestParams(key, options.agentId),
+    checkpointId,
+  });
+}
+
+export function requestSessionRewind(
+  client: SessionRequestClient,
+  key: string,
+  entryId: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsRewindResult> {
+  return client.request<SessionsRewindResult>("sessions.rewind", {
+    ...buildTranscriptMutationParams(key, options.agentId),
+    entryId,
+  });
+}
+
+export function requestSessionFork(
+  client: SessionRequestClient,
+  key: string,
+  entryId: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsForkResult> {
+  return client.request<SessionsForkResult>("sessions.fork", {
+    ...buildTranscriptMutationParams(key, options.agentId),
+    entryId,
+  });
+}
+
+export async function requestSessionBranches(
+  client: SessionRequestClient,
+  key: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionBranch[]> {
+  const result = await client.request<SessionsBranchesListResult>(
+    "sessions.branches.list",
+    buildTranscriptMutationParams(key, options.agentId),
+  );
+  return result.branches;
+}
+
+export function requestSessionBranchSwitch(
+  client: SessionRequestClient,
+  key: string,
+  leafEntryId: string,
+  options: { agentId?: string | null } = {},
+): Promise<SessionsBranchesSwitchResult> {
+  return client.request<SessionsBranchesSwitchResult>("sessions.branches.switch", {
+    ...buildTranscriptMutationParams(key, options.agentId),
+    leafEntryId,
+  });
+}

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,0 +1,315 @@
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
+import type {
+  SessionConnectionOwner,
+  SessionGateway,
+  SessionListOptions,
+  SessionRefreshOptions,
+  SessionState,
+} from "./session-capability.ts";
+import {
+  areUiSessionKeysEquivalent,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiSelectedGlobalAgentId,
+  uiSessionRowMatchesSelectedChat,
+} from "./session-key.ts";
+import { DEFAULT_SESSION_LIST_QUERY, requestSessionList } from "./session-requests.ts";
+
+type SessionRosterRefreshHost = {
+  connection: SessionConnectionOwner;
+  snapshot: () => SessionGateway["snapshot"];
+  readState: () => SessionState;
+  publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
+  observerError: () => string | null;
+  decorate: (result: SessionsListResult | null) => SessionsListResult | null;
+  onCanonicalList: (result: SessionsListResult | null) => void;
+};
+
+function appendSessionResults(
+  previous: SessionsListResult,
+  page: SessionsListResult,
+): SessionsListResult {
+  const seen = new Set<string>();
+  const sessions = [...previous.sessions, ...page.sessions].filter((row) => {
+    if (!row.key || seen.has(row.key)) {
+      return false;
+    }
+    seen.add(row.key);
+    return true;
+  });
+  const totalCount = page.totalCount ?? previous.totalCount;
+  const hasMore =
+    page.hasMore ??
+    (typeof totalCount === "number" && Number.isFinite(totalCount)
+      ? sessions.length < totalCount
+      : false);
+  return {
+    ...page,
+    count: sessions.length,
+    totalCount,
+    hasMore,
+    nextOffset: page.nextOffset ?? (hasMore ? sessions.length : null),
+    sessions,
+  };
+}
+
+export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
+  let inFlight: Promise<void> | null = null;
+  let queuedExplicitRefresh: SessionRefreshOptions | null = null;
+  let eventRefreshQueued = false;
+  let lastListOptions: SessionListOptions = {};
+  let hasForegroundListOptions = false;
+  let hasSeededListOptions = false;
+
+  const list = async (options: SessionListOptions = {}): Promise<SessionsListResult | null> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    const result = await requestSessionList(scope.client, options);
+    return host.connection.isCurrent(scope) ? host.decorate(result ?? null) : null;
+  };
+
+  const load = async (options: SessionRefreshOptions) => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return;
+    }
+    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
+    const durableListOptions: SessionListOptions = { ...requestOptions };
+    // Pagination is request-local; replacements retain filters but restart at page one.
+    delete durableListOptions.offset;
+    if (!backgroundHydrate) {
+      lastListOptions = durableListOptions;
+      hasForegroundListOptions = true;
+    } else if (!hasForegroundListOptions && !hasSeededListOptions) {
+      lastListOptions = durableListOptions;
+      hasSeededListOptions = true;
+    }
+    if (!backgroundHydrate) {
+      const error = host.observerError();
+      host.publish(
+        { ...host.readState(), loading: true, error, deletedSessions: [] },
+        error ? "session-observer" : undefined,
+      );
+    }
+    try {
+      const result = await requestSessionList(scope.client, requestOptions);
+      if (!host.connection.isCurrent(scope)) {
+        return;
+      }
+      const currentState = host.readState();
+      let nextResult =
+        result && append && requestOptions.offset && currentState.result
+          ? appendSessionResults(currentState.result, result)
+          : result;
+      if (append && nextResult && !backgroundHydrate) {
+        // Canonical event refreshes must retain all previously appended visible pages.
+        lastListOptions = {
+          ...durableListOptions,
+          limit: Math.max(
+            durableListOptions.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
+            nextResult.sessions.length,
+          ),
+        };
+      }
+      if (backgroundHydrate && nextResult) {
+        const snapshot = host.snapshot();
+        const currentKey = snapshot.sessionKey?.trim();
+        if (currentKey) {
+          const currentAgentId = normalizeAgentId(
+            parseAgentSessionKey(currentKey)?.agentId ?? resolveUiSelectedGlobalAgentId(snapshot),
+          );
+          const previousCurrentRow =
+            currentState.result?.sessions.find((row) =>
+              areUiSessionKeysEquivalent(row.key, currentKey),
+            ) ??
+            (currentState.agentId === currentAgentId
+              ? currentState.result?.sessions.find((row) =>
+                  uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
+                )
+              : undefined);
+          if (
+            previousCurrentRow &&
+            !nextResult.sessions.some((row) =>
+              uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
+            )
+          ) {
+            const sessions = [...nextResult.sessions, previousCurrentRow];
+            nextResult = { ...nextResult, count: sessions.length, sessions };
+          }
+        }
+      }
+      nextResult = host.decorate(nextResult);
+      host.onCanonicalList(nextResult);
+      const state = host.readState();
+      const error = host.observerError();
+      host.publish(
+        {
+          result: nextResult,
+          agentId: requestOptions.agentId?.trim() ? normalizeAgentId(requestOptions.agentId) : null,
+          modelOverrides: state.modelOverrides,
+          loading: backgroundHydrate ? state.loading : false,
+          error,
+          deletedSessions: [],
+          groups: state.groups,
+          sectionOrder: state.sectionOrder,
+        },
+        error ? "session-observer" : undefined,
+      );
+    } catch (error) {
+      if (host.connection.isCurrent(scope)) {
+        const state = host.readState();
+        host.publish(
+          {
+            ...state,
+            loading: backgroundHydrate ? state.loading : false,
+            error: String(error),
+            deletedSessions: [],
+          },
+          "operation",
+        );
+      }
+    }
+  };
+
+  const absorbPendingEventRefresh = () => {
+    eventRefreshCoordinator.absorb();
+    eventRefreshQueued = false;
+  };
+
+  const takeNextQueuedRefresh = (): SessionRefreshOptions | null => {
+    const explicitRefresh = queuedExplicitRefresh;
+    queuedExplicitRefresh = null;
+    if (explicitRefresh) {
+      // Replacement absorbs earlier events; append still needs its trailing replacement.
+      if (explicitRefresh.append !== true) {
+        absorbPendingEventRefresh();
+      }
+      return explicitRefresh;
+    }
+    if (!eventRefreshQueued) {
+      return null;
+    }
+    eventRefreshQueued = false;
+    return { ...lastListOptions, force: true };
+  };
+
+  const drainRefreshQueue = async (options: SessionRefreshOptions) => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return;
+    }
+    let next: SessionRefreshOptions | null = options;
+    while (next) {
+      await load(next);
+      if (!host.connection.isCurrent(scope)) {
+        return;
+      }
+      next = takeNextQueuedRefresh();
+    }
+  };
+
+  const startRefresh = (options: SessionRefreshOptions) => {
+    const request = drainRefreshQueue(options).finally(() => {
+      if (inFlight === request) {
+        inFlight = null;
+      }
+    });
+    inFlight = request;
+    return request;
+  };
+
+  const refresh = (options: SessionRefreshOptions = {}): Promise<void> => {
+    if (!host.connection.capture()) {
+      return Promise.resolve();
+    }
+    if (inFlight) {
+      queuedExplicitRefresh = options;
+      return inFlight;
+    }
+    const hasListOverrides = Object.entries(options).some(
+      ([key, value]) => key !== "force" && key !== "backgroundHydrate" && value !== undefined,
+    );
+    if (host.readState().result && !options.force && !hasListOverrides) {
+      return Promise.resolve();
+    }
+    if (options.append !== true) {
+      absorbPendingEventRefresh();
+    }
+    return startRefresh(options);
+  };
+
+  const refreshFromEvent = () => {
+    if (!host.connection.capture()) {
+      return Promise.resolve();
+    }
+    if (inFlight) {
+      eventRefreshQueued = true;
+      return inFlight;
+    }
+    return startRefresh({ ...lastListOptions, force: true });
+  };
+
+  const eventRefreshCoordinator = createSessionEventRefreshCoordinator({
+    canRefresh: () => host.connection.capture() !== null,
+    refresh: refreshFromEvent,
+  });
+  const flushEventRefresh = () => eventRefreshCoordinator.flush();
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      flushEventRefresh();
+    }
+  };
+  const observesPageLifecycle =
+    typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
+  if (observesPageLifecycle) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    globalThis.addEventListener("pagehide", flushEventRefresh);
+  }
+
+  const refreshReplacement = (agentId?: string | null): Promise<void> => {
+    const options = {
+      ...lastListOptions,
+      includeDerivedTitles: lastListOptions.includeDerivedTitles ?? true,
+    };
+    const normalizedAgentId = agentId?.trim();
+    if (normalizedAgentId) {
+      options.agentId = normalizedAgentId;
+    }
+    return refresh({ ...options, force: true });
+  };
+
+  return {
+    list,
+    refresh,
+    refreshReplacement,
+    setCreatorFilter(creatorId: string | null) {
+      const options = { ...lastListOptions, creatorId: creatorId?.trim() || undefined };
+      delete options.offset;
+      return refresh({ ...options, force: true });
+    },
+    lastOptions: () => lastListOptions,
+    scheduleEvent: () => eventRefreshCoordinator.schedule(),
+    reset() {
+      eventRefreshCoordinator.reset();
+      inFlight = null;
+      queuedExplicitRefresh = null;
+      eventRefreshQueued = false;
+    },
+    dispose() {
+      // Flush before disposal so page-exit events start the trailing canonical list.
+      flushEventRefresh();
+      eventRefreshCoordinator.dispose();
+      if (observesPageLifecycle) {
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+        globalThis.removeEventListener("pagehide", flushEventRefresh);
+      }
+      inFlight = null;
+      queuedExplicitRefresh = null;
+      eventRefreshQueued = false;
+    },
+  };
+}

--- a/ui/src/lib/sessions/session-scoped-operations.ts
+++ b/ui/src/lib/sessions/session-scoped-operations.ts
@@ -1,0 +1,301 @@
+import {
+  getGatewaySessionMessageSubscriptionCoordinator,
+  releaseGatewaySessionMessageSubscription,
+  resetGatewaySessionMessageSubscriptionCoordinator,
+} from "@openclaw/gateway-client/browser";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type {
+  SessionBranch,
+  SessionCompactionCheckpoint,
+  SessionsBranchesSwitchResult,
+  SessionsCompactionBranchResult,
+  SessionsCompactionRestoreResult,
+  SessionsForkResult,
+  SessionsRewindResult,
+  SessionWorkspaceGetResult,
+  SessionWorkspaceListResult,
+  SessionWorkspaceSetResult,
+} from "../../api/types.ts";
+import type {
+  SessionCompactResult,
+  SessionConnectionOwner,
+  SessionConnectionScope,
+  SessionMessageSubscription,
+  SessionSteerResult,
+} from "./session-capability.ts";
+import {
+  areUiSessionKeysEquivalent,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+} from "./session-key.ts";
+import {
+  requestSessionBranchSwitch,
+  requestSessionBranches,
+  requestSessionCheckpointBranch,
+  requestSessionCheckpointRestore,
+  requestSessionCheckpoints,
+  requestSessionCompact,
+  requestSessionFile,
+  requestSessionFilesList,
+  requestSessionFileSet,
+  requestSessionFork,
+  requestSessionRewind,
+  requestSessionSteer,
+} from "./session-requests.ts";
+
+type SessionScopedOperationsHost = {
+  connection: SessionConnectionOwner;
+  agentId: () => string | null;
+  refreshReplacement: (agentId?: string | null) => Promise<void>;
+};
+
+export function createSessionScopedOperations(host: SessionScopedOperationsHost) {
+  const ownedSubscriptions = new Set<SessionMessageSubscription>();
+
+  const compact = async (
+    key: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionCompactResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session compaction requires an active Gateway connection");
+    }
+    const result = await requestSessionCompact(scope.client, key, options);
+    if (!host.connection.isCurrent(scope)) {
+      throw new Error("Session compaction completed on a replaced Gateway connection");
+    }
+    return result;
+  };
+
+  const steer = async (
+    key: string,
+    message: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionSteerResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session steering requires an active Gateway connection");
+    }
+    const result = await requestSessionSteer(scope.client, key, message, options);
+    if (!host.connection.isCurrent(scope)) {
+      throw new Error("Session steering completed on a replaced Gateway connection");
+    }
+    return result;
+  };
+
+  const listFiles = async (
+    key: string,
+    options: { agentId?: string | null; path?: string; search?: string } = {},
+  ): Promise<SessionWorkspaceListResult | null> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    const result = await requestSessionFilesList(scope.client, key, options);
+    return host.connection.isCurrent(scope) ? result : null;
+  };
+
+  const getFile = async (
+    key: string,
+    path: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionWorkspaceGetResult | null> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    const result = await requestSessionFile(scope.client, key, path, options);
+    return host.connection.isCurrent(scope) ? result : null;
+  };
+
+  const setFile = async (
+    key: string,
+    path: string,
+    content: string,
+    options: { agentId?: string | null; expectedHash: string },
+  ): Promise<SessionWorkspaceSetResult | null> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return null;
+    }
+    const result = await requestSessionFileSet(scope.client, key, path, content, options);
+    return host.connection.isCurrent(scope) ? result : null;
+  };
+
+  const unsubscribeMessages = async (subscription: SessionMessageSubscription): Promise<void> => {
+    await releaseGatewaySessionMessageSubscription(subscription);
+    ownedSubscriptions.delete(subscription);
+  };
+
+  const subscribeMessages = async (
+    key: string,
+    options: { agentId?: string | null; includeApprovals?: boolean } = {},
+  ): Promise<SessionMessageSubscription> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session message subscription requires an active Gateway connection");
+    }
+    const normalizedKey = key.trim();
+    const agentId =
+      isUiGlobalSessionKey(normalizedKey) && options.agentId?.trim()
+        ? normalizeAgentId(options.agentId)
+        : null;
+    const subscription = await getGatewaySessionMessageSubscriptionCoordinator(scope.client, {
+      keysEquivalent: areUiSessionKeysEquivalent,
+    }).acquire(normalizedKey, {
+      agentId,
+      ...(options.includeApprovals ? { includeApprovals: true } : {}),
+    });
+    ownedSubscriptions.add(subscription);
+    if (!host.connection.isCurrent(scope)) {
+      await unsubscribeMessages(subscription).catch(() => undefined);
+      throw new Error("Session message subscription completed on a replaced Gateway connection");
+    }
+    return subscription;
+  };
+
+  const listCheckpoints = async (
+    key: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionCompactionCheckpoint[]> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return [];
+    }
+    const result = await requestSessionCheckpoints(scope.client, key, options);
+    return host.connection.isCurrent(scope) ? (result.checkpoints ?? []) : [];
+  };
+
+  const checkpointMutation = async <T>(
+    key: string,
+    checkpointId: string,
+    options: { agentId?: string | null },
+    request: (
+      client: GatewayBrowserClient,
+      key: string,
+      checkpointId: string,
+      options: { agentId?: string | null },
+    ) => Promise<T>,
+  ): Promise<T> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session checkpoint operation requires an active Gateway connection");
+    }
+    const result = await request(scope.client, key, checkpointId, options);
+    if (!host.connection.isCurrent(scope)) {
+      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
+    }
+    await host.refreshReplacement(options.agentId ?? host.agentId() ?? undefined);
+    if (!host.connection.isCurrent(scope)) {
+      throw new Error("Session checkpoint operation completed on a replaced Gateway connection");
+    }
+    return result;
+  };
+
+  const branchCheckpoint = (
+    key: string,
+    checkpointId: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionsCompactionBranchResult> =>
+    checkpointMutation(key, checkpointId, options, requestSessionCheckpointBranch);
+
+  const restoreCheckpoint = (
+    key: string,
+    checkpointId: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionsCompactionRestoreResult> =>
+    checkpointMutation(key, checkpointId, options, requestSessionCheckpointRestore);
+
+  const reconcileCommittedMutation = async (
+    scope: SessionConnectionScope,
+    agentId?: string | null,
+  ) => {
+    // The gateway response commits destructive work; refresh is connection-scoped
+    // best effort and must never turn that commit into uncertainty or a retry.
+    if (host.connection.isCurrent(scope)) {
+      await host.refreshReplacement(agentId ?? host.agentId() ?? undefined).catch(() => {});
+    }
+  };
+
+  const rewind = async (
+    key: string,
+    entryId: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionsRewindResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session rewind requires an active Gateway connection");
+    }
+    const result = await requestSessionRewind(scope.client, key, entryId, options);
+    await reconcileCommittedMutation(scope, options.agentId);
+    return result;
+  };
+
+  const forkAtMessage = async (
+    key: string,
+    entryId: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionsForkResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session fork requires an active Gateway connection");
+    }
+    const result = await requestSessionFork(scope.client, key, entryId, options);
+    await reconcileCommittedMutation(scope, options.agentId);
+    return result;
+  };
+
+  const listBranches = async (
+    key: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionBranch[]> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      return [];
+    }
+    const branches = await requestSessionBranches(scope.client, key, options);
+    return host.connection.isCurrent(scope) ? branches : [];
+  };
+
+  const switchBranch = async (
+    key: string,
+    leafEntryId: string,
+    options: { agentId?: string | null } = {},
+  ): Promise<SessionsBranchesSwitchResult> => {
+    const scope = host.connection.capture();
+    if (!scope) {
+      throw new Error("Session branch switch requires an active Gateway connection");
+    }
+    const result = await requestSessionBranchSwitch(scope.client, key, leafEntryId, options);
+    await reconcileCommittedMutation(scope, options.agentId);
+    return result;
+  };
+
+  return {
+    branchCheckpoint,
+    compact,
+    forkAtMessage,
+    getFile,
+    listBranches,
+    listCheckpoints,
+    listFiles,
+    restoreCheckpoint,
+    rewind,
+    setFile,
+    steer,
+    subscribeMessages,
+    switchBranch,
+    unsubscribeMessages,
+    retireConnection(previousClient: GatewayBrowserClient | null) {
+      if (previousClient) {
+        resetGatewaySessionMessageSubscriptionCoordinator(previousClient);
+      }
+      ownedSubscriptions.clear();
+    },
+    dispose() {
+      for (const subscription of ownedSubscriptions) {
+        void unsubscribeMessages(subscription).catch(() => undefined);
+      }
+    },
+  };
+}

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -7,6 +7,7 @@ import {
 } from "../../app/question-prompt.ts";
 import { loadSettings } from "../../app/settings.ts";
 import { readPresenceEntries } from "../../app/user-profile.ts";
+import { createGatewayConnectionLifecycle } from "../../lib/gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey } from "../../lib/sessions/index.ts";
@@ -41,6 +42,14 @@ import { normalizeSidebarLayout } from "./sidebar-layout.ts";
 import { reconcileWaitingApprovalsFromSnapshot } from "./tool-stream.ts";
 
 export abstract class ChatPaneContext extends ChatPaneLifecycle {
+  private gatewayConnectionLifecycle?: ReturnType<typeof createGatewayConnectionLifecycle>;
+
+  override disconnectedCallback() {
+    this.gatewayConnectionLifecycle?.dispose();
+    this.gatewayConnectionLifecycle = undefined;
+    super.disconnectedCallback();
+  }
+
   protected applySessionsState(stateValue: ApplicationContext["sessions"]["state"]) {
     const state = this.state;
     if (!state) {
@@ -160,8 +169,12 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     const previousMediaAuthToken = resolveAssistantAttachmentAuthToken(state);
     const wasConnected = state.connected;
     const previousSidebarSessionKey = canonicalUiSessionKeyForPersistence(state, state.sessionKey);
-    const sourceChanged =
-      state.client !== snapshot.client || wasConnected !== (snapshot.phase === "connected");
+    const connectionLifecycle = (this.gatewayConnectionLifecycle ??=
+      createGatewayConnectionLifecycle({
+        client: state.client,
+        phase: state.connected ? "connected" : "stopped",
+      }));
+    const sourceChanged = connectionLifecycle.transition(snapshot);
     const clientChanged = this.connectedClient !== snapshot.client;
     if (snapshot.phase !== "connected") {
       this.presencePayload = undefined;

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -814,6 +814,41 @@ describe("chat pane connection lifecycle", () => {
     expect(state.realtimeTalkCameraError).toBe(false);
   });
 
+  it("advances session ownership once per same-client connection transition", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const initialGeneration = pane.connectionGeneration;
+    const snapshot = { ...pane.context.gateway.snapshot, client };
+
+    state.chatLoading = true;
+    pane.applyGatewaySnapshot({ ...snapshot, phase: "reconnecting", hello: null });
+
+    expect(pane.connectionGeneration).toBe(initialGeneration + 1);
+    expect(state.connectionEpoch).toBe(initialGeneration + 1);
+    expect(state.chatLoading).toBe(false);
+
+    state.chatLoading = true;
+    pane.applyGatewaySnapshot({ ...snapshot, phase: "reconnecting", hello: null });
+
+    expect(pane.connectionGeneration).toBe(initialGeneration + 1);
+    expect(state.connectionEpoch).toBe(initialGeneration + 1);
+    expect(state.chatLoading).toBe(true);
+
+    pane.connectedClient = client;
+    pane.applyGatewaySnapshot({ ...snapshot, phase: "connected" });
+
+    expect(pane.connectionGeneration).toBe(initialGeneration + 2);
+    expect(state.connectionEpoch).toBe(initialGeneration + 2);
+    expect(state.chatLoading).toBe(false);
+
+    state.chatLoading = true;
+    pane.applyGatewaySnapshot({ ...snapshot, phase: "connected" });
+
+    expect(pane.connectionGeneration).toBe(initialGeneration + 2);
+    expect(state.connectionEpoch).toBe(initialGeneration + 2);
+    expect(state.chatLoading).toBe(true);
+  });
+
   it("rehydrates secondary session state after a same-client logical reconnect", () => {
     const client = {
       request: vi.fn(() => new Promise<never>(() => {})),

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -270,15 +270,16 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
     return;
   }
   const client = host.client;
+  const connectionEpoch = host.connectionEpoch;
   try {
     const result = await loadModelAuthStatus(client, opts);
-    if (host.client !== client || !host.connected) {
+    if (host.client !== client || !host.connected || host.connectionEpoch !== connectionEpoch) {
       return;
     }
     host.modelAuthStatusResult = result;
     host.modelAuthStatusError = null;
   } catch (err) {
-    if (host.client !== client || !host.connected) {
+    if (host.client !== client || !host.connected || host.connectionEpoch !== connectionEpoch) {
       return;
     }
     host.modelAuthStatusResult = { ts: 0, providers: [] };

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -22,7 +22,11 @@ import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
-import { invalidateChatMetadataCache, refreshChatMetadata } from "./chat-state-refresh.ts";
+import {
+  invalidateChatMetadataCache,
+  refreshChatMetadata,
+  refreshChatModelAuthStatus,
+} from "./chat-state-refresh.ts";
 import {
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
@@ -2551,5 +2555,45 @@ describe("refreshChatMetadata", () => {
     expect(SLASH_COMMANDS.some((command) => command.name === "other-command")).toBe(true);
     expect(SLASH_COMMANDS.some((command) => command.name === "work-command")).toBe(false);
   });
+});
+
+describe("refreshChatModelAuthStatus", () => {
+  it.each(["success", "failure"] as const)(
+    "ignores a stale auth status %s after reconnecting the same client",
+    async (outcome) => {
+      let resolveStatus!: (value: { ts: number; providers: never[] }) => void;
+      let rejectStatus!: (error: unknown) => void;
+      const response = new Promise<{ ts: number; providers: never[] }>((resolve, reject) => {
+        resolveStatus = resolve;
+        rejectStatus = reject;
+      });
+      const request = vi.fn(() => response);
+      const currentStatus = { ts: 2, providers: [] };
+      const state = {
+        client: { request },
+        connected: true,
+        connectionEpoch: 1,
+        modelAuthStatusResult: currentStatus,
+        modelAuthStatusError: null,
+      } as unknown as ChatPageHost;
+
+      const refresh = refreshChatModelAuthStatus(state);
+      state.connected = false;
+      state.connectionEpoch += 1;
+      state.connected = true;
+      state.connectionEpoch += 1;
+
+      if (outcome === "success") {
+        resolveStatus({ ts: 1, providers: [] });
+      } else {
+        rejectStatus(new Error("stale connection auth status"));
+      }
+      await refresh;
+
+      expect(state.modelAuthStatusResult).toBe(currentStatus);
+      expect(state.modelAuthStatusError).toBeNull();
+      expect(request).toHaveBeenCalledOnce();
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -467,6 +467,50 @@ describe("gateway-backed session route resolution", () => {
     expect(list).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      connectionChange: "gateway client replacement",
+      replaceConnection: (snapshot: ApplicationContext["gateway"]["snapshot"]) => {
+        snapshot.client = {} as NonNullable<typeof snapshot.client>;
+      },
+    },
+    {
+      connectionChange: "hello replacement on the same gateway client",
+      replaceConnection: (snapshot: ApplicationContext["gateway"]["snapshot"]) => {
+        snapshot.hello = {
+          snapshot: { sessionDefaults: { mainKey: "main" } },
+        } as NonNullable<typeof snapshot.hello>;
+      },
+    },
+  ])("does not trust a carried session after $connectionChange", async ({ replaceConnection }) => {
+    const oldSession = row({
+      key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001",
+      displayName: "Deploy monitor",
+    });
+    const currentSession = row({
+      key: "agent:roboclaw:thread:12345678-0bbb-4000-8000-000000000002",
+      displayName: "Deploy monitor",
+    });
+    const { context, list } = contextFor(() => result([currentSession]));
+    context.gateway.snapshot.hello = {
+      snapshot: { sessionDefaults: { mainKey: "main" } },
+    } as NonNullable<typeof context.gateway.snapshot.hello>;
+    const pathname = "/chat/roboclaw/deploy-monitor-12345678";
+
+    prepareSessionNavigationHandoff(context.gateway, pathname, oldSession.key);
+    replaceConnection(context.gateway.snapshot);
+
+    const loaded = await loadChatRoute(
+      context,
+      { pathname, search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: currentSession.key });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
   it("prefers the current location key over a residual colliding handoff", async () => {
     const current = row({
       key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001",

--- a/ui/src/pages/nodes/nodes-page.test.ts
+++ b/ui/src/pages/nodes/nodes-page.test.ts
@@ -26,6 +26,7 @@ type TestNodesPage = HTMLElement & {
     hostUpdate: () => void;
     hostDisconnected: () => void;
   };
+  disconnectedCallback: () => void;
   willUpdate: (changed: Map<PropertyKey, unknown>) => void;
   applyGatewaySnapshot: (
     snapshot: ApplicationGatewaySnapshot,
@@ -164,6 +165,72 @@ describe("NodesPage gateway lifecycle", () => {
     await currentLoad;
     expect(page.nodes).toEqual([{ id: "new" }]);
     expect(page.nodesLoading).toBe(false);
+
+    page.applyGatewaySnapshot(gatewaySnapshot(client, false), false);
+  });
+
+  it("retires an in-flight load when its gateway provider changes without a client change", async () => {
+    const first = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const second = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const request = vi
+      .fn<(method: string, params?: unknown) => Promise<unknown>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const snapshot = gatewaySnapshot(client, true);
+    const page = document.createElement("openclaw-nodes-page") as TestNodesPage;
+    page.context = {
+      runtimeConfig: { state: { configSnapshot: null, configLoading: false } },
+    } as unknown as ApplicationContext;
+    page.applyGatewaySnapshot(snapshot, false);
+
+    const staleLoad = loadNodes(page);
+    const previousGeneration = page.requestGeneration;
+    page.applyGatewaySnapshot(snapshot, true);
+    const currentLoad = loadNodes(page);
+
+    expect(page.requestGeneration).toBeGreaterThan(previousGeneration);
+    first.resolve({ nodes: [{ id: "old" }] });
+    await staleLoad;
+    expect(page.nodes).toEqual([]);
+    expect(page.nodesLoading).toBe(true);
+
+    second.resolve({ nodes: [{ id: "new" }] });
+    await currentLoad;
+    expect(page.nodes).toEqual([{ id: "new" }]);
+    expect(page.nodesLoading).toBe(false);
+
+    page.applyGatewaySnapshot(gatewaySnapshot(client, false), false);
+  });
+
+  it("restores request ownership when a disconnected page reconnects", async () => {
+    const first = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const second = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const request = vi
+      .fn<(method: string, params?: unknown) => Promise<unknown>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const snapshot = gatewaySnapshot(client, true);
+    const page = document.createElement("openclaw-nodes-page") as TestNodesPage;
+    page.context = {
+      runtimeConfig: { state: { configSnapshot: null, configLoading: false } },
+    } as unknown as ApplicationContext;
+    page.applyGatewaySnapshot(snapshot, false);
+
+    const staleLoad = loadNodes(page);
+    page.disconnectedCallback();
+    page.applyGatewaySnapshot(snapshot, false);
+    const currentLoad = loadNodes(page);
+
+    first.resolve({ nodes: [{ id: "old" }] });
+    await staleLoad;
+    expect(page.nodes).toEqual([]);
+    expect(page.nodesLoading).toBe(true);
+
+    second.resolve({ nodes: [{ id: "new" }] });
+    await currentLoad;
+    expect(page.nodes).toEqual([{ id: "new" }]);
 
     page.applyGatewaySnapshot(gatewaySnapshot(client, false), false);
   });

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -14,6 +14,7 @@ import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { currentConfigObject } from "../../lib/config/index.ts";
+import { createGatewayConnectionLifecycle } from "../../lib/gateway-connection-lifecycle.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import {
   approveDevicePairing,
@@ -80,7 +81,6 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
 
   @state() client: NodesPageDataState["client"] = null;
   @state() connected = false;
-  requestGeneration = 0;
   @state() nodesLoading = false;
   @state() nodes: Array<Record<string, unknown>> = [];
   @state() presence: PresenceEntry[] = [];
@@ -103,6 +103,10 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   private routeDataInitialized = false;
   private hasBoundGateway = false;
   private gatewaySource: ApplicationContext["gateway"] | null = null;
+  private readonly connectionLifecycle = createGatewayConnectionLifecycle({
+    client: null,
+    phase: "stopped",
+  });
   private readonly presenceTask = new Task(this, {
     autoRun: false,
     // Gateway identity invalidates same-client reconnects and source replacements.
@@ -199,8 +203,8 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   }
 
   override disconnectedCallback() {
+    this.connectionLifecycle.transition({ client: null, phase: "stopped" });
     this.subscriptions.clear();
-    this.requestGeneration += 1;
     void this.presenceTask.run([null, null]);
     this.client = null;
     this.connected = false;
@@ -210,6 +214,10 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     super.disconnectedCallback();
   }
 
+  get requestGeneration(): number {
+    return this.connectionLifecycle.epoch;
+  }
+
   private applyGatewaySnapshot(
     snapshot: ApplicationGatewaySnapshot,
     forceReset: boolean,
@@ -217,8 +225,10 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   ) {
     const clientChanged = this.client !== snapshot.client;
     const connectionChanged = this.connected !== (snapshot.phase === "connected");
-    if (forceReset || clientChanged || connectionChanged || snapshot.phase !== "connected") {
-      this.requestGeneration += 1;
+    const lifecycleChanged = this.connectionLifecycle.transition(snapshot);
+    if (forceReset && !lifecycleChanged) {
+      // Provider ownership can change while its client and phase stay identical.
+      this.connectionLifecycle.invalidate();
     }
     this.syncGatewayState(snapshot);
     if (forceReset || (!initialBind && (clientChanged || snapshot.phase !== "connected"))) {
@@ -253,6 +263,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     this.routeDataInitialized = true;
     const gateway = this.context.gateway;
     const snapshot = gateway.snapshot;
+    this.connectionLifecycle.transition(snapshot);
     if (data.gateway !== gateway || data.gatewaySnapshot !== snapshot) {
       this.resetServerState(snapshot);
       this.presence = readPresence(snapshot.hello?.snapshot) ?? [];


### PR DESCRIPTION
## What Problem This Solves

Control UI sessions, chat panes, agents, and nodes could retain stale asynchronous work across gateway reconnects or client replacement, while the application shell and session capability had grown beyond 2,000 lines each. That made reconnect behavior harder to reason about, left agent-file loading indicators stuck after disconnect, and allowed obsolete authentication or navigation handoffs to overwrite current connection state.

## Why This Change Was Made

Establish one shared connection-epoch ownership contract and one shared retry owner, then split the oversized session and application-shell modules into focused owners with explicit, compiler-checked boundaries. Session observation, roster refresh, navigation, rendering, shell chrome, gateway synchronization, and workboard lifecycle retain their existing product contracts while rejecting work from retired connections.

## User Impact

Sessions stay visible and correctly selected while the gateway reconnects, even when users rapidly switch chats. Agent-file loading state clears reliably after disconnect, stale authentication responses cannot overwrite the new connection, and navigation cannot consume a handoff from a retired gateway connection.

## Evidence

- Complete remote Control UI regression suite: **7,624 tests passed across 521 test files**.
- Focused owner regression run: **324 tests passed across 23 Control UI owner test files**.
- Real Chromium coverage: **27 browser tests passed across four end-to-end suites**, including rapid A→B→A reconnect navigation, one acknowledged observer per connection, selected-route preservation, and refreshed sidebar content.
- Both previously grandfathered oversized modules now meet the normal 700-line limit: application shell **2,331 → 601 lines**; session owner **2,101 → 478 lines**. Their max-lines baseline exemptions were removed.
- Fresh independent structured architecture review: **no accepted or actionable findings**.
- Remote validation passed the complete changed-code/type/lint gate, full production build, plugin SDK export checks, finalized UI asset checks, and Control UI startup-performance budgets.
