### PR TITLE
perf: count large histories before Gateway prewarm

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -229,18 +229,19 @@ export function canPrewarmCombinedSessionStoresForGateway(
   cfg: OpenClawConfig,
   params: { agentIds: readonly string[]; maxRows: number },
 ): boolean {
-  const resolvedTargets = params.agentIds.flatMap((agentId) => {
-    const resolved = resolveGatewaySessionStoreTargets(cfg, { agentId });
-    return [...resolved.durableTargets, ...resolved.incognitoTargets];
-  });
-  const targets = dedupeSessionStoreTargetsBySqliteTarget(resolvedTargets, {
-    defaultAgentId: normalizeAgentId(resolveDefaultAgentId(cfg)),
-  });
+  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
   let totalRows = 0;
-  for (const target of targets) {
-    totalRows += countSessionEntryRowsReadOnly(target);
-    if (totalRows > params.maxRows) {
-      return false;
+  for (const agentId of params.agentIds) {
+    const resolved = resolveGatewaySessionStoreTargets(cfg, { agentId });
+    const projectionTargets = dedupeSessionStoreTargetsBySqliteTarget(
+      [...resolved.durableTargets, ...resolved.incognitoTargets],
+      { defaultAgentId },
+    );
+    for (const target of projectionTargets) {
+      totalRows += countSessionEntryRowsReadOnly(target);
+      if (totalRows > params.maxRows) {
+        return false;
+      }
     }
   }
   return true;

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -16,7 +16,11 @@ import {
 import { listOpenIncognitoAgentDatabases } from "../../state/openclaw-agent-db.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveStorePath } from "./paths.js";
-import { listSessionEntries, listSessionEntriesReadOnly } from "./session-accessor.js";
+import {
+  countSessionEntryRowsReadOnly,
+  listSessionEntries,
+  listSessionEntriesReadOnly,
+} from "./session-accessor.js";
 import type { SessionEntryListScope } from "./session-accessor.types.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
 import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
@@ -31,6 +35,23 @@ import {
 import type { SessionEntry } from "./types.js";
 
 type GatewaySessionEntryProjection = NonNullable<SessionEntryListScope["projection"]>;
+
+type GatewaySessionStoreOptions = {
+  agentId?: string;
+  configuredAgentsOnly?: boolean;
+  includeIncognito?: boolean;
+  projection?: SessionEntryListScope["projection"];
+};
+
+type ResolvedGatewaySessionStoreTargets = {
+  configuredAgentIds?: ReadonlySet<string>;
+  defaultAgentId: string;
+  diagnostics: string[];
+  durableTargets: Array<{ agentId: string; storePath: string }>;
+  incognitoTargets: Array<{ agentId: string; storePath: string }>;
+  requestedAgentId?: string;
+  storeConfig?: string;
+};
 
 // Template-backed stores need per-agent scans before they can be merged for Gateway views.
 function isStorePathTemplate(store?: string): boolean {
@@ -97,20 +118,13 @@ function mergeSessionEntryIntoCombined(params: {
 }
 
 function mergeOpenIncognitoStores(params: {
-  allowedAgentIds?: ReadonlySet<string>;
   cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
-  agentId?: string;
   projection: GatewaySessionEntryProjection;
+  targets: Array<{ agentId: string; storePath: string }>;
 }): string[] {
   const storePaths: string[] = [];
-  for (const target of listOpenIncognitoAgentDatabases()) {
-    if (params.allowedAgentIds && !params.allowedAgentIds.has(target.agentId)) {
-      continue;
-    }
-    if (params.agentId && target.agentId !== params.agentId) {
-      continue;
-    }
+  for (const target of params.targets) {
     const store = loadGatewayStoreEntries({
       agentId: target.agentId,
       includeOpenDatabases: true,
@@ -138,27 +152,12 @@ function mergeOpenIncognitoStores(params: {
   return storePaths;
 }
 
-/** Loads and canonicalizes session entries for gateway views across one or more agent stores. */
-export function loadCombinedSessionStoreForGateway(
+function resolveGatewaySessionStoreTargets(
   cfg: OpenClawConfig,
-  opts: {
-    agentId?: string;
-    configuredAgentsOnly?: boolean;
-    includeIncognito?: boolean;
-    projection?: SessionEntryListScope["projection"];
-  } = {},
-): {
-  diagnostics?: string[];
-  durableStorePath?: string;
-  storePath: string;
-  store: Record<string, SessionEntry>;
-} {
+  opts: GatewaySessionStoreOptions,
+): ResolvedGatewaySessionStoreTargets {
   const storeConfig = cfg.session?.store;
-  const projection = opts.projection ?? "full";
   const diagnostics: string[] = [];
-  // Exclusion happens before path aggregation; filtering rows afterward would
-  // still leak a live incognito handle by changing the projected store path.
-  const includeIncognito = opts.includeIncognito !== false;
   const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
   const requestedAgentId =
     typeof opts.agentId === "string" && opts.agentId.trim()
@@ -171,6 +170,13 @@ export function loadCombinedSessionStoreForGateway(
   const allowedIncognitoAgentIds = requestedAgentId
     ? new Set([requestedAgentId])
     : configuredAgentIds;
+  const incognitoTargets =
+    opts.includeIncognito === false
+      ? []
+      : listOpenIncognitoAgentDatabases().filter(
+          (target) => !allowedIncognitoAgentIds || allowedIncognitoAgentIds.has(target.agentId),
+        );
+
   if (storeConfig && !isStorePathTemplate(storeConfig)) {
     const ownerIds = [
       ...new Set([
@@ -181,10 +187,7 @@ export function loadCombinedSessionStoreForGateway(
         ...(requestedAgentId ? [requestedAgentId] : []),
       ]),
     ];
-    const combined: Record<string, SessionEntry> = {};
-    // Runtime session access is SQLite-only: a fixed literal is a naming seed whose
-    // resolved database is partitioned per owner. Legacy flat JSON is migration-only.
-    const ownerTargets = dedupeSessionStoreTargetsBySqliteTarget(
+    const durableTargets = dedupeSessionStoreTargetsBySqliteTarget(
       ownerIds.map((agentId) => ({
         agentId,
         storePath: resolveStorePath(storeConfig, { agentId }),
@@ -194,7 +197,80 @@ export function loadCombinedSessionStoreForGateway(
         onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
       },
     );
-    for (const { agentId, storePath } of ownerTargets) {
+    return {
+      configuredAgentIds,
+      defaultAgentId,
+      diagnostics,
+      durableTargets,
+      incognitoTargets,
+      requestedAgentId,
+      storeConfig,
+    };
+  }
+
+  const durableTargets = requestedAgentId
+    ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)
+    : opts.configuredAgentsOnly === true
+      ? resolveSessionStoreTargets(cfg, { allAgents: true })
+      : resolveAllAgentSessionStoreTargetsSync(cfg);
+  return {
+    configuredAgentIds,
+    defaultAgentId,
+    diagnostics,
+    durableTargets,
+    incognitoTargets,
+    requestedAgentId,
+    storeConfig,
+  };
+}
+
+/** Checks whether Gateway prewarm can project the selected stores within a bounded row budget. */
+export function canPrewarmCombinedSessionStoresForGateway(
+  cfg: OpenClawConfig,
+  params: { agentIds: readonly string[]; maxRows: number },
+): boolean {
+  const resolvedTargets = params.agentIds.flatMap((agentId) => {
+    const resolved = resolveGatewaySessionStoreTargets(cfg, { agentId });
+    return [...resolved.durableTargets, ...resolved.incognitoTargets];
+  });
+  const targets = dedupeSessionStoreTargetsBySqliteTarget(resolvedTargets, {
+    defaultAgentId: normalizeAgentId(resolveDefaultAgentId(cfg)),
+  });
+  let totalRows = 0;
+  for (const target of targets) {
+    totalRows += countSessionEntryRowsReadOnly(target);
+    if (totalRows > params.maxRows) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Loads and canonicalizes session entries for gateway views across one or more agent stores. */
+export function loadCombinedSessionStoreForGateway(
+  cfg: OpenClawConfig,
+  opts: GatewaySessionStoreOptions = {},
+): {
+  diagnostics?: string[];
+  durableStorePath?: string;
+  storePath: string;
+  store: Record<string, SessionEntry>;
+} {
+  const projection = opts.projection ?? "full";
+  // Count admission and projection share this exact target set. Otherwise an optional
+  // prewarm can approve one database and synchronously materialize another.
+  const {
+    configuredAgentIds,
+    defaultAgentId,
+    diagnostics,
+    durableTargets,
+    incognitoTargets,
+    requestedAgentId,
+    storeConfig,
+  } = resolveGatewaySessionStoreTargets(cfg, opts);
+  if (storeConfig && !isStorePathTemplate(storeConfig)) {
+    const combined: Record<string, SessionEntry> = {};
+    for (const { agentId, storePath } of durableTargets) {
       const store = loadGatewayStoreEntries({ agentId, projection, storePath });
       for (const { sessionKey: key, entry } of store) {
         const canonicalKey = resolveStoredSessionKeyForAgentStore({
@@ -226,15 +302,12 @@ export function loadCombinedSessionStoreForGateway(
       }
     }
     const durableStorePath = resolveStorePath(storeConfig, { agentId: defaultAgentId });
-    const incognitoStorePaths = includeIncognito
-      ? mergeOpenIncognitoStores({
-          ...(allowedIncognitoAgentIds ? { allowedAgentIds: allowedIncognitoAgentIds } : {}),
-          cfg,
-          combined,
-          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
-          projection,
-        })
-      : [];
+    const incognitoStorePaths = mergeOpenIncognitoStores({
+      cfg,
+      combined,
+      projection,
+      targets: incognitoTargets,
+    });
     return {
       diagnostics,
       durableStorePath,
@@ -242,13 +315,8 @@ export function loadCombinedSessionStoreForGateway(
       store: combined,
     };
   }
-  const targets = requestedAgentId
-    ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)
-    : opts.configuredAgentsOnly === true
-      ? resolveSessionStoreTargets(cfg, { allAgents: true })
-      : resolveAllAgentSessionStoreTargetsSync(cfg);
   const combined: Record<string, SessionEntry> = {};
-  for (const target of targets) {
+  for (const target of durableTargets) {
     const agentId = target.agentId;
     const storePath = target.storePath;
     const store = loadGatewayStoreEntries({ agentId, projection, storePath });
@@ -282,17 +350,14 @@ export function loadCombinedSessionStoreForGateway(
     }
   }
 
-  const incognitoStorePaths = includeIncognito
-    ? mergeOpenIncognitoStores({
-        ...(allowedIncognitoAgentIds ? { allowedAgentIds: allowedIncognitoAgentIds } : {}),
-        cfg,
-        combined,
-        ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
-        projection,
-      })
-    : [];
+  const incognitoStorePaths = mergeOpenIncognitoStores({
+    cfg,
+    combined,
+    projection,
+    targets: incognitoTargets,
+  });
 
-  const durableStorePaths = targets.map((target) => target.storePath);
+  const durableStorePaths = durableTargets.map((target) => target.storePath);
   const durableStorePath = resolveCombinedStorePath(durableStorePaths, storeConfig);
   const storePath = resolveCombinedStorePath(
     [...durableStorePaths, ...incognitoStorePaths],

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -10,6 +10,7 @@ import { resolveAgentMainSessionKey } from "./main-session.js";
 import { resolveStorePath } from "./paths.js";
 import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
+  countSqliteSessionEntryRowsReadOnly as countSessionEntryRowsReadOnly,
   copySqliteSessionOwnedStateForCanonicalRepair as copySessionOwnedStateForCanonicalRepair,
   listSqliteSessionGenerationIdsForCanonicalRepair as listSessionGenerationIdsForCanonicalRepair,
   listSqliteSessionChildEntriesReadOnly as listSessionChildEntriesReadOnly,
@@ -58,6 +59,7 @@ export { clearPluginOwnedSessionState };
 // SQLite is the only runtime session store. Re-export its canonical entry
 // operations directly instead of maintaining a second pass-through layer.
 export {
+  countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
   listSessionGenerationIdsForCanonicalRepair,
   listSessionChildEntriesReadOnly,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -285,7 +285,6 @@ export function listSqliteSessionEntriesReadOnly(
 export function countSqliteSessionEntryRowsReadOnly(scope: SessionEntryListScope = {}): number {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
-    assertCanonicalSqliteSessionKeysCurrent(database);
     const db = getSessionKysely(database.db);
     const row = executeSqliteQueryTakeFirstSync(
       database.db,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -281,6 +281,23 @@ export function listSqliteSessionEntriesReadOnly(
   return result.found ? result.value : [];
 }
 
+/** Counts durable session rows without materializing entry JSON or warming the entry cache. */
+export function countSqliteSessionEntryRowsReadOnly(scope: SessionEntryListScope = {}): number {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    assertCanonicalSqliteSessionKeysCurrent(database);
+    const db = getSessionKysely(database.db);
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .select((expression) => expression.fn.countAll<number | bigint>().as("count")),
+    );
+    return normalizeSqliteNumber(row?.count ?? null) ?? 0;
+  }, toDatabaseOptions(resolved));
+  return result.found ? result.value : 0;
+}
+
 function listSqliteSessionEntriesFromDatabase(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -293,7 +293,7 @@ export function countSqliteSessionEntryRowsReadOnly(scope: SessionEntryListScope
         .selectFrom("session_nodes")
         .select((expression) => expression.fn.countAll<number | bigint>().as("count")),
     );
-    return normalizeSqliteNumber(row?.count ?? null) ?? 0;
+    return row ? normalizeSqliteNumber(row.count) : 0;
   }, toDatabaseOptions(resolved));
   return result.found ? result.value : 0;
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,5 +1,6 @@
 // Stable SQLite accessor surface. Domain owners live in the focused modules below.
 export {
+  countSqliteSessionEntryRowsReadOnly,
   listSqliteSessionEntries,
   listSqliteSessionChildEntriesReadOnly,
   listSqliteSessionEntriesReadOnly,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
@@ -227,6 +228,23 @@ describe("session accessor seam", () => {
     expect(readSqliteSessionEntryCount(database)).toBe(1);
     expect(readSqliteSessionEntryKeys(database)).toEqual(["agent:main:logical-entry"]);
     expect(countSessionEntryRowsReadOnly({ agentId: "main", storePath })).toBe(2);
+  });
+
+  it("counts rows on a cold handle without parsing invalid entry JSON", async () => {
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:cold-count", storePath },
+      { sessionId: "cold-count-session", updatedAt: 10 },
+    );
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "cold count database path",
+    );
+    closeOpenClawAgentDatabasesForTest();
+    const database = new DatabaseSync(databasePath);
+    database.prepare("UPDATE session_nodes SET entry_valid = 0").run();
+    database.close();
+
+    expect(countSessionEntryRowsReadOnly({ agentId: "main", storePath })).toBe(1);
   });
 
   it("retains legacy createdBy actor projections across rewrites", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -26,6 +26,7 @@ import {
   appendTranscriptMessage,
   applySessionEntryLifecycleMutation,
   commitReplySessionInitialization,
+  countSessionEntryRowsReadOnly,
   createSessionEntryWithTranscript,
   deleteSessionEntryLifecycle,
   findTranscriptEvent,
@@ -225,6 +226,7 @@ describe("session accessor seam", () => {
 
     expect(readSqliteSessionEntryCount(database)).toBe(1);
     expect(readSqliteSessionEntryKeys(database)).toEqual(["agent:main:logical-entry"]);
+    expect(countSessionEntryRowsReadOnly({ agentId: "main", storePath })).toBe(2);
   });
 
   it("retains legacy createdBy actor projections across rewrites", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -119,6 +119,7 @@ export type {
   UpdateSessionLastRouteParams,
 } from "./session-accessor.entry-mutation.js";
 export {
+  countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
   listSessionGenerationIdsForCanonicalRepair,
   clearPluginOwnedSessionState,

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -3,10 +3,9 @@ import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js"
 
 const mocks = vi.hoisted(() => ({
   events: [] as string[],
-  sessionEntryCounts: new Map<string, number>(),
-  countSessionEntryRowsReadOnly: vi.fn((options: { agentId: string }) => {
-    mocks.events.push(`sessions.count.${options.agentId}`);
-    return mocks.sessionEntryCounts.get(options.agentId) ?? 0;
+  canPrewarmCombinedSessionStoresForGateway: vi.fn(() => {
+    mocks.events.push("sessions.count");
+    return true;
   }),
   loadCombinedSessionStoreForGateway: vi.fn((_cfg: unknown, options: { agentId: string }) => {
     mocks.events.push(`sessions.load.${options.agentId}`);
@@ -30,12 +29,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../config/sessions/combined-store-gateway.js", () => ({
+  canPrewarmCombinedSessionStoresForGateway: mocks.canPrewarmCombinedSessionStoresForGateway,
   loadCombinedSessionStoreForGateway: mocks.loadCombinedSessionStoreForGateway,
-}));
-
-vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../config/sessions/session-accessor.js")>()),
-  countSessionEntryRowsReadOnly: mocks.countSessionEntryRowsReadOnly,
 }));
 
 vi.mock("./session-utils-list.js", () => ({
@@ -54,8 +49,11 @@ const { scheduleGatewayHandlerPrewarm } = await import("./server-startup-handler
 
 beforeEach(() => {
   mocks.events.length = 0;
-  mocks.sessionEntryCounts.clear();
-  mocks.countSessionEntryRowsReadOnly.mockClear();
+  mocks.canPrewarmCombinedSessionStoresForGateway.mockClear();
+  mocks.canPrewarmCombinedSessionStoresForGateway.mockImplementation(() => {
+    mocks.events.push("sessions.count");
+    return true;
+  });
   mocks.loadCombinedSessionStoreForGateway.mockClear();
   mocks.listSessionsFromStoreAsync.mockClear();
   mocks.listManagedPlugins.mockClear();
@@ -83,8 +81,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     await vi.runAllTimersAsync();
 
     expect(mocks.events).toEqual([
-      "sessions.count.main",
-      "sessions.count.research",
+      "sessions.count",
       "sessions.load.main",
       "sessions.rows.main",
       "sessions.load.research",
@@ -126,6 +123,10 @@ describe("scheduleGatewayHandlerPrewarm", () => {
       agentId: "research",
       limitPerHost: 40,
     });
+    expect(mocks.canPrewarmCombinedSessionStoresForGateway).toHaveBeenCalledWith(cfg, {
+      agentIds: ["main", "research"],
+      maxRows: 2_000,
+    });
     sidecar.stop();
   });
 
@@ -162,19 +163,26 @@ describe("scheduleGatewayHandlerPrewarm", () => {
 
   it("skips optional catalog prewarm when the combined session stores are large", async () => {
     vi.useFakeTimers();
-    mocks.sessionEntryCounts.set("main", 2_001);
+    const info = vi.fn();
+    mocks.canPrewarmCombinedSessionStoresForGateway.mockImplementation(() => {
+      mocks.events.push("sessions.count");
+      return false;
+    });
     const cfg = {
       agents: { list: [{ id: "main", default: true }, { id: "research" }] },
     } as never;
 
     scheduleGatewayHandlerPrewarm({
       cfgAtStart: cfg,
-      log: { warn: vi.fn() },
+      log: { info, warn: vi.fn() },
     });
     await vi.runAllTimersAsync();
 
-    expect(mocks.events).toEqual(["sessions.count.main", "plugins"]);
+    expect(mocks.events).toEqual(["sessions.count", "plugins"]);
     expect(mocks.prewarmSessionCatalogList).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(
+      "skipping optional dashboard session prewarm: combined stores exceed 2000 rows",
+    );
   });
 
   it("stops before scheduling another event-loop turn", async () => {

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -4,18 +4,16 @@ import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js"
 const mocks = vi.hoisted(() => ({
   events: [] as string[],
   sessionEntryCounts: new Map<string, number>(),
+  countSessionEntryRowsReadOnly: vi.fn((options: { agentId: string }) => {
+    mocks.events.push(`sessions.count.${options.agentId}`);
+    return mocks.sessionEntryCounts.get(options.agentId) ?? 0;
+  }),
   loadCombinedSessionStoreForGateway: vi.fn((_cfg: unknown, options: { agentId: string }) => {
     mocks.events.push(`sessions.load.${options.agentId}`);
-    const entryCount = mocks.sessionEntryCounts.get(options.agentId) ?? 0;
     return {
       durableStorePath: `/state/${options.agentId}.sqlite`,
       storePath: `/state/${options.agentId}.sqlite`,
-      store: Object.fromEntries(
-        Array.from({ length: entryCount }, (_, index) => [
-          `agent:${options.agentId}:fixture-${index}`,
-          { sessionId: `session-${index}`, updatedAt: index },
-        ]),
-      ),
+      store: {},
     };
   }),
   listSessionsFromStoreAsync: vi.fn(async (params: { opts: { agentId: string } }) => {
@@ -35,6 +33,11 @@ vi.mock("../config/sessions/combined-store-gateway.js", () => ({
   loadCombinedSessionStoreForGateway: mocks.loadCombinedSessionStoreForGateway,
 }));
 
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions/session-accessor.js")>()),
+  countSessionEntryRowsReadOnly: mocks.countSessionEntryRowsReadOnly,
+}));
+
 vi.mock("./session-utils-list.js", () => ({
   listSessionsFromStoreAsync: mocks.listSessionsFromStoreAsync,
 }));
@@ -52,6 +55,7 @@ const { scheduleGatewayHandlerPrewarm } = await import("./server-startup-handler
 beforeEach(() => {
   mocks.events.length = 0;
   mocks.sessionEntryCounts.clear();
+  mocks.countSessionEntryRowsReadOnly.mockClear();
   mocks.loadCombinedSessionStoreForGateway.mockClear();
   mocks.listSessionsFromStoreAsync.mockClear();
   mocks.listManagedPlugins.mockClear();
@@ -79,6 +83,8 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     await vi.runAllTimersAsync();
 
     expect(mocks.events).toEqual([
+      "sessions.count.main",
+      "sessions.count.research",
       "sessions.load.main",
       "sessions.rows.main",
       "sessions.load.research",
@@ -167,13 +173,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     });
     await vi.runAllTimersAsync();
 
-    expect(mocks.events).toEqual([
-      "sessions.load.main",
-      "sessions.rows.main",
-      "sessions.load.research",
-      "sessions.rows.research",
-      "plugins",
-    ]);
+    expect(mocks.events).toEqual(["sessions.count.main", "plugins"]);
     expect(mocks.prewarmSessionCatalogList).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -1,5 +1,4 @@
 import { listAgentIds } from "../agents/agent-scope-config.js";
-import { countSessionEntryRowsReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 
@@ -46,24 +45,30 @@ async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: strin
   });
 }
 
-function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmItem[] {
+function dashboardDataPrewarmItems(
+  cfg: OpenClawConfig,
+  log: { info?: (msg: string) => void },
+): GatewayHandlerPrewarmItem[] {
   const agentIds = listAgentIds(cfg);
   let sessionDataPrewarmChecked = false;
   let sessionDataPrewarmAllowed = false;
-  const shouldPrewarmSessionData = () => {
+  const shouldPrewarmSessionData = async () => {
     if (sessionDataPrewarmChecked) {
       return sessionDataPrewarmAllowed;
     }
     sessionDataPrewarmChecked = true;
-    let totalSessionEntries = 0;
-    for (const agentId of agentIds) {
-      totalSessionEntries += countSessionEntryRowsReadOnly({ agentId });
-      if (totalSessionEntries > SIDEBAR_PREWARM_MAX_SESSION_ENTRIES) {
-        return false;
-      }
+    const { canPrewarmCombinedSessionStoresForGateway } =
+      await import("../config/sessions/combined-store-gateway.js");
+    sessionDataPrewarmAllowed = canPrewarmCombinedSessionStoresForGateway(cfg, {
+      agentIds,
+      maxRows: SIDEBAR_PREWARM_MAX_SESSION_ENTRIES,
+    });
+    if (!sessionDataPrewarmAllowed) {
+      log.info?.(
+        `skipping optional dashboard session prewarm: combined stores exceed ${SIDEBAR_PREWARM_MAX_SESSION_ENTRIES} rows`,
+      );
     }
-    sessionDataPrewarmAllowed = true;
-    return true;
+    return sessionDataPrewarmAllowed;
   };
   return [
     ...agentIds.map((agentId) => ({
@@ -71,7 +76,7 @@ function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmIt
       load: async () => {
         // A count-only query keeps unusually large stores off the synchronous JSON projection
         // path. Request-time session and catalog handlers remain authoritative when skipped.
-        if (!shouldPrewarmSessionData()) {
+        if (!(await shouldPrewarmSessionData())) {
           return;
         }
         await prewarmGatewaySessionListData(cfg, agentId);
@@ -87,7 +92,7 @@ function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmIt
     ...agentIds.map((agentId) => ({
       name: `session-catalog.${agentId}`,
       load: async () => {
-        if (!shouldPrewarmSessionData()) {
+        if (!(await shouldPrewarmSessionData())) {
           return;
         }
         const { prewarmSessionCatalogList } = await import("./server-methods/session-catalog.js");
@@ -104,12 +109,12 @@ function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmIt
 export function scheduleGatewayHandlerPrewarm(params: {
   cfgAtStart: OpenClawConfig;
   startupTrace?: StartupTrace;
-  log: { warn: (msg: string) => void };
+  log: { info?: (msg: string) => void; warn: (msg: string) => void };
   items?: readonly GatewayHandlerPrewarmItem[];
 }): GatewayHandlerPrewarmHandle {
   // Frequent updater restarts make cold dashboard data the remaining slow tier.
   // Keep cheap session reads first, process-stable plugin data second, and provider catalogs last.
-  const items = params.items ?? dashboardDataPrewarmItems(params.cfgAtStart);
+  const items = params.items ?? dashboardDataPrewarmItems(params.cfgAtStart, params.log);
   let stopped = false;
   let nextIndex = 0;
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -1,10 +1,11 @@
 import { listAgentIds } from "../agents/agent-scope-config.js";
+import { countSessionEntryRowsReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 
 const SIDEBAR_SESSION_LIST_LIMIT = 60;
 const SIDEBAR_CATALOG_LIMIT_PER_HOST = 40;
-const SIDEBAR_CATALOG_PREWARM_MAX_SESSION_ENTRIES = 2_000;
+const SIDEBAR_PREWARM_MAX_SESSION_ENTRIES = 2_000;
 
 type StartupTrace = {
   measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
@@ -19,10 +20,7 @@ type GatewayHandlerPrewarmHandle = {
   stop: () => void;
 };
 
-async function prewarmGatewaySessionListData(
-  cfg: OpenClawConfig,
-  agentId: string,
-): Promise<number> {
+async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: string): Promise<void> {
   const [{ loadCombinedSessionStoreForGateway }, { listSessionsFromStoreAsync }] =
     await Promise.all([
       import("../config/sessions/combined-store-gateway.js"),
@@ -46,19 +44,37 @@ async function prewarmGatewaySessionListData(
       limit: SIDEBAR_SESSION_LIST_LIMIT,
     },
   });
-  return Object.keys(store).length;
 }
 
 function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmItem[] {
   const agentIds = listAgentIds(cfg);
-  let loadedSessionStores = 0;
-  let totalSessionEntries = 0;
+  let sessionDataPrewarmChecked = false;
+  let sessionDataPrewarmAllowed = false;
+  const shouldPrewarmSessionData = () => {
+    if (sessionDataPrewarmChecked) {
+      return sessionDataPrewarmAllowed;
+    }
+    sessionDataPrewarmChecked = true;
+    let totalSessionEntries = 0;
+    for (const agentId of agentIds) {
+      totalSessionEntries += countSessionEntryRowsReadOnly({ agentId });
+      if (totalSessionEntries > SIDEBAR_PREWARM_MAX_SESSION_ENTRIES) {
+        return false;
+      }
+    }
+    sessionDataPrewarmAllowed = true;
+    return true;
+  };
   return [
     ...agentIds.map((agentId) => ({
       name: `sessions.${agentId}`,
       load: async () => {
-        totalSessionEntries += await prewarmGatewaySessionListData(cfg, agentId);
-        loadedSessionStores += 1;
+        // A count-only query keeps unusually large stores off the synchronous JSON projection
+        // path. Request-time session and catalog handlers remain authoritative when skipped.
+        if (!shouldPrewarmSessionData()) {
+          return;
+        }
+        await prewarmGatewaySessionListData(cfg, agentId);
       },
     })),
     {
@@ -71,12 +87,7 @@ function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmIt
     ...agentIds.map((agentId) => ({
       name: `session-catalog.${agentId}`,
       load: async () => {
-        // Catalog providers may project every OpenClaw session before returning their bounded
-        // page. Keep that optional cold-cache work off the event loop for unusually large stores.
-        if (
-          loadedSessionStores !== agentIds.length ||
-          totalSessionEntries > SIDEBAR_CATALOG_PREWARM_MAX_SESSION_ENTRIES
-        ) {
+        if (!shouldPrewarmSessionData()) {
           return;
         }
         const { prewarmSessionCatalogList } = await import("./server-methods/session-catalog.js");

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -175,6 +175,62 @@ test("startup prewarm fills session snapshot and title caches before the first l
   }
 });
 
+test("startup skips a large session prewarm while request-time listing remains available", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: Object.fromEntries(
+      Array.from({ length: 2_001 }, (_, index) => [
+        `agent:main:large-${index}`,
+        sessionStoreEntry(`large-${index}`, { updatedAt: 1_781_000_000_000 - index }),
+      ]),
+    ),
+  });
+  const info = vi.fn();
+  const listSpy = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+  let sidecar: ReturnType<typeof scheduleGatewayHandlerPrewarm> | undefined;
+  vi.useFakeTimers();
+  try {
+    let resolveSessionPrewarm!: () => void;
+    const sessionPrewarm = new Promise<void>((resolve) => {
+      resolveSessionPrewarm = resolve;
+    });
+    sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storePath },
+      } as never,
+      log: { info, warn: vi.fn() },
+      startupTrace: {
+        measure: async (name, run) => {
+          try {
+            return await run();
+          } finally {
+            if (name === "post-ready.gateway-data.sessions.main") {
+              resolveSessionPrewarm();
+            }
+          }
+        },
+      },
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+    await sessionPrewarm;
+    sidecar.stop();
+    expect(info).toHaveBeenCalledWith(
+      "skipping optional dashboard session prewarm: combined stores exceed 2000 rows",
+    );
+    expect(listSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    const result = await directSessionReq("sessions.list", LIST_PARAMS);
+    expect(result.ok).toBe(true);
+  } finally {
+    sidecar?.stop();
+    vi.useRealTimers();
+    listSpy.mockRestore();
+  }
+});
+
 test("sessions.list projects out prompt snapshots without changing full entry reads", async () => {
   await createSessionStoreDir();
   await writeSessionStore({

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -1408,6 +1408,13 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
         "main",
       );
 
+      expect(
+        canPrewarmCombinedSessionStoresForGateway(cfg, {
+          agentIds: ["main", "ops"],
+          maxRows: 1,
+        }),
+      ).toBe(false);
+
       const { diagnostics, store } = loadCombinedSessionStoreForGateway(cfg);
       expect(store["agent:main:main"]?.sessionId).toBe("s-main-unscoped");
       expect(store["agent:ops:main"]).toBeUndefined();

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -15,6 +15,7 @@ import {
 import type { SubagentRunRecord } from "../agents/subagent-registry.types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { canPrewarmCombinedSessionStoresForGateway } from "../config/sessions/combined-store-gateway.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { registerAgentRunContext, resetAgentEventsForTest } from "../infra/agent-events.js";
 import {
@@ -1493,6 +1494,19 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
         { incognito: true, sessionId: "s-incognito-dynamic", updatedAt: 500 },
         "dynamic",
       );
+      await seedSessionEntry(
+        resolveIncognitoOpenClawAgentSqlitePath({ agentId: "ops" }),
+        "dashboard:incognito-ops",
+        { incognito: true, sessionId: "s-incognito-ops", updatedAt: 600 },
+        "ops",
+      );
+
+      expect(
+        canPrewarmCombinedSessionStoresForGateway(cfg, {
+          agentIds: ["ops"],
+          maxRows: 4,
+        }),
+      ).toBe(false);
 
       const { store } = loadCombinedSessionStoreForGateway(cfg);
       expect(store["agent:ops:main"]?.sessionId).toBe("s-ops");
@@ -1589,6 +1603,13 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       } as OpenClawConfig;
 
       const { store, storePath } = loadCombinedSessionStoreForGateway(cfg, { agentId: "codex" });
+
+      expect(
+        canPrewarmCombinedSessionStoresForGateway(cfg, {
+          agentIds: ["codex"],
+          maxRows: 0,
+        }),
+      ).toBe(false);
 
       expect(path.resolve(storePath)).toBe(path.resolve(codexStorePath));
       expect(store["agent:codex:acp-task"]?.sessionId).toBe("s-codex");


### PR DESCRIPTION
## What Problem This Solves

Completes the large-history Gateway recovery from #117108. Live deployment showed the event loop still blocked before catalog prewarming, while the sidebar session-list prewarm materialized a 15k-row store. Two consecutive starts reported ready and then timed out `/healthz` and RPC while consuming one CPU core for more than eight minutes.

## Root Cause

PR #115710 (`14ad80481ae1`, 2026-07-29) added unconditional post-ready sidebar prewarming. Its 60-session output limit applied only after every configured, custom/discovered, fixed-owner, and open-incognito store had been synchronously projected. PR #117108 skipped the later catalog prewarm but still paid this earlier full-store cost.

The first version of this PR had two important gaps: its count path still ran cold-handle canonical JSON validation, and it counted only default durable stores while projection could load custom/discovered and open-incognito stores. The current head fixes both at their shared combined-store owner.

## Why This Change Was Made

The combined-store owner now resolves one target policy for both admission and projection. A raw count-only SQLite query checks every physical store the optional prewarm may load, including custom/discovered, fixed-owner, and open-incognito databases. Above 2,000 rows, sidebar-session and catalog prewarming are skipped while plugin metadata still warms. Request-time session and catalog handlers remain authoritative, and startup records the intentional skip without exposing paths or session data.

## User Impact

Gateways with large histories remain responsive after restart instead of blocking health and update verification behind optional dashboard cache population. Normal-size stores retain the existing prewarm order.

## Evidence

- Original live reproduction: a 15,395-row Hetzner store made two Gateway starts CPU-bound for more than eight minutes after readiness, with HTTP and RPC unavailable during sidebar materialization.
- Exact head `2a893066d499b9799de39bef81d24d1704322ed4`: 127 focused tests passed across Gateway prewarm, combined/custom/incognito store selection, and the session accessor.
- The cold-handle regression corrupts `entry_valid` through a separate SQLite connection and proves the admission count returns without parsing or validating entry JSON.
- Custom-store and open-incognito regressions prove the admission budget covers the same targets the Gateway projection can load.
- A multi-agent fixed-store regression proves one shared physical database is budgeted once for each per-agent projection the scheduler will actually perform.
- [Blacksmith Testbox run 30680167318](https://github.com/openclaw/openclaw/actions/runs/30680167318): 36 exact-head integration tests passed, including multi-agent fixed-store accounting plus a real Gateway sessions harness that seeded 2,001 rows, recorded the optional-prewarm skip without materializing the store, and completed the authoritative `sessions.list` request in 424 ms.
- [Blacksmith Testbox changed gate 30680540357](https://github.com/openclaw/openclaw/actions/runs/30680540357): exact-head formatting, dependency/boundary guards, dead-code scans, core/core-test types, lint, database-first guards, and runtime import checks all passed.
- Autoreview: clean, no accepted/actionable findings.

Exact-head CI is in progress. Production-shaped sustained health/RPC proof will run immediately after merge through the supported updater before the remaining fleet advances.
