### PR TITLE
fix: prevent lost subagent replies and incorrect running session states

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -434,67 +434,93 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
-  it("notifies inbound event delivery after message sends", async () => {
-    const markDelivered = vi.fn();
-    const end = beginDiscordInboundEventDeliveryCorrelation(
-      "agent:main:discord:channel:c1",
-      {
-        outboundTo: "channel:c1",
-        outboundAccountId: "default",
-        markInboundEventDelivered: markDelivered,
+  it.each([
+    {
+      action: "send" as const,
+      params: { to: "channel:c1", message: "hello" },
+    },
+    {
+      action: "upload-file" as const,
+      params: { to: "channel:c1", filePath: "/tmp/image.png" },
+    },
+    {
+      action: "poll" as const,
+      params: {
+        to: "channel:c1",
+        pollQuestion: "Which option?",
+        pollOption: ["first", "second"],
       },
-      { inboundEventKind: "room_event" },
-    );
+    },
+    {
+      action: "sticker" as const,
+      params: { to: "channel:c1", stickerId: ["sticker-1"] },
+    },
+    {
+      action: "thread-reply" as const,
+      params: { threadId: "c1", message: "thread update" },
+    },
+    {
+      action: "thread-create" as const,
+      params: { channelId: "c1", messageId: "message-1", threadName: "investigation" },
+    },
+  ])(
+    "records room-event delivery only after $action receives a positive receipt",
+    async ({ action, params }) => {
+      const sessionKey = "agent:main:discord:channel:c1";
 
-    try {
-      await handleDiscordMessageAction({
-        action: "send",
-        params: {
-          to: "channel:c1",
-          message: "hello",
-        },
-        cfg: discordConfig(),
-        accountId: "default",
-        sessionKey: "agent:main:discord:channel:c1",
-        inboundEventKind: "room_event",
-      });
-    } finally {
-      end();
-    }
+      for (const ok of [false, true]) {
+        const markDelivered = vi.fn();
+        const onThreadAdopted = vi.fn();
+        const endDelivery = beginDiscordInboundEventDeliveryCorrelation(
+          sessionKey,
+          {
+            outboundTo: "channel:c1",
+            outboundAccountId: "default",
+            markInboundEventDelivered: markDelivered,
+          },
+          { inboundEventKind: "room_event" },
+        );
+        const endThreadRoute =
+          action === "thread-create"
+            ? beginDiscordActiveTurnThreadRoute(sessionKey, {
+                accountId: "default",
+                sourceChannelId: "c1",
+                sourceMessageId: "message-1",
+                onThreadAdopted,
+              })
+            : () => {};
 
-    expect(markDelivered).toHaveBeenCalledTimes(1);
-  });
+        handleDiscordActionMock.mockResolvedValueOnce({
+          content: [],
+          details: {
+            ok,
+            ...(ok ? {} : { error: "delivery failed" }),
+            ...(action === "thread-create" ? { thread: { id: "thread-1" } } : {}),
+          },
+        });
 
-  it("notifies inbound event delivery after visible message actions", async () => {
-    const markDelivered = vi.fn();
-    const end = beginDiscordInboundEventDeliveryCorrelation(
-      "agent:main:discord:channel:c1",
-      {
-        outboundTo: "channel:c1",
-        outboundAccountId: "default",
-        markInboundEventDelivered: markDelivered,
-      },
-      { inboundEventKind: "room_event" },
-    );
+        try {
+          const result = await handleDiscordMessageAction({
+            action,
+            params,
+            cfg: discordConfig({ threads: true, polls: true, stickers: true }),
+            accountId: "default",
+            sessionKey,
+            inboundEventKind: "room_event",
+          });
 
-    try {
-      await handleDiscordMessageAction({
-        action: "upload-file",
-        params: {
-          to: "channel:c1",
-          filePath: "/tmp/image.png",
-        },
-        cfg: discordConfig(),
-        accountId: "default",
-        sessionKey: "agent:main:discord:channel:c1",
-        inboundEventKind: "room_event",
-      });
-    } finally {
-      end();
-    }
-
-    expect(markDelivered).toHaveBeenCalledTimes(1);
-  });
+          expect(result.details).toMatchObject({ ok });
+          expect(markDelivered).toHaveBeenCalledTimes(ok ? 1 : 0);
+          if (action === "thread-create") {
+            expect(onThreadAdopted).toHaveBeenCalledTimes(ok ? 1 : 0);
+          }
+        } finally {
+          endThreadRoute();
+          endDelivery();
+        }
+      }
+    },
+  );
 
   it("maps upload-file to Discord sendMessage with media read context", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("image"));
@@ -644,7 +670,7 @@ describe("handleDiscordMessageAction", () => {
 
       handleDiscordActionMock.mockResolvedValueOnce({
         content: [],
-        details: { thread: { id: "thread-1" } },
+        details: { ok: true, thread: { id: "thread-1" } },
       });
       await handleDiscordMessageAction({
         action: "thread-create",
@@ -766,7 +792,7 @@ describe("handleDiscordMessageAction", () => {
     try {
       const expectedResult = {
         content: [],
-        details: { thread: { id: "thread-1" } },
+        details: { ok: true, thread: { id: "thread-1" } },
       };
       handleDiscordActionMock.mockResolvedValueOnce(expectedResult);
 

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -104,13 +104,27 @@ export async function handleDiscordMessageAction(
     mediaReadFile: ctx.mediaReadFile,
     ...readPolicyOptions,
   } as const;
-  const notifyVisibleOutbound = (to: string, fallbackSessionKey?: string) =>
+  const notifyVisibleOutbound = (
+    result: AgentToolResult<unknown>,
+    to: string,
+    fallbackSessionKey?: string,
+  ) => {
+    const details =
+      result.details && typeof result.details === "object" && !Array.isArray(result.details)
+        ? (result.details as { ok?: unknown })
+        : undefined;
+    // Resolved failures are not delivery receipts; clearing room history would
+    // otherwise permanently discard context without any visible reply.
+    if (details?.ok !== true) {
+      return;
+    }
     notifyDiscordInboundEventOutboundSuccess({
       sessionKey: ctx.sessionKey ?? fallbackSessionKey ?? undefined,
       to,
       accountId,
       inboundEventKind: ctx.inboundEventKind,
     });
+  };
   const withAdoptedThreadReplyRoute = (
     result: AgentToolResult<unknown>,
     to: string,
@@ -248,7 +262,7 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
-    notifyVisibleOutbound(to, sessionKey);
+    notifyVisibleOutbound(result, to, sessionKey);
     return withAdoptedThreadReplyRoute(result, to, sessionKey);
   }
 
@@ -287,7 +301,7 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
-    notifyVisibleOutbound(to, sessionKey);
+    notifyVisibleOutbound(result, to, sessionKey);
     return withAdoptedThreadReplyRoute(result, to, sessionKey);
   }
 
@@ -313,7 +327,7 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
-    notifyVisibleOutbound(to);
+    notifyVisibleOutbound(result, to);
     return result;
   }
 
@@ -453,17 +467,19 @@ export async function handleDiscordMessageAction(
     );
     const details =
       result.details && typeof result.details === "object" && !Array.isArray(result.details)
-        ? (result.details as { thread?: { id?: unknown } })
+        ? (result.details as { ok?: unknown; thread?: { id?: unknown } })
         : undefined;
-    const threadId = typeof details?.thread?.id === "string" ? details.thread.id : undefined;
-    await notifyDiscordActiveTurnThreadCreated({
-      sessionKey: ctx.sessionKey,
-      accountId,
-      sourceChannelId: resolveChannelId(),
-      sourceMessageId: messageId,
-      threadId,
-    });
-    notifyVisibleOutbound(resolveChannelId());
+    if (details?.ok === true) {
+      const threadId = typeof details.thread?.id === "string" ? details.thread.id : undefined;
+      await notifyDiscordActiveTurnThreadCreated({
+        sessionKey: ctx.sessionKey,
+        accountId,
+        sourceChannelId: resolveChannelId(),
+        sourceMessageId: messageId,
+        threadId,
+      });
+    }
+    notifyVisibleOutbound(result, resolveChannelId());
     return result;
   }
 
@@ -485,7 +501,7 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
-    notifyVisibleOutbound(to);
+    notifyVisibleOutbound(result, to);
     return result;
   }
 
@@ -513,7 +529,7 @@ export async function handleDiscordMessageAction(
   if (adminResult !== undefined) {
     if (action === "thread-reply") {
       const threadId = readStringParam(params, "threadId") ?? readTarget();
-      notifyVisibleOutbound(threadId);
+      notifyVisibleOutbound(adminResult, threadId);
       return withAdoptedThreadReplyRoute(adminResult, threadId);
     }
     return adminResult;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3309,7 +3309,7 @@ describe("qa mock openai server", () => {
     expect(outputText(await final.json())).toBe("subagent-1: ok\nsubagent-2: ok");
   });
 
-  it("completes subagent fanout from a continuation turn without tool output", async () => {
+  it("replays completed subagent fanout on requester-settle continuation turns", async () => {
     const server = await startMockServer();
 
     const prompt =
@@ -3354,6 +3354,43 @@ describe("qa mock openai server", () => {
     });
     expect(phaseOnlyFinal.status).toBe(200);
     expect(outputText(await phaseOnlyFinal.json())).toBe("subagent-1: ok\nsubagent-2: ok");
+
+    const settledContinuation = await postResponses(server, {
+      stream: false,
+      tools: [SESSIONS_SPAWN_TOOL],
+      input: [
+        makeUserInput(prompt),
+        makeUserInput(
+          "[Inter-session message]\nALPHA-OK\nBETA-OK\nAll spawned subagents have settled. Resume the parent turn and report both results together.",
+        ),
+      ],
+    });
+    expect(settledContinuation.status).toBe(200);
+    const settledPayload = await settledContinuation.json();
+    expect(outputText(settledPayload)).toBe("subagent-1: ok\nsubagent-2: ok");
+    expect(outputItems(settledPayload)).not.toContainEqual(
+      expect.objectContaining({ type: "function_call", name: "sessions_spawn" }),
+    );
+
+    const unrelatedContinuation = await postResponses(server, {
+      stream: false,
+      tools: [SESSIONS_SPAWN_TOOL],
+      input: [makeUserInput("Continue with an unrelated conversation.")],
+    });
+    expect(unrelatedContinuation.status).toBe(200);
+    expect(outputText(await unrelatedContinuation.json())).not.toBe(
+      "subagent-1: ok\nsubagent-2: ok",
+    );
+
+    const restartedFanout = await postResponses(server, {
+      stream: false,
+      tools: [SESSIONS_SPAWN_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    expect(restartedFanout.status).toBe(200);
+    expect(
+      outputToolArgsFromItem(outputToolCall(await restartedFanout.json(), "sessions_spawn")),
+    ).toEqual(expect.objectContaining({ label: "qa-fanout-alpha" }));
   });
 
   it("completes subagent fanout when beta completion arrives on a generic follow-up turn", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1477,6 +1477,10 @@ async function buildResponsesPayload(
     scenarioState.subagentFanoutPhase = 0;
     scenarioState.subagentFanoutCompletedWorkers.clear();
   }
+  // A later requester-settle wake must replay the completed synthesis without spawning again.
+  if (isSubagentFanoutPrompt && scenarioState.subagentFanoutPhase === 3) {
+    return buildAssistantEvents("subagent-1: ok\nsubagent-2: ok");
+  }
   if (canCallSessionsSpawn && isSubagentFanoutPrompt) {
     if (!toolOutput && scenarioState.subagentFanoutPhase === 0) {
       scenarioState.subagentFanoutPhase = 1;

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3895,6 +3895,50 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
+  it("directly delivers settle synthesis even when a direct-message requester turn is active", async () => {
+    const callGateway = createGatewayMock();
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    const origin = {
+      channel: "discord",
+      to: "dm:U123",
+      accountId: "acct-1",
+    };
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-dm",
+        isActive: true,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+      queueEmbeddedAgentMessageWithOutcome,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:discord:dm:U123",
+      targetRequesterSessionKey: "agent:main:discord:dm:U123",
+      triggerMessage: "all spawned subagents settled",
+      steerMessage: "all spawned subagents settled",
+      requesterOrigin: origin,
+      requesterSessionOrigin: origin,
+      directOrigin: origin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: false,
+      requireDirectDelivery: true,
+      directIdempotencyKey: "announce-requester-settle-direct",
+      sourceTool: "subagent_announce",
+    });
+
+    expectDeliveryPath(result, "direct");
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    const agentParams = expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "discord",
+      accountId: "acct-1",
+      to: "dm:U123",
+    });
+    expect(agentParams.sourceReplyDeliveryMode).toBeUndefined();
+  });
+
   it("does not retry session-file-changed failures with send evidence", async () => {
     const sendErr = new OutboundDeliveryError("outbound delivery failed", {
       cause: new Error("outbound delivery failed"),

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1721,6 +1721,7 @@ export async function deliverSubagentAnnouncement(params: {
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
+  requireDirectDelivery?: boolean;
   bestEffortDeliver?: boolean;
   durableGeneratedMediaHandoff?: boolean;
   directIdempotencyKey: string;
@@ -1843,6 +1844,7 @@ export async function deliverSubagentAnnouncement(params: {
 
   return await runSubagentAnnounceDispatch({
     expectsCompletionMessage: params.expectsCompletionMessage,
+    requireDirectDelivery: params.requireDirectDelivery,
     signal: params.signal,
     steer: async () =>
       await maybeSteerSubagentAnnounce({

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -45,6 +45,39 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
+  it.each([true, false])(
+    "never steers when direct delivery is required and direct delivery succeeds: %s",
+    async (delivered) => {
+      const steer = vi.fn(async () => ({ status: "steered" }) as const);
+      const direct = vi.fn(async () => ({
+        delivered,
+        path: "direct" as const,
+        ...(delivered ? {} : { error: "direct delivery failed" }),
+      }));
+
+      const result = await runSubagentAnnounceDispatch({
+        expectsCompletionMessage: false,
+        requireDirectDelivery: true,
+        steer,
+        direct,
+      });
+
+      expect(direct).toHaveBeenCalledOnce();
+      expect(steer).not.toHaveBeenCalled();
+      expect(result.delivered).toBe(delivered);
+      expect(result.path).toBe("direct");
+      expect(result.error).toBe(delivered ? undefined : "direct delivery failed");
+      expect(result.phases).toEqual([
+        {
+          phase: "direct-primary",
+          delivered,
+          path: "direct",
+          error: delivered ? undefined : "direct delivery failed",
+        },
+      ]);
+    },
+  );
+
   it("uses direct-first ordering for completion mode", async () => {
     const steer = vi.fn(async () => ({ status: "steered" }) as const);
     const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -64,6 +64,7 @@ function mapSteerOutcomeToDeliveryResult(
 /** Runs the ordered steer/direct announcement delivery strategy. */
 export async function runSubagentAnnounceDispatch(params: {
   expectsCompletionMessage: boolean;
+  requireDirectDelivery?: boolean;
   signal?: AbortSignal;
   steer: () => Promise<SubagentAnnounceSteerOutcome>;
   direct: () => Promise<SubagentAnnounceDeliveryResult>;
@@ -93,6 +94,14 @@ export async function runSubagentAnnounceDispatch(params: {
       delivered: false,
       path: "none",
     });
+  }
+
+  if (params.requireDirectDelivery) {
+    // Settle synthesis needs its own delivery turn; steering can inherit a
+    // message-tool-only completion turn and silently suppress the final reply.
+    const primaryDirect = await params.direct();
+    appendPhase("direct-primary", primaryDirect);
+    return withPhases(primaryDirect);
   }
 
   if (!params.expectsCompletionMessage) {

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -175,6 +175,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(call.targetRequesterSessionKey).toBe(REQUESTER);
     expect(call.requesterIsSubagent).toBe(false);
     expect(call.expectsCompletionMessage).toBe(false);
+    expect(call.requireDirectDelivery).toBe(true);
     expect(call.directIdempotencyKey).toBe(`announce:requester-settle:${REQUESTER}:run-a,run-b`);
     const message = String(call.triggerMessage);
     expect(message).toContain("settled");

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -396,6 +396,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         targetRequesterSessionKey: requesterSessionKey,
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
+        requireDirectDelivery: true,
         directIdempotencyKey: buildAnnounceIdempotencyKey(
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),

--- a/src/agents/subagent-list.test.ts
+++ b/src/agents/subagent-list.test.ts
@@ -212,6 +212,94 @@ describe("buildSubagentList", () => {
     expect(list.recent).toStrictEqual([]);
   });
 
+  it.each([
+    {
+      name: "a killed parent with a provider failure",
+      endedReason: SUBAGENT_ENDED_REASON_KILLED,
+      outcome: { status: "error", error: "agent run aborted" } as const,
+      pendingChildren: 1,
+      expectedStatus: "killed (waiting on 1 child)",
+    },
+    {
+      name: "a killed parent with an earlier successful provider outcome",
+      endedReason: SUBAGENT_ENDED_REASON_KILLED,
+      outcome: { status: "ok" } as const,
+      pendingChildren: 2,
+      expectedStatus: "killed (waiting on 2 children)",
+    },
+    {
+      name: "a failed parent",
+      outcome: { status: "error", error: "provider rejected the request" } as const,
+      pendingChildren: 1,
+      expectedStatus: "failed (waiting on 1 child)",
+    },
+    {
+      name: "a timed-out parent",
+      outcome: { status: "timeout" } as const,
+      pendingChildren: 2,
+      expectedStatus: "timeout (waiting on 2 children)",
+    },
+    {
+      name: "a successfully completed parent",
+      outcome: { status: "ok" } as const,
+      pendingChildren: 2,
+      expectedStatus: "active (waiting on 2 children)",
+    },
+    {
+      name: "a still-running parent",
+      ended: false,
+      pendingChildren: 1,
+      expectedStatus: "active (waiting on 1 child)",
+    },
+  ])(
+    "preserves the status of $name while descendants remain pending",
+    ({ endedReason, outcome, ended, pendingChildren, expectedStatus }) => {
+      const now = Date.now();
+      const parentRun = {
+        runId: `run-parent-${expectedStatus.replaceAll(" ", "-")}`,
+        childSessionKey: `agent:main:subagent:parent-${expectedStatus.replaceAll(" ", "-")}`,
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "orchestrate child workers",
+        cleanup: "keep",
+        createdAt: now - 120_000,
+        startedAt: now - 120_000,
+        ...(ended === false ? {} : { endedAt: now - 60_000 }),
+        ...(endedReason ? { endedReason } : {}),
+        ...(outcome ? { outcome } : {}),
+      } satisfies SubagentRunRecord;
+      addSubagentRunForTests(parentRun);
+      for (let childIndex = 0; childIndex < pendingChildren; childIndex += 1) {
+        addSubagentRunForTests({
+          runId: `${parentRun.runId}-child-${childIndex}`,
+          childSessionKey: `${parentRun.childSessionKey}:subagent:child-${childIndex}`,
+          requesterSessionKey: parentRun.childSessionKey,
+          requesterDisplayKey: "subagent:parent",
+          task: "child worker still running",
+          cleanup: "keep",
+          createdAt: now - 30_000,
+          startedAt: now - 30_000,
+        });
+      }
+
+      const list = buildSubagentList({
+        cfg: {} as OpenClawConfig,
+        runs: [parentRun],
+        recentMinutes: 30,
+      });
+
+      expect(list.active).toHaveLength(1);
+      expect(list.active[0]).toMatchObject({
+        runId: parentRun.runId,
+        status: expectedStatus,
+        pendingDescendants: pendingChildren,
+      });
+      expect(list.active[0]?.line).toContain(` ${expectedStatus}`);
+      expect(list.active[0]?.childSessions).toHaveLength(pendingChildren);
+      expect(list.recent).toStrictEqual([]);
+    },
+  );
+
   it("omits old ended descendants from child session summaries", () => {
     const now = Date.now();
     const parentRun = {

--- a/src/agents/subagent-registry-lifecycle-cleanup-base.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup-base.ts
@@ -1,3 +1,4 @@
+import { runWithoutOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
 import {
   isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkAdmission,
@@ -87,37 +88,41 @@ export function createSubagentRegistryLifecycleCleanupBase(
     // Completion makes the task projection non-blocking before delivery and
     // cleanup finish. This independent lease bridges that handoff and owns the
     // full detached attempt, including its final durable registry write.
-    void runWithGatewayIndependentRootWorkAdmission(async () => {
-      try {
-        await args.run();
-      } catch (err) {
-        defaultRuntime.log(
-          `[warn] subagent cleanup finalize failed (${args.runId}): ${String(err)}`,
-        );
-        const current = params.runs.get(args.runId);
-        if (
-          !current ||
-          current.cleanupCompletedAt ||
-          !isCleanupAttemptCurrent(args.runId, args.entry, args.cleanupGeneration)
-        ) {
-          return;
+    // Completion outlives the spawning attempt; inherited lock owners would
+    // reject requester transcript writes after that attempt is disposed.
+    runWithoutOwnedSessionTranscriptWrites(() => {
+      void runWithGatewayIndependentRootWorkAdmission(async () => {
+        try {
+          await args.run();
+        } catch (err) {
+          defaultRuntime.log(
+            `[warn] subagent cleanup finalize failed (${args.runId}): ${String(err)}`,
+          );
+          const current = params.runs.get(args.runId);
+          if (
+            !current ||
+            current.cleanupCompletedAt ||
+            !isCleanupAttemptCurrent(args.runId, args.entry, args.cleanupGeneration)
+          ) {
+            return;
+          }
+          current.cleanupHandled = false;
+          params.resumedRuns.delete(args.runId);
+          params.persist(args.runId);
         }
-        current.cleanupHandled = false;
-        params.resumedRuns.delete(args.runId);
-        params.persist(args.runId);
-      }
-    }).catch((err: unknown) => {
-      defaultRuntime.log(
-        `[warn] subagent cleanup admission failed (${args.runId}): ${String(err)}`,
-      );
-      if (isGatewayRestartDraining()) {
-        scheduleResumeSubagentRun(
-          args.runId,
-          args.entry,
-          MIN_ANNOUNCE_RETRY_DELAY_MS,
-          args.cleanupGeneration,
+      }).catch((err: unknown) => {
+        defaultRuntime.log(
+          `[warn] subagent cleanup admission failed (${args.runId}): ${String(err)}`,
         );
-      }
+        if (isGatewayRestartDraining()) {
+          scheduleResumeSubagentRun(
+            args.runId,
+            args.entry,
+            MIN_ANNOUNCE_RETRY_DELAY_MS,
+            args.cleanupGeneration,
+          );
+        }
+      });
     });
   };
 

--- a/src/agents/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagent-registry-lifecycle-requester-wake.ts
@@ -1,3 +1,4 @@
+import { runWithoutOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import type { createSubagentRegistryLifecycleCommon } from "./subagent-registry-lifecycle-common.js";
 import type {
@@ -203,36 +204,40 @@ export function createSubagentRegistryLifecycleRequesterWake(
       return;
     }
     scheduledRequesterSettleWakeRuns.add(runId);
-    void runWithGatewayIndependentRootWorkContinuation(() =>
-      params.maybeWakeRequesterAfterAllChildrenSettled({
-        requesterSessionKey,
-        requesterOrigin: entry.requesterOrigin,
-        settledEntry: entry,
-        transitionBatch: transitionRequesterSettleWakeBatch,
-        completeBatch: completeRequesterSettleWakeBatch,
-      }),
-    )
-      .catch((error: unknown) => {
-        params.warn("requester settle wake failed", {
-          error: buildSafeLifecycleErrorMeta(error),
-          runId: maskRunId(runId),
-          requesterSessionKey: maskSessionKey(requesterSessionKey),
-        });
-      })
-      .finally(() => {
-        scheduledRequesterSettleWakeRuns.delete(runId);
-        const wasRearmedWhileRunning = pendingRequesterSettleWakeRearms.delete(runId);
-        const current = params.runs.get(runId);
-        if (current === entry && current.requesterSettleWake) {
-          if (wasRearmedWhileRunning) {
-            // A requester yield can freeze a delivered batch while this run is
-            // resolving its earlier no-wake decision. Admit that durable update now.
-            scheduleRequesterSettleWake(runId, current);
-          } else {
-            scheduleRequesterSettleWakeRetry(runId, current);
+    // Wake turns outlive their spawning attempt; clear its owner before both
+    // dispatch and chained re-arms so transcript writes acquire a fresh lock.
+    runWithoutOwnedSessionTranscriptWrites(() => {
+      void runWithGatewayIndependentRootWorkContinuation(() =>
+        params.maybeWakeRequesterAfterAllChildrenSettled({
+          requesterSessionKey,
+          requesterOrigin: entry.requesterOrigin,
+          settledEntry: entry,
+          transitionBatch: transitionRequesterSettleWakeBatch,
+          completeBatch: completeRequesterSettleWakeBatch,
+        }),
+      )
+        .catch((error: unknown) => {
+          params.warn("requester settle wake failed", {
+            error: buildSafeLifecycleErrorMeta(error),
+            runId: maskRunId(runId),
+            requesterSessionKey: maskSessionKey(requesterSessionKey),
+          });
+        })
+        .finally(() => {
+          scheduledRequesterSettleWakeRuns.delete(runId);
+          const wasRearmedWhileRunning = pendingRequesterSettleWakeRearms.delete(runId);
+          const current = params.runs.get(runId);
+          if (current === entry && current.requesterSettleWake) {
+            if (wasRearmedWhileRunning) {
+              // A requester yield can freeze a delivered batch while this run is
+              // resolving its earlier no-wake decision. Admit that durable update now.
+              scheduleRequesterSettleWake(runId, current);
+            } else {
+              scheduleRequesterSettleWakeRetry(runId, current);
+            }
           }
-        }
-      });
+        });
+    });
   }
 
   return {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -2,6 +2,10 @@
 // detached task status, and resource retirement around child-run endings.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionStorePathForScope } from "../config/sessions/session-store-path.js";
+import {
+  runWithOwnedSessionTranscriptWriteLock,
+  withOwnedSessionTranscriptWrites,
+} from "../config/sessions/transcript-write-context.js";
 import type { CallGatewayOptions } from "../gateway/call.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -317,6 +321,51 @@ describe("subagent registry lifecycle hardening", () => {
     browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd.mockClear();
     bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey.mockClear();
     bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey.mockResolvedValue(true);
+  });
+
+  it("runs detached cleanup outside a disposed requester transcript owner", async () => {
+    const sessionKey = "agent:main:disposed-cleanup-owner";
+    const entry = createRunEntry({
+      requesterSessionKey: sessionKey,
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      retainAttachmentsOnKeep: true,
+    });
+    let disposed = false;
+    let releaseCleanup!: () => void;
+    const cleanupReady = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const staleWriteLock = vi.fn();
+    const withStaleWriteLock = async <T>(operation: () => Promise<T> | T): Promise<T> => {
+      staleWriteLock();
+      if (disposed) {
+        throw new Error("attempt disposed before transcript write");
+      }
+      return await operation();
+    };
+    const freshTranscriptWrite = vi.fn(async () => {});
+    const runSubagentAnnounceFlow = vi.fn(async () => {
+      await cleanupReady;
+      await runWithOwnedSessionTranscriptWriteLock({ sessionKey }, freshTranscriptWrite);
+      return true;
+    });
+    const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
+
+    await withOwnedSessionTranscriptWrites(
+      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      async () => {
+        expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+      },
+    );
+
+    disposed = true;
+    releaseCleanup();
+
+    await waitForLifecycleState(() => expect(freshTranscriptWrite).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("delivered"));
+    expect(staleWriteLock).not.toHaveBeenCalled();
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce();
   });
 
   it("emits one progress end event at the canonical terminal transition", async () => {
@@ -3333,6 +3382,53 @@ describe("requester settle wake trigger", () => {
     helperMocks.safeRemoveAttachmentsDir.mockClear();
     helperMocks.logAnnounceGiveUp.mockClear();
     taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockClear();
+  });
+
+  it("runs a detached settle wake outside a disposed requester transcript owner", async () => {
+    const sessionKey = "agent:main:disposed-settle-wake-owner";
+    const entry = createRunEntry({ requesterSessionKey: sessionKey, endedAt: 4_000 });
+    let disposed = false;
+    let releaseWake!: () => void;
+    const wakeReady = new Promise<void>((resolve) => {
+      releaseWake = resolve;
+    });
+    const staleWriteLock = vi.fn();
+    const withStaleWriteLock = async <T>(operation: () => Promise<T> | T): Promise<T> => {
+      staleWriteLock();
+      if (disposed) {
+        throw new Error("attempt disposed before transcript write");
+      }
+      return await operation();
+    };
+    const freshTranscriptWrite = vi.fn(async () => {});
+    const settleWake = vi.fn(async () => {
+      await wakeReady;
+      await runWithOwnedSessionTranscriptWriteLock({ sessionKey }, freshTranscriptWrite);
+      return false;
+    });
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled: settleWake,
+    });
+
+    await withOwnedSessionTranscriptWrites(
+      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      async () => {
+        controller.completeCleanupBookkeeping({
+          runId: entry.runId,
+          entry,
+          cleanup: "keep",
+          completedAt: 5_000,
+        });
+      },
+    );
+
+    disposed = true;
+    releaseWake();
+
+    await waitForLifecycleState(() => expect(freshTranscriptWrite).toHaveBeenCalledOnce());
+    expect(staleWriteLock).not.toHaveBeenCalled();
+    expect(settleWake).toHaveBeenCalledOnce();
   });
 
   it("fires the settle wake from keep-cleanup bookkeeping", () => {

--- a/src/agents/subagent-session-metrics.ts
+++ b/src/agents/subagent-session-metrics.ts
@@ -82,10 +82,15 @@ export function resolveSubagentDisplayStatus(
   entry: Pick<SubagentRunRecord, "endedAt" | "endedReason" | "outcome">,
   pendingDescendants = 0,
 ): string {
+  const status = resolveSubagentSessionStatus(entry) ?? "done";
   const pending = Math.max(0, pendingDescendants);
   if (pending > 0) {
     const childLabel = pending === 1 ? "child" : "children";
-    return `active (waiting on ${pending} ${childLabel})`;
+    const waiting = `waiting on ${pending} ${childLabel}`;
+    // Pending descendants keep the row active without hiding a terminal failure.
+    return status === "running" || status === "done"
+      ? `active (${waiting})`
+      : `${status} (${waiting})`;
   }
-  return resolveSubagentSessionStatus(entry) ?? "done";
+  return status;
 }

--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -69,6 +69,33 @@ describe("SidebarSessionNarrationController", () => {
     vi.useRealTimers();
   });
 
+  it("subscribes only to sessions with a projected active run", async () => {
+    const subscribeMessages = vi.fn((key: string) => Promise.resolve({ key, agentId: null }));
+    const unsubscribeMessages = vi.fn(() => Promise.resolve());
+    const source = { subscribeMessages, unsubscribeMessages } as unknown as SessionCapability;
+    const controller = new SidebarSessionNarrationController(() => undefined);
+
+    controller.sync({
+      enabled: true,
+      connected: true,
+      connectionIdentity: {},
+      source,
+      rows: [
+        { ...runningRow("agent:main:stale"), hasActiveRun: false, status: "running" },
+        { ...runningRow("agent:main:failed"), hasActiveRun: false, status: "failed" },
+        runningRow("agent:main:active"),
+      ],
+      openSessionKey: "",
+      agentId: "main",
+    });
+    await Promise.resolve();
+
+    expect(subscribeMessages).toHaveBeenCalledTimes(1);
+    expect(subscribeMessages).toHaveBeenCalledWith("agent:main:active", { agentId: undefined });
+
+    controller.disconnect();
+  });
+
   it("hands subtitle ownership only to a run-identified digest", async () => {
     const source = {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -90,10 +90,6 @@ function trailingInternalDelimiterPrefix(text: string): string {
   return "";
 }
 
-function rowIsRunning(row: SidebarRecentSession): boolean {
-  return row.hasActiveRun || row.status === "running";
-}
-
 function rowRecency(row: SidebarRecentSession): number {
   return row.startedAt ?? row.updatedAt ?? 0;
 }
@@ -161,7 +157,7 @@ export class SidebarSessionNarrationController {
       .map((row, index) => ({ row, index }))
       .filter(
         ({ row }) =>
-          rowIsRunning(row) && !areUiSessionKeysEquivalent(row.key, input.openSessionKey.trim()),
+          row.hasActiveRun && !areUiSessionKeysEquivalent(row.key, input.openSessionKey.trim()),
       )
       .toSorted(
         (left, right) => rowRecency(right.row) - rowRecency(left.row) || left.index - right.index,

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -5,10 +5,10 @@ import { buildSidebarSessionNavigationState } from "./app-sidebar-session-naviga
 import { projectSessionTree } from "./app-sidebar-session-tree.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 
-function projectDraftOwnership(
-  row: Pick<GatewaySessionRow, "createdActor" | "sharingRole" | "visibility">,
+function projectSidebarSession(
+  row: Partial<GatewaySessionRow>,
   selfUserId?: string,
-): boolean | undefined {
+): SidebarRecentSession {
   const context = {
     basePath: "",
     agents: { state: { agentsList: { mainKey: "main" } } },
@@ -45,8 +45,28 @@ function projectDraftOwnership(
     kind: "direct",
     updatedAt: 1,
     ...row,
-  }).draftOwnedBySelf;
+  });
 }
+
+function projectDraftOwnership(
+  row: Pick<GatewaySessionRow, "createdActor" | "sharingRole" | "visibility">,
+  selfUserId?: string,
+): boolean | undefined {
+  return projectSidebarSession(row, selfUserId).draftOwnedBySelf;
+}
+
+describe("sidebar session live-run projection", () => {
+  it.each([
+    ["legacy running status", { status: "running" }, true],
+    ["confirmed active run", { status: "running", hasActiveRun: true }, true],
+    ["stale running status", { status: "running", hasActiveRun: false }, false],
+    ["completed run with a stale active flag", { status: "done", hasActiveRun: true }, false],
+    ["failed run with a stale active flag", { status: "failed", hasActiveRun: true }, false],
+    ["archived active run", { status: "running", hasActiveRun: true, archived: true }, false],
+  ] as const)("normalizes %s before publishing sidebar state", (_name, row, expected) => {
+    expect(projectSidebarSession(row).hasActiveRun).toBe(expected);
+  });
+});
 
 describe("sidebar draft ownership presentation", () => {
   it("keeps owner drafts at normal emphasis", () => {
@@ -128,6 +148,30 @@ describe("sidebar navigation lineage ownership", () => {
       { key: controlParent.key, children: [] },
     ]);
   });
+
+  it.each([
+    ["legacy active child", { status: "running" }, 1, 0],
+    ["stale running child", { status: "running", hasActiveRun: false }, 0, 0],
+    ["failed child with a stale active flag", { status: "failed", hasActiveRun: true }, 0, 1],
+  ] as const)(
+    "counts normalized live runs for a %s",
+    (_name, runState, runningChildCount, failedChildCount) => {
+      const childRow = { ...child, ...runState };
+      const projected = projectSessionTree({
+        roots: [navigationParent],
+        agentRows: [navigationParent, childRow],
+        childRowsByParent: {},
+        loadingChildKeys: new Set(),
+        knownSessionAttention: [],
+        toSidebarSession: (row, isChild) => ({
+          ...projectSidebarSession(row),
+          isChild: isChild === true,
+        }),
+      });
+
+      expect(projected[0]).toMatchObject({ runningChildCount, failedChildCount });
+    },
+  );
 
   it("walks a directly opened child through its navigation parent, not its controller", async () => {
     const knownRows = new Map(

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -8,6 +8,7 @@ import {
   resolveSessionDisplayName,
   resolveSessionWorkSubtitle,
 } from "../lib/session-display.ts";
+import { isSessionRunActive } from "../lib/session-run-state.ts";
 import {
   groupSidebarSessionRows,
   sidebarSectionHasHeader,
@@ -136,7 +137,8 @@ export function buildSidebarSessionNavigationState(input: {
       }).href,
       active: row.key === navigation.activeRowKey,
       visuallyActive: input.highlightCurrentSession && row.key === navigation.currentSessionKey,
-      hasActiveRun: row.archived !== true && Boolean(row.hasActiveRun),
+      // Normalize optional gateway state before collapsing it to the sidebar's required fact.
+      hasActiveRun: row.archived !== true && isSessionRunActive(row),
       activeRunIds: row.archived === true ? undefined : row.activeRunIds,
       modelSelectionLocked: row.modelSelectionLocked === true,
       kind: row.kind,

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -317,7 +317,7 @@ export function renderRecentSession(params: {
       <span class="sidebar-recent-session__aside session-row-aside">
         <span class="session-row-trail" id=${metaId ?? nothing}
           >${session.isChild && session.runtimeMs != null
-            ? session.hasActiveRun || session.status === "running"
+            ? session.hasActiveRun
               ? html`<openclaw-elapsed-time
                   .startMs=${session.runtimeSampledAt! - session.runtimeMs}
                 ></openclaw-elapsed-time>`

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -83,10 +83,7 @@ export function projectSessionTree(params: {
     });
     const projected = toSidebarSession(row, isChild);
     const projectedRunningChildCount = children.reduce(
-      (count, child) =>
-        count +
-        (child.hasActiveRun || child.status === "running" ? 1 : 0) +
-        child.runningChildCount,
+      (count, child) => count + (child.hasActiveRun ? 1 : 0) + child.runningChildCount,
       0,
     );
     const runningChildCount = Math.max(

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -128,7 +128,6 @@ export function rowDemandsVisibility(
       : row.visuallyActive ||
         row.containsActiveDescendant ||
         row.hasActiveRun ||
-        row.status === "running" ||
         row.runningChildCount > 0 ||
         row.attention.kind !== "none";
 }

--- a/ui/src/components/session-attention-presentation.ts
+++ b/ui/src/components/session-attention-presentation.ts
@@ -42,7 +42,7 @@ export function sessionAttentionSubtitle(attention: SidebarSessionAttention): st
 }
 
 export function renderSessionState(session: SidebarRecentSession) {
-  if (session.hasActiveRun || session.status === "running") {
+  if (session.hasActiveRun) {
     return html`<span
       class="session-run-spinner sidebar-recent-session__state"
       role="img"

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -42,7 +42,7 @@ export function renderSessionLeadingState(
   ownerActor: SessionCreatedActor | null | undefined,
   attribution: "created" | "archived",
 ) {
-  const running = session.hasActiveRun || session.status === "running";
+  const running = session.hasActiveRun;
 
   if (session.attention.kind !== "none") {
     return {

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -26,6 +26,18 @@ describe("resolveSidebarSessionSubtitle", () => {
     ).toEqual({ subtitle: undefined, narration: undefined });
   });
 
+  it("ignores live narration when a stale running status has no projected active run", () => {
+    expect(
+      resolveSidebarSessionSubtitle({
+        session: { ...workSession(), status: "running" },
+        hasDisplay: false,
+        displaySubtitle: undefined,
+        sidebarLiveActivity: true,
+        narrationLine: "Still running",
+      }),
+    ).toEqual({ subtitle: "~/Projects/openclaw", narration: undefined });
+  });
+
   it("uses attention, agent status, observer, narration, then work subtitle precedence", () => {
     const session: SidebarRecentSession = {
       ...workSession(),

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -27,7 +27,7 @@ export function resolveSidebarSessionSubtitle(params: {
   // Agent-declared status (sessions tool) outranks live narration: it is an
   // explicit message to the user, not ambient activity.
   const agentStatus = session.agentStatusNote || undefined;
-  const running = session.hasActiveRun || session.status === "running";
+  const running = session.hasActiveRun;
   const activeRunIds = session.activeRunIds ?? [];
   const digestMatchesActiveRun = (
     digest: typeof params.observerDigest,

--- a/ui/src/components/session-row-visibility.test.ts
+++ b/ui/src/components/session-row-visibility.test.ts
@@ -18,7 +18,8 @@ const states = [
   ["visually active", { visuallyActive: true }, true, false, false],
   ["active descendant", { containsActiveDescendant: true }, true, false, false],
   ["active run", { hasActiveRun: true }, true, true, false],
-  ["running status", { status: "running" }, true, false, false],
+  ["stale running status", { status: "running" }, false, false, false],
+  ["failed session", { status: "failed" }, false, false, false],
   ["running descendant", { runningChildCount: 1 }, true, false, false],
   ["attention", { attention: { kind: "question" } }, true, false, true],
 ] as const;

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -26,6 +26,8 @@ suite.define(() => {
     const parentKey = "agent:main:release-plan";
     const childOneKey = "agent:main:research-sources";
     const childTwoKey = "agent:main:verify-tests";
+    const staleRunningChildKey = "agent:main:stale-running";
+    const failedChildKey = "agent:main:failed-checks";
     const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -52,12 +54,34 @@ suite.define(() => {
                   startedAt: baseTime - 62_000,
                   status: "done",
                 }),
+                {
+                  ...sessionRow(staleRunningChildKey, "Stale activity", baseTime - 3_000, {
+                    hasActiveRun: false,
+                    spawnedBy: parentKey,
+                    startedAt: baseTime - 64_000,
+                    status: "running",
+                  }),
+                  runtimeMs: 61_000,
+                  runtimeSampledAt: baseTime,
+                },
+                {
+                  ...sessionRow(failedChildKey, "Failed checks", baseTime - 4_000, {
+                    endedAt: baseTime - 4_000,
+                    hasActiveRun: true,
+                    spawnedBy: parentKey,
+                    startedAt: baseTime - 64_000,
+                    status: "failed",
+                  }),
+                  lastReadAt: baseTime,
+                  runtimeMs: 60_000,
+                  runtimeSampledAt: baseTime,
+                },
               ]),
             },
             {
               response: sessionsListResponse([
                 sessionRow(parentKey, "Plan release", baseTime, {
-                  childSessions: [childOneKey, childTwoKey],
+                  childSessions: [childOneKey, childTwoKey, staleRunningChildKey, failedChildKey],
                 }),
               ]),
             },
@@ -74,9 +98,11 @@ suite.define(() => {
       await expect.poll(() => page.locator(".sidebar-recent-session--child").count()).toBe(0);
       await captureUiProof(page, "child-sessions-collapsed.png");
 
-      await parent.getByRole("button", { name: "Show 2 child threads for Plan release" }).click();
+      await parent.getByRole("button", { name: "Show 4 child threads for Plan release" }).click();
       await page.getByText("Research sources", { exact: true }).waitFor({ state: "visible" });
       await page.getByText("Verify tests", { exact: true }).waitFor({ state: "visible" });
+      await page.getByText("Stale activity", { exact: true }).waitFor({ state: "visible" });
+      await page.getByText("Failed checks", { exact: true }).waitFor({ state: "visible" });
       await expect
         .poll(async () =>
           (await gateway.getRequests("sessions.list")).some(
@@ -86,11 +112,28 @@ suite.define(() => {
         .toBe(true);
 
       const childRows = page.locator(".sidebar-recent-session--child");
-      await expect.poll(() => childRows.count()).toBe(2);
+      await expect.poll(() => childRows.count()).toBe(4);
       expect(await childRows.getByRole("button", { name: "Open thread menu" }).count()).toBe(0);
       await childRows.nth(0).getByRole("img", { name: "Active run" }).waitFor();
       await childRows.nth(1).getByRole("img", { name: "Done" }).waitFor();
+
+      const staleRunningChild = page.locator(`[data-session-key="${staleRunningChildKey}"]`);
+      const failedChild = page.locator(`[data-session-key="${failedChildKey}"]`);
+      expect(await staleRunningChild.getByRole("img", { name: "Active run" }).count()).toBe(0);
+      expect(await failedChild.getByRole("img", { name: "Active run" }).count()).toBe(0);
+      await failedChild.getByRole("img", { name: "Failed" }).waitFor();
+      await expect.poll(() => childRows.getByRole("img", { name: "Active run" }).count()).toBe(1);
+
+      const childToggle = parent.locator(`[data-child-session-toggle="${parentKey}"]`);
+      expect(await childToggle.getAttribute("class")).toContain(
+        "sidebar-child-session-toggle--running",
+      );
+      for (const child of [staleRunningChild, failedChild]) {
+        expect(await child.locator("openclaw-elapsed-time").count()).toBe(0);
+        expect((await child.locator(".session-row-trail").textContent())?.trim()).toBeTruthy();
+      }
       await captureUiProof(page, "child-sessions-expanded.png");
+      await captureUiProof(page, "child-sessions-run-state-precedence.png");
 
       await childRows.nth(1).getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(childTwoKey));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users delegating parallel subagents could lose the parent’s final synthesized response, see failed or completed sessions continue to appear active, or lose Discord room-event context after an outbound action resolved without a successful delivery receipt.

## Why This Change Was Made

Keep terminal session status and sidebar run-state projections canonical, isolate detached subagent cleanup/wake work from disposed transcript ownership, and force the final requester-settle synthesis through an actual direct delivery turn. Discord only clears room-event history and adopts threads after an explicit successful delivery receipt. The deterministic QA provider also replays completed fanout synthesis on a genuine later settle wake without respawning children.

## User Impact

Users receive the final combined subagent response, see accurate failed/completed/running task indicators, retain Discord context after failed sends, and avoid detached transcript-write lifecycle failures. Existing private-message completion policy, child completion fallback, thread creation, normal delivery, and fresh fanout restarts remain covered.

## Evidence

Frozen baseline: 661afc22ac0eafe395625c8cc32469dabc22a5a0.

- Complete applicable unchanged QA catalog: 120 scenarios, 112 passed, 0 failed, 8 explicitly unsupported optional-tool skips. Baseline was 111 passed, 1 failed, 8 skipped; the original strict Subagent fanout synthesis scenario now passes both isolated and concurrently.
- 564 focused owner tests passed: subagents 309, Discord 36, Control UI 52, and mock provider 167.
- Real Chromium Control UI sidebar E2E: focused changed scenario passed with screenshot, complete browser file 8/8 passed.
- Genuine hydrated OpenAI openai/gpt-5.4 live-frontier scenario: 1/1 passed.
- Genuine 100-turn runtime soak and channel, plugin, cron, memory, recovery, restart, config, tool, observability, and provider scenarios passed.
- Private production build passed all phases with 148 SDK exports and 2,979 Control UI modules.
- Complete remote 28-file changed gate passed: five TypeScript lanes, core/plugin lint, formatting, max-lines, SDK, dependency, plugin-boundary, schema/security, and translation guards.
- Fresh independent autoreview reported zero accepted/actionable findings; secret scan clean.
- No public configuration, database-schema, protocol, authentication, or plugin-SDK surface changes.

## Current-Main Merge Verification

ClawSweeper’s only rank-up move was applied before landing: fetched latest origin/main e8d546c8da8d76f19e8e5df6df08f6ecc79a4123 and verified `git merge-tree --write-tree origin/main 71267584cac6eb01c99eb732461311f183d6503d` exits 0 with clean merge tree b24a54c8969112a16221b7cf761784c96ed5ed09. The reviewed/passed PR head remains unchanged. The review’s automated stored-data-model hint refers only to transient Control UI presentation/session projection files; this change introduces no persisted schema, migration, SQLite ownership, config, or serialized storage contract changes. No parallel repair job is required because this maintainer PR already owns the complete fix.
