### PR TITLE
fix(agents): keep subagent status consistent after restart and large fan-outs

### DIFF
--- a/src/agents/subagent-registry-deps.ts
+++ b/src/agents/subagent-registry-deps.ts
@@ -101,51 +101,24 @@ const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
 };
 
 export let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
-type ContextEngineInitModule = Pick<
-  {
-    ensureContextEnginesInitialized: () => void;
-  },
-  "ensureContextEnginesInitialized"
->;
-type ContextEngineRegistryModule = Pick<
-  {
-    resolveContextEngine: (
-      cfg?: OpenClawConfig,
-      options?: ResolveContextEngineOptions,
-    ) => Promise<ContextEngine>;
-  },
-  "resolveContextEngine"
->;
-type RuntimePluginsModule = Pick<
-  {
-    ensureRuntimePluginsLoaded: typeof ensureRuntimePluginsLoadedFn;
-  },
-  "ensureRuntimePluginsLoaded"
->;
+type SubagentRegistryRuntimeModule = {
+  ensureContextEnginesInitialized: () => void;
+  resolveContextEngine: (
+    cfg?: OpenClawConfig,
+    options?: ResolveContextEngineOptions,
+  ) => Promise<ContextEngine>;
+  ensureRuntimePluginsLoaded: typeof ensureRuntimePluginsLoadedFn;
+};
 
 const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./subagent-registry.runtime", ".js"] as const;
 
-const contextEngineInitLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<ContextEngineInitModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
+// All three capabilities belong to the same lazy runtime module and lifecycle.
+const subagentRegistryRuntimeLoader = createLazyPromiseLoader(() =>
+  importRuntimeModule<SubagentRegistryRuntimeModule>(
+    import.meta.url,
+    SUBAGENT_REGISTRY_RUNTIME_SPEC,
+  ),
 );
-const contextEngineRegistryLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<ContextEngineRegistryModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
-);
-const runtimePluginsLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
-);
-
-function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
-  return contextEngineInitLoader.load();
-}
-
-function loadContextEngineRegistryModule(): Promise<ContextEngineRegistryModule> {
-  return contextEngineRegistryLoader.load();
-}
-
-function loadRuntimePluginsModule(): Promise<RuntimePluginsModule> {
-  return runtimePluginsLoader.load();
-}
 
 export async function ensureSubagentRegistryPluginRuntimeLoaded(params: {
   config: OpenClawConfig;
@@ -157,20 +130,18 @@ export async function ensureSubagentRegistryPluginRuntimeLoaded(params: {
     await ensureRuntimePluginsLoaded(params);
     return;
   }
-  (await loadRuntimePluginsModule()).ensureRuntimePluginsLoaded(params);
+  (await subagentRegistryRuntimeLoader.load()).ensureRuntimePluginsLoaded(params);
 }
 
 export async function resolveSubagentRegistryContextEngine(
   cfg: OpenClawConfig,
   options?: ResolveContextEngineOptions,
 ) {
-  const initModule = await loadContextEngineInitModule();
-  const registryModule = await loadContextEngineRegistryModule();
+  const runtime = await subagentRegistryRuntimeLoader.load();
   const ensureContextEnginesInitialized =
-    subagentRegistryDeps.ensureContextEnginesInitialized ??
-    initModule.ensureContextEnginesInitialized;
+    subagentRegistryDeps.ensureContextEnginesInitialized ?? runtime.ensureContextEnginesInitialized;
   const resolveContextEngine =
-    subagentRegistryDeps.resolveContextEngine ?? registryModule.resolveContextEngine;
+    subagentRegistryDeps.resolveContextEngine ?? runtime.resolveContextEngine;
   ensureContextEnginesInitialized();
   return await resolveContextEngine(cfg, options);
 }
@@ -182,9 +153,7 @@ export function setSubagentRegistryDepsForTest(overrides?: Partial<SubagentRegis
 }
 
 export function resetSubagentRegistryRuntimeLoadersForTests() {
-  contextEngineInitLoader.clear();
-  contextEngineRegistryLoader.clear();
-  runtimePluginsLoader.clear();
+  subagentRegistryRuntimeLoader.clear();
   subagentAnnounceLoader.clear();
   browserCleanupLoader.clear();
 }

--- a/src/agents/subagent-registry-memory.ts
+++ b/src/agents/subagent-registry-memory.ts
@@ -25,29 +25,39 @@ function collectorGroupKey(entry: SubagentRunRecord): string | undefined {
   ]);
 }
 
-function removeRunFromChildSessionIndex(runId: string, entry: SubagentRunRecord) {
-  const sessionRuns = runsByChildSessionKey.get(entry.childSessionKey);
-  if (sessionRuns?.get(runId) !== entry) {
-    return;
-  }
-  sessionRuns.delete(runId);
-  if (sessionRuns.size === 0) {
-    runsByChildSessionKey.delete(entry.childSessionKey);
-  }
-}
-
-function removeRunFromCollectorGroupIndex(runId: string, entry: SubagentRunRecord) {
-  const key = collectorGroupKey(entry);
+function removeIndexedSubagentRun(
+  index: Map<string, Map<string, SubagentRunRecord>>,
+  key: string | undefined,
+  runId: string,
+  entry: SubagentRunRecord,
+) {
   if (!key) {
     return;
   }
-  const groupRuns = runsByCollectorGroupKey.get(key);
-  if (groupRuns?.get(runId) !== entry) {
+  const indexedRuns = index.get(key);
+  if (indexedRuns?.get(runId) !== entry) {
     return;
   }
-  groupRuns.delete(runId);
-  if (groupRuns.size === 0) {
-    runsByCollectorGroupKey.delete(key);
+  indexedRuns.delete(runId);
+  if (indexedRuns.size === 0) {
+    index.delete(key);
+  }
+}
+
+function indexSubagentRun(
+  index: Map<string, Map<string, SubagentRunRecord>>,
+  key: string | undefined,
+  runId: string,
+  entry: SubagentRunRecord,
+) {
+  if (!key) {
+    return;
+  }
+  const indexedRuns = index.get(key);
+  if (indexedRuns) {
+    indexedRuns.set(runId, entry);
+  } else {
+    index.set(key, new Map([[runId, entry]]));
   }
 }
 
@@ -55,28 +65,15 @@ class SubagentRunMap extends Map<string, SubagentRunRecord> {
   override set(runId: string, entry: SubagentRunRecord): this {
     const prev = this.get(runId);
     if (prev) {
-      removeRunFromChildSessionIndex(runId, prev);
-      removeRunFromCollectorGroupIndex(runId, prev);
+      removeIndexedSubagentRun(runsByChildSessionKey, prev.childSessionKey, runId, prev);
+      removeIndexedSubagentRun(runsByCollectorGroupKey, collectorGroupKey(prev), runId, prev);
       if (prev.collect === true && prev.childSessionKey) {
         collectorRunIdByChildSessionKey.delete(prev.childSessionKey);
       }
     }
     super.set(runId, entry);
-    let sessionRuns = runsByChildSessionKey.get(entry.childSessionKey);
-    if (!sessionRuns) {
-      sessionRuns = new Map();
-      runsByChildSessionKey.set(entry.childSessionKey, sessionRuns);
-    }
-    sessionRuns.set(runId, entry);
-    const groupKey = collectorGroupKey(entry);
-    if (groupKey) {
-      let groupRuns = runsByCollectorGroupKey.get(groupKey);
-      if (!groupRuns) {
-        groupRuns = new Map();
-        runsByCollectorGroupKey.set(groupKey, groupRuns);
-      }
-      groupRuns.set(runId, entry);
-    }
+    indexSubagentRun(runsByChildSessionKey, entry.childSessionKey, runId, entry);
+    indexSubagentRun(runsByCollectorGroupKey, collectorGroupKey(entry), runId, entry);
     if (entry.collect === true && entry.childSessionKey) {
       collectorRunIdByChildSessionKey.set(entry.childSessionKey, runId);
     }
@@ -86,8 +83,8 @@ class SubagentRunMap extends Map<string, SubagentRunRecord> {
   override delete(runId: string): boolean {
     const prev = this.get(runId);
     if (prev) {
-      removeRunFromChildSessionIndex(runId, prev);
-      removeRunFromCollectorGroupIndex(runId, prev);
+      removeIndexedSubagentRun(runsByChildSessionKey, prev.childSessionKey, runId, prev);
+      removeIndexedSubagentRun(runsByCollectorGroupKey, collectorGroupKey(prev), runId, prev);
     }
     if (
       prev?.collect === true &&

--- a/src/agents/subagent-registry-public-api.ts
+++ b/src/agents/subagent-registry-public-api.ts
@@ -1,4 +1,3 @@
-import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import {
   ackLeasedAgentSteeringItemsFromSubagentRuns,
   leasePendingAgentSteeringItemsFromSubagentRuns,
@@ -6,6 +5,7 @@ import {
 } from "./agent-steering-queue.js";
 import type { SubagentRegistryDeps } from "./subagent-registry-deps.js";
 import type { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import { getSubagentRunsForChildSession } from "./subagent-registry-memory.js";
 import {
   countActiveDescendantRunsFromRuns,
   countActiveRunsForSessionFromRuns,
@@ -38,6 +38,9 @@ export function createSubagentRegistryPublicApi(config: {
     startAnnounceCleanup,
     settleRequesterTurn,
   } = config;
+  const readRuns = () => deps().getSubagentRunsSnapshotForRead(runs);
+  const findRunById = (records: Map<string, SubagentRunRecord>, runId: string) =>
+    records.get(runId) ?? [...records.values()].find((entry) => entry.swarmRunId === runId);
 
   function leasePendingAgentSteeringItems(params: {
     requesterSessionKey: string;
@@ -45,12 +48,7 @@ export function createSubagentRegistryPublicApi(config: {
     now?: number;
   }) {
     restoreOnce();
-    const leased = leasePendingAgentSteeringItemsFromSubagentRuns({
-      runs,
-      requesterSessionKey: params.requesterSessionKey,
-      leaseId: params.leaseId,
-      now: params.now,
-    });
+    const leased = leasePendingAgentSteeringItemsFromSubagentRuns({ ...params, runs });
     if (leased) {
       persist(...leased.runIds);
     }
@@ -62,12 +60,7 @@ export function createSubagentRegistryPublicApi(config: {
     leaseId: string;
     now?: number;
   }): number {
-    const updated = ackLeasedAgentSteeringItemsFromSubagentRuns({
-      runs,
-      runIds: params.runIds,
-      leaseId: params.leaseId,
-      now: params.now,
-    });
+    const updated = ackLeasedAgentSteeringItemsFromSubagentRuns({ ...params, runs });
     if (updated > 0) {
       persist(...params.runIds);
       for (const runId of params.runIds) {
@@ -87,12 +80,7 @@ export function createSubagentRegistryPublicApi(config: {
     leaseId: string;
     error?: string;
   }): number {
-    const updated = releaseLeasedAgentSteeringItemsFromSubagentRuns({
-      runs,
-      runIds: params.runIds,
-      leaseId: params.leaseId,
-      error: params.error,
-    });
+    const updated = releaseLeasedAgentSteeringItemsFromSubagentRuns({ ...params, runs });
     if (updated > 0) {
       persist(...params.runIds);
     }
@@ -107,17 +95,14 @@ export function createSubagentRegistryPublicApi(config: {
   }
 
   function getSubagentRunByRunId(runId: string): SubagentRunRecord | undefined {
-    const key = runId.trim();
-    const snapshot = deps().getSubagentRunsSnapshotForRead(runs);
-    return snapshot.get(key) ?? [...snapshot.values()].find((entry) => entry.swarmRunId === key);
+    return findRunById(readRuns(), runId.trim());
   }
 
   function getSubagentRunsByRunIds(runIds: readonly string[]): {
     entries: Map<string, SubagentRunRecord>;
   } {
-    const snapshot = deps().getSubagentRunsSnapshotForRead(runs);
     const byId = new Map<string, SubagentRunRecord>();
-    for (const entry of snapshot.values()) {
+    for (const entry of readRuns().values()) {
       byId.set(entry.runId, entry);
       if (entry.swarmRunId) {
         byId.set(entry.swarmRunId, entry);
@@ -134,9 +119,7 @@ export function createSubagentRegistryPublicApi(config: {
   }
 
   function completeCollectorLaunchCleanup(runId: string): void {
-    const key = runId.trim();
-    const entry =
-      runs.get(key) ?? [...runs.values()].find((candidate) => candidate.swarmRunId === key);
+    const entry = findRunById(runs, runId.trim());
     if (!entry?.collectorLaunchCleanupPending) {
       return;
     }
@@ -153,14 +136,12 @@ export function createSubagentRegistryPublicApi(config: {
     const runId = identity.runId?.trim();
     const childSessionKey = identity.childSessionKey?.trim();
     const entry =
-      (runId
-        ? (runs.get(runId) ??
-          [...runs.values()].find((candidate) => candidate.swarmRunId === runId))
-        : undefined) ??
+      (runId ? findRunById(runs, runId) : undefined) ??
       (childSessionKey
-        ? [...runs.values()]
-            .filter((candidate) => candidate.childSessionKey === childSessionKey)
-            .toSorted((left, right) => (right.generation ?? 0) - (left.generation ?? 0))[0]
+        ? getLatestSubagentRunByChildSessionKeyFromRuns(
+            getSubagentRunsForChildSession(childSessionKey),
+            childSessionKey,
+          )
         : undefined);
     if (!entry?.collect || entry.collectorCompletion) {
       throw new Error("collector run is unavailable");
@@ -181,7 +162,7 @@ export function createSubagentRegistryPublicApi(config: {
   ): SubagentRunRecord[] {
     const key = groupId.trim();
     const requesterKey = requesterSessionKey?.trim();
-    return [...deps().getSubagentRunsSnapshotForRead(runs).values()].filter(
+    return [...readRuns().values()].filter(
       (entry) =>
         entry.collect === true &&
         entry.groupId === key &&
@@ -200,7 +181,7 @@ export function createSubagentRegistryPublicApi(config: {
     if (!key) {
       return undefined;
     }
-    return [...deps().getSubagentRunsSnapshotForRead(runs).values()].find(
+    return [...readRuns().values()].find(
       (entry) =>
         entry.collect === true &&
         entry.swarmLaunchReplayKey === key &&
@@ -213,37 +194,24 @@ export function createSubagentRegistryPublicApi(config: {
     requesterSessionKey: string,
     options?: { collect?: boolean },
   ): number {
-    return countActiveRunsForSessionFromRuns(
-      deps().getSubagentRunsSnapshotForRead(runs),
-      requesterSessionKey,
-      options,
-    );
+    return countActiveRunsForSessionFromRuns(readRuns(), requesterSessionKey, options);
   }
 
   function countActiveDescendantRuns(rootSessionKey: string): number {
-    return countActiveDescendantRunsFromRuns(
-      deps().getSubagentRunsSnapshotForRead(runs),
-      rootSessionKey,
-    );
+    return countActiveDescendantRunsFromRuns(readRuns(), rootSessionKey);
   }
 
   function countPendingDescendantRuns(rootSessionKey: string): number {
-    return countPendingDescendantRunsFromRuns(
-      deps().getSubagentRunsSnapshotForRead(runs),
-      rootSessionKey,
-    );
+    return countPendingDescendantRunsFromRuns(readRuns(), rootSessionKey);
   }
 
   function listDescendantRunsForRequester(rootSessionKey: string): SubagentRunRecord[] {
-    return listDescendantRunsForRequesterFromRuns(
-      deps().getSubagentRunsSnapshotForRead(runs),
-      rootSessionKey,
-    );
+    return listDescendantRunsForRequesterFromRuns(readRuns(), rootSessionKey);
   }
 
   function getSubagentRunByChildSessionKey(childSessionKey: string): SubagentRunRecord | null {
     return getSubagentRunByChildSessionKeyFromRuns(
-      deps().getSubagentRunsSnapshotForRead(runs),
+      deps().getSubagentRunsSnapshotForChildSession(runs, childSessionKey),
       childSessionKey,
     );
   }
@@ -251,27 +219,12 @@ export function createSubagentRegistryPublicApi(config: {
   function getLatestSubagentRunByChildSessionKey(
     childSessionKey: string,
   ): SubagentRunRecord | null {
-    const key = childSessionKey.trim();
-    if (!key) {
-      return null;
-    }
-
     return (
       getLatestSubagentRunByChildSessionKeyFromRuns(
-        deps().getSubagentRunsSnapshotForChildSession(runs, key),
-        key,
+        deps().getSubagentRunsSnapshotForChildSession(runs, childSessionKey),
+        childSessionKey,
       ) ?? null
     );
-  }
-
-  /** Re-admits a delivered child batch after its requester explicitly yields. */
-  function settleRequesterAfterSessionSpawns(params: {
-    requesterSessionKey: string;
-    requesterTurnRunId: string;
-    requesterYielded: boolean;
-    acceptedSessionSpawns: readonly AcceptedSessionSpawn[];
-  }): boolean {
-    return settleRequesterTurn(params);
   }
 
   /** Records sessions_yield before the active requester run is aborted. */
@@ -304,7 +257,7 @@ export function createSubagentRegistryPublicApi(config: {
     listDescendantRunsForRequester,
     getSubagentRunByChildSessionKey,
     getLatestSubagentRunByChildSessionKey,
-    settleRequesterAfterSessionSpawns,
+    settleRequesterAfterSessionSpawns: settleRequesterTurn,
     markRequesterTurnYielded,
   };
 }

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -44,16 +44,13 @@ export function listRunsForRequesterFromRuns(
 
   const results: SubagentRunRecord[] = [];
   for (const entry of runs.values()) {
-    if (entry.requesterSessionKey !== key) {
-      continue;
+    if (
+      entry.requesterSessionKey === key &&
+      (typeof lowerBound !== "number" || entry.createdAt >= lowerBound) &&
+      (typeof upperBound !== "number" || entry.createdAt <= upperBound)
+    ) {
+      results.push(entry);
     }
-    if (typeof lowerBound === "number" && entry.createdAt < lowerBound) {
-      continue;
-    }
-    if (typeof upperBound === "number" && entry.createdAt > upperBound) {
-      continue;
-    }
-    results.push(entry);
   }
   return results;
 }
@@ -64,10 +61,10 @@ export function listRunsForControllerFromRuns(
   controllerSessionKey: string,
 ): SubagentRunRecord[] {
   const key = controllerSessionKey.trim();
-  if (!key) {
-    return [];
-  }
   const results: SubagentRunRecord[] = [];
+  if (!key) {
+    return results;
+  }
   for (const entry of runs.values()) {
     if (resolveControllerSessionKey(entry) === key) {
       results.push(entry);
@@ -75,11 +72,6 @@ export function listRunsForControllerFromRuns(
   }
   return results;
 }
-
-type LatestRunPair<T extends SubagentRunReadRecord = SubagentRunRecord> = {
-  runId: string;
-  entry: T;
-};
 
 /** Cached read index for display, controller grouping, and descendant queries. */
 export type SubagentRunReadIndex<T extends SubagentRunReadRecord = SubagentRunRecord> = {
@@ -126,18 +118,6 @@ export function buildLatestSubagentRunReadIndexFromRuns(
   };
 }
 
-function rememberLatestRunPair<T extends SubagentRunReadRecord>(
-  map: Map<string, LatestRunPair<T>>,
-  key: string,
-  runId: string,
-  entry: T,
-): void {
-  const existing = map.get(key);
-  if (!existing || compareSubagentRunGeneration(entry, existing.entry) > 0) {
-    map.set(key, { runId, entry });
-  }
-}
-
 /** Builds a read index from snapshot and optional in-memory runs. */
 export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecord>(params: {
   runs: Map<string, T>;
@@ -149,9 +129,9 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
   const inMemoryDisplayByChildSessionKey = new Map<string, T>();
   const latestSnapshotActiveByChildSessionKey = new Map<string, T>();
   const latestSnapshotEndedByChildSessionKey = new Map<string, T>();
-  const latestRunByChildSessionKey = new Map<string, LatestRunPair<T>>();
+  const latestRunsByChildSessionKey = new Map<string, T>();
   const runsByControllerSessionKey = new Map<string, T[]>();
-  const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, LatestRunPair<T>>>();
+  const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, T>>();
   const activeDescendantCountBySessionKey = new Map<string, number>();
   const pendingDescendantCountBySessionKey = new Map<string, number>();
 
@@ -163,7 +143,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     rememberLatestRunEntry(inMemoryDisplayByChildSessionKey, childSessionKey, entry);
   }
 
-  for (const [runId, entry] of runs.entries()) {
+  for (const entry of runs.values()) {
     const childSessionKey = entry.childSessionKey.trim();
     const controllerSessionKey = resolveControllerSessionKey(entry);
     if (controllerSessionKey) {
@@ -177,12 +157,11 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     if (!childSessionKey) {
       continue;
     }
-    if (isLiveUnendedSubagentRun(entry, now)) {
-      rememberLatestRunEntry(latestSnapshotActiveByChildSessionKey, childSessionKey, entry);
-    } else {
-      rememberLatestRunEntry(latestSnapshotEndedByChildSessionKey, childSessionKey, entry);
-    }
-    rememberLatestRunPair(latestRunByChildSessionKey, childSessionKey, runId, entry);
+    const displayRuns = isLiveUnendedSubagentRun(entry, now)
+      ? latestSnapshotActiveByChildSessionKey
+      : latestSnapshotEndedByChildSessionKey;
+    rememberLatestRunEntry(displayRuns, childSessionKey, entry);
+    rememberLatestRunEntry(latestRunsByChildSessionKey, childSessionKey, entry);
 
     const requesterSessionKey = entry.requesterSessionKey;
     if (!requesterSessionKey) {
@@ -190,15 +169,10 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     }
     let latestByChild = latestRunByRequesterAndChildSessionKey.get(requesterSessionKey);
     if (!latestByChild) {
-      latestByChild = new Map<string, LatestRunPair<T>>();
+      latestByChild = new Map<string, T>();
       latestRunByRequesterAndChildSessionKey.set(requesterSessionKey, latestByChild);
     }
-    rememberLatestRunPair(latestByChild, childSessionKey, runId, entry);
-  }
-
-  const latestRunsByChildSessionKey = new Map<string, T>();
-  for (const [childSessionKey, pair] of latestRunByChildSessionKey) {
-    latestRunsByChildSessionKey.set(childSessionKey, pair.entry);
+    rememberLatestRunEntry(latestByChild, childSessionKey, entry);
   }
 
   const getDisplaySubagentRun = (childSessionKey: string): T | null => {
@@ -216,7 +190,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
 
   const forEachDescendantRun = (
     rootSessionKey: string,
-    visitor: (runId: string, entry: T) => void | boolean,
+    visitor: (entry: T) => void | boolean,
   ): void => {
     const root = rootSessionKey.trim();
     if (!root) {
@@ -225,27 +199,17 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     const pending = [root];
     const visited = new Set<string>([root]);
     for (const requester of pending) {
-      if (!requester) {
-        continue;
-      }
-      const latestByChild = latestRunByRequesterAndChildSessionKey.get(requester);
-      if (!latestByChild) {
-        continue;
-      }
-      for (const [childSessionKey, pair] of latestByChild) {
-        const latestForChildSession = latestRunByChildSessionKey.get(childSessionKey);
+      for (const [childSessionKey, entry] of latestRunByRequesterAndChildSessionKey.get(
+        requester,
+      ) ?? []) {
         // Only traverse the latest run per child; older retries should not keep descendants alive.
-        if (
-          !latestForChildSession ||
-          latestForChildSession.runId !== pair.runId ||
-          latestForChildSession.entry.requesterSessionKey !== requester
-        ) {
+        if (latestRunsByChildSessionKey.get(childSessionKey) !== entry) {
           continue;
         }
-        if (visitor(pair.runId, pair.entry) === true) {
+        if (visitor(entry) === true) {
           return;
         }
-        if (!childSessionKey || visited.has(childSessionKey)) {
+        if (visited.has(childSessionKey)) {
           continue;
         }
         visited.add(childSessionKey);
@@ -263,7 +227,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
       return activeDescendantCountBySessionKey.get(root) ?? 0;
     }
     let count = 0;
-    forEachDescendantRun(root, (_runId, entry) => {
+    forEachDescendantRun(root, (entry) => {
       if (isLiveUnendedSubagentRun(entry, now)) {
         count += 1;
       }
@@ -282,8 +246,8 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
   ): number => {
     const excludedRunId = options?.excludeRunId?.trim();
     let count = 0;
-    forEachDescendantRun(rootSessionKey, (runId, entry) => {
-      if (runId === excludedRunId) {
+    forEachDescendantRun(rootSessionKey, (entry) => {
+      if (entry.runId === excludedRunId) {
         return false;
       }
       const runPending = hasSubagentRunEnded(entry)
@@ -331,7 +295,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
 
   const listDescendantRunsForRequester = (rootSessionKey: string): T[] => {
     const descendants: T[] = [];
-    forEachDescendantRun(rootSessionKey, (_runId, entry) => {
+    forEachDescendantRun(rootSessionKey, (entry) => {
       descendants.push(entry);
     });
     return descendants;
@@ -351,7 +315,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
 
 /** Returns the latest-generation run for a child session. */
 export function getLatestSubagentRunByChildSessionKeyFromRuns(
-  runs: Map<string, SubagentRunRecord>,
+  runs: Map<string, SubagentRunRecord> | Iterable<SubagentRunRecord>,
   childSessionKey: string,
 ): SubagentRunRecord | undefined {
   const key = childSessionKey.trim();
@@ -359,7 +323,7 @@ export function getLatestSubagentRunByChildSessionKeyFromRuns(
     return undefined;
   }
   let latest: SubagentRunRecord | undefined;
-  for (const entry of runs.values()) {
+  for (const entry of runs instanceof Map ? runs.values() : runs) {
     if (entry.childSessionKey !== key) {
       continue;
     }
@@ -465,10 +429,7 @@ export function countActiveRunsForSessionFromRuns(
     if (resolveConcurrencyOwnerSessionKey(entry) !== key) {
       continue;
     }
-    const existing = latestByChildSessionKey.get(entry.childSessionKey);
-    if (!existing || compareSubagentRunGeneration(entry, existing) > 0) {
-      latestByChildSessionKey.set(entry.childSessionKey, entry);
-    }
+    rememberLatestRunEntry(latestByChildSessionKey, entry.childSessionKey, entry);
   }
 
   let count = 0;

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -143,7 +143,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     rememberLatestRunEntry(inMemoryDisplayByChildSessionKey, childSessionKey, entry);
   }
 
-  for (const entry of runs.values()) {
+  for (const [, entry] of runs.entries()) {
     const childSessionKey = entry.childSessionKey.trim();
     const controllerSessionKey = resolveControllerSessionKey(entry);
     if (controllerSessionKey) {

--- a/src/agents/subagent-registry-read.scoped.test.ts
+++ b/src/agents/subagent-registry-read.scoped.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const mocks = vi.hoisted(() => ({
+  getSubagentRunsForChildSession: vi.fn<(childSessionKey: string) => Iterable<SubagentRunRecord>>(
+    () => [],
+  ),
   getSubagentRunsSnapshotForChildSession: vi.fn<
     (
       runs: Map<string, SubagentRunRecord>,
@@ -22,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./subagent-registry-memory.js", () => ({
+  getSubagentRunsForChildSession: mocks.getSubagentRunsForChildSession,
   subagentRuns: new Map<string, SubagentRunRecord>(),
 }));
 
@@ -49,6 +53,7 @@ describe("subagent registry scoped reads", () => {
   let mod: typeof import("./subagent-registry-read.js");
 
   beforeEach(async () => {
+    mocks.getSubagentRunsForChildSession.mockReset().mockReturnValue([]);
     mocks.getSubagentRunsSnapshotForChildSession.mockReset().mockReturnValue(new Map());
     mocks.getSubagentRunsSnapshotForController.mockReset().mockReturnValue(new Map());
     mocks.getSubagentRunsSnapshotForRead.mockClear();
@@ -70,6 +75,17 @@ describe("subagent registry scoped reads", () => {
     expect(mod.getSessionDisplaySubagentRunByChildSessionKey(childSessionKey)).toEqual(latest);
     expect(mocks.getSubagentRunsSnapshotForChildSession).toHaveBeenCalledTimes(2);
     expect(mocks.getSubagentRunsSnapshotForRead).not.toHaveBeenCalled();
+  });
+
+  it("prefers the latest indexed live generation without loading persisted rows", () => {
+    const childSessionKey = "agent:main:subagent:child";
+    const older = createRun({ runId: "older", childSessionKey, generation: 1, createdAt: 200 });
+    const latest = createRun({ runId: "latest", childSessionKey, generation: 2, createdAt: 100 });
+    mocks.getSubagentRunsForChildSession.mockReturnValue([older, latest]);
+
+    expect(mod.getSessionDisplaySubagentRunByChildSessionKey(childSessionKey)).toBe(latest);
+    expect(mocks.getSubagentRunsForChildSession).toHaveBeenCalledWith(childSessionKey);
+    expect(mocks.getSubagentRunsSnapshotForChildSession).not.toHaveBeenCalled();
   });
 
   it("uses the controller snapshot while retaining legacy requester-owned runs", () => {

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -4,7 +4,7 @@
  * Combines persisted snapshots with in-memory live runs for UI, announce, control, and recovery paths.
  */
 import { getAgentRunContext } from "../infra/agent-events.js";
-import { subagentRuns } from "./subagent-registry-memory.js";
+import { getSubagentRunsForChildSession, subagentRuns } from "./subagent-registry-memory.js";
 import {
   buildLatestSubagentRunReadIndexFromRuns,
   buildSubagentRunReadIndexFromRuns,
@@ -23,7 +23,6 @@ import {
   getSubagentRunsSnapshotForRead,
 } from "./subagent-registry-state.js";
 import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
-import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 
 export {
   getSubagentSessionRuntimeMs,
@@ -90,15 +89,10 @@ export function getSessionDisplaySubagentRunByChildSessionKey(
     return null;
   }
 
-  let latestInMemory: SubagentRunRecord | null = null;
-  for (const entry of subagentRuns.values()) {
-    if (entry.childSessionKey !== key) {
-      continue;
-    }
-    if (!latestInMemory || compareSubagentRunGeneration(entry, latestInMemory) > 0) {
-      latestInMemory = entry;
-    }
-  }
+  const latestInMemory = getLatestSubagentRunByChildSessionKeyFromRuns(
+    getSubagentRunsForChildSession(key),
+    key,
+  );
   // Fresh in-memory terminal state is more accurate than an older active snapshot row.
   return (
     latestInMemory ??

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -72,8 +72,16 @@ function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
 }
 
+function restoreSubagentRunRecord(entry: SubagentRunRecord, snapshot: SubagentRunRecord): void {
+  const target = entry as unknown as Record<string, unknown>;
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, snapshot);
+}
+
 function resolveSwarmWaitOwnerSessionKeys(
-  runs: ReadonlyMap<string, SubagentRunRecord>,
+  getRunsForChildSession: (childSessionKey: string) => Iterable<SubagentRunRecord>,
   requesterSessionKey: string,
 ): string[] {
   const ownerSessionKeys: string[] = [];
@@ -83,11 +91,8 @@ function resolveSwarmWaitOwnerSessionKeys(
     visited.add(currentSessionKey);
     ownerSessionKeys.push(currentSessionKey);
     let latestOwner: SubagentRunRecord | undefined;
-    for (const candidate of runs.values()) {
-      if (
-        candidate.childSessionKey === currentSessionKey &&
-        (!latestOwner || compareSubagentRunGeneration(candidate, latestOwner) > 0)
-      ) {
+    for (const candidate of getRunsForChildSession(currentSessionKey)) {
+      if (!latestOwner || compareSubagentRunGeneration(candidate, latestOwner) > 0) {
         latestOwner = candidate;
       }
     }
@@ -240,6 +245,7 @@ export type RegisterSubagentRunParams = {
 
 export function createSubagentRunManager(params: {
   runs: Map<string, SubagentRunRecord>;
+  getRunsForChildSession: (childSessionKey: string) => Iterable<SubagentRunRecord>;
   resumedRuns: Set<string>;
   persist(...runIds: string[]): void;
   persistOrThrow(...runIds: string[]): void;
@@ -288,12 +294,15 @@ export function createSubagentRunManager(params: {
   }): Promise<void>;
   resolveSubagentTask(entry: SubagentRunRecord): DetachedTaskFindResult;
 }) {
+  const findRunByIdentity = (runId: string): SubagentRunRecord | undefined =>
+    params.runs.get(runId) ??
+    [...params.runs.values()].find((candidate) => candidate.swarmRunId === runId);
+
   const markOlderKillReconciliationsSuperseded = (next: SubagentRunRecord) => {
     const snapshots = new Map<SubagentRunRecord, SubagentRunRecord["killReconciliation"]>();
-    for (const candidate of params.runs.values()) {
+    for (const candidate of params.getRunsForChildSession(next.childSessionKey)) {
       if (
         candidate.runId === next.runId ||
-        candidate.childSessionKey !== next.childSessionKey ||
         compareSubagentRunGeneration(candidate, next) >= 0 ||
         !candidate.killReconciliation
       ) {
@@ -311,10 +320,8 @@ export function createSubagentRunManager(params: {
   const currentRunOwnsSession = (entry: SubagentRunRecord): boolean =>
     params.runs.get(entry.runId) === entry &&
     entry.killReconciliation?.supersededAt === undefined &&
-    !Array.from(params.runs.values()).some(
-      (candidate) =>
-        candidate.childSessionKey === entry.childSessionKey &&
-        compareSubagentRunGeneration(candidate, entry) > 0,
+    !Array.from(params.getRunsForChildSession(entry.childSessionKey)).some(
+      (candidate) => compareSubagentRunGeneration(candidate, entry) > 0,
     );
 
   const restoreKillReconciliationSnapshots = (
@@ -655,7 +662,7 @@ export function createSubagentRunManager(params: {
 
     const now = Date.now();
     const generation = nextSubagentRunGeneration(
-      [...params.runs.values(), source],
+      [...params.getRunsForChildSession(source.childSessionKey), source],
       source.childSessionKey,
     );
     const cfg = params.getRuntimeConfig();
@@ -793,7 +800,10 @@ export function createSubagentRunManager(params: {
       return;
     }
     const now = Date.now();
-    const generation = nextSubagentRunGeneration(params.runs.values(), childSessionKey);
+    const generation = nextSubagentRunGeneration(
+      params.getRunsForChildSession(childSessionKey),
+      childSessionKey,
+    );
     const cfg = params.getRuntimeConfig();
     const spawnMode = registerParams.spawnMode === "session" ? "session" : "run";
     const archiveAtMs = resolveSubagentArchiveAtMs({
@@ -834,7 +844,10 @@ export function createSubagentRunManager(params: {
       swarmRequesterSessionKey: registerParams.swarmRequesterSessionKey,
       swarmWaitOwnerSessionKeys:
         registerParams.collect && registerParams.swarmRequesterSessionKey
-          ? resolveSwarmWaitOwnerSessionKeys(params.runs, registerParams.swarmRequesterSessionKey)
+          ? resolveSwarmWaitOwnerSessionKeys(
+              params.getRunsForChildSession,
+              registerParams.swarmRequesterSessionKey,
+            )
           : undefined,
       swarmRunId: registerParams.collect ? runId : undefined,
       schedulerSlotId: registerParams.collect ? runId : undefined,
@@ -928,9 +941,7 @@ export function createSubagentRunManager(params: {
 
   const startQueuedSubagentRun = (runId: string, gatewayRunId?: string) => {
     const key = runId.trim();
-    const entry =
-      params.runs.get(key) ??
-      [...params.runs.values()].find((candidate) => candidate.swarmRunId === key);
+    const entry = findRunByIdentity(key);
     const lifecycleStarted =
       entry?.execution?.status === "running" &&
       typeof entry.execution.startedAt === "number" &&
@@ -961,13 +972,16 @@ export function createSubagentRunManager(params: {
     }
     const acceptedAt = Date.now();
     const previousRunId = entry.runId;
-    const previousStartedAt = entry.startedAt;
-    const previousSessionStartedAt = entry.sessionStartedAt;
-    const previousExecution = entry.execution;
-    const previousQueuedLaunch = entry.queuedLaunch;
-    const previousSwarmRunId = entry.swarmRunId;
-    const previousSchedulerSlotId = entry.schedulerSlotId;
-    const previousSwarmLaunchPending = entry.swarmLaunchPending;
+    const previous = structuredClone(entry);
+    const restoreQueuedRun = () => {
+      if (previousRunId !== nextRunId) {
+        params.runs.delete(nextRunId);
+      }
+      restoreSubagentRunRecord(entry, previous);
+      if (previousRunId !== nextRunId) {
+        params.runs.set(previousRunId, entry);
+      }
+    };
     entry.swarmRunId ??= previousRunId;
     entry.schedulerSlotId ??= entry.swarmRunId;
     if (previousRunId !== nextRunId) {
@@ -975,50 +989,34 @@ export function createSubagentRunManager(params: {
       entry.runId = nextRunId;
       params.runs.set(nextRunId, entry);
     }
-    if (terminalBeforeAcceptance) {
-      entry.swarmLaunchPending = false;
-      entry.queuedLaunch = undefined;
-      try {
-        params.persistOrThrow(previousRunId, nextRunId);
-        return true;
-      } catch (error) {
-        if (previousRunId !== nextRunId) {
-          params.runs.delete(nextRunId);
-          entry.runId = previousRunId;
-          params.runs.set(previousRunId, entry);
-        }
-        entry.queuedLaunch = previousQueuedLaunch;
-        entry.swarmRunId = previousSwarmRunId;
-        entry.schedulerSlotId = previousSchedulerSlotId;
-        entry.swarmLaunchPending = previousSwarmLaunchPending;
-        throw error;
+    if (!terminalBeforeAcceptance) {
+      // Acceptance is not a lifecycle start; preserve a raced start or leave its clock unset.
+      const lifecycleStartedAt =
+        entry.execution?.status === "running" ? entry.execution.startedAt : undefined;
+      if (typeof lifecycleStartedAt === "number") {
+        entry.startedAt = lifecycleStartedAt;
+        entry.sessionStartedAt ??= lifecycleStartedAt;
+        entry.execution = {
+          ...entry.execution,
+          status: "running",
+          acceptedAt,
+          startedAt: lifecycleStartedAt,
+        };
+      } else {
+        delete entry.startedAt;
+        delete entry.sessionStartedAt;
+        entry.execution = { ...entry.execution, status: "running", acceptedAt };
+        delete entry.execution.startedAt;
       }
-    }
-    // Gateway acceptance only proves admission. Preserve a lifecycle start that
-    // raced ahead of this response; otherwise leave the run clock unset until
-    // preparation and lane dequeue emit the canonical start event.
-    const lifecycleStartedAt =
-      entry.execution?.status === "running" ? entry.execution.startedAt : undefined;
-    if (typeof lifecycleStartedAt === "number") {
-      entry.startedAt = lifecycleStartedAt;
-      entry.sessionStartedAt ??= lifecycleStartedAt;
-      entry.execution = {
-        ...entry.execution,
-        status: "running",
-        acceptedAt,
-        startedAt: lifecycleStartedAt,
-      };
-    } else {
-      delete entry.startedAt;
-      delete entry.sessionStartedAt;
-      entry.execution = { ...entry.execution, status: "running", acceptedAt };
-      delete entry.execution.startedAt;
     }
     entry.swarmLaunchPending = false;
     entry.queuedLaunch = undefined;
     let persistedRunning = false;
     try {
       params.persistOrThrow(previousRunId, nextRunId);
+      if (terminalBeforeAcceptance) {
+        return true;
+      }
       persistedRunning = true;
       startTaskRunByRunId({
         runId: entry.taskRunId ?? entry.runId,
@@ -1028,18 +1026,7 @@ export function createSubagentRunManager(params: {
         lastEventAt: acceptedAt,
       });
     } catch (error) {
-      if (previousRunId !== nextRunId) {
-        params.runs.delete(nextRunId);
-        entry.runId = previousRunId;
-        params.runs.set(previousRunId, entry);
-      }
-      entry.startedAt = previousStartedAt;
-      entry.sessionStartedAt = previousSessionStartedAt;
-      entry.execution = previousExecution;
-      entry.queuedLaunch = previousQueuedLaunch;
-      entry.swarmRunId = previousSwarmRunId;
-      entry.schedulerSlotId = previousSchedulerSlotId;
-      entry.swarmLaunchPending = previousSwarmLaunchPending;
+      restoreQueuedRun();
       if (persistedRunning) {
         try {
           params.persistOrThrow(previousRunId, nextRunId);
@@ -1064,9 +1051,7 @@ export function createSubagentRunManager(params: {
 
   const failQueuedSubagentRun = (runId: string, error: string) => {
     const key = runId.trim();
-    const entry =
-      params.runs.get(key) ??
-      [...params.runs.values()].find((candidate) => candidate.swarmRunId === key);
+    const entry = findRunByIdentity(key);
     if (!entry || entry.execution?.status !== "queued") {
       return false;
     }
@@ -1083,11 +1068,7 @@ export function createSubagentRunManager(params: {
     try {
       params.persistOrThrow(entry.runId);
     } catch (persistError) {
-      const target = entry as unknown as Record<string, unknown>;
-      for (const property of Object.keys(target)) {
-        delete target[property];
-      }
-      Object.assign(target, snapshot);
+      restoreSubagentRunRecord(entry, snapshot);
       throw persistError;
     }
     try {
@@ -1113,9 +1094,7 @@ export function createSubagentRunManager(params: {
   };
 
   const settleFailedQueuedSubagentLaunch = (runId: string, error: string) => {
-    const entry =
-      params.runs.get(runId) ??
-      [...params.runs.values()].find((candidate) => candidate.swarmRunId === runId);
+    const entry = findRunByIdentity(runId);
     if (!entry?.collect) {
       return false;
     }
@@ -1144,11 +1123,7 @@ export function createSubagentRunManager(params: {
     try {
       params.persistOrThrow(entry.runId);
     } catch (persistError) {
-      const target = entry as unknown as Record<string, unknown>;
-      for (const property of Object.keys(target)) {
-        delete target[property];
-      }
-      Object.assign(target, snapshot);
+      restoreSubagentRunRecord(entry, snapshot);
       throw persistError;
     }
     return true;
@@ -1187,11 +1162,10 @@ export function createSubagentRunManager(params: {
     if (typeof markParams.runId === "string" && markParams.runId.trim()) {
       runIds.add(markParams.runId.trim());
     }
-    if (typeof markParams.childSessionKey === "string" && markParams.childSessionKey.trim()) {
-      for (const [runId, entry] of params.runs.entries()) {
-        if (entry.childSessionKey === markParams.childSessionKey.trim()) {
-          runIds.add(runId);
-        }
+    const childSessionKey = markParams.childSessionKey?.trim();
+    if (childSessionKey) {
+      for (const entry of params.getRunsForChildSession(childSessionKey)) {
+        runIds.add(entry.runId);
       }
     }
     if (runIds.size === 0) {
@@ -1313,11 +1287,7 @@ export function createSubagentRunManager(params: {
         params.persistOrThrow(...[...entrySnapshots.keys()].map((entry) => entry.runId));
       } catch (error) {
         for (const [entry, snapshot] of entrySnapshots) {
-          const target = entry as unknown as Record<string, unknown>;
-          for (const key of Object.keys(target)) {
-            delete target[key];
-          }
-          Object.assign(target, snapshot);
+          restoreSubagentRunRecord(entry, snapshot);
         }
         throw error;
       }

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -16,19 +16,28 @@ import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-regist
 
 const SUBAGENT_RUNS_READ_CACHE_TTL_MS = 500;
 
-let persistedSubagentRunsReadCache:
-  | {
-      loadedAtMs: number;
-      runs: Map<string, SubagentRunRecord>;
-    }
-  | undefined;
+type SubagentRunsSnapshot<T extends SubagentRunReadRecord> = {
+  loadedAtMs: number;
+  runs: Map<string, T>;
+};
 
-let persistedSubagentSessionListRunsReadCache:
-  | {
-      loadedAtMs: number;
-      runs: Map<string, SubagentRunReadRecord>;
-    }
-  | undefined;
+type SubagentRunsCache<T extends SubagentRunReadRecord> = {
+  snapshot?: SubagentRunsSnapshot<T>;
+  load: () => Map<string, T>;
+  copy: (entry: SubagentRunRecord) => T;
+  project: (entry: SubagentRunRecord) => T;
+};
+
+const persistedSubagentRunsReadCache: SubagentRunsCache<SubagentRunRecord> = {
+  load: loadSubagentRegistryFromSqlite,
+  copy: structuredClone,
+  project: (entry) => entry,
+};
+const persistedSubagentSessionListRunsReadCache: SubagentRunsCache<SubagentRunReadRecord> = {
+  load: () => loadSubagentSessionListRunsFromSqlite(),
+  copy: projectSubagentRunForSessionList,
+  project: projectSubagentRunForSessionList,
+};
 
 type SubagentRegistryPersistListener = () => void;
 
@@ -50,12 +59,6 @@ export function onSubagentRegistryPersisted(listener: SubagentRegistryPersistLis
   return () => {
     SUBAGENT_REGISTRY_PERSIST_LISTENERS.delete(listener);
   };
-}
-
-function cloneSubagentRunsSnapshot(
-  runs: Map<string, SubagentRunRecord>,
-): Map<string, SubagentRunRecord> {
-  return new Map([...runs.entries()].map(([runId, entry]) => [runId, structuredClone(entry)]));
 }
 
 function projectSubagentRunForSessionList(entry: SubagentRunRecord): SubagentRunReadRecord {
@@ -94,77 +97,54 @@ function projectSubagentRunForSessionList(entry: SubagentRunRecord): SubagentRun
   };
 }
 
-function projectSubagentRunsForSessionList(
+function rememberSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
+  cache: SubagentRunsCache<T>,
   runs: Map<string, SubagentRunRecord>,
-): Map<string, SubagentRunReadRecord> {
-  return new Map(
-    [...runs.entries()].map(([runId, entry]) => [runId, projectSubagentRunForSessionList(entry)]),
-  );
-}
-
-function rememberPersistedSubagentRunsSnapshot(runs: Map<string, SubagentRunRecord>): void {
-  const loadedAtMs = Date.now();
-  persistedSubagentRunsReadCache = {
-    loadedAtMs,
-    runs: cloneSubagentRunsSnapshot(runs),
-  };
-  persistedSubagentSessionListRunsReadCache = {
-    loadedAtMs,
-    runs: projectSubagentRunsForSessionList(runs),
-  };
-}
-
-function rememberPersistedSubagentRunChanges(
-  runs: Map<string, SubagentRunRecord>,
-  changedRunIds: readonly string[],
+  changedRunIds: readonly string[] | undefined,
+  loadedAtMs: number,
 ): void {
-  const loadedAtMs = Date.now();
-  if (!persistedSubagentRunsReadCache) {
-    persistedSubagentRunsReadCache = {
+  const snapshot = cache.snapshot;
+  if (!changedRunIds || !snapshot) {
+    cache.snapshot = {
       loadedAtMs,
-      runs: cloneSubagentRunsSnapshot(runs),
-    };
-  } else {
-    for (const runId of new Set(changedRunIds)) {
-      const entry = runs.get(runId);
-      if (entry) {
-        persistedSubagentRunsReadCache.runs.set(runId, structuredClone(entry));
-      } else {
-        persistedSubagentRunsReadCache.runs.delete(runId);
-      }
-    }
-    persistedSubagentRunsReadCache.loadedAtMs = loadedAtMs;
-  }
-
-  if (!persistedSubagentSessionListRunsReadCache) {
-    persistedSubagentSessionListRunsReadCache = {
-      loadedAtMs,
-      runs: projectSubagentRunsForSessionList(runs),
+      runs: new Map([...runs].map(([runId, entry]) => [runId, cache.copy(entry)])),
     };
     return;
   }
   for (const runId of new Set(changedRunIds)) {
     const entry = runs.get(runId);
     if (entry) {
-      persistedSubagentSessionListRunsReadCache.runs.set(
-        runId,
-        projectSubagentRunForSessionList(entry),
-      );
+      snapshot.runs.set(runId, cache.copy(entry));
     } else {
-      persistedSubagentSessionListRunsReadCache.runs.delete(runId);
+      snapshot.runs.delete(runId);
     }
   }
-  persistedSubagentSessionListRunsReadCache.loadedAtMs = loadedAtMs;
+  snapshot.loadedAtMs = loadedAtMs;
+}
+
+function rememberPersistedSubagentRunsSnapshot(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds?: readonly string[],
+): void {
+  const loadedAtMs = Date.now();
+  rememberSubagentRunsSnapshot(persistedSubagentRunsReadCache, runs, changedRunIds, loadedAtMs);
+  rememberSubagentRunsSnapshot(
+    persistedSubagentSessionListRunsReadCache,
+    runs,
+    changedRunIds,
+    loadedAtMs,
+  );
 }
 
 function shouldReadPersistedSubagentRuns(): boolean {
   return !isVitestRuntimeEnv() || process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE === "1";
 }
 
-function getFreshPersistedSubagentRunsSnapshot(
+function getFreshPersistedSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
+  cache: SubagentRunsCache<T>,
   nowMs: number,
-): Map<string, SubagentRunRecord> | null {
-  const cached = persistedSubagentRunsReadCache;
+): Map<string, T> | null {
+  const cached = cache.snapshot;
   return cached &&
     nowMs >= cached.loadedAtMs &&
     nowMs - cached.loadedAtMs < SUBAGENT_RUNS_READ_CACHE_TTL_MS
@@ -172,58 +152,42 @@ function getFreshPersistedSubagentRunsSnapshot(
     : null;
 }
 
-function loadPersistedSubagentRunsForRead(): Map<string, SubagentRunRecord> {
+function loadPersistedSubagentRunsForRead<T extends SubagentRunReadRecord>(
+  cache: SubagentRunsCache<T>,
+): Map<string, T> {
   const nowMs = Date.now();
-  const cached = getFreshPersistedSubagentRunsSnapshot(nowMs);
+  const cached = getFreshPersistedSubagentRunsSnapshot(cache, nowMs);
   if (cached) {
     return cached;
   }
-
-  const runs = loadSubagentRegistryFromSqlite();
-  rememberPersistedSubagentRunsSnapshot(runs);
-  return persistedSubagentRunsReadCache?.runs ?? runs;
-}
-
-function loadPersistedSubagentSessionListRunsForRead(): Map<string, SubagentRunReadRecord> {
-  const nowMs = Date.now();
-  const cached = persistedSubagentSessionListRunsReadCache;
-  if (
-    cached &&
-    nowMs >= cached.loadedAtMs &&
-    nowMs - cached.loadedAtMs < SUBAGENT_RUNS_READ_CACHE_TTL_MS
-  ) {
-    return cached.runs;
-  }
-
-  const runs = loadSubagentSessionListRunsFromSqlite();
-  persistedSubagentSessionListRunsReadCache = {
-    loadedAtMs: nowMs,
-    runs,
-  };
-  return runs;
-}
-
-function loadPersistedSubagentRunsForScopedRead(params: {
-  load: () => SubagentRunRecord[];
-  matches: (entry: SubagentRunRecord) => boolean;
-}): Map<string, SubagentRunRecord> {
-  // A fresh broad snapshot represents same-process writes, including the
-  // existing best-effort persistence-failure behavior. Otherwise query the index directly.
-  const cached = getFreshPersistedSubagentRunsSnapshot(Date.now());
-  const entries = cached ? [...cached.values()].filter(params.matches) : params.load();
-  return new Map(entries.map((entry) => [entry.runId, entry]));
-}
-
-function resolvesToControllerSessionKey(
-  entry: SubagentRunRecord,
-  controllerSessionKey: string,
-): boolean {
-  return (entry.controllerSessionKey?.trim() || entry.requesterSessionKey) === controllerSessionKey;
+  cache.snapshot = { loadedAtMs: nowMs, runs: cache.load() };
+  return cache.snapshot.runs;
 }
 
 export function clearSubagentRunsReadCacheForTest(): void {
-  persistedSubagentRunsReadCache = undefined;
-  persistedSubagentSessionListRunsReadCache = undefined;
+  persistedSubagentRunsReadCache.snapshot = undefined;
+  persistedSubagentSessionListRunsReadCache.snapshot = undefined;
+}
+
+function persistSubagentRuns(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds: readonly string[] | undefined,
+  strict: boolean,
+): void {
+  try {
+    if (changedRunIds) {
+      saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
+    } else {
+      saveSubagentRegistryToSqlite(runs);
+    }
+  } catch (error) {
+    if (strict) {
+      throw error;
+    }
+  }
+  // In-process readers must observe the authoritative memory snapshot before the wake.
+  rememberPersistedSubagentRunsSnapshot(runs, changedRunIds);
+  emitSubagentRegistryPersisted();
 }
 
 export function persistSubagentRunsToDisk(
@@ -231,23 +195,7 @@ export function persistSubagentRunsToDisk(
   // Undefined replaces the complete snapshot; an array applies exact row mutations.
   changedRunIds?: readonly string[],
 ) {
-  try {
-    if (changedRunIds) {
-      saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
-    } else {
-      saveSubagentRegistryToSqlite(runs);
-    }
-  } catch {
-    // ignore persistence failures
-  } finally {
-    // In-process readers must observe the authoritative memory snapshot before the wake.
-    if (changedRunIds) {
-      rememberPersistedSubagentRunChanges(runs, changedRunIds);
-    } else {
-      rememberPersistedSubagentRunsSnapshot(runs);
-    }
-    emitSubagentRegistryPersisted();
-  }
+  persistSubagentRuns(runs, changedRunIds, false);
 }
 
 export function persistSubagentRunsToDiskOrThrow(
@@ -255,14 +203,7 @@ export function persistSubagentRunsToDiskOrThrow(
   // Undefined replaces the complete snapshot; an array applies exact row mutations.
   changedRunIds?: readonly string[],
 ) {
-  if (changedRunIds) {
-    saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
-    rememberPersistedSubagentRunChanges(runs, changedRunIds);
-  } else {
-    saveSubagentRegistryToSqlite(runs);
-    rememberPersistedSubagentRunsSnapshot(runs);
-  }
-  emitSubagentRegistryPersisted();
+  persistSubagentRuns(runs, changedRunIds, true);
 }
 
 export function restoreSubagentRunsFromDisk(params: {
@@ -287,107 +228,80 @@ export function restoreSubagentRunsFromDisk(params: {
   return added;
 }
 
-export function getSubagentRunsSnapshotForRead(
+function getSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
   inMemoryRuns: Map<string, SubagentRunRecord>,
-): Map<string, SubagentRunRecord> {
-  const merged = new Map<string, SubagentRunRecord>();
+  cache: SubagentRunsCache<T>,
+  scope?: {
+    key: string;
+    load: (key: string) => T[];
+    matches: (entry: T, key: string) => boolean;
+  },
+): Map<string, T> {
+  const merged = new Map<string, T>();
+  const key = scope?.key.trim() ?? "";
+  if (scope && !key) {
+    return merged;
+  }
   if (shouldReadPersistedSubagentRuns()) {
     try {
       // Persisted state lets other worker processes observe active runs.
-      // Cache this hot cross-process snapshot briefly; writes refresh the local
-      // cache and the TTL bounds visibility of changes from other processes.
-      for (const [runId, entry] of loadPersistedSubagentRunsForRead().entries()) {
-        merged.set(runId, entry);
-      }
-    } catch {
-      // Ignore disk read failures and fall back to local memory.
-    }
-  }
-  for (const [runId, entry] of inMemoryRuns.entries()) {
-    merged.set(runId, entry);
-  }
-  return merged;
-}
-
-export function getSubagentSessionListRunsSnapshotForRead(
-  inMemoryRuns: Map<string, SubagentRunRecord>,
-): Map<string, SubagentRunReadRecord> {
-  const merged = new Map<string, SubagentRunReadRecord>();
-  if (shouldReadPersistedSubagentRuns()) {
-    try {
-      for (const [runId, entry] of loadPersistedSubagentSessionListRunsForRead()) {
-        merged.set(runId, entry);
+      // Scoped reads use indexed SQL unless a fresh local write owns the result.
+      const cached = scope ? getFreshPersistedSubagentRunsSnapshot(cache, Date.now()) : null;
+      const persisted = scope
+        ? cached
+          ? [...cached.values()].filter((entry) => scope.matches(entry, key))
+          : scope.load(key)
+        : loadPersistedSubagentRunsForRead(cache).values();
+      for (const entry of persisted) {
+        merged.set(entry.runId, scope ? structuredClone(entry) : entry);
       }
     } catch {
       // Ignore disk read failures and fall back to local memory.
     }
   }
   for (const [runId, entry] of inMemoryRuns) {
-    merged.set(runId, projectSubagentRunForSessionList(entry));
+    const projected = cache.project(entry);
+    if (!scope || scope.matches(projected, key)) {
+      merged.set(runId, projected);
+    } else {
+      // Live memory wins even when a run moved out of the persisted scope.
+      merged.delete(runId);
+    }
   }
   return merged;
+}
+
+export function getSubagentRunsSnapshotForRead(
+  inMemoryRuns: Map<string, SubagentRunRecord>,
+): Map<string, SubagentRunRecord> {
+  return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache);
+}
+
+export function getSubagentSessionListRunsSnapshotForRead(
+  inMemoryRuns: Map<string, SubagentRunRecord>,
+): Map<string, SubagentRunReadRecord> {
+  return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentSessionListRunsReadCache);
 }
 
 export function getSubagentRunsSnapshotForController(
   inMemoryRuns: Map<string, SubagentRunRecord>,
   controllerSessionKey: string,
 ): Map<string, SubagentRunRecord> {
-  const key = controllerSessionKey.trim();
-  const merged = new Map<string, SubagentRunRecord>();
-  if (!key) {
-    return merged;
-  }
-  if (shouldReadPersistedSubagentRuns()) {
-    try {
-      for (const [runId, entry] of loadPersistedSubagentRunsForScopedRead({
-        load: () => loadSubagentRunsForControllerFromSqlite(key),
-        matches: (candidate) => resolvesToControllerSessionKey(candidate, key),
-      })) {
-        merged.set(runId, structuredClone(entry));
-      }
-    } catch {
-      // Ignore disk read failures and fall back to local memory.
-    }
-  }
-  for (const [runId, entry] of inMemoryRuns) {
-    if (resolvesToControllerSessionKey(entry, key)) {
-      merged.set(runId, entry);
-    } else {
-      // Live memory is authoritative even when a run moved out of this persisted scope.
-      merged.delete(runId);
-    }
-  }
-  return merged;
+  return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache, {
+    key: controllerSessionKey,
+    load: loadSubagentRunsForControllerFromSqlite,
+    matches: (entry, key) =>
+      (entry.controllerSessionKey?.trim() || entry.requesterSessionKey) === key,
+  });
 }
 
 export function getSubagentRunsSnapshotForChildSession(
   inMemoryRuns: Map<string, SubagentRunRecord>,
   childSessionKey: string,
 ): Map<string, SubagentRunRecord> {
-  const key = childSessionKey.trim();
-  const merged = new Map<string, SubagentRunRecord>();
-  if (!key) {
-    return merged;
-  }
-  if (shouldReadPersistedSubagentRuns()) {
-    try {
-      for (const [runId, entry] of loadPersistedSubagentRunsForScopedRead({
-        load: () => loadSubagentRunsForChildSessionFromSqlite(key),
-        matches: (candidate) => candidate.childSessionKey === key,
-      })) {
-        merged.set(runId, structuredClone(entry));
-      }
-    } catch {
-      // Ignore disk read failures and fall back to local memory.
-    }
-  }
-  for (const [runId, entry] of inMemoryRuns) {
-    if (entry.childSessionKey === key) {
-      merged.set(runId, entry);
-    } else {
-      // Match full-snapshot overlay semantics for runs that changed child association.
-      merged.delete(runId);
-    }
-  }
-  return merged;
+  return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache, {
+    key: childSessionKey,
+    load: loadSubagentRunsForChildSessionFromSqlite,
+    matches: (entry, key) => entry.childSessionKey === key,
+  });
 }

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -171,6 +171,7 @@ describe("subagent registry sqlite store", () => {
         getNodeSqliteKysely<SubagentRegistryDatabase>(db)
           .updateTable("subagent_runs")
           .set({
+            expects_completion_message: 0,
             frozen_result_text: "stale typed completion",
             pending_final_delivery_last_error: "stale typed delivery",
             requester_settle_wake_status: "pending",
@@ -182,11 +183,14 @@ describe("subagent registry sqlite store", () => {
 
       closeOpenClawStateDatabaseForTest();
       const restored = loadSubagentRegistryFromSqlite().get(run.runId);
+      expect(restored?.expectsCompletionMessage).toBe(true);
       expect(restored?.completion?.resultText).toBe("done");
-      expect(restored?.delivery?.lastError).toBe("retry later");
+      expect(restored?.delivery).toMatchObject({ status: "pending", lastError: "retry later" });
       expect(restored?.requesterSettleWake).toEqual(run.requesterSettleWake);
       expect(restored?.outcome?.status).toBe("ok");
-      expect(loadSubagentSessionListRunsFromSqlite().get(run.runId)?.outcome?.status).toBe("ok");
+      const sessionListRun = loadSubagentSessionListRunsFromSqlite().get(run.runId);
+      expect(sessionListRun?.outcome?.status).toBe("ok");
+      expect(sessionListRun?.delivery?.status).toBe("pending");
     });
   });
 
@@ -332,6 +336,7 @@ describe("subagent registry sqlite store", () => {
         stateDb
           .updateTable("subagent_runs")
           .set({
+            expects_completion_message: 1,
             payload_json: JSON.stringify({
               ...run,
               delivery: { status: "delivered", announcedAt: 300, deliveredAt: 300 },

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -154,6 +154,42 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
+  it("keeps the complete payload authoritative over stale derived state columns", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        requesterSettleWake: {
+          status: "dispatching",
+          attemptCount: 2,
+          batchRunIds: ["run-one"],
+        },
+      });
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const { db } = openOpenClawStateDatabase();
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<SubagentRegistryDatabase>(db)
+          .updateTable("subagent_runs")
+          .set({
+            frozen_result_text: "stale typed completion",
+            pending_final_delivery_last_error: "stale typed delivery",
+            requester_settle_wake_status: "pending",
+            requester_settle_wake_attempt_count: 99,
+            outcome_json: JSON.stringify({ status: "timeout" }),
+          })
+          .where("run_id", "=", run.runId),
+      );
+
+      closeOpenClawStateDatabaseForTest();
+      const restored = loadSubagentRegistryFromSqlite().get(run.runId);
+      expect(restored?.completion?.resultText).toBe("done");
+      expect(restored?.delivery?.lastError).toBe("retry later");
+      expect(restored?.requesterSettleWake).toEqual(run.requesterSettleWake);
+      expect(restored?.outcome?.status).toBe("ok");
+      expect(loadSubagentSessionListRunsFromSqlite().get(run.runId)?.outcome?.status).toBe("ok");
+    });
+  });
+
   it("loads a canonical lightweight session-list projection", async () => {
     await withTempStateEnv(async () => {
       const run = createRun({

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -116,7 +116,7 @@ function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | 
   if (payload.requesterOrigin) {
     payload.requesterOrigin = normalizeDeliveryContext(payload.requesterOrigin);
   }
-  if (row.expects_completion_message === 0) {
+  if (payload.expectsCompletionMessage === false) {
     payload.delivery.status = "not_required";
   }
   const record = normalizeSubagentRunState(payload);

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -13,15 +13,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
-import type {
-  PendingFinalDeliveryPayload,
-  RequesterSettleWakeState,
-  SubagentCompletionDeliveryState,
-  SubagentCompletionState,
-  SubagentExecutionState,
-  SubagentRunReadRecord,
-  SubagentRunRecord,
-} from "./subagent-registry.types.js";
+import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 
 type SubagentRunsTable = OpenClawStateKyselyDatabase["subagent_runs"];
 type SubagentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "subagent_runs">;
@@ -99,229 +91,35 @@ function boolToSqlite(value: boolean | undefined): number | null {
   return value === undefined ? null : value ? 1 : 0;
 }
 
-function sqliteBool(value: number | null): boolean | undefined {
-  return value == null ? undefined : value !== 0;
-}
-
 function normalizeFiniteNumber(value: number | null): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function createDeliveryFromTypedColumns(
-  row: SubagentRunSqliteRow,
-  fallback: SubagentCompletionDeliveryState | undefined,
-): SubagentCompletionDeliveryState | undefined {
-  // Typed delivery columns own retry/delivered state; payload_json supplies
-  // canonical delivery fields without dedicated columns.
-  const delivery = fallback ? { ...fallback } : undefined;
-  const payload = parseJson(row.pending_final_delivery_payload_json) as
-    | PendingFinalDeliveryPayload
-    | undefined;
-  const status =
-    row.expects_completion_message === 0
-      ? "not_required"
-      : row.pending_final_delivery
-        ? "pending"
-        : delivery?.status;
-  if (!status && row.completion_announced_at == null && row.last_announce_delivery_error == null) {
-    return delivery;
-  }
-  return {
-    status: status ?? "pending",
-    ...delivery,
-    ...(payload ? { payload } : {}),
-    ...(normalizeFiniteNumber(row.pending_final_delivery_created_at) !== undefined
-      ? { createdAt: row.pending_final_delivery_created_at ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.pending_final_delivery_last_attempt_at) !== undefined
-      ? { lastAttemptAt: row.pending_final_delivery_last_attempt_at ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.pending_final_delivery_attempt_count) !== undefined
-      ? { attemptCount: row.pending_final_delivery_attempt_count ?? undefined }
-      : {}),
-    ...(row.pending_final_delivery_last_error !== null
-      ? { lastError: row.pending_final_delivery_last_error }
-      : {}),
-    ...(row.completion_announced_at !== null && row.expects_completion_message === 1
-      ? {
-          status: "delivered",
-          announcedAt: row.completion_announced_at,
-          deliveredAt: delivery?.deliveredAt ?? row.completion_announced_at,
-        }
-      : row.completion_announced_at !== null
-        ? { announcedAt: row.completion_announced_at }
-        : {}),
-    ...(row.expects_completion_message === 0 ? { status: "not_required" } : {}),
-  };
-}
-
-function createRequesterSettleWakeFromTypedColumns(
-  row: SubagentRunSqliteRow,
-  fallback: RequesterSettleWakeState | undefined,
-): RequesterSettleWakeState | undefined {
-  const fallbackStatus =
-    fallback?.status === "pending" || fallback?.status === "dispatching"
-      ? fallback.status
-      : undefined;
-  const status =
-    row.requester_settle_wake_status === "pending" ||
-    row.requester_settle_wake_status === "dispatching"
-      ? row.requester_settle_wake_status
-      : fallbackStatus;
-  if (!status) {
-    return undefined;
-  }
-  const parsedBatchRunIds = parseJson(row.requester_settle_wake_batch_run_ids_json);
-  const batchRunIds = Array.isArray(parsedBatchRunIds)
-    ? parsedBatchRunIds.filter(
-        (value): value is string => typeof value === "string" && Boolean(value),
-      )
-    : fallback?.batchRunIds;
-  return {
-    ...fallback,
-    status,
-    attemptCount:
-      normalizeFiniteNumber(row.requester_settle_wake_attempt_count) ?? fallback?.attemptCount ?? 0,
-    ...(normalizeFiniteNumber(row.requester_settle_wake_replay_count) !== undefined
-      ? { replayCount: row.requester_settle_wake_replay_count ?? undefined }
-      : fallback?.replayCount !== undefined
-        ? { replayCount: fallback.replayCount }
-        : {}),
-    ...(normalizeFiniteNumber(row.requester_settle_wake_next_attempt_at) !== undefined
-      ? { nextAttemptAt: row.requester_settle_wake_next_attempt_at ?? undefined }
-      : fallback?.nextAttemptAt !== undefined
-        ? { nextAttemptAt: fallback.nextAttemptAt }
-        : {}),
-    ...(batchRunIds && batchRunIds.length > 0 ? { batchRunIds } : {}),
-    ...(row.requester_settle_wake_last_error !== null
-      ? { lastError: row.requester_settle_wake_last_error }
-      : {}),
-    ...(sqliteBool(row.requester_settle_wake_retire_after) !== undefined
-      ? { retireAfterSettle: sqliteBool(row.requester_settle_wake_retire_after) }
-      : {}),
-  };
-}
-
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */
 function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
-  const parsedPayload = parseJson(row.payload_json);
+  const payload = parseJson(row.payload_json);
   // SQLite shipped after nested state became canonical; unowned rows are transient.
-  if (!isCanonicalSubagentRunRecord(parsedPayload)) {
+  if (!isCanonicalSubagentRunRecord(payload)) {
     return null;
   }
-  const payload = parsedPayload;
-  const requesterOrigin =
-    (parseJson(row.requester_origin_json) as SubagentRunRecord["requesterOrigin"] | undefined) ??
-    payload.requesterOrigin;
-  const outcome =
-    (parseJson(row.outcome_json) as SubagentRunRecord["outcome"] | undefined) ?? payload.outcome;
-  const completion: SubagentCompletionState | undefined = {
-    ...(payload.completion ?? { required: row.expects_completion_message === 1 }),
-    required: payload.completion?.required ?? row.expects_completion_message === 1,
-    ...(row.frozen_result_text !== null ? { resultText: row.frozen_result_text } : {}),
-    ...(row.frozen_result_captured_at !== null
-      ? { capturedAt: row.frozen_result_captured_at }
-      : {}),
-    ...(row.fallback_frozen_result_text !== null
-      ? { fallbackResultText: row.fallback_frozen_result_text }
-      : {}),
-    ...(row.fallback_frozen_result_captured_at !== null
-      ? { fallbackCapturedAt: row.fallback_frozen_result_captured_at }
-      : {}),
-  };
-  const execution: SubagentExecutionState | undefined = payload.execution
-    ? {
-        ...payload.execution,
-        ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
-        ...(row.ended_at !== null ? { status: "terminal", endedAt: row.ended_at, outcome } : {}),
-      }
-    : undefined;
-  const delivery = createDeliveryFromTypedColumns(row, payload.delivery);
-  const requesterSettleWake = createRequesterSettleWakeFromTypedColumns(
-    row,
-    payload.requesterSettleWake,
-  );
-  const structured = parseJson(row.swarm_structured_json);
-  const outputSchema = parseJson(row.swarm_output_schema_json);
-  const usage = parseJson(row.swarm_usage_json) as
-    | { inputTokens: number; outputTokens: number }
-    | undefined;
-  const collectorStatus =
-    row.swarm_completion_status === "done" ||
-    row.swarm_completion_status === "failed" ||
-    row.swarm_completion_status === "killed" ||
-    row.swarm_completion_status === "timeout"
-      ? row.swarm_completion_status
-      : undefined;
-  const record = normalizeSubagentRunState({
-    ...payload,
-    runId: row.run_id,
-    childSessionKey: row.child_session_key,
-    ...(row.controller_session_key ? { controllerSessionKey: row.controller_session_key } : {}),
-    requesterSessionKey: row.requester_session_key,
-    ...(requesterOrigin ? { requesterOrigin: normalizeDeliveryContext(requesterOrigin) } : {}),
-    requesterDisplayKey: row.requester_display_key,
-    task: row.task,
-    cleanup: row.cleanup === "delete" ? "delete" : "keep",
-    ...(row.task_name ? { taskName: row.task_name } : {}),
-    ...(row.label ? { label: row.label } : {}),
-    ...(row.model ? { model: row.model } : {}),
-    ...(row.agent_dir ? { agentDir: row.agent_dir } : {}),
-    ...(row.workspace_dir ? { workspaceDir: row.workspace_dir } : {}),
-    ...(row.run_timeout_seconds !== null ? { runTimeoutSeconds: row.run_timeout_seconds } : {}),
-    ...(row.spawn_mode === "session" || row.spawn_mode === "run"
-      ? { spawnMode: row.spawn_mode }
-      : {}),
-    createdAt: row.created_at,
-    ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
-    ...(row.session_started_at !== null ? { sessionStartedAt: row.session_started_at } : {}),
-    ...(row.accumulated_runtime_ms !== null
-      ? { accumulatedRuntimeMs: row.accumulated_runtime_ms }
-      : {}),
-    ...(row.ended_at !== null ? { endedAt: row.ended_at } : {}),
-    ...(outcome ? { outcome } : {}),
-    ...(row.archive_at_ms !== null ? { archiveAtMs: row.archive_at_ms } : {}),
-    ...(row.cleanup_completed_at !== null ? { cleanupCompletedAt: row.cleanup_completed_at } : {}),
-    ...(sqliteBool(row.cleanup_handled) !== undefined
-      ? { cleanupHandled: sqliteBool(row.cleanup_handled) }
-      : {}),
-    ...(row.suppress_announce_reason === "steer-restart" ||
-    row.suppress_announce_reason === "killed"
-      ? { suppressAnnounceReason: row.suppress_announce_reason }
-      : {}),
-    ...(sqliteBool(row.expects_completion_message) !== undefined
-      ? { expectsCompletionMessage: sqliteBool(row.expects_completion_message) }
-      : {}),
-    ...(row.ended_reason
-      ? { endedReason: row.ended_reason as SubagentRunRecord["endedReason"] }
-      : {}),
-    ...(row.pause_reason === "sessions_yield" ? { pauseReason: row.pause_reason } : {}),
-    ...(sqliteBool(row.wake_on_descendant_settle) !== undefined
-      ? { wakeOnDescendantSettle: sqliteBool(row.wake_on_descendant_settle) }
-      : {}),
-    ...(execution ? { execution } : {}),
-    completion,
-    ...(row.ended_hook_emitted_at !== null
-      ? { endedHookEmittedAt: row.ended_hook_emitted_at }
-      : {}),
-    ...(delivery ? { delivery } : {}),
-    ...(requesterSettleWake ? { requesterSettleWake } : {}),
-    ...(sqliteBool(row.swarm_collector) !== undefined
-      ? { collect: sqliteBool(row.swarm_collector) }
-      : {}),
-    ...(row.swarm_group_id ? { groupId: row.swarm_group_id } : {}),
-    ...(outputSchema ? { outputSchema: outputSchema as Record<string, unknown> } : {}),
-    ...(collectorStatus
-      ? {
-          collectorCompletion: {
-            status: collectorStatus,
-            ...(structured !== undefined ? { structured } : {}),
-            ...(row.swarm_schema_error ? { schemaError: row.swarm_schema_error } : {}),
-            ...(usage ? { usage } : {}),
-          },
-        }
-      : {}),
-  });
+  // This module owns every production write and commits indexed columns with
+  // this complete payload atomically; rehydrating both created competing state.
+  payload.runId = row.run_id;
+  payload.childSessionKey = row.child_session_key;
+  payload.requesterSessionKey = row.requester_session_key;
+  const controllerSessionKey = row.controller_session_key?.trim();
+  if (controllerSessionKey) {
+    payload.controllerSessionKey = controllerSessionKey;
+  } else {
+    delete payload.controllerSessionKey;
+  }
+  if (payload.requesterOrigin) {
+    payload.requesterOrigin = normalizeDeliveryContext(payload.requesterOrigin);
+  }
+  if (row.expects_completion_message === 0) {
+    payload.delivery.status = "not_required";
+  }
+  const record = normalizeSubagentRunState(payload);
   return record.runId && record.childSessionKey && record.requesterSessionKey ? record : null;
 }
 
@@ -441,33 +239,34 @@ function writeSubagentRunValues(
   });
 }
 
-function readSubagentRegistryRows(): SubagentRunSqliteRow[] {
+type SubagentRegistryReadScope =
+  | { kind: "controller"; sessionKey: string }
+  | { kind: "child"; sessionKey: string };
+
+function readSubagentRegistryRows(scope?: SubagentRegistryReadScope): SubagentRunSqliteRow[] {
   const { db } = openOpenClawStateDatabase();
   const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
-  return executeSqliteQuerySync(
-    db,
-    stateDb
-      .selectFrom("subagent_runs")
-      .selectAll()
-      .orderBy("created_at", "asc")
-      .orderBy("run_id", "asc"),
-  ).rows;
+  let query = stateDb.selectFrom("subagent_runs").selectAll();
+  if (scope?.kind === "child") {
+    query = query.where("child_session_key", "=", scope.sessionKey);
+  } else if (scope?.kind === "controller") {
+    // The writer trims controller keys; older null/empty rows belong to their requester.
+    query = query.where((eb) =>
+      eb.or([
+        eb("controller_session_key", "=", scope.sessionKey),
+        eb.and([
+          eb.or([eb("controller_session_key", "is", null), eb("controller_session_key", "=", "")]),
+          eb("requester_session_key", "=", scope.sessionKey),
+        ]),
+      ]),
+    );
+  }
+  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("run_id", "asc"))
+    .rows;
 }
 
 function subagentPayloadJsonValue<T>(path: string) {
   return /* kysely-allow-raw: SQLite JSON1 projects bounded fields from the canonical payload column. */ sql<T>`json_extract(payload_json, ${path})`;
-}
-
-function subagentOutcomeStatusJsonValue() {
-  return /* kysely-allow-raw: outcome_json is authoritative when valid; canonical payload is the fallback. */ sql<
-    string | null
-  >`COALESCE(
-    CASE
-      WHEN json_valid(outcome_json)
-      THEN json_extract(outcome_json, '$.status')
-    END,
-    json_extract(payload_json, '$.outcome.status')
-  )`;
 }
 
 function canonicalSubagentPayloadFilter() {
@@ -515,7 +314,7 @@ function readSubagentSessionListRows(): SubagentRunReadSqliteRow[] {
         "ended_reason",
         "cleanup_completed_at",
         subagentPayloadJsonValue<number | null>("$.generation").as("generation"),
-        subagentOutcomeStatusJsonValue().as("outcome_status"),
+        subagentPayloadJsonValue<string | null>("$.outcome.status").as("outcome_status"),
         subagentPayloadJsonValue<string | null>("$.delivery.status").as("delivery_status"),
         subagentPayloadJsonValue<number | null>("$.delivery.suspendedAt").as(
           "delivery_suspended_at",
@@ -546,113 +345,58 @@ function rowToSubagentRunReadRecord(row: SubagentRunReadSqliteRow): SubagentRunR
   const deliveryStatus = DELIVERY_STATUSES.has(row.delivery_status ?? "")
     ? (row.delivery_status as NonNullable<SubagentRunRecord["delivery"]>["status"])
     : undefined;
-  return {
-    runId,
-    childSessionKey,
-    ...(row.controller_session_key?.trim()
-      ? { controllerSessionKey: row.controller_session_key.trim() }
-      : {}),
-    requesterSessionKey,
-    ...(row.model ? { model: row.model } : {}),
-    ...(normalizeFiniteNumber(row.generation) !== undefined
-      ? { generation: row.generation ?? undefined }
-      : {}),
-    createdAt: row.created_at,
-    ...(normalizeFiniteNumber(row.started_at) !== undefined
-      ? { startedAt: row.started_at ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.session_started_at) !== undefined
-      ? { sessionStartedAt: row.session_started_at ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.accumulated_runtime_ms) !== undefined
-      ? { accumulatedRuntimeMs: row.accumulated_runtime_ms ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.ended_at) !== undefined
-      ? { endedAt: row.ended_at ?? undefined }
-      : {}),
-    ...(normalizeFiniteNumber(row.run_timeout_seconds) !== undefined
-      ? { runTimeoutSeconds: row.run_timeout_seconds ?? undefined }
-      : {}),
-    ...(row.ended_reason
-      ? { endedReason: row.ended_reason as SubagentRunRecord["endedReason"] }
-      : {}),
-    ...(outcomeStatus ? { outcome: { status: outcomeStatus } } : {}),
-    ...(normalizeFiniteNumber(row.cleanup_completed_at) !== undefined
-      ? { cleanupCompletedAt: row.cleanup_completed_at ?? undefined }
-      : {}),
-    ...(deliveryStatus
-      ? {
-          delivery: {
+  return Object.fromEntries(
+    Object.entries({
+      runId,
+      childSessionKey,
+      controllerSessionKey: row.controller_session_key?.trim() || undefined,
+      requesterSessionKey,
+      model: row.model || undefined,
+      generation: normalizeFiniteNumber(row.generation),
+      createdAt: row.created_at,
+      startedAt: normalizeFiniteNumber(row.started_at),
+      sessionStartedAt: normalizeFiniteNumber(row.session_started_at),
+      accumulatedRuntimeMs: normalizeFiniteNumber(row.accumulated_runtime_ms),
+      endedAt: normalizeFiniteNumber(row.ended_at),
+      runTimeoutSeconds: normalizeFiniteNumber(row.run_timeout_seconds),
+      endedReason: row.ended_reason || undefined,
+      outcome: outcomeStatus ? { status: outcomeStatus } : undefined,
+      cleanupCompletedAt: normalizeFiniteNumber(row.cleanup_completed_at),
+      delivery: deliveryStatus
+        ? {
             status: deliveryStatus,
             ...(normalizeFiniteNumber(row.delivery_suspended_at) !== undefined
               ? { suspendedAt: row.delivery_suspended_at ?? undefined }
               : {}),
-          },
-        }
-      : {}),
-  };
+          }
+        : undefined,
+    }).filter(([, value]) => value !== undefined),
+  ) as SubagentRunReadRecord;
+}
+
+function loadScopedSubagentRuns(scope: SubagentRegistryReadScope): SubagentRunRecord[] {
+  const key = scope.sessionKey.trim();
+  if (!key) {
+    return [];
+  }
+  return readSubagentRegistryRows({ ...scope, sessionKey: key }).flatMap((row) => {
+    const run = rowToSubagentRunRecord(row);
+    return run ? [run] : [];
+  });
 }
 
 /** Loads runs controlled by one session, preserving the legacy requester fallback. */
 export function loadSubagentRunsForControllerFromSqlite(
   controllerSessionKey: string,
 ): SubagentRunRecord[] {
-  const key = controllerSessionKey.trim();
-  if (!key) {
-    return [];
-  }
-  const { db } = openOpenClawStateDatabase();
-  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
-  const rows = executeSqliteQuerySync(
-    db,
-    stateDb
-      .selectFrom("subagent_runs")
-      .selectAll()
-      // The write boundary canonicalizes controller keys; null/empty retains legacy fallback.
-      .where((eb) =>
-        eb.or([
-          eb("controller_session_key", "=", key),
-          eb.and([
-            eb.or([
-              eb("controller_session_key", "is", null),
-              eb("controller_session_key", "=", ""),
-            ]),
-            eb("requester_session_key", "=", key),
-          ]),
-        ]),
-      )
-      .orderBy("created_at", "asc")
-      .orderBy("run_id", "asc"),
-  ).rows;
-  return rows.flatMap((row) => {
-    const run = rowToSubagentRunRecord(row);
-    return run ? [run] : [];
-  });
+  return loadScopedSubagentRuns({ kind: "controller", sessionKey: controllerSessionKey });
 }
 
 /** Loads all persisted generations for one child session through its existing index. */
 export function loadSubagentRunsForChildSessionFromSqlite(
   childSessionKey: string,
 ): SubagentRunRecord[] {
-  const key = childSessionKey.trim();
-  if (!key) {
-    return [];
-  }
-  const { db } = openOpenClawStateDatabase();
-  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
-  const rows = executeSqliteQuerySync(
-    db,
-    stateDb
-      .selectFrom("subagent_runs")
-      .selectAll()
-      .where("child_session_key", "=", key)
-      .orderBy("created_at", "asc")
-      .orderBy("run_id", "asc"),
-  ).rows;
-  return rows.flatMap((row) => {
-    const run = rowToSubagentRunRecord(row);
-    return run ? [run] : [];
-  });
+  return loadScopedSubagentRuns({ kind: "child", sessionKey: childSessionKey });
 }
 
 /** Loads the canonical subagent registry from shared SQLite state. */

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -8,7 +8,6 @@ import {
   runWithGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { prependAgentSteeringPrompt } from "./agent-steering-queue.js";
-import type { AgentRunSessionTarget } from "./run-session-target.js";
 import {
   getDeliveryAttemptCount,
   getDeliveryLastAttemptAt,
@@ -425,6 +424,7 @@ const subagentListener = createSubagentRegistryListener({
 
 const subagentRunManager = createSubagentRunManager({
   runs: subagentRuns,
+  getRunsForChildSession: getSubagentRunsForChildSession,
   resumedRuns,
   persist: persistSubagentRuns,
   persistOrThrow: persistSubagentRunsOrThrow,
@@ -492,41 +492,13 @@ configureSubagentRegistrySteerRuntime({
   },
 });
 
-export function markSubagentRunForSteerRestart(runId: string) {
-  return subagentRunManager.markSubagentRunForSteerRestart(runId);
-}
-
-export function clearSubagentRunSteerRestart(runId: string) {
-  return subagentRunManager.clearSubagentRunSteerRestart(runId);
-}
-
-export function replaceSubagentRunAfterSteer(params: {
-  previousRunId: string;
-  nextRunId: string;
-  fallback?: SubagentRunRecord;
-  runTimeoutSeconds?: number;
-  preserveFrozenResultFallback?: boolean;
-  transcriptTarget?: AgentRunSessionTarget;
-  task?: string;
-}) {
-  return subagentRunManager.replaceSubagentRunAfterSteer(params);
-}
-
-export function registerSubagentRun(params: RegisterSubagentRunParams) {
-  subagentRunManager.registerSubagentRun(params);
-}
-
-export function startQueuedSubagentRun(runId: string, gatewayRunId?: string) {
-  return subagentRunManager.startQueuedSubagentRun(runId, gatewayRunId);
-}
-
-function failQueuedSubagentRun(runId: string, error: string) {
-  return subagentRunManager.failQueuedSubagentRun(runId, error);
-}
-
-export function settleFailedQueuedSubagentLaunch(runId: string, error: string) {
-  return subagentRunManager.settleFailedQueuedSubagentLaunch(runId, error);
-}
+export const markSubagentRunForSteerRestart = subagentRunManager.markSubagentRunForSteerRestart;
+export const clearSubagentRunSteerRestart = subagentRunManager.clearSubagentRunSteerRestart;
+export const replaceSubagentRunAfterSteer = subagentRunManager.replaceSubagentRunAfterSteer;
+export const registerSubagentRun: (params: RegisterSubagentRunParams) => void =
+  subagentRunManager.registerSubagentRun;
+export const startQueuedSubagentRun = subagentRunManager.startQueuedSubagentRun;
+export const settleFailedQueuedSubagentLaunch = subagentRunManager.settleFailedQueuedSubagentLaunch;
 
 function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   clearScheduledResumeTimers();
@@ -551,7 +523,7 @@ function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
 }
 
 const testing = {
-  failQueuedSubagentRun,
+  failQueuedSubagentRun: subagentRunManager.failQueuedSubagentRun,
   async sweepOnceForTests() {
     await subagentSweeper.sweepOnce();
   },
@@ -567,18 +539,7 @@ function addSubagentRunForTests(entry: SubagentRunRecord) {
   subagentRuns.set(entry.runId, entry);
 }
 
-function releaseSubagentRun(runId: string) {
-  subagentRunManager.releaseSubagentRun(runId);
-}
-
-export function markSubagentRunTerminated(params: {
-  runId?: string;
-  childSessionKey?: string;
-  reason?: string;
-  suppressTaskDelivery?: boolean;
-}): number {
-  return subagentRunManager.markSubagentRunTerminated(params);
-}
+export const markSubagentRunTerminated = subagentRunManager.markSubagentRunTerminated;
 
 export { prependAgentSteeringPrompt };
 
@@ -633,7 +594,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[SUBAGENT_REGISTRY_TEST_HANDLE] = {
     addSubagentRunForTests,
     finalizeInterruptedSubagentRun: completionRuntime.finalizeInterruptedSubagentRun,
-    releaseSubagentRun,
+    releaseSubagentRun: subagentRunManager.releaseSubagentRun,
     resetSubagentRegistryForTests,
     testing,
   };

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -55,7 +55,7 @@ export type PendingFinalDeliveryPayload = {
   wakeOnDescendantSettle?: boolean;
 };
 
-export type SubagentExecutionState = {
+type SubagentExecutionState = {
   status: "queued" | "running" | "interrupted" | "terminal";
   acceptedAt?: number;
   startedAt?: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes inconsistent subagent completion, delivery, requester-wake, and outcome state after Gateway recovery when redundant derived SQLite columns disagree with the canonical persisted run. Also removes whole-registry scans from high-fanout child-session ownership, steering, cancellation, structured-output, and session-display paths.

## Why This Change Was Made

The complete subagent run payload and its indexed SQLite columns are written atomically by one production owner, but reads rebuilt lifecycle state from both representations through independent delivery, wake, snapshot, projection, rollback, and runtime-loader paths. Make the canonical payload authoritative, retain indexed columns and bounded session-list projections, share one typed snapshot lifecycle, reuse existing child-session indexes, and centralize identity-preserving transactional rollback.

This maintainer-requested, AI-assisted cleanup removes **537 handwritten production lines** while adding **57 lines of focused regression coverage**. It does not change the SQLite schema/version, public plugin SDK, archive/restart contracts, collector authorization, direct completion delivery, or exact-row transaction behavior.

## User Impact

Subagent status, completion results, delivery retries, requester wake obligations, and swarm output remain consistent across Gateway restart and SQLite reconnection. Large subagent fan-outs avoid repeated full-registry scans while preserving the existing collector, cancellation, steering, waiting, and session-list behavior.

## Evidence

- Blacksmith Testbox: `provider=blacksmith-testbox`, lease `tbx_01kyxg62bc8261r8tqb6zsqd8b`.
- **553 tests passed** across 18 focused files: SQLite storage, exact-row trigger auditing, malformed-state rejection, canonical completion/delivery normalization, best-effort/fail-closed persistence, 500 ms cross-process snapshots, scoped child/controller queries, descendant generation/cycles, registry lifecycle, restart replay, steer/restart rollback, announce retries, collector wait authorization, real swarm orchestration, Gateway session-list topology, and the complete MCP runtime fixture suite.
- Focused owner proof:
  `pnpm test src/agents/subagent-delivery-state.test.ts src/agents/subagent-registry.store.sqlite.test.ts src/agents/subagent-registry-state.test.ts src/agents/subagent-registry-memory.test.ts src/agents/subagent-registry-queries.test.ts src/agents/subagent-registry-read-context.test.ts src/agents/subagent-registry-read.scoped.test.ts`
- Lifecycle/restart/Gateway proof:
  `pnpm test src/agents/subagent-registry.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.persistence.test.ts src/agents/subagent-registry.persistence.resume.test.ts src/agents/subagent-registry.steer-restart.test.ts src/agents/subagent-registry.announce-loop-guard.test.ts src/agents/subagent-control.test.ts src/agents/tools/agents-wait-tool.test.ts src/agents/tools/swarm-tools.integration.test.ts src/gateway/session-utils.subagent.test.ts`
- Real SQLite recovery regression mutates `expects_completion_message=0` alongside conflicting derived completion, delivery, wake, and outcome columns, closes the database, reopens it, and proves both full lifecycle hydration and bounded session-list projections retain canonical pending delivery. The opposite-direction regression also verifies a canonical `expectsCompletionMessage=false` still preserves the shipped `not_required` repair even when the indexed flag is stale at `1`.
- Performance-contract regression proves a 100-node descendant index consumes exactly one source `Map.entries()` scan and zero `Map.values()` scans across repeated descendant queries.
- The initially timing-sensitive `src/agents/agent-bundle-mcp-runtime.test.ts` fixture was rerun separately as part of this same Blacksmith command; all **90 MCP runtime tests passed**.
- Independent structured review: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`; clean, no accepted/actionable findings.
- Remote changed-file guard, formatting, production/test typecheck, and architecture checks: `corepack pnpm check:changed`.
- ClawSweeper's completed exact-head review cleared the P1 and accepted the real behavior proof; [exact-head CI run 30679038420](https://github.com/openclaw/openclaw/actions/runs/30679038420) and its required `openclaw/ci-gate` are green after rerunning only the independently verified, unrelated MCP fixture timing race, and refreshing against current `main` is intentionally unnecessary unless a merge conflict or material persistence-path overlap appears.

## Real behavior proof: after-fix SQLite close and reopen

Inspectable, redacted terminal output from the production SQLite persistence owner running against a real shared-state database on Blacksmith Testbox, with no mocked gateway or storage. The command writes a canonical pending completion, corrupts its redundant indexed flag and derived columns through the production Kysely adapter, closes the database, reopens it, and reads both the full lifecycle record and bounded Gateway session projection:

```text
{"phase":"before-restart","indexedExpectsCompletionMessage":0,"canonicalExpectsCompletionMessage":true,"canonicalDeliveryStatus":"pending","canonicalOutcome":"ok"}
{"phase":"after-sqlite-close-and-reopen","indexedExpectsCompletionMessage":0,"recoveredExpectsCompletionMessage":true,"recoveredDeliveryStatus":"pending","recoveredDeliveryError":"canonical retry","recoveredCompletion":"canonical completion","recoveredOutcome":"ok","sessionListDeliveryStatus":"pending","sessionListOutcome":"ok"}
PASS real SQLite close/reopen: stale indexed expects_completion_message=0 cannot suppress canonical pending delivery
```
