### PR TITLE
fix(openai): clear ChatGPT SSE fallback per session

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -4,6 +4,7 @@ import { zstdDecompressSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { configureAiTransportHost } from "../host.js";
+import { cleanupSessionResources } from "../session-resources.js";
 import type { Context, Model } from "../types.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -499,7 +500,7 @@ describe("ChatGPT Responses cached transport", () => {
     }
   });
 
-  it("lazily builds authenticated SSE requests after session-scoped websocket fallback", async () => {
+  it("keeps SSE fallback sticky only for the active session lifecycle", async () => {
     let websocketAttempts = 0;
 
     class FailingWebSocket {
@@ -528,20 +529,31 @@ describe("ChatGPT Responses cached transport", () => {
     vi.stubGlobal("WebSocket", FailingWebSocket);
     vi.stubGlobal("fetch", fetchMock);
     const apiKey = createJwt();
-    const options = { apiKey, sessionId: "sticky-sse-fallback" };
+    const runSession = (sessionId: string) =>
+      streamOpenAICodexResponses(model, context, { apiKey, sessionId }).result();
 
-    const first = await streamOpenAICodexResponses(model, context, options).result();
-    const second = await streamOpenAICodexResponses(model, context, options).result();
+    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+    expect(websocketAttempts).toBe(2);
 
-    expect(first.stopReason).toBe("stop");
-    expect(second.stopReason).toBe("stop");
-    expect(websocketAttempts).toBe(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    cleanupSessionResources("sticky-sse-fallback");
+    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+    expect(websocketAttempts).toBe(2);
+    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+    expect(websocketAttempts).toBe(3);
+
+    cleanupSessionResources();
+    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+    expect(websocketAttempts).toBe(5);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
 
     for (const { headers, body } of captured) {
       expect(headers.get("authorization")).toBe(`Bearer ${apiKey}`);
       expect(headers.get("chatgpt-account-id")).toBe("acct-1");
-      expect(headers.get("session_id")).toBe("sticky-sse-fallback");
+      expect(headers.get("session_id")).toMatch(/^(sticky|unrelated)-sse-fallback$/);
       expect(headers.get("accept")).toBe("text/event-stream");
       expect(headers.get("content-type")).toBe("application/json");
       expect(headers.get("content-encoding")).toBe("zstd");
@@ -550,7 +562,7 @@ describe("ChatGPT Responses cached transport", () => {
         JSON.parse(Buffer.from(zstdDecompressSync(body as Uint8Array)).toString("utf8")),
       ).toMatchObject({
         model: model.id,
-        prompt_cache_key: "sticky-sse-fallback",
+        prompt_cache_key: headers.get("session_id"),
       });
     }
   });

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -1,4 +1,5 @@
 import { once } from "node:events";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { zstdDecompressSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -501,68 +502,174 @@ describe("ChatGPT Responses cached transport", () => {
   });
 
   it("keeps SSE fallback sticky only for the active session lifecycle", async () => {
-    let websocketAttempts = 0;
-
-    class FailingWebSocket {
-      constructor() {
-        websocketAttempts += 1;
-        throw new Error("websocket connect failed");
-      }
-
-      send(): void {}
-      close(): void {}
-      addEventListener(): void {}
-      removeEventListener(): void {}
-    }
-
-    const captured: Array<{ headers: Headers; body: BodyInit | null | undefined }> = [];
-    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
-      captured.push({ headers: new Headers(init?.headers), body: init?.body });
-      return new Response(
-        `data: ${JSON.stringify(completion(`resp_sse_${captured.length}`))}\n\n`,
-        {
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-        },
-      );
+    const websocketUpgrades: Array<{
+      method: string;
+      path: string;
+      authorization?: string;
+      accountId?: string;
+      openaiBeta?: string;
+      sessionId?: string;
+      requestId?: string;
+    }> = [];
+    const sseRequests: Array<{
+      method: string;
+      path: string;
+      authorization?: string;
+      accountId?: string;
+      sessionId?: string;
+      requestId?: string;
+      accept?: string;
+      contentType?: string;
+      contentEncoding?: string;
+      body: Buffer;
+    }> = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      request.on("end", () => {
+        const requestNumber = sseRequests.length + 1;
+        sseRequests.push({
+          method: request.method ?? "",
+          path: request.url ?? "",
+          authorization: request.headers.authorization,
+          accountId: request.headers["chatgpt-account-id"] as string | undefined,
+          sessionId: request.headers.session_id as string | undefined,
+          requestId: request.headers["x-client-request-id"] as string | undefined,
+          accept: request.headers.accept,
+          contentType: request.headers["content-type"],
+          contentEncoding: request.headers["content-encoding"],
+          body: Buffer.concat(chunks),
+        });
+        response.writeHead(200, {
+          connection: "close",
+          "content-type": "text/event-stream",
+        });
+        response.end(`data: ${JSON.stringify(completion(`resp_sse_${requestNumber}`))}\n\n`);
+      });
     });
-    vi.stubGlobal("WebSocket", FailingWebSocket);
-    vi.stubGlobal("fetch", fetchMock);
+    server.on("upgrade", (request, socket) => {
+      websocketUpgrades.push({
+        method: request.method ?? "",
+        path: request.url ?? "",
+        authorization: request.headers.authorization,
+        accountId: request.headers["chatgpt-account-id"] as string | undefined,
+        openaiBeta: request.headers["openai-beta"] as string | undefined,
+        sessionId: request.headers.session_id as string | undefined,
+        requestId: request.headers["x-client-request-id"] as string | undefined,
+      });
+      socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+    const loopbackModel = {
+      ...model,
+      baseUrl: `http://127.0.0.1:${port}/backend-api`,
+    } satisfies Model<"openai-chatgpt-responses">;
+    vi.stubGlobal("WebSocket", WebSocket);
     const apiKey = createJwt();
     const runSession = (sessionId: string) =>
-      streamOpenAICodexResponses(model, context, { apiKey, sessionId }).result();
+      streamOpenAICodexResponses(loopbackModel, context, { apiKey, sessionId }).result();
 
-    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
-    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
-    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
-    expect(websocketAttempts).toBe(2);
+    try {
+      const firstStickyResult = await runSession("sticky-sse-fallback");
+      expect(firstStickyResult).toMatchObject({
+        stopReason: "stop",
+        diagnostics: [
+          {
+            type: "provider_transport_failure",
+            error: { message: "Unexpected server response: 426" },
+            details: {
+              configuredTransport: "auto",
+              fallbackTransport: "sse",
+              eventsEmitted: false,
+              phase: "before_message_stream_start",
+            },
+          },
+        ],
+      });
+      const stickyResult = await runSession("sticky-sse-fallback");
+      expect(stickyResult.stopReason).toBe("stop");
+      expect(stickyResult.diagnostics).toBeUndefined();
+      expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+      expect(websocketUpgrades).toHaveLength(2);
 
-    cleanupSessionResources("sticky-sse-fallback");
-    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
-    expect(websocketAttempts).toBe(2);
-    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
-    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
-    expect(websocketAttempts).toBe(3);
+      cleanupSessionResources("sticky-sse-fallback");
+      expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+      expect(websocketUpgrades).toHaveLength(2);
+      expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+      expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+      expect(websocketUpgrades).toHaveLength(3);
 
-    cleanupSessionResources();
-    expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
-    expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
-    expect(websocketAttempts).toBe(5);
-    expect(fetchMock).toHaveBeenCalledTimes(8);
+      cleanupSessionResources();
+      expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
+      expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
+      expect(websocketUpgrades).toHaveLength(5);
+      expect(sseRequests).toHaveLength(8);
 
-    for (const { headers, body } of captured) {
-      expect(headers.get("authorization")).toBe(`Bearer ${apiKey}`);
-      expect(headers.get("chatgpt-account-id")).toBe("acct-1");
-      expect(headers.get("session_id")).toMatch(/^(sticky|unrelated)-sse-fallback$/);
-      expect(headers.get("accept")).toBe("text/event-stream");
-      expect(headers.get("content-type")).toBe("application/json");
-      expect(headers.get("content-encoding")).toBe("zstd");
-      expect(body).toBeInstanceOf(Uint8Array);
-      expect(
-        JSON.parse(Buffer.from(zstdDecompressSync(body as Uint8Array)).toString("utf8")),
-      ).toMatchObject({
-        model: model.id,
-        prompt_cache_key: headers.get("session_id"),
+      expect(websocketUpgrades.map((request) => request.sessionId)).toEqual([
+        "sticky-sse-fallback",
+        "unrelated-sse-fallback",
+        "sticky-sse-fallback",
+        "sticky-sse-fallback",
+        "unrelated-sse-fallback",
+      ]);
+      expect(sseRequests.map((request) => request.sessionId)).toEqual([
+        "sticky-sse-fallback",
+        "sticky-sse-fallback",
+        "unrelated-sse-fallback",
+        "unrelated-sse-fallback",
+        "sticky-sse-fallback",
+        "sticky-sse-fallback",
+        "sticky-sse-fallback",
+        "unrelated-sse-fallback",
+      ]);
+
+      for (const request of websocketUpgrades) {
+        expect(request).toMatchObject({
+          method: "GET",
+          path: "/backend-api/codex/responses",
+          authorization: `Bearer ${apiKey}`,
+          accountId: "acct-1",
+          openaiBeta: "responses_websockets=2026-02-06",
+          requestId: request.sessionId,
+        });
+      }
+      for (const request of sseRequests) {
+        expect(request).toMatchObject({
+          method: "POST",
+          path: "/backend-api/codex/responses",
+          authorization: `Bearer ${apiKey}`,
+          accountId: "acct-1",
+          requestId: request.sessionId,
+          accept: "text/event-stream",
+          contentType: "application/json",
+          contentEncoding: "zstd",
+        });
+        expect(request.body).not.toHaveLength(0);
+        const payload = JSON.parse(zstdDecompressSync(request.body).toString("utf8"));
+        expect(payload).toMatchObject({
+          model: model.id,
+          prompt_cache_key: request.sessionId,
+        });
+      }
+
+      console.info(
+        "[behavior-evidence] chatgpt-sse-fallback-cleanup",
+        JSON.stringify({
+          transport: "real ws client and loopback HTTP server",
+          rejectedUpgradeStatus: 426,
+          websocketSessionIds: websocketUpgrades.map((request) => request.sessionId),
+          sseSessionIds: sseRequests.map((request) => request.sessionId),
+          firstFallbackError: firstStickyResult.diagnostics?.[0]?.error?.message,
+          scopedCleanupRetriedOnly: "sticky-sse-fallback",
+          globalCleanupRetried: ["sticky-sse-fallback", "unrelated-sse-fallback"],
+        }),
+      );
+    } finally {
+      cleanupSessionResources();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
       });
     }
   });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -920,8 +920,8 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
     }
     closeWebSocketSilently(entry.socket, 1000, "debug_close");
   };
-  // Sticky SSE fallback follows the cached socket lifecycle; otherwise reused
-  // session ids stay degraded and the process-local set grows indefinitely.
+  // Sticky SSE fallback follows the provider session-resource lifecycle;
+  // otherwise reused session ids stay degraded and the set grows indefinitely.
   if (sessionId) {
     websocketSseFallbackSessions.delete(sessionId);
     const entry = websocketSessionCache.get(sessionId);

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -920,7 +920,10 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
     }
     closeWebSocketSilently(entry.socket, 1000, "debug_close");
   };
+  // Sticky SSE fallback follows the cached socket lifecycle; otherwise reused
+  // session ids stay degraded and the process-local set grows indefinitely.
   if (sessionId) {
+    websocketSseFallbackSessions.delete(sessionId);
     const entry = websocketSessionCache.get(sessionId);
     if (entry) {
       closeEntry(entry);
@@ -932,6 +935,7 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
     closeEntry(entry);
   }
   websocketSessionCache.clear();
+  websocketSseFallbackSessions.clear();
 }
 
 registerSessionResourceCleanup(closeOpenAICodexWebSocketSessions);


### PR DESCRIPTION
## What Problem This Solves

Managed ChatGPT transport fallback is intentionally sticky for one active session after a pre-stream WebSocket failure. The provider cleanup hook closed cached sockets, but it never removed the matching session from `websocketSseFallbackSessions`. Reusing a disposed session ID therefore stayed on SSE forever, and global cleanup left every fallback ID retained for the process lifetime.

## Why This Change Was Made

The registered session-resource cleanup is the canonical owner for both the cached WebSocket and the fallback marker derived from that transport lifecycle. Scoped cleanup now deletes only that session's marker; global cleanup clears all markers. No new cache, timeout, fallback policy, or transport path is introduced.

This matches Codex's current session-scoped `ModelClientState`: fallback is sticky across turns inside one client session and disappears with that session lifecycle.

## User Impact

Disposed or replaced ChatGPT sessions can attempt WebSocket transport again instead of remaining permanently degraded to SSE. Long-running processes also stop retaining stale fallback session IDs indefinitely.

## Evidence

- Exact reviewed head: `355aa8ee9e0f7be84fc901dbbdd65cb8b89f24be`.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30676568318
  - 7/7 cached transport tests passed.
  - The lifecycle regression used the real pinned `ws` client against a loopback HTTP server that rejected actual upgrade requests with HTTP 426 and served actual SSE POST responses.
  - The complete scoped changed gate passed: formatting, production and test typechecking, lint, dead-code, dependency, boundary, database-first, and import-cycle checks.
- Redacted runtime transcript:

  ```text
  [behavior-evidence] chatgpt-sse-fallback-cleanup {"transport":"real ws client and loopback HTTP server","rejectedUpgradeStatus":426,"websocketSessionIds":["sticky-sse-fallback","unrelated-sse-fallback","sticky-sse-fallback","sticky-sse-fallback","unrelated-sse-fallback"],"sseSessionIds":["sticky-sse-fallback","sticky-sse-fallback","unrelated-sse-fallback","unrelated-sse-fallback","sticky-sse-fallback","sticky-sse-fallback","sticky-sse-fallback","unrelated-sse-fallback"],"firstFallbackError":"Unexpected server response: 426","scopedCleanupRetriedOnly":"sticky-sse-fallback","globalCleanupRetried":["sticky-sse-fallback","unrelated-sse-fallback"]}
  ```

- The same regression verifies WebSocket and SSE authorization/session headers plus the decoded zstd request payload for every SSE request.
- Direct Codex source inspection at `003ec63bba93cf994246799f795a6a4f6d67743a`:
  - `codex-rs/core/src/client.rs:243-265,490-539,941-952,1793-1870`
  - `codex-rs/core/tests/suite/websocket_fallback.rs:209-254`
- Direct pinned `ws@8.21.1` source/type inspection:
  - `node_modules/ws/lib/websocket.js:46-88,920-955`
  - `node_modules/@types/ws/index.d.ts:41-90,117-195`
- Fresh whole-branch autoreview: clean, confidence 0.99; the only independent-review wording nit was corrected in a comment-only follow-up.

Release-note context: Managed ChatGPT sessions no longer retain sticky SSE fallback after their session lifecycle is cleaned up.
