### PR TITLE
fix(doctor): persist default agent roster during repair

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1627,9 +1627,29 @@ describe("doctor config flow", () => {
     });
 
     expect(result.shouldWriteConfig).toBe(true);
+    expect(result.explicitSetPaths).toEqual([["agents", "entries"]]);
     expect(result.cfg.agents?.entries).toEqual({
       main: { default: true, workspace: "/tmp/migrated-main" },
     });
+    expect(terminalNoteMock).toHaveBeenCalledWith(
+      "Prepared agents.entries with exactly one explicit default agent for persistence.",
+      "Doctor changes",
+    );
+    expect(terminalNoteMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("Persisted agents.entries"),
+      expect.anything(),
+    );
+  });
+
+  it("drops roster write intent when a preview repair is declined", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: { agents: { entries: { main: { default: true } } } },
+      parsedConfig: {},
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(result.shouldWriteConfig).toBe(false);
+    expect(result.explicitSetPaths).toBeUndefined();
   });
 
   it("removes a legacy list when Doctor persists keyed roster entries", async () => {
@@ -1777,6 +1797,7 @@ describe("doctor config flow", () => {
     });
 
     expect(result.shouldWriteConfig).toBe(false);
+    expect(result.explicitSetPaths).toBeUndefined();
     expect(result.cfg.agents?.entries).toEqual({ ops: { default: true } });
   });
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -162,6 +162,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     pendingChanges: false,
     fixHints: [],
   };
+  const explicitSetPaths: string[][] = [];
   let shouldRepairCronCodexModelRefsAfterConfigWrite = false;
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
   const applyConfigMutation = (
@@ -213,11 +214,14 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
           entries: migratedEntries as NonNullable<OpenClawConfig["agents"]>["entries"],
         },
       },
-      changes: ["Persisted agents.entries with exactly one explicit default agent."],
+      changes: ["Prepared agents.entries with exactly one explicit default agent for persistence."],
     };
     applyConfigMutation(rosterRepair, {
       fixHint: `Run "${doctorFixCommand}" to persist the explicit agent roster.`,
     });
+    // Read-time normalization already exposes this roster in the runtime shape.
+    // Preserve doctor's write intent so the atomic writer does not restore the authored omission.
+    explicitSetPaths.push(["agents", "entries"]);
   }
   applyConfigMutation(materializeDefaultAgentRoles(state.candidate), {
     fixHint: `Run "${doctorFixCommand}" to persist explicit ambient agent targets.`,
@@ -503,6 +507,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     sourceConfigValid: snapshot.valid,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),
+    ...(finalized.shouldWriteConfig && explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
     ...(singleTopLevelIncludeWrite ? { skipWizardMetadataForIncludeWrite: true } : {}),
     ...(shouldRepairCronCodexModelRefsAfterConfigWrite
       ? { shouldRepairCronCodexModelRefsAfterConfigWrite: true }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -33,9 +33,10 @@ export async function runWriteConfigHealth(
   const { replaceConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
+  const configResultWritePending =
+    ctx.configResult.shouldWriteConfig === true && ctx.configResultWriteCommitted !== true;
   const shouldWriteConfig =
-    (ctx.configResult.shouldWriteConfig && ctx.configResultWriteCommitted !== true) ||
-    JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
+    configResultWritePending || JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
   if (shouldWriteConfig) {
     const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
     if (ctx.configResult.skipWizardMetadataForIncludeWrite !== true) {
@@ -58,6 +59,9 @@ export async function runWriteConfigHealth(
         allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
         skipPluginValidation:
           ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
+        ...(configResultWritePending && ctx.configResult.explicitSetPaths
+          ? { explicitSetPaths: ctx.configResult.explicitSetPaths }
+          : {}),
         preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
         ...(legacyParentVersionOverride
           ? { lastTouchedVersionOverride: legacyParentVersionOverride }

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -15,6 +15,7 @@ type DoctorConfigResult = {
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
+  explicitSetPaths?: readonly (readonly string[])[];
   skipWizardMetadataForIncludeWrite?: boolean;
   preservedLegacyRootKeys?: readonly string[];
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3646,6 +3646,35 @@ describe("doctor health contributions", () => {
       );
     });
 
+    it("forwards explicit paths only for the pending doctor migration write", async () => {
+      const ctx = buildWriteConfigCtx({});
+      ctx.configResult.explicitSetPaths = [["agents", "entries"]];
+
+      await writeConfigContribution.run(ctx);
+
+      expect(mocks.replaceConfigFile).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          writeOptions: expect.objectContaining({
+            explicitSetPaths: [["agents", "entries"]],
+          }),
+        }),
+      );
+
+      ctx.cfg = { gateway: { mode: "remote" } };
+      await writeConfigContribution.run(ctx);
+
+      expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(2);
+      expect(mocks.replaceConfigFile).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          writeOptions: expect.not.objectContaining({
+            explicitSetPaths: expect.anything(),
+          }),
+        }),
+      );
+    });
+
     it("points update-time config rewrites at the pre-update backup", async () => {
       vi.mocked(fs.existsSync).mockImplementation((value) => String(value).endsWith(".pre-update"));
       const ctx = buildWriteConfigCtx({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` could be told that the explicit default-agent roster was persisted even though `openclaw.json` still omitted `agents.entries.<id>.default: true`.

## Why This Change Was Made

Doctor now carries its accepted roster migration as explicit write intent through the existing atomic config writer, which otherwise correctly preserves authored roster omissions during unrelated writes. The intent is limited to the pending migration write, so declined previews, include-owned rosters, later health writes, and legacy update handoffs keep their existing boundaries. The pre-write message now says the roster was prepared for persistence; the normal post-write message remains the durability signal.

## User Impact

`openclaw doctor --fix` now durably records the normalized default-agent roster before reporting the config update. Legacy update parents that intentionally cannot accept doctor writes still report the explicit skip without claiming persistence.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/commands/doctor-config-flow.test.ts src/flows/doctor-health-contributions.test.ts` — 158 passed.
- Changed gates: core typecheck, core test typecheck, lint, formatting, API/boundary/dead-code/schema guards passed. The remote hydration attempt failed before checks because its temporary install could not resolve `typescript`; the trusted local fallback completed successfully.
- Black-box Testbox proof: ordinary doctor persisted the default, a second run retained it, legacy handoff left it absent, and neither path emitted the premature `Persisted agents.entries` claim: https://github.com/openclaw/openclaw/actions/runs/30673646693
- Structured autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, high reasoning).
