### PR TITLE
fix(signal): avoid replaying ambiguously delivered quoted messages

### DIFF
--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -710,6 +710,7 @@ describe("sendMessageSignal receipts", () => {
   it.each([
     "Signal RPC -32602: quote rejected",
     'Signal RPC -32602: Unrecognized field "quoteTimestamp"',
+    "Signal REST 400: quote metadata invalid",
   ])("falls back to an ordinary send when native quote metadata fails: %s", async (message) => {
     signalRpcRequestMock
       .mockRejectedValueOnce(new Error(message))
@@ -781,8 +782,12 @@ describe("sendMessageSignal receipts", () => {
     });
   });
 
-  it("does not retry ordinary send failures as quote fallback", async () => {
-    signalRpcRequestMock.mockRejectedValueOnce(new Error("Signal HTTP timed out after 10000ms"));
+  it.each([
+    "Signal HTTP timed out after 10000ms",
+    "quote metadata not found after an unknown transport failure",
+    "Signal RPC -32000: quote metadata was rejected after an ambiguous send",
+  ])("does not retry an unconfirmed quote rejection: %s", async (message) => {
+    signalRpcRequestMock.mockRejectedValueOnce(new Error(message));
 
     await expect(
       sendMessageSignal("+15551234567", "hello", {
@@ -791,9 +796,110 @@ describe("sendMessageSignal receipts", () => {
         replyToAuthor: "+15550002222",
         replyToBody: "original",
       }),
-    ).rejects.toThrow("Signal HTTP timed out");
+    ).rejects.toThrow(message);
 
     expect(signalRpcRequestMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Signal quoted-message provider replay safety", () => {
+  it.each([
+    { label: "HTTP 408", transportKind: "container", status: 408, fallback: false },
+    { label: "HTTP 429", transportKind: "container", status: 429, fallback: false },
+    { label: "HTTP 503", transportKind: "container", status: 503, fallback: false },
+    { label: "HTTP 400", transportKind: "container", status: 400, fallback: true },
+    { label: "RPC -32603", transportKind: "external-native", rpcCode: -32603, fallback: false },
+    { label: "RPC -32602", transportKind: "external-native", rpcCode: -32602, fallback: true },
+  ] as const)("replays a real $label request only after definitive rejection", async (testCase) => {
+    const requests: Array<Record<string, unknown>> = [];
+    const server = http.createServer((request, response) => {
+      let body = "";
+      request.on("data", (chunk: Buffer) => {
+        body += chunk.toString("utf8");
+      });
+      request.on("end", () => {
+        const payload = JSON.parse(body) as Record<string, unknown>;
+        requests.push(payload);
+        if (requests.length === 1) {
+          if (testCase.transportKind === "container") {
+            response.writeHead(testCase.status, { "content-type": "text/plain" });
+            response.end("quote storage not found during upstream outage");
+          } else {
+            response.writeHead(200, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: payload.id,
+                error: {
+                  code: testCase.rpcCode,
+                  message: "quote storage not found during upstream outage",
+                },
+              }),
+            );
+          }
+          return;
+        }
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify(
+            testCase.transportKind === "container"
+              ? { timestamp: 1700000000002 }
+              : {
+                  jsonrpc: "2.0",
+                  id: payload.id,
+                  result: { timestamp: 1700000000002 },
+                },
+          ),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as { port: number };
+    const cfg = {
+      channels: {
+        signal: {
+          accounts: {
+            default: {
+              account: "+15550001111",
+              transport: { kind: testCase.transportKind, url: `http://127.0.0.1:${port}` },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    vi.doUnmock("./client-adapter.js");
+    vi.resetModules();
+    const { sendMessageSignal: sendWithRealContainer } = await import("./send.js");
+
+    try {
+      const delivery = sendWithRealContainer("+15551234567", "deliver only once", {
+        cfg,
+        textMode: "plain",
+        replyToId: "1700000000001",
+        replyToAuthor: "+15550002222",
+        replyToBody: "original",
+      });
+      if (testCase.fallback) {
+        await expect(delivery).resolves.toMatchObject({ messageId: "1700000000002" });
+      } else {
+        const expectedError =
+          testCase.transportKind === "container"
+            ? `Signal REST ${testCase.status}`
+            : `Signal RPC ${testCase.rpcCode}`;
+        await expect(delivery).rejects.toThrow(expectedError);
+      }
+      expect(requests).toHaveLength(testCase.fallback ? 2 : 1);
+      const quoteTimestampPath =
+        testCase.transportKind === "container" ? "quote_timestamp" : "params.quoteTimestamp";
+      expect(requests[0]).toHaveProperty(quoteTimestampPath, 1700000000001);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   });
 });
 

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -259,6 +259,22 @@ function resolveSignalQuoteParams(opts: SignalSendOpts):
 function isSignalQuoteMetadataRejection(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = normalizeLowercaseStringOrEmpty(message);
+  const rpcCode = /^signal rpc (-?\d+):/u.exec(normalized)?.[1];
+  if (rpcCode !== undefined) {
+    if (rpcCode !== "-32602") {
+      return false;
+    }
+  } else {
+    const restStatusText = /^signal rest (\d{3}):/u.exec(normalized)?.[1];
+    if (!restStatusText) {
+      return false;
+    }
+    const restStatus = Number(restStatusText);
+    // Only a definitive provider rejection makes replaying the send safe.
+    if (restStatus < 400 || restStatus >= 500 || restStatus === 408 || restStatus === 429) {
+      return false;
+    }
+  }
   if (!normalized.includes("quote")) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Prevent Signal quoted-message sends from being replayed after ambiguous provider outages, timeouts, rate limits, or native internal errors.
- Keep normal quote fallback for definitive native invalid-params and non-transient container HTTP 4xx responses.
- Preserve existing media, native reply receipt metadata, provider boundaries, public APIs, and configuration.

## Root cause

The existing private quote-fallback classifier trusted human-readable phrases such as `quote ... not found`. A container can return actual HTTP 503 with exactly that wording after an ambiguous send; OpenClaw immediately issued a second POST with the same visible text and recipient. Native internal errors and HTTP 408/429 had the same defect.

The canonical private classifier now first requires authoritative native JSON-RPC `-32602` or a definitive container HTTP 4xx other than 408/429, then applies the existing quote-specific predicate.

## Verification

- Authentic latest-main owner baseline: **10 failing regressions and 30 passing controls**, including three real localhost provider runs that incorrectly issued duplicate POSTs.
- Final focused owner suite: **36 tests passing**, including actual localhost container HTTP 408/429/503 and native JSON-RPC -32603 (one POST), and real HTTP 400 / native -32602 safe fallback (two POSTs).
- Actual upstream signal-cli defines `-32602` as invalid params and `-32603` as internal error.
- Full branch P0–P3 autoreview with genuine TruffleHog 3.96: zero findings, confidence 0.95. Three additional independent strict source/dependency/runtime reviews: clean, confidence 0.99.
- Exact immutable hosted candidate proof: detached HEAD `83508ea5c2c1b76332d89b0ea2024b96aa733d17`, tree `e94418f5399eecedf918a1c236e040d0344bf321`, direct parent `a1b41d5ddb057fe0956b1d53c19fdbf4d33430d9`, clean index, and both exact reviewed owner-file SHA-256 hashes independently verified before execution.
- Full production plugin typecheck and full plugin test typecheck: both passing.
- Hosted Signal owner/provider/caller proof: **17 real suites, 301 tests passing**, including actual localhost provider HTTP 408/429/503 and native JSON-RPC error boundaries; no raw channel-fetch boundary violations.
- Hosted Testbox wrapper completed successfully (`exitCode=0`, `runStatus=succeeded`, 113.6 seconds). Lease `tbx_01kyxc54ytf26jyw4erggmpjta` was stopped and independently confirmed **completed** through direct `blacksmith testbox status`.
- Infrastructure workflow: https://github.com/openclaw/openclaw/actions/runs/30676058309. This workflow runs on `main`; it is infrastructure evidence, **not candidate-head GitHub CI**. Exact candidate head/tree/parent/blob identity and successful candidate execution were verified inside its hosted lease.
- Latest tracked `origin/main` `0ae516da1fa38bdea03423d9de6520623c94f72e` still contains the bug, has no subsequent changes to either owner file, and merge-tree verification against the reviewed candidate is clean.
