### PR TITLE
perf: large session history blocks Gateway after restart

### DIFF
--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -3,12 +3,19 @@ import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js"
 
 const mocks = vi.hoisted(() => ({
   events: [] as string[],
+  sessionEntryCounts: new Map<string, number>(),
   loadCombinedSessionStoreForGateway: vi.fn((_cfg: unknown, options: { agentId: string }) => {
     mocks.events.push(`sessions.load.${options.agentId}`);
+    const entryCount = mocks.sessionEntryCounts.get(options.agentId) ?? 0;
     return {
       durableStorePath: `/state/${options.agentId}.sqlite`,
       storePath: `/state/${options.agentId}.sqlite`,
-      store: {},
+      store: Object.fromEntries(
+        Array.from({ length: entryCount }, (_, index) => [
+          `agent:${options.agentId}:fixture-${index}`,
+          { sessionId: `session-${index}`, updatedAt: index },
+        ]),
+      ),
     };
   }),
   listSessionsFromStoreAsync: vi.fn(async (params: { opts: { agentId: string } }) => {
@@ -44,6 +51,7 @@ const { scheduleGatewayHandlerPrewarm } = await import("./server-startup-handler
 
 beforeEach(() => {
   mocks.events.length = 0;
+  mocks.sessionEntryCounts.clear();
   mocks.loadCombinedSessionStoreForGateway.mockClear();
   mocks.listSessionsFromStoreAsync.mockClear();
   mocks.listManagedPlugins.mockClear();
@@ -144,6 +152,29 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     expect(requestLoad).toHaveBeenCalledOnce();
     expect(laterPrewarm).toHaveBeenCalledOnce();
     await expect(requestLoad()).resolves.toBe("request result");
+  });
+
+  it("skips optional catalog prewarm when the combined session stores are large", async () => {
+    vi.useFakeTimers();
+    mocks.sessionEntryCounts.set("main", 2_001);
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }, { id: "research" }] },
+    } as never;
+
+    scheduleGatewayHandlerPrewarm({
+      cfgAtStart: cfg,
+      log: { warn: vi.fn() },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mocks.events).toEqual([
+      "sessions.load.main",
+      "sessions.rows.main",
+      "sessions.load.research",
+      "sessions.rows.research",
+      "plugins",
+    ]);
+    expect(mocks.prewarmSessionCatalogList).not.toHaveBeenCalled();
   });
 
   it("stops before scheduling another event-loop turn", async () => {

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -4,6 +4,7 @@ import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-w
 
 const SIDEBAR_SESSION_LIST_LIMIT = 60;
 const SIDEBAR_CATALOG_LIMIT_PER_HOST = 40;
+const SIDEBAR_CATALOG_PREWARM_MAX_SESSION_ENTRIES = 2_000;
 
 type StartupTrace = {
   measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
@@ -18,7 +19,10 @@ type GatewayHandlerPrewarmHandle = {
   stop: () => void;
 };
 
-async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: string): Promise<void> {
+async function prewarmGatewaySessionListData(
+  cfg: OpenClawConfig,
+  agentId: string,
+): Promise<number> {
   const [{ loadCombinedSessionStoreForGateway }, { listSessionsFromStoreAsync }] =
     await Promise.all([
       import("../config/sessions/combined-store-gateway.js"),
@@ -42,14 +46,20 @@ async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: strin
       limit: SIDEBAR_SESSION_LIST_LIMIT,
     },
   });
+  return Object.keys(store).length;
 }
 
 function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmItem[] {
   const agentIds = listAgentIds(cfg);
+  let loadedSessionStores = 0;
+  let totalSessionEntries = 0;
   return [
     ...agentIds.map((agentId) => ({
       name: `sessions.${agentId}`,
-      load: () => prewarmGatewaySessionListData(cfg, agentId),
+      load: async () => {
+        totalSessionEntries += await prewarmGatewaySessionListData(cfg, agentId);
+        loadedSessionStores += 1;
+      },
     })),
     {
       name: "plugins",
@@ -61,6 +71,14 @@ function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmIt
     ...agentIds.map((agentId) => ({
       name: `session-catalog.${agentId}`,
       load: async () => {
+        // Catalog providers may project every OpenClaw session before returning their bounded
+        // page. Keep that optional cold-cache work off the event loop for unusually large stores.
+        if (
+          loadedSessionStores !== agentIds.length ||
+          totalSessionEntries > SIDEBAR_CATALOG_PREWARM_MAX_SESSION_ENTRIES
+        ) {
+          return;
+        }
         const { prewarmSessionCatalogList } = await import("./server-methods/session-catalog.js");
         await prewarmSessionCatalogList({
           config: cfg,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway restart could report ready and then become unresponsive for many minutes while optional session-catalog prewarming synchronously projected a large session store. On the Hetzner recovery host, two consecutive exact-main starts timed out `/healthz` and RPC while the Gateway consumed a full CPU core for more than eight minutes.

## Why This Change Was Made

The earlier sidebar session-list prewarm already materializes each configured agent store. The startup sequence now carries those counts forward and skips only optional catalog prewarming when the combined store exceeds 2,000 entries or when a session-store prewarm failed. Request-time catalog loading remains authoritative, so no catalog capability is disabled.

## User Impact

Gateways with unusually large session histories remain responsive after restart instead of blocking health checks and update verification behind cold catalog work. Normal-size stores retain the existing warm-cache behavior.

## Evidence

- Live exact-main reproduction: two consecutive Gateway starts reached the ready log, then `/healthz`, deep RPC, and verbose health timed out while `post-ready.gateway-data.session-catalog.main` held roughly one CPU core for more than eight minutes.
- Blacksmith Testbox `tbx_01kyx7zh36v81sq0a9f78gzs36`: 6/6 focused startup and session-catalog prewarm tests passed. The regression materializes a 2,001-entry store and requires session-list/plugin prewarming to continue while catalog prewarming is skipped.
- Autoreview: clean, no accepted/actionable findings.
