### PR TITLE
fix(gateway): honor canonical If-Modified-Since validators

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -250,6 +250,7 @@ describe("handleControlUiHttpRequest", () => {
     basePath?: string;
     auth?: ResolvedGatewayAuth;
     headers?: IncomingMessage["headers"];
+    distinctHeaders?: IncomingMessage["headersDistinct"];
     trustedProxies?: string[];
     remoteAddress?: string;
   }) {
@@ -259,6 +260,14 @@ describe("handleControlUiHttpRequest", () => {
         url: params.url,
         method: params.method,
         headers: params.headers ?? {},
+        headersDistinct:
+          params.distinctHeaders ??
+          Object.fromEntries(
+            Object.entries(params.headers ?? {}).map(([name, value]) => [
+              name,
+              Array.isArray(value) ? value : [String(value)],
+            ]),
+          ),
         socket: { remoteAddress: params.remoteAddress ?? "127.0.0.1" },
       } as IncomingMessage,
       res,
@@ -600,6 +609,74 @@ describe("handleControlUiHttpRequest", () => {
             expect.anything(),
           );
           expect(conditional.end).toHaveBeenCalledWith();
+        },
+      });
+    },
+  );
+
+  it.each(["GET", "HEAD"] as const)(
+    "revalidates assistant media with If-Modified-Since before ranges for %s",
+    async (method) => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-modified-since-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "photo.png");
+          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
+          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
+          const lastModified = initial.setHeader.mock.calls.find(
+            ([name]) => name === "Last-Modified",
+          )?.[1];
+          expect(lastModified).toEqual(expect.any(String));
+
+          const unchanged = await runAssistantMediaRequest({
+            url,
+            method,
+            auth,
+            headers: {
+              "if-modified-since": String(lastModified),
+              range: "bytes=0-3",
+              "if-range": '"stale"',
+            },
+          });
+
+          expect(unchanged.res.statusCode).toBe(304);
+          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+          expect(unchanged.setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
+          expect(unchanged.end).toHaveBeenCalledWith();
+        },
+      });
+    },
+  );
+
+  it.each(["GET", "HEAD"] as const)(
+    "ignores duplicate assistant-media dates discarded by normalized Node headers for %s",
+    async (method) => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-duplicate-modified-since-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "photo.png");
+          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
+          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
+          const lastModified = String(
+            initial.setHeader.mock.calls.find(([name]) => name === "Last-Modified")?.[1],
+          );
+
+          const duplicate = await runAssistantMediaRequest({
+            url,
+            method,
+            auth,
+            headers: { "if-modified-since": lastModified },
+            distinctHeaders: {
+              "if-modified-since": [lastModified, "not-an-http-date"],
+            },
+          });
+
+          expect(duplicate.res.statusCode).toBe(200);
+          expect(duplicate.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
         },
       });
     },

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -731,9 +731,7 @@ export async function handleControlUiAssistantMediaRequest(
     const byteResponse = resolveByteResponse({
       file: opened.stat,
       method: req.method,
-      rangeHeader: req.headers.range,
-      ifRangeHeader: req.headers["if-range"],
-      ifNoneMatchHeader: req.headers["if-none-match"],
+      request: req,
     });
     writeByteHeaders(res, byteResponse);
     await byteStream.pipe(byteResponse, req.method);

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import http, { type ServerResponse } from "node:http";
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -11,11 +11,36 @@ import {
 
 const FILE = { size: 10, mtimeMs: 1_752_000_000_123.5 };
 const LAST_MODIFIED = new Date(FILE.mtimeMs).toUTCString();
+const HTTP_DATE_VARIANTS = [
+  { label: "IMF-fixdate", value: LAST_MODIFIED },
+  { label: "obsolete RFC 850", value: "Tuesday, 08-Jul-25 18:40:00 GMT" },
+  { label: "ANSI C asctime", value: "Tue Jul  8 18:40:00 2025" },
+] as const;
+
+function createByteRequest(
+  headers: Record<string, string | string[] | undefined>,
+): Pick<IncomingMessage, "headers" | "headersDistinct"> {
+  const entries = Object.entries(headers).flatMap(([name, value]) =>
+    value === undefined ? [] : [[name, value] as const],
+  );
+  return {
+    headers: Object.fromEntries(
+      entries.map(([name, value]) => [name, Array.isArray(value) ? value.join(", ") : value]),
+    ),
+    headersDistinct: Object.fromEntries(
+      entries.map(([name, value]) => [name, Array.isArray(value) ? value : [value]]),
+    ),
+  };
+}
 
 describe("resolveByteResponse", () => {
   it("resolves an open-ended range", () => {
     expect(
-      resolveByteResponse({ file: FILE, method: "GET", rangeHeader: "bytes=4-" }),
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=4-" }),
+      }),
     ).toMatchObject({
       kind: "partial",
       statusCode: 206,
@@ -26,7 +51,11 @@ describe("resolveByteResponse", () => {
 
   it("resolves a suffix range", () => {
     expect(
-      resolveByteResponse({ file: FILE, method: "GET", rangeHeader: "bytes=-3" }),
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=-3" }),
+      }),
     ).toMatchObject({
       kind: "partial",
       statusCode: 206,
@@ -37,7 +66,11 @@ describe("resolveByteResponse", () => {
 
   it("resolves an exact range", () => {
     expect(
-      resolveByteResponse({ file: FILE, method: "GET", rangeHeader: "bytes=2-5" }),
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=2-5" }),
+      }),
     ).toMatchObject({
       kind: "partial",
       statusCode: 206,
@@ -47,7 +80,11 @@ describe("resolveByteResponse", () => {
   });
 
   it("returns 416 with the complete file size for an out-of-bounds range", () => {
-    const plan = resolveByteResponse({ file: FILE, method: "GET", rangeHeader: "bytes=10-20" });
+    const plan = resolveByteResponse({
+      file: FILE,
+      method: "GET",
+      request: createByteRequest({ range: "bytes=10-20" }),
+    });
     expect(plan).toMatchObject({
       kind: "unsatisfiable",
       statusCode: 416,
@@ -65,7 +102,13 @@ describe("resolveByteResponse", () => {
   it.each(["items=0-1", "bytes=broken", "bytes=0-1,4-5"])(
     "falls back to a full response for malformed or multipart range %s",
     (rangeHeader) => {
-      expect(resolveByteResponse({ file: FILE, method: "GET", rangeHeader })).toMatchObject({
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          method: "GET",
+          request: createByteRequest({ range: rangeHeader }),
+        }),
+      ).toMatchObject({
         kind: "full",
         statusCode: 200,
         contentLength: 10,
@@ -79,8 +122,7 @@ describe("resolveByteResponse", () => {
       resolveByteResponse({
         file: FILE,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: etag,
+        request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
       }),
     ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
   });
@@ -90,8 +132,7 @@ describe("resolveByteResponse", () => {
       resolveByteResponse({
         file: FILE,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: LAST_MODIFIED,
+        request: createByteRequest({ range: "bytes=1-2", "if-range": LAST_MODIFIED }),
       }),
     ).toMatchObject({
       kind: "partial",
@@ -108,7 +149,13 @@ describe("resolveByteResponse", () => {
     { label: "unsatisfiable", method: "GET", rangeHeader: "bytes=10-11", statusCode: 416 },
   ])("bounds a future file timestamp to the $label response origin", (params) => {
     const nowMs = FILE.mtimeMs - 60_000;
-    const plan = resolveByteResponse({ file: FILE, nowMs, ...params });
+    const { rangeHeader, ...rest } = params;
+    const plan = resolveByteResponse({
+      file: FILE,
+      nowMs,
+      ...rest,
+      request: createByteRequest({ range: rangeHeader }),
+    });
 
     expect(plan.statusCode).toBe(params.statusCode);
     expect(plan.lastModified).toBe(new Date(nowMs).toUTCString());
@@ -137,8 +184,7 @@ describe("resolveByteResponse", () => {
         file: FILE,
         nowMs,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: emittedLastModified,
+        request: createByteRequest({ range: "bytes=1-2", "if-range": emittedLastModified }),
       }),
     ).toMatchObject({ kind: "partial", statusCode: 206, lastModified: emittedLastModified });
     expect(
@@ -146,8 +192,7 @@ describe("resolveByteResponse", () => {
         file: FILE,
         nowMs,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: LAST_MODIFIED,
+        request: createByteRequest({ range: "bytes=1-2", "if-range": LAST_MODIFIED }),
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, lastModified: emittedLastModified });
   });
@@ -158,7 +203,14 @@ describe("resolveByteResponse", () => {
       const nowMs = FILE.mtimeMs - 60_000;
       const etag = resolveByteResponse({ file: FILE, nowMs }).etag;
 
-      expect(resolveByteResponse({ file: FILE, method, nowMs, ifNoneMatchHeader: etag })).toEqual({
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          method,
+          nowMs,
+          request: createByteRequest({ "if-none-match": etag }),
+        }),
+      ).toEqual({
         kind: "not-modified",
         statusCode: 304,
         etag,
@@ -166,6 +218,157 @@ describe("resolveByteResponse", () => {
       });
     },
   );
+
+  it.each(
+    HTTP_DATE_VARIANTS.flatMap(({ label, value }) =>
+      (["GET", "HEAD"] as const).map((method) => ({ label, value, method })),
+    ),
+  )("revalidates $method using a $label If-Modified-Since date", ({ value, method }) => {
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method,
+        request: createByteRequest({ "if-modified-since": value }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304, lastModified: LAST_MODIFIED });
+  });
+
+  it.each(["GET", "HEAD"] as const)(
+    "honors a later If-Modified-Since date before ranges for %s",
+    (method) => {
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          method,
+          request: createByteRequest({
+            "if-modified-since": new Date(Date.parse(LAST_MODIFIED) + 1_000).toUTCString(),
+            range: "bytes=1-2",
+            "if-range": '"stale"',
+          }),
+        }),
+      ).toMatchObject({ kind: "not-modified", statusCode: 304, lastModified: LAST_MODIFIED });
+    },
+  );
+
+  it.each(["GET", "HEAD"] as const)(
+    "compares If-Modified-Since against the future-clamped %s validator",
+    (method) => {
+      const nowMs = FILE.mtimeMs - 60_000;
+      const emittedLastModified = new Date(nowMs).toUTCString();
+
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          nowMs,
+          method,
+          request: createByteRequest({ "if-modified-since": emittedLastModified }),
+        }),
+      ).toMatchObject({ kind: "not-modified", statusCode: 304, lastModified: emittedLastModified });
+    },
+  );
+
+  it("interprets an obsolete RFC 850 year within the RFC's rolling 50-year window", () => {
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        nowMs: Date.UTC(2026, 0, 1),
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": "Sunday, 06-Nov-50 00:00:00 GMT" }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304 });
+  });
+
+  it("includes a leap second when applying the RFC 850 rolling-year boundary", () => {
+    expect(
+      resolveByteResponse({
+        file: { size: 10, mtimeMs: Date.UTC(1977, 0, 1) },
+        nowMs: Date.UTC(2026, 11, 31, 23, 59, 59),
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": "Friday, 31-Dec-76 23:59:60 GMT" }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304 });
+  });
+
+  it("accepts a valid HTTP-date leap second without JavaScript date normalization", () => {
+    expect(
+      resolveByteResponse({
+        file: { size: 10, mtimeMs: Date.UTC(2017, 0, 1) },
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": "Sat, 31 Dec 2016 23:59:60 GMT" }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304 });
+  });
+
+  it.each([
+    { label: "an ISO timestamp", value: new Date(FILE.mtimeMs).toISOString() },
+    { label: "the wrong timezone", value: LAST_MODIFIED.replace("GMT", "UTC") },
+    { label: "a lowercase weekday", value: LAST_MODIFIED.replace("Tue", "tue") },
+    { label: "the wrong calendar weekday", value: LAST_MODIFIED.replace("Tue", "Wed") },
+    { label: "a four-digit IMF year before 1900", value: "Tue, 08 Jul 0025 18:40:00 GMT" },
+    { label: "a four-digit asctime year before 1900", value: "Tue Jul  8 18:40:00 0025" },
+    { label: "a four-digit IMF year zero", value: "Tue, 08 Jul 0000 18:40:00 GMT" },
+    { label: "a four-digit asctime year zero", value: "Tue Jul  8 18:40:00 0000" },
+    { label: "a four-digit IMF year 0099", value: "Tue, 08 Jul 0099 18:40:00 GMT" },
+    { label: "a four-digit asctime year 0099", value: "Tue Jul  8 18:40:00 0099" },
+    { label: "a normalized invalid calendar day", value: "Tue, 32 Jul 2025 18:40:00 GMT" },
+    { label: "trailing content", value: `${LAST_MODIFIED} trailing` },
+    { label: "multiple date members", value: `${LAST_MODIFIED}, ${LAST_MODIFIED}` },
+    { label: "multiple header fields", value: [LAST_MODIFIED, LAST_MODIFIED] },
+  ])("ignores $label in If-Modified-Since", ({ value }) => {
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": value }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200 });
+  });
+
+  it.each(["", '"different"', ['"different"']] as Array<string | string[]>)(
+    "ignores If-Modified-Since whenever any If-None-Match field is present (%j)",
+    (ifNoneMatch) => {
+      expect(
+        resolveByteResponse({
+          file: FILE,
+          method: "GET",
+          request: createByteRequest({
+            "if-none-match": ifNoneMatch,
+            "if-modified-since": LAST_MODIFIED,
+          }),
+        }),
+      ).toMatchObject({ kind: "full", statusCode: 200 });
+    },
+  );
+
+  it("ignores duplicate singleton dates hidden by Node's normalized headers", () => {
+    const headers = { "if-modified-since": LAST_MODIFIED };
+
+    expect(
+      resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: {
+          headers,
+          headersDistinct: {
+            "if-modified-since": [
+              LAST_MODIFIED,
+              new Date(Date.parse(LAST_MODIFIED) - 1_000).toUTCString(),
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200 });
+  });
+
+  it("interprets asctime dates as UTC rather than the host's local timezone", () => {
+    expect(
+      resolveByteResponse({
+        file: { size: 10, mtimeMs: Date.UTC(1994, 10, 6, 12) },
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": "Sun Nov  6 08:49:37 1994" }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200 });
+  });
 
   it.each([
     {
@@ -196,8 +399,7 @@ describe("resolveByteResponse", () => {
       resolveByteResponse({
         file: FILE,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: header,
+        request: createByteRequest({ range: "bytes=1-2", "if-range": header }),
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
@@ -207,8 +409,7 @@ describe("resolveByteResponse", () => {
       resolveByteResponse({
         file: FILE,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: '"different"',
+        request: createByteRequest({ range: "bytes=1-2", "if-range": '"different"' }),
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
@@ -224,7 +425,7 @@ describe("resolveByteResponse", () => {
     const plan = resolveByteResponse({
       file: FILE,
       method: "GET",
-      ifNoneMatchHeader: header(etag),
+      request: createByteRequest({ "if-none-match": header(etag) }),
     });
 
     expect(plan).toEqual({
@@ -251,9 +452,11 @@ describe("resolveByteResponse", () => {
         resolveByteResponse({
           file: FILE,
           method,
-          rangeHeader: "bytes=1-2",
-          ifRangeHeader: '"stale"',
-          ifNoneMatchHeader: etag,
+          request: createByteRequest({
+            range: "bytes=1-2",
+            "if-range": '"stale"',
+            "if-none-match": etag,
+          }),
         }),
       ).toEqual({ kind: "not-modified", statusCode: 304, etag, lastModified: LAST_MODIFIED });
     },
@@ -266,9 +469,11 @@ describe("resolveByteResponse", () => {
       resolveByteResponse({
         file: FILE,
         method: "GET",
-        rangeHeader: "bytes=1-2",
-        ifRangeHeader: etag,
-        ifNoneMatchHeader: '"stale"',
+        request: createByteRequest({
+          range: "bytes=1-2",
+          "if-range": etag,
+          "if-none-match": '"stale"',
+        }),
       }),
     ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
   });
@@ -280,7 +485,11 @@ describe("resolveByteResponse", () => {
   ])(
     "emits the same Last-Modified validator on $label responses",
     ({ rangeHeader, statusCode }) => {
-      const plan = resolveByteResponse({ file: FILE, method: "GET", rangeHeader });
+      const plan = resolveByteResponse({
+        file: FILE,
+        method: "GET",
+        request: createByteRequest({ range: rangeHeader }),
+      });
       const setHeader = vi.fn();
       const res = { statusCode: 0, setHeader } as unknown as ServerResponse;
 

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -1,7 +1,18 @@
 import { createHash } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { matchesHttpIfNoneMatch } from "./http-conditional.js";
+
+const HTTP_DATE_MONTHS = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(" ");
+const HTTP_DATE_WEEKDAYS = "Sun Mon Tue Wed Thu Fri Sat".split(" ");
+const HTTP_DATE_FULL_WEEKDAYS = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(
+  " ",
+);
+const HTTP_DATE_PATTERNS = [
+  /^(?<weekday>Sun|Mon|Tue|Wed|Thu|Fri|Sat), (?<day>\d{2}) (?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?<year>\d{4}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) GMT$/,
+  /^(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), (?<day>\d{2})-(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(?<year>\d{2}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) GMT$/,
+  /^(?<weekday>Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?<day> \d|\d{2}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) (?<year>\d{4})$/,
+] as const;
 
 type FileIdentity = {
   size: number;
@@ -40,6 +51,69 @@ type ByteResponsePlan = {
       statusCode: 304;
     }
 );
+
+function parseConditionalHttpDate(value: string, nowMs: number): number | undefined {
+  const groups =
+    HTTP_DATE_PATTERNS[0].exec(value)?.groups ??
+    HTTP_DATE_PATTERNS[1].exec(value)?.groups ??
+    HTTP_DATE_PATTERNS[2].exec(value)?.groups;
+  if (!groups) {
+    return undefined;
+  }
+  const month = HTTP_DATE_MONTHS.indexOf(groups.month ?? "");
+  const weekdayName = groups.weekday ?? "";
+  const weekday =
+    weekdayName.length === 3
+      ? HTTP_DATE_WEEKDAYS.indexOf(weekdayName)
+      : HTTP_DATE_FULL_WEEKDAYS.indexOf(weekdayName);
+  let year = Number(groups.year);
+  const day = Number((groups.day ?? "").trim());
+  const hours = Number(groups.hours);
+  const minutes = Number(groups.minutes);
+  const seconds = Number(groups.seconds);
+  if (groups.year?.length === 2) {
+    const now = new Date(nowMs);
+    if (Number.isNaN(now.getTime())) {
+      return undefined;
+    }
+    year += Math.floor(now.getUTCFullYear() / 100) * 100;
+    const fiftyYearsFromNow = Date.UTC(
+      now.getUTCFullYear() + 50,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      now.getUTCHours(),
+      now.getUTCMinutes(),
+      now.getUTCSeconds(),
+      now.getUTCMilliseconds(),
+    );
+    // RFC 9110 places two-digit years over 50 years ahead in the previous century.
+    const candidate =
+      Date.UTC(year, month, day, hours, minutes, Math.min(seconds, 59)) +
+      (seconds === 60 ? 1_000 : 0);
+    if (candidate > fiftyYearsFromNow) {
+      year -= 100;
+    }
+  }
+  if (year < 1900 || hours > 23 || minutes > 59 || seconds > 60) {
+    return undefined;
+  }
+  // JavaScript Date cannot represent :60; validate :59 before advancing the leap second.
+  const calendarSecond = Math.min(seconds, 59);
+  const timestamp = Date.UTC(year, month, day, hours, minutes, calendarSecond);
+  const parsed = new Date(timestamp);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hours ||
+    parsed.getUTCMinutes() !== minutes ||
+    parsed.getUTCSeconds() !== calendarSecond ||
+    parsed.getUTCDay() !== weekday
+  ) {
+    return undefined;
+  }
+  return seconds === 60 ? timestamp + 1_000 : timestamp;
+}
 
 function createByteEtag(file: FileIdentity): string {
   // Gateway media files are write-once, so size + mtimeMs uniquely version their bytes here.
@@ -86,17 +160,27 @@ export function resolveByteResponse(params: {
   file: FileIdentity;
   nowMs?: number;
   method?: string;
-  rangeHeader?: string | string[];
-  ifRangeHeader?: string | string[];
-  ifNoneMatchHeader?: string | string[];
+  request?: Pick<IncomingMessage, "headers" | "headersDistinct">;
 }): ByteResponsePlan {
   const etag = createByteEtag(params.file);
   const originatedAtMs = params.nowMs ?? Date.now();
   // Filesystem clocks may lead this host; validators cannot postdate message origination.
-  const lastModified = new Date(Math.min(params.file.mtimeMs, originatedAtMs)).toUTCString();
+  const lastModifiedMs = Math.floor(Math.min(params.file.mtimeMs, originatedAtMs) / 1_000) * 1_000;
+  const lastModified = new Date(lastModifiedMs).toUTCString();
+  const headers = params.request?.headers;
+  const ifNoneMatch = headers?.["if-none-match"];
+  const ifModifiedSinceValues = params.request?.headersDistinct["if-modified-since"];
+  // Node drops duplicate singleton fields from headers; only the distinct list is authoritative.
+  const ifModifiedSince =
+    ifModifiedSinceValues?.length === 1 ? ifModifiedSinceValues[0] : undefined;
+  // Any If-None-Match field supersedes If-Modified-Since, even when no ETag matches.
   if (
     (params.method === "GET" || params.method === "HEAD") &&
-    matchesHttpIfNoneMatch(params.ifNoneMatchHeader, etag)
+    (matchesHttpIfNoneMatch(ifNoneMatch, etag) ||
+      (ifNoneMatch === undefined &&
+        typeof ifModifiedSince === "string" &&
+        (parseConditionalHttpDate(ifModifiedSince, originatedAtMs) ?? Number.NEGATIVE_INFINITY) >=
+          lastModifiedMs))
   ) {
     // RFC 9110 evaluates representation validators before Range or If-Range.
     return { kind: "not-modified", statusCode: 304, etag, lastModified };
@@ -108,19 +192,21 @@ export function resolveByteResponse(params: {
     etag,
     lastModified,
   } as const;
-  if (params.method !== "GET" || typeof params.rangeHeader !== "string") {
+  const rangeHeader = headers?.range;
+  if (params.method !== "GET" || typeof rangeHeader !== "string") {
     return full;
   }
+  const ifRangeHeader = headers?.["if-range"];
   if (
-    params.ifRangeHeader !== undefined &&
-    params.ifRangeHeader !== etag &&
+    ifRangeHeader !== undefined &&
+    ifRangeHeader !== etag &&
     // If-Range must exactly match the emitted HTTP-date; parsing accepts invalid lookalikes.
-    params.ifRangeHeader !== lastModified
+    ifRangeHeader !== lastModified
   ) {
     return full;
   }
 
-  const range = parseByteRange(params.rangeHeader, params.file.size);
+  const range = parseByteRange(rangeHeader, params.file.size);
   if (range === "invalid") {
     return full;
   }

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -218,7 +218,7 @@ async function requestManagedImage(params: {
   scopes?: string[];
   denyAuth?: boolean;
   authResponse?: Record<string, unknown>;
-  headers?: Record<string, string>;
+  headers?: http.ClientRequestArgs["headers"];
   transcriptMessages?: Record<string, unknown>[];
   sessionEntry?: { sessionId: string; sessionFile?: string };
   resolvedTranscriptPath?: string | null;
@@ -530,6 +530,61 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       expect(result.headers["content-length"]).toBeUndefined();
       expect(result.headers["content-range"]).toBeUndefined();
       expect(result.body).toHaveLength(0);
+    },
+  );
+
+  it.each(["GET", "HEAD"] as const)(
+    "revalidates managed media with If-Modified-Since before ranges for %s",
+    async (method) => {
+      const { attachmentId, sessionKey } = await createFixture(stateDir);
+      const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+      const request = { stateDir, pathName, authResponse: { authMethod: "token" } };
+      const initial = await requestManagedImage({ ...request, method: "HEAD" });
+      const lastModified = initial.result.headers["last-modified"];
+      expect(lastModified).toEqual(expect.any(String));
+
+      const unchanged = await requestManagedImage({
+        ...request,
+        method,
+        headers: {
+          "if-modified-since": String(lastModified),
+          range: "bytes=0-3",
+          "if-range": '"stale"',
+        },
+      });
+
+      expect(unchanged.result.statusCode).toBe(304);
+      expect(unchanged.result.headers["last-modified"]).toBe(lastModified);
+      expect(unchanged.result.headers["content-length"]).toBeUndefined();
+      expect(unchanged.result.headers["content-range"]).toBeUndefined();
+      expect(unchanged.result.body).toHaveLength(0);
+    },
+  );
+
+  it.each(["GET", "HEAD"] as const)(
+    "ignores duplicate managed-media dates discarded by normalized Node headers for %s",
+    async (method) => {
+      const { attachmentId, sessionKey } = await createFixture(stateDir);
+      const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+      const request = { stateDir, pathName, authResponse: { authMethod: "token" } };
+      const initial = await requestManagedImage({ ...request, method: "HEAD" });
+      const lastModified = String(initial.result.headers["last-modified"]);
+
+      const duplicate = await requestManagedImage({
+        ...request,
+        method,
+        headers: [
+          "Host",
+          "127.0.0.1",
+          "If-Modified-Since",
+          lastModified,
+          "iF-mOdIfIeD-sInCe",
+          "not-an-http-date",
+        ],
+      });
+
+      expect(duplicate.result.statusCode).toBe(200);
+      expect(duplicate.result.headers["last-modified"]).toBe(lastModified);
     },
   );
 

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1518,9 +1518,7 @@ export async function handleManagedOutgoingMediaHttpRequest(
   const byteResponse = resolveByteResponse({
     file: opened.stat,
     method: req.method,
-    rangeHeader: req.headers.range,
-    ifRangeHeader: req.headers["if-range"],
-    ifNoneMatchHeader: req.headers["if-none-match"],
+    request: req,
   });
   writeByteHeaders(res, byteResponse);
   // Stream from the verified descriptor so a path swap cannot bypass fs-safe after validation.


### PR DESCRIPTION
## What Problem This Solves

Authenticated assistant-media and managed-media responses publish `Last-Modified` but ignored every `If-Modified-Since` request. Browser caches therefore re-downloaded unchanged images, audio, and video instead of receiving a bodyless `304 Not Modified`; ranged requests could also transfer bytes before evaluating the date validator.

Independent real bearer-authenticated production HTTP against frozen `main` `e857d8e5c690814ebd0d5e4e84d32174a537fdfa` reproduced **24 incorrect responses** across both routes, `GET`, `HEAD`, all three valid HTTP-date formats, range precedence, and future-dated files.

## Why This Change Was Made

The canonical Gateway byte-response owner already controlled ETags, `Last-Modified`, `Range`, `If-Range`, and descriptor lifetimes. Its private request contract omitted `If-Modified-Since`, and both route callers duplicated incomplete header selection.

This refactor gives that existing owner one canonical Node HTTP-request contract and removes the duplicated three-header extraction from **both** callers. It obtains `If-Modified-Since` exclusively from Node's authoritative `headersDistinct` collection: Node silently discards duplicate singleton fields from normalized `headers`, so a date is accepted only when exactly one wire field exists. Its file-private HTTP-date parser strictly accepts IMF-fixdate, obsolete RFC 850, and ANSI C `asctime`; validates weekday, real calendar date, UTC, minimum four-digit year, leap seconds, and RFC 850's rolling 50-year rule. It compares against the actual second-precision, future-clamped `Last-Modified` emitted by that same response.

`If-None-Match` always takes precedence whenever present, including empty or nonmatching values. Invalid/multiple dates are ignored. Existing ETags, strong/date `If-Range`, range outcomes, `304` metadata, `401`, `416`, authentication, and descriptor ownership remain unchanged.

The full repair stays within three existing private production files. The two oversized route owners each become **two lines shorter**; there is no public API, protocol, configuration, authentication, security, persistent-state, SDK, AI/package dependency, fallback, or compatibility-shim change.

Protocol: [RFC 9110 §5.6.7, HTTP-date](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7), [RFC 9110 §13.1.3, If-Modified-Since](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3), and [Node.js IncomingMessage.headersDistinct](https://nodejs.org/api/http.html#messageheadersdistinct).

## User Impact

- Unchanged assistant and managed media now return metadata-only `304` responses for valid conditional `GET` and `HEAD`, avoiding duplicate transfers.
- Legacy intermediaries using RFC 850 or ANSI C date formats interoperate correctly.
- ETag-aware clients preserve authoritative ETag precedence, even when the ETag does not match.
- Future-skewed filesystem clocks, resumed ranges, malformed dates, unauthorized access, and unsatisfiable ranges retain their existing correct behavior.

## Evidence

Frozen current-main base: `e857d8e5c690814ebd0d5e4e84d32174a537fdfa`.

Final immutable candidate: `de6e3fa773cc768b1614c7000c4a316055974b09`.

### Regression-first and focused owner/sibling suites

- Exact frozen-main tests first produced **16 authentic failures** across the shared owner and both private HTTP routes.
- Independent review then caught two subtle date-parser defects before publication; each was reproduced with new failing regressions and repaired: four-digit years accidentally entering the RFC 850 two-digit century rule, and a leap second crossing the exact 50-year RFC 850 boundary.
- Genuine whole-branch autoreview caught an additional real transport-boundary defect: Node silently discarded duplicate singleton date fields before the private owner saw them. Actual authenticated raw-TCP requests reproduced false `304` responses on both routes; the final canonical `request` contract uses authoritative `headersDistinct` and exact-one validation, with mixed-case duplicate-wire regressions.
- The corrected immutable candidate passes all existing and new shared-owner, assistant-route, and managed-route tests:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/http-byte-range.test.ts \
  src/gateway/control-ui.http.test.ts \
  src/gateway/managed-image-attachments.test.ts

Test Files  3 passed (3)
     Tests  271 passed (271)
```

- Focused `oxlint --type-aware --type-check` on all six changed files, targeted `oxfmt --check`, and `git diff --check` passed.

### Real authenticated production HTTP

An independently owned proof started actual loopback TCP servers and exercised the unmocked assistant-media and managed-media production handlers with real bearer-authenticated requests, real files, past/future mtimes, full/ranged `GET`, and `HEAD`.

```json
{"candidate":"de6e3fa773cc768b1614c7000c4a316055974b09","actualProductionAssertions":301,"strictIndependentDateOracleAssertions":74,"totalIndependentAssertions":375,"routes":["assistant-media","managed-media"],"baselineIncorrectResponses":24,"conditionalStatuses":[304,200,206,416,401],"validDateFormats":["IMF-fixdate","RFC850","asctime"],"bodyless304":true,"futureClampedLastModified":true,"etagPresencePrecedence":true,"duplicateRawWireFieldsIgnored":true}
```

All **301 actual production HTTP assertions** and **74 independent adversarial HTTP-date oracle assertions** passed. Genuine bearer-authenticated raw `net.Socket` requests exercised mixed-case, identical, triple, reversed, and comma-folded duplicate wire headers against both production routes and both methods; duplicate values never produced a false `304`. Every legitimate `304` omitted body, `Content-Length`, and `Content-Range` while retaining ETag and the authoritative emitted `Last-Modified`. Invalid dates, `0000`/`0025`/`0099` years, wrong weekdays, impossible dates, rolling `2050`/`1977`, and leap-second boundary cases were independently checked.

### Review

Two independently acting agents reviewed the entire exact immutable owner, both complete route callers, sibling ETag/range implementations, direct Node/file/descriptor dependency behavior, scoped guidance, current `main`, and current RFC semantics. Both returned **zero P0/P1/P2/P3 findings**, confidence **0.99**; the first personally reran the complete **271/271** suites, a **26/26** adversarial oracle, and **10/10** real mixed-case raw HTTP assertions.

Genuine complete-branch `autoreview --mode branch --base e857d8e5c690814ebd0d5e4e84d32174a537fdfa --max-priority P3`: **zero P0/P1/P2/P3 findings**, TruffleHog clean, verdict **patch is correct**, confidence **0.98**.
