### PR TITLE
fix(agents): describeMessageTool third-party plugins

### DIFF
--- a/src/plugin-sdk/chat-channel-meta.test.ts
+++ b/src/plugin-sdk/chat-channel-meta.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression tests for SDK chat channel metadata resolution across bundled and
+ * third-party plugin channels (openclaw/openclaw#114553).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { getChatChannelMeta } from "./core.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+function createThirdPartyChannelPlugin(id: string, label: string): ChannelPlugin {
+  return createChannelTestPluginBase({ id, label }) as ChannelPlugin;
+}
+
+describe("plugin-sdk getChatChannelMeta", () => {
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("resolves metadata for bundled chat channels", () => {
+    const meta = getChatChannelMeta("telegram");
+
+    expect(meta.id).toBe("telegram");
+    expect(meta.label).toBeTruthy();
+  });
+
+  it("resolves metadata for a registered third-party channel plugin", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "zulip",
+          source: "test",
+          plugin: createThirdPartyChannelPlugin("zulip", "Zulip"),
+        },
+      ]),
+    );
+
+    const meta = getChatChannelMeta("zulip");
+
+    expect(meta.id).toBe("zulip");
+    expect(meta.label).toBe("Zulip");
+  });
+
+  it("still throws a clear error for unknown channel ids", () => {
+    expect(() => getChatChannelMeta("no-such-channel")).toThrow(
+      "expected chat channel metadata: no-such-channel to be defined",
+    );
+  });
+});

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -5,6 +5,7 @@ import { buildChatChannelMetaById } from "../channels/chat-meta-shared.js";
 import type { ChatChannelId } from "../channels/ids.js";
 import { emptyChannelConfigSchema } from "../channels/plugins/config-schema.js";
 import { buildAccountScopedDmSecurityPolicy } from "../channels/plugins/helpers.js";
+import { getLoadedChannelPluginForRead } from "../channels/plugins/registry-loaded.js";
 import {
   createScopedAccountReplyToModeResolver,
   createTopLevelChannelReplyToModeResolver,
@@ -22,7 +23,7 @@ import type {
   ChannelThreadingAdapter,
 } from "../channels/plugins/types.core.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
-import type { ChannelMeta } from "../channels/plugins/types.public.js";
+import type { ChannelId, ChannelMeta } from "../channels/plugins/types.public.js";
 import type { ReplyToMode } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildOutboundBaseSessionKey } from "../infra/outbound/base-session-key.js";
@@ -329,12 +330,17 @@ function resolveSdkChatChannelMeta(id: string) {
       metaById: buildChatChannelMetaById(),
     };
   }
-  // Optional by design: createChannelPluginBase serves external plugin ids that
-  // are never in the bundled catalog; their meta comes entirely from params.meta.
-  return cachedSdkChatChannelMeta.metaById[id];
+  const bundled = cachedSdkChatChannelMeta.metaById[id];
+  if (bundled) {
+    return bundled;
+  }
+  // Third-party channel plugins are never in the bundled catalog. Fall back to
+  // the active plugin registry so SDK helpers resolve metadata for any properly
+  // registered channel, while unknown ids still resolve to undefined and fail.
+  return getLoadedChannelPluginForRead(id as ChannelId)?.meta;
 }
 
-/** Resolve bundled chat channel metadata while respecting the active bundled-plugin directory. */
+/** Resolve chat channel metadata for bundled or actively registered plugin channels. */
 export function getChatChannelMeta(id: ChatChannelId): ChannelMeta {
   return expectDefined(resolveSdkChatChannelMeta(id), `chat channel metadata: ${id}`);
 }


### PR DESCRIPTION
Closes #114553
Supersedes #114629

## What Problem This Solves

Fixes an issue where users running a third-party channel plugin (observed: Zulip) would see `describeMessageTool` fail deterministically with `expected chat channel metadata: zulip to be defined` whenever the tool resolved channel metadata. Channel metadata resolution only consulted the static first-party channel catalog, so any properly configured and active third-party channel was treated as unknown.

## Why This Change Was Made

`getChatChannelMeta` now falls back to the active plugin registry when an id is missing from the bundled channel catalog, returning the plugin-registered `meta` for properly registered third-party channels. Bundled channels still resolve from the catalog first (no behavior change), and ids that are neither bundled nor actively registered still resolve to `undefined` and fail with the same clear error, preserving the intended guard against typos and misconfiguration.

## User Impact

Users with third-party channel plugins installed and enabled can now use SDK helpers such as `describeMessageTool` without hitting a metadata resolution error. No change for first-party channel users; unknown or unregistered channel ids still fail loudly with a descriptive message.

## Evidence

New regression tests in `src/plugin-sdk/chat-channel-meta.test.ts` cover bundled resolution, registered third-party resolution, and the unknown-id error path:

```
✓ plugin-sdk ../../src/plugin-sdk/chat-channel-meta.test.ts (3 tests) 77ms
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Contract lanes:

```
pnpm test:contracts:plugins  → Test Files 40 passed (40), Tests 972 passed (972)
pnpm test:contracts:channels → Test Files 13 passed (13), Tests 33 passed (33)
```

Import boundary checks (src/** boundary changed by the new import):

```
node scripts/check-src-extension-import-boundary.mjs --json        → [] (exit 0)
node scripts/check-sdk-package-extension-import-boundary.mjs --json → [] (exit 0)
```

---

🤖 AI-assisted change (OpenClaw fix worker). Reviewed and validated against the issue's root-cause trace.