### PR TITLE
fix(models): reuse prepared plugin metadata

### DIFF
--- a/src/agents/agent-model-discovery.ts
+++ b/src/agents/agent-model-discovery.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
+import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
 import { normalizeModelCompat } from "../plugins/provider-model-compat.js";
 import {
   applyProviderResolvedTransportWithPlugin,
@@ -44,6 +45,10 @@ type DiscoverModelsOptions = {
   normalizeModels?: boolean;
 };
 
+type NormalizeDiscoveredModelOptions = Pick<DiscoverModelsOptions, "config" | "workspaceDir"> & {
+  providerMetadataOwners?: PluginMetadataSnapshotOwnerMaps;
+};
+
 type DiscoverCapturedModelsOptions = Omit<
   DiscoverModelsOptions,
   "modelsJsonContents" | "normalizeModels" | "pluginCatalogs"
@@ -56,7 +61,7 @@ type DiscoverCapturedModelsOptions = Omit<
 export function normalizeDiscoveredAgentModel<T>(
   value: T,
   agentDir: string,
-  options?: Pick<DiscoverModelsOptions, "config" | "workspaceDir">,
+  options?: NormalizeDiscoveredModelOptions,
 ): T {
   if (!isRecord(value)) {
     return value;
@@ -106,7 +111,7 @@ export function normalizeDiscoveredAgentModel<T>(
   ) {
     return value;
   }
-  return normalizeModelCompat(transportNormalized as Model) as T;
+  return normalizeModelCompat(transportNormalized as Model, options?.providerMetadataOwners) as T;
 }
 
 function createOpenClawModelRegistry(
@@ -151,7 +156,12 @@ function createOpenClawModelRegistry(
     if (!agentDir) {
       throw new Error("agent directory is required for model normalization");
     }
-    return normalizeDiscoveredAgentModel(entry, agentDir, options);
+    return normalizeDiscoveredAgentModel(entry, agentDir, {
+      ...options,
+      ...(pluginMetadataSnapshot?.owners
+        ? { providerMetadataOwners: pluginMetadataSnapshot.owners }
+        : {}),
+    });
   };
 
   registry.getAll = () => {

--- a/src/agents/prepared-model-registry.test.ts
+++ b/src/agents/prepared-model-registry.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
 
 const mocks = vi.hoisted(() => {
   class OwnerNotPublishedError extends Error {}
@@ -53,6 +54,9 @@ function createSnapshot(
     fork: vi.fn(),
     getAll: vi.fn(() => models),
     getAvailable: vi.fn(() => models),
+    getProviderMetadataOwners: vi.fn<() => PluginMetadataSnapshotOwnerMaps | undefined>(
+      () => undefined,
+    ),
     find: vi.fn((provider: string, id: string) =>
       models.find((model) => model.provider === provider && model.id === id),
     ),
@@ -165,6 +169,31 @@ describe("prepared agent model registry", () => {
     expect(normalized).toMatchObject({ provider: "openai", id: "gpt-test" });
     expect(loaded.registry.find("openai", "gpt-test")).toBe(normalized);
     expect(rawFind).toHaveBeenCalledWith("openai", "gpt-test");
+  });
+
+  it("normalizes with the registry's exact plugin metadata generation", async () => {
+    const { registry, snapshot } = createSnapshot();
+    const providerMetadataOwners = {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    };
+    registry.getProviderMetadataOwners.mockReturnValue(providerMetadataOwners);
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+
+    const loaded = await loadPreparedAgentModelRegistry({});
+    loaded.registry.getAll();
+
+    expect(mocks.normalizeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "gpt-test" }),
+      "/agents/main",
+      expect.objectContaining({ providerMetadataOwners }),
+    );
   });
 
   it("prepares a distinct credential-free lifecycle owner", async () => {

--- a/src/agents/prepared-model-registry.ts
+++ b/src/agents/prepared-model-registry.ts
@@ -48,10 +48,12 @@ function createRegistryView(params: {
   const matchesProviderFilter = (entry: Model) =>
     !providerFilter || normalizeProviderId(entry.provider) === providerFilter;
   const shouldNormalize = params.normalizeModels !== false;
+  const providerMetadataOwners = registry.getProviderMetadataOwners();
   const normalizeEntry = (entry: Model) =>
     shouldNormalize
       ? normalizeDiscoveredAgentModel(entry, params.agentDir, {
           config: params.config,
+          ...(providerMetadataOwners ? { providerMetadataOwners } : {}),
           ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
         })
       : entry;

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -165,6 +165,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot,
 }));
 
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import {
   resolveProviderEndpoint,
   resolveProviderRequestCapabilities,
@@ -206,6 +207,7 @@ describe("provider attribution", () => {
     providerMetadataState.pluginIdScoped = false;
     providerMetadataState.snapshot = undefined;
     loadPluginMetadataSnapshot.mockClear();
+    clearPluginMetadataLifecycleCaches();
   });
 
   it("uses provider facts from the replacement plugin snapshot after reload", () => {
@@ -285,6 +287,20 @@ describe("provider attribution", () => {
       ).toBe("custom");
     }
     expect(loadPluginMetadataSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("scans plugin metadata once when falling back without a lifecycle snapshot", () => {
+    providerMetadataState.pluginIdScoped = true;
+    providerMetadataState.snapshot = undefined;
+
+    for (let index = 0; index < 10; index += 1) {
+      resolveProviderRequestPolicy({ provider: "fallback-provider" });
+    }
+    expect(loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+
+    clearPluginMetadataLifecycleCaches();
+    resolveProviderRequestPolicy({ provider: "fallback-provider" });
+    expect(loadPluginMetadataSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it("uses explicitly prepared provider facts without reading process metadata", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -8,6 +8,7 @@ import type {
   PluginManifestProviderEndpoint,
   PluginManifestProviderRequestProvider,
 } from "../plugins/manifest.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import { normalizePluginProviderBaseUrl } from "../plugins/plugin-metadata-provider-facts.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -179,6 +180,28 @@ type ProviderMetadataOwners = {
   providerRequests: ReadonlyMap<string, PluginManifestProviderRequestProvider>;
 };
 
+let fallbackProviderMetadataOwnersMemo: ProviderMetadataOwners | undefined;
+
+function clearFallbackProviderMetadataOwnersMemo(): void {
+  fallbackProviderMetadataOwnersMemo = undefined;
+}
+
+// This input-free fallback is process-stable until plugin metadata lifecycle reset.
+// Without the memo, model catalog normalization rescans every manifest per model.
+registerPluginMetadataProcessMemoLifecycleClear(clearFallbackProviderMetadataOwnersMemo);
+
+function resolveFallbackProviderMetadataOwners(): ProviderMetadataOwners {
+  if (fallbackProviderMetadataOwnersMemo) {
+    return fallbackProviderMetadataOwnersMemo;
+  }
+  const fallback = loadPluginMetadataSnapshot({ config: {} }).owners;
+  fallbackProviderMetadataOwnersMemo = {
+    providerEndpoints: fallback.providerEndpoints ?? [],
+    providerRequests: fallback.providerRequests ?? new Map(),
+  };
+  return fallbackProviderMetadataOwnersMemo;
+}
+
 function resolveProviderMetadataOwners(
   prepared?: PluginMetadataSnapshotOwnerMaps,
 ): ProviderMetadataOwners {
@@ -197,11 +220,7 @@ function resolveProviderMetadataOwners(
       providerRequests: current.owners?.providerRequests ?? new Map(),
     };
   }
-  const fallback = loadPluginMetadataSnapshot({ config: {} }).owners;
-  return {
-    providerEndpoints: fallback.providerEndpoints ?? [],
-    providerRequests: fallback.providerRequests ?? new Map(),
-  };
+  return resolveFallbackProviderMetadataOwners();
 }
 
 function resolveManifestProviderRequest(params: {

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -7,6 +7,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
 
 const applyPluginAutoEnableMock = vi.hoisted(() =>
   vi.fn((params: { config?: OpenClawConfig }) => ({
@@ -55,6 +56,44 @@ describe("resolveBundledPluginCompatibleActivationInputs", () => {
       config: { plugins: { allow: ["openai"] } },
       env: process.env,
       manifestRegistry,
+    });
+  });
+
+  it("uses the caller's exact metadata generation across lifecycle replacement", () => {
+    const firstManifestRegistry = makeRegistry([
+      { id: "first", channels: [], providers: ["first"] },
+    ]);
+    const secondManifestRegistry = makeRegistry([
+      { id: "second", channels: [], providers: ["second"] },
+    ]);
+    const firstDiscovery = { plugins: [], diagnostics: [] } as unknown as PluginDiscoveryResult;
+    const secondDiscovery = { plugins: [], diagnostics: [] } as unknown as PluginDiscoveryResult;
+
+    for (const [manifestRegistry, discovery] of [
+      [firstManifestRegistry, firstDiscovery],
+      [secondManifestRegistry, secondDiscovery],
+    ] as const) {
+      resolveBundledPluginCompatibleActivationInputs({
+        rawConfig: { plugins: { allow: [manifestRegistry.plugins[0]!.id] } },
+        manifestRegistry,
+        discovery,
+        applyAutoEnable: true,
+        compatMode: {},
+        resolveCompatPluginIds: () => [],
+      });
+    }
+
+    expect(applyPluginAutoEnableMock).toHaveBeenNthCalledWith(1, {
+      config: { plugins: { allow: ["first"] } },
+      env: process.env,
+      manifestRegistry: firstManifestRegistry,
+      discovery: firstDiscovery,
+    });
+    expect(applyPluginAutoEnableMock).toHaveBeenNthCalledWith(2, {
+      config: { plugins: { allow: ["second"] } },
+      env: process.env,
+      manifestRegistry: secondManifestRegistry,
+      discovery: secondDiscovery,
     });
   });
 });

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -13,6 +13,7 @@ import {
 } from "./config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 
 type PluginActivationCompatConfig = {
   enablementPluginIds?: readonly string[];
@@ -58,6 +59,7 @@ type BundledPluginCompatibleActivationParams = {
     onlyPluginIds?: readonly string[];
   }) => string[];
   discovery?: PluginDiscoveryResult;
+  manifestRegistry?: PluginManifestRegistry;
 };
 
 export function withActivatedPluginIds(params: {
@@ -147,15 +149,18 @@ function applyPluginAutoEnableForActivation(params: {
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;
   discovery?: PluginDiscoveryResult;
+  manifestRegistry?: PluginManifestRegistry;
 }) {
-  const currentSnapshot = getCurrentPluginMetadataSnapshot({
-    config: params.config,
-    env: params.env,
-    workspaceDir: params.workspaceDir,
-    allowWorkspaceScopedSnapshot: true,
-  });
+  const currentSnapshot = params.manifestRegistry
+    ? undefined
+    : getCurrentPluginMetadataSnapshot({
+        config: params.config,
+        env: params.env,
+        workspaceDir: params.workspaceDir,
+        allowWorkspaceScopedSnapshot: true,
+      });
   const defaultDiscoverySnapshot =
-    normalizePluginsConfig(params.config.plugins).loadPaths.length === 0
+    !params.manifestRegistry && normalizePluginsConfig(params.config.plugins).loadPaths.length === 0
       ? getCurrentPluginMetadataSnapshot({
           env: params.env,
           workspaceDir: params.workspaceDir,
@@ -164,12 +169,15 @@ function applyPluginAutoEnableForActivation(params: {
         })
       : undefined;
   const currentManifestRegistry =
-    currentSnapshot?.manifestRegistry ?? defaultDiscoverySnapshot?.manifestRegistry;
+    params.manifestRegistry ??
+    currentSnapshot?.manifestRegistry ??
+    defaultDiscoverySnapshot?.manifestRegistry;
   return applyPluginAutoEnable({
     config: params.config,
     env: params.env,
     manifestRegistry: currentManifestRegistry,
-    discovery: params.discovery,
+    discovery:
+      params.discovery ?? currentSnapshot?.discovery ?? defaultDiscoverySnapshot?.discovery,
   });
 }
 
@@ -181,6 +189,7 @@ function resolvePluginActivationSnapshot(params: {
   workspaceDir?: string;
   applyAutoEnable?: boolean;
   discovery?: PluginDiscoveryResult;
+  manifestRegistry?: PluginManifestRegistry;
 }): PluginActivationInputs {
   const env = params.env ?? process.env;
   const rawConfig = params.rawConfig ?? params.resolvedConfig;
@@ -193,6 +202,7 @@ function resolvePluginActivationSnapshot(params: {
       env,
       workspaceDir: params.workspaceDir,
       discovery: params.discovery,
+      manifestRegistry: params.manifestRegistry,
     });
     resolvedConfig = autoEnabled.config;
     autoEnabledReasons = autoEnabled.autoEnabledReasons;
@@ -219,6 +229,7 @@ function resolvePluginActivationInputs(params: {
   compat?: PluginActivationCompatConfig;
   applyAutoEnable?: boolean;
   discovery?: PluginDiscoveryResult;
+  manifestRegistry?: PluginManifestRegistry;
 }): PluginActivationInputs {
   const env = params.env ?? process.env;
   const snapshot = resolvePluginActivationSnapshot({
@@ -229,6 +240,7 @@ function resolvePluginActivationInputs(params: {
     workspaceDir: params.workspaceDir,
     applyAutoEnable: params.applyAutoEnable,
     discovery: params.discovery,
+    manifestRegistry: params.manifestRegistry,
   });
   const config = applyPluginCompatibilityOverrides({
     config: snapshot.config,
@@ -257,6 +269,7 @@ export function resolveBundledPluginCompatibleActivationInputs(
     workspaceDir: params.workspaceDir,
     applyAutoEnable: params.applyAutoEnable,
     discovery: params.discovery,
+    manifestRegistry: params.manifestRegistry,
   });
   const shouldResolveCompatPluginIds = shouldResolveBundledCompatPluginIds({
     compatMode: params.compatMode,
@@ -280,6 +293,7 @@ export function resolveBundledPluginCompatibleActivationInputs(
       compatPluginIds,
     }),
     discovery: params.discovery,
+    manifestRegistry: params.manifestRegistry,
   });
 
   return {
@@ -302,6 +316,7 @@ export function resolveBundledPluginCompatibleLoadValues(
       env,
       workspaceDir: params.workspaceDir,
       discovery: params.discovery,
+      manifestRegistry: params.manifestRegistry,
     });
     resolvedConfig = autoEnabled.config;
     autoEnabledReasons = autoEnabled.autoEnabledReasons;

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -63,7 +63,10 @@ export type PluginMetadataSnapshot = {
   discovery?: PluginDiscoveryResult;
 };
 
-export type PluginMetadataRegistryView = Pick<PluginMetadataSnapshot, "index" | "manifestRegistry">;
+export type PluginMetadataRegistryView = Pick<
+  PluginMetadataSnapshot,
+  "index" | "manifestRegistry" | "discovery"
+>;
 
 export type PluginMetadataManifestView = Pick<PluginMetadataSnapshot, "index" | "plugins">;
 

--- a/src/plugins/provider-model-compat.prepared.test.ts
+++ b/src/plugins/provider-model-compat.prepared.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachModelProviderMetadataOwners } from "../agents/provider-request-config.js";
+import type { Model } from "../llm/types.js";
+import type { PluginMetadataSnapshotOwnerMaps } from "./plugin-metadata-snapshot.types.js";
+
+const resolveProviderRequestCapabilities = vi.hoisted(() =>
+  vi.fn(() => ({
+    supportsDeveloperRole: false,
+    supportsUsageInStreaming: false,
+    supportsStrictMode: false,
+  })),
+);
+
+vi.mock("../agents/provider-attribution.js", () => ({
+  resolveProviderRequestCapabilities,
+}));
+
+vi.mock("@openclaw/ai/transports", () => ({
+  resolveOpenAICompletionsCompat: (
+    model: Model,
+    resolveCapabilities: (input: Model) => {
+      supportsDeveloperRole: boolean;
+      supportsUsageInStreaming: boolean;
+      supportsStrictMode: boolean;
+    },
+  ) => resolveCapabilities(model),
+}));
+
+import { normalizeModelCompat } from "./provider-model-compat.js";
+
+function makeOwners(provider: string): PluginMetadataSnapshotOwnerMaps {
+  return {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map([[provider, [provider]]]),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  };
+}
+
+const model = {
+  id: "model",
+  name: "Model",
+  provider: "custom",
+  api: "openai-completions",
+  baseUrl: "https://models.example/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 8_192,
+} as Model;
+
+describe("normalizeModelCompat prepared metadata", () => {
+  it("uses the exact owner generation supplied by its registry", () => {
+    const firstOwners = makeOwners("first");
+    const secondOwners = makeOwners("second");
+
+    normalizeModelCompat(attachModelProviderMetadataOwners(model, firstOwners));
+    normalizeModelCompat(attachModelProviderMetadataOwners(model, secondOwners));
+
+    expect(resolveProviderRequestCapabilities).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ providerMetadataOwners: firstOwners }),
+    );
+    expect(resolveProviderRequestCapabilities).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ providerMetadataOwners: secondOwners }),
+    );
+  });
+});

--- a/src/plugins/provider-model-compat.ts
+++ b/src/plugins/provider-model-compat.ts
@@ -2,9 +2,11 @@
 import { resolveUnsupportedToolSchemaKeywords } from "@openclaw/ai/internal/openai";
 import { resolveOpenAICompletionsCompat } from "@openclaw/ai/transports";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
+import { getModelProviderMetadataOwners } from "../agents/provider-request-config.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import "../llm/ai-transport-host.js";
 import type { Model } from "../llm/types.js";
+import type { PluginMetadataSnapshotOwnerMaps } from "./plugin-metadata-snapshot.types.js";
 
 export function extractModelCompat(
   modelOrCompat: { compat?: unknown } | ModelCompatConfig | undefined,
@@ -67,7 +69,10 @@ function normalizeAnthropicBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/v1\/?$/, "");
 }
 
-export function normalizeModelCompat(model: Model): Model {
+export function normalizeModelCompat(
+  model: Model,
+  providerMetadataOwners?: PluginMetadataSnapshotOwnerMaps,
+): Model {
   const baseUrl = model.baseUrl ?? "";
 
   if (isAnthropicMessagesModel(model) && baseUrl) {
@@ -85,7 +90,16 @@ export function normalizeModelCompat(model: Model): Model {
   if (!baseUrl) {
     return model;
   }
-  const resolved = resolveOpenAICompletionsCompat(model, resolveProviderRequestCapabilities);
+  const resolvedProviderMetadataOwners =
+    providerMetadataOwners ?? getModelProviderMetadataOwners(model);
+  const resolved = resolveOpenAICompletionsCompat(model, (input) =>
+    resolveProviderRequestCapabilities({
+      ...input,
+      ...(resolvedProviderMetadataOwners
+        ? { providerMetadataOwners: resolvedProviderMetadataOwners }
+        : {}),
+    }),
+  );
   if (
     resolved.supportsDeveloperRole &&
     resolved.supportsUsageInStreaming &&

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -254,6 +254,8 @@ function resolveRuntimeProviderPluginLoadState(
     workspaceDir: base.workspaceDir,
     onlyPluginIds: runtimeRequestedPluginIds,
     applyAutoEnable: params.applyAutoEnable ?? true,
+    discovery: snapshot.discovery,
+    manifestRegistry: snapshot.manifestRegistry,
     compatMode: {
       vitest: params.bundledProviderVitestCompat,
     },


### PR DESCRIPTION
Closes #117130

## What Problem This Solves

`models list` already loads one plugin metadata snapshot, but provider resolution dropped its manifest registry and discovery before bundled-plugin activation. Model compatibility normalization also dropped the model registry's exact provider-owner generation. Those losses forced per-model metadata discovery. The remaining input-free attribution fallback had no prepared fact to consume and rescanned the same process-stable metadata.

On a 3,000-model catalog the reported command performed 6,124 completed `plugins.metadata.scan` spans and took 99.1 seconds in the contributor's isolated packaged benchmark.

## Why This Change Was Made

- carry the prepared manifest registry and discovery through provider activation
- carry exact provider-owner maps through model discovery, prepared registries, and compatibility normalization
- consume the canonical attached owner map when a model already carries one
- retain one bounded process memo only for the unavoidable input-free attribution fallback
- clear that memo through the existing plugin-metadata lifecycle reset
- avoid the previous config/env identity cache and its stale-generation risk

This keeps metadata ownership at the plugin lifecycle boundary and makes the hot path consume prepared facts instead of rediscovering them.

## Evidence

Representative `models list --plain` run with 3,000 configured models:

| build | output | completed `plugins.metadata.scan` spans |
| --- | ---: | ---: |
| reported before fix | 3,000 models | 6,124 |
| rewritten branch | 3,008 lines | 23 |

That is 6,124 -> 23 scans, a 99.6% reduction (about 266x fewer scans).

The contributor's isolated packaged benchmark measured 99.1s -> 12.3s. I did not claim an independent Testbox wall-time comparison: the source checkout resolves official external plugins from workspace TypeScript trees, where each scan costs several seconds and dominates wall time. The diagnostic span count is the stable invariant for this regression.

Validation:

- final focused lifecycle/runtime/prepared-registry suite: 120/120 passed
- previous production rewrite changed gate: exit 0 on Blacksmith Testbox
- exact head: `f7de523101af001370e06458d680bf90dbffc9d0`
- exact tree: `1d05e67b6d59e404e089c2423d3be18beef49f54`
- frozen base: `02419ed1998feeaeaca21a92de7d23e805742f13`
- signed commit verified with Vincent Koc's ED25519 key
- packaged build completed during benchmark preparation
- `git diff --check`: clean
- formatting: all touched files clean
- full source clone integrity: `git fsck --no-dangling` clean

Testbox run: https://github.com/openclaw/openclaw/actions/runs/30687803223
Focused run: https://github.com/openclaw/openclaw/actions/runs/30687373568

The final exact-head GitHub matrix is running. A prior exact-head `check-test-types` failure exposed an under-typed test double; the mock now explicitly carries `PluginMetadataSnapshotOwnerMaps | undefined`, and the focused contract suite is green.

## Scope

Production: +85/-20, net +65. Tests: +158. Total: +243/-20.

The production growth is the explicit prepared-fact plumbing plus the lifecycle-owned fallback memo. It replaces per-model rediscovery without adding a second config/env cache or fallback stack.

Co-authored-by: Sasan Sotoodehfar <sasan1200@gmail.com>
