### PR TITLE
fix(ai): preserve structured Chat content, refusals, and reasoning

### DIFF
--- a/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
+++ b/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
@@ -1,0 +1,464 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import { convertMessages } from "../openai-completions-messages.js";
+import { resolveOpenAICompletionsCompat } from "../transports/openai-completions-compat.js";
+import { createOpenAICompletionsTransportStreamFn } from "../transports/openai-completions-transport.js";
+import type { AssistantMessageEventStreamLike, Context, Model } from "../types.js";
+import { streamOpenAICompletions } from "./openai-completions.js";
+
+const reasoningModel = {
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  api: "openai-completions",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+} satisfies Model<"openai-completions">;
+
+const context = {
+  messages: [{ role: "user", content: "Reply exactly", timestamp: 1 }],
+} satisfies Context;
+
+type StructuredContentScenario = {
+  name: string;
+  choice: Record<string, unknown>;
+  followupChoice?: Record<string, unknown>;
+  expectedContent: Array<Record<string, unknown>>;
+  reasoningEnabled?: boolean;
+  reasoningEffort?: "medium" | "none";
+};
+
+const scenarios: StructuredContentScenario[] = [
+  {
+    name: "the unchanged scalar text contract",
+    choice: { delta: { content: "Scalar answer" } },
+    expectedContent: [{ type: "text", text: "Scalar answer" }],
+  },
+  {
+    name: "a provider-compatible typed text object",
+    choice: { delta: { content: { type: "text", text: "Visible object" } } },
+    expectedContent: [{ type: "text", text: "Visible object" }],
+  },
+  {
+    name: "nested typed text content",
+    choice: { delta: { content: { type: "output_text", content: { text: "Nested answer" } } } },
+    expectedContent: [{ type: "text", text: "Nested answer" }],
+  },
+  {
+    name: "mixed private reasoning and visible text",
+    choice: {
+      delta: {
+        content: [
+          { type: "reasoning", text: "Private thought" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [
+      { type: "thinking", thinking: "Private thought" },
+      { type: "text", text: "Visible answer" },
+    ],
+  },
+  ...(["reasoning_content", "reasoning", "reasoning_text"] as const).map((field) => ({
+    name: `private reasoning mirrored in ${field} and structured content`,
+    choice: {
+      delta: {
+        [field]: "Private thought",
+        content: [
+          { type: "reasoning", text: "Private thought" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [
+      { type: "thinking", thinking: "Private thought", thinkingSignature: field },
+      { type: "text", text: "Visible answer" },
+    ],
+  })),
+  ...(["reasoning_content", "reasoning", "reasoning_text"] as const).map((field) => ({
+    name: `distinct private reasoning in ${field} and structured content`,
+    choice: {
+      delta: {
+        [field]: "Dedicated private thought.",
+        content: [
+          { type: "reasoning", text: "Distinct structured private thought." },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [
+      {
+        type: "thinking",
+        thinking: "Dedicated private thought.Distinct structured private thought.",
+        thinkingSignature: field,
+      },
+      { type: "text", text: "Visible answer" },
+    ],
+  })),
+  {
+    name: "split structured reasoning mirrored in the dedicated field",
+    choice: {
+      delta: {
+        reasoning_content: "Private thought",
+        content: [
+          { type: "reasoning", text: "Private " },
+          { type: "reasoning", text: "thought" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [
+      { type: "thinking", thinking: "Private thought", thinkingSignature: "reasoning_content" },
+      { type: "text", text: "Visible answer" },
+    ],
+  },
+  {
+    name: "standalone dedicated reasoning alongside visible structured text",
+    choice: {
+      delta: {
+        reasoning_content: "Private thought",
+        content: [{ type: "text", text: "Visible answer" }],
+      },
+    },
+    expectedContent: [
+      { type: "thinking", thinking: "Private thought", thinkingSignature: "reasoning_content" },
+      { type: "text", text: "Visible answer" },
+    ],
+  },
+  {
+    name: "structured reasoning that is disabled",
+    reasoningEnabled: false,
+    choice: {
+      delta: {
+        content: [
+          { type: "thinking", thinking: [{ type: "text", text: "Do not expose this" }] },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible answer" }],
+  },
+  {
+    name: "dedicated and structured mirrored reasoning that is disabled",
+    reasoningEnabled: false,
+    choice: {
+      delta: {
+        reasoning_content: "Do not expose this",
+        content: [
+          { type: "reasoning", text: "Do not expose this" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible answer" }],
+  },
+  {
+    name: "structured reasoning explicitly disabled on a capable model",
+    reasoningEffort: "none",
+    choice: {
+      delta: {
+        content: [
+          { type: "reasoning", text: "Do not expose this" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible answer" }],
+  },
+  {
+    name: "pending partial inline reasoning remains private after a structured thought",
+    choice: { delta: { content: "<thi" } },
+    followupChoice: {
+      delta: {
+        content: [
+          { type: "reasoning", text: "Structured private thought" },
+          { type: "text", text: "nk>SECRET</think>SAFE" },
+        ],
+      },
+    },
+    expectedContent: [
+      { type: "thinking", thinking: "Structured private thought" },
+      { type: "text", text: "SAFE" },
+    ],
+  },
+  {
+    name: "dedicated and structured reasoning explicitly disabled on a capable model",
+    reasoningEffort: "none",
+    choice: {
+      delta: {
+        reasoning_content: "Do not expose this",
+        content: [
+          { type: "reasoning", text: "Another private thought" },
+          { type: "text", text: "Visible answer" },
+        ],
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible answer" }],
+  },
+  {
+    name: "a documented refusal content part",
+    choice: {
+      delta: { content: [{ type: "refusal", refusal: "I cannot help with that." }] },
+    },
+    expectedContent: [{ type: "text", text: "I cannot help with that." }],
+  },
+  {
+    name: "the same refusal mirrored in structured and top-level fields",
+    choice: {
+      delta: {
+        content: [{ type: "refusal", refusal: "Safety refusal." }],
+        refusal: "Safety refusal.",
+      },
+    },
+    expectedContent: [{ type: "text", text: "Safety refusal." }],
+  },
+  {
+    name: "distinct structured and top-level refusals",
+    choice: {
+      delta: {
+        content: [{ type: "refusal", refusal: "Provider refusal. " }],
+        refusal: "Operator guidance.",
+      },
+    },
+    expectedContent: [{ type: "text", text: "Provider refusal. Operator guidance." }],
+  },
+  {
+    name: "split structured refusal mirrored in the top-level field",
+    choice: {
+      delta: {
+        content: [
+          { type: "refusal", refusal: "Safety " },
+          { type: "refusal", refusal: "refusal." },
+        ],
+        refusal: "Safety refusal.",
+      },
+    },
+    expectedContent: [{ type: "text", text: "Safety refusal." }],
+  },
+  {
+    name: "identical refusals intentionally repeated across separate chunks",
+    choice: { delta: { refusal: "Safety refusal." } },
+    followupChoice: { delta: { refusal: "Safety refusal." } },
+    expectedContent: [{ type: "text", text: "Safety refusal.Safety refusal." }],
+  },
+  {
+    name: "documented mixed assistant text and refusal parts",
+    choice: {
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Visible prefix. " },
+          { type: "refusal", refusal: "Safety refusal." },
+        ],
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible prefix. Safety refusal." }],
+  },
+  {
+    name: "an existing top-level refusal without duplication",
+    choice: {
+      delta: {
+        content: [{ type: "text", text: "Visible prefix. " }],
+        refusal: "Safety refusal.",
+      },
+    },
+    expectedContent: [{ type: "text", text: "Visible prefix. Safety refusal." }],
+  },
+  {
+    name: "unknown structured parts without object coercion",
+    choice: {
+      delta: { content: [{ type: "unknown", text: "Do not expose this" }] },
+    },
+    expectedContent: [],
+  },
+];
+
+function installChatChunk(scenario: StructuredContentScenario, model: Model): void {
+  const choices = [scenario.choice, ...(scenario.followupChoice ? [scenario.followupChoice] : [])];
+  const body = `${choices
+    .map(
+      (choice, index) =>
+        `data: ${JSON.stringify({
+          id: `chatcmpl-${scenario.name.replaceAll(" ", "-")}`,
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              ...choice,
+              finish_reason: index === choices.length - 1 ? "stop" : null,
+            },
+          ],
+        })}\n\n`,
+    )
+    .join("")}data: [DONE]\n\n`;
+  configureAiTransportHost({
+    buildModelFetch: () => async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+  });
+}
+
+function installDeferredStructuredChatChunks(model: Model): () => void {
+  let releaseTerminal: (() => void) | undefined;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encodeChunk = (delta: Record<string, unknown>, finishReason: "stop" | null) =>
+        encoder.encode(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-incremental-structured-content",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: model.id,
+            choices: [{ index: 0, delta, finish_reason: finishReason }],
+          })}\n\n`,
+        );
+      controller.enqueue(
+        encodeChunk(
+          {
+            content: [
+              { type: "reasoning", text: "Private thought" },
+              { type: "text", text: "VISIBLE_ONE" },
+            ],
+          },
+          null,
+        ),
+      );
+      releaseTerminal = () => {
+        controller.enqueue(encodeChunk({ content: "VISIBLE_TWO" }, "stop"));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      };
+    },
+  });
+  configureAiTransportHost({
+    buildModelFetch: () => async () =>
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+  });
+  return () => releaseTerminal?.();
+}
+
+const createManagedStream = createOpenAICompletionsTransportStreamFn();
+
+function createManagedFixtureStream(
+  model: Model,
+  scenario: StructuredContentScenario,
+): AssistantMessageEventStreamLike {
+  const options = {
+    apiKey: "fixture-token",
+    reasoningEffort: scenario.reasoningEffort ?? "medium",
+  };
+  const stream = createManagedStream(model, context, options);
+  if (stream instanceof Promise) {
+    throw new Error("OpenAI Chat Completions transport must return its stream synchronously");
+  }
+  return stream;
+}
+
+let previousHost: ReturnType<typeof getAiTransportHost>;
+
+beforeEach(() => {
+  previousHost = getAiTransportHost();
+});
+
+afterEach(() => {
+  configureAiTransportHost(previousHost);
+});
+
+describe.each([
+  {
+    name: "package",
+    createStream: (model: Model<"openai-completions">, scenario: StructuredContentScenario) =>
+      streamOpenAICompletions(model, context, {
+        apiKey: "fixture-token",
+        reasoningEffort: scenario.reasoningEffort ?? "medium",
+      }),
+  },
+  { name: "managed", createStream: createManagedFixtureStream },
+])("$name Chat Completions structured content", ({ createStream }) => {
+  it.each(scenarios)("preserves $name", async (scenario) => {
+    const model = {
+      ...reasoningModel,
+      reasoning: scenario.reasoningEnabled ?? true,
+    } satisfies Model<"openai-completions">;
+    installChatChunk(scenario, model);
+
+    const result = await createStream(model, scenario).result();
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual(scenario.expectedContent);
+    expect(JSON.stringify(result.content)).not.toContain("[object Object]");
+
+    const visibleAnswer = result.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+    if (visibleAnswer && result.content.some((block) => block.type === "thinking")) {
+      const assistantReplay = convertMessages(
+        model,
+        { messages: [...context.messages, result] },
+        resolveOpenAICompletionsCompat(model),
+      ).find((message) => message.role === "assistant");
+      expect(assistantReplay?.content).toBe(visibleAnswer);
+    }
+  });
+
+  it.each(["medium", "none"] as const)(
+    "streams visible structured content before terminal when reasoning is %s",
+    async (reasoningEffort) => {
+      const releaseTerminal = installDeferredStructuredChatChunks(reasoningModel);
+      const scenario: StructuredContentScenario = {
+        name: "incremental structured reasoning",
+        choice: {},
+        expectedContent: [],
+        reasoningEffort,
+      };
+      const stream = createStream(reasoningModel, scenario);
+      let resolveFirstVisible: ((value: string) => void) | undefined;
+      const firstVisible = new Promise<string>((resolve) => {
+        resolveFirstVisible = resolve;
+      });
+      const textDeltas: string[] = [];
+      const consumeEvents = (async () => {
+        for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+          if (event.type === "text_delta" && typeof event.delta === "string") {
+            textDeltas.push(event.delta);
+            resolveFirstVisible?.(event.delta);
+            resolveFirstVisible = undefined;
+          }
+        }
+      })();
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const firstDelta = await Promise.race([
+          firstVisible,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("Visible content was buffered until the terminal chunk")),
+              500,
+            );
+          }),
+        ]);
+        expect(firstDelta).toBe("VISIBLE_ONE");
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        releaseTerminal();
+      }
+      await consumeEvents;
+      await stream.result();
+      expect(textDeltas).toEqual(["VISIBLE_ONE", "VISIBLE_TWO"]);
+    },
+  );
+});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -18,7 +18,11 @@ import {
   type ResolvedOpenAICompletionsCompat,
 } from "../transports/openai-completions-compat.js";
 import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
-import { parseOpenAICompletionsUsage } from "../transports/openai-transport-shared.js";
+import {
+  isOpenAICompletionsThinkingEnabled,
+  parseOpenAICompletionsUsage,
+  readOpenAICompletionsContentDeltas,
+} from "../transports/openai-transport-shared.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
@@ -271,12 +275,12 @@ export const streamOpenAICompletions: StreamFunction<
         }
         return textBlock;
       };
-      const ensureThinkingBlock = (thinkingSignature: string) => {
+      const ensureThinkingBlock = (thinkingSignature: string | undefined) => {
         if (!thinkingBlock) {
           thinkingBlock = {
             type: "thinking",
             thinking: "",
-            thinkingSignature,
+            ...(thinkingSignature ? { thinkingSignature } : {}),
           };
           appendBlock(thinkingBlock);
           stream.push({
@@ -309,7 +313,7 @@ export const streamOpenAICompletions: StreamFunction<
           partial: output,
         });
       };
-      const appendThinkingDelta = (thinkingSignature: string, delta: string) => {
+      const appendThinkingDelta = (thinkingSignature: string | undefined, delta: string) => {
         const block = ensureThinkingBlock(thinkingSignature);
         block.thinking += delta;
         stream.push({
@@ -450,7 +454,11 @@ export const streamOpenAICompletions: StreamFunction<
             // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
             const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
             const deltaFields = choiceDelta as Record<string, unknown>;
-            const shouldEmitReasoning = Boolean(model.reasoning && options?.reasoningEffort);
+            const shouldEmitReasoning = Boolean(
+              model.reasoning &&
+              options?.reasoningEffort &&
+              isOpenAICompletionsThinkingEnabled(options.reasoningEffort),
+            );
             let foundReasoningField: string | null = null;
             for (const field of reasoningFields) {
               const value = deltaFields[field];
@@ -472,20 +480,21 @@ export const streamOpenAICompletions: StreamFunction<
                 appendThinkingDelta(thinkingSignature, delta);
               }
             }
-            if (
-              choiceDelta.content !== null &&
-              choiceDelta.content !== undefined &&
-              choiceDelta.content.length > 0
-            ) {
-              appendPartitionedContent(choiceDelta.content, Boolean(foundReasoningField));
-            }
-
-            // Chat Completions can put safety/structured-output refusals in a
-            // top-level `refusal` field with content null. Surface that as
-            // visible text so the assistant turn is not empty.
-            const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
-            if (refusalText.length > 0) {
-              appendPartitionedContent(refusalText, Boolean(foundReasoningField));
+            for (const contentDelta of readOpenAICompletionsContentDeltas(
+              choiceDelta.content,
+              choiceDelta.refusal,
+              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
+            )) {
+              if (contentDelta.kind === "thinking") {
+                if (reasoningTagTextPartitioner.hasPending()) {
+                  reasoningTagTextPartitioner.markStrict();
+                }
+                if (shouldEmitReasoning) {
+                  appendThinkingDelta(contentDelta.signature, contentDelta.text);
+                }
+              } else {
+                appendPartitionedContent(contentDelta.text, Boolean(foundReasoningField));
+              }
             }
 
             const toolCallDeltas = normalizedDelta.toolCalls;

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -73,12 +73,15 @@ import {
 import {
   GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP,
   createModelStreamCooperativeScheduler,
+  isOpenAICompletionsThinkingEnabled,
   log,
   parseOpenAICompletionsUsage,
+  readOpenAICompletionsContentDeltas,
   resolvePromptCacheKey,
   sortTransportToolsByName,
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
+  type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
 import { failTransportStream, finalizeTransportStream } from "./transport-stream-shared.js";
@@ -452,7 +455,7 @@ async function processOpenAICompletionsStream(
     }
     previous.text += next.text;
   };
-  const appendThinkingDeltaInternal = (reasoningDelta: { signature: string; text: string }) => {
+  const appendThinkingDeltaInternal = (reasoningDelta: { signature?: string; text: string }) => {
     if (!currentBlock || currentBlock.type !== "thinking") {
       currentBlock = {
         type: "thinking",
@@ -504,7 +507,7 @@ async function processOpenAICompletionsStream(
     }
     isFlushingPendingPostToolCallDeltas = false;
   };
-  const appendThinkingDelta = (reasoningDelta: { signature: string; text: string }) => {
+  const appendThinkingDelta = (reasoningDelta: { signature?: string; text: string }) => {
     flushPendingPostToolCallDeltas();
     appendThinkingDeltaInternal(reasoningDelta);
   };
@@ -626,7 +629,7 @@ async function processOpenAICompletionsStream(
     if (latestBlock?.type === "text" || latestBlock?.type === "toolCall") {
       return;
     }
-    appendThinkingDelta({ signature: "", text: "" });
+    appendThinkingDelta({ text: "" });
   };
   const flushReasoningTagTextPartitionerAtEnd = () => {
     for (const delta of reasoningTagTextPartitioner.flush()) {
@@ -701,49 +704,52 @@ async function processOpenAICompletionsStream(
       if (hasMirroredReasoning) {
         reasoningTagTextPartitioner.markStrict();
       }
-      if (choiceDelta.content) {
-        // Structured content can contain visible text and thinking blocks in the
-        // same delta, so route each extracted block through the normal stream path.
-        const contentDeltas = getCompletionsContentDeltas(choiceDelta.content);
-        for (const contentDelta of contentDeltas) {
-          if (contentDelta.kind === "text") {
-            const routedDeltas = hasMirroredReasoning
-              ? reasoningTagTextPartitioner.push(contentDelta.text)
-              : reasoningTagTextPartitioner.pushVisible(contentDelta.text);
-            for (const routedDelta of routedDeltas) {
-              appendPartitionedVisibleDelta(routedDelta);
-            }
-          } else {
-            reasoningTagTextPartitioner.markStrict();
-            appendRoutedContentDelta(contentDelta);
+      // Share the content/refusal owner to avoid duplicate mirrored refusals.
+      const contentDeltas = readOpenAICompletionsContentDeltas(
+        choiceDelta.content,
+        choiceDelta.refusal,
+        reasoningDeltas
+          .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
+          .map((reasoningDelta) => reasoningDelta.text),
+      );
+      const appendReasoningDeltas = () => {
+        for (const reasoningDelta of reasoningDeltas) {
+          if (reasoningDelta.kind === "thinking" && !emitReasoning) {
+            continue;
+          }
+          if (currentBlock?.type === "toolCall") {
+            queuePostToolCallDelta({ ...reasoningDelta });
+            continue;
+          }
+          if (reasoningDelta.kind === "text") {
+            appendTextDelta(reasoningDelta.text);
+          } else if (emitReasoning) {
+            appendThinkingDelta(reasoningDelta);
           }
         }
+      };
+      // The dedicated field owns reasoning order/signature; a distinct content
+      // thought follows it, while an exact mirror was removed by the decoder.
+      if (hasMirroredReasoning) {
+        appendReasoningDeltas();
       }
-      // Chat Completions can put safety/structured-output refusals in a top-level
-      // `refusal` field with content null. Surface that as visible text so the
-      // assistant turn is not empty (Responses path already routes refusal deltas).
-      const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
-      if (refusalText) {
-        const routedDeltas = hasMirroredReasoning
-          ? reasoningTagTextPartitioner.push(refusalText)
-          : reasoningTagTextPartitioner.pushVisible(refusalText);
-        for (const routedDelta of routedDeltas) {
-          appendPartitionedVisibleDelta(routedDelta);
+      for (const contentDelta of contentDeltas) {
+        if (contentDelta.kind === "text") {
+          const routedDeltas = hasMirroredReasoning
+            ? reasoningTagTextPartitioner.push(contentDelta.text)
+            : reasoningTagTextPartitioner.pushVisible(contentDelta.text);
+          for (const routedDelta of routedDeltas) {
+            appendPartitionedVisibleDelta(routedDelta);
+          }
+        } else {
+          if (reasoningTagTextPartitioner.hasPending()) {
+            reasoningTagTextPartitioner.markStrict();
+          }
+          appendRoutedContentDelta(contentDelta);
         }
       }
-      for (const reasoningDelta of reasoningDeltas) {
-        if (reasoningDelta.kind === "thinking" && !emitReasoning) {
-          continue;
-        }
-        if (currentBlock?.type === "toolCall") {
-          queuePostToolCallDelta({ ...reasoningDelta });
-          continue;
-        }
-        if (reasoningDelta.kind === "text") {
-          appendTextDelta(reasoningDelta.text);
-        } else if (emitReasoning) {
-          appendThinkingDelta(reasoningDelta);
-        }
+      if (!hasMirroredReasoning) {
+        appendReasoningDeltas();
       }
       const toolCallDeltas = normalizedDelta.toolCalls;
       if (toolCallDeltas.length > 0) {
@@ -853,17 +859,6 @@ async function processOpenAICompletionsStream(
     tagPendingCommentaryText(output.content);
   }
 }
-
-type CompletionsReasoningDelta =
-  | {
-      kind: "thinking";
-      signature: string;
-      text: string;
-    }
-  | {
-      kind: "text";
-      text: string;
-    };
 
 function shouldFilterDeepSeekDsmlText(compat: ReturnType<typeof getCompat>) {
   return compat.thinkingFormat === "deepseek";
@@ -1068,49 +1063,6 @@ function longestDeepSeekDsmlToolOpenPrefixSuffixLength(text: string) {
     }
   }
   return 0;
-}
-
-function getCompletionsContentDeltas(content: unknown): CompletionsReasoningDelta[] {
-  if (typeof content === "string") {
-    return content ? [{ kind: "text", text: content }] : [];
-  }
-  if (Array.isArray(content)) {
-    return content.flatMap((item) => getCompletionsContentDeltas(item));
-  }
-  if (!content || typeof content !== "object") {
-    return [];
-  }
-  const record = content as Record<string, unknown>;
-  const type = typeof record.type === "string" ? record.type.toLowerCase() : "";
-  // Some OpenAI-compatible providers, notably Mistral thinking models, stream
-  // `delta.content` as typed objects. Never coerce those objects directly or
-  // they become persisted visible text like "[object Object]".
-  const extractText = (value: unknown): string => {
-    if (typeof value === "string") {
-      return value;
-    }
-    if (Array.isArray(value)) {
-      return value.map((item) => extractText(item)).join("");
-    }
-    if (value && typeof value === "object") {
-      const nested = value as Record<string, unknown>;
-      return extractText(nested.text ?? nested.content ?? nested.thinking);
-    }
-    return "";
-  };
-  const text = extractText(record.text ?? record.content ?? record.thinking);
-  if (!text) {
-    return [];
-  }
-  // Preserve provider reasoning as OpenClaw thinking blocks so channel/UI
-  // surfaces can decide whether to show it instead of leaking it as answer text.
-  if (type.includes("thinking") || type.includes("reasoning")) {
-    return [{ kind: "thinking", signature: "content", text }];
-  }
-  if (type === "text" || type === "output_text" || type.endsWith(".output_text")) {
-    return [{ kind: "text", text }];
-  }
-  return [];
 }
 
 function getCompletionsReasoningDeltas(
@@ -1322,11 +1274,6 @@ function resolveOpenAICompletionsEffectiveContextTokens(
 
 function isQwenOpenAICompletionsThinkingFormat(format: string): boolean {
   return format === "qwen" || format === "qwen-chat-template";
-}
-
-function isOpenAICompletionsThinkingEnabled(effort: OpenAIReasoningEffort): boolean {
-  const normalized = effort.trim().toLowerCase();
-  return normalized !== "off" && normalized !== "none";
 }
 
 function setQwenChatTemplateThinking(params: Record<string, unknown>, enabled: boolean): void {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -27,6 +27,10 @@ export const log = {
 
 export type { OpenAICompletionsOptions } from "../provider-options.js";
 
+export type OpenAICompletionsContentDelta =
+  | { kind: "thinking"; signature?: string; text: string }
+  | { kind: "text"; text: string; source?: "refusal" };
+
 type OpenAIModeCompatInput = Omit<OpenAICompletionsCompat, "thinkingFormat"> & {
   thinkingFormat?: string;
   requiresStringContent?: boolean;
@@ -141,4 +145,91 @@ export function resolvePromptCacheKey(
     return undefined;
   }
   return clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId);
+}
+
+export function isOpenAICompletionsThinkingEnabled(effort: string): boolean {
+  const normalized = effort.trim().toLowerCase();
+  return normalized !== "off" && normalized !== "none";
+}
+
+export function readOpenAICompletionsContentDeltas(
+  content: unknown,
+  topLevelRefusal?: unknown,
+  mirroredThinking: readonly string[] = [],
+): OpenAICompletionsContentDelta[] {
+  let deltas = readOpenAICompletionsContentPartDeltas(content);
+  if (mirroredThinking.length > 0) {
+    const structuredThinking = deltas
+      .filter((delta) => delta.kind === "thinking")
+      .map((delta) => delta.text);
+    const mirrorsCombinedThinking =
+      structuredThinking.length > 1 && mirroredThinking.includes(structuredThinking.join(""));
+    // Suppress exact same-chunk mirrors, not independent structured thoughts.
+    deltas = deltas.filter(
+      (delta) =>
+        delta.kind !== "thinking" ||
+        (!mirrorsCombinedThinking && !mirroredThinking.includes(delta.text)),
+    );
+  }
+  if (typeof topLevelRefusal !== "string" || !topLevelRefusal) {
+    return deltas;
+  }
+  const structuredRefusals = deltas
+    .filter((delta) => delta.kind === "text" && delta.source === "refusal")
+    .map((delta) => delta.text);
+  // Compatible providers may mirror one refusal as parts and a top-level field;
+  // suppress only that exact duplicate, never distinct text or later chunks.
+  if (
+    structuredRefusals.some((refusal) => refusal === topLevelRefusal) ||
+    (structuredRefusals.length > 1 && structuredRefusals.join("") === topLevelRefusal)
+  ) {
+    return deltas;
+  }
+  return [...deltas, { kind: "text", text: topLevelRefusal, source: "refusal" }];
+}
+
+function readOpenAICompletionsContentPartDeltas(content: unknown): OpenAICompletionsContentDelta[] {
+  if (typeof content === "string") {
+    return content ? [{ kind: "text", text: content }] : [];
+  }
+  if (Array.isArray(content)) {
+    return content.flatMap(readOpenAICompletionsContentPartDeltas);
+  }
+  if (!content || typeof content !== "object") {
+    return [];
+  }
+  const record = content as Record<string, unknown>;
+  const type = typeof record.type === "string" ? record.type.toLowerCase() : "";
+  // Compatible providers stream typed objects; direct coercion persists them
+  // as "[object Object]" instead of preserving visible text and reasoning.
+  const extractText = (value: unknown): string => {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(extractText).join("");
+    }
+    if (value && typeof value === "object") {
+      const nested = value as Record<string, unknown>;
+      return extractText(nested.text ?? nested.content ?? nested.thinking ?? nested.refusal);
+    }
+    return "";
+  };
+  const text = extractText(record.text ?? record.content ?? record.thinking ?? record.refusal);
+  if (!text) {
+    return [];
+  }
+  // Thinking stays distinct so channel/UI policy controls its visibility.
+  if (type.includes("thinking") || type.includes("reasoning")) {
+    // Content parts supply no replay-field signature. Inventing "content"
+    // overwrites the visible assistant answer on the next completion request.
+    return [{ kind: "thinking", text }];
+  }
+  if (type === "refusal") {
+    return [{ kind: "text", text, source: "refusal" }];
+  }
+  if (["text", "output_text"].includes(type) || type.endsWith(".output_text")) {
+    return [{ kind: "text", text }];
+  }
+  return [];
 }

--- a/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
+++ b/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
@@ -1031,7 +1031,7 @@ describe("openai transport stream", () => {
     await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
 
     expect(output.content).toEqual([
-      { type: "thinking", thinking: "Need to think.", thinkingSignature: "content" },
+      { type: "thinking", thinking: "Need to think." },
       { type: "text", text: "Visible answer." },
     ]);
   });


### PR DESCRIPTION
## What Problem This Solves

The two OpenAI Chat Completions streaming owners interpreted structured assistant content differently. The package owner could discard typed answers, stringify objects as `[object Object]`, or mishandle private reasoning; the managed owner could silently discard documented refusal parts. Mirrored reasoning/refusal payloads could duplicate or lose legitimate content, an explicit `none` reasoning setting could be ignored, a synthetic thinking signature could overwrite the visible assistant answer on the **next provider request**, and unconditional strict inline-tag mode could withhold every answer token until completion.

Exact frozen parent: `a1b41d5ddb057fe0956b1d53c19fdbf4d33430d9`. Immutable candidate: `ba13cc48699f39cb5e3726a37d5a2ea4d5858539`.

## Why This Change Was Made

Move structured-content decoding and the existing thinking-effort policy into the existing private shared OpenAI transport owner; route both Chat streaming producers through that single canonical implementation. Preserve actual provider-provided thinking signatures, omit a signature entirely when a structured part supplies none, deduplicate only same-chunk exact mirrors, emit dedicated reasoning before visible content, and enter strict inline-tag buffering only when an actually pending partial tag requires it.

Production change: **166 additions / 119 deletions = +47 lines**, explicitly maintainer-approved. Managed owner deletes its duplicate private decoder, type, and effort predicate. The only fifth touched file updates an existing sibling test's previously unsafe synthetic signature expectation. No public plugin SDK, configuration, auth, persistence, protocol, snapshot, or dependency surface changes.

## User Impact

- Typed Chat answers remain visible instead of disappearing or becoming object strings.
- Structured and provider-dedicated private reasoning remains private, distinct thoughts are retained, explicit `none` suppresses thinking, and provider signatures are never invented.
- Actual next-turn provider requests keep the visible assistant answer; private reasoning can no longer overwrite `assistant.content`.
- Documented refusal parts and distinct refusal messages remain visible while exact same-chunk mirrors are not duplicated.
- Safe answer tokens stream incrementally before the terminal event; partial inline reasoning tags still cannot expose private text.
- Existing cache accounting remains `input=75`, `cacheRead=25`, `cost=.00012124999999999999`; all four protected provider snapshots remain byte-identical.

## Evidence

### Actual installed OpenAI SDK, real localhost HTTP

`openai@6.49.0` made **44 real HTTP requests across 16 scenarios**, including **12 actual next-turn outbound provider requests**. Selected exact normalized results:

```json
[
  {
    "scenario": "typed-text",
    "package": [
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "private-reasoning-visible-text",
    "package": [
      {
        "type": "thinking",
        "thinking": "Private thought"
      },
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "managed": [
      {
        "type": "thinking",
        "thinking": "Private thought"
      },
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "distinct-dedicated-and-structured-reasoning_content",
    "package": [
      {
        "type": "thinking",
        "thinking": "Dedicated private thought.Distinct structured private thought.",
        "thinkingSignature": "reasoning_content"
      },
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "managed": [
      {
        "type": "thinking",
        "thinking": "Dedicated private thought.Distinct structured private thought.",
        "thinkingSignature": "reasoning_content"
      },
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "explicit-none-structured-reasoning",
    "package": [
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Visible answer"
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "documented-refusal",
    "package": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "mirrored-structured-top-level-refusal",
    "package": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "distinct-structured-top-level-refusals",
    "package": [
      {
        "type": "text",
        "text": "Provider refusal. Operator guidance."
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Provider refusal. Operator guidance."
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "split-structured-top-level-refusal",
    "package": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Safety refusal."
      }
    ],
    "input": 75,
    "cacheRead": 25
  },
  {
    "scenario": "repeated-separate-chunk-refusal",
    "package": [
      {
        "type": "text",
        "text": "Safety refusal.Safety refusal."
      }
    ],
    "managed": [
      {
        "type": "text",
        "text": "Safety refusal.Safety refusal."
      }
    ],
    "input": 75,
    "cacheRead": 25
  }
]
```

Actual next-turn assistant messages preserve the visible answer and do not invent a reasoning field for unsigned structured thoughts:

```json
[
  {
    "scenario": "private-reasoning-visible-text",
    "lane": "package",
    "assistantContent": "Visible answer",
    "providerReasoningFields": []
  },
  {
    "scenario": "private-reasoning-visible-text",
    "lane": "managed",
    "assistantContent": "Visible answer",
    "providerReasoningFields": []
  },
  {
    "scenario": "mirrored-dedicated-and-structured-reasoning",
    "lane": "package",
    "assistantContent": "Visible answer",
    "providerReasoningFields": [
      "reasoning_content"
    ]
  },
  {
    "scenario": "mirrored-dedicated-and-structured-reasoning",
    "lane": "managed",
    "assistantContent": "Visible answer",
    "providerReasoningFields": []
  },
  {
    "scenario": "distinct-dedicated-and-structured-reasoning_content",
    "lane": "package",
    "assistantContent": "Visible answer",
    "providerReasoningFields": [
      "reasoning_content"
    ]
  },
  {
    "scenario": "distinct-dedicated-and-structured-reasoning_content",
    "lane": "managed",
    "assistantContent": "Visible answer",
    "providerReasoningFields": []
  }
]
```

### Delayed real SDK streaming; terminal intentionally withheld

| Producer | Reasoning | First visible token | Terminal chunk | First token before terminal |
| --- | --- | ---: | ---: | --- |
| package | medium | 28 ms | 300 ms | yes |
| managed | medium | 6 ms | 278 ms | yes |
| package | none | 4 ms | 279 ms | yes |
| managed | none | 5 ms | 280 ms | yes |

The regression suite additionally feeds partial `<thi` followed by structured thinking and `nk>SECRET</think>SAFE`; both producers return `SAFE` and never expose `SECRET`.

### Full hosted type and owner proof

Blacksmith Testbox lease `tbx_01kyxcycme3d367hneahmmrxnr`: [exact-head hosted verification](https://github.com/openclaw/openclaw/actions/runs/30676613734).

```sh
pnpm tsgo:test
# core test project: passed
# extensions test project: passed
# root test project: passed

pnpm test \
  packages/ai/src/providers/openai-completions-structured-content-parity.test.ts \
  packages/ai/src/providers/openai-completions-usage-parity.test.ts \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/openai-completions.compat.test.ts \
  packages/ai/src/provider-transport-parity.test.ts \
  src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
# 179 unit + 40 agent = 219 / 219 passed
```

Wrapper exit: `0`; run status: `succeeded`; lease independently verified `completed`/stopped. The backing Actions step can report cancellation during successful externally owned Testbox teardown; the authoritative wrapper exit and timing JSON both report success.

### Independent review and protected contracts

- Fresh whole-branch `gpt-5.6-sol` high-reasoning autoreview against exact parent, explicit `--max-priority P3`: **zero findings**, confidence **0.87**; genuine TruffleHog clean.
- Blind review one: **0 actionable P0/P1/P2/P3**, confidence **0.995**; **241/241** tests plus real SDK/deferred-terminal/next-turn proof.
- Blind review two: **0 actionable P0/P1/P2/P3**, confidence **0.995**; **408/408** tests across eight files plus independent real SDK privacy/latency proof.
- Personally inspected installed upstream OpenAI Chat content/refusal contracts, installed Mistral typed-thinking/delta contracts, and direct sibling Codex typed-output/event-mapping/SSE source.
- Protected snapshots: OpenAI success `e2a1b1100acdf7c5f24c5c7cadd60e924c29b2ab`; OpenAI error `4156ead6875cd55590550f5313f7fd69e72c9a4b`; Anthropic success `84170ce01bdf669d23d22abb9d280c70ea2fb614`; Anthropic error `1cde0a07d3c44dcd1719e74da77db5139e37edc5`.
- Latest verified main `a7b4a4735628c5b411adc361b8289f3cc41ed271`: zero touched-owner changes since the frozen parent; clean merge tree `c188f4d5eb662825a35fe8878f50727ac5d7926a`.
