### PR TITLE
fix(agents): record tool trajectory events on fallback-served turns

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -105,6 +105,7 @@ export async function runEmbeddedAttemptExecutionPhase(
       sandboxSessionKey: input.setup.sandboxSessionKey,
       builtinToolNames,
       replaySafeToolNames,
+      trajectoryRecorder: sessionRuntime.trajectoryRecorder,
     },
     lifecycle: {
       isYieldDetected: () => input.lifecycle.readYieldState().yieldDetected,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -86,6 +86,7 @@ export function prepareEmbeddedAttemptStream(input: {
   sandboxSessionKey: string;
   builtinToolNames: ReadonlySet<string>;
   replaySafeToolNames: ReadonlySet<string>;
+  trajectoryRecorder?: EmbeddedRunAttemptParams["trajectoryRecorder"];
 }) {
   const attempt = input.attempt;
   const hookRunner = input.hookRunner;
@@ -260,6 +261,7 @@ export function prepareEmbeddedAttemptStream(input: {
       onDeliveredMessageToolOnlySourceReply: input.markSourceReplyDelivered,
       onAgentToolResult: attempt.onAgentToolResult,
       observeToolTerminal: attempt.observeToolTerminal,
+      trajectoryRecorder: input.trajectoryRecorder,
       onToolResult: attempt.onToolResult,
       onReasoningStream: attempt.onReasoningStream,
       streamReasoningInNonStreamModes: attempt.streamReasoningInNonStreamModes,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -142,6 +142,10 @@ function createTestContext(): {
   >;
   onAgentEvent: ReturnType<typeof vi.fn>;
   onExecutionPhase: ReturnType<typeof vi.fn>;
+  trajectoryRecorder: {
+    recordEvent: ReturnType<typeof vi.fn>;
+    flush: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  };
   trace: ReturnType<typeof vi.fn>;
   isEnabled: ReturnType<typeof vi.fn>;
 } {
@@ -150,6 +154,10 @@ function createTestContext(): {
   const onBlockReplyFlush = vi.fn<NonNullable<ToolHandlerContext["params"]["onBlockReplyFlush"]>>();
   const onAgentEvent = vi.fn();
   const onExecutionPhase = vi.fn();
+  const trajectoryRecorder = {
+    recordEvent: vi.fn(),
+    flush: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  };
   const warn = vi.fn();
   const trace = vi.fn();
   const isEnabled = vi.fn(() => false);
@@ -163,6 +171,7 @@ function createTestContext(): {
       onAgentEvent,
       onExecutionPhase,
       onToolResult: undefined,
+      trajectoryRecorder,
     },
     flushBlockReplyBuffer: vi.fn(),
     hookRunner: undefined,
@@ -208,7 +217,16 @@ function createTestContext(): {
     trimMessagingToolSent: vi.fn(),
   };
 
-  return { ctx, warn, onBlockReplyFlush, onAgentEvent, onExecutionPhase, trace, isEnabled };
+  return {
+    ctx,
+    warn,
+    onBlockReplyFlush,
+    onAgentEvent,
+    onExecutionPhase,
+    trajectoryRecorder,
+    trace,
+    isEnabled,
+  };
 }
 
 type CapturedAgentEvent = { stream?: string; data?: Record<string, unknown> };
@@ -343,6 +361,72 @@ function requireSingleMessagingTarget(ctx: ToolHandlerContext) {
   expect(targets).toHaveLength(1);
   return requireRecord(targets[0], "messaging target");
 }
+
+describe("trajectory tool audit events", () => {
+  it("records tool.call and tool.result for an executed tool", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-1",
+      args: { path: "/tmp/trajectory-fixture.txt" },
+      isError: false,
+      result: { content: "fixture" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.call",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-1",
+        name: "read",
+      }),
+    );
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-1",
+        name: "read",
+        success: true,
+      }),
+    );
+  });
+
+  it("marks failed tool results as success: false in the trajectory", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-2",
+      args: { path: "/tmp/missing.txt" },
+      isError: true,
+      result: { error: "missing file" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-2",
+        name: "read",
+        success: false,
+      }),
+    );
+  });
+
+  it("skips trajectory recording when no recorder is wired", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+    ctx.params.trajectoryRecorder = undefined;
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-3",
+      args: { path: "/tmp/trajectory-fixture.txt" },
+      isError: false,
+      result: { content: "fixture" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).not.toHaveBeenCalled();
+  });
+});
 
 describe("handleToolExecutionStart read path checks", () => {
   it("delivers a numbered ask_user prompt with question id association", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1133,6 +1133,11 @@ export function handleToolExecutionStart(
     );
 
     const shouldEmitToolEvents = ctx.shouldEmitToolResult();
+    ctx.params.trajectoryRecorder?.recordEvent("tool.call", {
+      toolCallId,
+      name: toolName,
+      args: sanitizeToolArgs(args) as Record<string, unknown>,
+    });
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "tool",
@@ -1431,6 +1436,12 @@ export async function handleToolExecutionEnd(
   const eventResult = isExecToolName(toolName)
     ? capLiveExecResult(sanitizedResult)
     : sanitizedResult;
+  ctx.params.trajectoryRecorder?.recordEvent("tool.result", {
+    toolCallId,
+    name: toolName,
+    success: !observerIsError,
+    result: eventResult,
+  });
   const toolStartKey = buildToolStartKey(runId, toolCallId);
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -298,6 +298,7 @@ type ToolHandlerParams = Pick<
   | "onHeartbeatToolResponse"
   | "onAgentToolResult"
   | "observeToolTerminal"
+  | "trajectoryRecorder"
   | "onToolResult"
   | "config"
   | "messageChannel"

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -56,6 +56,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onAgentToolResult?: (event: { toolName: string; result: unknown; isError: boolean }) => void;
   observeToolTerminal?: EmbeddedRunAttemptParams["observeToolTerminal"];
+  /** Attempt-scoped trajectory recorder for runtime tool audit events. */
+  trajectoryRecorder?: EmbeddedRunAttemptParams["trajectoryRecorder"];
   onReasoningStream?: (payload: ReasoningStreamPayload) => void | Promise<void>;
   /** Expands window reasoning beyond "stream" mode for callers with their own display gate. */
   streamReasoningInNonStreamModes?: boolean;


### PR DESCRIPTION
Closes #114602
Supersedes #114662

## What Problem This Solves

Fixes an issue where operators auditing agent sessions via `*.trajectory.jsonl` would see **no `tool.call` / `tool.result` events** for turns served by a fallback model (after `model.fallback_step`), even though those turns really executed tools — MCP writes landed mid-turn and the reply's cost line reported the calls. Audit layers treating trajectory tool records as ground truth saw an empty trajectory while real side effects happened, and the failure was misdiagnosed as the model *claiming* calls it never made.

## Why This Change Was Made

The embedded runner's per-attempt trajectory recorder only received lifecycle events (`session.started`, `prompt.submitted`, `model.completed`, …). Tool execution start/end, observed by the embedded session subscription, was never forwarded to the recorder, so tool-executing turns left no runtime tool audit events. The fix threads the attempt-scoped trajectory recorder into the session subscription and records `tool.call` on `tool_execution_start` and `tool.result` (with `success`) on `tool_execution_end`, mirroring the existing worker live-event projection (`src/gateway/worker-environments/live-event-projection.ts`). Because the fallback loop re-runs the full attempt path — including recorder creation — per candidate, fallback-served attempts now record the same tool events as primary-served attempts through one shared seam.

## User Impact

Operators and audit/receipt tooling now see `tool.call` / `tool.result` trajectory events for every tool-executing turn, including fallback-served turns, with payloads sanitized through the same `sanitizeToolArgs` / `sanitizeToolResult` (and exec output capping) used for live tool events. No behavior change for turns without tools or with trajectory capture disabled.

## Evidence

- New regression coverage in `src/agents/embedded-agent-subscribe.handlers.tools.test.ts`: `tool.call` + `tool.result` (with `success: true`) recorded for an executed tool; `success: false` recorded for a failed tool; no recording when no recorder is wired.
- `pnpm vitest run src/agents/embedded-agent-subscribe.handlers.tools.test.ts` — 284 passed (2 projects, includes 3 new tests).
- `pnpm vitest run src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts` — 8 passed (subscription params wiring).
- `tsc --noEmit -p tsconfig.core.json` — no errors in touched files (only pre-existing unrelated errors in `src/media-understanding/` test helpers).

AI-assisted: yes (OpenClaw subagent).