### PR TITLE
fix(line): prevent duplicate auto replies after ambiguous delivery

### DIFF
--- a/extensions/line/src/auto-reply-delivery-recovery.test.ts
+++ b/extensions/line/src/auto-reply-delivery-recovery.test.ts
@@ -12,6 +12,135 @@ import {
 } from "./auto-reply-delivery.test-helpers.js";
 
 describe("deliverLineAutoReply HTTP recovery", () => {
+  const createHttpError = (status: number) =>
+    new HTTPFetchError(`${status} - provider rejected the request`, {
+      status,
+      statusText: "provider rejected the request",
+      headers: new Headers(),
+      body: "provider error",
+    });
+
+  it.each([
+    { label: "an actual LINE HTTP timeout", error: createHttpError(408) },
+    { label: "an actual LINE upstream failure", error: createHttpError(503) },
+    {
+      label: "a wrapped actual LINE upstream failure",
+      error: new Error("reply failed", { cause: createHttpError(502) }),
+    },
+    {
+      label: "an actual LINE upstream failure behind two SDK wrappers",
+      error: new Error("reply failed", {
+        cause: new Error("provider request failed", { cause: createHttpError(503) }),
+      }),
+    },
+    {
+      label: "an actual LINE upstream failure behind an SDK error property",
+      error: Object.assign(new Error("reply failed"), { error: createHttpError(503) }),
+    },
+    {
+      label: "an authoritative LINE upstream failure wrapping a pre-connect error",
+      error: Object.assign(createHttpError(503), {
+        cause: Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }),
+      }),
+    },
+    {
+      label: "a connection reset after dispatch",
+      error: Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+    },
+    {
+      label: "a request timeout after dispatch",
+      error: Object.assign(new Error("reply request timed out"), { code: "ETIMEDOUT" }),
+    },
+    {
+      label: "an undici response-body timeout",
+      error: Object.assign(new Error("response body timed out"), {
+        code: "UND_ERR_BODY_TIMEOUT",
+      }),
+    },
+    {
+      label: "an aborted request",
+      error: Object.assign(new Error("reply was aborted"), { name: "AbortError" }),
+    },
+    { label: "the actual undici fetch error", error: new TypeError("fetch failed") },
+    {
+      label: "a wrapped undici fetch error",
+      error: new Error("reply failed", { cause: new TypeError("fetch failed") }),
+    },
+  ])("does not replay a possibly accepted reply after $label", async ({ error }) => {
+    const onReplyError = vi.fn();
+    const replyMessageLine = vi.fn(async () => {
+      throw error;
+    });
+    const { deps, pushMessagesLine } = createDeps({
+      onReplyError,
+      replyMessageLine: replyMessageLine as LineAutoReplyDeps["replyMessageLine"],
+    });
+
+    await expect(
+      deliverLineAutoReply({
+        ...baseDeliveryParams,
+        payload: { text: "do not duplicate this reply" },
+        lineData: {},
+        deps,
+      }),
+    ).rejects.toBe(error);
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(onReplyError).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "an actual rejected LINE reply", error: createHttpError(400) },
+    {
+      label: "an actual rejected LINE reply behind two SDK wrappers",
+      error: new Error("reply failed", {
+        cause: new Error("provider request failed", { cause: createHttpError(400) }),
+      }),
+    },
+    { label: "an actual LINE reply rate-limit rejection", error: createHttpError(429) },
+    {
+      label: "a refused connection before request dispatch",
+      error: Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }),
+    },
+    {
+      label: "a wrapped DNS failure before request dispatch",
+      error: new TypeError("fetch failed", {
+        cause: Object.assign(new Error("getaddrinfo failed"), { code: "ENOTFOUND" }),
+      }),
+    },
+    { label: "a known local pre-dispatch failure", error: new Error("reply failed") },
+    { label: "a raw pre-dispatch parsing failure", error: new SyntaxError("invalid request") },
+  ])("keeps the push fallback after $label", async ({ error }) => {
+    const onReplyError = vi.fn();
+    const replyMessageLine = vi.fn(async () => {
+      throw error;
+    });
+    const { deps, pushMessagesLine } = createDeps({
+      onReplyError,
+      replyMessageLine: replyMessageLine as LineAutoReplyDeps["replyMessageLine"],
+    });
+
+    await expect(
+      deliverLineAutoReply({
+        ...baseDeliveryParams,
+        payload: { text: "preserve the reply" },
+        lineData: {},
+        deps,
+      }),
+    ).resolves.toMatchObject({
+      status: "delivered",
+      replyTokenUsed: true,
+      visibleReplySent: true,
+    });
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(onReplyError).toHaveBeenCalledExactlyOnceWith(error);
+    expect(pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
+      "line:user:1",
+      [{ type: "text", text: "preserve the reply" }],
+      { cfg: LINE_TEST_CFG, accountId: "acc" },
+    );
+  });
+
   it("does not replay an accepted reply after local bookkeeping fails", async () => {
     const acceptedError = createChannelPartialDeliveryError(
       new Error("activity store unavailable"),
@@ -20,7 +149,9 @@ describe("deliverLineAutoReply HTTP recovery", () => {
     const replyMessageLine = vi.fn(async () => {
       throw acceptedError;
     });
+    const onReplyError = vi.fn();
     const { deps, pushMessagesLine } = createDeps({
+      onReplyError,
       replyMessageLine: replyMessageLine as LineAutoReplyDeps["replyMessageLine"],
     });
 
@@ -38,6 +169,39 @@ describe("deliverLineAutoReply HTTP recovery", () => {
       error: acceptedError,
     });
     expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(onReplyError).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it("does not replay a successful reply when its provider response cannot be parsed", async () => {
+    const acceptedError = createChannelPartialDeliveryError(
+      new SyntaxError("Unexpected end of JSON input"),
+      { messageIds: [], visibleReplySent: true },
+    );
+    const onReplyError = vi.fn();
+    const replyMessageLine = vi.fn(async () => {
+      throw acceptedError;
+    });
+    const { deps, pushMessagesLine } = createDeps({
+      onReplyError,
+      replyMessageLine: replyMessageLine as LineAutoReplyDeps["replyMessageLine"],
+    });
+
+    await expect(
+      deliverLineAutoReply({
+        ...baseDeliveryParams,
+        payload: { text: "accepted despite its malformed receipt" },
+        lineData: {},
+        deps,
+      }),
+    ).resolves.toMatchObject({
+      status: "partial",
+      replyTokenUsed: true,
+      visibleReplySent: true,
+      error: acceptedError,
+    });
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(onReplyError).not.toHaveBeenCalled();
     expect(pushMessagesLine).not.toHaveBeenCalled();
   });
 

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -2,9 +2,15 @@
 import { HTTPFetchError, type messagingApi } from "@line/bot-sdk";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  collectErrorGraphCandidates,
+  extractErrorCode,
+  readErrorName,
+} from "openclaw/plugin-sdk/error-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { FlexContainer } from "./flex-templates.js";
@@ -54,10 +60,43 @@ function toLineDeliveryError(error: unknown): Error {
 }
 
 function getLineHttpError(error: unknown): HTTPFetchError | undefined {
-  if (error instanceof HTTPFetchError) {
-    return error;
+  return collectErrorGraphCandidates(error, (candidate) => [candidate.cause, candidate.error]).find(
+    (candidate): candidate is HTTPFetchError => candidate instanceof HTTPFetchError,
+  );
+}
+
+function canFallbackAfterLineReplyFailure(error: unknown): boolean {
+  const httpError = getLineHttpError(error);
+  if (httpError) {
+    return httpError.status >= 400 && httpError.status < 500 && httpError.status !== 408;
   }
-  return error instanceof Error && error.cause instanceof HTTPFetchError ? error.cause : undefined;
+
+  const candidates = collectErrorGraphCandidates(error, (candidate) => [
+    candidate.cause,
+    candidate.error,
+  ]);
+  if (
+    candidates.some(
+      (candidate) =>
+        readErrorName(candidate) === "AbortError" ||
+        classifyTransientNetworkErrorCode(extractErrorCode(candidate)) === "ambiguous",
+    )
+  ) {
+    return false;
+  }
+  if (
+    candidates.some(
+      (candidate) =>
+        classifyTransientNetworkErrorCode(extractErrorCode(candidate)) === "pre-connect",
+    )
+  ) {
+    return true;
+  }
+
+  // Undici rejects an unknown network outcome with this exact TypeError shape.
+  return !candidates.some(
+    (candidate) => candidate instanceof TypeError && candidate.message === "fetch failed",
+  );
 }
 
 function markLineVisibleDeliveryError(error: unknown): Error {
@@ -160,13 +199,12 @@ export async function deliverLineAutoReply(params: {
           accountId,
         });
       } catch (err) {
-        deps.onReplyError?.(err);
-        // The reply is already provider-visible; replaying its batch as a push duplicates it.
-        if (isChannelPartialDeliveryError(err)) {
+        // Reply tokens are single-use, and a push cannot deduplicate a possibly accepted reply.
+        if (isChannelPartialDeliveryError(err) || !canFallbackAfterLineReplyFailure(err)) {
           throw err;
         }
-        // A transport-failed reply may have landed; only a definitive LINE 400
-        // makes text recovery after a rejected push fallback safe.
+        deps.onReplyError?.(err);
+        // Only a definitive LINE 400 makes text recovery after a rejected push safe.
         await pushLineMessages(
           replyBatch,
           getLineHttpError(err)?.status === 400,


### PR DESCRIPTION
## Summary

- Prevent a LINE reply with an ambiguous provider/network outcome from being replayed as a separate push.
- Keep real provider rejections, proven pre-connect failures, local pre-dispatch failures, reply-token overflow, and rich-message recovery on their existing safe fallback paths.
- Traverse the complete SDK error graph for authoritative nested provider statuses and emit the operator's “falling back to push” diagnostic only when a push is actually attempted.

## Root cause

The inbound LINE auto-reply owner previously converted every reply failure into a push of the same batch. LINE reply tokens are single-use, and LINE does not offer reply-request retry keys, so a lost 408/5xx response, reset, timeout, abort, or Undici `TypeError("fetch failed")` can conceal an already accepted reply. The push is a different provider request and can duplicate what the user sees.

The existing owner also inspected only one error-wrapper level and reported “falling back to push” before deciding whether a fallback was safe. The canonical private HTTP-error helper now searches the complete `cause`/`error` graph, and the fallback callback runs only immediately before a safe push. Actual successful-response parsing failures were already tagged as accepted partial deliveries by the lower send owner; they remain non-replayable, while raw pre-dispatch `SyntaxError` failures preserve their existing fallback.

## Verification

- Authentic existing-owner baseline: **10 failing** real provider/network duplicate-delivery regressions, followed by a second authentic baseline with **2 failing** nested actual `HTTPFetchError(503)` regressions.
- Final exact immutable owner proof: **31/31 passing**, including actual LINE HTTP 400/408/429/502/503, deeply wrapped SDK provider errors, `.error` wrappers, provider-status precedence, `ECONNRESET`, `ETIMEDOUT`, Undici body timeout, `AbortError`, native/wrapped Undici fetch failures, DNS/refused pre-connect controls, accepted malformed-response partial delivery, raw pre-dispatch `SyntaxError`, operator diagnostic truth, and existing rich/overflow recovery.
- Genuine complete-branch Codex `gpt-5.6-sol` / high / **P0–P3** structured autoreview: **clean; zero findings; confidence 0.95**. Genuine TruffleHog 3.96 secret scan: clean.
- Three independent full-owner/source/dependency reviews: **clean**, confidence 0.99 each.
- Exact newest-main audit confirms the bug remains present, neither approved owner file changed in the intervening 475-file merge, and this immutable candidate merges without conflicts.
- Exact detached hosted Blacksmith Testbox proof: **both complete plugin production/test TypeScript gates passing; 4 owner/provider/monitor suites and 111/111 tests passing; targeted formatting/lint, raw-channel-fetch guard, and all three plugin SDK boundary guards passing**. The same exclusive lease was explicitly stopped and independently confirmed completed; [hosted run](https://github.com/openclaw/openclaw/actions/runs/30674984066).

## Provider contracts

- [LINE Messaging API reference: reply tokens can be used only once](https://developers.line.biz/en/reference/messaging-api/nojs/).
- [LINE API retry-key policy: retry keys cover push/multicast/narrowcast/broadcast, not reply](https://developers.line.biz/en/docs/messaging-api/retrying-api-request/).
