### PR TITLE
fix(slack): preserve durable retries for thread-history failures

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -159,6 +159,7 @@ describe("createSlackMessageHandler", () => {
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
+    expect(resolveThreadTsMock.mock.calls[0]?.[0]).not.toHaveProperty("turnAdoptionLifecycle");
     expect(enqueueMock).toHaveBeenCalledTimes(1);
   });
 
@@ -358,6 +359,11 @@ describe("createSlackMessageHandler", () => {
     );
 
     await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(1));
+    expect(resolveThreadTsMock).toHaveBeenCalledWith({
+      message: expect.objectContaining({ channel: "C111", ts: "1709000000.000550" }),
+      source: "message",
+      turnAdoptionLifecycle,
+    });
     const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
     await runOnFlush([entry]);
     await handled;

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -394,7 +394,11 @@ export function createSlackMessageHandler(params: {
       opts.eventScope
         ? createSlackThreadTsResolver({ client: opts.eventScope.client })
         : threadTsResolver
-    ).resolve({ message, source: opts.source });
+    ).resolve({
+      message,
+      source: opts.source,
+      ...(opts.turnAdoptionLifecycle ? { turnAdoptionLifecycle: opts.turnAdoptionLifecycle } : {}),
+    });
     const teamId = opts.eventScope?.teamId;
     const debounceKey = buildSlackDebounceKey(resolvedMessage, ctx.accountId, teamId);
     const conversationKey = buildTopLevelSlackConversationKey(

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -1,12 +1,29 @@
 // Slack tests cover monitor.thread resolution plugin behavior.
+import {
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+  WebAPIRateLimitedError,
+  WebAPIRequestError,
+} from "@slack/web-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SlackMessageEvent } from "../types.js";
+import type { SlackIngressTurnLifecycle } from "./ingress.js";
 import { createSlackThreadTsResolver } from "./thread-resolution.js";
 
 type SlackThreadClient = Parameters<typeof createSlackThreadTsResolver>[0]["client"];
 
 function createThreadClient(history: ReturnType<typeof vi.fn>): SlackThreadClient {
   return { conversations: { history } } as unknown as SlackThreadClient;
+}
+
+function createDurableTurnLifecycle(): SlackIngressTurnLifecycle {
+  return {
+    admission: "exclusive",
+    abortSignal: new AbortController().signal,
+    onAdopted: vi.fn(),
+    onDeferred: vi.fn(),
+    onAbandoned: vi.fn(),
+  };
 }
 
 describe("createSlackThreadTsResolver", () => {
@@ -61,6 +78,195 @@ describe("createSlackThreadTsResolver", () => {
     expect(first["_ambiguousThreadReply"]).toBe(true);
     expect(second["_ambiguousThreadReply"]).toBe(true);
     expect(historyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      label: "an actual Slack HTTP 408 timeout",
+      error: new WebAPIHTTPError(408, "Request Timeout", {}, "timeout"),
+    },
+    {
+      label: "an actual Slack HTTP 429 rejection",
+      error: new WebAPIHTTPError(429, "Too Many Requests", {}, "rate limited"),
+    },
+    {
+      label: "an actual Slack HTTP 503 outage",
+      error: new WebAPIHTTPError(503, "Service Unavailable", {}, "outage"),
+    },
+    {
+      label: "an actual Slack rate-limit error",
+      error: new WebAPIRateLimitedError(1),
+    },
+    {
+      label: "an actual Slack request timeout",
+      error: new WebAPIRequestError(
+        Object.assign(new Error("request timed out"), { code: "ETIMEDOUT" }),
+      ),
+    },
+    {
+      label: "the actual Slack SDK AbortSignal.timeout DOMException",
+      error: new WebAPIRequestError(new DOMException("request timed out", "TimeoutError")),
+    },
+    {
+      label: "an actual Slack connection reset",
+      error: new WebAPIRequestError(
+        Object.assign(new Error("socket was reset"), { code: "ECONNRESET" }),
+      ),
+    },
+  ])("hands $label to durable ingress without poisoning the cache", async ({ error }) => {
+    const historyMock = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ messages: [{ ts: "1", thread_ts: "9" }] });
+    const resolver = createSlackThreadTsResolver({
+      client: createThreadClient(historyMock),
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+    ).rejects.toBe(error);
+    await expect(
+      resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ thread_ts: "9" });
+
+    expect(historyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps direct transient failures ambiguous without poisoning their future lookup", async () => {
+    const historyMock = vi
+      .fn()
+      .mockRejectedValueOnce(new WebAPIHTTPError(503, "Service Unavailable", {}, "outage"))
+      .mockResolvedValueOnce({ messages: [{ ts: "1", thread_ts: "9" }] });
+    const resolver = createSlackThreadTsResolver({
+      client: createThreadClient(historyMock),
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+
+    await expect(resolver.resolve({ message, source: "message" })).resolves.toMatchObject({
+      _ambiguousThreadReply: true,
+    });
+    await expect(resolver.resolve({ message, source: "app_mention" })).resolves.toMatchObject({
+      thread_ts: "9",
+    });
+
+    expect(historyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases all coalesced durable twins for their existing queue retry", async () => {
+    let rejectHistory!: (error: unknown) => void;
+    const historyMock = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectHistory = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ messages: [{ ts: "1", thread_ts: "9" }] });
+    const resolver = createSlackThreadTsResolver({
+      client: createThreadClient(historyMock),
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const firstLifecycle = createDurableTurnLifecycle();
+    const secondLifecycle = createDurableTurnLifecycle();
+    const first = resolver.resolve({
+      message,
+      source: "message",
+      turnAdoptionLifecycle: firstLifecycle,
+    });
+    const second = resolver.resolve({
+      message,
+      source: "app_mention",
+      turnAdoptionLifecycle: secondLifecycle,
+    });
+    const outage = new WebAPIHTTPError(503, "Service Unavailable", {}, "outage");
+
+    expect(historyMock).toHaveBeenCalledTimes(1);
+    rejectHistory(outage);
+    await expect(Promise.allSettled([first, second])).resolves.toEqual([
+      { status: "rejected", reason: outage },
+      { status: "rejected", reason: outage },
+    ]);
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle: firstLifecycle }),
+    ).resolves.toMatchObject({ thread_ts: "9" });
+    expect(historyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "HTTP 400 rejection",
+      error: new WebAPIHTTPError(400, "Bad Request", {}, "invalid request"),
+    },
+    {
+      label: "HTTP 403 denial",
+      error: new WebAPIHTTPError(403, "Forbidden", {}, "missing scope"),
+    },
+    {
+      label: "HTTP 404 missing message",
+      error: new WebAPIHTTPError(404, "Not Found", {}, "message not found"),
+    },
+    {
+      label: "Slack platform missing_scope",
+      error: new WebAPIPlatformError({ ok: false, error: "missing_scope" }),
+    },
+    {
+      label: "unclassified local failure",
+      error: new Error("local lookup unavailable"),
+    },
+    {
+      label: "operator-canceled Slack request",
+      error: new WebAPIRequestError(new DOMException("request was canceled", "AbortError")),
+    },
+  ])("preserves cached ambiguity for definitive $label", async ({ error }) => {
+    const historyMock = vi.fn().mockRejectedValue(error);
+    const resolver = createSlackThreadTsResolver({
+      client: createThreadClient(historyMock),
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ _ambiguousThreadReply: true });
+    await expect(
+      resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ _ambiguousThreadReply: true });
+    expect(historyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retain a durable transient failure forever with a non-expiring cache", async () => {
+    const historyMock = vi
+      .fn()
+      .mockRejectedValueOnce(new WebAPIHTTPError(503, "Service Unavailable", {}, "outage"))
+      .mockResolvedValueOnce({ messages: [{ ts: "1", thread_ts: "9" }] });
+    const resolver = createSlackThreadTsResolver({
+      client: createThreadClient(historyMock),
+      cacheTtlMs: 0,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+    ).rejects.toBeInstanceOf(WebAPIHTTPError);
+    await expect(
+      resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ thread_ts: "9" });
+    await resolver.resolve({ message, source: "message", turnAdoptionLifecycle });
+
+    expect(historyMock).toHaveBeenCalledTimes(2);
   });
 
   it("falls back to the default ttl when cacheTtlMs is non-finite", async () => {

--- a/extensions/slack/src/monitor/thread-resolution.ts
+++ b/extensions/slack/src/monitor/thread-resolution.ts
@@ -1,14 +1,26 @@
 // Slack plugin module implements thread resolution behavior.
-import type { WebClient as SlackWebClient } from "@slack/web-api";
+import {
+  type WebClient as SlackWebClient,
+  WebAPIHTTPError,
+  WebAPIRateLimitedError,
+  WebAPIRequestError,
+} from "@slack/web-api";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+import {
+  collectErrorGraphCandidates,
+  extractErrorCode,
+  readErrorName,
+} from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
   parseFiniteNumber,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../errors.js";
 import type { SlackMessageEvent } from "../types.js";
+import type { SlackIngressTurnLifecycle } from "./ingress.js";
 
 type ThreadTsCacheEntry = {
   threadTs: string | null;
@@ -28,30 +40,46 @@ const markAmbiguousThreadReply = (message: SlackMessageEvent): SlackMessageEvent
   _ambiguousThreadReply: true,
 });
 
+function isTransientSlackThreadLookupError(error: unknown): boolean {
+  if (error instanceof WebAPIRateLimitedError) {
+    return true;
+  }
+  if (error instanceof WebAPIHTTPError) {
+    return (
+      error.statusCode === 408 ||
+      error.statusCode === 429 ||
+      (error.statusCode >= 500 && error.statusCode < 600)
+    );
+  }
+  if (!(error instanceof WebAPIRequestError)) {
+    return false;
+  }
+  return collectErrorGraphCandidates(error.original, (current) => [
+    current.cause,
+    current.error,
+    current.original,
+  ]).some(
+    (candidate) =>
+      classifyTransientNetworkErrorCode(extractErrorCode(candidate)) ||
+      readErrorName(candidate) === "TimeoutError",
+  );
+}
+
 async function resolveThreadTsFromHistory(params: {
   client: SlackWebClient;
   channelId: string;
   messageTs: string;
 }) {
-  try {
-    const response = (await params.client.conversations.history({
-      channel: params.channelId,
-      latest: params.messageTs,
-      oldest: params.messageTs,
-      inclusive: true,
-      limit: 1,
-    })) as { messages?: Array<{ ts?: string; thread_ts?: string }> };
-    const message =
-      response.messages?.find((entry) => entry.ts === params.messageTs) ?? response.messages?.[0];
-    return normalizeThreadTs(message?.thread_ts);
-  } catch (err) {
-    if (shouldLogVerbose()) {
-      logVerbose(
-        `slack inbound: failed to resolve thread_ts via conversations.history for channel=${params.channelId} ts=${params.messageTs}: ${formatSlackError(err)}`,
-      );
-    }
-    return undefined;
-  }
+  const response = (await params.client.conversations.history({
+    channel: params.channelId,
+    latest: params.messageTs,
+    oldest: params.messageTs,
+    inclusive: true,
+    limit: 1,
+  })) as { messages?: Array<{ ts?: string; thread_ts?: string }> };
+  const message =
+    response.messages?.find((entry) => entry.ts === params.messageTs) ?? response.messages?.[0];
+  return normalizeThreadTs(message?.thread_ts);
 }
 
 export function createSlackThreadTsResolver(params: {
@@ -103,6 +131,7 @@ export function createSlackThreadTsResolver(params: {
     resolve: async (request: {
       message: SlackMessageEvent;
       source: "message" | "app_mention";
+      turnAdoptionLifecycle?: SlackIngressTurnLifecycle;
     }): Promise<SlackMessageEvent> => {
       const { message } = request;
       if (!message.parent_user_id || message.thread_ts || !message.ts) {
@@ -135,6 +164,19 @@ export function createSlackThreadTsResolver(params: {
       let resolved: string | undefined;
       try {
         resolved = await pending;
+      } catch (err) {
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `slack inbound: failed to resolve thread_ts via conversations.history for channel=${message.channel} ts=${message.ts}: ${formatSlackError(err)}`,
+          );
+        }
+        if (isTransientSlackThreadLookupError(err)) {
+          if (request.turnAdoptionLifecycle) {
+            // The already-acknowledged durable ingress owner retries without dropping the turn.
+            throw err;
+          }
+          return markAmbiguousThreadReply(message);
+        }
       } finally {
         inflight.delete(cacheKey);
       }


### PR DESCRIPTION
## Summary

- Let Slack's existing durable ingress queue retry genuinely transient thread-history failures instead of treating provider outages as authoritative missing threads.
- Pass the already-existing durable turn lifecycle across the private message-handler/resolver boundary; no new retry stack, config, public plugin API, or persistence path.
- Preserve ordinary/direct ambiguous-thread behavior, authoritative missing-thread caching, definitive provider rejection, non-expiring successful caches, and explicitly canceled requests.

## Root cause

The private Slack thread resolver swallowed every `conversations.history` failure and cached a `null` thread as if Slack had successfully confirmed that no thread exists. For the default one-minute cache this caused later `message` / `app_mention` event twins to be silently discarded; with `cacheTtlMs: 0`, one transient provider outage could poison the cache indefinitely. Slack's real fetch timeout is subtler than a conventional `ETIMEDOUT`: the installed Slack Web API client wraps `AbortSignal.timeout()`'s `DOMException` named `TimeoutError` with numeric code 23 in `WebAPIRequestError`.

The correct retry owner already exists. Slack acknowledges an Events API event only after it is durably appended, then dispatches it with an existing turn-adoption lifecycle. By forwarding that same lifecycle to the private resolver, genuine provider HTTP 408/429/5xx, Slack rate-limit errors, recognized transient network errors, and actual SDK timeout DOM exceptions now propagate to the durable queue's existing backoff/replay owner. Calls without durable ownership retain their intentional ambiguous result, without caching a transient outage as an authoritative negative.

## Verification

- First authentic latest-main RED: **10 failing / 29 passing** existing-owner/caller tests exposed swallowed actual Slack SDK HTTP 408/429/503, rate-limit, ETIMEDOUT, ECONNRESET, poisoned direct/TTL-zero caches, concurrent event twins, and missing lifecycle forwarding.
- A second independent actual Slack SDK/localhost audit invalidated the first candidate after discovering real `DOMException("TimeoutError")` has numeric code 23; an authentic new owner RED and actual hanging HTTP request both reproduced the miss. Explicit `AbortError` cancellation remains a negative control.
- Final focused existing owner + caller suites: **41/41 passing**; independent expanded existing owner, caller, real listener, SQLite ingress, and generic ingress-drain suites: **108/108 passing**.
- Actual end-to-end production-owner proof, **without mocks**, executed twice against the exact candidate using a real localhost Slack API server, the installed Slack Web API SDK, the real SQLite durable ingress queue, actual listeners/lifecycles, and the persistent logical twin-deduplication owner:
  - Real Slack **HTTP 503**: two event acknowledgements, one durable queue release/retry, two provider requests, **exactly one visible delivery**, zero ambiguous drops, and both event tombstones completed.
  - Real Slack **AbortSignal timeout / DOMException TimeoutError / code 23**: the same two acknowledgements, two provider requests, **exactly one visible delivery**, zero ambiguous drops, and both completed event tombstones.
- Full exact immutable branch Codex `gpt-5.6-sol` / high / **P0–P3** structured automated review: **clean; zero findings; confidence 0.94**. Genuine TruffleHog secret scan: clean.
- Three fresh independent owner/dependency reviews: **zero P0–P3 findings; confidence 0.99 each**. Earlier rejected candidates were discarded after independent reviews discovered simultaneous-twin and actual SDK-timeout edge cases.
- Exact detached hosted Blacksmith Testbox validation: **full plugin production and plugin-test TypeScript gates passing; six Slack owner/caller/listener/real-SDK/durable-ingress suites 91/91; three canonical core queue/drain/retry suites 61/61; both real-provider/SQLite event-twin scenarios passing; targeted formatting/lint plus raw-fetch and all three plugin-SDK boundary guards passing**. The sole authorized lease was explicitly stopped and independently confirmed completed; [hosted run](https://github.com/openclaw/openclaw/actions/runs/30676262368).

## Compatibility and risk

Only private Slack owner/caller files and their existing tests change. Definitive Slack HTTP 400/403/404 and `missing_scope` errors retain cached ambiguity; successful missing-thread responses stay authoritative; direct calls remain fail-closed; explicit request cancellation is not retried. The existing generic durable queue retains its current backoff policy; teaching that shared owner to honor provider-specific `Retry-After` hints is a separate follow-up.
