### PR TITLE
fix(ui): reset connection lineage when switching Gateway targets

### DIFF
--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -1,0 +1,100 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  GatewayBrowserClient,
+  GatewayBrowserClientOptions,
+  GatewayHelloOk,
+} from "../api/gateway.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import "./app-host.ts";
+import type { ApplicationContext, ApplicationGateway } from "./context.ts";
+import { createApplicationGateway } from "./gateway-store.ts";
+import { loadSettings } from "./settings.ts";
+
+const HELLO: GatewayHelloOk = {
+  type: "hello-ok",
+  protocol: 1,
+  auth: { role: "operator", scopes: [] },
+};
+
+function createGatewayHarness() {
+  vi.stubGlobal("localStorage", createStorageMock());
+  vi.stubGlobal("sessionStorage", createStorageMock());
+  const clients: Array<{ opts: GatewayBrowserClientOptions }> = [];
+  const gateway = createApplicationGateway(loadSettings(), "", "", (opts) => {
+    const client = {
+      opts,
+      instanceId: opts.instanceId,
+      start: vi.fn(),
+      stop: vi.fn(),
+      request: vi.fn(),
+    };
+    clients.push(client);
+    return client as unknown as GatewayBrowserClient;
+  });
+  return { gateway, clients };
+}
+
+function renderGatewaySurface(gateway: ApplicationGateway): string {
+  const app = document.createElement("openclaw-app") as unknown as {
+    runtime: { context: ApplicationContext };
+    render: () => { strings: readonly string[] };
+    synchronizeGateway: (gateway: ApplicationGateway) => void;
+  };
+  app.runtime = {
+    context: {
+      gateway,
+      basePath: "",
+      config: { current: { terminalEnabled: false } },
+    } as unknown as ApplicationContext,
+  };
+  app.synchronizeGateway(gateway);
+  return app.render().strings.join("");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("Control UI Gateway target lineage", () => {
+  it("returns to the login gate when a newly selected Gateway's first attempt fails", () => {
+    const { gateway, clients } = createGatewayHarness();
+    gateway.start();
+    clients[0]?.opts.onHello?.(HELLO);
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+    clients[1]?.opts.onClose?.({ code: 1006, reason: "remote refused", willRetry: true });
+
+    const surface = renderGatewaySurface(gateway);
+
+    expect(surface).toContain("<openclaw-login-gate");
+    expect(surface).not.toContain("<openclaw-app-shell");
+  });
+
+  it("keeps an established Gateway's dashboard mounted during its own retry", () => {
+    const { gateway, clients } = createGatewayHarness();
+    gateway.start();
+    clients[0]?.opts.onHello?.(HELLO);
+    clients[0]?.opts.onClose?.({ code: 1006, reason: "same gateway blip", willRetry: true });
+
+    const surface = renderGatewaySurface(gateway);
+
+    expect(surface).toContain("<openclaw-app-shell");
+    expect(surface).not.toContain("<openclaw-login-gate");
+  });
+
+  it("retains a replacement Gateway's dashboard after its own successful hello", () => {
+    const { gateway, clients } = createGatewayHarness();
+    gateway.start();
+    clients[0]?.opts.onHello?.(HELLO);
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+    clients[1]?.opts.onHello?.(HELLO);
+    clients[1]?.opts.onClose?.({ code: 1006, reason: "replacement blip", willRetry: true });
+
+    const surface = renderGatewaySurface(gateway);
+
+    expect(surface).toContain("<openclaw-app-shell");
+    expect(surface).not.toContain("<openclaw-login-gate");
+  });
+});

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -224,6 +224,68 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.lastError).toContain("4008");
   });
 
+  it("starts a newly selected Gateway as a fresh connection", () => {
+    const { gateway, clients, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test", token: "other-token" });
+
+    expect(clients[0]?.stopped).toBe(1);
+    expect(current().opts.url).toBe("wss://other-gateway.example.test");
+    expect(current().opts.token).toBe("other-token");
+    expect(gateway.snapshot.phase).toBe("connecting");
+  });
+
+  it("keeps a newly selected Gateway's first retry at the login gate", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+
+    current().opts.onClose?.({ code: 1006, reason: "remote refused", willRetry: true });
+
+    expect(gateway.snapshot.phase).toBe("connecting");
+    expect(gateway.snapshot.lastError).toBe("disconnected (1006): remote refused");
+  });
+
+  it("treats a newly selected Gateway's first terminal close as never connected", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+
+    current().opts.onClose?.({ code: 4008, reason: "remote rejected", willRetry: false });
+
+    expect(gateway.snapshot.phase).toBe("stopped");
+    expect(gateway.snapshot.lastError).toBe("disconnected (4008): remote rejected");
+  });
+
+  it("retains a newly selected Gateway's shell after its own successful hello", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+    current().opts.onHello?.(HELLO);
+
+    current().opts.onClose?.({ code: 1006, reason: "remote blip", willRetry: true });
+
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+  });
+
+  it("preserves an established Gateway's lineage when its unchanged URL is resubmitted", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+    const gatewayUrl = gateway.connection.gatewayUrl;
+
+    gateway.connect({ gatewayUrl, token: "replacement-token", sessionKey: "agent:main:other" });
+
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+    expect(current().opts.token).toBe("replacement-token");
+    expect(gateway.snapshot.sessionKey).toBe("agent:main:other");
+  });
+
   it.each(["stopped", "connecting", "connected", "reconnecting", "offline"] as const)(
     "stop() resets %s to stopped",
     (phase) => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -94,7 +94,7 @@ export function createApplicationGateway(
   let canvasSurfaceLeaseClient: GatewayBrowserClient | null = null;
   let canvasSurfaceLeaseStarted = false;
   let canvasSurfaceLeaseGeneration = 0;
-  // Session lineage for this page lifetime: once a hello succeeded, later
+  // Session lineage belongs to the selected Gateway: once its hello succeeds,
   // transport drops render as "reconnecting" (shell + banner) instead of
   // kicking the operator back to the login gate.
   let everConnected = false;
@@ -273,6 +273,10 @@ export function createApplicationGateway(
     const gatewayUrlChanged =
       connectionOverrides.gatewayUrl !== undefined &&
       connectionOverrides.gatewayUrl !== connection.gatewayUrl;
+    // A different Gateway has no established session to keep mounted on failure.
+    if (gatewayUrlChanged) {
+      everConnected = false;
+    }
     connection = nextConnection;
     // Trust the connected gateway's origin for avatar route resolution so
     // split-origin Control UI deployments load uploaded/proxied avatars.


### PR DESCRIPTION
## What Problem This Solves

The Control UI tracked whether **any** Gateway had ever connected during the page lifetime. After the operator selected a different Gateway, that previous Gateway's successful session was incorrectly treated as a successful session for the replacement target.

On frozen current main `9878bfc8e505f9bbc87905b67488248e51546eaf`:

1. Gateway A successfully connects and establishes its normal dashboard session.
2. The operator explicitly selects Gateway B from the Connection page or confirms a remote-Gateway handoff.
3. Before Gateway B has ever completed its own handshake, its snapshot already says `reconnecting`.
4. If Gateway B is unreachable, the app keeps showing Gateway A's old dashboard and suppresses the login gate that provides Gateway B's URL, credentials, and failure diagnostic.
5. A terminal first-connect failure is also misclassified as `offline` instead of the existing never-connected `stopped` state.

This violates the existing documented boundary: retain the dashboard for a dropped **established session**, but show the login surface when a new Gateway needs operator input.

## Why This Change Was Made

Keep session lineage at its existing private Gateway-store owner and scope it to the currently selected Gateway:

- Reuse the already authoritative `gatewayUrlChanged` fact, which intentionally distinguishes a real Gateway selection from the login form resubmitting the unchanged URL.
- Reset `everConnected` **only** when that fact is true, before creating the replacement client.
- Leave same-Gateway manual retries, event-gap recovery, unchanged-URL token/session updates, explicit stop behavior, operator-owned Gateway selection, credentials, and all shared client/protocol behavior unchanged.
- Add direct owner cases for replacement first connection, retryable failure, terminal failure, replacement's own successful session, and unchanged-target resubmission.
- Add a small focused app-host integration suite that renders the real production login-gate/dashboard templates from the real production Gateway store; avoid expanding the existing grandfathered oversized app-host test module.

Only one private production owner changes. There are no public SDK/API, protocol, authentication, security, configuration, storage, documentation, or dependency changes.

## User Impact

Selecting another Gateway now starts a genuine first connection for that target. If it cannot connect, the operator gets the real login gate with the replacement Gateway's settings and actionable error instead of being trapped inside the previously connected Gateway's stale dashboard.

Once the replacement Gateway completes its own hello, subsequent drops correctly retain its dashboard and reconnect automatically. Existing same-Gateway retries, event-gap reconnection, terminal failures, stop/restart, token updates, and session changes retain their behavior.

## Evidence

- Immutable candidate: `2a1fe006af044c98a67498815714a5195b8903a3`.
- Frozen latest-main parent: `9878bfc8e505f9bbc87905b67488248e51546eaf`.
- True frozen-baseline owner/app-host RED: **4 failures, 66 passing controls**. Baseline returned `reconnecting` instead of `connecting` for a new Gateway, `offline` instead of `stopped` for its terminal failure, and the real app-host renderer produced `<openclaw-app-shell>` instead of `<openclaw-login-gate>`.
- Exact immutable candidate owner, full preexisting app-host suite, focused real app-host renderer, and observer lifecycle tests: **82/82 passed**:

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs \
    ui/src/app/gateway-store.test.ts \
    ui/src/app/gateway-store.observers.test.ts \
    ui/src/app/app-host.gateway-lineage.test.ts \
    ui/src/app/app-host.test.ts
  ```

- Genuine type-aware `oxlint --type-aware --type-check`, targeted `oxfmt --check`, and `git diff --check`: clean.
- Independent actual **Google Chrome 150.0.7871.187** baseline-to-candidate matrix: **21/21 passed** against real localhost WebSocket Gateways, seven authenticated device/connect frames, and two genuinely stalled native TCP/WebSocket upgrade attempts. Gateway A completed its real challenge/hello; selecting real Gateway B now immediately reports `connecting` and renders the actual login-gate decision, including after B's first genuine transport failure. Gateway B's own successful hello followed by a real `1012` server close preserves its dashboard; unchanged-origin manual reconnect, real sequence-gap recovery, and explicit stop remain unchanged.
- Independent whole-owner/browser review: **zero P0–P3 findings**, confidence **0.99**.
- Fresh official whole-branch Codex autoreview against the exact frozen parent through **P3**: **zero findings**, confidence **0.96**; genuine TruffleHog secret scan clean.

## Agent Transcript

Agent-created change developed in an isolated frozen-main worktree after explicit maintainer approval. The current-main failure was reproduced before editing, independently verified with real Chrome and two real Gateway origins, and guarded by focused owner plus real app-host rendering tests. No secrets, credentials, personal data, live operator state, public API, authentication policy, or configuration were changed or included in proof artifacts.
