### PR TITLE
refactor(approvals): share secure reaction binding validation across messaging channels

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -127,7 +127,6 @@ extensions/google/transport-stream.ts
 extensions/imessage/src/actions.test.ts
 extensions/imessage/src/actions.ts
 extensions/imessage/src/approval-reactions.test.ts
-extensions/imessage/src/approval-reactions.ts
 extensions/imessage/src/monitor.last-route.test.ts
 extensions/imessage/src/monitor/inbound-processing.ts
 extensions/imessage/src/monitor/monitor-provider.ts

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -2,12 +2,18 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import {
   addApprovalReactionHintToText,
+  approvalReactionDecisionSetsMatch,
   buildApprovalReactionHint,
   createApprovalReactionTargetStore,
+  extractApprovalReactionPromptBinding,
   hasApprovalReactionHintText,
   listApprovalReactionBindings,
+  normalizeApprovalReactionDecision,
+  readApprovalReactionDeliveredBinding,
+  readApprovalReactionPresentationBinding,
   resolveTypedApprovalReactionTarget,
   type ApprovalReactionDecisionBinding,
+  type ApprovalReactionDeliveryBinding,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -184,7 +190,7 @@ function readPersistedTarget(value: unknown): IMessageApprovalReactionTarget | n
   }
   const allowedDecisions = target.allowedDecisions
     .map((valueValue) =>
-      typeof valueValue === "string" ? normalizeApprovalDecision(valueValue) : null,
+      typeof valueValue === "string" ? normalizeApprovalReactionDecision(valueValue) : null,
     )
     .filter((valueLocal): valueLocal is ExecApprovalReplyDecision => Boolean(valueLocal));
   if (allowedDecisions.length === 0) {
@@ -240,99 +246,11 @@ export function appendIMessageApprovalReactionHintForOutboundMessage(text: strin
   });
 }
 
-type IMessageApprovalDeliveryBinding = {
-  approvalId: string;
+type IMessageApprovalDeliveryBinding = ApprovalReactionDeliveryBinding & {
   approvalSlug: string;
-  approvalKind: "exec" | "plugin";
-  allowedDecisions: ExecApprovalReplyDecision[];
 };
 
 const IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY = "imessageApprovalReactionBindingV1";
-
-function readStrictDecisionList(value: unknown): ExecApprovalReplyDecision[] | null {
-  if (!Array.isArray(value) || value.length === 0) {
-    return null;
-  }
-  const decisions: ExecApprovalReplyDecision[] = [];
-  for (const entry of value) {
-    if (entry !== "allow-once" && entry !== "allow-always" && entry !== "deny") {
-      return null;
-    }
-    if (decisions.includes(entry)) {
-      return null;
-    }
-    decisions.push(entry);
-  }
-  return decisions;
-}
-
-function decisionSetsMatch(
-  left: readonly ExecApprovalReplyDecision[],
-  right: readonly ExecApprovalReplyDecision[],
-): boolean {
-  return left.length === right.length && left.every((decision) => right.includes(decision));
-}
-
-function readStrictApprovalMetadata(payload: ReplyPayload): IMessageApprovalDeliveryBinding | null {
-  const value = payload.channelData?.execApproval;
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  const approvalId = typeof record.approvalId === "string" ? record.approvalId.trim() : "";
-  const approvalSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
-  const approvalKind = record.approvalKind;
-  const allowedDecisions = readStrictDecisionList(record.allowedDecisions);
-  if (
-    !approvalId ||
-    !approvalSlug ||
-    (approvalKind !== "exec" && approvalKind !== "plugin") ||
-    !allowedDecisions
-  ) {
-    return null;
-  }
-  return { approvalId, approvalSlug, approvalKind, allowedDecisions };
-}
-
-function bindingsMatch(
-  left: IMessageApprovalDeliveryBinding,
-  right: IMessageApprovalDeliveryBinding,
-): boolean {
-  return (
-    left.approvalId === right.approvalId &&
-    left.approvalSlug === right.approvalSlug &&
-    left.approvalKind === right.approvalKind &&
-    decisionSetsMatch(left.allowedDecisions, right.allowedDecisions)
-  );
-}
-
-function readTypedApprovalPresentationBinding(
-  payload: ReplyPayload,
-): IMessageApprovalDeliveryBinding | null {
-  const metadata = readStrictApprovalMetadata(payload);
-  if (!metadata) {
-    return null;
-  }
-  const approvalActions = (payload.presentation?.blocks ?? [])
-    .flatMap((block) => (block.type === "buttons" ? block.buttons : []))
-    .map((button) => button.action)
-    .filter((action) => action?.type === "approval");
-  if (approvalActions.length === 0) {
-    return null;
-  }
-  const allowedDecisions: ExecApprovalReplyDecision[] = [];
-  for (const action of approvalActions) {
-    if (
-      action.approvalId !== metadata.approvalId ||
-      action.approvalKind !== metadata.approvalKind ||
-      allowedDecisions.includes(action.decision)
-    ) {
-      return null;
-    }
-    allowedDecisions.push(action.decision);
-  }
-  return decisionSetsMatch(metadata.allowedDecisions, allowedDecisions) ? metadata : null;
-}
 
 function visibleApprovalBindingMatches(
   text: string | undefined,
@@ -371,13 +289,13 @@ function visibleApprovalBindingMatches(
       continue;
     }
     for (const token of decisionsText.split(/[\s|,]+/)) {
-      const decision = normalizeApprovalDecision(token);
+      const decision = normalizeApprovalReactionDecision(token);
       if (decision && !visibleDecisions.includes(decision)) {
         visibleDecisions.push(decision);
       }
     }
   }
-  if (!decisionSetsMatch(binding.allowedDecisions, visibleDecisions)) {
+  if (!approvalReactionDecisionSetsMatch(binding.allowedDecisions, visibleDecisions)) {
     return false;
   }
   if (!options.requireReactionHint) {
@@ -387,43 +305,16 @@ function visibleApprovalBindingMatches(
   return Boolean(hint && text.includes(hint));
 }
 
-function readDeliveredApprovalBinding(
-  payload: ReplyPayload,
-): IMessageApprovalDeliveryBinding | null {
-  const metadata = readStrictApprovalMetadata(payload);
-  const value = payload.channelData?.[IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY];
-  if (!metadata || !value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  const approvalId = typeof record.approvalId === "string" ? record.approvalId.trim() : "";
-  const approvalSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
-  const approvalKind = record.approvalKind;
-  const allowedDecisions = readStrictDecisionList(record.allowedDecisions);
-  if (
-    record.version !== 1 ||
-    !approvalId ||
-    !approvalSlug ||
-    (approvalKind !== "exec" && approvalKind !== "plugin") ||
-    !allowedDecisions
-  ) {
-    return null;
-  }
-  const marker: IMessageApprovalDeliveryBinding = {
-    approvalId,
-    approvalSlug,
-    approvalKind,
-    allowedDecisions,
-  };
-  return bindingsMatch(metadata, marker) ? metadata : null;
-}
-
 /** Preserve a validated typed approval binding until the iMessage GUID is known. */
 export function addIMessageApprovalReactionHintToStructuredPayload(params: {
   payload: ReplyPayload;
   approvalKind: "exec" | "plugin";
 }): ReplyPayload | null {
-  const metadata = readTypedApprovalPresentationBinding(params.payload);
+  const metadata = readApprovalReactionPresentationBinding({
+    payload: params.payload,
+    requireApprovalSlug: true,
+    trimApprovalId: true,
+  }) as IMessageApprovalDeliveryBinding | null;
   const text = params.payload.text;
   if (metadata?.approvalKind !== params.approvalKind || !text) {
     return null;
@@ -451,18 +342,6 @@ export function addIMessageApprovalReactionHintToStructuredPayload(params: {
   };
 }
 
-function normalizeApprovalDecision(value: string): ExecApprovalReplyDecision | null {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "always") {
-    return "allow-always";
-  }
-  if (normalized === "allow-once" || normalized === "allow-always" || normalized === "deny") {
-    return normalized;
-  }
-  return null;
-}
-
-const APPROVAL_ID_LINE_RE = /^\s*ID:\s*([A-Za-z0-9][A-Za-z0-9._:-]*)\s*$/i;
 const APPROVE_COMMAND_LINE_RE = /\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i;
 
 export function extractIMessageApprovalPromptBinding(text: string): {
@@ -470,49 +349,7 @@ export function extractIMessageApprovalPromptBinding(text: string): {
   approvalKind: "exec" | "plugin";
   allowedDecisions: ExecApprovalReplyDecision[];
 } | null {
-  // Strip bold markers the prompt builder emits (**Exec approval required**,
-  // **ID:** …) so the canonical-format checks below still recognize the prompt.
-  const lines = text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
-  const hasExecHeader = lines.some((line) =>
-    /^\s*[^A-Za-z0-9]*Exec approval required\s*$/i.test(line),
-  );
-  const hasPluginHeader = lines.some((line) =>
-    /^\s*[^A-Za-z0-9]*Plugin approval required\s*$/i.test(line),
-  );
-  if (hasExecHeader === hasPluginHeader) {
-    return null;
-  }
-  const approvalKind = hasPluginHeader ? "plugin" : "exec";
-  // Only treat as an approval prompt if it carries the canonical "ID: <approvalId>"
-  // header that the SDK payload builders emit. This prevents arbitrary outbound
-  // text containing `/approve <id> allow-once` (agent help text, quoted docs,
-  // pasted snippets) from getting a reaction binding registered against it.
-  const idHeaderMatch = lines
-    .map((line) => line.match(APPROVAL_ID_LINE_RE))
-    .find((match): match is RegExpMatchArray => Boolean(match));
-  if (!idHeaderMatch) {
-    return null;
-  }
-  const approvalId = idHeaderMatch[1];
-  if (!approvalId) {
-    return null;
-  }
-  const allowedDecisions: ExecApprovalReplyDecision[] = [];
-  for (const line of lines) {
-    const match = line.match(APPROVE_COMMAND_LINE_RE);
-    const decisionsText = match?.[2];
-    if (!match || match[1] !== approvalId || !decisionsText) {
-      continue;
-    }
-    const decisions = decisionsText.split(/[\s|,]+/);
-    for (const decisionText of decisions) {
-      const decision = normalizeApprovalDecision(decisionText);
-      if (decision && !allowedDecisions.includes(decision)) {
-        allowedDecisions.push(decision);
-      }
-    }
-  }
-  return allowedDecisions.length > 0 ? { approvalId, approvalKind, allowedDecisions } : null;
+  return extractApprovalReactionPromptBinding({ text });
 }
 
 export function registerIMessageApprovalReactionTarget(params: {
@@ -643,7 +480,12 @@ export function registerIMessageApprovalReactionTargetForDeliveredPayload(params
   if (params.target.channel.trim().toLowerCase() !== "imessage") {
     return false;
   }
-  const binding = readDeliveredApprovalBinding(params.payload);
+  const binding = readApprovalReactionDeliveredBinding({
+    payload: params.payload,
+    channelDataKey: IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY,
+    requireApprovalSlug: true,
+    trimApprovalId: true,
+  }) as IMessageApprovalDeliveryBinding | null;
   if (!binding) {
     return false;
   }
@@ -921,4 +763,3 @@ export function clearIMessageApprovalReactionTargetsForTest(): void {
   pendingReactionPollTargets.clear();
   resolverRuntimeLoader.clear();
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -5,6 +5,7 @@ import {
   addApprovalReactionHintToText,
   buildApprovalReactionHint,
   createApprovalReactionTargetStore,
+  extractApprovalReactionPromptBinding,
   hasApprovalReactionHintText,
   listApprovalReactionBindings,
   resolveTypedApprovalReactionTarget,
@@ -387,58 +388,15 @@ function isStandaloneApprovalPromptText(text: string): boolean {
   return resolveStandaloneApprovalPromptKind(text) !== null;
 }
 
-function normalizeApprovalDecision(value: string): ExecApprovalReplyDecision | null {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "always") {
-    return "allow-always";
-  }
-  if (normalized === "allow-once" || normalized === "allow-always" || normalized === "deny") {
-    return normalized;
-  }
-  return null;
-}
-
-const APPROVAL_ID_LINE_RE = /^\s*ID:\s*([A-Za-z0-9][A-Za-z0-9._:-]*)\s*$/i;
-const APPROVE_REPLY_COMMAND_LINE_RE =
-  /^\s*Reply with:\s*\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i;
-
 function extractSignalApprovalPromptBinding(text: string): {
   approvalId: string;
   approvalKind: ApprovalKind;
   allowedDecisions: ExecApprovalReplyDecision[];
 } | null {
-  // Strip bold markers (**ID:** …) before matching the canonical ID header.
-  const lines = text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
-  const idHeaderMatch = lines
-    .map((line) => line.match(APPROVAL_ID_LINE_RE))
-    .find((match): match is RegExpMatchArray => Boolean(match));
-  if (!idHeaderMatch) {
-    return null;
-  }
-  const approvalId = idHeaderMatch[1];
-  if (!approvalId) {
-    return null;
-  }
   const approvalKind = resolveStandaloneApprovalPromptKind(text);
-  if (!approvalKind) {
-    return null;
-  }
-  const allowedDecisions: ExecApprovalReplyDecision[] = [];
-  for (const line of lines) {
-    const match = line.match(APPROVE_REPLY_COMMAND_LINE_RE);
-    const commandApprovalId = match?.[1];
-    const decisionList = match?.[2];
-    if (commandApprovalId !== approvalId || !decisionList) {
-      continue;
-    }
-    for (const decisionText of decisionList.split(/[\s|,]+/)) {
-      const decision = normalizeApprovalDecision(decisionText);
-      if (decision && !allowedDecisions.includes(decision)) {
-        allowedDecisions.push(decision);
-      }
-    }
-  }
-  return allowedDecisions.length > 0 ? { approvalId, approvalKind, allowedDecisions } : null;
+  return approvalKind
+    ? extractApprovalReactionPromptBinding({ text, approvalKind, replyInstructionOnly: true })
+    : null;
 }
 
 function buildTargetRoute(params: {

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -1,10 +1,15 @@
 // Whatsapp plugin module implements approval reactions behavior.
 import type { WAMessage } from "baileys";
 import {
+  approvalReactionDecisionSetsMatch,
   createApprovalReactionTargetStore,
   listApprovalReactionBindings,
+  readApprovalReactionDecisionList,
+  readApprovalReactionDeliveredBinding,
+  readApprovalReactionPresentationBinding,
   resolveTypedApprovalReactionTarget,
   type ApprovalReactionDecisionBinding,
+  type ApprovalReactionDeliveryBinding,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -24,12 +29,7 @@ const DELIVERY_BINDING_CHANNEL_DATA_KEY = "whatsappApprovalReactionBindingV1";
 
 type WhatsAppApprovalKind = "exec" | "plugin";
 
-type WhatsAppApprovalDeliveryBinding = {
-  version: 1;
-  approvalId: string;
-  approvalKind: WhatsAppApprovalKind;
-  allowedDecisions: ExecApprovalReplyDecision[];
-};
+type WhatsAppApprovalDeliveryBinding = ApprovalReactionDeliveryBinding;
 
 type WhatsAppApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
@@ -143,84 +143,6 @@ function listWhatsAppApprovalReactionBindings(
 const APPROVAL_ID_LINE_RE = /^\s*ID:\s*(\S(?:.*\S)?)\s*$/i;
 const APPROVAL_KIND_LINE_RE = /^\s*(?:\S+\s+)?(Exec|Plugin) approval required\s*$/i;
 
-function isApprovalDecision(value: unknown): value is ExecApprovalReplyDecision {
-  return value === "allow-once" || value === "allow-always" || value === "deny";
-}
-
-function readStrictDecisionList(value: unknown): ExecApprovalReplyDecision[] | null {
-  if (!Array.isArray(value) || value.length === 0 || !value.every(isApprovalDecision)) {
-    return null;
-  }
-  return new Set(value).size === value.length ? [...value] : null;
-}
-
-function readStrictApprovalMetadata(payload: ReplyPayload): WhatsAppApprovalDeliveryBinding | null {
-  const value = payload.channelData?.execApproval;
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  const approvalId = record.approvalId;
-  const approvalKind = record.approvalKind;
-  const allowedDecisions = readStrictDecisionList(record.allowedDecisions);
-  if (
-    typeof approvalId !== "string" ||
-    !approvalId ||
-    approvalId !== approvalId.trim() ||
-    (approvalKind !== "exec" && approvalKind !== "plugin") ||
-    !allowedDecisions
-  ) {
-    return null;
-  }
-  return { version: 1, approvalId, approvalKind, allowedDecisions };
-}
-
-function listTypedApprovalActions(presentation: MessagePresentation) {
-  return presentation.blocks.flatMap((block) => {
-    if (block.type === "buttons") {
-      return block.buttons.flatMap((button) =>
-        button.action?.type === "approval" ? [button.action] : [],
-      );
-    }
-    return [];
-  });
-}
-
-function decisionSetsMatch(
-  left: readonly ExecApprovalReplyDecision[],
-  right: readonly ExecApprovalReplyDecision[],
-): boolean {
-  return left.length === right.length && left.every((decision) => right.includes(decision));
-}
-
-function readTypedApprovalDeliveryBinding(params: {
-  payload: ReplyPayload;
-  presentation: MessagePresentation;
-}): WhatsAppApprovalDeliveryBinding | null {
-  const metadata = readStrictApprovalMetadata(params.payload);
-  if (!metadata) {
-    return null;
-  }
-  const actions = listTypedApprovalActions(params.presentation);
-  if (
-    actions.length === 0 ||
-    actions.some(
-      (action) =>
-        action.approvalId !== metadata.approvalId || action.approvalKind !== metadata.approvalKind,
-    )
-  ) {
-    return null;
-  }
-  const actionDecisions = actions.map((action) => action.decision);
-  if (
-    new Set(actionDecisions).size !== actionDecisions.length ||
-    !decisionSetsMatch(metadata.allowedDecisions, actionDecisions)
-  ) {
-    return null;
-  }
-  return metadata;
-}
-
 function visibleApprovalBindingMatches(
   text: string | null | undefined,
   binding: WhatsAppApprovalDeliveryBinding,
@@ -277,35 +199,11 @@ function visibleApprovalBindingMatches(
   const visibleDecisions = decisionLines.map(
     (line) => knownBindings.find((entry) => `${entry.emoji} ${entry.label}` === line)?.decision,
   );
-  if (!visibleDecisions.every(isApprovalDecision)) {
+  const decisions = readApprovalReactionDecisionList(visibleDecisions);
+  if (!decisions) {
     return false;
   }
-  return (
-    new Set(visibleDecisions).size === visibleDecisions.length &&
-    decisionSetsMatch(binding.allowedDecisions, visibleDecisions)
-  );
-}
-
-function readDeliveredApprovalBinding(
-  payload: ReplyPayload,
-): WhatsAppApprovalDeliveryBinding | null {
-  const metadata = readStrictApprovalMetadata(payload);
-  const value = payload.channelData?.[DELIVERY_BINDING_CHANNEL_DATA_KEY];
-  if (!metadata || !value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  const allowedDecisions = readStrictDecisionList(record.allowedDecisions);
-  if (
-    record.version !== 1 ||
-    record.approvalId !== metadata.approvalId ||
-    record.approvalKind !== metadata.approvalKind ||
-    !allowedDecisions ||
-    !decisionSetsMatch(metadata.allowedDecisions, allowedDecisions)
-  ) {
-    return null;
-  }
-  return metadata;
+  return approvalReactionDecisionSetsMatch(binding.allowedDecisions, decisions);
 }
 
 /** Preserve a validated typed approval binding until the platform message id is known. */
@@ -313,7 +211,7 @@ export function prepareWhatsAppApprovalPayloadForDelivery(params: {
   payload: ReplyPayload;
   presentation: MessagePresentation;
 }): ReplyPayload | null {
-  const binding = readTypedApprovalDeliveryBinding(params);
+  const binding = readApprovalReactionPresentationBinding(params);
   if (!binding) {
     return null;
   }
@@ -325,7 +223,7 @@ export function prepareWhatsAppApprovalPayloadForDelivery(params: {
     ...params.payload,
     channelData: {
       ...params.payload.channelData,
-      [DELIVERY_BINDING_CHANNEL_DATA_KEY]: binding,
+      [DELIVERY_BINDING_CHANNEL_DATA_KEY]: { version: 1, ...binding },
     },
   };
 }
@@ -410,7 +308,10 @@ export function registerWhatsAppApprovalReactionTargetForDeliveredPayload(params
   if (params.target.channel.trim().toLowerCase() !== "whatsapp") {
     return false;
   }
-  const binding = readDeliveredApprovalBinding(params.payload);
+  const binding = readApprovalReactionDeliveredBinding({
+    payload: params.payload,
+    channelDataKey: DELIVERY_BINDING_CHANNEL_DATA_KEY,
+  });
   if (!binding) {
     return false;
   }

--- a/src/plugin-sdk/approval-reaction-binding.ts
+++ b/src/plugin-sdk/approval-reaction-binding.ts
@@ -1,0 +1,190 @@
+import type { ExecApprovalReplyDecision } from "../infra/exec-approval-reply.js";
+import type { MessagePresentation } from "../interactive/payload.js";
+import type { ReplyPayload } from "./reply-payload.js";
+
+type ApprovalKind = "exec" | "plugin";
+
+/** Validated identity and decisions shared by typed approval delivery surfaces. */
+export type ApprovalReactionDeliveryBinding = {
+  approvalId: string;
+  approvalKind: ApprovalKind;
+  allowedDecisions: ExecApprovalReplyDecision[];
+  approvalSlug?: string;
+};
+
+/** Read a nonempty, duplicate-free list without accepting unrecognized decisions. */
+export function readApprovalReactionDecisionList(
+  value: unknown,
+): ExecApprovalReplyDecision[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+  const decisions: ExecApprovalReplyDecision[] = [];
+  for (const decision of value) {
+    if (
+      (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") ||
+      decisions.includes(decision)
+    ) {
+      return null;
+    }
+    decisions.push(decision);
+  }
+  return decisions;
+}
+
+/** Normalize the shipped approval command spelling without accepting other decisions. */
+export function normalizeApprovalReactionDecision(value: string): ExecApprovalReplyDecision | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "always") {
+    return "allow-always";
+  }
+  return normalized === "allow-once" || normalized === "allow-always" || normalized === "deny"
+    ? normalized
+    : null;
+}
+
+/** Read only canonical approval prompts; unrelated `/approve` help must never gain controls. */
+export function extractApprovalReactionPromptBinding(params: {
+  text: string;
+  approvalKind?: ApprovalKind;
+  replyInstructionOnly?: boolean;
+}): ApprovalReactionDeliveryBinding | null {
+  const lines = params.text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
+  let approvalKind = params.approvalKind;
+  if (!approvalKind) {
+    const exec = lines.some((line) => /^\s*[^A-Za-z0-9]*Exec approval required\s*$/i.test(line));
+    const plugin = lines.some((line) =>
+      /^\s*[^A-Za-z0-9]*Plugin approval required\s*$/i.test(line),
+    );
+    if (exec === plugin) {
+      return null;
+    }
+    approvalKind = plugin ? "plugin" : "exec";
+  }
+  const approvalId = lines
+    .map((line) => line.match(/^\s*ID:\s*([A-Za-z0-9][A-Za-z0-9._:-]*)\s*$/i))
+    .find(Boolean)?.[1];
+  if (!approvalId) {
+    return null;
+  }
+  const commandPattern = params.replyInstructionOnly
+    ? /^\s*Reply with:\s*\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i
+    : /\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i;
+  const allowedDecisions: ExecApprovalReplyDecision[] = [];
+  for (const line of lines) {
+    const match = line.match(commandPattern);
+    if (match?.[1] !== approvalId || !match[2]) {
+      continue;
+    }
+    for (const token of match[2].split(/[\s|,]+/)) {
+      const decision = normalizeApprovalReactionDecision(token);
+      if (decision && !allowedDecisions.includes(decision)) {
+        allowedDecisions.push(decision);
+      }
+    }
+  }
+  return allowedDecisions.length ? { approvalId, approvalKind, allowedDecisions } : null;
+}
+
+/** Compare approved decision sets independently of presentation order. */
+export function approvalReactionDecisionSetsMatch(
+  left: readonly ExecApprovalReplyDecision[],
+  right: readonly ExecApprovalReplyDecision[],
+): boolean {
+  return left.length === right.length && left.every((decision) => right.includes(decision));
+}
+
+/** Validate canonical approval metadata without inferring its owner from text. */
+export function readApprovalReactionDeliveryMetadata(
+  payload: ReplyPayload,
+  options: { requireApprovalSlug?: boolean; trimApprovalId?: boolean } = {},
+): ApprovalReactionDeliveryBinding | null {
+  const value = payload.channelData?.execApproval;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.approvalId !== "string") {
+    return null;
+  }
+  const approvalId = options.trimApprovalId ? record.approvalId.trim() : record.approvalId;
+  const approvalSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
+  const allowedDecisions = readApprovalReactionDecisionList(record.allowedDecisions);
+  if (
+    !approvalId ||
+    (!options.trimApprovalId && approvalId !== approvalId.trim()) ||
+    (options.requireApprovalSlug && !approvalSlug) ||
+    (record.approvalKind !== "exec" && record.approvalKind !== "plugin") ||
+    !allowedDecisions
+  ) {
+    return null;
+  }
+  return {
+    approvalId,
+    approvalKind: record.approvalKind,
+    allowedDecisions,
+    ...(approvalSlug ? { approvalSlug } : {}),
+  };
+}
+
+/** Verify that typed presentation controls exactly match authoritative approval metadata. */
+export function readApprovalReactionPresentationBinding(params: {
+  payload: ReplyPayload;
+  presentation?: MessagePresentation;
+  requireApprovalSlug?: boolean;
+  trimApprovalId?: boolean;
+}): ApprovalReactionDeliveryBinding | null {
+  const metadata = readApprovalReactionDeliveryMetadata(params.payload, params);
+  if (!metadata) {
+    return null;
+  }
+  const actions = (params.presentation ?? params.payload.presentation)?.blocks.flatMap((block) =>
+    block.type === "buttons"
+      ? block.buttons.flatMap((button) =>
+          button.action?.type === "approval" ? [button.action] : [],
+        )
+      : [],
+  );
+  if (
+    !actions?.length ||
+    actions.some(
+      (action) =>
+        action.approvalId !== metadata.approvalId || action.approvalKind !== metadata.approvalKind,
+    )
+  ) {
+    return null;
+  }
+  const decisions = readApprovalReactionDecisionList(actions.map((action) => action.decision));
+  return decisions && approvalReactionDecisionSetsMatch(metadata.allowedDecisions, decisions)
+    ? metadata
+    : null;
+}
+
+/** Revalidate the private delivery marker against canonical typed approval metadata. */
+export function readApprovalReactionDeliveredBinding(params: {
+  payload: ReplyPayload;
+  channelDataKey: string;
+  requireApprovalSlug?: boolean;
+  trimApprovalId?: boolean;
+}): ApprovalReactionDeliveryBinding | null {
+  const metadata = readApprovalReactionDeliveryMetadata(params.payload, params);
+  const marker = params.payload.channelData?.[params.channelDataKey];
+  if (!metadata || !marker || typeof marker !== "object" || Array.isArray(marker)) {
+    return null;
+  }
+  const record = marker as Record<string, unknown>;
+  const markerId =
+    typeof record.approvalId === "string" && params.trimApprovalId
+      ? record.approvalId.trim()
+      : record.approvalId;
+  const markerSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
+  const decisions = readApprovalReactionDecisionList(record.allowedDecisions);
+  return record.version === 1 &&
+    markerId === metadata.approvalId &&
+    record.approvalKind === metadata.approvalKind &&
+    (!params.requireApprovalSlug || markerSlug === metadata.approvalSlug) &&
+    decisions &&
+    approvalReactionDecisionSetsMatch(metadata.allowedDecisions, decisions)
+    ? metadata
+    : null;
+}

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -11,8 +11,12 @@ import {
   buildApprovalReactionPromptPayloadForRequest,
   buildApprovalReactionHint,
   createApprovalReactionTargetStore,
+  extractApprovalReactionPromptBinding,
   listApprovalReactionBindings,
   normalizeApprovalReactionEmoji,
+  readApprovalReactionDecisionList,
+  readApprovalReactionDeliveredBinding,
+  readApprovalReactionPresentationBinding,
   resolveApprovalReactionDecision,
   resolveTypedApprovalReactionTarget,
   shouldSuppressLocalNativeExecApprovalPrompt,
@@ -73,6 +77,96 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       resolveApprovalReactionDecision({
         reactionKey: "1️⃣",
         allowedDecisions: ["allow-once", "allow-always", "deny"],
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts only complete, unique typed approval decision lists", () => {
+    expect(readApprovalReactionDecisionList(["deny", "allow-once"])).toEqual([
+      "deny",
+      "allow-once",
+    ]);
+    for (const invalid of [[], ["allow-once", "allow-once"], ["always"], "deny"]) {
+      expect(readApprovalReactionDecisionList(invalid)).toBeNull();
+    }
+  });
+
+  it("extracts only canonical approval prompts and preserves strict reply-only channels", () => {
+    const text = [
+      "**Plugin approval required**",
+      "**ID:** plugin:approval-123",
+      "Allow Once: /approve plugin:approval-123 allow-once",
+      "Reply with: /approve plugin:approval-123 deny|always",
+    ].join("\n");
+    expect(extractApprovalReactionPromptBinding({ text })).toEqual({
+      approvalId: "plugin:approval-123",
+      approvalKind: "plugin",
+      allowedDecisions: ["allow-once", "deny", "allow-always"],
+    });
+    expect(
+      extractApprovalReactionPromptBinding({
+        text,
+        approvalKind: "plugin",
+        replyInstructionOnly: true,
+      }),
+    ).toMatchObject({ allowedDecisions: ["deny", "allow-always"] });
+    expect(
+      extractApprovalReactionPromptBinding({
+        text: "Helpful example:\n/approve plugin:approval-123 allow-once",
+      }),
+    ).toBeNull();
+  });
+
+  it("fails closed when typed approval presentation or delivery marker disagrees", () => {
+    const metadata = {
+      approvalId: "plugin:approval-123",
+      approvalSlug: "approval-123",
+      approvalKind: "plugin" as const,
+      allowedDecisions: ["allow-once", "deny"] as const,
+    };
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: metadata.allowedDecisions.map((decision) => ({
+            label: decision,
+            action: {
+              type: "approval" as const,
+              approvalId: metadata.approvalId,
+              approvalKind: metadata.approvalKind,
+              decision,
+            },
+          })),
+        },
+      ],
+    };
+    const payload = {
+      presentation,
+      channelData: {
+        execApproval: metadata,
+        privateBinding: { version: 1, ...metadata },
+      },
+    };
+    expect(readApprovalReactionPresentationBinding({ payload })).toMatchObject(metadata);
+    expect(
+      readApprovalReactionDeliveredBinding({
+        payload,
+        channelDataKey: "privateBinding",
+        requireApprovalSlug: true,
+      }),
+    ).toMatchObject(metadata);
+    const invalidPayload = {
+      ...payload,
+      channelData: {
+        ...payload.channelData,
+        execApproval: { ...metadata, allowedDecisions: ["allow-once", "allow-once"] },
+      },
+    };
+    expect(readApprovalReactionPresentationBinding({ payload: invalidPayload })).toBeNull();
+    expect(
+      readApprovalReactionDeliveredBinding({
+        payload: invalidPayload,
+        channelDataKey: "privateBinding",
       }),
     ).toBeNull();
   });

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -20,6 +20,16 @@ import {
 } from "./approval-renderers.js";
 export { shouldSuppressLocalNativeExecApprovalPrompt } from "./approval-native-helpers.js";
 import type { ReplyPayload } from "./reply-payload.js";
+export {
+  approvalReactionDecisionSetsMatch,
+  extractApprovalReactionPromptBinding,
+  normalizeApprovalReactionDecision,
+  readApprovalReactionDecisionList,
+  readApprovalReactionDeliveredBinding,
+  readApprovalReactionDeliveryMetadata,
+  readApprovalReactionPresentationBinding,
+  type ApprovalReactionDeliveryBinding,
+} from "./approval-reaction-binding.js";
 
 type ApprovalKind = "exec" | "plugin";
 type KeyedStore<TValue> = {


### PR DESCRIPTION
## What Problem This Solves

Signal, iMessage, and WhatsApp independently validated approval decisions, prompt identity, typed actions, and private delivery markers, creating duplicated security-sensitive logic and opportunities for channel behavior to drift.

## Why This Change Was Made

Move shared fail-closed approval binding validation and canonical prompt extraction into one focused private SDK owner while preserving the existing public runtime seam and every channel-specific authorization, account, route, identity, and delivery boundary. The iMessage implementation shrinks enough to remove its grandfathered oversized-file suppression and baseline entry.

## User Impact

No intended user-visible behavior change. Approval reactions retain explicit approver checks, owner/action correlation, private message binding, and channel-specific delivery behavior across Signal, iMessage, and WhatsApp.

Production code: 100 fewer lines. One max-lines suppression retired. Focused regression coverage: 94 added test lines.

## Evidence

Blacksmith Testbox tbx_01kyx6am9njyb7pq2tn8w8694v completed all 93 focused SDK and channel approval tests plus the full changed gate, including all four core/plugin typecheck lanes, complete core/UI/package/plugin/tooling lint, SDK API/export/budget checks, dead-code checks, database/security guards, and max-lines ratchet (1023 to 1022). Fresh structured autoreview found no actionable findings.

Remote proof: https://github.com/openclaw/openclaw/actions/runs/30671508882

### Real production-owner behavior proof: no mocked auth, reaction, or storage owners

Exact reviewed head: `342f7fca1de749055a3a14da891364d858381a61`. On a fresh Linux Blacksmith Testbox, an isolated production-source probe injected the real SQLite-backed plugin state owner into each actual Signal, iMessage, and WhatsApp runtime. It invoked each real approval authorization owner with allowed and denied actors, registered actual channel reaction targets, verified the durable SQLite row, cleared process-local target caches, reopened the persisted binding, observed both approve and reject emoji decisions, rejected cross-account access, and deleted the durable target. Signal additionally rejected the wrong outbound-message author. The same probe exercised production typed presentation/action and private delivery-marker correlation, including hostile mismatches. No production owner, authorization decision, reaction registry, persistence store, or SQLite database was mocked; platform transports were not contacted.

Redacted observed transcript:

```text
OWNER_PROOF channel=signal authorized=true unauthorized=false sqlite_persisted=true restart_hydrated=true approved=allow-once rejected=deny account_isolated=true consumed=true
OWNER_PROOF channel=imessage authorized=true unauthorized=false sqlite_persisted=true restart_hydrated=true approved=allow-once rejected=deny account_isolated=true consumed=true
OWNER_PROOF channel=whatsapp authorized=true unauthorized=false sqlite_persisted=true restart_hydrated=true approved=allow-once rejected=deny account_isolated=true consumed=true
CALLBACK_PROOF typed_owner_match=true mismatched_owner=rejected private_marker_match=true tampered_marker=rejected unrelated_prompt=rejected visible_hint=true
RESULT PASS production_owners=3 mocked_owners=0 real_sqlite=true
```

The same fresh remote run then passed 22 owner-level regression checks without replacing the approval authorization or SQLite persistence owners: 10 SQLite plugin-state end-to-end cases, 6 iMessage actor-authorization cases, 3 WhatsApp actor-authorization cases, and 3 Signal actor-authorization cases. SQLite cases covered close/reopen survival, exactly-once consumption, plugin namespace isolation, TTL expiry, bounded eviction, and redacted failure diagnostics.

```text
pnpm test extensions/signal/src/approval-auth.test.ts extensions/imessage/src/approval-auth.test.ts extensions/whatsapp/src/approval-auth.test.ts src/plugin-state/plugin-state-store.e2e.test.ts -- --reporter=verbose
[test] passed 4 Vitest shards in 11.74s
blacksmith run summary sync=delegated command=54.661s total=56.983s exit=0
```

Real-owner remote run: https://github.com/openclaw/openclaw/actions/runs/30673466056 (Blacksmith lease `tbx_01kyx8qb8pdtgc44wqnz4eza38`; Blacksmith stops successful one-shot leases, so the backing runner step can display canceled after the command exits successfully).

Exact-head hosted CI also passed: https://github.com/openclaw/openclaw/actions/runs/30672740652, including the required `openclaw/ci-gate`. GitHub currently reports the exact reviewed head as `MERGEABLE`; current-main drift is advisory, so the already-proven green head was intentionally not rebased.

Total owner-boundary evidence: 93 original focused SDK/channel reaction tests + 22 additional real-owner auth/SQLite E2E tests + the unmocked three-channel production behavior transcript above.