### PR TITLE
feat(imessage): add bounded native history reads

### DIFF
--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -183,6 +183,48 @@ describe("imessage actions runtime", () => {
 
     expect(createIMessageRpcClientMock).toHaveBeenCalledTimes(2);
   });
+
+  it("reads recent messages by resolving an iMessage handle to chat history", async () => {
+    const request = vi.fn().mockResolvedValueOnce({
+      chatGuid: "iMessage;-;+15551234567",
+      messages: [{ id: 100, guid: "message-guid", text: "hello" }],
+    });
+    const stop = vi.fn().mockResolvedValue(undefined);
+    createIMessageRpcClientMock.mockResolvedValueOnce({ request, stop });
+
+    await expect(
+      imessageActionsRuntime.readMessages({
+        target: {
+          kind: "handle",
+          to: "+15551234567",
+          service: "imessage",
+          serviceExplicit: true,
+        },
+        limit: 5,
+        includeAttachments: false,
+        options: { cliPath: "imsg", dbPath: "/tmp/messages.db", timeoutMs: 8000 },
+      }),
+    ).resolves.toStrictEqual({
+      chatGuid: "iMessage;-;+15551234567",
+      chatIdentifier: "+15551234567",
+      messages: [{ id: 100, guid: "message-guid", text: "hello" }],
+    });
+
+    expect(request.mock.calls).toStrictEqual([
+      [
+        "messages.history",
+        {
+          target: "+15551234567",
+          to: "+15551234567",
+          service: "imessage",
+          limit: 5,
+          attachments: false,
+        },
+        { timeoutMs: 8000 },
+      ],
+    ]);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("findChatGuid cross-format identifier resolution", () => {

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -17,7 +17,7 @@ import {
   resolveIMessageMessageId as resolveIMessageMessageIdImpl,
   type IMessageChatContext,
 } from "./monitor-reply-cache.js";
-import type { IMessageTarget } from "./targets.js";
+import { normalizeIMessageHandle, type IMessageTarget } from "./targets.js";
 
 type CliRunOptions = {
   cliPath: string;
@@ -52,7 +52,17 @@ type IMessageChatListResponse = {
   chats?: unknown;
 };
 
+type IMessageHistoryResponse = {
+  messages?: unknown;
+};
+
 function asChatList(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (chat): chat is Record<string, unknown> =>
+        chat != null && typeof chat === "object" && !Array.isArray(chat),
+    );
+  }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return [];
   }
@@ -124,11 +134,12 @@ function chatListCacheSet(
 }
 
 /**
- * Strip the iMessage;-;/SMS;-;/any;-; service prefix that Messages uses
+ * Strip the iMessage;-;/SMS;-;/RCS;-;/any;-; service prefix that Messages uses
  * for direct DM chats. Different layers report direct DMs in different
  * forms — the action surface synthesizes `iMessage;-;<phone>` from a
  * handle target, while imsg's chats.list returns `identifier: <phone>`
- * and `guid: any;-;<phone>`. Comparing the raw strings would falsely
+ * and `guid: any;-;<phone>`. BlueBubbles can also expose Apple Messages RCS
+ * conversations as `RCS;-;<phone>`. Comparing the raw strings would falsely
  * miss the match.
  */
 export function normalizeDirectChatIdentifierForTest(raw: string): string {
@@ -142,6 +153,18 @@ export function findChatGuidForTest(
   return findChatGuid(chats, target);
 }
 
+function directChatIdentifierMatches(candidate: string | undefined, wanted: string): boolean {
+  if (!candidate) {
+    return false;
+  }
+  const normalizedCandidate = normalizeDirectChatIdentifier(candidate);
+  const normalizedWanted = normalizeDirectChatIdentifier(wanted);
+  return (
+    candidate === wanted ||
+    normalizedCandidate === normalizedWanted ||
+    normalizeIMessageHandle(normalizedCandidate) === normalizeIMessageHandle(normalizedWanted)
+  );
+}
 function findChatGuid(
   chats: readonly Record<string, unknown>[],
   target: Extract<IMessageTarget, { kind: "chat_id" | "chat_identifier" }>,
@@ -167,8 +190,8 @@ function findChatGuid(
     if (
       identifier === target.chatIdentifier ||
       guid === target.chatIdentifier ||
-      (identifier && normalizeDirectChatIdentifier(identifier) === wanted) ||
-      normalizeDirectChatIdentifier(guid) === wanted
+      directChatIdentifierMatches(identifier, wanted) ||
+      directChatIdentifierMatches(guid, wanted)
     ) {
       return guid;
     }
@@ -176,6 +199,54 @@ function findChatGuid(
   return null;
 }
 
+function findChat(
+  chats: readonly Record<string, unknown>[],
+  target: IMessageTarget,
+): Record<string, unknown> | null {
+  if (target.kind === "chat_id") {
+    for (const chat of chats) {
+      if (numberFromUnknown(chat.id) === target.chatId) {
+        return chat;
+      }
+    }
+    return null;
+  }
+
+  if (target.kind === "chat_guid") {
+    for (const chat of chats) {
+      if (stringFromUnknown(chat.guid) === target.chatGuid) {
+        return chat;
+      }
+    }
+    return null;
+  }
+
+  const wanted =
+    target.kind === "chat_identifier"
+      ? target.chatIdentifier
+      : `${target.service === "sms" ? "SMS" : "iMessage"};-;${target.to}`;
+  const normalizedWanted = normalizeDirectChatIdentifier(wanted);
+  for (const chat of chats) {
+    const identifier = stringFromUnknown(chat.identifier);
+    const guid = stringFromUnknown(chat.guid);
+    if (
+      identifier === wanted ||
+      guid === wanted ||
+      directChatIdentifierMatches(identifier, normalizedWanted) ||
+      directChatIdentifierMatches(guid, normalizedWanted)
+    ) {
+      return chat;
+    }
+  }
+  return null;
+}
+
+function normalizeHistoryLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return 10;
+  }
+  return Math.min(Math.max(1, Math.floor(limit)), 50);
+}
 async function runIMessageCliJson(
   args: readonly string[],
   options: CliRunOptions,
@@ -534,6 +605,86 @@ export const imessageActionsRuntime = {
         return { messageId: resolveMessageId(result) };
       },
     );
+  },
+
+  async readMessages(params: {
+    target: IMessageTarget;
+    limit?: number;
+    includeAttachments?: boolean;
+    options: CliRunOptions;
+  }): Promise<{
+    chatId?: number;
+    chatGuid?: string;
+    chatIdentifier?: string;
+    messages: unknown[];
+  }> {
+    const client = await createIMessageRpcClient({
+      cliPath: params.options.cliPath,
+      dbPath: params.options.dbPath,
+    });
+    try {
+      const limit = normalizeHistoryLimit(params.limit);
+      if (params.target.kind === "handle") {
+        try {
+          const result = await client.request<IMessageHistoryResponse & Record<string, unknown>>(
+            "messages.history",
+            {
+              target: params.target.to,
+              to: params.target.to,
+              service: params.target.service,
+              limit,
+              attachments: params.includeAttachments === true,
+            },
+            { timeoutMs: params.options.timeoutMs },
+          );
+          const messages = Array.isArray(result.messages) ? result.messages : [];
+          const chatGuid =
+            stringFromUnknown(result.chatGuid) ?? stringFromUnknown(result.chat_guid);
+          if (chatGuid || messages.length > 0) {
+            return {
+              ...(chatGuid ? { chatGuid } : {}),
+              chatIdentifier: params.target.to,
+              messages,
+            };
+          }
+        } catch {
+          // Native imsg history has historically required chat_id. Fall back to
+          // chats.list resolution for native providers when handle history is
+          // unavailable.
+        }
+      }
+      const list = asChatList(
+        await client.request<IMessageChatListResponse>(
+          "chats.list",
+          { limit: 1000 },
+          { timeoutMs: params.options.timeoutMs },
+        ),
+      );
+      const chat = findChat(list, params.target);
+      const chatId = chat ? numberFromUnknown(chat.id) : undefined;
+      if (!chat || chatId === undefined) {
+        throw new Error("iMessage read failed: chat not found for supplied target.");
+      }
+      const chatGuid = stringFromUnknown(chat.guid);
+      const chatIdentifier = stringFromUnknown(chat.identifier);
+      const result = await client.request<IMessageHistoryResponse>(
+        "messages.history",
+        {
+          chat_id: chatId,
+          limit,
+          attachments: params.includeAttachments === true,
+        },
+        { timeoutMs: params.options.timeoutMs },
+      );
+      return {
+        chatId,
+        ...(chatGuid ? { chatGuid } : {}),
+        ...(chatIdentifier ? { chatIdentifier } : {}),
+        messages: Array.isArray(result.messages) ? result.messages : [],
+      };
+    } finally {
+      await client.stop();
+    }
   },
 };
 

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -11,6 +11,7 @@ const runtimeMock = vi.hoisted(() => ({
   resolveIMessageMessageId: vi.fn((id: string) => id),
   authorizeMessageReference: vi.fn(),
   resolveChatGuidForTarget: vi.fn(),
+  readMessages: vi.fn(),
   sendReaction: vi.fn(),
   sendRichMessage: vi.fn(),
   editMessage: vi.fn(),
@@ -105,6 +106,7 @@ describe("imessage message actions", () => {
     runtimeMock.resolveIMessageMessageId.mockImplementation((id: string) => id);
     runtimeMock.authorizeMessageReference.mockReset();
     runtimeMock.resolveChatGuidForTarget.mockReset();
+    runtimeMock.readMessages.mockReset();
     runtimeMock.sendReaction.mockReset();
     runtimeMock.sendRichMessage.mockReset();
     runtimeMock.editMessage.mockReset();
@@ -164,7 +166,7 @@ describe("imessage message actions", () => {
       currentChannelId: "chat_guid:iMessage;+;chat0000",
     } as never);
 
-    expect(described?.actions).toStrictEqual([]);
+    expect(described?.actions).toStrictEqual(["read"]);
   });
 
   it("advertises private API actions while private API status is unknown", () => {
@@ -176,6 +178,7 @@ describe("imessage message actions", () => {
     } as never);
 
     expect(described?.actions).toStrictEqual([
+      "read",
       "react",
       "edit",
       "reply",
@@ -207,6 +210,7 @@ describe("imessage message actions", () => {
     } as never);
 
     expect(described?.actions).toStrictEqual([
+      "read",
       "react",
       "edit",
       "unsend",
@@ -593,6 +597,71 @@ describe("imessage message actions", () => {
     expect(described?.actions).not.toContain("react");
     expect(described?.actions).not.toContain("reply");
     expect(described?.actions).toContain("edit");
+    expect(described?.actions).toContain("read");
+  });
+
+  it("reads recent messages without requiring the private API bridge", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: false,
+      v2Ready: false,
+      selectors: {},
+    });
+    runtimeMock.readMessages.mockResolvedValue({
+      chatId: 42,
+      chatGuid: "iMessage;-;+15551234567",
+      chatIdentifier: "+15551234567",
+      messages: [
+        {
+          id: 100,
+          guid: "message-guid",
+          sender: "+15551234567",
+          is_from_me: false,
+          text: "hello",
+          created_at: "2026-06-09T20:00:00.000Z",
+          chat_id: 42,
+        },
+      ],
+    });
+
+    const result = await imessageMessageActions.handleAction?.({
+      action: "read",
+      cfg: cfg(),
+      params: {
+        target: "imessage:+15551234567",
+        limit: 5,
+      },
+    } as never);
+
+    expect(runtimeMock.readMessages).toHaveBeenCalledWith({
+      target: {
+        kind: "handle",
+        to: "+15551234567",
+        service: "imessage",
+        serviceExplicit: true,
+      },
+      limit: 5,
+      includeAttachments: false,
+      options: imsgOptions(),
+    });
+    expect(result?.details).toStrictEqual({
+      ok: true,
+      chatId: 42,
+      chatGuid: "iMessage;-;+15551234567",
+      chatIdentifier: "+15551234567",
+      messages: [
+        {
+          id: 100,
+          messageId: "message-guid",
+          sender: "+15551234567",
+          isFromMe: false,
+          text: "hello",
+          createdAt: "2026-06-09T20:00:00.000Z",
+          chatId: 42,
+        },
+      ],
+    });
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
   });
 
   it("requires a trusted requester for group management from iMessage turns", () => {

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -45,6 +45,7 @@ const log = createSubsystemLogger("channels/imessage");
 const providerId = "imessage";
 
 const SUPPORTED_ACTIONS = new Set<ChannelMessageActionName>([
+  "read",
   ...IMESSAGE_ACTION_NAMES,
   "upload-file",
 ]);
@@ -254,6 +255,42 @@ function buildChatContextFromActionParams(params: {
   return target ? chatContextFromIMessageTarget(target, params.service) : {};
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function publicMessageFromHistoryRow(row: unknown) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    return null;
+  }
+  const record = row as Record<string, unknown>;
+  const attachments = Array.isArray(record.attachments) ? record.attachments : undefined;
+  return {
+    ...(numberValue(record.id) !== undefined ? { id: numberValue(record.id) } : {}),
+    ...(stringValue(record.guid) ? { messageId: stringValue(record.guid) } : {}),
+    ...(stringValue(record.sender) ? { sender: stringValue(record.sender) } : {}),
+    ...(booleanValue(record.is_from_me) !== undefined
+      ? { isFromMe: booleanValue(record.is_from_me) }
+      : {}),
+    ...(stringValue(record.text) ? { text: stringValue(record.text) } : {}),
+    ...(stringValue(record.created_at) ? { createdAt: stringValue(record.created_at) } : {}),
+    ...(numberValue(record.chat_id) !== undefined ? { chatId: numberValue(record.chat_id) } : {}),
+    ...(stringValue(record.chat_guid) ? { chatGuid: stringValue(record.chat_guid) } : {}),
+    ...(stringValue(record.chat_identifier)
+      ? { chatIdentifier: stringValue(record.chat_identifier) }
+      : {}),
+    ...(attachments ? { attachments } : {}),
+  };
+}
+
 function mapTapbackReaction(emoji?: string): string | undefined {
   const value = normalizeOptionalLowercaseString(emoji)?.replace(/\ufe0f/g, "");
   if (!value) {
@@ -413,6 +450,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     normalizeOptionalLowercaseString(toolContext?.currentChannelProvider) === "imessage" &&
     GROUP_MANAGEMENT_ACTIONS.has(action),
   messageActionTargetAliases: {
+    read: createIMessageTargetAliases(),
     react: createIMessageTargetAliases(["messageId"]),
     edit: createIMessageTargetAliases(["messageId"]),
     unsend: createIMessageTargetAliases(["messageId"]),
@@ -453,7 +491,9 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       cfg,
       accountId: accountId ?? undefined,
     });
-    assertActionEnabled(action, account.config.actions);
+    if (action !== "read") {
+      assertActionEnabled(action, account.config.actions);
+    }
     const cliPathForProbe = account.config.cliPath?.trim() || "imsg";
     let privateApiStatus = getCachedIMessagePrivateApiStatus(cliPathForProbe);
     const probePrivateApiStatus = async (forceRefresh = false) => {
@@ -539,6 +579,35 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         },
       });
     };
+
+    if (action === "read") {
+      const limit = readPositiveIntegerParam(params, "limit");
+      const includeAttachments = readBooleanParam(params, "attachments") ?? false;
+      const target = resolveIMessageActionTarget({
+        actionParams: params,
+        currentChannelId: toolContext?.currentChannelId,
+      });
+      if (!target) {
+        throw new Error(
+          "iMessage read requires chatGuid, chatId, chatIdentifier, or a chat target.",
+        );
+      }
+      const result = await runtime.readMessages({
+        target,
+        limit,
+        includeAttachments,
+        options: opts,
+      });
+      return jsonResult({
+        ok: true,
+        ...(result.chatId !== undefined ? { chatId: result.chatId } : {}),
+        ...(result.chatGuid ? { chatGuid: result.chatGuid } : {}),
+        ...(result.chatIdentifier ? { chatIdentifier: result.chatIdentifier } : {}),
+        messages: result.messages
+          .map((message) => publicMessageFromHistoryRow(message))
+          .filter((message): message is NonNullable<typeof message> => Boolean(message)),
+      });
+    }
 
     if (action === "react") {
       await assertPrivateApiEnabled();

--- a/extensions/imessage/src/message-tool-api.test.ts
+++ b/extensions/imessage/src/message-tool-api.test.ts
@@ -61,6 +61,7 @@ describe("iMessage message-tool artifact", () => {
     });
 
     expect(discovery?.actions).toStrictEqual([
+      "read",
       "react",
       "unsend",
       "reply",
@@ -145,6 +146,6 @@ describe("iMessage message-tool artifact", () => {
       currentChannelId: "chat_id:1",
     });
 
-    expect(discovery?.actions).toStrictEqual([]);
+    expect(discovery?.actions).toStrictEqual(["read"]);
   });
 });

--- a/extensions/imessage/src/message-tool-api.ts
+++ b/extensions/imessage/src/message-tool-api.ts
@@ -49,6 +49,7 @@ export function describeIMessageMessageTool({
   const privateApiStatus = getCachedIMessagePrivateApiStatus(cliPath);
   const gate = createActionGate(account.config.actions);
   const actions = new Set<ChannelMessageActionName>();
+  actions.add("read");
   for (const action of IMESSAGE_ACTION_NAMES) {
     const spec = IMESSAGE_ACTIONS[action];
     if (!spec?.gate || !gate(spec.gate)) {


### PR DESCRIPTION
Closes #117109

## What Problem This Solves

Users and agents cannot explicitly retrieve a small recent-history window for a known native iMessage handle or chat through the `message` tool. They must rely on inbound context seeding or provider-specific side paths when recent conversation context is needed.

## Why This Change Was Made

This adds a read-only `message(action="read")` surface to the native iMessage extension. It resolves handle, chat ID, chat GUID, and chat-identifier targets; defaults to 10 messages; caps reads at 50; uses native handle lookup when supported; and falls back to chat-list resolution for providers that require a numeric chat ID.

The action is independent of private-API mutation capabilities and performs no send, reaction, or other mutation. Returned rows are normalized into a bounded public payload.

## User Impact

An iMessage workflow can now refresh recent context for a known conversation before drafting or deciding what to do. The feature does not grant outbound authority or alter existing send/approval behavior.

## Evidence

- Focused current-head tests: 3 files, 96 tests passed.
- Channel contracts: 4 shards, 50 files, 481 tests passed.
- `pnpm build`: passed.
- `pnpm check`: passed.
- Extension typecheck after rebasing onto current `main`: passed.
- `git diff --check upstream/main...HEAD`: passed.
- Full `pnpm test:extension imessage`: 51 files and 898 tests passed; one unchanged `send.test.ts` file had five timer failures (`configureSqliteWalMaintenance`, plus Vitest warnings for pre-existing un-awaited rejection assertions). This branch does not modify that test or its send/runtime code.

The implementation and PR preparation were AI-assisted. I reviewed and adapted the change against current upstream code, resolved the target-alias changes introduced since the original implementation, and ran the validation above.
