### PR TITLE
fix(secrets): preflight exec provider command paths before config acceptance

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -112,12 +112,34 @@ machine-output spelling and keeps stdout reserved for the schema document.
 
 ### `config validate`
 
-Validates the current config against the active schema without starting the gateway. It also checks provider/source compatibility for every registry-declared SecretRef, including disabled plugin or channel configuration. This strict command can report an inactive mismatch that does not block normal Gateway startup, where SecretRef resolution remains limited to effectively active surfaces.
+Validates the current config against the active schema without starting the
+gateway. It also checks provider/source compatibility for every
+registry-declared SecretRef, including disabled plugin or channel
+configuration. This strict command can report an inactive mismatch that does
+not block normal Gateway startup, where SecretRef resolution remains limited to
+effectively active surfaces. Additionally, after schema validation passes,
+`config validate` runs the same non-executing exec-provider command-path trust
+checks (absolute path, symlink, trusted-directory, permission, ownership, and
+Windows ACL) that gateway startup activation applies, so a symlinked, missing,
+or unsafe `exec` command cannot pass validation and then fail on the next
+restart. These exec-provider checks cover every configured manual exec
+provider, not only the ones active on the current surfaces, matching the
+all-provider scope of the provider/source compatibility check above. Writes use
+targeted preflight instead: `config set/patch/unset` checks providers changed by
+the operation, or all providers when the write changes the `secrets.providers`
+collection itself.
 
 ```bash
 openclaw config validate
 openclaw config validate --json
 ```
+
+<Note>
+The exec-provider checks inspect the filesystem of the host where the CLI
+runs. Run `config validate` on the gateway host itself (or on a host with
+matching command paths, ownership, and ACLs) before relying on the result for
+restart safety.
+</Note>
 
 <Note>
 If validation is already failing, start with `openclaw configure` or `openclaw doctor --fix`. `openclaw chat` does not bypass the invalid-config guard.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -112,22 +112,11 @@ machine-output spelling and keeps stdout reserved for the schema document.
 
 ### `config validate`
 
-Validates the current config against the active schema without starting the
-gateway. It also checks provider/source compatibility for every
-registry-declared SecretRef, including disabled plugin or channel
-configuration. This strict command can report an inactive mismatch that does
-not block normal Gateway startup, where SecretRef resolution remains limited to
-effectively active surfaces. Additionally, after schema validation passes,
-`config validate` runs the same non-executing exec-provider command-path trust
-checks (absolute path, symlink, trusted-directory, permission, ownership, and
-Windows ACL) that gateway startup activation applies, so a symlinked, missing,
-or unsafe `exec` command cannot pass validation and then fail on the next
-restart. These exec-provider checks cover every configured manual exec
-provider, not only the ones active on the current surfaces, matching the
-all-provider scope of the provider/source compatibility check above. Writes use
-targeted preflight instead: `config set/patch/unset` checks providers changed by
-the operation, or all providers when the write changes the `secrets.providers`
-collection itself.
+Validates the current config against the active schema without starting the gateway. It also checks provider/source compatibility for every registry-declared SecretRef, including disabled plugin or channel configuration. This strict command can report an inactive mismatch that does not block normal Gateway startup, where SecretRef resolution remains limited to effectively active surfaces.
+
+After schema validation, it checks every configured manual exec provider's command path using the same non-executing trust checks as startup: file presence, symlinks, trusted directories, permissions, ownership, and Windows ACL availability. `config set`, `config patch`, and `config unset` apply these checks only to providers changed or referenced by the operation, including during dry runs. Replacing the `secrets` or `secrets.providers` collection checks every remaining provider. An unrelated inactive provider does not block targeted repairs or removal of that provider.
+
+Path validation does not execute providers or verify their output. Passing it does not guarantee successful secret resolution; exec dry runs require `--allow-exec` to test that separately.
 
 ```bash
 openclaw config validate
@@ -137,8 +126,8 @@ openclaw config validate --json
 <Note>
 The exec-provider checks inspect the filesystem of the host where the CLI
 runs. Run `config validate` on the gateway host itself (or on a host with
-matching command paths, ownership, and ACLs) before relying on the result for
-restart safety.
+matching command paths, ownership, and ACLs). Paths and permissions can change
+after validation; startup checks them again before execution.
 </Note>
 
 <Note>
@@ -386,7 +375,7 @@ openclaw config set channels.discord.token \
     - Builder mode: runs SecretRef resolvability checks for changed refs/providers.
     - JSON mode (`--strict-json`, `--json`, or batch mode): runs schema validation plus SecretRef resolvability checks.
     - Policy validation runs against the full post-change config, so parent-object writes (for example setting `hooks` as an object) cannot bypass unsupported-surface validation.
-    - Exec SecretRef checks are skipped by default to avoid command side effects; pass `--allow-exec` to opt in (this may execute provider commands). `--allow-exec` is dry-run only and errors without `--dry-run`.
+    - Exec command-path trust checks run without executing providers. Exec SecretRef resolvability checks are skipped by default to avoid command side effects; pass `--allow-exec` to opt in (this may execute provider commands). `--allow-exec` is dry-run only and errors without `--dry-run`.
 
   </Accordion>
   <Accordion title="--dry-run --json fields">

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -217,7 +217,7 @@ Notes:
 
 ### Exec provider safety
 
-Package managers often expose symlinked command paths. Resolve the real binary path (for example with `realpath "$(command -v vault)"`) and configure that absolute, non-symlink path; use `trustedDirs` to restrict executables to approved directories. On Windows, provider paths fail closed when ACL verification is unavailable, with no provider-level bypass.
+Homebrew installs often expose symlinked binaries under `/opt/homebrew/bin/*`. Symlinked command paths are rejected — point `command` at the regular target file instead (for example `python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vault`; re-resolve after each `brew upgrade`), paired with `trustedDirs` (for example `["/opt/homebrew"]`) so only package-manager paths qualify. On Windows, if ACL verification is unavailable for a provider path, OpenClaw fails closed.
 
 ## Apply a saved plan
 

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -217,7 +217,7 @@ Notes:
 
 ### Exec provider safety
 
-Homebrew installs often expose symlinked binaries under `/opt/homebrew/bin/*`. Symlinked command paths are rejected — point `command` at the regular target file instead (for example `python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vault`; re-resolve after each `brew upgrade`), paired with `trustedDirs` (for example `["/opt/homebrew"]`) so only package-manager paths qualify. On Windows, if ACL verification is unavailable for a provider path, OpenClaw fails closed.
+Package managers often expose symlinked command paths. Resolve the real binary path (for example with `realpath "$(command -v vault)"`) and configure that absolute, non-symlink path; use `trustedDirs` to restrict executables to approved directories. Run `openclaw config validate` on the Gateway host to check manual exec command paths without executing providers. On Windows, provider paths fail closed when ACL verification is unavailable, with no provider-level bypass.
 
 ## Apply a saved plan
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1571,9 +1571,9 @@ Validation:
 Notes:
 
 - `file` provider supports `mode: "json"` and `mode: "singleValue"` (`id` must be `"value"` in singleValue mode).
-- File and exec provider paths fail closed when Windows ACL verification is unavailable; no opt-out exists. Ensure command or file paths are on a local NTFS volume with inspectable ACLs.
+- File and exec provider paths fail closed when Windows ACL verification is unavailable. Use paths whose ACLs OpenClaw can verify; there is no provider-level bypass.
 - `exec` provider requires an absolute `command` path and uses protocol payloads on stdin/stdout.
-- Symlink command paths are rejected with no opt-out; `command` must not be group- or world-writable and (on POSIX) be owned by the current user (Windows instead requires inspectable ACLs on a local NTFS volume).
+- Symlink command paths are rejected. Configure the resolved absolute binary path instead; it must not be group- or world-writable and, on POSIX, must be owned by the current user.
 - If `trustedDirs` is configured, the command path (after `~` expansion) must be inside an approved directory; symlinked commands are rejected before this check, so the configured path itself is what `trustedDirs` constrains.
 - `exec` child environment is minimal by default; pass required variables explicitly with `passEnv`.
 - Secret refs are resolved at activation time into an in-memory snapshot, then request paths read the snapshot only.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1571,10 +1571,10 @@ Validation:
 Notes:
 
 - `file` provider supports `mode: "json"` and `mode: "singleValue"` (`id` must be `"value"` in singleValue mode).
-- File and exec provider paths fail closed when Windows ACL verification is unavailable. Use paths whose ACLs OpenClaw can verify; there is no provider-level bypass.
+- File and exec provider paths fail closed when Windows ACL verification is unavailable; no opt-out exists. Ensure command or file paths are on a local NTFS volume with inspectable ACLs.
 - `exec` provider requires an absolute `command` path and uses protocol payloads on stdin/stdout.
-- Symlink command paths are rejected. Configure the resolved absolute binary path instead.
-- If `trustedDirs` is configured, the command path must be inside an approved directory.
+- Symlink command paths are rejected with no opt-out; `command` must not be group- or world-writable and (on POSIX) be owned by the current user (Windows instead requires inspectable ACLs on a local NTFS volume).
+- If `trustedDirs` is configured, the command path (after `~` expansion) must be inside an approved directory; symlinked commands are rejected before this check, so the configured path itself is what `trustedDirs` constrains.
 - `exec` child environment is minimal by default; pass required variables explicitly with `passEnv`.
 - Secret refs are resolved at activation time into an in-memory snapshot, then request paths read the snapshot only.
 - Active-surface filtering applies during activation: unresolved refs on enabled surfaces fail startup/reload, while inactive surfaces are skipped with diagnostics.

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -224,16 +224,16 @@ Provider aliases are source-specific. A matching explicit provider entry wins; i
 - `mode: "json"` (default) expects a JSON object payload and resolves `id` as a JSON pointer.
 - `mode: "singleValue"` expects ref id `"value"` and returns the raw file contents (trailing newline stripped).
 - Path must pass ownership/permission checks; `timeoutMs` (default 5000) and `maxBytes` (default 1 MiB) bound the read.
-- Windows fail-closed: if ACL verification is unavailable for the path, resolution fails. Move the secret to a path whose ACLs OpenClaw can verify; there is no provider-level bypass.
+- Windows fail-closed: if ACL verification is unavailable for the path, resolution fails; no opt-out exists.
 
 </Accordion>
 
 <Accordion title="Exec provider">
 - Runs the configured absolute binary path directly, no shell.
-- `command` must be a regular file, not a symlink. For package-manager shims, resolve the real binary path (for example with `realpath "$(command -v vault)"`) and configure that absolute path. Use `trustedDirs` to restrict executables to approved directories.
+- `command` must not be a symlink, not group- or world-writable, and (on POSIX) be owned by the current user. On Windows, inspectable ACLs are required instead (see the Windows fail-closed note below). Homebrew shims are symlinks and are rejected — point `command` at the real target path instead. Resolve it portably with `python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vault` (works on macOS and Linux; re-resolve after each `brew upgrade`), and pair it with `trustedDirs` (for example `["/opt/homebrew"]`) so only package-manager paths qualify.
 - Supports `timeoutMs` (default 5000), `noOutputTimeoutMs` (default equals `timeoutMs`), `maxOutputBytes` (default 1 MiB), `env`/`passEnv` allowlist, and `trustedDirs`.
 - `jsonOnly` defaults to `true`. With `jsonOnly: false` and a single requested id, plain non-JSON stdout is accepted as that id's value.
-- Windows fail-closed: if ACL verification is unavailable for the command path, resolution fails. Use a command path whose ACLs OpenClaw can verify; there is no provider-level bypass.
+- Windows fail-closed: if ACL verification is unavailable for the command path, resolution fails.
 - Plugin-managed exec providers can use `pluginIntegration` instead of a copied `command`/`args`. OpenClaw resolves the current command details from the installed plugin manifest during startup/reload; if the plugin is disabled, removed, untrusted, or no longer declares the integration, active SecretRefs on that provider fail closed.
 
 Request payload (stdin):
@@ -529,8 +529,8 @@ For a dedicated 1Password guide covering service accounts, the bundled agent ski
         providers: {
           vault_openai: {
             source: "exec",
-            command: "/absolute/non-symlink/path/to/vault",
-            trustedDirs: ["/absolute/non-symlink/path/to"],
+            command: "<vault-real-path>", // resolve with the portable realpath command above; must not be a symlink
+            trustedDirs: ["/opt/homebrew"],
             args: ["kv", "get", "-field=OPENAI_API_KEY", "secret/openclaw"],
             passEnv: ["VAULT_ADDR", "VAULT_TOKEN"],
             jsonOnly: false,
@@ -636,8 +636,8 @@ For a dedicated 1Password guide covering service accounts, the bundled agent ski
         providers: {
           sops_openai: {
             source: "exec",
-            command: "/absolute/non-symlink/path/to/sops",
-            trustedDirs: ["/absolute/non-symlink/path/to"],
+            command: "<sops-real-path>", // resolve with the portable realpath command above; must not be a symlink
+            trustedDirs: ["/opt/homebrew"],
             args: ["-d", "--extract", '["providers"]["openai"]["apiKey"]', "/path/to/secrets.enc.json"],
             passEnv: ["SOPS_AGE_KEY_FILE"],
             jsonOnly: false,

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -224,16 +224,17 @@ Provider aliases are source-specific. A matching explicit provider entry wins; i
 - `mode: "json"` (default) expects a JSON object payload and resolves `id` as a JSON pointer.
 - `mode: "singleValue"` expects ref id `"value"` and returns the raw file contents (trailing newline stripped).
 - Path must pass ownership/permission checks; `timeoutMs` (default 5000) and `maxBytes` (default 1 MiB) bound the read.
-- Windows fail-closed: if ACL verification is unavailable for the path, resolution fails; no opt-out exists.
+- Windows fail-closed: if ACL verification is unavailable for the path, resolution fails. Move the secret to a path whose ACLs OpenClaw can verify; there is no provider-level bypass.
 
 </Accordion>
 
 <Accordion title="Exec provider">
 - Runs the configured absolute binary path directly, no shell.
-- `command` must not be a symlink, not group- or world-writable, and (on POSIX) be owned by the current user. On Windows, inspectable ACLs are required instead (see the Windows fail-closed note below). Homebrew shims are symlinks and are rejected — point `command` at the real target path instead. Resolve it portably with `python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vault` (works on macOS and Linux; re-resolve after each `brew upgrade`), and pair it with `trustedDirs` (for example `["/opt/homebrew"]`) so only package-manager paths qualify.
+- `command` must not be a symlink, must not be group- or world-writable, and on POSIX must be owned by the current user. For package-manager shims, resolve the real binary path (for example with `realpath "$(command -v vault)"`) and configure that absolute path. Use `trustedDirs` to restrict executables to approved directories.
+- [`config validate`](/cli/config#config-validate) checks every manual exec command path without executing providers. Config writes and dry runs check only changed or newly referenced providers, so an unrelated inactive provider does not block repairs. These are path trust checks, not proof that a provider can execute or return a secret.
 - Supports `timeoutMs` (default 5000), `noOutputTimeoutMs` (default equals `timeoutMs`), `maxOutputBytes` (default 1 MiB), `env`/`passEnv` allowlist, and `trustedDirs`.
 - `jsonOnly` defaults to `true`. With `jsonOnly: false` and a single requested id, plain non-JSON stdout is accepted as that id's value.
-- Windows fail-closed: if ACL verification is unavailable for the command path, resolution fails.
+- Windows fail-closed: if ACL verification is unavailable for the command path, resolution fails. Use a command path whose ACLs OpenClaw can verify; there is no provider-level bypass.
 - Plugin-managed exec providers can use `pluginIntegration` instead of a copied `command`/`args`. OpenClaw resolves the current command details from the installed plugin manifest during startup/reload; if the plugin is disabled, removed, untrusted, or no longer declares the integration, active SecretRefs on that provider fail closed.
 
 Request payload (stdin):
@@ -529,8 +530,8 @@ For a dedicated 1Password guide covering service accounts, the bundled agent ski
         providers: {
           vault_openai: {
             source: "exec",
-            command: "<vault-real-path>", // resolve with the portable realpath command above; must not be a symlink
-            trustedDirs: ["/opt/homebrew"],
+            command: "/absolute/non-symlink/path/to/vault",
+            trustedDirs: ["/absolute/non-symlink/path/to"],
             args: ["kv", "get", "-field=OPENAI_API_KEY", "secret/openclaw"],
             passEnv: ["VAULT_ADDR", "VAULT_TOKEN"],
             jsonOnly: false,
@@ -636,8 +637,8 @@ For a dedicated 1Password guide covering service accounts, the bundled agent ski
         providers: {
           sops_openai: {
             source: "exec",
-            command: "<sops-real-path>", // resolve with the portable realpath command above; must not be a symlink
-            trustedDirs: ["/opt/homebrew"],
+            command: "/absolute/non-symlink/path/to/sops",
+            trustedDirs: ["/absolute/non-symlink/path/to"],
             args: ["-d", "--extract", '["providers"]["openai"]["apiKey"]', "/path/to/secrets.enc.json"],
             passEnv: ["SOPS_AGE_KEY_FILE"],
             jsonOnly: false,

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -580,13 +580,7 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
 }
 
 function buildDeleteOperation(path: PathSegment[]): ConfigSetOperation {
-  return {
-    inputMode: "json",
-    requestedPath: path,
-    setPath: path,
-    value: undefined,
-    mutation: "delete",
-  };
+  return { ...buildUnsetOperation(path), inputMode: "json" };
 }
 
 export function buildUnsetOperation(

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -48,8 +48,7 @@ import {
   collectDryRunResolvabilityErrors,
   collectDryRunSchemaErrors,
   collectDryRunStaticErrorsForSkippedExecRefs,
-  collectManualExecProviderCommandPathErrors,
-  collectPluginIntegrationProviderErrors,
+  collectConfigSecretProviderErrors,
   dedupeDryRunErrors,
   formatDryRunFailureMessage,
   loadValidConfigForWrite,
@@ -329,11 +328,9 @@ export async function runConfigOperations(params: {
       const writePath = recordOperation(operation);
       const unsetResult = unsetAtPath(next, operation.setPath);
       if (!unsetResult.removed && operation.inputMode === "unset") {
+        const requestedPath = formatConfigSetPath(operation.requestedPath, operation.pathTokens);
         const runtimeOnly = getAtPath(snapshot.runtimeConfig, operation.setPath).found;
-        const message = formatConfigUnsetMissingPathMessage({
-          path: formatConfigSetPath(operation.requestedPath, operation.pathTokens),
-          runtimeOnly,
-        });
+        const message = formatConfigUnsetMissingPathMessage({ path: requestedPath, runtimeOnly });
         if (options.dryRun && options.json) {
           throw new ConfigSetDryRunValidationError({
             ok: false,
@@ -348,7 +345,7 @@ export async function runConfigOperations(params: {
                 kind: "missing-path",
                 message: runtimeOnly
                   ? message
-                  : `Config path not found: ${formatConfigSetPath(operation.requestedPath, operation.pathTokens)}. Nothing was changed.`,
+                  : `Config path not found: ${requestedPath}. Nothing was changed.`,
               },
             ],
           });
@@ -415,10 +412,10 @@ export async function runConfigOperations(params: {
     "",
     { normalizeRoot: true },
   ).map((line) => line.trim());
-  const pluginIntegrationErrors = collectPluginIntegrationProviderErrors({
-    config: nextConfig,
-    operations: appliedOperations,
-  });
+  const providerErrors = formatConfigIssueLines(
+    await collectConfigSecretProviderErrors({ config: nextConfig, operations: appliedOperations }),
+    "",
+  ).map((message): ConfigSetDryRunError => ({ kind: "schema", message }));
 
   if (options.dryRun) {
     const hasJsonMode = operations.some(({ inputMode }) => inputMode === "json");
@@ -448,12 +445,7 @@ export async function runConfigOperations(params: {
     if ((!hasJsonMode || !requiresFullSchemaValidation) && policyIssueLines.length > 0) {
       errors.push(...policyIssueLines.map((message) => ({ kind: "schema" as const, message })));
     }
-    errors.push(...pluginIntegrationErrors);
-    const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
-      config: nextConfig,
-      operations,
-    });
-    errors.push(...execProviderCommandPathErrors);
+    errors.push(...providerErrors);
     if (requiresFullSchemaValidation) {
       errors.push(
         ...collectDryRunSchemaErrors(
@@ -482,10 +474,7 @@ export async function runConfigOperations(params: {
       inputModes: uniqueValues(operations.map(({ inputMode }) => inputMode)),
       checks: {
         schema:
-          requiresFullSchemaValidation ||
-          policyIssueLines.length > 0 ||
-          pluginIntegrationErrors.length > 0 ||
-          execProviderCommandPathErrors.length > 0,
+          requiresFullSchemaValidation || policyIssueLines.length > 0 || providerErrors.length > 0,
         resolvability: checksRefs || modelRefCheck.refsTotal > 0,
         resolvabilityComplete:
           (checksRefs || modelRefCheck.refsTotal > 0) &&
@@ -536,23 +525,11 @@ export async function runConfigOperations(params: {
   if (policyIssueLines.length > 0) {
     throw new Error(formatPolicyFailure(policyIssueLines));
   }
-  if (pluginIntegrationErrors.length > 0) {
+  if (providerErrors.length > 0) {
     throw new Error(
       [
-        "Config validation failed: plugin-managed SecretRef provider integration is invalid.",
-        ...pluginIntegrationErrors.map((error) => `- ${error.message}`),
-      ].join("\n"),
-    );
-  }
-  const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
-    config: nextConfig,
-    operations,
-  });
-  if (execProviderCommandPathErrors.length > 0) {
-    throw new Error(
-      [
-        "Config validation failed: exec SecretRef provider command path is unsafe.",
-        ...execProviderCommandPathErrors.map((error) => `- ${error.message}`),
+        "Config validation failed: SecretRef provider configuration is invalid.",
+        ...providerErrors.map((error) => `- ${error.message}`),
       ].join("\n"),
     );
   }

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -48,6 +48,7 @@ import {
   collectDryRunResolvabilityErrors,
   collectDryRunSchemaErrors,
   collectDryRunStaticErrorsForSkippedExecRefs,
+  collectManualExecProviderCommandPathErrors,
   collectPluginIntegrationProviderErrors,
   dedupeDryRunErrors,
   formatDryRunFailureMessage,
@@ -418,6 +419,7 @@ export async function runConfigOperations(params: {
     config: nextConfig,
     operations: appliedOperations,
   });
+
   if (options.dryRun) {
     const hasJsonMode = operations.some(({ inputMode }) => inputMode === "json");
     const hasBuilderMode = operations.some(({ inputMode }) => inputMode === "builder");
@@ -447,6 +449,11 @@ export async function runConfigOperations(params: {
       errors.push(...policyIssueLines.map((message) => ({ kind: "schema" as const, message })));
     }
     errors.push(...pluginIntegrationErrors);
+    const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
+      config: nextConfig,
+      operations,
+    });
+    errors.push(...execProviderCommandPathErrors);
     if (requiresFullSchemaValidation) {
       errors.push(
         ...collectDryRunSchemaErrors(
@@ -477,7 +484,8 @@ export async function runConfigOperations(params: {
         schema:
           requiresFullSchemaValidation ||
           policyIssueLines.length > 0 ||
-          pluginIntegrationErrors.length > 0,
+          pluginIntegrationErrors.length > 0 ||
+          execProviderCommandPathErrors.length > 0,
         resolvability: checksRefs || modelRefCheck.refsTotal > 0,
         resolvabilityComplete:
           (checksRefs || modelRefCheck.refsTotal > 0) &&
@@ -533,6 +541,18 @@ export async function runConfigOperations(params: {
       [
         "Config validation failed: plugin-managed SecretRef provider integration is invalid.",
         ...pluginIntegrationErrors.map((error) => `- ${error.message}`),
+      ].join("\n"),
+    );
+  }
+  const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
+    config: nextConfig,
+    operations,
+  });
+  if (execProviderCommandPathErrors.length > 0) {
+    throw new Error(
+      [
+        "Config validation failed: exec SecretRef provider command path is unsafe.",
+        ...execProviderCommandPathErrors.map((error) => `- ${error.message}`),
       ].join("\n"),
     );
   }

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -4,13 +4,9 @@ import { readConfigFileSnapshotForWrite } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
+import type { ConfigValidationIssue } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  coerceSecretRef,
-  resolveSecretInputRef,
-  type PluginIntegrationSecretProviderConfig,
-  type SecretRef,
-} from "../config/types.secrets.js";
+import { coerceSecretRef, resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { validateConfigObjectRawWithPlugins } from "../config/validation.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -77,10 +73,10 @@ export async function loadValidConfigForWrite(runtime: RuntimeEnv = defaultRunti
 
 export { formatInvalidConfigRepairHint };
 
-export function strictlyValidateConfigSnapshotForCli(
+export async function strictlyValidateConfigSnapshotForCli(
   snapshot: ConfigFileSnapshot,
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">,
-): ConfigFileSnapshot {
+): Promise<ConfigFileSnapshot> {
   if (!snapshot.valid) {
     return snapshot;
   }
@@ -88,7 +84,10 @@ export function strictlyValidateConfigSnapshotForCli(
     semanticValidation: "strict",
     pluginMetadataSnapshot,
   });
-  return validated.ok ? snapshot : { ...snapshot, valid: false, issues: validated.issues };
+  const issues = validated.ok
+    ? await collectConfigSecretProviderErrors({ config: snapshot.runtimeConfig })
+    : validated.issues;
+  return issues.length === 0 ? snapshot : { ...snapshot, valid: false, issues };
 }
 
 function collectSecretRefsFromUnknown(value: unknown): SecretRef[] {
@@ -278,19 +277,16 @@ function touchesSecretProviderCollection(path: readonly string[]): boolean {
   );
 }
 
-/**
- * Collects the provider aliases a set of write operations touches, plus whether
- * the whole provider collection was touched (forcing all providers to be
- * inspected). Shared by the plugin-integration and manual exec-provider
- * preflights so both honor the same touch scope.
- */
-function collectTouchedProviders(params: {
-  operations: ConfigSetOperation[];
-  validateAllProviders?: boolean;
-}): { touchedProviderAliases: Set<string>; validateAllProviders: boolean } {
+export async function collectConfigSecretProviderErrors(params: {
+  config: OpenClawConfig;
+  operations?: ConfigSetOperation[];
+}): Promise<ConfigValidationIssue[]> {
+  const providers = params.config.secrets?.providers ?? {};
   const touchedProviderAliases = new Set<string>();
-  let validateAllProviders = params.validateAllProviders === true;
-  for (const operation of params.operations) {
+  // Explicit validation checks all manual providers; writes must leave unrelated
+  // dormant providers alone so operators can repair the rest of their config.
+  let validateAllProviders = params.operations === undefined;
+  for (const operation of params.operations ?? []) {
     if (operation.touchedProviderAlias) {
       touchedProviderAliases.add(operation.touchedProviderAlias);
     }
@@ -302,106 +298,46 @@ function collectTouchedProviders(params: {
     }
     validateAllProviders ||= touchesSecretProviderCollection(operation.setPath);
   }
-  return { touchedProviderAliases, validateAllProviders };
-}
-
-export function collectPluginIntegrationProviderErrors(params: {
-  config: OpenClawConfig;
-  operations: ConfigSetOperation[];
-  validateAllProviders?: boolean;
-}): ConfigSetDryRunError[] {
-  const providers = params.config.secrets?.providers ?? {};
-  const { touchedProviderAliases, validateAllProviders } = collectTouchedProviders(params);
-  if (!validateAllProviders && touchedProviderAliases.size === 0) {
-    return [];
-  }
-  const integrationProviders: Array<{
-    alias: string;
-    provider: PluginIntegrationSecretProviderConfig;
-  }> = [];
-  for (const [alias, provider] of Object.entries(providers)) {
-    if (
-      (validateAllProviders || touchedProviderAliases.has(alias)) &&
-      isPluginIntegrationSecretProviderConfig(provider)
-    ) {
-      integrationProviders.push({ alias, provider });
-    }
-  }
-  if (integrationProviders.length === 0) {
-    return [];
-  }
-  const manifestRegistry = loadPluginMetadataSnapshot({
-    config: params.config,
-    env: process.env,
-  }).manifestRegistry;
-  const errors: ConfigSetDryRunError[] = [];
-  for (const { alias, provider } of integrationProviders) {
-    const resolved = resolveSecretProviderIntegrationConfig({
-      manifestRegistry,
-      providerAlias: alias,
-      providerConfig: provider,
-      config: params.config,
-      env: process.env,
-    });
-    if (!resolved.ok) {
-      errors.push({ kind: "schema", message: `secrets.providers.${alias}: ${resolved.reason}` });
-    }
-  }
-  return errors;
-}
-
-/**
- * Runs the non-executing exec-provider command-path trust checks (the same
- * rules startup activation applies) over the manual exec providers in the
- * candidate config. A write checks only the providers it touches, or every
- * provider when the write edits the provider collection itself; `config
- * validate` scans the whole config separately. Plugin-integration providers
- * are out of scope here; their materialized command parity is left to
- * maintainers.
- */
-export async function collectManualExecProviderCommandPathErrors(params: {
-  config: OpenClawConfig;
-  operations: ConfigSetOperation[];
-  validateAllProviders?: boolean;
-}): Promise<ConfigSetDryRunError[]> {
-  const providers = params.config.secrets?.providers ?? {};
-  const { touchedProviderAliases, validateAllProviders } = collectTouchedProviders(params);
-  if (!validateAllProviders && touchedProviderAliases.size === 0) {
-    return [];
-  }
-
-  const errors: ConfigSetDryRunError[] = [];
+  const issues: ConfigValidationIssue[] = [];
+  let manifestRegistry: PluginMetadataSnapshot["manifestRegistry"] | undefined;
   for (const [alias, provider] of Object.entries(providers)) {
     if (!validateAllProviders && !touchedProviderAliases.has(alias)) {
       continue;
     }
+    const providerPath = `secrets.providers.${alias}`;
     if (isPluginIntegrationSecretProviderConfig(provider)) {
-      continue;
-    }
-    // A value-mode write can set a provider to `null` or a primitive without
-    // triggering full schema validation; guard the `in` check so malformed
-    // provider values fall through to the normal config error path instead of
-    // throwing a raw TypeError.
-    if (provider === null || typeof provider !== "object") {
-      continue;
-    }
-    if (!("command" in provider)) {
-      continue;
-    }
-    try {
-      await assertSecureExecCommandPath({
-        command: provider.command,
-        label: `secrets.providers.${alias}.command`,
-        trustedDirs: provider.trustedDirs,
+      // Preserve write-time manifest validation without adding executable-path
+      // policy to plugin integrations; activation owns their materialized command.
+      if (!params.operations) {
+        continue;
+      }
+      manifestRegistry ??= loadPluginMetadataSnapshot({
+        config: params.config,
+        env: process.env,
+      }).manifestRegistry;
+      const resolved = resolveSecretProviderIntegrationConfig({
+        manifestRegistry,
+        providerAlias: alias,
+        providerConfig: provider,
+        config: params.config,
+        env: process.env,
       });
-    } catch (err) {
-      errors.push({
-        kind: "schema",
-        message: `secrets.providers.${alias}: ${String(err)}`,
-      });
+      if (!resolved.ok) {
+        issues.push({ path: providerPath, message: resolved.reason });
+      }
+    } else if (isPlainRecord(provider) && "command" in provider) {
+      try {
+        await assertSecureExecCommandPath({
+          command: provider.command,
+          label: `${providerPath}.command`,
+          trustedDirs: provider.trustedDirs,
+        });
+      } catch (err) {
+        issues.push({ path: `${providerPath}.command`, message: formatErrorMessage(err) });
+      }
     }
   }
-  return errors;
+  return issues;
 }
 
 export function dedupeDryRunErrors(errors: ConfigSetDryRunError[]): ConfigSetDryRunError[] {

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -16,6 +16,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { type RuntimeEnv, defaultRuntime, writeRuntimeJson } from "../runtime.js";
+import { assertSecureExecCommandPath } from "../secrets/exec-provider-path-validation.js";
 import {
   isPluginIntegrationSecretProviderConfig,
   resolveSecretProviderIntegrationConfig,
@@ -277,13 +278,18 @@ function touchesSecretProviderCollection(path: readonly string[]): boolean {
   );
 }
 
-export function collectPluginIntegrationProviderErrors(params: {
-  config: OpenClawConfig;
+/**
+ * Collects the provider aliases a set of write operations touches, plus whether
+ * the whole provider collection was touched (forcing all providers to be
+ * inspected). Shared by the plugin-integration and manual exec-provider
+ * preflights so both honor the same touch scope.
+ */
+function collectTouchedProviders(params: {
   operations: ConfigSetOperation[];
-}): ConfigSetDryRunError[] {
-  const providers = params.config.secrets?.providers ?? {};
-  let validateAllProviders = false;
+  validateAllProviders?: boolean;
+}): { touchedProviderAliases: Set<string>; validateAllProviders: boolean } {
   const touchedProviderAliases = new Set<string>();
+  let validateAllProviders = params.validateAllProviders === true;
   for (const operation of params.operations) {
     if (operation.touchedProviderAlias) {
       touchedProviderAliases.add(operation.touchedProviderAlias);
@@ -296,6 +302,16 @@ export function collectPluginIntegrationProviderErrors(params: {
     }
     validateAllProviders ||= touchesSecretProviderCollection(operation.setPath);
   }
+  return { touchedProviderAliases, validateAllProviders };
+}
+
+export function collectPluginIntegrationProviderErrors(params: {
+  config: OpenClawConfig;
+  operations: ConfigSetOperation[];
+  validateAllProviders?: boolean;
+}): ConfigSetDryRunError[] {
+  const providers = params.config.secrets?.providers ?? {};
+  const { touchedProviderAliases, validateAllProviders } = collectTouchedProviders(params);
   if (!validateAllProviders && touchedProviderAliases.size === 0) {
     return [];
   }
@@ -329,6 +345,60 @@ export function collectPluginIntegrationProviderErrors(params: {
     });
     if (!resolved.ok) {
       errors.push({ kind: "schema", message: `secrets.providers.${alias}: ${resolved.reason}` });
+    }
+  }
+  return errors;
+}
+
+/**
+ * Runs the non-executing exec-provider command-path trust checks (the same
+ * rules startup activation applies) over the manual exec providers in the
+ * candidate config. A write checks only the providers it touches, or every
+ * provider when the write edits the provider collection itself; `config
+ * validate` scans the whole config separately. Plugin-integration providers
+ * are out of scope here; their materialized command parity is left to
+ * maintainers.
+ */
+export async function collectManualExecProviderCommandPathErrors(params: {
+  config: OpenClawConfig;
+  operations: ConfigSetOperation[];
+  validateAllProviders?: boolean;
+}): Promise<ConfigSetDryRunError[]> {
+  const providers = params.config.secrets?.providers ?? {};
+  const { touchedProviderAliases, validateAllProviders } = collectTouchedProviders(params);
+  if (!validateAllProviders && touchedProviderAliases.size === 0) {
+    return [];
+  }
+
+  const errors: ConfigSetDryRunError[] = [];
+  for (const [alias, provider] of Object.entries(providers)) {
+    if (!validateAllProviders && !touchedProviderAliases.has(alias)) {
+      continue;
+    }
+    if (isPluginIntegrationSecretProviderConfig(provider)) {
+      continue;
+    }
+    // A value-mode write can set a provider to `null` or a primitive without
+    // triggering full schema validation; guard the `in` check so malformed
+    // provider values fall through to the normal config error path instead of
+    // throwing a raw TypeError.
+    if (provider === null || typeof provider !== "object") {
+      continue;
+    }
+    if (!("command" in provider)) {
+      continue;
+    }
+    try {
+      await assertSecureExecCommandPath({
+        command: provider.command,
+        label: `secrets.providers.${alias}.command`,
+        trustedDirs: provider.trustedDirs,
+      });
+    } catch (err) {
+      errors.push({
+        kind: "schema",
+        message: `secrets.providers.${alias}: ${String(err)}`,
+      });
     }
   }
   return errors;

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -258,9 +258,11 @@ function setGatewaySnapshot(secrets?: OpenClawConfig["secrets"]): void {
 }
 
 function createValidExecutableFixture(): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-valid-exec-"));
-  const fixturePath = path.join(root, "node");
-  fs.copyFileSync(process.execPath, fixturePath);
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-valid-exec-")),
+  );
+  const fixturePath = path.join(root, "helper");
+  fs.writeFileSync(fixturePath, "#!/bin/sh\nexit 1\n");
   fs.chmodSync(fixturePath, 0o755);
   return fixturePath;
 }
@@ -1808,25 +1810,22 @@ describe("config cli", () => {
             },
           });
 
-          await expect(runConfigCommand(["config", "validate", "--json"])).rejects.toThrow(
-            ExitError,
-          );
-
-          const payload = JSON.parse(String(firstMockArg(mockLog))) as {
-            valid: boolean;
-            path: string;
-            issues: string[];
-          };
-          // Machine-readable validate output must surface the exec provider
-          // command-path failure as an issue string (see ClawSweeper review on
-          // #117128 — cover the --json contract, not just the text surface).
-          expect(payload.valid).toBe(false);
-          expect(payload.issues).toEqual(
-            expect.arrayContaining([expect.stringContaining("secrets.providers.execmain")]),
-          );
-          expect(payload.issues.some((issue) => issue.includes("must not be a symlink"))).toBe(
-            true,
-          );
+          const payload = await runValidateJsonAndGetPayload();
+          expect(payload).toMatchObject({
+            ok: false,
+            error: {
+              type: "cli_error",
+              message: expect.stringContaining("OpenClaw config is invalid"),
+            },
+            valid: false,
+            path: "/tmp/openclaw.json",
+            issues: [
+              {
+                path: "secrets.providers.execmain.command",
+                message: expect.stringContaining("must not be a symlink"),
+              },
+            ],
+          });
           expect(mockError).not.toHaveBeenCalled();
         } finally {
           fs.rmSync(root, { recursive: true, force: true });
@@ -2380,21 +2379,50 @@ describe("config cli", () => {
       expect(requireRecord(resolveOptions, "resolve options").env).toBeTypeOf("object");
     });
 
-    it.skipIf(process.platform === "win32")(
-      "rejects writes that set an exec provider command to a symlink",
-      async () => {
+    it.skipIf(process.platform === "win32").each([
+      ["set", false],
+      ["set", true],
+      ["patch", false],
+      ["patch", true],
+      ["unset", false],
+      ["unset", true],
+    ] as const)(
+      "rejects unsafe exec provider paths on %s (dry run: %s)",
+      async (mutation, dryRun) => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-link-"));
         const symlinkPath = path.join(root, "node-link");
         fs.symlinkSync(process.execPath, symlinkPath);
         try {
-          setGatewaySnapshot();
+          setGatewaySnapshot({
+            providers: {
+              execmain: {
+                source: "exec",
+                command: mutation === "set" ? process.execPath : symlinkPath,
+                trustedDirs: [root],
+              },
+            },
+          });
+          const patchFile = path.join(root, "patch.json");
+          fs.writeFileSync(
+            patchFile,
+            JSON.stringify({ secrets: { providers: { execmain: { trustedDirs: null } } } }),
+          );
+          const args = {
+            set: ["set", "secrets.providers.execmain.command", symlinkPath],
+            patch: ["patch", "--file", patchFile],
+            unset: ["unset", "secrets.providers.execmain.trustedDirs"],
+          }[mutation];
 
           await expect(
-            runConfigCommand(["config", "set", "secrets.providers.execmain.command", symlinkPath]),
-          ).rejects.toThrow("exec SecretRef provider command path is unsafe");
+            runConfigCommand(["config", ...args, ...(dryRun ? ["--dry-run"] : [])]),
+          ).rejects.toThrow(ExitError);
 
           expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
           expectErrorIncludes("must not be a symlink");
+          if (!dryRun) {
+            expectErrorIncludes("SecretRef provider configuration is invalid");
+          }
         } finally {
           fs.rmSync(root, { recursive: true, force: true });
         }
@@ -2419,34 +2447,16 @@ describe("config cli", () => {
       expectErrorIncludes("Dry run failed: config schema validation failed.");
     });
 
-    it("does not throw a raw TypeError when a value-mode write sets a provider to null", async () => {
-      // A value-mode write can set secrets.providers.<alias> to a non-object
-      // (null/primitive) without triggering full schema validation. The
-      // exec-provider preflight must narrow to a non-null object instead of
-      // throwing a raw TypeError on `"command" in provider` (see ClawSweeper
-      // review on #117128).
+    it("leaves null providers to schema validation in value-mode dry runs", async () => {
       setGatewaySnapshot();
 
-      // The command may succeed (value mode skips schema validation) or fail
-      // (later schema/policy check); either is acceptable as long as no raw
-      // TypeError leaks out of the preflight.
-      let thrown: unknown;
-      try {
-        await runConfigCommand(["config", "set", "secrets.providers.ghost", "null", "--dry-run"]);
-      } catch (err) {
-        thrown = err;
-      }
-      const message =
-        thrown instanceof Error
-          ? thrown.message
-          : typeof thrown === "string"
-            ? thrown
-            : thrown == null
-              ? ""
-              : JSON.stringify(thrown);
-      expect(message).not.toMatch(/Cannot use 'in' operator/i);
-      expect(message).not.toMatch(/^TypeError/u);
+      await runConfigCommand(["config", "set", "secrets.providers.ghost", "null", "--dry-run"]);
+
+      expect(mockError).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
+      expectLogIncludes("Dry run note: value mode does not run schema/resolvability checks.");
+      expectLogIncludes("Dry run successful:");
     });
 
     it.skipIf(process.platform === "win32")(
@@ -2496,45 +2506,6 @@ describe("config cli", () => {
           );
         } finally {
           fs.rmSync(root, { recursive: true, force: true });
-        }
-      },
-    );
-
-    it.skipIf(process.platform === "win32")(
-      "accepts a valid exec command in --dry-run --json and reports no schema errors",
-      async () => {
-        const validCommandPath = createValidExecutableFixture();
-        try {
-          setGatewaySnapshot({
-            providers: { execmain: { source: "exec", command: validCommandPath } },
-          });
-
-          await runConfigCommand([
-            "config",
-            "set",
-            "channels.discord.token",
-            "--ref-provider",
-            "execmain",
-            "--ref-source",
-            "exec",
-            "--ref-id",
-            "DISCORD_BOT_TOKEN",
-            "--dry-run",
-            "--json",
-          ]);
-
-          expect(mockWriteConfigFile).not.toHaveBeenCalled();
-          const payload = parseLastLogPayload() as {
-            ok: boolean;
-            checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
-            errors?: Array<{ kind: string; message: string }>;
-          };
-          // A valid exec provider passes the non-executing command-path check,
-          // so the dry run succeeds with no schema-class errors.
-          expect(payload.ok).toBe(true);
-          expect(payload.checks.schema).toBe(false);
-        } finally {
-          fs.rmSync(path.dirname(validCommandPath), { recursive: true, force: true });
         }
       },
     );
@@ -3155,6 +3126,53 @@ describe("config cli", () => {
         ["channels", "discord", "guilds", "123"],
       ]);
     });
+
+    it.skipIf(process.platform === "win32").each([
+      ["patch", false],
+      ["patch", true],
+      ["unset", false],
+      ["unset", true],
+    ] as const)(
+      "allows %s to remove an unsafe exec provider while preserving another dormant provider (dry run: %s)",
+      async (mutation, dryRun) => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-provider-remove-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot({
+            providers: {
+              execmain: { source: "exec", command: symlinkPath },
+              dormant: { source: "exec", command: symlinkPath },
+            },
+          });
+          const pathname = path.join(root, "patch.json");
+          fs.writeFileSync(
+            pathname,
+            JSON.stringify({ secrets: { providers: { execmain: null } } }),
+          );
+          const args =
+            mutation === "patch"
+              ? ["patch", "--file", pathname]
+              : ["unset", "secrets.providers.execmain"];
+
+          await runConfigCommand(["config", ...args, ...(dryRun ? ["--dry-run"] : [])]);
+
+          expect(mockError).not.toHaveBeenCalled();
+          expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
+          if (dryRun) {
+            expect(mockWriteConfigFile).not.toHaveBeenCalled();
+            expectLogIncludes("Dry run successful:");
+          } else {
+            expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+            expect(firstWrittenConfig().secrets?.providers).toEqual({
+              dormant: { source: "exec", command: symlinkPath },
+            });
+          }
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
 
     it("treats empty object config patches as recursive merges", async () => {
       const resolved = {
@@ -3867,96 +3885,20 @@ describe("config cli", () => {
 
         const payload = parseLastLogPayload() as {
           ok: boolean;
-          checks: { resolvability: boolean; resolvabilityComplete: boolean };
+          checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
           refsChecked: number;
           skippedExecRefs: number;
         };
         expect(payload.ok).toBe(true);
+        expect(payload.checks.schema).toBe(false);
         expect(payload.checks.resolvability).toBe(true);
         expect(payload.checks.resolvabilityComplete).toBe(false);
         expect(payload.refsChecked).toBe(0);
         expect(payload.skippedExecRefs).toBe(1);
+        expect(mockWriteConfigFile).not.toHaveBeenCalled();
+        expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
       } finally {
         fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true });
-      }
-    });
-
-    it("reports checks.schema false when no exec provider is touched by the dry run", async () => {
-      // An env-only provider runs no exec command-path check, so checks.schema
-      // stays false on a successful dry run (no schema-class errors).
-      setGatewaySnapshot({ providers: { default: { source: "env" } } });
-
-      await runConfigCommand([
-        "config",
-        "set",
-        "channels.discord.token",
-        "--ref-provider",
-        "default",
-        "--ref-source",
-        "env",
-        "--ref-id",
-        "DISCORD_BOT_TOKEN",
-        "--dry-run",
-        "--json",
-      ]);
-
-      const payload = parseLastLogPayload() as {
-        ok: boolean;
-        checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
-      };
-      expect(payload.ok).toBe(true);
-      expect(payload.checks.schema).toBe(false);
-    });
-
-    it("reports checks.schema true when a touched exec provider fails preflight alongside an untouched valid one", async () => {
-      const validPath = createValidExecutableFixture();
-      const badRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-mix-"));
-      const symlinkPath = path.join(badRoot, "bad-link");
-      fs.symlinkSync(process.execPath, symlinkPath);
-      try {
-        setGatewaySnapshot({
-          providers: {
-            good: { source: "exec", command: validPath },
-            bad: { source: "exec", command: symlinkPath },
-          },
-        });
-
-        await expect(
-          runConfigCommand([
-            "config",
-            "set",
-            "channels.discord.token",
-            "--ref-provider",
-            "bad",
-            "--ref-source",
-            "exec",
-            "--ref-id",
-            "DISCORD_BOT_TOKEN",
-            "--dry-run",
-            "--json",
-          ]),
-        ).rejects.toThrow(ExitError);
-
-        const payload = parseLastLogPayload() as {
-          ok: boolean;
-          checks: { schema: boolean };
-          errors?: Array<{ kind: string; message: string }>;
-        };
-        // The bad provider's symlink is touched, so the preflight ran and
-        // checks.schema must be true; the symlink error is reported.
-        expect(payload.ok).toBe(false);
-        expect(payload.checks.schema).toBe(true);
-        expect(payload.errors).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              kind: "schema",
-              message: expect.stringContaining("secrets.providers.bad"),
-            }),
-          ]),
-        );
-      } finally {
-        fs.rmSync(badRoot, { recursive: true, force: true });
-        fs.rmSync(path.dirname(validPath), { recursive: true, force: true });
       }
     });
 
@@ -4935,44 +4877,6 @@ describe("config cli", () => {
       expectErrorIncludes("Dry run failed: 1 SecretRef assignment(s) could not be resolved.");
       expectErrorIncludes("provider removed");
     });
-
-    it.skipIf(process.platform === "win32")(
-      "rejects a non-dry-run unset that persists an unsafe exec provider command path",
-      async () => {
-        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-unset-link-"));
-        const symlinkPath = path.join(root, "node-link");
-        fs.symlinkSync(process.execPath, symlinkPath);
-        try {
-          const resolved: OpenClawConfig = {
-            gateway: { port: 18789 },
-            secrets: {
-              providers: {
-                execmain: {
-                  source: "exec",
-                  command: symlinkPath,
-                  trustedDirs: ["/tmp"],
-                },
-              },
-            },
-          } as OpenClawConfig;
-          setSnapshot(resolved, resolved);
-          setSnapshot(resolved, resolved);
-
-          // A non-dry-run unset that touches an exec provider (here, removing an
-          // unrelated sub-field while leaving the unsafe command in place) must run
-          // the same targeted preflight as `config set/patch` before persistence, so
-          // a dormant unsafe command path cannot survive an unset-based rewrite.
-          await expect(
-            runConfigCommand(["config", "unset", "secrets.providers.execmain.trustedDirs"]),
-          ).rejects.toThrow("exec SecretRef provider command path is unsafe");
-
-          expect(mockWriteConfigFile).not.toHaveBeenCalled();
-          expectErrorIncludes("must not be a symlink");
-        } finally {
-          fs.rmSync(root, { recursive: true, force: true });
-        }
-      },
-    );
 
     it("validates existing refs when unset dry-run removes secret defaults", async () => {
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -257,6 +257,14 @@ function setGatewaySnapshot(secrets?: OpenClawConfig["secrets"]): void {
   setSnapshot(resolved, resolved);
 }
 
+function createValidExecutableFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-valid-exec-"));
+  const fixturePath = path.join(root, "node");
+  fs.copyFileSync(process.execPath, fixturePath);
+  fs.chmodSync(fixturePath, 0o755);
+  return fixturePath;
+}
+
 function setSnapshotOnce(snapshot: ConfigFileSnapshot) {
   mockReadConfigFileSnapshot.mockResolvedValueOnce(snapshot);
 }
@@ -1734,6 +1742,97 @@ describe("config cli", () => {
       expectErrorIncludes("Config file not found:");
       expect(mockLog).not.toHaveBeenCalled();
     });
+
+    it.skipIf(process.platform === "win32")(
+      "rejects exec SecretRef providers whose command path is a symlink",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-validate-link-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot({
+            providers: {
+              execmain: {
+                source: "exec",
+                command: symlinkPath,
+              },
+            },
+          });
+
+          await expect(runConfigCommand(["config", "validate"])).rejects.toThrow(ExitError);
+
+          expectErrorIncludes("secrets.providers.execmain");
+          expectErrorIncludes("must not be a symlink");
+          expect(mockLog).not.toHaveBeenCalled();
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
+
+    it("accepts exec SecretRef providers with a valid command path", async () => {
+      const fixturePath = createValidExecutableFixture();
+      try {
+        setGatewaySnapshot({
+          providers: {
+            execmain: {
+              source: "exec",
+              command: fixturePath,
+            },
+          },
+        });
+
+        await runConfigCommand(["config", "validate"]);
+
+        expect(mockExit).not.toHaveBeenCalled();
+        expect(mockError).not.toHaveBeenCalled();
+        expectLogIncludes("Config valid:");
+      } finally {
+        fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true });
+      }
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "reports exec provider command-path errors in --json validate output",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-validate-json-link-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot({
+            providers: {
+              execmain: {
+                source: "exec",
+                command: symlinkPath,
+              },
+            },
+          });
+
+          await expect(runConfigCommand(["config", "validate", "--json"])).rejects.toThrow(
+            ExitError,
+          );
+
+          const payload = JSON.parse(String(firstMockArg(mockLog))) as {
+            valid: boolean;
+            path: string;
+            issues: string[];
+          };
+          // Machine-readable validate output must surface the exec provider
+          // command-path failure as an issue string (see ClawSweeper review on
+          // #117128 — cover the --json contract, not just the text surface).
+          expect(payload.valid).toBe(false);
+          expect(payload.issues).toEqual(
+            expect.arrayContaining([expect.stringContaining("secrets.providers.execmain")]),
+          );
+          expect(payload.issues.some((issue) => issue.includes("must not be a symlink"))).toBe(
+            true,
+          );
+          expect(mockError).not.toHaveBeenCalled();
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
   });
 
   describe("config schema", () => {
@@ -2281,6 +2380,27 @@ describe("config cli", () => {
       expect(requireRecord(resolveOptions, "resolve options").env).toBeTypeOf("object");
     });
 
+    it.skipIf(process.platform === "win32")(
+      "rejects writes that set an exec provider command to a symlink",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-link-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot();
+
+          await expect(
+            runConfigCommand(["config", "set", "secrets.providers.execmain.command", symlinkPath]),
+          ).rejects.toThrow("exec SecretRef provider command path is unsafe");
+
+          expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          expectErrorIncludes("must not be a symlink");
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
+
     it("requires schema validation in JSON dry-run mode", async () => {
       setGatewaySnapshot();
 
@@ -2298,6 +2418,126 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expectErrorIncludes("Dry run failed: config schema validation failed.");
     });
+
+    it("does not throw a raw TypeError when a value-mode write sets a provider to null", async () => {
+      // A value-mode write can set secrets.providers.<alias> to a non-object
+      // (null/primitive) without triggering full schema validation. The
+      // exec-provider preflight must narrow to a non-null object instead of
+      // throwing a raw TypeError on `"command" in provider` (see ClawSweeper
+      // review on #117128).
+      setGatewaySnapshot();
+
+      // The command may succeed (value mode skips schema validation) or fail
+      // (later schema/policy check); either is acceptable as long as no raw
+      // TypeError leaks out of the preflight.
+      let thrown: unknown;
+      try {
+        await runConfigCommand(["config", "set", "secrets.providers.ghost", "null", "--dry-run"]);
+      } catch (err) {
+        thrown = err;
+      }
+      const message =
+        thrown instanceof Error
+          ? thrown.message
+          : typeof thrown === "string"
+            ? thrown
+            : thrown == null
+              ? ""
+              : JSON.stringify(thrown);
+      expect(message).not.toMatch(/Cannot use 'in' operator/i);
+      expect(message).not.toMatch(/^TypeError/u);
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "reports exec path preflight in --dry-run --json checks for ref-builder commands",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-dryrun-link-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot({
+            providers: { execmain: { source: "exec", command: symlinkPath } },
+          });
+
+          await expect(
+            runConfigCommand([
+              "config",
+              "set",
+              "channels.discord.token",
+              "--ref-provider",
+              "execmain",
+              "--ref-source",
+              "exec",
+              "--ref-id",
+              "DISCORD_BOT_TOKEN",
+              "--dry-run",
+              "--json",
+            ]),
+          ).rejects.toThrow(ExitError);
+
+          expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          const payload = parseLastLogPayload() as {
+            ok: boolean;
+            checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
+            errors?: Array<{ kind: string; message: string }>;
+          };
+          expect(payload.ok).toBe(false);
+          // The exec-path preflight is schema-class validation; when it fails,
+          // the JSON report must not claim no schema check ran.
+          expect(payload.checks.schema).toBe(true);
+          expect(payload.errors).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                kind: "schema",
+                message: expect.stringContaining("secrets.providers.execmain"),
+              }),
+            ]),
+          );
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
+
+    it.skipIf(process.platform === "win32")(
+      "accepts a valid exec command in --dry-run --json and reports no schema errors",
+      async () => {
+        const validCommandPath = createValidExecutableFixture();
+        try {
+          setGatewaySnapshot({
+            providers: { execmain: { source: "exec", command: validCommandPath } },
+          });
+
+          await runConfigCommand([
+            "config",
+            "set",
+            "channels.discord.token",
+            "--ref-provider",
+            "execmain",
+            "--ref-source",
+            "exec",
+            "--ref-id",
+            "DISCORD_BOT_TOKEN",
+            "--dry-run",
+            "--json",
+          ]);
+
+          expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          const payload = parseLastLogPayload() as {
+            ok: boolean;
+            checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
+            errors?: Array<{ kind: string; message: string }>;
+          };
+          // A valid exec provider passes the non-executing command-path check,
+          // so the dry run succeeds with no schema-class errors.
+          expect(payload.ok).toBe(true);
+          expect(payload.checks.schema).toBe(false);
+        } finally {
+          fs.rmSync(path.dirname(validCommandPath), { recursive: true, force: true });
+        }
+      },
+    );
 
     it("dry-runs config patch channel fields against plugin-owned schemas", async () => {
       setExternalFeishuSchema();
@@ -2422,54 +2662,68 @@ describe("config cli", () => {
     });
 
     it("skips exec SecretRef resolvability checks in dry-run by default", async () => {
-      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
+      const fixturePath = createValidExecutableFixture();
+      try {
+        setGatewaySnapshot({
+          providers: { runner: { source: "exec", command: fixturePath } },
+        });
 
-      await runConfigCommand([
-        "config",
-        "set",
-        "channels.discord.token",
-        "--ref-provider",
-        "runner",
-        "--ref-source",
-        "exec",
-        "--ref-id",
-        "openai",
-        "--dry-run",
-      ]);
+        await runConfigCommand([
+          "config",
+          "set",
+          "channels.discord.token",
+          "--ref-provider",
+          "runner",
+          "--ref-source",
+          "exec",
+          "--ref-id",
+          "openai",
+          "--dry-run",
+        ]);
 
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-      expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
-      expectLogIncludes(
-        "Dry run note: skipped 1 exec SecretRef resolvability check(s). Re-run with --allow-exec",
-      );
+        expect(mockWriteConfigFile).not.toHaveBeenCalled();
+        expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
+        expectLogIncludes(
+          "Dry run note: skipped 1 exec SecretRef resolvability check(s). Re-run with --allow-exec",
+        );
+      } finally {
+        fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true });
+      }
     });
 
     it("allows exec SecretRef resolvability checks in dry-run when --allow-exec is set", async () => {
-      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
+      const fixturePath = createValidExecutableFixture();
+      try {
+        setGatewaySnapshot({
+          providers: { runner: { source: "exec", command: fixturePath } },
+        });
 
-      await runConfigCommand([
-        "config",
-        "set",
-        "channels.discord.token",
-        "--ref-provider",
-        "runner",
-        "--ref-source",
-        "exec",
-        "--ref-id",
-        "openai",
-        "--dry-run",
-        "--allow-exec",
-      ]);
+        await runConfigCommand([
+          "config",
+          "set",
+          "channels.discord.token",
+          "--ref-provider",
+          "runner",
+          "--ref-source",
+          "exec",
+          "--ref-id",
+          "openai",
+          "--dry-run",
+          "--allow-exec",
+        ]);
 
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-      expect(mockResolveSecretRefValue).toHaveBeenCalledTimes(1);
-      const [secretRef, resolveOptions] = requireResolveSecretRefCall(0);
-      const secretRefRecord = requireRecord(secretRef, "exec SecretRef");
-      expect(secretRefRecord.source).toBe("exec");
-      expect(secretRefRecord.provider).toBe("runner");
-      expect(secretRefRecord.id).toBe("openai");
-      expect(resolveOptions).toBeTypeOf("object");
-      expectLogExcludes("Dry run note: skipped 1 exec SecretRef resolvability check(s).");
+        expect(mockWriteConfigFile).not.toHaveBeenCalled();
+        expect(mockResolveSecretRefValue).toHaveBeenCalledTimes(1);
+        const [secretRef, resolveOptions] = requireResolveSecretRefCall(0);
+        const secretRefRecord = requireRecord(secretRef, "exec SecretRef");
+        expect(secretRefRecord.source).toBe("exec");
+        expect(secretRefRecord.provider).toBe("runner");
+        expect(secretRefRecord.id).toBe("openai");
+        expect(resolveOptions).toBeTypeOf("object");
+        expectLogExcludes("Dry run note: skipped 1 exec SecretRef resolvability check(s).");
+      } finally {
+        fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true });
+      }
     });
 
     it("rejects --allow-exec without --dry-run", async () => {
@@ -3162,6 +3416,8 @@ describe("config cli", () => {
           fs.rmSync(invalidPatch, { force: true });
         }
         const invalidPayload = lastMockArg(defaultRuntime.writeJson) as {
+          ok?: boolean;
+          checks?: { schema?: boolean };
           errors?: Array<{ message?: string }>;
         };
         const errorMessages = invalidPayload.errors?.map((error) => error.message ?? "") ?? [];
@@ -3173,6 +3429,10 @@ describe("config cli", () => {
             message.includes(`does not declare secret provider integration "missing"`),
           ),
         ).toBe(true);
+        // The integration was selected and materialization was attempted (and
+        // failed); checks.schema reflects that schema-class validation ran.
+        expect(invalidPayload.ok).toBe(false);
+        expect(invalidPayload.checks?.schema).toBe(true);
       } finally {
         fs.rmSync(rootDir, { recursive: true, force: true });
       }
@@ -3585,34 +3845,176 @@ describe("config cli", () => {
     });
 
     it("emits skipped exec metadata for --dry-run --json success", async () => {
-      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
+      const fixturePath = createValidExecutableFixture();
+      try {
+        setGatewaySnapshot({
+          providers: { runner: { source: "exec", command: fixturePath } },
+        });
+
+        await runConfigCommand([
+          "config",
+          "set",
+          "channels.discord.token",
+          "--ref-provider",
+          "runner",
+          "--ref-source",
+          "exec",
+          "--ref-id",
+          "openai",
+          "--dry-run",
+          "--json",
+        ]);
+
+        const payload = parseLastLogPayload() as {
+          ok: boolean;
+          checks: { resolvability: boolean; resolvabilityComplete: boolean };
+          refsChecked: number;
+          skippedExecRefs: number;
+        };
+        expect(payload.ok).toBe(true);
+        expect(payload.checks.resolvability).toBe(true);
+        expect(payload.checks.resolvabilityComplete).toBe(false);
+        expect(payload.refsChecked).toBe(0);
+        expect(payload.skippedExecRefs).toBe(1);
+      } finally {
+        fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true });
+      }
+    });
+
+    it("reports checks.schema false when no exec provider is touched by the dry run", async () => {
+      // An env-only provider runs no exec command-path check, so checks.schema
+      // stays false on a successful dry run (no schema-class errors).
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await runConfigCommand([
         "config",
         "set",
         "channels.discord.token",
         "--ref-provider",
-        "runner",
+        "default",
         "--ref-source",
-        "exec",
+        "env",
         "--ref-id",
-        "openai",
+        "DISCORD_BOT_TOKEN",
         "--dry-run",
         "--json",
       ]);
 
       const payload = parseLastLogPayload() as {
         ok: boolean;
-        checks: { resolvability: boolean; resolvabilityComplete: boolean };
-        refsChecked: number;
-        skippedExecRefs: number;
+        checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
       };
       expect(payload.ok).toBe(true);
-      expect(payload.checks.resolvability).toBe(true);
-      expect(payload.checks.resolvabilityComplete).toBe(false);
-      expect(payload.refsChecked).toBe(0);
-      expect(payload.skippedExecRefs).toBe(1);
+      expect(payload.checks.schema).toBe(false);
     });
+
+    it("reports checks.schema true when a touched exec provider fails preflight alongside an untouched valid one", async () => {
+      const validPath = createValidExecutableFixture();
+      const badRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-mix-"));
+      const symlinkPath = path.join(badRoot, "bad-link");
+      fs.symlinkSync(process.execPath, symlinkPath);
+      try {
+        setGatewaySnapshot({
+          providers: {
+            good: { source: "exec", command: validPath },
+            bad: { source: "exec", command: symlinkPath },
+          },
+        });
+
+        await expect(
+          runConfigCommand([
+            "config",
+            "set",
+            "channels.discord.token",
+            "--ref-provider",
+            "bad",
+            "--ref-source",
+            "exec",
+            "--ref-id",
+            "DISCORD_BOT_TOKEN",
+            "--dry-run",
+            "--json",
+          ]),
+        ).rejects.toThrow(ExitError);
+
+        const payload = parseLastLogPayload() as {
+          ok: boolean;
+          checks: { schema: boolean };
+          errors?: Array<{ kind: string; message: string }>;
+        };
+        // The bad provider's symlink is touched, so the preflight ran and
+        // checks.schema must be true; the symlink error is reported.
+        expect(payload.ok).toBe(false);
+        expect(payload.checks.schema).toBe(true);
+        expect(payload.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: "schema",
+              message: expect.stringContaining("secrets.providers.bad"),
+            }),
+          ]),
+        );
+      } finally {
+        fs.rmSync(badRoot, { recursive: true, force: true });
+        fs.rmSync(path.dirname(validPath), { recursive: true, force: true });
+      }
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "allows a config write that leaves an untouched inactive unsafe exec provider in place",
+      async () => {
+        // Ordinary writes preserve targeted validation for recovery. An
+        // untouched dormant exec provider may be repaired separately without
+        // blocking an unrelated Discord-token dry run; `config validate` is
+        // the strict all-provider surface (see #117128).
+        const badRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-untouched-"));
+        const symlinkPath = path.join(badRoot, "bad-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          setGatewaySnapshot({
+            providers: {
+              default: { source: "env" },
+              bad: { source: "exec", command: symlinkPath },
+            },
+          });
+
+          // Dry run must succeed and not write despite the dormant unsafe
+          // exec provider — targeted preflight skips untouched providers.
+          await runConfigCommand([
+            "config",
+            "set",
+            "channels.discord.token",
+            "--ref-provider",
+            "default",
+            "--ref-source",
+            "env",
+            "--ref-id",
+            "DISCORD_BOT_TOKEN",
+            "--dry-run",
+            "--json",
+          ]);
+          expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          expect(mockError).not.toHaveBeenCalled();
+
+          // A real write also succeeds; the unrelated dormant provider does
+          // not block routine configuration recovery.
+          await runConfigCommand([
+            "config",
+            "set",
+            "channels.discord.token",
+            "--ref-provider",
+            "default",
+            "--ref-source",
+            "env",
+            "--ref-id",
+            "DISCORD_BOT_TOKEN",
+          ]);
+          expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+        } finally {
+          fs.rmSync(badRoot, { recursive: true, force: true });
+        }
+      },
+    );
 
     it("emits structured JSON for --dry-run --json failure", async () => {
       setGatewaySnapshot({ providers: { default: { source: "env" } } });
@@ -4533,6 +4935,44 @@ describe("config cli", () => {
       expectErrorIncludes("Dry run failed: 1 SecretRef assignment(s) could not be resolved.");
       expectErrorIncludes("provider removed");
     });
+
+    it.skipIf(process.platform === "win32")(
+      "rejects a non-dry-run unset that persists an unsafe exec provider command path",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-unset-link-"));
+        const symlinkPath = path.join(root, "node-link");
+        fs.symlinkSync(process.execPath, symlinkPath);
+        try {
+          const resolved: OpenClawConfig = {
+            gateway: { port: 18789 },
+            secrets: {
+              providers: {
+                execmain: {
+                  source: "exec",
+                  command: symlinkPath,
+                  trustedDirs: ["/tmp"],
+                },
+              },
+            },
+          } as OpenClawConfig;
+          setSnapshot(resolved, resolved);
+          setSnapshot(resolved, resolved);
+
+          // A non-dry-run unset that touches an exec provider (here, removing an
+          // unrelated sub-field while leaving the unsafe command in place) must run
+          // the same targeted preflight as `config set/patch` before persistence, so
+          // a dormant unsafe command path cannot survive an unset-based rewrite.
+          await expect(
+            runConfigCommand(["config", "unset", "secrets.providers.execmain.trustedDirs"]),
+          ).rejects.toThrow("exec SecretRef provider command path is unsafe");
+
+          expect(mockWriteConfigFile).not.toHaveBeenCalled();
+          expectErrorIncludes("must not be a symlink");
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
 
     it("validates existing refs when unset dry-run removes secret defaults", async () => {
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -35,7 +35,6 @@ import {
 import { getAtPath, isConfigSchemaPath, parseConfigSetPath } from "./config-cli-path.js";
 import { handleConfigMutationError, runConfigOperations } from "./config-cli-runner.js";
 import {
-  collectManualExecProviderCommandPathErrors,
   ensureValidConfigSnapshotForCli,
   formatInvalidConfigRepairHint,
   strictlyValidateConfigSnapshotForCli,
@@ -213,10 +212,9 @@ export async function runConfigUnset(opts: {
       throw new Error("--json can only be used with --dry-run.");
     }
     const pathTokens = parseConcreteConfigPathTokens(opts.path);
-    const parsedPath = pathTokens.map(String);
     await runConfigOperations({
       runtime,
-      operations: [buildUnsetOperation(parsedPath, pathTokens)],
+      operations: [buildUnsetOperation(pathTokens.map(String), pathTokens)],
       options: cliOptions,
       successMode: "set",
     });
@@ -259,7 +257,7 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
   let outputPath = CONFIG_PATH ?? "openclaw.json";
   try {
     const read = await readConfigFileSnapshotWithPluginMetadata({ observe: false });
-    const snapshot = strictlyValidateConfigSnapshotForCli(
+    const snapshot = await strictlyValidateConfigSnapshotForCli(
       read.snapshot,
       read.pluginMetadataSnapshot,
     );
@@ -305,38 +303,6 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
       return;
     }
     const warnings = normalizeConfigIssues(snapshot.warnings);
-    // Run the same non-executing exec-provider command-path trust checks that
-    // startup activation applies, so a symlinked, missing, or unsafe command
-    // cannot pass validation and then crash the gateway on the next restart
-    // (see #117051).
-    const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
-      config: snapshot.runtimeConfig,
-      operations: [],
-      validateAllProviders: true,
-    });
-    if (execProviderCommandPathErrors.length > 0) {
-      if (opts.json) {
-        writeRuntimeJson(
-          runtime,
-          {
-            valid: false,
-            path: outputPath,
-            issues: execProviderCommandPathErrors.map((error) => error.message),
-          },
-          0,
-        );
-      } else {
-        runtime.error(danger(`OpenClaw config is invalid: ${shortPath}`));
-        for (const error of execProviderCommandPathErrors) {
-          runtime.error(`  ${error.message}`);
-        }
-        runtime.error(
-          formatInvalidConfigRepairHint(snapshot, "to repair, or fix the keys above manually."),
-        );
-      }
-      runtime.exit(1);
-      return;
-    }
     if (opts.json) {
       writeRuntimeJson(runtime, { valid: true, path: outputPath, warnings }, 0);
     } else {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -35,6 +35,7 @@ import {
 import { getAtPath, isConfigSchemaPath, parseConfigSetPath } from "./config-cli-path.js";
 import { handleConfigMutationError, runConfigOperations } from "./config-cli-runner.js";
 import {
+  collectManualExecProviderCommandPathErrors,
   ensureValidConfigSnapshotForCli,
   formatInvalidConfigRepairHint,
   strictlyValidateConfigSnapshotForCli,
@@ -304,6 +305,38 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
       return;
     }
     const warnings = normalizeConfigIssues(snapshot.warnings);
+    // Run the same non-executing exec-provider command-path trust checks that
+    // startup activation applies, so a symlinked, missing, or unsafe command
+    // cannot pass validation and then crash the gateway on the next restart
+    // (see #117051).
+    const execProviderCommandPathErrors = await collectManualExecProviderCommandPathErrors({
+      config: snapshot.runtimeConfig,
+      operations: [],
+      validateAllProviders: true,
+    });
+    if (execProviderCommandPathErrors.length > 0) {
+      if (opts.json) {
+        writeRuntimeJson(
+          runtime,
+          {
+            valid: false,
+            path: outputPath,
+            issues: execProviderCommandPathErrors.map((error) => error.message),
+          },
+          0,
+        );
+      } else {
+        runtime.error(danger(`OpenClaw config is invalid: ${shortPath}`));
+        for (const error of execProviderCommandPathErrors) {
+          runtime.error(`  ${error.message}`);
+        }
+        runtime.error(
+          formatInvalidConfigRepairHint(snapshot, "to repair, or fix the keys above manually."),
+        );
+      }
+      runtime.exit(1);
+      return;
+    }
     if (opts.json) {
       writeRuntimeJson(runtime, { valid: true, path: outputPath, warnings }, 0);
     } else {

--- a/src/secrets/exec-provider-path-validation.test.ts
+++ b/src/secrets/exec-provider-path-validation.test.ts
@@ -1,9 +1,8 @@
-/** Tests the non-executing exec-provider command-path validator (see #117051). */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
+import { withMockedWindowsAclVerificationUnavailable } from "../test-utils/vitest-spies.js";
 import { assertSecureExecCommandPath } from "./exec-provider-path-validation.js";
 
 describe("exec provider command path validation", () => {
@@ -13,6 +12,7 @@ describe("exec provider command path validation", () => {
   }
   let fixtureRoot = "";
   let validExecutablePath = "";
+  let executionMarkerPath = "";
   let caseId = 0;
   const createCaseDir = async (label: string): Promise<string> => {
     const dir = path.join(fixtureRoot, `${label}-${caseId++}`);
@@ -21,12 +21,15 @@ describe("exec provider command path validation", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exec-provider-path-validation-"));
-    // Copy the runtime executable so the fixture is a regular file with closed
-    // permissions on every platform (hosted-runner node binaries can be
-    // world-writable, which the validator correctly rejects).
+    fixtureRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "exec-provider-path-validation-")),
+    );
     validExecutablePath = path.join(fixtureRoot, "valid-executable");
-    await fs.copyFile(process.execPath, validExecutablePath);
+    executionMarkerPath = path.join(fixtureRoot, "executed");
+    await fs.writeFile(
+      validExecutablePath,
+      `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(${JSON.stringify(executionMarkerPath)}, "executed");\n`,
+    );
     await fs.chmod(validExecutablePath, 0o755);
   });
   afterAll(async () => {
@@ -39,6 +42,7 @@ describe("exec provider command path validation", () => {
       label: "secrets.providers.execmain.command",
     });
     expect(securePath).toBe(validExecutablePath);
+    await expect(fs.access(executionMarkerPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   itPosix("rejects missing command paths", async () => {
@@ -64,7 +68,7 @@ describe("exec provider command path validation", () => {
   itPosix("rejects symlinked command paths", async () => {
     const root = await createCaseDir("link");
     const symlinkPath = path.join(root, "exec-link");
-    await fs.symlink(process.execPath, symlinkPath);
+    await fs.symlink(validExecutablePath, symlinkPath);
     await expect(
       assertSecureExecCommandPath({
         command: symlinkPath,
@@ -87,13 +91,9 @@ describe("exec provider command path validation", () => {
   });
 
   itPosix("accepts regular files lacking the owner-execute bit (startup parity)", async () => {
-    // The validator mirrors current startup activation, which does not require
-    // the owner-execute bit. Tightening this is upgrade-sensitive and left to
-    // maintainers (see #117128).
     const root = await createCaseDir("non-exec");
     const scriptPath = path.join(root, "not-executable");
-    await fs.copyFile(process.execPath, scriptPath);
-    // Readable, owner-owned, not world/group-writable, but NOT executable.
+    await fs.writeFile(scriptPath, "not executable\n");
     await fs.chmod(scriptPath, 0o600);
     await expect(
       assertSecureExecCommandPath({
@@ -109,7 +109,7 @@ describe("exec provider command path validation", () => {
     await fs.mkdir(trustedDir);
     await expect(
       assertSecureExecCommandPath({
-        command: process.execPath,
+        command: validExecutablePath,
         label: "secrets.providers.execmain.command",
         trustedDirs: [trustedDir],
       }),
@@ -120,8 +120,8 @@ describe("exec provider command path validation", () => {
     const root = await createCaseDir("trusted-ok");
     const trustedDir = path.join(root, "trusted");
     await fs.mkdir(trustedDir, { recursive: true });
-    const copy = path.join(trustedDir, "node");
-    await fs.copyFile(process.execPath, copy);
+    const copy = path.join(trustedDir, "helper");
+    await fs.writeFile(copy, "#!/bin/sh\nexit 1\n");
     await fs.chmod(copy, 0o755);
     await expect(
       assertSecureExecCommandPath({
@@ -133,22 +133,21 @@ describe("exec provider command path validation", () => {
   });
 
   it("fails closed with a supported recovery message when Windows ACL verification is unavailable", async () => {
-    // On a POSIX host, mocking process.platform to win32 makes the real
-    // inspectPathPermissions attempt Windows ACL inspection and return
-    // source="unknown" (icacls is unavailable), which exercises the Windows
-    // fail-closed branch without a Windows runner.
-    await withMockedWindowsPlatform(async () => {
-      try {
-        await assertSecureExecCommandPath({
-          command: process.execPath,
-          label: "secrets.providers.execmain.command",
+    await withMockedWindowsAclVerificationUnavailable(
+      path.join(fixtureRoot, "missing-windows-system-root"),
+      async () => {
+        await expect(
+          assertSecureExecCommandPath({
+            command: validExecutablePath,
+            label: "secrets.providers.execmain.command",
+          }),
+        ).rejects.toMatchObject({
+          code: "permission-unverified",
+          message: expect.stringMatching(
+            /ACL verification unavailable on Windows.*no provider-level bypass/,
+          ),
         });
-        expect.unreachable("expected the Windows ACL check to fail closed");
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        expect(message).toMatch(/ACL verification is unavailable on Windows/);
-        expect(message).toMatch(/fails closed/);
-      }
-    });
+      },
+    );
   });
 });

--- a/src/secrets/exec-provider-path-validation.test.ts
+++ b/src/secrets/exec-provider-path-validation.test.ts
@@ -1,0 +1,154 @@
+/** Tests the non-executing exec-provider command-path validator (see #117051). */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
+import { assertSecureExecCommandPath } from "./exec-provider-path-validation.js";
+
+describe("exec provider command path validation", () => {
+  const isWindows = process.platform === "win32";
+  function itPosix(name: string, fn: () => Promise<void> | void) {
+    it.skipIf(isWindows)(name, fn);
+  }
+  let fixtureRoot = "";
+  let validExecutablePath = "";
+  let caseId = 0;
+  const createCaseDir = async (label: string): Promise<string> => {
+    const dir = path.join(fixtureRoot, `${label}-${caseId++}`);
+    await fs.mkdir(dir);
+    return dir;
+  };
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exec-provider-path-validation-"));
+    // Copy the runtime executable so the fixture is a regular file with closed
+    // permissions on every platform (hosted-runner node binaries can be
+    // world-writable, which the validator correctly rejects).
+    validExecutablePath = path.join(fixtureRoot, "valid-executable");
+    await fs.copyFile(process.execPath, validExecutablePath);
+    await fs.chmod(validExecutablePath, 0o755);
+  });
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("accepts a valid regular executable without executing it", async () => {
+    const securePath = await assertSecureExecCommandPath({
+      command: validExecutablePath,
+      label: "secrets.providers.execmain.command",
+    });
+    expect(securePath).toBe(validExecutablePath);
+  });
+
+  itPosix("rejects missing command paths", async () => {
+    const root = await createCaseDir("missing");
+    await expect(
+      assertSecureExecCommandPath({
+        command: path.join(root, "no-such-binary"),
+        label: "secrets.providers.execmain.command",
+      }),
+    ).rejects.toThrow("is not readable");
+  });
+
+  itPosix("rejects directory command paths", async () => {
+    const root = await createCaseDir("dir");
+    await expect(
+      assertSecureExecCommandPath({
+        command: root,
+        label: "secrets.providers.execmain.command",
+      }),
+    ).rejects.toThrow("must be a file");
+  });
+
+  itPosix("rejects symlinked command paths", async () => {
+    const root = await createCaseDir("link");
+    const symlinkPath = path.join(root, "exec-link");
+    await fs.symlink(process.execPath, symlinkPath);
+    await expect(
+      assertSecureExecCommandPath({
+        command: symlinkPath,
+        label: "secrets.providers.execmain.command",
+      }),
+    ).rejects.toThrow("must not be a symlink");
+  });
+
+  itPosix("rejects world-writable command paths", async () => {
+    const root = await createCaseDir("writable");
+    const scriptPath = path.join(root, "helper");
+    await fs.writeFile(scriptPath, "#!/bin/sh\nexit 0\n");
+    await fs.chmod(scriptPath, 0o666);
+    await expect(
+      assertSecureExecCommandPath({
+        command: scriptPath,
+        label: "secrets.providers.execmain.command",
+      }),
+    ).rejects.toThrow("permissions are too open");
+  });
+
+  itPosix("accepts regular files lacking the owner-execute bit (startup parity)", async () => {
+    // The validator mirrors current startup activation, which does not require
+    // the owner-execute bit. Tightening this is upgrade-sensitive and left to
+    // maintainers (see #117128).
+    const root = await createCaseDir("non-exec");
+    const scriptPath = path.join(root, "not-executable");
+    await fs.copyFile(process.execPath, scriptPath);
+    // Readable, owner-owned, not world/group-writable, but NOT executable.
+    await fs.chmod(scriptPath, 0o600);
+    await expect(
+      assertSecureExecCommandPath({
+        command: scriptPath,
+        label: "secrets.providers.execmain.command",
+      }),
+    ).resolves.toBe(scriptPath);
+  });
+
+  itPosix("rejects commands outside trustedDirs", async () => {
+    const root = await createCaseDir("trusted");
+    const trustedDir = path.join(root, "trusted");
+    await fs.mkdir(trustedDir);
+    await expect(
+      assertSecureExecCommandPath({
+        command: process.execPath,
+        label: "secrets.providers.execmain.command",
+        trustedDirs: [trustedDir],
+      }),
+    ).rejects.toThrow("is outside trustedDirs");
+  });
+
+  itPosix("accepts a regular command inside trustedDirs", async () => {
+    const root = await createCaseDir("trusted-ok");
+    const trustedDir = path.join(root, "trusted");
+    await fs.mkdir(trustedDir, { recursive: true });
+    const copy = path.join(trustedDir, "node");
+    await fs.copyFile(process.execPath, copy);
+    await fs.chmod(copy, 0o755);
+    await expect(
+      assertSecureExecCommandPath({
+        command: copy,
+        label: "secrets.providers.execmain.command",
+        trustedDirs: [trustedDir],
+      }),
+    ).resolves.toBe(copy);
+  });
+
+  it("fails closed with a supported recovery message when Windows ACL verification is unavailable", async () => {
+    // On a POSIX host, mocking process.platform to win32 makes the real
+    // inspectPathPermissions attempt Windows ACL inspection and return
+    // source="unknown" (icacls is unavailable), which exercises the Windows
+    // fail-closed branch without a Windows runner.
+    await withMockedWindowsPlatform(async () => {
+      try {
+        await assertSecureExecCommandPath({
+          command: process.execPath,
+          label: "secrets.providers.execmain.command",
+        });
+        expect.unreachable("expected the Windows ACL check to fail closed");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toMatch(/ACL verification is unavailable on Windows/);
+        expect(message).toMatch(/fails closed/);
+      }
+    });
+  });
+});

--- a/src/secrets/exec-provider-path-validation.ts
+++ b/src/secrets/exec-provider-path-validation.ts
@@ -1,0 +1,99 @@
+/**
+ * Non-executing structural validation for manual exec secret-provider command
+ * paths. Shares the exact trust rules used by startup activation so a
+ * candidate configuration cannot pass schema/write validation and then fail
+ * gateway cold start (see #117051).
+ */
+import path from "node:path";
+import { FsSafeError } from "../infra/fs-safe.js";
+import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
+import { isPathInside } from "../security/scan-paths.js";
+import { resolveUserPath } from "../utils.js";
+
+const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
+const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
+
+function isAbsolutePathname(value: string): boolean {
+  return (
+    path.isAbsolute(value) ||
+    WINDOWS_ABS_PATH_PATTERN.test(value) ||
+    WINDOWS_UNC_PATH_PATTERN.test(value)
+  );
+}
+
+async function readFileStatOrThrow(pathname: string, label: string) {
+  const stat = await safeStat(pathname);
+  if (!stat.ok) {
+    throw new Error(`${label} is not readable: ${pathname}`);
+  }
+  if (stat.isDir) {
+    throw new Error(`${label} must be a file: ${pathname}`);
+  }
+  return stat;
+}
+
+type ExecProviderCommandPathValidationParams = {
+  command: string;
+  label: string;
+  trustedDirs?: string[];
+};
+
+/**
+ * Validates a manual exec provider command path without executing it. Mirrors
+ * the current startup activation rules exactly: absolute path, non-symlink,
+ * optional trusted-directory containment, non-writable-by-others permissions,
+ * current-user ownership, and Windows ACL availability. Kept at parity with
+ * `resolve.ts` cold-start activation so the validator never blocks a command
+ * the running gateway would already accept (see #117128).
+ */
+export async function assertSecureExecCommandPath(
+  params: ExecProviderCommandPathValidationParams,
+): Promise<string> {
+  const targetPath = resolveUserPath(params.command);
+  if (!isAbsolutePathname(targetPath)) {
+    throw new Error(`${params.label} must be an absolute path.`);
+  }
+
+  const effectivePath = targetPath;
+  const stat = await readFileStatOrThrow(effectivePath, params.label);
+  if (stat.isSymlink) {
+    throw new Error(`${params.label} must not be a symlink: ${effectivePath}`);
+  }
+
+  if (params.trustedDirs && params.trustedDirs.length > 0) {
+    const trusted = params.trustedDirs.map((entry) => resolveUserPath(entry));
+    const inTrustedDir = trusted.some((dir) => isPathInside(dir, effectivePath));
+    if (!inTrustedDir) {
+      throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
+    }
+  }
+
+  const perms = await inspectPathPermissions(effectivePath);
+  if (!perms.ok) {
+    throw new Error(`${params.label} permissions could not be verified: ${effectivePath}`);
+  }
+  if (perms.worldWritable || perms.groupWritable) {
+    throw new Error(`${params.label} permissions are too open: ${effectivePath}`);
+  }
+
+  if (process.platform === "win32" && perms.source === "unknown") {
+    // Preserve the permission-unverified FsSafeError shape so the resolver maps
+    // this to SECRET_PROVIDER_PATH_SECURITY_UNVERIFIABLE (matching the original
+    // assertSecurePath semantics); a plain Error would degrade to
+    // SECRET_PROVIDER_UNAVAILABLE and lose the Windows fail-closed diagnostic.
+    throw new FsSafeError(
+      "permission-unverified",
+      `${params.label} ACL verification is unavailable on Windows for ${effectivePath}. OpenClaw fails closed when command-path permissions cannot be verified; move the command to a path whose ACLs OpenClaw can verify. There is no provider-level bypass.`,
+    );
+  }
+
+  if (process.platform !== "win32" && typeof process.getuid === "function" && stat.uid != null) {
+    const uid = process.getuid();
+    if (stat.uid !== uid) {
+      throw new Error(
+        `${params.label} must be owned by the current user (uid=${uid}): ${effectivePath}`,
+      );
+    }
+  }
+  return effectivePath;
+}

--- a/src/secrets/exec-provider-path-validation.ts
+++ b/src/secrets/exec-provider-path-validation.ts
@@ -1,89 +1,53 @@
-/**
- * Non-executing structural validation for manual exec secret-provider command
- * paths. Shares the exact trust rules used by startup activation so a
- * candidate configuration cannot pass schema/write validation and then fail
- * gateway cold start (see #117051).
- */
-import path from "node:path";
 import { FsSafeError } from "../infra/fs-safe.js";
-import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
-import { isPathInside } from "../security/scan-paths.js";
-import { resolveUserPath } from "../utils.js";
+import { resolveUserPath } from "../infra/home-dir.js";
+import { isPathInside } from "../infra/path-safety.js";
+import { inspectPathPermissions, safeStat } from "../infra/permissions.js";
 
-const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
-const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
-
-function isAbsolutePathname(value: string): boolean {
-  return (
-    path.isAbsolute(value) ||
-    WINDOWS_ABS_PATH_PATTERN.test(value) ||
-    WINDOWS_UNC_PATH_PATTERN.test(value)
-  );
-}
-
-async function readFileStatOrThrow(pathname: string, label: string) {
-  const stat = await safeStat(pathname);
-  if (!stat.ok) {
-    throw new Error(`${label} is not readable: ${pathname}`);
-  }
-  if (stat.isDir) {
-    throw new Error(`${label} must be a file: ${pathname}`);
-  }
-  return stat;
-}
-
-type ExecProviderCommandPathValidationParams = {
+/** Checks the same command-path trust boundary before validation, writes, and execution. */
+export async function assertSecureExecCommandPath(params: {
   command: string;
   label: string;
   trustedDirs?: string[];
-};
-
-/**
- * Validates a manual exec provider command path without executing it. Mirrors
- * the current startup activation rules exactly: absolute path, non-symlink,
- * optional trusted-directory containment, non-writable-by-others permissions,
- * current-user ownership, and Windows ACL availability. Kept at parity with
- * `resolve.ts` cold-start activation so the validator never blocks a command
- * the running gateway would already accept (see #117128).
- */
-export async function assertSecureExecCommandPath(
-  params: ExecProviderCommandPathValidationParams,
-): Promise<string> {
-  const targetPath = resolveUserPath(params.command);
-  if (!isAbsolutePathname(targetPath)) {
+}): Promise<string> {
+  const commandPath = resolveUserPath(params.command);
+  // resolveUserPath expands and absolutizes nonempty input; the schema rejects relative commands.
+  if (!commandPath) {
     throw new Error(`${params.label} must be an absolute path.`);
   }
 
-  const effectivePath = targetPath;
-  const stat = await readFileStatOrThrow(effectivePath, params.label);
+  const stat = await safeStat(commandPath);
+  if (!stat.ok) {
+    throw new Error(`${params.label} is not readable: ${commandPath}`);
+  }
+  if (stat.isDir) {
+    throw new Error(`${params.label} must be a file: ${commandPath}`);
+  }
   if (stat.isSymlink) {
-    throw new Error(`${params.label} must not be a symlink: ${effectivePath}`);
+    throw new Error(`${params.label} must not be a symlink: ${commandPath}`);
   }
 
   if (params.trustedDirs && params.trustedDirs.length > 0) {
     const trusted = params.trustedDirs.map((entry) => resolveUserPath(entry));
-    const inTrustedDir = trusted.some((dir) => isPathInside(dir, effectivePath));
+    const inTrustedDir = trusted.some((dir) => isPathInside(dir, commandPath));
     if (!inTrustedDir) {
-      throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
+      throw new Error(`${params.label} is outside trustedDirs: ${commandPath}`);
     }
   }
 
-  const perms = await inspectPathPermissions(effectivePath);
+  const perms = await inspectPathPermissions(commandPath);
   if (!perms.ok) {
-    throw new Error(`${params.label} permissions could not be verified: ${effectivePath}`);
+    throw new Error(`${params.label} permissions could not be verified: ${commandPath}`);
   }
   if (perms.worldWritable || perms.groupWritable) {
-    throw new Error(`${params.label} permissions are too open: ${effectivePath}`);
+    throw new Error(`${params.label} permissions are too open: ${commandPath}`);
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
-    // Preserve the permission-unverified FsSafeError shape so the resolver maps
-    // this to SECRET_PROVIDER_PATH_SECURITY_UNVERIFIABLE (matching the original
-    // assertSecurePath semantics); a plain Error would degrade to
-    // SECRET_PROVIDER_UNAVAILABLE and lose the Windows fail-closed diagnostic.
+    // The resolver maps this typed receipt to SECRET_PROVIDER_PATH_SECURITY_UNVERIFIABLE.
+    // A plain Error would lose the Windows recovery diagnostic.
     throw new FsSafeError(
       "permission-unverified",
-      `${params.label} ACL verification is unavailable on Windows for ${effectivePath}. OpenClaw fails closed when command-path permissions cannot be verified; move the command to a path whose ACLs OpenClaw can verify. There is no provider-level bypass.`,
+      `${params.label} ACL verification unavailable on Windows for ${commandPath}. Move the command to a path whose ACLs OpenClaw can verify; there is no provider-level bypass.`,
     );
   }
 
@@ -91,9 +55,9 @@ export async function assertSecureExecCommandPath(
     const uid = process.getuid();
     if (stat.uid !== uid) {
       throw new Error(
-        `${params.label} must be owned by the current user (uid=${uid}): ${effectivePath}`,
+        `${params.label} must be owned by the current user (uid=${uid}): ${commandPath}`,
       );
     }
   }
-  return effectivePath;
+  return commandPath;
 }

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -1,5 +1,4 @@
 /** Resolves SecretRef values from env, file, exec, and store secret providers. */
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
@@ -20,11 +19,10 @@ import {
   type PluginManifestRegistry,
 } from "../plugins/manifest-registry.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
-import { isPathInside } from "../security/scan-paths.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { resolveUserPath } from "../utils.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
+import { assertSecureExecCommandPath } from "./exec-provider-path-validation.js";
 import { readJsonPointer } from "./json-pointer.js";
 import {
   isPluginIntegrationSecretProviderConfig,
@@ -65,8 +63,6 @@ const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
 // Exec diagnostics cross CLI, RPC, and log boundaries; surface only canonical safe codes.
 const SAFE_EXEC_ERROR_CODES = new Set(["AMBIGUOUS_DUPLICATE_KEY", "NOT_FOUND"]);
-const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
-const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
 
 export type { SecretRefResolveCache } from "./resolve-types.js";
 
@@ -117,25 +113,6 @@ function throwUnknownProviderResolutionError(params: {
     message: formatErrorMessage(params.err),
     cause: params.err,
   });
-}
-
-async function readFileStatOrThrow(pathname: string, label: string) {
-  const stat = await safeStat(pathname);
-  if (!stat.ok) {
-    throw new Error(`${label} is not readable: ${pathname}`);
-  }
-  if (stat.isDir) {
-    throw new Error(`${label} must be a file: ${pathname}`);
-  }
-  return stat;
-}
-
-function isAbsolutePathname(value: string): boolean {
-  return (
-    path.isAbsolute(value) ||
-    WINDOWS_ABS_PATH_PATTERN.test(value) ||
-    WINDOWS_UNC_PATH_PATTERN.test(value)
-  );
 }
 
 function resolveResolutionLimits(): ResolutionLimits {
@@ -212,72 +189,6 @@ function resolveConfiguredProvider(params: {
     return resolved.providerConfig;
   }
   return providerConfig;
-}
-
-async function assertSecurePath(params: {
-  targetPath: string;
-  label: string;
-  trustedDirs?: string[];
-  allowReadableByOthers?: boolean;
-  allowSymlinkPath?: boolean;
-}): Promise<string> {
-  if (!isAbsolutePathname(params.targetPath)) {
-    throw new Error(`${params.label} must be an absolute path.`);
-  }
-
-  let effectivePath = params.targetPath;
-  let stat = await readFileStatOrThrow(effectivePath, params.label);
-  if (stat.isSymlink) {
-    if (!params.allowSymlinkPath) {
-      throw new Error(`${params.label} must not be a symlink: ${effectivePath}`);
-    }
-    try {
-      effectivePath = await fs.realpath(effectivePath);
-    } catch {
-      throw new Error(`${params.label} symlink target is not readable: ${params.targetPath}`);
-    }
-    if (!isAbsolutePathname(effectivePath)) {
-      throw new Error(`${params.label} resolved symlink target must be an absolute path.`);
-    }
-    stat = await readFileStatOrThrow(effectivePath, params.label);
-    if (stat.isSymlink) {
-      throw new Error(`${params.label} symlink target must not be a symlink: ${effectivePath}`);
-    }
-  }
-
-  if (params.trustedDirs && params.trustedDirs.length > 0) {
-    const trusted = params.trustedDirs.map((entry) => resolveUserPath(entry));
-    const inTrustedDir = trusted.some((dir) => isPathInside(dir, effectivePath));
-    if (!inTrustedDir) {
-      throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
-    }
-  }
-  const perms = await inspectPathPermissions(effectivePath);
-  if (!perms.ok) {
-    throw new Error(`${params.label} permissions could not be verified: ${effectivePath}`);
-  }
-  const writableByOthers = perms.worldWritable || perms.groupWritable;
-  const readableByOthers = perms.worldReadable || perms.groupReadable;
-  if (writableByOthers || (!params.allowReadableByOthers && readableByOthers)) {
-    throw new Error(`${params.label} permissions are too open: ${effectivePath}`);
-  }
-
-  if (process.platform === "win32" && perms.source === "unknown") {
-    throw new FsSafeError(
-      "permission-unverified",
-      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Move the command to a path whose ACLs OpenClaw can verify; there is no provider-level bypass.`,
-    );
-  }
-
-  if (process.platform !== "win32" && typeof process.getuid === "function" && stat.uid != null) {
-    const uid = process.getuid();
-    if (stat.uid !== uid) {
-      throw new Error(
-        `${params.label} must be owned by the current user (uid=${uid}): ${effectivePath}`,
-      );
-    }
-  }
-  return effectivePath;
 }
 
 async function readFileProviderPayload(params: {
@@ -525,15 +436,12 @@ async function resolveExecRefs(params: {
     });
   }
 
-  const commandPath = resolveUserPath(params.providerConfig.command);
   let secureCommandPath: string;
   try {
-    secureCommandPath = await assertSecurePath({
-      targetPath: commandPath,
+    secureCommandPath = await assertSecureExecCommandPath({
+      command: params.providerConfig.command,
       label: `secrets.providers.${params.providerName}.command`,
       trustedDirs: params.providerConfig.trustedDirs,
-      allowReadableByOthers: true,
-      allowSymlinkPath: false,
     });
   } catch (err) {
     throwUnknownProviderResolutionError({


### PR DESCRIPTION
Closes #117051

## What Problem This Solves

`openclaw config validate` could accept a manual exec SecretRef command that startup later rejected because its path was missing, symlinked, writable by others, or not owned by the current user. James Churchill reported a symlinked command passing validation before a failed restart.

## Why This Change Was Made

Share the existing startup command-path trust check with config acceptance. The validator does not execute the provider and does not tighten startup policy.

The maintainer pass also removes the structures that let validation drift:

- `config set`, `config patch`, and `config unset` use one mutation runner for preflight, validation, persistence, and apply hints. The maintainer refactor removed the duplicate unset flow; while proof ran, #131369 independently landed that consolidation for agent-roster edits. The rebased change uses its canonical `appliedOperations`, preserving roster normalization and write topology.
- Patch deletions use the same operation constructor as `unset`, preserving provider and SecretRef metadata. A patch that deletes a provider subfield can no longer bypass preflight.
- One provider collector handles existing plugin-integration materialization checks and manual exec path checks. It produces ordinary config issues, so `config validate --json` retains its established failure envelope and `{path, message}` issue objects.
- The extracted startup validator drops obsolete symlink/readability switches, a one-use helper, and a redundant absolute-path predicate after path normalization. Windows permission failures keep their typed diagnostic.
- Tests consolidate repeated fixtures and cases, replace copied Node binaries with small files where nothing executes, and make the Windows ACL-unavailable test deterministic on Windows too.

## User Impact

Explicit `config validate` checks every configured manual exec provider, including inactive providers. This is intentionally stricter than startup's active-surface selection. Targeted writes and dry runs check providers changed or referenced by the operation; replacing the provider collection checks every remaining provider. Unrelated dormant providers do not block repairs, and removing a broken provider remains possible.

Run validation on the Gateway host: it inspects that host's filesystem. These are path trust checks, not a guarantee that a command can execute or return a valid secret. Startup checks again before execution. No config keys, environment options, manifest fields, or CLI flags were added. Plugin-integration materialized-command policy is unchanged.

## Evidence

Validation ran on an isolated, secretless Linux AWS Crabbox, with a fresh temporary HOME, public networking, no Tailscale, no instance profile, and a verified IMDS credential absence. No contributor code ran on the maintainer host.

- Original PR: 269 focused tests passed.
- Added regressions against original head `aef72f1052cece19a472e8fd6495c4816d1c93f2`: three expected failures proved the malformed validation JSON and both normal/dry patch-deletion bypasses.
- Before rebase, the refactored candidate passed 293 tests across `src/cli/config-cli.test.ts`, `src/secrets/exec-provider-path-validation.test.ts`, `src/secrets/resolve.test.ts`, and `src/secrets/provider-integrations.test.ts`.
- Real CLI via `node --import ./scripts/tsx.mjs src/entry.ts config ...`: unsafe JSON validation exited 1 with structured issues; deleting `trustedDirs` via patch exited 1 and left the file unchanged; safe-path validation exited 0; removing the broken provider exited 0. The provider execution marker stayed absent in every case.
- Rebased head `f7ffd235efef9e81952fc710736bc3f36f1931d8`: 312 tests passed, adding `src/cli/config-cli.integration.test.ts` to the focused suite. All four real CLI scenarios passed again (AWS `run_be3ad1fcbad6`).
- Fresh Codex autoreview passed with no actionable findings at the helper's default P0 threshold; manual review and independent evidence inspection additionally covered the concrete JSON, deletion, and Windows-test defects.

Focused command: `pnpm test src/cli/config-cli.test.ts src/secrets/resolve.test.ts src/secrets/exec-provider-path-validation.test.ts src/secrets/provider-integrations.test.ts`.

Production/test type checks and the complete changed-surface guard suite passed before rebase (AWS `run_67121eb28381`) and again on the rebased head (AWS `run_be3ad1fcbad6`), including lint, formatting, assertion safety, dead exports, plugin boundaries, storage rules, and runtime imports. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33144134891) completed successfully for `f7ffd235efef9e81952fc710736bc3f36f1931d8`. Windows live CLI and macOS ownership edge cases were not exercised; Windows receipt behavior is covered by deterministic tests, and existing startup policy is preserved.

Final diff against refreshed main: production +135/-168 (net -33); tests +563/-66 (net +497); docs +17/-5. Before the mainline overlap was absorbed, the maintainer pass reduced the incoming PR by 260 net production lines and 98 test lines. No assertion-baseline change remains because main already contains that shrink.

Best-fix verdict: shared startup policy plus one mutation flow. Separate command-specific guards were rejected because they already missed ordinary unset and patch deletions. A schema-only fix cannot perform these asynchronous filesystem checks. Tightening executable/Windows ownership policy is separate from this parity repair.

ClawSweeper rank-up move retained: strict all-provider manual-exec validation is documented; targeted writes preserve inactive-provider recovery. The latest review's production-growth risk is resolved by the refactor.

Thanks @SunnyShu0925 for the original fix and @jamesachurchill for the report.
