### PR TITLE
refactor(auto-reply): unify slash command and directive ownership

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -505,7 +505,6 @@ src/agents/transcript-redact.test.ts
 src/agents/workspace.ts
 src/agents/worktrees/service.ts
 src/auto-reply/command-control.test.ts
-src/auto-reply/commands-registry.shared.ts
 src/auto-reply/inbound.test.ts
 src/auto-reply/reply/abort.test.ts
 src/auto-reply/reply/agent-runner-memory.test.ts
@@ -517,7 +516,6 @@ src/auto-reply/reply/commands-acp.test.ts
 src/auto-reply/reply/commands-approve.test.ts
 src/auto-reply/reply/commands-models.ts
 src/auto-reply/reply/commands-status.test.ts
-src/auto-reply/reply/directive-handling.impl.ts
 src/auto-reply/reply/directive-handling.model.test.ts
 src/auto-reply/reply/dispatch-acp.test.ts
 src/auto-reply/reply/dispatch-acp.ts

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -1,4 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
 /** Command authorization helpers for owner and allowlist checks. */
 import {
   normalizeOptionalLowercaseString,
@@ -13,6 +12,7 @@ import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAccountEntry } from "../routing/account-lookup.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isInternalMessageChannel,
@@ -32,20 +32,31 @@ export type CommandAuthorization = {
   to?: string;
 };
 
-type InferredProviderCandidate = {
+type ProviderResolution = {
   providerId: ChannelId;
   hadResolutionError: boolean;
 };
 
-type InferredProviderProbe = {
-  candidates: InferredProviderCandidate[];
-  droppedResolutionError: boolean;
+type AllowFromParams = {
+  plugin?: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
 };
 
 type ProviderAllowFromResolution = {
   allowFrom: Array<string | number>;
   allowFromList: string[];
   hadResolutionError: boolean;
+};
+
+type AllowFromAccountConfig = {
+  allowFrom?: Array<string | number>;
+  dm?: { allowFrom?: Array<string | number> };
+};
+
+type AllowFromChannelConfig = AllowFromAccountConfig & {
+  defaultAccount?: string;
+  accounts?: Record<string, AllowFromAccountConfig | undefined>;
 };
 
 type OwnerAuthorizationState = {
@@ -92,54 +103,39 @@ function resolveProviderFromContext(
     }
   }
   const inferredProviders = probeInferredProviders(ctx, cfg);
-  const inferred = inferredProviders.candidates;
-  if (inferred.length === 1) {
-    return {
-      providerId: expectDefined(inferred[0], "inferred entry at 0").providerId,
-      hadResolutionError: expectDefined(inferred[0], "inferred entry at 0").hadResolutionError,
-    };
+  const inferred = inferredProviders.candidates[0];
+  if (inferredProviders.candidates.length === 1 && inferred) {
+    return inferred;
   }
   return {
     providerId: undefined,
     hadResolutionError:
       inferredProviders.droppedResolutionError ||
-      inferred.some((entry) => entry.hadResolutionError),
+      inferredProviders.candidates.some((entry) => entry.hadResolutionError),
   };
 }
 
-function probeInferredProviders(ctx: MsgContext, cfg: OpenClawConfig): InferredProviderProbe {
+function probeInferredProviders(ctx: MsgContext, cfg: OpenClawConfig) {
   let droppedResolutionError = false;
-  const candidates = listLoadedChannelPlugins()
-    .map((plugin) => {
-      const resolvedAllowFrom = buildProviderAllowFromResolution({
-        plugin: plugin as ChannelPlugin,
-        cfg,
-        accountId: ctx.AccountId,
-      });
-      if (resolvedAllowFrom.allowFromList.length === 0) {
-        if (resolvedAllowFrom.hadResolutionError) {
-          droppedResolutionError = true;
-        }
-        return null;
-      }
-      return {
-        providerId: plugin.id,
-        hadResolutionError: resolvedAllowFrom.hadResolutionError,
-      };
-    })
-    .filter((value): value is InferredProviderCandidate => Boolean(value));
-  return {
-    candidates,
-    droppedResolutionError,
-  };
+  const candidates: ProviderResolution[] = [];
+  for (const plugin of listLoadedChannelPlugins()) {
+    const resolved = resolveProviderAllowFrom({
+      plugin: plugin as ChannelPlugin,
+      cfg,
+      accountId: ctx.AccountId,
+    });
+    if (resolved.allowFromList.length > 0) {
+      candidates.push({ providerId: plugin.id, hadResolutionError: resolved.hadResolutionError });
+    } else if (resolved.hadResolutionError) {
+      droppedResolutionError = true;
+    }
+  }
+  return { candidates, droppedResolutionError };
 }
 
-function formatAllowFromList(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  allowFrom: Array<string | number>;
-}): string[] {
+function formatAllowFromList(
+  params: AllowFromParams & { allowFrom: Array<string | number> },
+): string[] {
   const { plugin, cfg, accountId, allowFrom } = params;
   if (!allowFrom || allowFrom.length === 0) {
     return [];
@@ -150,19 +146,10 @@ function formatAllowFromList(params: {
   return normalizeStringEntries(allowFrom);
 }
 
-function normalizeAllowFromEntry(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  value: string;
-}): string[] {
-  const normalized = formatAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    allowFrom: [params.value],
-  });
-  return normalized.filter((entry) => entry.trim().length > 0);
+function normalizeAllowFromEntry(params: AllowFromParams & { value: string }): string[] {
+  return formatAllowFromList({ ...params, allowFrom: [params.value] }).filter((entry) =>
+    Boolean(entry.trim()),
+  );
 }
 
 function isWildcardAllowFromEntry(entry: string): boolean {
@@ -177,85 +164,47 @@ function stripWildcardAllowFrom(list: string[]): string[] {
   return list.filter((entry) => !isWildcardAllowFromEntry(entry));
 }
 
-function resolveProviderAllowFrom(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-}): {
-  allowFrom: Array<string | number>;
-  hadResolutionError: boolean;
-} {
+function resolveProviderAllowFrom(
+  params: AllowFromParams & {
+    providerId?: ChannelId;
+    forceFallbackResolutionError?: boolean;
+  },
+): ProviderAllowFromResolution {
   const { plugin, cfg, accountId } = params;
-  const providerId = plugin?.id;
-  if (!plugin?.config?.resolveAllowFrom) {
-    return {
-      allowFrom: resolveFallbackAllowFrom({ cfg, providerId, accountId }),
-      hadResolutionError: false,
-    };
-  }
+  // An unloaded channel has no trusted allowlist owner unless failed provider inference forces it.
+  const providerId = params.forceFallbackResolutionError
+    ? (params.providerId ?? plugin?.id)
+    : plugin?.id;
+  const resolveFallback = () => resolveFallbackAllowFrom({ cfg, providerId, accountId });
+  let hadResolutionError = Boolean(params.forceFallbackResolutionError);
+  let allowFrom: Array<string | number>;
 
-  try {
-    const allowFrom = plugin.config.resolveAllowFrom({ cfg, accountId });
-    if (allowFrom == null) {
-      return {
-        allowFrom: [],
-        hadResolutionError: false,
-      };
-    }
-    if (!Array.isArray(allowFrom)) {
-      console.warn(
-        `[command-auth] resolveAllowFrom returned an invalid allowFrom for provider "${providerId}", falling back to config allowFrom: invalid_result`,
-      );
-      return {
-        allowFrom: resolveFallbackAllowFrom({ cfg, providerId, accountId }),
-        hadResolutionError: true,
-      };
-    }
-    return {
-      allowFrom,
-      hadResolutionError: false,
-    };
-  } catch (err) {
-    console.warn(
-      `[command-auth] resolveAllowFrom threw for provider "${providerId}", falling back to config allowFrom: ${describeAllowFromResolutionError(err)}`,
-    );
-    return {
-      allowFrom: resolveFallbackAllowFrom({ cfg, providerId, accountId }),
-      hadResolutionError: true,
-    };
-  }
-}
-
-function buildProviderAllowFromResolution(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  providerId?: ChannelId;
-  forceFallbackResolutionError?: boolean;
-}): ProviderAllowFromResolution {
-  const providerId = params.providerId ?? params.plugin?.id;
-  const resolvedAllowFrom = params.forceFallbackResolutionError
-    ? {
-        allowFrom: resolveFallbackAllowFrom({
-          cfg: params.cfg,
-          providerId,
-          accountId: params.accountId,
-        }),
-        hadResolutionError: true,
+  if (hadResolutionError || !plugin?.config?.resolveAllowFrom) {
+    allowFrom = resolveFallback();
+  } else {
+    try {
+      const resolved = plugin.config.resolveAllowFrom({ cfg, accountId });
+      if (resolved == null || Array.isArray(resolved)) {
+        allowFrom = resolved ?? [];
+      } else {
+        console.warn(
+          `[command-auth] resolveAllowFrom returned an invalid allowFrom for provider "${providerId}", falling back to config allowFrom: invalid_result`,
+        );
+        hadResolutionError = true;
+        allowFrom = resolveFallback();
       }
-    : resolveProviderAllowFrom({
-        plugin: params.plugin,
-        cfg: params.cfg,
-        accountId: params.accountId,
-      });
+    } catch (err) {
+      console.warn(
+        `[command-auth] resolveAllowFrom threw for provider "${providerId}", falling back to config allowFrom: ${describeAllowFromResolutionError(err)}`,
+      );
+      hadResolutionError = true;
+      allowFrom = resolveFallback();
+    }
+  }
   return {
-    ...resolvedAllowFrom,
-    allowFromList: formatAllowFromList({
-      plugin: params.plugin,
-      cfg: params.cfg,
-      accountId: params.accountId,
-      allowFrom: resolvedAllowFrom.allowFrom,
-    }),
+    allowFrom,
+    allowFromList: formatAllowFromList({ plugin, cfg, accountId, allowFrom }),
+    hadResolutionError,
   };
 }
 
@@ -267,13 +216,9 @@ function describeAllowFromResolutionError(err: unknown): string {
   return "unknown_error";
 }
 
-function resolveOwnerAllowFromList(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  providerId?: ChannelId;
-  allowFrom?: Array<string | number>;
-}): string[] {
+function resolveOwnerAllowFromList(
+  params: AllowFromParams & { providerId?: ChannelId; allowFrom?: Array<string | number> },
+): string[] {
   const raw = params.allowFrom ?? params.cfg.commands?.ownerAllowFrom;
   if (!Array.isArray(raw) || raw.length === 0) {
     return [];
@@ -302,12 +247,7 @@ function resolveOwnerAllowFromList(params: {
     }
     filtered.push(trimmed);
   }
-  return formatAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    allowFrom: filtered,
-  });
+  return formatAllowFromList({ ...params, allowFrom: filtered });
 }
 
 /**
@@ -315,20 +255,16 @@ function resolveOwnerAllowFromList(params: {
  * Returns the provider-specific list if defined, otherwise the "*" global list.
  * Returns null if commands.allowFrom is not configured at all (fall back to channel allowFrom).
  */
-function resolveCommandsAllowFromList(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  providerId?: ChannelId;
-}): string[] | null {
-  const { plugin, cfg, accountId, providerId } = params;
-  const commandsAllowFrom = cfg.commands?.allowFrom;
+function resolveCommandsAllowFromList(
+  params: AllowFromParams & { providerId?: ChannelId },
+): string[] | null {
+  const commandsAllowFrom = params.cfg.commands?.allowFrom;
   if (!commandsAllowFrom || typeof commandsAllowFrom !== "object") {
     return null; // Not configured, fall back to channel allowFrom
   }
 
   // Check provider-specific list first, then fall back to global "*"
-  const providerKey = providerId ?? "";
+  const providerKey = params.providerId ?? "";
   const providerList = commandsAllowFrom[providerKey];
   const globalList = commandsAllowFrom["*"];
 
@@ -337,22 +273,12 @@ function resolveCommandsAllowFromList(params: {
     return null; // No applicable list found
   }
 
-  return formatAllowFromList({
-    plugin,
-    cfg,
-    accountId,
-    allowFrom: rawList,
-  });
+  return formatAllowFromList({ ...params, allowFrom: rawList });
 }
 
-function resolveOwnerCandidatesForCommands(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  to?: string;
-  allowAll: boolean;
-  allowFromList: string[];
-}): string[] {
+function resolveOwnerCandidatesForCommands(
+  params: AllowFromParams & { to?: string; allowAll: boolean; allowFromList: string[] },
+): string[] {
   if (params.allowAll) {
     return [];
   }
@@ -360,51 +286,31 @@ function resolveOwnerCandidatesForCommands(params: {
   if (ownerCandidatesForCommands.length > 0 || !params.to) {
     return ownerCandidatesForCommands;
   }
-  const normalizedTo = normalizeAllowFromEntry({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    value: params.to,
-  });
-  return normalizedTo.length > 0 ? [...ownerCandidatesForCommands, ...normalizedTo] : [];
+  return normalizeAllowFromEntry({ ...params, value: params.to });
 }
 
-function resolveOwnerAuthorizationState(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  providerId?: ChannelId;
-  to?: string;
-  allowFromList: string[];
-  hadResolutionError: boolean;
-  configOwnerAllowFrom?: Array<string | number>;
-  contextOwnerAllowFrom?: Array<string | number>;
-}): OwnerAuthorizationState {
+function resolveOwnerAuthorizationState(
+  params: AllowFromParams & {
+    providerId?: ChannelId;
+    to?: string;
+    allowFromList: string[];
+    hadResolutionError: boolean;
+    configOwnerAllowFrom?: Array<string | number>;
+    contextOwnerAllowFrom?: Array<string | number>;
+  },
+): OwnerAuthorizationState {
   const configOwnerAllowFromList = resolveOwnerAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    providerId: params.providerId,
+    ...params,
     allowFrom: params.configOwnerAllowFrom,
   });
   const contextOwnerAllowFromList = resolveOwnerAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    providerId: params.providerId,
+    ...params,
     allowFrom: params.contextOwnerAllowFrom,
   });
   const allowAll =
     !params.hadResolutionError &&
     (params.allowFromList.length === 0 || hasWildcardAllowFrom(params.allowFromList));
-  const channelCommandOwners = resolveOwnerCandidatesForCommands({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    to: params.to,
-    allowAll,
-    allowFromList: params.allowFromList,
-  });
+  const channelCommandOwners = resolveOwnerCandidatesForCommands({ ...params, allowAll });
   const explicitOwners = Array.from(new Set(stripWildcardAllowFrom(configOwnerAllowFromList)));
   const contextCommandOwners = stripWildcardAllowFrom(contextOwnerAllowFromList);
   // Channel and context lists can authorize commands within one transport, but only the global
@@ -455,16 +361,14 @@ function resolveCommandSenderAuthorization(params: {
   return params.commandAuthorized && (params.isOwnerForCommands || params.nativeCommandAuthorized);
 }
 
-function resolveSenderCandidates(params: {
-  plugin?: ChannelPlugin;
-  providerId?: ChannelId;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  senderId?: string | null;
-  senderE164?: string | null;
-  from?: string | null;
-  chatType?: string | null;
-}): string[] {
+function resolveSenderCandidates(
+  params: AllowFromParams & {
+    senderId?: string | null;
+    senderE164?: string | null;
+    from?: string | null;
+    chatType?: string | null;
+  },
+): string[] {
   const { plugin, cfg, accountId } = params;
   const candidates: string[] = [];
   const pushCandidate = (value?: string | null) => {
@@ -510,21 +414,7 @@ function resolveFallbackAllowFrom(params: {
     return [];
   }
   const channels = params.cfg.channels as
-    | Record<
-        string,
-        | {
-            allowFrom?: Array<string | number>;
-            dm?: { allowFrom?: Array<string | number> };
-            accounts?: Record<
-              string,
-              {
-                allowFrom?: Array<string | number>;
-                dm?: { allowFrom?: Array<string | number> };
-              }
-            >;
-          }
-        | undefined
-      >
+    | Record<string, AllowFromChannelConfig | undefined>
     | undefined;
   const channelCfg = channels?.[providerId];
   const accountCfg =
@@ -539,49 +429,18 @@ function resolveFallbackAllowFrom(params: {
 }
 
 function resolveFallbackAccountConfig(
-  accounts:
-    | Record<
-        string,
-        | {
-            allowFrom?: Array<string | number>;
-            dm?: { allowFrom?: Array<string | number> };
-          }
-        | undefined
-      >
-    | undefined,
+  accounts: AllowFromChannelConfig["accounts"],
   accountId?: string | null,
 ) {
   const normalizedAccountId = normalizeOptionalLowercaseString(accountId);
   if (!accounts || !normalizedAccountId) {
     return undefined;
   }
-  const direct = accounts[normalizedAccountId];
-  if (direct) {
-    return direct;
-  }
-  const matchKey = Object.keys(accounts).find(
-    (key) => normalizeOptionalLowercaseString(key) === normalizedAccountId,
-  );
-  return matchKey ? accounts[matchKey] : undefined;
+  // Preserve existing inherited-key precedence before the canonical own-key/case-insensitive lookup.
+  return accounts[normalizedAccountId] ?? resolveAccountEntry(accounts, normalizedAccountId);
 }
 
-function resolveFallbackDefaultAccountConfig(
-  channelCfg:
-    | {
-        allowFrom?: Array<string | number>;
-        dm?: { allowFrom?: Array<string | number> };
-        defaultAccount?: string;
-        accounts?: Record<
-          string,
-          | {
-              allowFrom?: Array<string | number>;
-              dm?: { allowFrom?: Array<string | number> };
-            }
-          | undefined
-        >;
-      }
-    | undefined,
-) {
+function resolveFallbackDefaultAccountConfig(channelCfg: AllowFromChannelConfig | undefined) {
   const accounts = channelCfg?.accounts;
   if (!accounts) {
     return undefined;
@@ -623,7 +482,7 @@ export function resolveCommandAuthorization(params: {
     providerId,
   });
 
-  const resolvedAllowFrom = buildProviderAllowFromResolution({
+  const resolvedAllowFrom = resolveProviderAllowFrom({
     plugin,
     cfg,
     accountId: ctx.AccountId,
@@ -644,7 +503,6 @@ export function resolveCommandAuthorization(params: {
 
   const senderCandidates = resolveSenderCandidates({
     plugin,
-    providerId,
     cfg,
     accountId: ctx.AccountId,
     senderId: ctx.SenderId,

--- a/src/auto-reply/commands-registry-list.ts
+++ b/src/auto-reply/commands-registry-list.ts
@@ -41,22 +41,13 @@ export function listChatCommands(params?: {
 
 /** Applies config feature flags to command keys that can be operator-disabled. */
 export function isCommandEnabled(cfg: OpenClawConfig, commandKey: string): boolean {
-  if (commandKey === "config") {
-    return isCommandFlagEnabled(cfg, "config");
-  }
-  if (commandKey === "mcp") {
-    return isCommandFlagEnabled(cfg, "mcp");
-  }
-  if (commandKey === "plugins") {
-    return isCommandFlagEnabled(cfg, "plugins");
-  }
-  if (commandKey === "debug") {
-    return isCommandFlagEnabled(cfg, "debug");
-  }
-  if (commandKey === "bash") {
-    return isCommandFlagEnabled(cfg, "bash");
-  }
-  return true;
+  return commandKey === "config" ||
+    commandKey === "mcp" ||
+    commandKey === "plugins" ||
+    commandKey === "debug" ||
+    commandKey === "bash"
+    ? isCommandFlagEnabled(cfg, commandKey)
+    : true;
 }
 
 /** Lists commands visible for a specific config, preserving dynamic skill commands. */
@@ -64,9 +55,5 @@ export function listChatCommandsForConfig(
   cfg: OpenClawConfig,
   params?: { skillCommands?: SkillCommandSpec[] },
 ): ChatCommandDefinition[] {
-  const base = getChatCommands().filter((command) => isCommandEnabled(cfg, command.key));
-  if (!params?.skillCommands?.length) {
-    return base;
-  }
-  return [...base, ...buildSkillCommandDefinitions(params.skillCommands)];
+  return listChatCommands(params).filter((command) => isCommandEnabled(cfg, command.key));
 }

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -15,36 +15,41 @@ import type {
 } from "./commands-registry.types.js";
 
 type TextAliasSpec = {
-  key: string;
+  command: ChatCommandDefinition;
   canonical: string;
   acceptsArgs: boolean;
 };
 
-let cachedTextAliasMap: Map<string, TextAliasSpec> | null = null;
-let cachedTextAliasCommands: ChatCommandDefinition[] | null = null;
-let cachedDetection: CommandDetection | undefined;
-let cachedDetectionCommands: ChatCommandDefinition[] | null = null;
+type CommandRegistryLookup = {
+  commands: ChatCommandDefinition[];
+  aliases: Map<string, TextAliasSpec>;
+  detection: CommandDetection;
+};
+
+let cachedRegistryLookup: CommandRegistryLookup | undefined;
 
 function appendMultilineTail(head: string, tail: string | undefined, spec?: TextAliasSpec): string {
   if (!tail) {
     return head;
   }
-  if (!spec || spec.key === "skill" || spec.key === "learn") {
+  if (!spec || spec.command.key === "skill" || spec.command.key === "learn") {
     return `${head}\n${tail}`;
   }
-  if (spec.key === "reset") {
+  if (spec.command.key === "reset") {
     const flattened = tail.replace(/\s+/g, " ").trim();
     return flattened ? `${head} ${flattened}` : head;
   }
   return head;
 }
 
-function getTextAliasMap(): Map<string, TextAliasSpec> {
+function getCommandRegistryLookup(): CommandRegistryLookup {
   const commands = getChatCommands();
-  if (cachedTextAliasMap && cachedTextAliasCommands === commands) {
-    return cachedTextAliasMap;
+  if (cachedRegistryLookup?.commands === commands) {
+    return cachedRegistryLookup;
   }
-  const map = new Map<string, TextAliasSpec>();
+  const aliases = new Map<string, TextAliasSpec>();
+  const exact = new Set<string>();
+  const patterns: string[] = [];
   for (const command of commands) {
     // Canonicalize to the primary text alias, not `/${key}`. Some command keys are
     // internal identifiers while the public text command is a dedicated alias.
@@ -55,14 +60,27 @@ function getTextAliasMap(): Map<string, TextAliasSpec> {
       if (!normalized) {
         continue;
       }
-      if (!map.has(normalized)) {
-        map.set(normalized, { key: command.key, canonical, acceptsArgs });
+      if (!aliases.has(normalized)) {
+        aliases.set(normalized, { command, canonical, acceptsArgs });
       }
+      exact.add(normalized);
+      const escaped = escapeRegExp(normalized);
+      patterns.push(
+        acceptsArgs
+          ? `${escaped}(?:\\s+[\\s\\S]+|\\s*:\\s*[\\s\\S]*)?`
+          : `${escaped}(?:\\s*:\\s*)?`,
+      );
     }
   }
-  cachedTextAliasMap = map;
-  cachedTextAliasCommands = commands;
-  return map;
+  cachedRegistryLookup = {
+    commands,
+    aliases,
+    detection: {
+      exact,
+      regex: patterns.length ? new RegExp(`^(?:${patterns.join("|")})$`, "i") : /$^/,
+    },
+  };
+  return cachedRegistryLookup;
 }
 
 /** Normalizes command text to canonical aliases, removing bot mentions when appropriate. */
@@ -96,7 +114,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
       : normalized;
 
   const lowered = normalizeLowercaseStringOrEmpty(commandBody);
-  const textAliasMap = getTextAliasMap();
+  const textAliasMap = getCommandRegistryLookup().aliases;
   const exact = textAliasMap.get(lowered);
   if (exact) {
     return appendMultilineTail(exact.canonical, multilineTail, exact);
@@ -124,36 +142,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
 
 /** Returns cached exact and regex detectors for the current command registry instance. */
 export function getCommandDetection(_cfg?: OpenClawConfig): CommandDetection {
-  const commands = getChatCommands();
-  if (cachedDetection && cachedDetectionCommands === commands) {
-    return cachedDetection;
-  }
-  const exact = new Set<string>();
-  const patterns: string[] = [];
-  for (const cmd of commands) {
-    for (const alias of cmd.textAliases) {
-      const normalized = normalizeOptionalLowercaseString(alias);
-      if (!normalized) {
-        continue;
-      }
-      exact.add(normalized);
-      const escaped = escapeRegExp(normalized);
-      if (!escaped) {
-        continue;
-      }
-      if (cmd.acceptsArgs) {
-        patterns.push(`${escaped}(?:\\s+[\\s\\S]+|\\s*:\\s*[\\s\\S]*)?`);
-      } else {
-        patterns.push(`${escaped}(?:\\s*:\\s*)?`);
-      }
-    }
-  }
-  cachedDetection = {
-    exact,
-    regex: patterns.length ? new RegExp(`^(?:${patterns.join("|")})$`, "i") : /$^/,
-  };
-  cachedDetectionCommands = commands;
-  return cachedDetection;
+  return getCommandRegistryLookup().detection;
 }
 
 /** Resolves a raw text command to the matching normalized alias when known. */
@@ -175,7 +164,7 @@ export function maybeResolveTextAlias(raw: string, cfg?: OpenClawConfig) {
     return null;
   }
   const tokenKey = `/${tokenMatch[1]}`;
-  return getTextAliasMap().has(tokenKey) ? tokenKey : null;
+  return getCommandRegistryLookup().aliases.has(tokenKey) ? tokenKey : null;
 }
 
 /** Resolves a raw text command into its command definition and raw argument tail. */
@@ -191,17 +180,13 @@ export function resolveTextCommand(
   if (!alias) {
     return null;
   }
-  const spec = getTextAliasMap().get(alias);
+  const spec = getCommandRegistryLookup().aliases.get(alias);
   if (!spec) {
     return null;
   }
-  const command = getChatCommands().find((entry) => entry.key === spec.key);
-  if (!command) {
-    return null;
-  }
   if (!spec.acceptsArgs) {
-    return { command };
+    return { command: spec.command };
   }
   const args = trimmed.slice(alias.length).trim();
-  return { command, args: args || undefined };
+  return { command: spec.command, args: args || undefined };
 }

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -92,23 +92,11 @@ function registerAlias(commands: ChatCommandDefinition[], key: string, ...aliase
   if (!command) {
     throw new Error(`registerAlias: unknown command key: ${key}`);
   }
-  const existing = new Set<string>();
-  for (const alias of command.textAliases) {
-    const lowered = normalizeOptionalLowercaseString(alias);
-    if (lowered) {
-      existing.add(lowered);
-    }
-  }
+  const existing = new Set(command.textAliases.map((alias) => alias.toLowerCase()));
   for (const alias of aliases) {
     const trimmed = alias.trim();
-    if (!trimmed) {
-      continue;
-    }
     const lowered = normalizeOptionalLowercaseString(trimmed);
-    if (!lowered) {
-      continue;
-    }
-    if (existing.has(lowered)) {
+    if (!lowered || existing.has(lowered)) {
       continue;
     }
     existing.add(lowered);
@@ -167,6 +155,55 @@ export function assertCommandRegistry(commands: ChatCommandDefinition[]): void {
   }
 }
 
+type BuiltinCommandArgument = NonNullable<ChatCommandDefinition["args"]>[number];
+type BuiltinCommandArgumentOptions = Omit<
+  BuiltinCommandArgument,
+  "name" | "description" | "type"
+> & { type?: BuiltinCommandArgument["type"] };
+type BuiltinCommandOptions = Omit<
+  DefineChatCommandInput,
+  "key" | "description" | "category" | "tier" | "nativeName" | "textAlias"
+> & { nativeName?: string | false };
+type BuiltinCommandDescriptor = readonly [
+  key: string,
+  description: string,
+  category: CommandCategory,
+  tier: CommandTier,
+  options?: BuiltinCommandOptions,
+];
+
+function defineBuiltinCommand(...definition: BuiltinCommandDescriptor): BuiltinCommandDescriptor {
+  return definition;
+}
+
+function defineCommandArgument(
+  name: string,
+  description: string,
+  options: BuiltinCommandArgumentOptions = {},
+): BuiltinCommandArgument {
+  return { name, description, type: "string", ...options };
+}
+
+function defineBuiltinChatCommand([
+  key,
+  description,
+  category,
+  tier,
+  options = {},
+]: BuiltinCommandDescriptor): ChatCommandDefinition {
+  const { nativeName = key, textAliases, ...fields } = options;
+  return defineChatCommand({
+    key,
+    nativeName: nativeName === false ? undefined : nativeName,
+    description,
+    textAlias: textAliases ? undefined : `/${key}`,
+    textAliases,
+    category,
+    tier,
+    ...fields,
+  });
+}
+
 /** Builds the built-in command list with context-aware thinking choices. */
 export function buildBuiltinChatCommands(
   params: { listThinkingLevels?: ListThinkingLevels } = {},
@@ -177,262 +214,149 @@ export function buildBuiltinChatCommands(
     const levels = configuredThinkingLevels(provider, model, catalog, agentRuntime);
     return ["default", ...levels.filter((level) => level !== "default")];
   };
-  const commands: ChatCommandDefinition[] = [
-    defineChatCommand({
-      key: "help",
-      nativeName: "help",
-      description: "Show available commands.",
-      textAlias: "/help",
-      category: "status",
-      tier: "essential",
-    }),
-    defineChatCommand({
-      key: "commands",
-      nativeName: "commands",
-      description: "List all slash commands.",
-      textAlias: "/commands",
-      category: "status",
-      tier: "power",
-    }),
-    defineChatCommand({
-      key: "tools",
-      nativeName: "tools",
-      description: "List available runtime tools.",
-      textAlias: "/tools",
-      category: "status",
+  const definitions: BuiltinCommandDescriptor[] = [
+    defineBuiltinCommand("help", "Show available commands.", "status", "essential"),
+    defineBuiltinCommand("commands", "List all slash commands.", "status", "power"),
+    defineBuiltinCommand("tools", "List available runtime tools.", "status", "standard", {
       args: [
-        {
-          name: "mode",
-          description: "compact or verbose",
-          type: "string",
-          choices: ["compact", "verbose"],
-        },
+        defineCommandArgument("mode", "compact or verbose", { choices: ["compact", "verbose"] }),
       ],
       argsMenu: "auto",
-      tier: "standard",
     }),
-    defineChatCommand({
-      key: "skill",
-      nativeName: "skill",
-      description: "Run a skill by name.",
-      textAlias: "/skill",
-      category: "tools",
-      tier: "standard",
+    defineBuiltinCommand("skill", "Run a skill by name.", "tools", "standard", {
       args: [
-        {
-          name: "name",
-          description: "Skill name",
-          type: "string",
-          required: true,
-        },
-        {
-          name: "input",
-          description: "Skill input",
-          type: "string",
-          captureRemaining: true,
-        },
+        defineCommandArgument("name", "Skill name", { required: true }),
+        defineCommandArgument("input", "Skill input", { captureRemaining: true }),
       ],
     }),
-    defineChatCommand({
-      key: "learn",
-      nativeName: "learn",
-      description: "Draft a reusable skill from recent work or named sources.",
-      textAlias: "/learn",
-      category: "tools",
-      tier: "standard",
-      acceptsArgs: true,
-      args: [
-        {
-          name: "request",
-          description: "Sources and requirements for the skill draft",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "loop",
-      nativeName: "loop",
-      description: "Loop a prompt: /loop [interval] <prompt> | /loop status | /loop stop [name]",
-      textAlias: "/loop",
-      category: "tools",
-      tier: "standard",
-      args: [
-        {
-          name: "spec",
-          description: "[interval] prompt, or status/stop",
-          type: "string",
-          required: false,
-          captureRemaining: true,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "status",
-      nativeName: "status",
-      description: "Show current status.",
-      textAlias: "/status",
-      category: "status",
-      tier: "essential",
+    defineBuiltinCommand(
+      "learn",
+      "Draft a reusable skill from recent work or named sources.",
+      "tools",
+      "standard",
+      {
+        args: [
+          defineCommandArgument("request", "Sources and requirements for the skill draft", {
+            captureRemaining: true,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand(
+      "loop",
+      "Loop a prompt: /loop [interval] <prompt> | /loop status | /loop stop [name]",
+      "tools",
+      "standard",
+      {
+        args: [
+          defineCommandArgument("spec", "[interval] prompt, or status/stop", {
+            required: false,
+            captureRemaining: true,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand("status", "Show current status.", "status", "essential", {
       acceptsArgs: true,
     }),
-    defineChatCommand({
-      key: "goal",
-      nativeName: "goal",
-      description: "Show or control the current goal.",
-      textAlias: "/goal",
-      category: "status",
-      tier: "standard",
-      acceptsArgs: true,
+    defineBuiltinCommand("goal", "Show or control the current goal.", "status", "standard", {
       args: [
-        {
-          name: "action",
-          description: "status, start, edit, pause, resume, complete, block, clear",
-          type: "string",
-          choices: ["status", "start", "edit", "pause", "resume", "complete", "block", "clear"],
-        },
-        {
-          name: "text",
-          description: "Goal objective or note",
-          type: "string",
-          captureRemaining: true,
-        },
+        defineCommandArgument(
+          "action",
+          "status, start, edit, pause, resume, complete, block, clear",
+          {
+            choices: ["status", "start", "edit", "pause", "resume", "complete", "block", "clear"],
+          },
+        ),
+        defineCommandArgument("text", "Goal objective or note", { captureRemaining: true }),
       ],
     }),
-    defineChatCommand({
-      key: "diagnostics",
-      nativeName: "diagnostics",
-      description: "Explain Gateway diagnostics and Codex feedback upload options.",
-      textAlias: "/diagnostics",
-      acceptsArgs: true,
-      category: "status",
-      tier: "standard",
-      args: [
-        {
-          name: "note",
-          description: "Optional note for Codex feedback upload",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "login",
-      nativeName: "login",
+    defineBuiltinCommand(
+      "diagnostics",
+      "Explain Gateway diagnostics and Codex feedback upload options.",
+      "status",
+      "standard",
+      {
+        args: [
+          defineCommandArgument("note", "Optional note for Codex feedback upload", {
+            captureRemaining: true,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand("login", "Pair Codex login.", "management", "standard", {
       nativeProviders: ["discord", "slack", "telegram"],
-      description: "Pair Codex login.",
-      textAlias: "/login",
-      category: "management",
-      tier: "standard",
       args: [
-        {
-          name: "provider",
-          description: "Provider to pair",
-          type: "string",
-          choices: ["codex", "openai"],
-        },
+        defineCommandArgument("provider", "Provider to pair", { choices: ["codex", "openai"] }),
       ],
     }),
-    defineChatCommand({
-      key: "openclaw",
-      description: "Run the OpenClaw setup and repair helper.",
-      textAlias: "/openclaw",
+    defineBuiltinCommand(
+      "openclaw",
+      "Run the OpenClaw setup and repair helper.",
+      "management",
+      "essential",
+      {
+        nativeName: false,
+        acceptsArgs: true,
+      },
+    ),
+    defineBuiltinCommand("tasks", "List background tasks for this session.", "status", "standard"),
+    defineBuiltinCommand("allowlist", "List/add/remove allowlist entries.", "management", "power", {
+      nativeName: false,
       acceptsArgs: true,
-      scope: "text",
-      category: "management",
-      tier: "essential",
     }),
-    defineChatCommand({
-      key: "tasks",
-      nativeName: "tasks",
-      description: "List background tasks for this session.",
-      textAlias: "/tasks",
-      category: "status",
-      tier: "standard",
-    }),
-    defineChatCommand({
-      key: "allowlist",
-      description: "List/add/remove allowlist entries.",
-      textAlias: "/allowlist",
+    defineBuiltinCommand("approve", "Approve or deny exec requests.", "management", "power", {
       acceptsArgs: true,
-      scope: "text",
-      category: "management",
-      tier: "power",
     }),
-    defineChatCommand({
-      key: "approve",
-      nativeName: "approve",
-      description: "Approve or deny exec requests.",
-      textAlias: "/approve",
-      acceptsArgs: true,
-      category: "management",
-      tier: "power",
-    }),
-    defineChatCommand({
-      key: "context",
-      nativeName: "context",
-      description: "Explain how context is built and used.",
-      textAlias: "/context",
-      acceptsArgs: true,
-      category: "status",
-      tier: "standard",
-    }),
-    defineChatCommand({
-      key: "btw",
-      nativeName: "btw",
-      nativeAliases: ["side"],
-      description: "Ask a side question without changing future session context.",
-      textAliases: ["/btw", "/side"],
-      acceptsArgs: true,
-      category: "tools",
-      tier: "standard",
-    }),
-    defineChatCommand({
-      key: "export-session",
-      nativeName: "export-session",
-      description: "Export current session to an owner-only HTML file in the workspace.",
-      textAliases: ["/export-session", "/export"],
-      acceptsArgs: true,
-      category: "status",
-      tier: "essential",
+    defineBuiltinCommand(
+      "context",
+      "Explain how context is built and used.",
+      "status",
+      "standard",
+      { acceptsArgs: true },
+    ),
+    defineBuiltinCommand(
+      "btw",
+      "Ask a side question without changing future session context.",
+      "tools",
+      "standard",
+      {
+        nativeAliases: ["side"],
+        textAliases: ["/btw", "/side"],
+        acceptsArgs: true,
+      },
+    ),
+    defineBuiltinCommand(
+      "export-session",
+      "Export current session to an owner-only HTML file in the workspace.",
+      "status",
+      "essential",
+      {
+        textAliases: ["/export-session", "/export"],
+        args: [
+          defineCommandArgument("path", "Output path inside workspace (default: workspace)", {
+            required: false,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand(
+      "export-trajectory",
+      "Export a JSONL trajectory bundle for the active session.",
+      "status",
+      "essential",
+      {
+        textAliases: ["/export-trajectory", "/trajectory"],
+        args: [
+          defineCommandArgument("path", "Output directory (default: workspace)", {
+            required: false,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand("tts", "Control text-to-speech (TTS).", "media", "standard", {
       args: [
-        {
-          name: "path",
-          description: "Output path inside workspace (default: workspace)",
-          type: "string",
-          required: false,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "export-trajectory",
-      nativeName: "export-trajectory",
-      description: "Export a JSONL trajectory bundle for the active session.",
-      textAliases: ["/export-trajectory", "/trajectory"],
-      acceptsArgs: true,
-      category: "status",
-      tier: "essential",
-      args: [
-        {
-          name: "path",
-          description: "Output directory (default: workspace)",
-          type: "string",
-          required: false,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "tts",
-      nativeName: "tts",
-      description: "Control text-to-speech (TTS).",
-      textAlias: "/tts",
-      category: "media",
-      tier: "standard",
-      args: [
-        {
-          name: "action",
-          description: "TTS action",
-          type: "string",
+        defineCommandArgument("action", "TTS action", {
           choices: [
             { value: "on", label: "On" },
             { value: "off", label: "Off" },
@@ -443,13 +367,8 @@ export function buildBuiltinChatCommands(
             { value: "audio", label: "Audio" },
             { value: "help", label: "Help" },
           ],
-        },
-        {
-          name: "value",
-          description: "Provider, limit, or text",
-          type: "string",
-          captureRemaining: true,
-        },
+        }),
+        defineCommandArgument("value", "Provider, limit, or text", { captureRemaining: true }),
       ],
       argsMenu: {
         arg: "action",
@@ -465,77 +384,41 @@ export function buildBuiltinChatCommands(
           "• Help – Show usage guide",
       },
     }),
-    defineChatCommand({
-      key: "whoami",
-      nativeName: "whoami",
-      description: "Show your sender id.",
-      textAlias: "/whoami",
-      category: "status",
-      tier: "power",
-    }),
-    defineChatCommand({
-      key: "session",
-      nativeName: "session",
-      description: "Manage session-level settings (for example /session idle).",
-      textAlias: "/session",
-      category: "session",
-      tier: "power",
+    defineBuiltinCommand("whoami", "Show your sender id.", "status", "power"),
+    defineBuiltinCommand(
+      "session",
+      "Manage session-level settings (for example /session idle).",
+      "session",
+      "power",
+      {
+        args: [
+          defineCommandArgument("action", "idle | max-age", { choices: ["idle", "max-age"] }),
+          defineCommandArgument("value", "Duration (24h, 90m) or off", { captureRemaining: true }),
+        ],
+        argsMenu: "auto",
+      },
+    ),
+    defineBuiltinCommand(
+      "subagents",
+      "Inspect subagent runs for this session.",
+      "management",
+      "standard",
+      {
+        args: [
+          defineCommandArgument("action", "list | log | info", {
+            choices: ["list", "log", "info"],
+          }),
+          defineCommandArgument("target", "Run id, index, or session key"),
+          defineCommandArgument("value", "Additional input (limit/message)", {
+            captureRemaining: true,
+          }),
+        ],
+        argsMenu: "auto",
+      },
+    ),
+    defineBuiltinCommand("acp", "Manage ACP sessions and runtime options.", "management", "power", {
       args: [
-        {
-          name: "action",
-          description: "idle | max-age",
-          type: "string",
-          choices: ["idle", "max-age"],
-        },
-        {
-          name: "value",
-          description: "Duration (24h, 90m) or off",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-      argsMenu: "auto",
-    }),
-    defineChatCommand({
-      key: "subagents",
-      nativeName: "subagents",
-      description: "Inspect subagent runs for this session.",
-      textAlias: "/subagents",
-      category: "management",
-      tier: "standard",
-      args: [
-        {
-          name: "action",
-          description: "list | log | info",
-          type: "string",
-          choices: ["list", "log", "info"],
-        },
-        {
-          name: "target",
-          description: "Run id, index, or session key",
-          type: "string",
-        },
-        {
-          name: "value",
-          description: "Additional input (limit/message)",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-      argsMenu: "auto",
-    }),
-    defineChatCommand({
-      key: "acp",
-      nativeName: "acp",
-      description: "Manage ACP sessions and runtime options.",
-      textAlias: "/acp",
-      category: "management",
-      tier: "power",
-      args: [
-        {
-          name: "action",
-          description: "Action to run",
-          type: "string",
+        defineCommandArgument("action", "Action to run", {
           preferAutocomplete: true,
           choices: [
             "spawn",
@@ -555,356 +438,158 @@ export function buildBuiltinChatCommands(
             "install",
             "help",
           ],
-        },
-        {
-          name: "value",
-          description: "Action arguments",
-          type: "string",
-          captureRemaining: true,
-        },
+        }),
+        defineCommandArgument("value", "Action arguments", { captureRemaining: true }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "focus",
-      nativeName: "focus",
-      description:
-        "Bind this thread (Discord) or topic/conversation (Telegram) to a session target.",
-      textAlias: "/focus",
-      category: "management",
-      tier: "power",
+    defineBuiltinCommand(
+      "focus",
+      "Bind this thread (Discord) or topic/conversation (Telegram) to a session target.",
+      "management",
+      "power",
+      {
+        args: [
+          defineCommandArgument("target", "Subagent label/index or session key/id/label", {
+            captureRemaining: true,
+          }),
+        ],
+      },
+    ),
+    defineBuiltinCommand(
+      "unfocus",
+      "Remove the current thread (Discord) or topic/conversation (Telegram) binding.",
+      "management",
+      "power",
+    ),
+    defineBuiltinCommand(
+      "agents",
+      "List thread-bound agents for this session.",
+      "management",
+      "standard",
+    ),
+    defineBuiltinCommand(
+      "steer",
+      "Send guidance to the active run in this session.",
+      "management",
+      "standard",
+      {
+        args: [defineCommandArgument("message", "Steering message", { captureRemaining: true })],
+      },
+    ),
+    defineBuiltinCommand("config", "Show or set config values.", "management", "power", {
       args: [
-        {
-          name: "target",
-          description: "Subagent label/index or session key/id/label",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "unfocus",
-      nativeName: "unfocus",
-      description: "Remove the current thread (Discord) or topic/conversation (Telegram) binding.",
-      textAlias: "/unfocus",
-      category: "management",
-      tier: "power",
-    }),
-    defineChatCommand({
-      key: "agents",
-      nativeName: "agents",
-      description: "List thread-bound agents for this session.",
-      textAlias: "/agents",
-      category: "management",
-      tier: "standard",
-    }),
-    defineChatCommand({
-      key: "steer",
-      nativeName: "steer",
-      description: "Send guidance to the active run in this session.",
-      textAlias: "/steer",
-      category: "management",
-      tier: "standard",
-      args: [
-        {
-          name: "message",
-          description: "Steering message",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
-    }),
-    defineChatCommand({
-      key: "config",
-      nativeName: "config",
-      description: "Show or set config values.",
-      textAlias: "/config",
-      category: "management",
-      tier: "power",
-      args: [
-        {
-          name: "action",
-          description: "show | get | set | unset",
-          type: "string",
+        defineCommandArgument("action", "show | get | set | unset", {
           choices: ["show", "get", "set", "unset"],
-        },
-        {
-          name: "path",
-          description: "Config path",
-          type: "string",
-        },
-        {
-          name: "value",
-          description: "Value for set",
-          type: "string",
-          captureRemaining: true,
-        },
+        }),
+        defineCommandArgument("path", "Config path"),
+        defineCommandArgument("value", "Value for set", { captureRemaining: true }),
       ],
       argsParsing: "none",
       formatArgs: COMMAND_ARG_FORMATTERS.config,
     }),
-    defineChatCommand({
-      key: "mcp",
-      nativeName: "mcp",
-      description: "Show or set OpenClaw MCP servers.",
-      textAlias: "/mcp",
-      category: "management",
-      tier: "power",
+    defineBuiltinCommand("mcp", "Show or set OpenClaw MCP servers.", "management", "power", {
       args: [
-        {
-          name: "action",
-          description: "show | get | set | unset",
-          type: "string",
+        defineCommandArgument("action", "show | get | set | unset", {
           choices: ["show", "get", "set", "unset"],
-        },
-        {
-          name: "path",
-          description: "MCP server name",
-          type: "string",
-        },
-        {
-          name: "value",
-          description: "JSON config for set",
-          type: "string",
-          captureRemaining: true,
-        },
+        }),
+        defineCommandArgument("path", "MCP server name"),
+        defineCommandArgument("value", "JSON config for set", { captureRemaining: true }),
       ],
       argsParsing: "none",
       formatArgs: COMMAND_ARG_FORMATTERS.mcp,
     }),
-    defineChatCommand({
-      key: "plugins",
-      nativeName: "plugins",
-      description: "List, show, enable, or disable plugins.",
-      textAliases: ["/plugins", "/plugin"],
-      category: "management",
-      tier: "power",
+    defineBuiltinCommand(
+      "plugins",
+      "List, show, enable, or disable plugins.",
+      "management",
+      "power",
+      {
+        textAliases: ["/plugins", "/plugin"],
+        args: [
+          defineCommandArgument("action", "list | show | get | enable | disable", {
+            choices: ["list", "show", "get", "enable", "disable"],
+          }),
+          defineCommandArgument("path", "Plugin id or name"),
+        ],
+        argsParsing: "none",
+        formatArgs: COMMAND_ARG_FORMATTERS.plugins,
+      },
+    ),
+    defineBuiltinCommand("debug", "Set runtime debug overrides.", "management", "power", {
       args: [
-        {
-          name: "action",
-          description: "list | show | get | enable | disable",
-          type: "string",
-          choices: ["list", "show", "get", "enable", "disable"],
-        },
-        {
-          name: "path",
-          description: "Plugin id or name",
-          type: "string",
-        },
-      ],
-      argsParsing: "none",
-      formatArgs: COMMAND_ARG_FORMATTERS.plugins,
-    }),
-    defineChatCommand({
-      key: "debug",
-      nativeName: "debug",
-      description: "Set runtime debug overrides.",
-      textAlias: "/debug",
-      category: "management",
-      tier: "power",
-      args: [
-        {
-          name: "action",
-          description: "show | reset | set | unset",
-          type: "string",
+        defineCommandArgument("action", "show | reset | set | unset", {
           choices: ["show", "reset", "set", "unset"],
-        },
-        {
-          name: "path",
-          description: "Debug path",
-          type: "string",
-        },
-        {
-          name: "value",
-          description: "Value for set",
-          type: "string",
-          captureRemaining: true,
-        },
+        }),
+        defineCommandArgument("path", "Debug path"),
+        defineCommandArgument("value", "Value for set", { captureRemaining: true }),
       ],
       argsParsing: "none",
       formatArgs: COMMAND_ARG_FORMATTERS.debug,
     }),
-    defineChatCommand({
-      key: "usage",
-      nativeName: "usage",
-      description: "Usage footer or cost summary.",
-      textAlias: "/usage",
-      category: "options",
-      tier: "standard",
+    defineBuiltinCommand("usage", "Usage footer or cost summary.", "options", "standard", {
       args: [
-        {
-          name: "mode",
-          description: "off, tokens, full, or cost",
-          type: "string",
+        defineCommandArgument("mode", "off, tokens, full, or cost", {
           choices: ["off", "tokens", "full", "cost"],
-        },
+        }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "stop",
-      nativeName: "stop",
-      description: "Stop the current run.",
-      textAlias: "/stop",
-      category: "session",
-      tier: "essential",
-    }),
-    defineChatCommand({
-      key: "restart",
-      nativeName: "restart",
-      description: "Restart OpenClaw.",
-      textAlias: "/restart",
-      category: "tools",
-      tier: "power",
-    }),
-    defineChatCommand({
-      key: "activation",
-      nativeName: "activation",
-      description: "Set group activation mode.",
-      textAlias: "/activation",
-      category: "management",
-      tier: "power",
+    defineBuiltinCommand("stop", "Stop the current run.", "session", "essential"),
+    defineBuiltinCommand("restart", "Restart OpenClaw.", "tools", "power"),
+    defineBuiltinCommand("activation", "Set group activation mode.", "management", "power", {
       args: [
-        {
-          name: "mode",
-          description: "mention or always",
-          type: "string",
-          choices: ["mention", "always"],
-        },
+        defineCommandArgument("mode", "mention or always", { choices: ["mention", "always"] }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "send",
-      nativeName: "send",
-      description: "Set send policy.",
-      textAlias: "/send",
-      category: "management",
-      tier: "power",
+    defineBuiltinCommand("send", "Set send policy.", "management", "power", {
       args: [
-        {
-          name: "mode",
-          description: "on, off, or inherit",
-          type: "string",
+        defineCommandArgument("mode", "on, off, or inherit", {
           choices: ["on", "off", "inherit"],
-        },
+        }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "reset",
-      nativeName: "reset",
-      description: "Reset the current session.",
-      textAlias: "/reset",
+    defineBuiltinCommand("reset", "Reset the current session.", "session", "essential", {
       acceptsArgs: true,
-      category: "session",
-      tier: "essential",
     }),
-    defineChatCommand({
-      key: "new",
-      nativeName: "new",
-      description: "Start a new session.",
-      textAlias: "/new",
+    defineBuiltinCommand("new", "Start a new session.", "session", "essential", {
       acceptsArgs: true,
-      category: "session",
-      tier: "essential",
     }),
-    defineChatCommand({
-      key: "name",
-      nativeName: "name",
-      description: "Name or rename the current session.",
-      textAlias: "/name",
-      acceptsArgs: true,
-      category: "session",
-      tier: "standard",
+    defineBuiltinCommand("name", "Name or rename the current session.", "session", "standard", {
       args: [
-        {
-          name: "title",
-          description: "New session name (omit to see a suggestion)",
-          type: "string",
+        defineCommandArgument("title", "New session name (omit to see a suggestion)", {
           captureRemaining: true,
-        },
+        }),
       ],
     }),
-    defineChatCommand({
-      key: "compact",
-      nativeName: "compact",
-      description: "Compact the session context.",
-      textAlias: "/compact",
-      category: "session",
-      tier: "essential",
+    defineBuiltinCommand("compact", "Compact the session context.", "session", "essential", {
       args: [
-        {
-          name: "instructions",
-          description: "Extra compaction instructions",
-          type: "string",
+        defineCommandArgument("instructions", "Extra compaction instructions", {
           captureRemaining: true,
-        },
+        }),
       ],
     }),
-    defineChatCommand({
-      key: "think",
-      nativeName: "think",
-      description: "Set thinking level.",
-      textAlias: "/think",
-      category: "options",
-      tier: "essential",
+    defineBuiltinCommand("think", "Set thinking level.", "options", "essential", {
       args: [
-        {
-          name: "level",
-          description: "Thinking level",
-          type: "string",
+        defineCommandArgument("level", "Thinking level", {
           choices: ({ provider, model, catalog, agentRuntime }) =>
             listThinkingLevelChoices(provider, model, catalog, agentRuntime),
-        },
+        }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "verbose",
-      nativeName: "verbose",
-      description: "Toggle verbose mode.",
-      textAlias: "/verbose",
-      category: "options",
-      tier: "standard",
-      args: [
-        {
-          name: "mode",
-          description: "on, off, or full",
-          type: "string",
-          choices: ["on", "off", "full"],
-        },
-      ],
+    defineBuiltinCommand("verbose", "Toggle verbose mode.", "options", "standard", {
+      args: [defineCommandArgument("mode", "on, off, or full", { choices: ["on", "off", "full"] })],
     }),
-    defineChatCommand({
-      key: "trace",
-      nativeName: "trace",
-      description: "Toggle plugin trace lines.",
-      textAlias: "/trace",
-      category: "options",
-      tier: "power",
-      args: [
-        {
-          name: "mode",
-          description: "on, off, or raw",
-          type: "string",
-          choices: ["on", "off", "raw"],
-        },
-      ],
+    defineBuiltinCommand("trace", "Toggle plugin trace lines.", "options", "power", {
+      args: [defineCommandArgument("mode", "on, off, or raw", { choices: ["on", "off", "raw"] })],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "fast",
-      nativeName: "fast",
-      description: "Toggle fast mode.",
-      textAlias: "/fast",
-      category: "options",
-      tier: "standard",
+    defineBuiltinCommand("fast", "Toggle fast mode.", "options", "standard", {
       args: [
-        {
-          name: "mode",
-          description: "on, off, auto, default, or status",
-          type: "string",
+        defineCommandArgument("mode", "on, off, auto, default, or status", {
           choices: ({ cfg, provider, model }) => [
             "on",
             "off",
@@ -917,155 +602,64 @@ export function buildBuiltinChatCommands(
             "default",
             "status",
           ],
-        },
+        }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "reasoning",
-      nativeName: "reasoning",
-      description: "Toggle reasoning visibility.",
-      textAlias: "/reasoning",
-      category: "options",
-      tier: "standard",
+    defineBuiltinCommand("reasoning", "Toggle reasoning visibility.", "options", "standard", {
       args: [
-        {
-          name: "mode",
-          description: "on, off, or stream",
-          type: "string",
-          choices: ["on", "off", "stream"],
-        },
+        defineCommandArgument("mode", "on, off, or stream", { choices: ["on", "off", "stream"] }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "elevated",
-      nativeName: "elevated",
-      description: "Toggle elevated mode.",
-      textAlias: "/elevated",
-      category: "options",
-      tier: "power",
+    defineBuiltinCommand("elevated", "Toggle elevated mode.", "options", "power", {
       args: [
-        {
-          name: "mode",
-          description: "on, off, ask, or full",
-          type: "string",
+        defineCommandArgument("mode", "on, off, ask, or full", {
           choices: ["on", "off", "ask", "full"],
-        },
+        }),
       ],
       argsMenu: "auto",
     }),
-    defineChatCommand({
-      key: "exec",
-      nativeName: "exec",
-      description: "Set exec defaults for this session.",
-      textAlias: "/exec",
-      category: "options",
-      tier: "power",
+    defineBuiltinCommand("exec", "Set exec defaults for this session.", "options", "power", {
       args: [
-        {
-          name: "host",
-          description: "sandbox, gateway, or node",
-          type: "string",
+        defineCommandArgument("host", "sandbox, gateway, or node", {
           choices: ["sandbox", "gateway", "node"],
-        },
-        {
-          name: "security",
-          description: "deny, allowlist, or full",
-          type: "string",
+        }),
+        defineCommandArgument("security", "deny, allowlist, or full", {
           choices: ["deny", "allowlist", "full"],
-        },
-        {
-          name: "ask",
-          description: "off, on-miss, or always",
-          type: "string",
+        }),
+        defineCommandArgument("ask", "off, on-miss, or always", {
           choices: ["off", "on-miss", "always"],
-        },
-        {
-          name: "node",
-          description: "Node id or name",
-          type: "string",
-        },
+        }),
+        defineCommandArgument("node", "Node id or name"),
       ],
       argsParsing: "none",
       formatArgs: COMMAND_ARG_FORMATTERS.exec,
     }),
-    defineChatCommand({
-      key: "model",
-      nativeName: "model",
-      description: "Show or set the model.",
-      textAlias: "/model",
-      category: "options",
-      tier: "essential",
-      args: [
-        {
-          name: "model",
-          description: "Model id (provider/model or id)",
-          type: "string",
-        },
-      ],
+    defineBuiltinCommand("model", "Show or set the model.", "options", "essential", {
+      args: [defineCommandArgument("model", "Model id (provider/model or id)")],
     }),
-    defineChatCommand({
-      key: "models",
-      nativeName: "models",
-      description: "List model providers/models.",
-      textAlias: "/models",
-      tier: "standard",
-      argsParsing: "none",
+    defineBuiltinCommand("models", "List model providers/models.", "options", "standard", {
       acceptsArgs: true,
-      category: "options",
     }),
-    defineChatCommand({
-      key: "queue",
-      nativeName: "queue",
-      description: "Adjust queue settings.",
-      textAlias: "/queue",
-      category: "options",
-      tier: "power",
+    defineBuiltinCommand("queue", "Adjust queue settings.", "options", "power", {
       args: [
-        {
-          name: "mode",
-          description: "queue mode",
-          type: "string",
+        defineCommandArgument("mode", "queue mode", {
           choices: ["steer", "followup", "collect", "interrupt"],
-        },
-        {
-          name: "debounce",
-          description: "debounce duration (e.g. 500ms, 2s)",
-          type: "string",
-        },
-        {
-          name: "cap",
-          description: "queue cap",
-          type: "number",
-        },
-        {
-          name: "drop",
-          description: "drop policy",
-          type: "string",
-          choices: ["old", "new", "summarize"],
-        },
+        }),
+        defineCommandArgument("debounce", "debounce duration (e.g. 500ms, 2s)"),
+        defineCommandArgument("cap", "queue cap", { type: "number" }),
+        defineCommandArgument("drop", "drop policy", { choices: ["old", "new", "summarize"] }),
       ],
       argsParsing: "none",
       formatArgs: COMMAND_ARG_FORMATTERS.queue,
     }),
-    defineChatCommand({
-      key: "bash",
-      description: "Run host shell commands (host-only).",
-      textAlias: "/bash",
-      scope: "text",
-      category: "tools",
-      tier: "power",
-      args: [
-        {
-          name: "command",
-          description: "Shell command",
-          type: "string",
-          captureRemaining: true,
-        },
-      ],
+    defineBuiltinCommand("bash", "Run host shell commands (host-only).", "tools", "power", {
+      nativeName: false,
+      args: [defineCommandArgument("command", "Shell command", { captureRemaining: true })],
     }),
   ];
+  const commands = definitions.map(defineBuiltinChatCommand);
 
   registerAlias(commands, "whoami", "/id");
   registerAlias(commands, "think", "/thinking", "/t");
@@ -1076,4 +670,3 @@ export function buildBuiltinChatCommands(
   assertCommandRegistry(commands);
   return commands;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -4,13 +4,63 @@ import { logVerbose } from "../../globals.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import type { ReplyPayload } from "../types.js";
-import type { CommandHandlerResult, HandleCommandsParams } from "./commands-types.js";
+import type {
+  CommandHandler,
+  CommandHandlerResult,
+  HandleCommandsParams,
+} from "./commands-types.js";
+
+/** Builds the standard terminal text response shared by chat command handlers. */
+export function commandReply(text: string): CommandHandlerResult {
+  return { shouldContinue: false, reply: { text } };
+}
+
+/** Returns command arguments only when the complete slash-command token matches. */
+export function matchCommandPrefix(body: string, command: string): string | null {
+  return body === command
+    ? ""
+    : body.startsWith(`${command} `)
+      ? body.slice(command.length).trim()
+      : null;
+}
+
+/** Keeps matching, text-command enablement, and sender authorization in one owner. */
+export function defineAuthorizedTextCommand<T>(
+  options: {
+    label: string;
+    match: (body: string, params: HandleCommandsParams) => T | null;
+    ownerOnly?: boolean | ((params: HandleCommandsParams, match: T) => boolean);
+    silentUnauthorized?: boolean;
+  },
+  run: (
+    params: HandleCommandsParams,
+    match: T,
+  ) => Promise<CommandHandlerResult | null> | CommandHandlerResult | null,
+): CommandHandler {
+  return async (params, allowTextCommands) => {
+    if (!allowTextCommands) {
+      return null;
+    }
+    const match = options.match(params.command.commandBodyNormalized, params);
+    if (match === null) {
+      return null;
+    }
+    const unauthorized = rejectUnauthorizedCommand(params, options.label);
+    if (unauthorized) {
+      return options.silentUnauthorized ? { shouldContinue: false } : unauthorized;
+    }
+    const ownerOnly =
+      typeof options.ownerOnly === "function"
+        ? options.ownerOnly(params, match)
+        : options.ownerOnly;
+    return ownerOnly
+      ? (rejectNonOwnerCommand(params, options.label) ?? run(params, match))
+      : run(params, match);
+  };
+}
 
 function buildNativeCommandGateReply(text: string): CommandHandlerResult {
-  return {
-    shouldContinue: false,
-    reply: { text },
-  };
+  return commandReply(text);
 }
 
 export function rejectUnauthorizedCommand(
@@ -63,10 +113,7 @@ export function requireGatewayClientScope(
   logVerbose(
     `Ignoring ${config.label} from gateway client missing scope: ${config.allowedScopes.join(" or ")}`,
   );
-  return {
-    shouldContinue: false,
-    reply: { text: config.missingText },
-  };
+  return commandReply(config.missingText);
 }
 
 export function buildDisabledCommandReply(params: {

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -19,6 +19,7 @@ import {
 import { DEFAULT_ACCOUNT_ID, normalizeOptionalAccountId } from "../../routing/session-key.js";
 import { resolveChannelAccountId, resolveCommandSurfaceChannel } from "./channel-context.js";
 import {
+  commandReply,
   rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
   requireCommandFlagEnabled,
@@ -224,16 +225,6 @@ async function updatePairingStoreAllowlist(params: {
   }
 }
 
-function mapResolvedAllowlistNames(entries: ResolvedAllowlistName[]): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const entry of entries) {
-    if (entry.resolved && entry.name) {
-      map.set(entry.input, entry.name);
-    }
-  }
-  return map;
-}
-
 async function resolveAllowlistNames(params: {
   cfg: OpenClawConfig;
   channelId: ChannelId;
@@ -248,7 +239,11 @@ async function resolveAllowlistNames(params: {
     scope: params.scope,
     entries: params.entries,
   });
-  return mapResolvedAllowlistNames(resolved ?? []);
+  return new Map(
+    (resolved ?? []).flatMap((entry: ResolvedAllowlistName) =>
+      entry.resolved && entry.name ? [[entry.input, entry.name] as const] : [],
+    ),
+  );
 }
 
 async function readAllowlistConfig(params: {
@@ -275,7 +270,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     return null;
   }
   if (parsed.action === "error") {
-    return { shouldContinue: false, reply: { text: `⚠️ ${parsed.message}` } };
+    return commandReply(`⚠️ ${parsed.message}`);
   }
   const unauthorized = rejectUnauthorizedCommand(params, "/allowlist");
   if (unauthorized) {
@@ -293,18 +288,12 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     params.command.channelId ??
     normalizeChannelId(params.command.channel);
   if (!channelId) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚠️ Unknown channel. Add channel=<id> to the command." },
-    };
+    return commandReply("⚠️ Unknown channel. Add channel=<id> to the command.");
   }
   if (normalizeOptionalString(parsed.account) && !normalizeOptionalAccountId(parsed.account)) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚠️ Invalid account id. Reserved keys (__proto__, constructor, prototype) are blocked.",
-      },
-    };
+    return commandReply(
+      "⚠️ Invalid account id. Reserved keys (__proto__, constructor, prototype) are blocked.",
+    );
   }
   const accountId = resolveAllowlistAccountId({
     cfg: params.cfg,
@@ -324,10 +313,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   if (parsed.action === "list") {
     const supportsStore = Boolean(plugin?.pairing);
     if (!plugin?.allowlist?.readConfig && !supportsStore) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${channelId} does not expose allowlist configuration.` },
-      };
+      return commandReply(`⚠️ ${channelId} does not expose allowlist configuration.`);
     }
     const storeAllowFrom = supportsStore
       ? await readChannelAllowFromStore(channelId, process.env, accountId).catch(() => [])
@@ -345,25 +331,12 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       entries: entry.entries.map(String).filter(Boolean),
     }));
 
-    const dmDisplay = normalizeAllowFrom({
-      cfg: params.cfg,
-      channelId,
-      accountId,
-      values: dmAllowFrom,
-    });
-    const groupDisplay = normalizeAllowFrom({
-      cfg: params.cfg,
-      channelId,
-      accountId,
-      values: groupAllowFrom,
-    });
+    const normalizeValues = (values: Array<string | number>) =>
+      normalizeAllowFrom({ cfg: params.cfg, channelId, accountId, values });
+    const dmDisplay = normalizeValues(dmAllowFrom);
+    const groupDisplay = normalizeValues(groupAllowFrom);
     const groupOverrideEntries = groupOverrides.flatMap((entry) => entry.entries);
-    const groupOverrideDisplay = normalizeAllowFrom({
-      cfg: params.cfg,
-      channelId,
-      accountId,
-      values: groupOverrideEntries,
-    });
+    const groupOverrideDisplay = normalizeValues(groupOverrideEntries);
 
     const resolvedDm =
       parsed.resolve && dmDisplay.length > 0
@@ -401,13 +374,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       lines.push(`DM allowFrom (config): ${formatEntryList(dmDisplay, resolvedDm)}`);
     }
     if (supportsStore && storeAllowFrom.length > 0) {
-      const storeLabel = normalizeAllowFrom({
-        cfg: params.cfg,
-        channelId,
-        accountId,
-        values: storeAllowFrom,
-      });
-      lines.push(`Paired allowFrom (store): ${formatEntryList(storeLabel)}`);
+      lines.push(`Paired allowFrom (store): ${formatEntryList(normalizeValues(storeAllowFrom))}`);
     }
     if (showGroup) {
       if (groupAllowFrom.length > 0) {
@@ -416,18 +383,14 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       if (groupOverrides.length > 0) {
         lines.push("Group overrides:");
         for (const entry of groupOverrides) {
-          const normalized = normalizeAllowFrom({
-            cfg: params.cfg,
-            channelId,
-            accountId,
-            values: entry.entries,
-          });
-          lines.push(`- ${entry.label}: ${formatEntryList(normalized, resolvedGroup)}`);
+          lines.push(
+            `- ${entry.label}: ${formatEntryList(normalizeValues(entry.entries), resolvedGroup)}`,
+          );
         }
       }
     }
 
-    return { shouldContinue: false, reply: { text: lines.join("\n") } };
+    return commandReply(lines.join("\n"));
   }
 
   const missingAdminScope = requireGatewayClientScope(params, {
@@ -449,12 +412,9 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   }
 
   if (parsed.scope === "group" && parsed.target === "store") {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚠️ Pairing-store allowlist edits apply to DMs only; omit --store for groups.",
-      },
-    };
+    return commandReply(
+      "⚠️ Pairing-store allowlist edits apply to DMs only; omit --store for groups.",
+    );
   }
 
   const shouldUpdateConfig = parsed.target !== "store";
@@ -465,28 +425,19 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
 
   if (shouldUpdateConfig) {
     if (parsed.scope === "all") {
-      return {
-        shouldContinue: false,
-        reply: { text: "⚠️ /allowlist add|remove requires scope dm or group." },
-      };
+      return commandReply("⚠️ /allowlist add|remove requires scope dm or group.");
     }
     if (!plugin?.allowlist?.applyConfigEdit) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `⚠️ ${channelId} does not support ${parsed.scope} allowlist edits via /allowlist.`,
-        },
-      };
+      return commandReply(
+        `⚠️ ${channelId} does not support ${parsed.scope} allowlist edits via /allowlist.`,
+      );
     }
     const applyConfigEdit = plugin.allowlist.applyConfigEdit;
     const editScope = parsed.scope;
 
     const snapshot = await readConfigFileSnapshot();
     if (!snapshot.valid || !snapshot.parsed || typeof snapshot.parsed !== "object") {
-      return {
-        shouldContinue: false,
-        reply: { text: "⚠️ Config file is invalid; fix it before using /allowlist." },
-      };
+      return commandReply("⚠️ Config file is invalid; fix it before using /allowlist.");
     }
     const parsedConfig = structuredClone(snapshot.parsed as Record<string, unknown>);
     const editResult = await plugin.allowlist.applyConfigEdit({
@@ -498,18 +449,12 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       entry: parsed.entry,
     });
     if (!editResult) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `⚠️ ${channelId} does not support ${parsed.scope} allowlist edits via /allowlist.`,
-        },
-      };
+      return commandReply(
+        `⚠️ ${channelId} does not support ${parsed.scope} allowlist edits via /allowlist.`,
+      );
     }
     if (editResult.kind === "invalid-entry") {
-      return {
-        shouldContinue: false,
-        reply: { text: "⚠️ Invalid allowlist entry." },
-      };
+      return commandReply("⚠️ Invalid allowlist entry.");
     }
     const deniedText = resolveConfigWriteDeniedText({
       cfg: params.cfg,
@@ -521,12 +466,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       fallbackChannelId: channelId,
     });
     if (deniedText) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: deniedText,
-        },
-      };
+      return commandReply(deniedText);
     }
     const configChanged = editResult.changed;
 
@@ -542,7 +482,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
         });
       } catch (error) {
         if (error instanceof AutoReplyConfigMutationError) {
-          return { shouldContinue: false, reply: { text: `⚠️ ${error.message}` } };
+          return commandReply(`⚠️ ${error.message}`);
         }
         throw error;
       }
@@ -550,7 +490,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
 
     if (!configChanged && !shouldTouchStore) {
       const message = parsed.action === "add" ? "✅ Already allowlisted." : "⚠️ Entry not found.";
-      return { shouldContinue: false, reply: { text: message } };
+      return commandReply(message);
     }
 
     if (shouldTouchStore) {
@@ -572,19 +512,11 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       locations.push("pairing store");
     }
     const targetLabel = locations.length > 0 ? locations.join(" + ") : "no-op";
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `✅ ${scopeLabel} allowlist ${actionLabel}: ${targetLabel}.`,
-      },
-    };
+    return commandReply(`✅ ${scopeLabel} allowlist ${actionLabel}: ${targetLabel}.`);
   }
 
   if (!shouldTouchStore) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚠️ This channel does not support allowlist storage." },
-    };
+    return commandReply("⚠️ This channel does not support allowlist storage.");
   }
 
   const storeDeniedText = resolveConfigWriteDeniedText({
@@ -597,10 +529,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     fallbackChannelId: channelId,
   });
   if (storeDeniedText) {
-    return {
-      shouldContinue: false,
-      reply: { text: storeDeniedText },
-    };
+    return commandReply(storeDeniedText);
   }
 
   await updatePairingStoreAllowlist({
@@ -612,8 +541,5 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
 
   const actionLabel = parsed.action === "add" ? "added" : "removed";
   const scopeLabel = parsed.scope === "group" ? "group" : "DM";
-  return {
-    shouldContinue: false,
-    reply: { text: `✅ ${scopeLabel} allowlist ${actionLabel} in pairing store.` },
-  };
+  return commandReply(`✅ ${scopeLabel} allowlist ${actionLabel} in pairing store.`);
 };

--- a/src/auto-reply/reply/commands-bash.ts
+++ b/src/auto-reply/reply/commands-bash.ts
@@ -1,34 +1,30 @@
 // Implements bash command execution, approval, and stop handling.
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { handleBashChatCommand } from "./bash-command.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { defineAuthorizedTextCommand, matchCommandPrefix } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
-export const handleBashCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const { command } = params;
-  const bashSlashRequested =
-    command.commandBodyNormalized === "/bash" || command.commandBodyNormalized.startsWith("/bash ");
-  const bashBangRequested = command.commandBodyNormalized.startsWith("!");
-  if (!bashSlashRequested && !(bashBangRequested && command.isAuthorizedSender)) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/bash");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const agentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
-    : params.agentId;
-  const reply = await handleBashChatCommand({
-    ctx: params.ctx,
-    cfg: params.cfg,
-    agentId,
-    sessionKey: params.sessionKey,
-    isGroup: params.isGroup,
-    elevated: params.elevated,
-  });
-  return { shouldContinue: false, reply };
-};
+export const handleBashCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/bash",
+    match: (body, params) =>
+      matchCommandPrefix(body, "/bash") !== null ||
+      (body.startsWith("!") && params.command.isAuthorizedSender)
+        ? true
+        : null,
+  },
+  async (params) => {
+    const agentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+      : params.agentId;
+    const reply = await handleBashChatCommand({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      agentId,
+      sessionKey: params.sessionKey,
+      isGroup: params.isGroup,
+      elevated: params.elevated,
+    });
+    return { shouldContinue: false, reply };
+  },
+);

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -11,166 +11,148 @@ import {
   revokeMessageActionTurnCapability,
 } from "../../gateway/message-action-turn-capability.js";
 import { extractBtwQuestion } from "./btw-command.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const BTW_USAGE = "Usage: /btw [side question]";
 
 /** Command handler for /btw side questions. */
-export const handleBtwCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const question = extractBtwQuestion(params.command.commandBodyNormalized);
-  if (question === null) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/btw");
-  if (unauthorized) {
-    return unauthorized;
-  }
-
-  if (!question) {
-    return {
-      shouldContinue: false,
-      reply: { text: BTW_USAGE },
-    };
-  }
-
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-
-  if (!targetSessionEntry?.sessionId) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚠️ /btw requires an active session with existing context." },
-    };
-  }
-
-  const sessionAgentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
-    : params.agentId;
-  const agentDir =
-    (sessionAgentId ? resolveAgentDir(params.cfg, sessionAgentId) : undefined) ?? params.agentDir;
-
-  if (!agentDir) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚠️ /btw is unavailable because the active agent directory could not be resolved.",
-      },
-    };
-  }
-
-  try {
-    await params.typing?.startTypingLoop();
-    const messageTo =
-      params.ctx.OriginatingTo?.trim() || params.command.to || params.command.channelId;
-    const nativeChannelId =
-      params.ctx.NativeChannelId?.trim() || params.ctx.ChatId?.trim() || undefined;
-    const currentChannelId = nativeChannelId ?? messageTo;
-    const chatType = normalizeChatType(params.ctx.ChatType);
-    const groupId = resolveGroupSessionKey(params.ctx)?.id ?? targetSessionEntry.groupId;
-    const runId = params.opts?.runId ?? `btw-${randomUUID()}`;
-    const currentChannelProvider = normalizeAnyChannelId(params.ctx.Provider);
-    const capabilitySessionKey = params.ctx.RuntimePolicySessionKey ?? params.sessionKey;
-    const messageActionTurnCapability =
-      isTrustedMessageActionTurnIngress(params.ctx.Provider) &&
-      sessionAgentId &&
-      capabilitySessionKey &&
-      currentChannelProvider &&
-      currentChannelId
-        ? mintMessageActionTurnCapability({
-            agentId: sessionAgentId,
-            runId,
-            sessionKey: capabilitySessionKey,
-            sessionId: targetSessionEntry.sessionId,
-            requesterAccountId: params.ctx.AccountId,
-            requesterSenderId: params.ctx.SenderId ?? params.command.senderId,
-            toolContext: {
-              currentChannelId,
-              currentChatType: chatType,
-              currentMessagingTarget: messageTo,
-              currentChannelProvider,
-              currentMessageId: params.ctx.MessageSidFull ?? params.ctx.MessageSid,
-            },
-          })
-        : undefined;
-    let reply: Awaited<ReturnType<typeof runBtwSideQuestion>>;
-    try {
-      reply = await runBtwSideQuestion({
-        cfg: params.cfg,
-        agentDir,
-        provider: params.provider,
-        model: params.model,
-        question,
-        sessionEntry: targetSessionEntry,
-        sessionStore: params.sessionStore,
-        sessionKey: params.sessionKey,
-        ...(params.ctx.RuntimePolicySessionKey
-          ? { sandboxSessionKey: params.ctx.RuntimePolicySessionKey }
-          : {}),
-        storePath: params.storePath,
-        // BTW is intentionally a quick side question, so do not inherit slower
-        // session-level think/reasoning settings from the main run.
-        resolvedThinkLevel: "off",
-        resolvedReasoningLevel: "off",
-        blockReplyChunking: params.blockReplyChunking,
-        resolvedBlockStreamingBreak: params.resolvedBlockStreamingBreak,
-        opts: { ...params.opts, runId },
-        isNewSession: false,
-        ...(params.command.channel ? { messageChannel: params.command.channel } : {}),
-        ...(params.command.channel ? { messageProvider: params.command.channel } : {}),
-        ...(chatType ? { chatType } : {}),
-        ...(params.ctx.AccountId ? { agentAccountId: params.ctx.AccountId } : {}),
-        ...(messageTo ? { messageTo } : {}),
-        ...(params.ctx.MessageThreadId !== undefined
-          ? { messageThreadId: params.ctx.MessageThreadId }
-          : params.ctx.TransportThreadId !== undefined
-            ? { messageThreadId: params.ctx.TransportThreadId }
-            : {}),
-        ...(nativeChannelId ? { chatId: nativeChannelId } : {}),
-        ...(messageActionTurnCapability ? { messageActionTurnCapability } : {}),
-        ...(groupId ? { groupId } : {}),
-        ...(params.ctx.GroupChannel || params.ctx.GroupSubject || targetSessionEntry.groupChannel
-          ? {
-              groupChannel:
-                params.ctx.GroupChannel ??
-                params.ctx.GroupSubject ??
-                targetSessionEntry.groupChannel,
-            }
-          : {}),
-        ...(params.ctx.GroupSpace || targetSessionEntry.space
-          ? { groupSpace: params.ctx.GroupSpace ?? targetSessionEntry.space }
-          : {}),
-        ...(params.ctx.MemberRoleIds ? { memberRoleIds: params.ctx.MemberRoleIds } : {}),
-        ...(targetSessionEntry.parentSessionKey
-          ? { spawnedBy: targetSessionEntry.parentSessionKey }
-          : {}),
-        ...(params.ctx.SenderId || params.command.senderId
-          ? { senderId: params.ctx.SenderId ?? params.command.senderId }
-          : {}),
-        ...(params.ctx.SenderName ? { senderName: params.ctx.SenderName } : {}),
-        ...(params.ctx.SenderUsername ? { senderUsername: params.ctx.SenderUsername } : {}),
-        ...(params.ctx.SenderE164 ? { senderE164: params.ctx.SenderE164 } : {}),
-        senderIsOwner: params.command.senderIsOwner,
-        ...(currentChannelId ? { currentChannelId } : {}),
-      });
-    } finally {
-      revokeMessageActionTurnCapability(messageActionTurnCapability);
+export const handleBtwCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/btw", match: (body) => extractBtwQuestion(body) },
+  async (params, question) => {
+    if (!question) {
+      return commandReply(BTW_USAGE);
     }
-    return {
-      shouldContinue: false,
-      reply: reply ? { ...reply, btw: { question } } : reply,
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message.trim() : "";
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `⚠️ /btw failed${message ? `: ${message}` : "."}`,
-        btw: { question },
-        isError: true,
-      },
-    };
-  }
-};
+
+    const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+
+    if (!targetSessionEntry?.sessionId) {
+      return commandReply("⚠️ /btw requires an active session with existing context.");
+    }
+
+    const sessionAgentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+      : params.agentId;
+    const agentDir =
+      (sessionAgentId ? resolveAgentDir(params.cfg, sessionAgentId) : undefined) ?? params.agentDir;
+
+    if (!agentDir) {
+      return commandReply(
+        "⚠️ /btw is unavailable because the active agent directory could not be resolved.",
+      );
+    }
+
+    try {
+      await params.typing?.startTypingLoop();
+      const messageTo =
+        params.ctx.OriginatingTo?.trim() || params.command.to || params.command.channelId;
+      const nativeChannelId =
+        params.ctx.NativeChannelId?.trim() || params.ctx.ChatId?.trim() || undefined;
+      const currentChannelId = nativeChannelId ?? messageTo;
+      const chatType = normalizeChatType(params.ctx.ChatType);
+      const groupId = resolveGroupSessionKey(params.ctx)?.id ?? targetSessionEntry.groupId;
+      const runId = params.opts?.runId ?? `btw-${randomUUID()}`;
+      const currentChannelProvider = normalizeAnyChannelId(params.ctx.Provider);
+      const capabilitySessionKey = params.ctx.RuntimePolicySessionKey ?? params.sessionKey;
+      const messageActionTurnCapability =
+        isTrustedMessageActionTurnIngress(params.ctx.Provider) &&
+        sessionAgentId &&
+        capabilitySessionKey &&
+        currentChannelProvider &&
+        currentChannelId
+          ? mintMessageActionTurnCapability({
+              agentId: sessionAgentId,
+              runId,
+              sessionKey: capabilitySessionKey,
+              sessionId: targetSessionEntry.sessionId,
+              requesterAccountId: params.ctx.AccountId,
+              requesterSenderId: params.ctx.SenderId ?? params.command.senderId,
+              toolContext: {
+                currentChannelId,
+                currentChatType: chatType,
+                currentMessagingTarget: messageTo,
+                currentChannelProvider,
+                currentMessageId: params.ctx.MessageSidFull ?? params.ctx.MessageSid,
+              },
+            })
+          : undefined;
+      let reply: Awaited<ReturnType<typeof runBtwSideQuestion>>;
+      try {
+        reply = await runBtwSideQuestion({
+          cfg: params.cfg,
+          agentDir,
+          provider: params.provider,
+          model: params.model,
+          question,
+          sessionEntry: targetSessionEntry,
+          sessionStore: params.sessionStore,
+          sessionKey: params.sessionKey,
+          ...(params.ctx.RuntimePolicySessionKey
+            ? { sandboxSessionKey: params.ctx.RuntimePolicySessionKey }
+            : {}),
+          storePath: params.storePath,
+          // BTW is intentionally a quick side question, so do not inherit slower
+          // session-level think/reasoning settings from the main run.
+          resolvedThinkLevel: "off",
+          resolvedReasoningLevel: "off",
+          blockReplyChunking: params.blockReplyChunking,
+          resolvedBlockStreamingBreak: params.resolvedBlockStreamingBreak,
+          opts: { ...params.opts, runId },
+          isNewSession: false,
+          ...(params.command.channel ? { messageChannel: params.command.channel } : {}),
+          ...(params.command.channel ? { messageProvider: params.command.channel } : {}),
+          ...(chatType ? { chatType } : {}),
+          ...(params.ctx.AccountId ? { agentAccountId: params.ctx.AccountId } : {}),
+          ...(messageTo ? { messageTo } : {}),
+          ...(params.ctx.MessageThreadId !== undefined
+            ? { messageThreadId: params.ctx.MessageThreadId }
+            : params.ctx.TransportThreadId !== undefined
+              ? { messageThreadId: params.ctx.TransportThreadId }
+              : {}),
+          ...(nativeChannelId ? { chatId: nativeChannelId } : {}),
+          ...(messageActionTurnCapability ? { messageActionTurnCapability } : {}),
+          ...(groupId ? { groupId } : {}),
+          ...(params.ctx.GroupChannel || params.ctx.GroupSubject || targetSessionEntry.groupChannel
+            ? {
+                groupChannel:
+                  params.ctx.GroupChannel ??
+                  params.ctx.GroupSubject ??
+                  targetSessionEntry.groupChannel,
+              }
+            : {}),
+          ...(params.ctx.GroupSpace || targetSessionEntry.space
+            ? { groupSpace: params.ctx.GroupSpace ?? targetSessionEntry.space }
+            : {}),
+          ...(params.ctx.MemberRoleIds ? { memberRoleIds: params.ctx.MemberRoleIds } : {}),
+          ...(targetSessionEntry.parentSessionKey
+            ? { spawnedBy: targetSessionEntry.parentSessionKey }
+            : {}),
+          ...(params.ctx.SenderId || params.command.senderId
+            ? { senderId: params.ctx.SenderId ?? params.command.senderId }
+            : {}),
+          ...(params.ctx.SenderName ? { senderName: params.ctx.SenderName } : {}),
+          ...(params.ctx.SenderUsername ? { senderUsername: params.ctx.SenderUsername } : {}),
+          ...(params.ctx.SenderE164 ? { senderE164: params.ctx.SenderE164 } : {}),
+          senderIsOwner: params.command.senderIsOwner,
+          ...(currentChannelId ? { currentChannelId } : {}),
+        });
+      } finally {
+        revokeMessageActionTurnCapability(messageActionTurnCapability);
+      }
+      return {
+        shouldContinue: false,
+        reply: reply ? { ...reply, btw: { question } } : reply,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message.trim() : "";
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `⚠️ /btw failed${message ? `: ${message}` : "."}`,
+          btw: { question },
+          isError: true,
+        },
+      };
+    }
+  },
+);

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -19,8 +19,8 @@ import { loadGatewayRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import {
-  rejectNonOwnerCommand,
-  rejectUnauthorizedCommand,
+  commandReply,
+  defineAuthorizedTextCommand,
   requireCommandFlagEnabled,
   requireGatewayClientScope,
 } from "./command-gates.js";
@@ -48,264 +48,172 @@ function formatConfigSetValueLabel(params: {
     : (JSON.stringify(redactedValue) ?? "null");
 }
 
-export const handleConfigCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const configCommand = parseConfigCommand(params.command.commandBodyNormalized);
-  if (!configCommand) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/config");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const allowInternalReadOnlyShow =
-    configCommand.action === "show" && isInternalMessageChannel(params.command.channel);
-  const nonOwner = allowInternalReadOnlyShow ? null : rejectNonOwnerCommand(params, "/config");
-  if (nonOwner) {
-    return nonOwner;
-  }
-  const disabled = requireCommandFlagEnabled(params.cfg, {
+export const handleConfigCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
     label: "/config",
-    configKey: "config",
-  });
-  if (disabled) {
-    return disabled;
-  }
-  if (configCommand.action === "error") {
-    return {
-      shouldContinue: false,
-      reply: { text: `⚠️ ${configCommand.message}` },
-    };
-  }
-
-  let parsedWritePath: string[] | undefined;
-  if (configCommand.action === "set" || configCommand.action === "unset") {
-    const missingAdminScope = requireGatewayClientScope(params, {
-      label: "/config write",
-      allowedScopes: ["operator.admin"],
-      missingText: "❌ /config set|unset requires operator.admin for gateway clients.",
+    match: parseConfigCommand,
+    ownerOnly: (params, command) =>
+      command.action !== "show" || !isInternalMessageChannel(params.command.channel),
+  },
+  async (params, configCommand) => {
+    const disabled = requireCommandFlagEnabled(params.cfg, {
+      label: "/config",
+      configKey: "config",
     });
-    if (missingAdminScope) {
-      return missingAdminScope;
+    if (disabled) {
+      return disabled;
     }
-    const parsedPath = parseConfigPath(configCommand.path);
-    if (!parsedPath.ok) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${parsedPath.error}` },
-      };
+    if (configCommand.action === "error") {
+      return commandReply(`⚠️ ${configCommand.message}`);
     }
-    parsedWritePath = parsedPath.path;
-    const channelId = params.command.channelId ?? normalizeChannelId(params.command.channel);
-    const deniedText = resolveConfigWriteDeniedText({
-      cfg: params.cfg,
-      channel: params.command.channel,
-      originChannelId: channelId,
-      originAccountId: resolveChannelAccountId({
-        cfg: params.cfg,
-        ctx: params.ctx,
-        command: params.command,
-      }),
-      gatewayClientScopes: params.ctx.GatewayClientScopes,
-      target: resolveConfigWriteTargetFromPath(parsedWritePath),
-    });
-    if (deniedText) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: deniedText,
-        },
-      };
-    }
-  }
 
-  const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.valid || !snapshot.parsed || typeof snapshot.parsed !== "object") {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚠️ Config file is invalid; fix it before using /config.",
-      },
-    };
-  }
-  const schema = loadGatewayRuntimeConfigSchema();
-  const redactedSnapshot = redactConfigSnapshot(snapshot, schema.uiHints);
-  const parsedBase = structuredClone(redactedSnapshot.parsed as Record<string, unknown>);
-
-  if (configCommand.action === "show") {
-    const pathRaw = normalizeOptionalString(configCommand.path);
-    if (pathRaw) {
-      const parsedPath = parseConfigPath(pathRaw);
+    let parsedWritePath: string[] | undefined;
+    if (configCommand.action === "set" || configCommand.action === "unset") {
+      const missingAdminScope = requireGatewayClientScope(params, {
+        label: "/config write",
+        allowedScopes: ["operator.admin"],
+        missingText: "❌ /config set|unset requires operator.admin for gateway clients.",
+      });
+      if (missingAdminScope) {
+        return missingAdminScope;
+      }
+      const parsedPath = parseConfigPath(configCommand.path);
       if (!parsedPath.ok) {
-        return {
-          shouldContinue: false,
-          reply: { text: `⚠️ ${parsedPath.error}` },
-        };
+        return commandReply(`⚠️ ${parsedPath.error}`);
       }
-      const value = getConfigValueAtPath(parsedBase, parsedPath.path);
-      const rendered = JSON.stringify(value ?? null, null, 2);
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `⚙️ Config ${pathRaw}:\n\`\`\`json\n${rendered}\n\`\`\``,
-        },
-      };
+      parsedWritePath = parsedPath.path;
+      const channelId = params.command.channelId ?? normalizeChannelId(params.command.channel);
+      const deniedText = resolveConfigWriteDeniedText({
+        cfg: params.cfg,
+        channel: params.command.channel,
+        originChannelId: channelId,
+        originAccountId: resolveChannelAccountId({
+          cfg: params.cfg,
+          ctx: params.ctx,
+          command: params.command,
+        }),
+        gatewayClientScopes: params.ctx.GatewayClientScopes,
+        target: resolveConfigWriteTargetFromPath(parsedWritePath),
+      });
+      if (deniedText) {
+        return commandReply(deniedText);
+      }
     }
-    const json = JSON.stringify(parsedBase, null, 2);
-    return {
-      shouldContinue: false,
-      reply: { text: `⚙️ Config (raw):\n\`\`\`json\n${json}\n\`\`\`` },
-    };
-  }
 
-  if (configCommand.action === "unset") {
-    const path = parsedWritePath ?? [];
-    try {
-      const removed = await unsetConfigPath(path);
-      if (!removed) {
-        return {
-          shouldContinue: false,
-          reply: { text: `⚙️ No config value found for ${configCommand.path}.` },
-        };
-      }
-    } catch (error) {
-      const message = formatAutoReplyConfigMutationError(error);
-      if (message) {
-        return { shouldContinue: false, reply: { text: `⚠️ ${message}` } };
-      }
-      throw error;
-    }
-    return {
-      shouldContinue: false,
-      reply: { text: `⚙️ Config updated: ${configCommand.path} removed.` },
-    };
-  }
-
-  if (configCommand.action === "set") {
-    const path = parsedWritePath ?? [];
-    try {
-      await setConfigPath(path, configCommand.value);
-    } catch (error) {
-      const message = formatAutoReplyConfigMutationError(error);
-      if (message) {
-        return { shouldContinue: false, reply: { text: `⚠️ ${message}` } };
-      }
-      throw error;
-    }
-    const valueLabel = formatConfigSetValueLabel({
-      path,
-      value: configCommand.value,
-      uiHints: schema.uiHints,
-    });
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `⚙️ Config updated: ${configCommand.path}=${valueLabel ?? "null"}`,
-      },
-    };
-  }
-
-  return null;
-};
-
-export const handleDebugCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const debugCommand = parseDebugCommand(params.command.commandBodyNormalized);
-  if (!debugCommand) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/debug");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const nonOwner = rejectNonOwnerCommand(params, "/debug");
-  if (nonOwner) {
-    return nonOwner;
-  }
-  const disabled = requireCommandFlagEnabled(params.cfg, {
-    label: "/debug",
-    configKey: "debug",
-  });
-  if (disabled) {
-    return disabled;
-  }
-  if (debugCommand.action === "error") {
-    return {
-      shouldContinue: false,
-      reply: { text: `⚠️ ${debugCommand.message}` },
-    };
-  }
-  if (debugCommand.action === "show") {
-    const overrides = getConfigOverrides();
-    const hasOverrides = Object.keys(overrides).length > 0;
-    if (!hasOverrides) {
-      return {
-        shouldContinue: false,
-        reply: { text: "⚙️ Debug overrides: (none)" },
-      };
+    const snapshot = await readConfigFileSnapshot();
+    if (!snapshot.valid || !snapshot.parsed || typeof snapshot.parsed !== "object") {
+      return commandReply("⚠️ Config file is invalid; fix it before using /config.");
     }
     const schema = loadGatewayRuntimeConfigSchema();
-    const redactedOverrides = redactConfigObject(overrides, schema.uiHints);
-    const json = JSON.stringify(redactedOverrides, null, 2);
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `⚙️ Debug overrides (memory-only):\n\`\`\`json\n${json}\n\`\`\``,
-      },
-    };
-  }
-  if (debugCommand.action === "reset") {
-    resetConfigOverrides();
-    return {
-      shouldContinue: false,
-      reply: { text: "⚙️ Debug overrides cleared; using config on disk." },
-    };
-  }
-  if (debugCommand.action === "unset") {
-    const result = unsetConfigOverride(debugCommand.path);
-    if (!result.ok) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${result.error}` },
-      };
-    }
-    if (!result.value) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `⚙️ No debug override found for ${debugCommand.path}.`,
-        },
-      };
-    }
-    return {
-      shouldContinue: false,
-      reply: { text: `⚙️ Debug override removed for ${debugCommand.path}.` },
-    };
-  }
-  if (debugCommand.action === "set") {
-    const result = setConfigOverride(debugCommand.path, debugCommand.value);
-    if (!result.ok) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${result.error}` },
-      };
-    }
-    const valueLabel = formatConfigSetValueLabel({
-      path: result.value,
-      value: debugCommand.value,
-      uiHints: loadGatewayRuntimeConfigSchema().uiHints,
-    });
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `⚙️ Debug override set: ${debugCommand.path}=${valueLabel ?? "null"}`,
-      },
-    };
-  }
+    const redactedSnapshot = redactConfigSnapshot(snapshot, schema.uiHints);
+    const parsedBase = structuredClone(redactedSnapshot.parsed as Record<string, unknown>);
 
-  return null;
-};
+    if (configCommand.action === "show") {
+      const pathRaw = normalizeOptionalString(configCommand.path);
+      if (pathRaw) {
+        const parsedPath = parseConfigPath(pathRaw);
+        if (!parsedPath.ok) {
+          return commandReply(`⚠️ ${parsedPath.error}`);
+        }
+        const value = getConfigValueAtPath(parsedBase, parsedPath.path);
+        const rendered = JSON.stringify(value ?? null, null, 2);
+        return commandReply(`⚙️ Config ${pathRaw}:\n\`\`\`json\n${rendered}\n\`\`\``);
+      }
+      const json = JSON.stringify(parsedBase, null, 2);
+      return commandReply(`⚙️ Config (raw):\n\`\`\`json\n${json}\n\`\`\``);
+    }
+
+    if (configCommand.action === "unset") {
+      const path = parsedWritePath ?? [];
+      try {
+        const removed = await unsetConfigPath(path);
+        if (!removed) {
+          return commandReply(`⚙️ No config value found for ${configCommand.path}.`);
+        }
+      } catch (error) {
+        const message = formatAutoReplyConfigMutationError(error);
+        if (message) {
+          return commandReply(`⚠️ ${message}`);
+        }
+        throw error;
+      }
+      return commandReply(`⚙️ Config updated: ${configCommand.path} removed.`);
+    }
+
+    if (configCommand.action === "set") {
+      const path = parsedWritePath ?? [];
+      try {
+        await setConfigPath(path, configCommand.value);
+      } catch (error) {
+        const message = formatAutoReplyConfigMutationError(error);
+        if (message) {
+          return commandReply(`⚠️ ${message}`);
+        }
+        throw error;
+      }
+      const valueLabel = formatConfigSetValueLabel({
+        path,
+        value: configCommand.value,
+        uiHints: schema.uiHints,
+      });
+      return commandReply(`⚙️ Config updated: ${configCommand.path}=${valueLabel ?? "null"}`);
+    }
+
+    return null;
+  },
+);
+
+export const handleDebugCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/debug", match: parseDebugCommand, ownerOnly: true },
+  (params, debugCommand) => {
+    const disabled = requireCommandFlagEnabled(params.cfg, {
+      label: "/debug",
+      configKey: "debug",
+    });
+    if (disabled) {
+      return disabled;
+    }
+    if (debugCommand.action === "error") {
+      return commandReply(`⚠️ ${debugCommand.message}`);
+    }
+    if (debugCommand.action === "show") {
+      const overrides = getConfigOverrides();
+      const hasOverrides = Object.keys(overrides).length > 0;
+      if (!hasOverrides) {
+        return commandReply("⚙️ Debug overrides: (none)");
+      }
+      const schema = loadGatewayRuntimeConfigSchema();
+      const redactedOverrides = redactConfigObject(overrides, schema.uiHints);
+      const json = JSON.stringify(redactedOverrides, null, 2);
+      return commandReply(`⚙️ Debug overrides (memory-only):\n\`\`\`json\n${json}\n\`\`\``);
+    }
+    if (debugCommand.action === "reset") {
+      resetConfigOverrides();
+      return commandReply("⚙️ Debug overrides cleared; using config on disk.");
+    }
+    if (debugCommand.action === "unset") {
+      const result = unsetConfigOverride(debugCommand.path);
+      if (!result.ok) {
+        return commandReply(`⚠️ ${result.error}`);
+      }
+      if (!result.value) {
+        return commandReply(`⚙️ No debug override found for ${debugCommand.path}.`);
+      }
+      return commandReply(`⚙️ Debug override removed for ${debugCommand.path}.`);
+    }
+    if (debugCommand.action === "set") {
+      const result = setConfigOverride(debugCommand.path, debugCommand.value);
+      if (!result.ok) {
+        return commandReply(`⚠️ ${result.error}`);
+      }
+      const valueLabel = formatConfigSetValueLabel({
+        path: result.value,
+        value: debugCommand.value,
+        uiHints: loadGatewayRuntimeConfigSchema().uiHints,
+      });
+      return commandReply(`⚙️ Debug override set: ${debugCommand.path}=${valueLabel ?? "null"}`);
+    }
+
+    return null;
+  },
+);

--- a/src/auto-reply/reply/commands-context-command.ts
+++ b/src/auto-reply/reply/commands-context-command.ts
@@ -1,21 +1,13 @@
 // Implements context inspection commands for the active reply session.
-import { logVerbose } from "../../globals.js";
+import { defineAuthorizedTextCommand, matchCommandPrefix } from "./command-gates.js";
 import { buildContextReply } from "./commands-context-report.js";
 import type { CommandHandler } from "./commands-types.js";
 
-export const handleContextCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/context" && !normalized.startsWith("/context ")) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /context from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  return { shouldContinue: false, reply: await buildContextReply(params) };
-};
+export const handleContextCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/context",
+    match: (body) => matchCommandPrefix(body, "/context"),
+    silentUnauthorized: true,
+  },
+  async (params) => ({ shouldContinue: false, reply: await buildContextReply(params) }),
+);

--- a/src/auto-reply/reply/commands-dock.ts
+++ b/src/auto-reply/reply/commands-dock.ts
@@ -11,6 +11,7 @@ import {
 } from "../../utils/delivery-context.shared.js";
 import { resolveTextCommand } from "../commands-registry.js";
 import { resolveCommandSurfaceChannel } from "./channel-context.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import { persistSessionEntry } from "./commands-session-store.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 
@@ -117,86 +118,61 @@ function resolveLinkedDockTarget(params: {
   return null;
 }
 
-export const handleDockCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const targetChannel = resolveDockCommandTarget(params);
-  if (!targetChannel) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    return { shouldContinue: false };
-  }
+export const handleDockCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/dock",
+    match: (_body, params) => resolveDockCommandTarget(params),
+    silentUnauthorized: true,
+  },
+  async (params, targetChannel) => {
+    const sourceChannel = resolveCommandSurfaceChannel(params);
+    if (sourceChannel === targetChannel) {
+      return commandReply(`Already docked to ${targetChannel}.`);
+    }
+    if (!isDirectDockSource(params)) {
+      return commandReply(
+        `Cannot dock to ${targetChannel}: docking is only available from direct chats.`,
+      );
+    }
 
-  const sourceChannel = resolveCommandSurfaceChannel(params);
-  if (sourceChannel === targetChannel) {
-    return {
-      shouldContinue: false,
-      reply: { text: `Already docked to ${targetChannel}.` },
-    };
-  }
-  if (!isDirectDockSource(params)) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `Cannot dock to ${targetChannel}: docking is only available from direct chats.`,
+    const sourceCandidates = buildSourceIdentityCandidates(params, sourceChannel);
+    if (sourceCandidates.size === 0) {
+      return commandReply(`Cannot dock to ${targetChannel}: sender id is unavailable.`);
+    }
+
+    const target = resolveLinkedDockTarget({
+      identityLinks: params.cfg.session?.identityLinks,
+      sourceCandidates,
+      targetChannel,
+    });
+    if (!target?.peerId) {
+      return commandReply(
+        `Cannot dock to ${targetChannel}: add this sender and a ${targetChannel}:... peer to session.identityLinks.`,
+      );
+    }
+
+    const sessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+    if (!sessionEntry || !params.sessionStore || !params.sessionKey) {
+      return commandReply(`Cannot dock to ${targetChannel}: no active session entry was found.`);
+    }
+
+    sessionEntry.delivery = normalizeSessionDeliveryState({
+      context: {
+        channel: targetChannel,
+        to: target.peerId,
+        accountId: resolveTargetChannelAccountId(params, targetChannel),
       },
-    };
-  }
+      origin: sessionDeliveryOrigin(sessionEntry),
+    });
+    params.sessionEntry = sessionEntry;
+    const persisted = await persistSessionEntry({
+      ...params,
+      touchedFields: ["delivery"],
+    });
+    if (!persisted) {
+      return commandReply(`Cannot dock to ${targetChannel}: session route could not be saved.`);
+    }
 
-  const sourceCandidates = buildSourceIdentityCandidates(params, sourceChannel);
-  if (sourceCandidates.size === 0) {
-    return {
-      shouldContinue: false,
-      reply: { text: `Cannot dock to ${targetChannel}: sender id is unavailable.` },
-    };
-  }
-
-  const target = resolveLinkedDockTarget({
-    identityLinks: params.cfg.session?.identityLinks,
-    sourceCandidates,
-    targetChannel,
-  });
-  if (!target?.peerId) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: `Cannot dock to ${targetChannel}: add this sender and a ${targetChannel}:... peer to session.identityLinks.`,
-      },
-    };
-  }
-
-  const sessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-  if (!sessionEntry || !params.sessionStore || !params.sessionKey) {
-    return {
-      shouldContinue: false,
-      reply: { text: `Cannot dock to ${targetChannel}: no active session entry was found.` },
-    };
-  }
-
-  sessionEntry.delivery = normalizeSessionDeliveryState({
-    context: {
-      channel: targetChannel,
-      to: target.peerId,
-      accountId: resolveTargetChannelAccountId(params, targetChannel),
-    },
-    origin: sessionDeliveryOrigin(sessionEntry),
-  });
-  params.sessionEntry = sessionEntry;
-  const persisted = await persistSessionEntry({
-    ...params,
-    touchedFields: ["delivery"],
-  });
-  if (!persisted) {
-    return {
-      shouldContinue: false,
-      reply: { text: `Cannot dock to ${targetChannel}: session route could not be saved.` },
-    };
-  }
-
-  return {
-    shouldContinue: false,
-    reply: { text: `Docked replies to ${targetChannel}.` },
-  };
-};
+    return commandReply(`Docked replies to ${targetChannel}.`);
+  },
+);

--- a/src/auto-reply/reply/commands-goal.ts
+++ b/src/auto-reply/reply/commands-goal.ts
@@ -13,7 +13,7 @@ import {
 } from "../../config/sessions.js";
 import { loadSessionEntry as getSessionEntry } from "../../config/sessions/session-accessor.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { commandReply as goalReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
 import type {
   CommandHandler,
@@ -76,13 +76,6 @@ function syncGoalSessionEntry(params: HandleCommandsParams): void {
   params.sessionEntry = entry;
 }
 
-function goalReply(text: string): CommandHandlerResult {
-  return {
-    shouldContinue: false,
-    reply: { text },
-  };
-}
-
 function hasCommandLikeGoalText(trimmed: string): boolean {
   return /(?:^|\s)\//.test(trimmed) || trimmed.startsWith("!");
 }
@@ -129,144 +122,136 @@ function goalErrorReply(error: unknown): CommandHandlerResult {
 }
 
 /** Command handler for /goal lifecycle commands. */
-export const handleGoalCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const parsed = parseGoalCommand(params.command.commandBodyNormalized);
-  if (!parsed) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/goal");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const actor = { type: "human" as const };
-  const goalAgentId = params.agentId;
+export const handleGoalCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/goal", match: parseGoalCommand },
+  async (params, parsed) => {
+    const actor = { type: "human" as const };
+    const goalAgentId = params.agentId;
 
-  try {
-    switch (parsed.action) {
-      case "status": {
-        const snapshot = await getSessionGoal({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          fallbackEntry: params.sessionEntry,
-          persist: false,
-        });
-        syncGoalSessionEntry(params);
-        return goalReply(formatSessionGoalStatus(snapshot.goal));
-      }
-      case "start":
-      case "set":
-      case "create": {
-        const objective = normalizeOptionalString(parsed.text);
-        if (!objective) {
-          return goalReply("Usage: /goal start <objective>");
+    try {
+      switch (parsed.action) {
+        case "status": {
+          const snapshot = await getSessionGoal({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            fallbackEntry: params.sessionEntry,
+            persist: false,
+          });
+          syncGoalSessionEntry(params);
+          return goalReply(formatSessionGoalStatus(snapshot.goal));
         }
-        const goal = await createSessionGoal({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          objective,
-          fallbackEntry: params.sessionEntry,
-          actor,
-          agentId: goalAgentId,
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        applyCommandTextToParams(params, formatGoalContinuationPrompt(goal.objective));
-        return goalContinuation();
-      }
-      case "edit": {
-        const objective = normalizeOptionalString(parsed.text);
-        if (!objective) {
-          return goalReply("Usage: /goal edit <objective>");
-        }
-        const goal = await updateSessionGoalObjective({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          objective,
-          actor,
-          agentId: goalAgentId,
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        return goalReply(`Goal updated: ${goal.objective}`);
-      }
-      case "pause": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          status: "paused",
-          actor,
-          agentId: goalAgentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        return goalReply(`Goal paused: ${goal.objective}`);
-      }
-      case "resume": {
-        await updateSessionGoalStatus({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          status: "active",
-          actor,
-          agentId: goalAgentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        const message = formatGoalResumeContinuationPrompt(parsed.text);
-        applyCommandTextToParams(params, message);
-        return goalContinuation();
-      }
-      case "complete":
-      case "done": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          status: "complete",
-          actor,
-          agentId: goalAgentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        return goalReply(`Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}`);
-      }
-      case "block":
-      case "blocked": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          status: "blocked",
-          actor,
-          agentId: goalAgentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        syncGoalSessionEntry(params);
-        markCommandSessionMetadataChanged(params);
-        return goalReply(`Goal blocked: ${goal.objective}`);
-      }
-      case "clear": {
-        const removed = await clearSessionGoal({
-          sessionKey: params.sessionKey,
-          storePath: params.storePath,
-          actor,
-          agentId: goalAgentId,
-        });
-        syncGoalSessionEntry(params);
-        if (removed) {
+        case "start":
+        case "set":
+        case "create": {
+          const objective = normalizeOptionalString(parsed.text);
+          if (!objective) {
+            return goalReply("Usage: /goal start <objective>");
+          }
+          const goal = await createSessionGoal({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            objective,
+            fallbackEntry: params.sessionEntry,
+            actor,
+            agentId: goalAgentId,
+          });
+          syncGoalSessionEntry(params);
           markCommandSessionMetadataChanged(params);
+          applyCommandTextToParams(params, formatGoalContinuationPrompt(goal.objective));
+          return goalContinuation();
         }
-        return goalReply(removed ? "Goal cleared." : "No goal to clear.");
+        case "edit": {
+          const objective = normalizeOptionalString(parsed.text);
+          if (!objective) {
+            return goalReply("Usage: /goal edit <objective>");
+          }
+          const goal = await updateSessionGoalObjective({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            objective,
+            actor,
+            agentId: goalAgentId,
+          });
+          syncGoalSessionEntry(params);
+          markCommandSessionMetadataChanged(params);
+          return goalReply(`Goal updated: ${goal.objective}`);
+        }
+        case "pause": {
+          const goal = await updateSessionGoalStatus({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            status: "paused",
+            actor,
+            agentId: goalAgentId,
+            ...(parsed.text ? { note: parsed.text } : {}),
+          });
+          syncGoalSessionEntry(params);
+          markCommandSessionMetadataChanged(params);
+          return goalReply(`Goal paused: ${goal.objective}`);
+        }
+        case "resume": {
+          await updateSessionGoalStatus({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            status: "active",
+            actor,
+            agentId: goalAgentId,
+            ...(parsed.text ? { note: parsed.text } : {}),
+          });
+          syncGoalSessionEntry(params);
+          markCommandSessionMetadataChanged(params);
+          const message = formatGoalResumeContinuationPrompt(parsed.text);
+          applyCommandTextToParams(params, message);
+          return goalContinuation();
+        }
+        case "complete":
+        case "done": {
+          const goal = await updateSessionGoalStatus({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            status: "complete",
+            actor,
+            agentId: goalAgentId,
+            ...(parsed.text ? { note: parsed.text } : {}),
+          });
+          syncGoalSessionEntry(params);
+          markCommandSessionMetadataChanged(params);
+          return goalReply(`Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}`);
+        }
+        case "block":
+        case "blocked": {
+          const goal = await updateSessionGoalStatus({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            status: "blocked",
+            actor,
+            agentId: goalAgentId,
+            ...(parsed.text ? { note: parsed.text } : {}),
+          });
+          syncGoalSessionEntry(params);
+          markCommandSessionMetadataChanged(params);
+          return goalReply(`Goal blocked: ${goal.objective}`);
+        }
+        case "clear": {
+          const removed = await clearSessionGoal({
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            actor,
+            agentId: goalAgentId,
+          });
+          syncGoalSessionEntry(params);
+          if (removed) {
+            markCommandSessionMetadataChanged(params);
+          }
+          return goalReply(removed ? "Goal cleared." : "No goal to clear.");
+        }
+        default:
+          return goalReply(
+            "Usage: /goal <objective> | /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear",
+          );
       }
-      default:
-        return goalReply(
-          "Usage: /goal <objective> | /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear",
-        );
+    } catch (error) {
+      return goalErrorReply(error);
     }
-  } catch (error) {
-    return goalErrorReply(error);
-  }
-};
+  },
+);

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -2,7 +2,6 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveToolInventory } from "../../agents/tools-effective-inventory.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
-import { logVerbose } from "../../globals.js";
 import {
   listSkillCommandsForAgents,
   resolveSkillCommandInvocation,
@@ -15,7 +14,12 @@ import {
 } from "../status.js";
 import { buildThreadingToolContext } from "./agent-runner-utils.js";
 import { resolveChannelAccountId } from "./channel-context.js";
-import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
+import {
+  commandReply,
+  defineAuthorizedTextCommand,
+  matchCommandPrefix,
+  rejectUnauthorizedCommand,
+} from "./command-gates.js";
 import { buildExportSessionReply } from "./commands-export-session.js";
 import { buildExportTrajectoryCommandReply } from "./commands-export-trajectory.js";
 import { buildStatusPluginsReply, buildStatusReply } from "./commands-status.js";
@@ -48,69 +52,47 @@ async function resolveSkillCommands(
 }
 
 /** Command handler for /help. */
-export const handleHelpCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  if (params.command.commandBodyNormalized !== "/help") {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /help from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  return {
-    shouldContinue: false,
-    reply: { text: buildHelpMessage(params.cfg) },
-  };
-};
+export const handleHelpCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/help", match: (body) => (body === "/help" ? true : null), silentUnauthorized: true },
+  (params) => commandReply(buildHelpMessage(params.cfg)),
+);
 
 /** Command handler for /commands. */
-export const handleCommandsListCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  if (params.command.commandBodyNormalized !== "/commands") {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /commands from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  const agentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
-    : params.agentId;
-  const skillCommands = await resolveSkillCommands(params);
-  const surface = params.ctx.Surface;
-  const commandPlugin = surface ? getChannelPlugin(surface) : null;
-  const paginated = buildCommandsMessagePaginated(params.cfg, skillCommands, {
-    page: 1,
-    surface,
-  });
-  const channelData = commandPlugin?.commands?.buildCommandsListChannelData?.({
-    currentPage: paginated.currentPage,
-    totalPages: paginated.totalPages,
-    agentId,
-  });
-  if (channelData) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: paginated.text,
-        channelData,
-      },
-    };
-  }
+export const handleCommandsListCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/commands",
+    match: (body) => (body === "/commands" ? true : null),
+    silentUnauthorized: true,
+  },
+  async (params) => {
+    const agentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+      : params.agentId;
+    const skillCommands = await resolveSkillCommands(params);
+    const surface = params.ctx.Surface;
+    const commandPlugin = surface ? getChannelPlugin(surface) : null;
+    const paginated = buildCommandsMessagePaginated(params.cfg, skillCommands, {
+      page: 1,
+      surface,
+    });
+    const channelData = commandPlugin?.commands?.buildCommandsListChannelData?.({
+      currentPage: paginated.currentPage,
+      totalPages: paginated.totalPages,
+      agentId,
+    });
+    if (channelData) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: paginated.text,
+          channelData,
+        },
+      };
+    }
 
-  return {
-    shouldContinue: false,
-    reply: { text: buildCommandsMessage(params.cfg, skillCommands, { surface }) },
-  };
-};
+    return commandReply(buildCommandsMessage(params.cfg, skillCommands, { surface }));
+  },
+);
 
 function buildSkillCommandUsage(skillCommands: NonNullable<HandleCommandsParams["skillCommands"]>) {
   const lines = ["Usage: /skill <name> [input]"];
@@ -129,37 +111,28 @@ function buildSkillCommandUsage(skillCommands: NonNullable<HandleCommandsParams[
 }
 
 /** Command handler for /skill usage help. */
-export const handleSkillCommandUsage: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/skill" && !normalized.startsWith("/skill ")) {
-    return null;
-  }
-  // Bare or unknown /skill commands are deterministic help responses; handling
-  // them here avoids falling through into a full agent/model turn.
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /skill from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const [, rawName] = normalized.match(/^\/skill(?:\s+([^\s]+))?/u) ?? [];
-  const skillCommands = await resolveSkillCommands(params, { requireFullList: true });
-  if (
-    rawName &&
-    resolveSkillCommandInvocation({ commandBodyNormalized: normalized, skillCommands })
-  ) {
-    return null;
-  }
-  const prefix = rawName ? `Unknown skill: ${rawName}\n\n` : "";
-  return {
-    shouldContinue: false,
-    reply: { text: `${prefix}${buildSkillCommandUsage(skillCommands)}` },
-  };
-};
+export const handleSkillCommandUsage: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/skill",
+    match: (body) => matchCommandPrefix(body, "/skill"),
+    silentUnauthorized: true,
+  },
+  async (params) => {
+    const normalized = params.command.commandBodyNormalized;
+    // Bare or unknown /skill commands are deterministic help responses; handling
+    // them here avoids falling through into a full agent/model turn.
+    const [, rawName] = normalized.match(/^\/skill(?:\s+([^\s]+))?/u) ?? [];
+    const skillCommands = await resolveSkillCommands(params, { requireFullList: true });
+    if (
+      rawName &&
+      resolveSkillCommandInvocation({ commandBodyNormalized: normalized, skillCommands })
+    ) {
+      return null;
+    }
+    const prefix = rawName ? `Unknown skill: ${rawName}\n\n` : "";
+    return commandReply(`${prefix}${buildSkillCommandUsage(skillCommands)}`);
+  },
+);
 
 /** Command handler for /tools. */
 export const handleToolsCommand: CommandHandler = async (params, allowTextCommands) => {
@@ -177,10 +150,7 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
   } else {
     return null;
   }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /tools from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
+  if (rejectUnauthorizedCommand(params, "/tools")) {
     return { shouldContinue: false };
   }
 
@@ -232,126 +202,88 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
         params.ctx.ChatType,
       ),
     });
-    return {
-      shouldContinue: false,
-      reply: { text: buildToolsMessage(result, { verbose }) },
-    };
+    return commandReply(buildToolsMessage(result, { verbose }));
   } catch {
     // Inventory resolves in-process after sender authorization; this path cannot receive
     // gateway RPC scope errors, so failures here are local discovery failures.
-    return {
-      shouldContinue: false,
-      reply: { text: "Couldn't load available tools right now. Try again in a moment." },
-    };
+    return commandReply("Couldn't load available tools right now. Try again in a moment.");
   }
 };
 
 /** Command handler for /status. */
-export const handleStatusCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalizedStatusCommand = params.command.commandBodyNormalized.trim();
-  const statusRequested =
-    params.directives.hasStatusDirective ||
-    normalizedStatusCommand === "/status" ||
-    normalizedStatusCommand.startsWith("/status ");
-  if (!statusRequested) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /status from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  if (normalizedStatusCommand === "/status plugins") {
-    const reply = await buildStatusPluginsReply({
+export const handleStatusCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/status",
+    match: (body, params) => {
+      const normalized = body.trim();
+      return params.directives.hasStatusDirective ||
+        matchCommandPrefix(normalized, "/status") !== null
+        ? normalized
+        : null;
+    },
+    silentUnauthorized: true,
+  },
+  async (params, normalizedStatusCommand) => {
+    if (normalizedStatusCommand === "/status plugins") {
+      const reply = await buildStatusPluginsReply({
+        cfg: params.cfg,
+        command: params.command,
+        workspaceDir: params.workspaceDir,
+      });
+      return { shouldContinue: false, reply };
+    }
+    if (normalizedStatusCommand.startsWith("/status ")) {
+      return commandReply("⚠️ Unknown /status subcommand. Try /status or /status plugins.");
+    }
+    const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+    const reply = await buildStatusReply({
       cfg: params.cfg,
       command: params.command,
+      sessionEntry: targetSessionEntry,
+      sessionKey: params.sessionKey,
+      parentSessionKey: targetSessionEntry?.parentSessionKey ?? params.ctx.ParentSessionKey,
+      sessionScope: params.sessionScope,
+      storePath: params.storePath,
+      provider: params.provider,
+      model: params.model,
+      contextTokens: params.contextTokens,
+      thinkingCatalog: params.thinkingCatalog,
       workspaceDir: params.workspaceDir,
+      resolvedThinkLevel: params.resolvedThinkLevel,
+      resolvedFastMode: params.resolvedFastMode,
+      resolvedVerboseLevel: params.resolvedVerboseLevel,
+      resolvedReasoningLevel: params.resolvedReasoningLevel,
+      resolvedElevatedLevel: params.resolvedElevatedLevel,
+      resolveDefaultThinkingLevel: params.resolveDefaultThinkingLevel,
+      isGroup: params.isGroup,
+      defaultGroupActivation: params.defaultGroupActivation,
+      mediaDecisions: params.ctx.MediaUnderstandingDecisions,
     });
     return { shouldContinue: false, reply };
-  }
-  if (normalizedStatusCommand.startsWith("/status ")) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚠️ Unknown /status subcommand. Try /status or /status plugins." },
-    };
-  }
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-  const reply = await buildStatusReply({
-    cfg: params.cfg,
-    command: params.command,
-    sessionEntry: targetSessionEntry,
-    sessionKey: params.sessionKey,
-    parentSessionKey: targetSessionEntry?.parentSessionKey ?? params.ctx.ParentSessionKey,
-    sessionScope: params.sessionScope,
-    storePath: params.storePath,
-    provider: params.provider,
-    model: params.model,
-    contextTokens: params.contextTokens,
-    thinkingCatalog: params.thinkingCatalog,
-    workspaceDir: params.workspaceDir,
-    resolvedThinkLevel: params.resolvedThinkLevel,
-    resolvedFastMode: params.resolvedFastMode,
-    resolvedVerboseLevel: params.resolvedVerboseLevel,
-    resolvedReasoningLevel: params.resolvedReasoningLevel,
-    resolvedElevatedLevel: params.resolvedElevatedLevel,
-    resolveDefaultThinkingLevel: params.resolveDefaultThinkingLevel,
-    isGroup: params.isGroup,
-    defaultGroupActivation: params.defaultGroupActivation,
-    mediaDecisions: params.ctx.MediaUnderstandingDecisions,
-  });
-  return { shouldContinue: false, reply };
-};
+  },
+);
 
 /** Command handler for /export-session. */
-export const handleExportSessionCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (
-    normalized !== "/export-session" &&
-    !normalized.startsWith("/export-session ") &&
-    normalized !== "/export" &&
-    !normalized.startsWith("/export ")
-  ) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/export-session");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const nonOwner = rejectNonOwnerCommand(params, "/export-session");
-  if (nonOwner) {
-    return nonOwner;
-  }
-  return { shouldContinue: false, reply: await buildExportSessionReply(params) };
-};
+export const handleExportSessionCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/export-session",
+    match: (body) =>
+      matchCommandPrefix(body, "/export-session") ?? matchCommandPrefix(body, "/export"),
+    ownerOnly: true,
+  },
+  async (params) => ({ shouldContinue: false, reply: await buildExportSessionReply(params) }),
+);
 
 /** Command handler for /export-trajectory. */
-export const handleExportTrajectoryCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (
-    normalized !== "/export-trajectory" &&
-    !normalized.startsWith("/export-trajectory ") &&
-    normalized !== "/trajectory" &&
-    !normalized.startsWith("/trajectory ")
-  ) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/export-trajectory");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const nonOwner = rejectNonOwnerCommand(params, "/export-trajectory");
-  if (nonOwner) {
-    return nonOwner;
-  }
-  return { shouldContinue: false, reply: await buildExportTrajectoryCommandReply(params) };
-};
+export const handleExportTrajectoryCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/export-trajectory",
+    match: (body) =>
+      matchCommandPrefix(body, "/export-trajectory") ?? matchCommandPrefix(body, "/trajectory"),
+    ownerOnly: true,
+  },
+  async (params) => ({
+    shouldContinue: false,
+    reply: await buildExportTrajectoryCommandReply(params),
+  }),
+);

--- a/src/auto-reply/reply/commands-learn.ts
+++ b/src/auto-reply/reply/commands-learn.ts
@@ -16,12 +16,8 @@ import { resolveConfiguredModelCompat } from "../../agents/tools-effective-inven
 import { buildLearnPrompt, DEFAULT_LEARN_REQUEST } from "../../skills/workshop/learn-prompt.js";
 import { resolveSkillWorkshopToolPolicyAvailability } from "../../skills/workshop/tool-policy-diagnostic.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
-import type {
-  CommandHandler,
-  CommandHandlerResult,
-  HandleCommandsParams,
-} from "./commands-types.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
+import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 
 const LEARN_COMMAND_PREFIX = "/learn";
@@ -140,30 +136,15 @@ function workshopIsAvailable(params: HandleCommandsParams): boolean {
   }
 }
 
-function unavailableReply(): CommandHandlerResult {
-  return {
-    shouldContinue: false,
-    reply: { text: SKILL_WORKSHOP_UNAVAILABLE_REPLY },
-  };
-}
-
 /** Command handler for /learn skill-draft requests. */
-export const handleLearnCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const request = parseLearnRequest(params.command.commandBodyNormalized);
-  if (!request) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, LEARN_COMMAND_PREFIX);
-  if (unauthorized) {
-    return unauthorized;
-  }
-  if (!workshopIsAvailable(params)) {
-    return unavailableReply();
-  }
+export const handleLearnCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: LEARN_COMMAND_PREFIX, match: parseLearnRequest },
+  (params, request) => {
+    if (!workshopIsAvailable(params)) {
+      return commandReply(SKILL_WORKSHOP_UNAVAILABLE_REPLY);
+    }
 
-  applyCommandTextToParams(params, buildLearnPrompt(request));
-  return { shouldContinue: true };
-};
+    applyCommandTextToParams(params, buildLearnPrompt(request));
+    return { shouldContinue: true };
+  },
+);

--- a/src/auto-reply/reply/commands-loop.ts
+++ b/src/auto-reply/reply/commands-loop.ts
@@ -4,8 +4,8 @@ import { AUTOMATIONS_TOOL_NAME } from "../../agents/tools/automations-tool-name.
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
-import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
-import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
+import { commandReply as directReply, defineAuthorizedTextCommand } from "./command-gates.js";
+import type { CommandHandler } from "./commands-types.js";
 
 const LOOP_COMMAND_PREFIX = "/loop";
 const LOOP_MIN_INTERVAL_MS = 30_000;
@@ -13,10 +13,6 @@ const LOOP_DEFAULT_INTERVAL_MS = 15 * 60_000;
 const LOOP_NAME_MAX_LENGTH = 40;
 const LOOP_USAGE =
   "Usage: /loop [interval] <prompt> — repeat a prompt in this chat (e.g. /loop 5m check deploy status). Without interval the loop self-paces between 1m and 1h. /loop status lists loops; /loop stop [name] stops.";
-
-function directReply(text: string): CommandHandlerResult {
-  return { shouldContinue: false, reply: { text } };
-}
 
 function loopShortName(prompt: string): string {
   return truncateUtf16Safe(prompt.trim(), LOOP_NAME_MAX_LENGTH).trimEnd();
@@ -84,61 +80,58 @@ function buildLoopStopWorkOrder(name: string, sessionKey: string): string {
 }
 
 /** Command handler for conversation-bound recurring loops. */
-export const handleLoopCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const trimmed = params.command.commandBodyNormalized.trim();
-  const commandEnd = trimmed.search(/\s/u);
-  const commandToken = commandEnd === -1 ? trimmed : trimmed.slice(0, commandEnd);
-  if (commandToken.toLowerCase() !== LOOP_COMMAND_PREFIX) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, LOOP_COMMAND_PREFIX);
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const nonOwner = rejectNonOwnerCommand(params, LOOP_COMMAND_PREFIX);
-  if (nonOwner) {
-    return nonOwner;
-  }
-
-  const spec = commandEnd === -1 ? "" : trimmed.slice(commandEnd).trim();
-  if (!spec || spec.toLowerCase() === "help") {
-    return directReply(LOOP_USAGE);
-  }
-  if (spec.toLowerCase() === "status") {
-    applyCommandTextToParams(params, buildLoopStatusWorkOrder(params.sessionKey));
-    return { shouldContinue: true };
-  }
-
-  const [firstToken = ""] = spec.split(/\s+/u);
-  if (firstToken.toLowerCase() === "stop") {
-    const name = spec.slice(firstToken.length).trim();
-    applyCommandTextToParams(params, buildLoopStopWorkOrder(name, params.sessionKey));
-    return { shouldContinue: true };
-  }
-
-  let everyMs: number | undefined;
-  // Preserve parseDurationMs semantics: bare numbers are milliseconds.
-  // The 30s floor rejects hot-loop values instead of reinterpreting them as prompt text.
-  try {
-    everyMs = parseDurationMs(firstToken);
-  } catch {
-    everyMs = undefined;
-  }
-  if (everyMs !== undefined) {
-    if (everyMs < LOOP_MIN_INTERVAL_MS) {
-      return directReply(`${LOOP_USAGE} Minimum interval 30s.`);
-    }
-    const prompt = spec.slice(firstToken.length).trim();
-    if (!prompt) {
+export const handleLoopCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: LOOP_COMMAND_PREFIX,
+    match: (body) => {
+      const trimmed = body.trim();
+      const commandEnd = trimmed.search(/\s/u);
+      const token = commandEnd === -1 ? trimmed : trimmed.slice(0, commandEnd);
+      return token.toLowerCase() === LOOP_COMMAND_PREFIX
+        ? commandEnd === -1
+          ? ""
+          : trimmed.slice(commandEnd).trim()
+        : null;
+    },
+    ownerOnly: true,
+  },
+  (params, spec) => {
+    if (!spec || spec.toLowerCase() === "help") {
       return directReply(LOOP_USAGE);
     }
-    applyCommandTextToParams(params, buildFixedLoopWorkOrder(prompt, everyMs, params.sessionKey));
-    return { shouldContinue: true };
-  }
+    if (spec.toLowerCase() === "status") {
+      applyCommandTextToParams(params, buildLoopStatusWorkOrder(params.sessionKey));
+      return { shouldContinue: true };
+    }
 
-  applyCommandTextToParams(params, buildSelfPacedLoopWorkOrder(spec, params.sessionKey));
-  return { shouldContinue: true };
-};
+    const [firstToken = ""] = spec.split(/\s+/u);
+    if (firstToken.toLowerCase() === "stop") {
+      const name = spec.slice(firstToken.length).trim();
+      applyCommandTextToParams(params, buildLoopStopWorkOrder(name, params.sessionKey));
+      return { shouldContinue: true };
+    }
+
+    let everyMs: number | undefined;
+    // Preserve parseDurationMs semantics: bare numbers are milliseconds.
+    // The 30s floor rejects hot-loop values instead of reinterpreting them as prompt text.
+    try {
+      everyMs = parseDurationMs(firstToken);
+    } catch {
+      everyMs = undefined;
+    }
+    if (everyMs !== undefined) {
+      if (everyMs < LOOP_MIN_INTERVAL_MS) {
+        return directReply(`${LOOP_USAGE} Minimum interval 30s.`);
+      }
+      const prompt = spec.slice(firstToken.length).trim();
+      if (!prompt) {
+        return directReply(LOOP_USAGE);
+      }
+      applyCommandTextToParams(params, buildFixedLoopWorkOrder(prompt, everyMs, params.sessionKey));
+      return { shouldContinue: true };
+    }
+
+    applyCommandTextToParams(params, buildSelfPacedLoopWorkOrder(spec, params.sessionKey));
+    return { shouldContinue: true };
+  },
+);

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -11,8 +11,8 @@ import { buildConfigSchema } from "../../config/schema.js";
 import type { ExecApprovalRequest } from "../../infra/exec-approvals.js";
 import type { ReplyPayload } from "../types.js";
 import {
-  rejectNonOwnerCommand,
-  rejectUnauthorizedCommand,
+  commandReply,
+  defineAuthorizedTextCommand,
   requireCommandFlagEnabled,
   requireGatewayClientScope,
 } from "./command-gates.js";
@@ -22,7 +22,6 @@ import {
   readCommandMessageThreadId,
   resolvePrivateCommandApprovalRouteExpiresAtMs,
   resolvePrivateCommandRouteTargets,
-  type PrivateCommandRouteTarget,
 } from "./commands-private-route.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { parseMcpCommand } from "./mcp-commands.js";
@@ -31,20 +30,6 @@ const MCP_SHOW_PRIVATE_ROUTE_UNAVAILABLE =
   "I couldn't find a private owner route for MCP configuration. Run /mcp show from an owner DM so sensitive server details are not posted in this chat.";
 const MCP_SHOW_PRIVATE_ROUTE_ACK =
   "MCP server configuration is sensitive. I sent the details to the owner privately.";
-
-type McpCommandDeps = {
-  resolvePrivateMcpTargets: (params: HandleCommandsParams) => Promise<PrivateCommandRouteTarget[]>;
-  deliverPrivateMcpReply: (params: {
-    commandParams: HandleCommandsParams;
-    targets: PrivateCommandRouteTarget[];
-    reply: ReplyPayload;
-  }) => Promise<boolean>;
-};
-
-const defaultMcpCommandDeps: McpCommandDeps = {
-  resolvePrivateMcpTargets: resolvePrivateMcpTargetsForCommand,
-  deliverPrivateMcpReply: deliverPrivateCommandReply,
-};
 
 function renderJsonBlock(label: string, value: unknown): string {
   return `${label}\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
@@ -106,15 +91,6 @@ async function buildMcpShowReply(name?: string): Promise<ReplyPayload> {
   };
 }
 
-async function resolvePrivateMcpTargetsForCommand(
-  params: HandleCommandsParams,
-): Promise<PrivateCommandRouteTarget[]> {
-  return await resolvePrivateCommandRouteTargets({
-    commandParams: params,
-    request: buildMcpShowPrivateRouteRequest(params),
-  });
-}
-
 function buildMcpShowPrivateRouteRequest(params: HandleCommandsParams): ExecApprovalRequest {
   const now = Date.now();
   const agentId =
@@ -139,61 +115,33 @@ function buildMcpShowPrivateRouteRequest(params: HandleCommandsParams): ExecAppr
   };
 }
 
-async function deliverGroupMcpShowReplyPrivately(
-  deps: McpCommandDeps,
-  params: HandleCommandsParams,
-  name?: string,
-) {
-  const targets = await deps.resolvePrivateMcpTargets(params);
+async function deliverGroupMcpShowReplyPrivately(params: HandleCommandsParams, name?: string) {
+  const targets = await resolvePrivateCommandRouteTargets({
+    commandParams: params,
+    request: buildMcpShowPrivateRouteRequest(params),
+  });
   if (targets.length === 0) {
-    return {
-      shouldContinue: false,
-      reply: { text: MCP_SHOW_PRIVATE_ROUTE_UNAVAILABLE },
-    };
+    return commandReply(MCP_SHOW_PRIVATE_ROUTE_UNAVAILABLE);
   }
   const privateReply = await buildMcpShowReply(name);
   for (const target of targets) {
     if (
-      await deps.deliverPrivateMcpReply({
+      await deliverPrivateCommandReply({
         commandParams: params,
         targets: [target],
         reply: privateReply,
       })
     ) {
-      return {
-        shouldContinue: false,
-        reply: { text: MCP_SHOW_PRIVATE_ROUTE_ACK },
-      };
+      return commandReply(MCP_SHOW_PRIVATE_ROUTE_ACK);
     }
   }
-  return {
-    shouldContinue: false,
-    reply: { text: MCP_SHOW_PRIVATE_ROUTE_UNAVAILABLE },
-  };
+  return commandReply(MCP_SHOW_PRIVATE_ROUTE_UNAVAILABLE);
 }
 
-/** Creates an MCP command handler with injectable private-route dependencies. */
-function createMcpCommandHandler(deps: Partial<McpCommandDeps> = {}): CommandHandler {
-  const resolvedDeps: McpCommandDeps = {
-    ...defaultMcpCommandDeps,
-    ...deps,
-  };
-  return async (params, allowTextCommands) => {
-    if (!allowTextCommands) {
-      return null;
-    }
-    const mcpCommand = parseMcpCommand(params.command.commandBodyNormalized);
-    if (!mcpCommand) {
-      return null;
-    }
-    const unauthorized = rejectUnauthorizedCommand(params, "/mcp");
-    if (unauthorized) {
-      return unauthorized;
-    }
-    const nonOwner = rejectNonOwnerCommand(params, "/mcp");
-    if (nonOwner) {
-      return nonOwner;
-    }
+/** Command handler for /mcp show/set/unset operations. */
+export const handleMcpCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/mcp", match: parseMcpCommand, ownerOnly: true },
+  async (params, mcpCommand) => {
     const disabled = requireCommandFlagEnabled(params.cfg, {
       label: "/mcp",
       configKey: "mcp",
@@ -202,15 +150,12 @@ function createMcpCommandHandler(deps: Partial<McpCommandDeps> = {}): CommandHan
       return disabled;
     }
     if (mcpCommand.action === "error") {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${mcpCommand.message}` },
-      };
+      return commandReply(`⚠️ ${mcpCommand.message}`);
     }
 
     if (mcpCommand.action === "show") {
       if (params.isGroup) {
-        return await deliverGroupMcpShowReplyPrivately(resolvedDeps, params, mcpCommand.name);
+        return await deliverGroupMcpShowReplyPrivately(params, mcpCommand.name);
       }
       return {
         shouldContinue: false,
@@ -233,38 +178,18 @@ function createMcpCommandHandler(deps: Partial<McpCommandDeps> = {}): CommandHan
         server: mcpCommand.value,
       });
       if (!result.ok) {
-        return {
-          shouldContinue: false,
-          reply: { text: `⚠️ ${result.error}` },
-        };
+        return commandReply(`⚠️ ${result.error}`);
       }
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `🔌 MCP server "${mcpCommand.name}" saved to ${result.path}.`,
-        },
-      };
+      return commandReply(`🔌 MCP server "${mcpCommand.name}" saved to ${result.path}.`);
     }
 
     const result = await unsetConfiguredMcpServer({ name: mcpCommand.name });
     if (!result.ok) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${result.error}` },
-      };
+      return commandReply(`⚠️ ${result.error}`);
     }
     if (!result.removed) {
-      return {
-        shouldContinue: false,
-        reply: { text: `🔌 No MCP server named "${mcpCommand.name}" in ${result.path}.` },
-      };
+      return commandReply(`🔌 No MCP server named "${mcpCommand.name}" in ${result.path}.`);
     }
-    return {
-      shouldContinue: false,
-      reply: { text: `🔌 MCP server "${mcpCommand.name}" removed from ${result.path}.` },
-    };
-  };
-}
-
-/** Command handler for /mcp show/set/unset operations. */
-export const handleMcpCommand: CommandHandler = createMcpCommandHandler();
+    return commandReply(`🔌 MCP server "${mcpCommand.name}" removed from ${result.path}.`);
+  },
+);

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -9,13 +9,9 @@ import {
 import { normalizeStoreSessionKey } from "../../config/sessions/store-entry.js";
 import { deriveSessionTitle } from "../../gateway/session-utils.js";
 import { parseSessionLabel } from "../../sessions/session-label.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { commandReply as nameReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
-import type {
-  CommandHandler,
-  CommandHandlerResult,
-  HandleCommandsParams,
-} from "./commands-types.js";
+import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 
 const NAME_COMMAND_PREFIX = "/name";
 
@@ -28,10 +24,6 @@ function parseNameCommand(raw: string): { title: string } | null {
   }
   const argText = commandEnd === -1 ? "" : trimmed.slice(commandEnd).trim();
   return { title: argText };
-}
-
-function nameReply(text: string): CommandHandlerResult {
-  return { shouldContinue: false, reply: { text } };
 }
 
 function syncNameSessionEntry(params: HandleCommandsParams): void {
@@ -49,82 +41,74 @@ function syncNameSessionEntry(params: HandleCommandsParams): void {
   params.sessionEntry = entry;
 }
 
-export const handleNameCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const parsed = parseNameCommand(params.command.commandBodyNormalized);
-  if (!parsed) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/name");
-  if (unauthorized) {
-    return unauthorized;
-  }
-
-  if (!params.storePath || !params.sessionKey) {
-    return nameReply("Naming is not available for this session.");
-  }
-
-  const title = normalizeOptionalString(parsed.title);
-
-  // No argument: surface the current name plus a deterministic suggestion
-  // derived locally (no LLM, no mutation). Apply it with `/name <title>`.
-  if (!title) {
-    const entry =
-      loadSessionEntryReadOnly({ sessionKey: params.sessionKey, storePath: params.storePath }) ??
-      params.sessionEntry;
-    const current = normalizeOptionalString(entry?.label);
-    const suggestionEntry = entry ? { ...entry, label: undefined } : undefined;
-    const suggestion = deriveSessionTitle(suggestionEntry);
-    const lines: string[] = [];
-    lines.push(
-      current ? `Current session name: ${current}` : "This session has no custom name yet.",
-    );
-    if (suggestion && suggestion !== current) {
-      lines.push(`Suggested name: ${suggestion}`);
+export const handleNameCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/name", match: parseNameCommand },
+  async (params, parsed) => {
+    if (!params.storePath || !params.sessionKey) {
+      return nameReply("Naming is not available for this session.");
     }
-    lines.push("Use /name <title> to set a name (mirrors the session manager).");
-    return nameReply(lines.join("\n"));
-  }
 
-  const storePath = params.storePath;
-  const sessionKey = normalizeStoreSessionKey(params.sessionKey);
-  // Reuse the canonical label validation (`parseSessionLabel`) and the same
-  // cross-store uniqueness rule enforced by the web/admin `sessions.patch`
-  // path so chat naming behaves identically to the session manager.
-  const result = await applySessionPatchProjection<{ ok: false; error: string }>({
-    storePath,
-    resolveTarget: () => ({ primaryKey: sessionKey, candidateKeys: [sessionKey] }),
-    project: ({ entries, existingEntry }) => {
-      // Native slash may invoke `/name` before the fast path persists the entry.
-      // Seed a copy under the canonical key without mutating params on failed writes.
-      const entry = existingEntry ?? (params.sessionEntry ? { ...params.sessionEntry } : undefined);
-      if (!entry) {
-        return { ok: false, error: "no active session to name" };
+    const title = normalizeOptionalString(parsed.title);
+
+    // No argument: surface the current name plus a deterministic suggestion
+    // derived locally (no LLM, no mutation). Apply it with `/name <title>`.
+    if (!title) {
+      const entry =
+        loadSessionEntryReadOnly({ sessionKey: params.sessionKey, storePath: params.storePath }) ??
+        params.sessionEntry;
+      const current = normalizeOptionalString(entry?.label);
+      const suggestionEntry = entry ? { ...entry, label: undefined } : undefined;
+      const suggestion = deriveSessionTitle(suggestionEntry);
+      const lines: string[] = [];
+      lines.push(
+        current ? `Current session name: ${current}` : "This session has no custom name yet.",
+      );
+      if (suggestion && suggestion !== current) {
+        lines.push(`Suggested name: ${suggestion}`);
       }
-      const validated = parseSessionLabel(title);
-      if (!validated.ok) {
-        return { ok: false, error: validated.error };
-      }
-      for (const other of entries) {
-        if (other.sessionKey !== sessionKey && other.entry.label === validated.label) {
-          return { ok: false, error: `label already in use: ${validated.label}` };
+      lines.push("Use /name <title> to set a name (mirrors the session manager).");
+      return nameReply(lines.join("\n"));
+    }
+
+    const storePath = params.storePath;
+    const sessionKey = normalizeStoreSessionKey(params.sessionKey);
+    // Reuse the canonical label validation (`parseSessionLabel`) and the same
+    // cross-store uniqueness rule enforced by the web/admin `sessions.patch`
+    // path so chat naming behaves identically to the session manager.
+    const result = await applySessionPatchProjection<{ ok: false; error: string }>({
+      storePath,
+      resolveTarget: () => ({ primaryKey: sessionKey, candidateKeys: [sessionKey] }),
+      project: ({ entries, existingEntry }) => {
+        // Native slash may invoke `/name` before the fast path persists the entry.
+        // Seed a copy under the canonical key without mutating params on failed writes.
+        const entry =
+          existingEntry ?? (params.sessionEntry ? { ...params.sessionEntry } : undefined);
+        if (!entry) {
+          return { ok: false, error: "no active session to name" };
         }
-      }
-      entry.label = validated.label;
-      entry.updatedAt = Math.max(entry.updatedAt ?? 0, Date.now());
-      return {
-        ok: true,
-        entry,
-      };
-    },
-  });
+        const validated = parseSessionLabel(title);
+        if (!validated.ok) {
+          return { ok: false, error: validated.error };
+        }
+        for (const other of entries) {
+          if (other.sessionKey !== sessionKey && other.entry.label === validated.label) {
+            return { ok: false, error: `label already in use: ${validated.label}` };
+          }
+        }
+        entry.label = validated.label;
+        entry.updatedAt = Math.max(entry.updatedAt ?? 0, Date.now());
+        return {
+          ok: true,
+          entry,
+        };
+      },
+    });
 
-  if (!result.ok) {
-    return nameReply(`Couldn't rename the session: ${result.error}`);
-  }
-  syncNameSessionEntry(params);
-  markCommandSessionMetadataChanged(params);
-  return nameReply(`✅ Session renamed to “${result.entry.label}”.`);
-};
+    if (!result.ok) {
+      return nameReply(`Couldn't rename the session: ${result.error}`);
+    }
+    syncNameSessionEntry(params);
+    markCommandSessionMetadataChanged(params);
+    return nameReply(`✅ Session renamed to “${result.entry.label}”.`);
+  },
+);

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -23,8 +23,9 @@ import {
   type PluginStatusReport,
 } from "../../plugins/status.js";
 import {
+  commandReply,
+  defineAuthorizedTextCommand,
   rejectNonOwnerCommand,
-  rejectUnauthorizedCommand,
   requireCommandFlagEnabled,
   requireGatewayClientScope,
 } from "./command-gates.js";
@@ -37,28 +38,10 @@ function renderJsonBlock(label: string, value: unknown): string {
   return `${label}\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
 }
 
-function buildPluginInspectJson(params: {
-  id: string;
-  config: OpenClawConfig;
-  installRecords: Record<string, PluginInstallRecord>;
-  report: PluginStatusReport;
-}): {
-  inspect: NonNullable<ReturnType<typeof buildPluginInspectReport>>;
-  compatibilityWarnings: Array<{
-    code: string;
-    severity: string;
-    message: string;
-  }>;
-  install: PluginInstallRecord | null;
-} | null {
-  const inspect = buildPluginInspectReport({
-    id: params.id,
-    config: params.config,
-    report: params.report,
-  });
-  if (!inspect) {
-    return null;
-  }
+function buildPluginInspectJson(
+  inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
+  installRecords: Record<string, PluginInstallRecord>,
+) {
   return {
     inspect,
     compatibilityWarnings: inspect.compatibility.map((warning) => ({
@@ -66,35 +49,8 @@ function buildPluginInspectJson(params: {
       severity: warning.severity,
       message: formatPluginCompatibilityNotice(warning),
     })),
-    install: params.installRecords[inspect.plugin.id] ?? null,
+    install: installRecords[inspect.plugin.id] ?? null,
   };
-}
-
-function buildAllPluginInspectJson(params: {
-  config: OpenClawConfig;
-  installRecords: Record<string, PluginInstallRecord>;
-  report: PluginStatusReport;
-}): Array<{
-  inspect: ReturnType<typeof buildAllPluginInspectReports>[number];
-  compatibilityWarnings: Array<{
-    code: string;
-    severity: string;
-    message: string;
-  }>;
-  install: PluginInstallRecord | null;
-}> {
-  return buildAllPluginInspectReports({
-    config: params.config,
-    report: params.report,
-  }).map((inspect) => ({
-    inspect,
-    compatibilityWarnings: inspect.compatibility.map((warning) => ({
-      code: warning.code,
-      severity: warning.severity,
-      message: formatPluginCompatibilityNotice(warning),
-    })),
-    install: params.installRecords[inspect.plugin.id] ?? null,
-  }));
 }
 
 function formatPluginLabel(plugin: PluginRecord): string {
@@ -226,190 +182,143 @@ async function loadPluginCommandConfig(): Promise<
   };
 }
 
-export const handlePluginsCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const pluginsCommand = parsePluginsCommand(params.command.commandBodyNormalized);
-  if (!pluginsCommand) {
-    return null;
-  }
-  const unauthorized = rejectUnauthorizedCommand(params, "/plugins");
-  if (unauthorized) {
-    return unauthorized;
-  }
-  const disabled = requireCommandFlagEnabled(params.cfg, {
-    label: "/plugins",
-    configKey: "plugins",
-  });
-  if (disabled) {
-    return disabled;
-  }
-  if (pluginsCommand.action === "error") {
-    return {
-      shouldContinue: false,
-      reply: { text: `⚠️ ${pluginsCommand.message}` },
-    };
-  }
-
-  if (isPluginsWriteAction(pluginsCommand.action)) {
-    const missingAdminScope = requireGatewayClientScope(params, {
-      label: "/plugins write",
-      allowedScopes: ["operator.admin"],
-      missingText:
-        "❌ /plugins install|enable|disable requires operator.admin for gateway clients.",
+export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/plugins", match: parsePluginsCommand },
+  async (params, pluginsCommand) => {
+    const disabled = requireCommandFlagEnabled(params.cfg, {
+      label: "/plugins",
+      configKey: "plugins",
     });
-    if (missingAdminScope) {
-      return missingAdminScope;
+    if (disabled) {
+      return disabled;
     }
-    if (!params.command.senderIsOwner && !hasGatewayAdminScope(params)) {
-      const nonOwner = rejectNonOwnerCommand(params, "/plugins write");
-      if (nonOwner) {
-        return nonOwner;
-      }
+    if (pluginsCommand.action === "error") {
+      return commandReply(`⚠️ ${pluginsCommand.message}`);
     }
-    const nixModeWrite = rejectNixModePluginWrite();
-    if (nixModeWrite) {
-      return nixModeWrite;
-    }
-  }
 
-  if (pluginsCommand.action === "install") {
-    return await withPluginLifecycleLease({}, async () => {
-      const loadedConfig = await loadPluginCommandConfig();
-      if (!loadedConfig.ok) {
-        return {
-          shouldContinue: false,
-          reply: { text: `⚠️ ${loadedConfig.error}` },
-        };
-      }
-      const installed = await installPluginFromPluginsCommand({
-        raw: pluginsCommand.spec,
-        force: pluginsCommand.force,
-        snapshot: loadedConfig.snapshot,
+    if (isPluginsWriteAction(pluginsCommand.action)) {
+      const missingAdminScope = requireGatewayClientScope(params, {
+        label: "/plugins write",
+        allowedScopes: ["operator.admin"],
+        missingText:
+          "❌ /plugins install|enable|disable requires operator.admin for gateway clients.",
       });
-      if (!installed.ok) {
-        return {
-          shouldContinue: false,
-          reply: { text: `⚠️ ${installed.error}` },
-        };
+      if (missingAdminScope) {
+        return missingAdminScope;
       }
-      return {
-        shouldContinue: false,
-        reply: {
-          text: [
+      if (!params.command.senderIsOwner && !hasGatewayAdminScope(params)) {
+        const nonOwner = rejectNonOwnerCommand(params, "/plugins write");
+        if (nonOwner) {
+          return nonOwner;
+        }
+      }
+      const nixModeWrite = rejectNixModePluginWrite();
+      if (nixModeWrite) {
+        return nixModeWrite;
+      }
+    }
+
+    if (pluginsCommand.action === "install") {
+      return await withPluginLifecycleLease({}, async () => {
+        const loadedConfig = await loadPluginCommandConfig();
+        if (!loadedConfig.ok) {
+          return commandReply(`⚠️ ${loadedConfig.error}`);
+        }
+        const installed = await installPluginFromPluginsCommand({
+          raw: pluginsCommand.spec,
+          force: pluginsCommand.force,
+          snapshot: loadedConfig.snapshot,
+        });
+        if (!installed.ok) {
+          return commandReply(`⚠️ ${installed.error}`);
+        }
+        return commandReply(
+          [
             `🔌 Installed plugin "${installed.pluginId}". Gateway restart will load the new plugin source.`,
             ...(installed.warnings ?? []).map((warning) => `⚠️ ${warning}`),
           ].join("\n"),
-        },
-      };
-    });
-  }
-
-  const handleLoadedCommand = async () => {
-    const loaded = await loadPluginCommandState(params.workspaceDir, {
-      loadModules: pluginsCommand.action === "inspect",
-    });
-    if (!loaded.ok) {
-      return {
-        shouldContinue: false,
-        reply: { text: `⚠️ ${loaded.error}` },
-      };
-    }
-
-    if (pluginsCommand.action === "list") {
-      return {
-        shouldContinue: false,
-        reply: { text: formatPluginsList(loaded.report) },
-      };
-    }
-
-    if (pluginsCommand.action === "inspect") {
-      const installRecords = await loadInstalledPluginIndexInstallRecords();
-      if (!pluginsCommand.name) {
-        return {
-          shouldContinue: false,
-          reply: { text: formatPluginsList(loaded.report) },
-        };
-      }
-      if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
-        return {
-          shouldContinue: false,
-          reply: {
-            text: renderJsonBlock(
-              "🔌 Plugins",
-              buildAllPluginInspectJson({ ...loaded, installRecords }),
-            ),
-          },
-        };
-      }
-      const payload = buildPluginInspectJson({
-        id: pluginsCommand.name,
-        config: loaded.config,
-        installRecords,
-        report: loaded.report,
+        );
       });
-      if (!payload) {
-        return {
-          shouldContinue: false,
-          reply: { text: `🔌 No plugin named "${pluginsCommand.name}" found.` },
-        };
+    }
+
+    const handleLoadedCommand = async () => {
+      const loaded = await loadPluginCommandState(params.workspaceDir, {
+        loadModules: pluginsCommand.action === "inspect",
+      });
+      if (!loaded.ok) {
+        return commandReply(`⚠️ ${loaded.error}`);
       }
-      return {
-        shouldContinue: false,
-        reply: {
-          text: renderJsonBlock(`🔌 Plugin "${payload.inspect.plugin.id}"`, {
-            ...payload.inspect,
+
+      if (pluginsCommand.action === "list") {
+        return commandReply(formatPluginsList(loaded.report));
+      }
+
+      if (pluginsCommand.action === "inspect") {
+        const installRecords = await loadInstalledPluginIndexInstallRecords();
+        if (!pluginsCommand.name) {
+          return commandReply(formatPluginsList(loaded.report));
+        }
+        if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
+          const reports = buildAllPluginInspectReports(loaded).map((inspect) =>
+            buildPluginInspectJson(inspect, installRecords),
+          );
+          return commandReply(renderJsonBlock("🔌 Plugins", reports));
+        }
+        const inspect = buildPluginInspectReport({
+          id: pluginsCommand.name,
+          config: loaded.config,
+          report: loaded.report,
+        });
+        if (!inspect) {
+          return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
+        }
+        const payload = buildPluginInspectJson(inspect, installRecords);
+        return commandReply(
+          renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
+            ...inspect,
             compatibilityWarnings: payload.compatibilityWarnings,
             install: payload.install,
           }),
-        },
-      };
-    }
-
-    const plugin = findPlugin(loaded.report, pluginsCommand.name);
-    if (!plugin) {
-      return {
-        shouldContinue: false,
-        reply: { text: `🔌 No plugin named "${pluginsCommand.name}" found.` },
-      };
-    }
-
-    let registryWarning: string | undefined;
-    try {
-      const committedConfig = await setPluginEnabledFromCommand({
-        pluginId: plugin.id,
-        enabled: pluginsCommand.action === "enable",
-        action: pluginsCommand.action,
-      });
-      await refreshPluginRegistryAfterConfigMutation({
-        config: committedConfig,
-        reason: "policy-changed",
-        logger: {
-          warn: (message) => {
-            registryWarning = message;
-          },
-        },
-      });
-    } catch (error) {
-      if (error instanceof AutoReplyConfigMutationError) {
-        return { shouldContinue: false, reply: { text: `⚠️ ${error.message}` } };
+        );
       }
-      throw error;
-    }
 
-    return {
-      shouldContinue: false,
-      reply: {
-        text:
-          `🔌 Plugin "${plugin.id}" ${pluginsCommand.action}d in ${loaded.path}. Gateway reload will apply it to new agent turns.` +
+      const plugin = findPlugin(loaded.report, pluginsCommand.name);
+      if (!plugin) {
+        return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
+      }
+
+      let registryWarning: string | undefined;
+      try {
+        const committedConfig = await setPluginEnabledFromCommand({
+          pluginId: plugin.id,
+          enabled: pluginsCommand.action === "enable",
+          action: pluginsCommand.action,
+        });
+        await refreshPluginRegistryAfterConfigMutation({
+          config: committedConfig,
+          reason: "policy-changed",
+          logger: {
+            warn: (message) => {
+              registryWarning = message;
+            },
+          },
+        });
+      } catch (error) {
+        if (error instanceof AutoReplyConfigMutationError) {
+          return commandReply(`⚠️ ${error.message}`);
+        }
+        throw error;
+      }
+
+      return commandReply(
+        `🔌 Plugin "${plugin.id}" ${pluginsCommand.action}d in ${loaded.path}. Gateway reload will apply it to new agent turns.` +
           (registryWarning ? `\n${registryWarning}` : ""),
-      },
+      );
     };
-  };
 
-  if (pluginsCommand.action === "enable" || pluginsCommand.action === "disable") {
-    return await withPluginLifecycleLease({}, handleLoadedCommand);
-  }
-  return await handleLoadedCommand();
-};
+    if (pluginsCommand.action === "enable" || pluginsCommand.action === "disable") {
+      return await withPluginLifecycleLease({}, handleLoadedCommand);
+    }
+    return await handleLoadedCommand();
+  },
+);

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -49,27 +49,25 @@ import {
   resolveEffectiveResponseUsage,
 } from "../thinking.js";
 import { resolveCommandSurfaceChannel } from "./channel-context.js";
-import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
+import {
+  commandReply as sessionCommandReply,
+  defineAuthorizedTextCommand,
+  matchCommandPrefix,
+  rejectNonOwnerCommand,
+  rejectUnauthorizedCommand,
+} from "./command-gates.js";
 import { handleAbortTrigger, handleStopCommand } from "./commands-session-abort.js";
 import {
   persistSessionEntry,
   sessionEntryPersistenceConflictReply,
 } from "./commands-session-store.js";
-import type {
-  CommandHandler,
-  CommandHandlerResult,
-  HandleCommandsParams,
-} from "./commands-types.js";
+import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { resolveConversationBindingContextFromAcpCommand } from "./conversation-binding-input.js";
 
 const SESSION_COMMAND_PREFIX = "/session";
 const SESSION_DURATION_OFF_VALUES = new Set(["off", "disable", "disabled", "none", "0"]);
 const SESSION_ACTION_IDLE = "idle";
 const SESSION_ACTION_MAX_AGE = "max-age";
-
-function sessionCommandReply(text: string): CommandHandlerResult {
-  return { shouldContinue: false, reply: { text } };
-}
 
 function buildRestartCommandSentinel(params: HandleCommandsParams): RestartSentinelPayload | null {
   const sessionKey = normalizeOptionalString(params.sessionKey);
@@ -250,136 +248,148 @@ export const handleActivationCommand: CommandHandler = async (params, allowTextC
   return sessionCommandReply(`⚙️ Group activation set to ${activationCommand.mode}.`);
 };
 
-export const handleSendPolicyCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const sendPolicyCommand = parseSendPolicyCommand(params.command.commandBodyNormalized);
-  if (!sendPolicyCommand.hasCommand) {
-    return null;
-  }
-  const unauthorizedResult = rejectUnauthorizedCommand(params, "/send");
-  if (unauthorizedResult) {
-    return unauthorizedResult;
-  }
-  const nonOwnerResult = rejectNonOwnerCommand(params, "/send");
-  if (nonOwnerResult) {
-    return nonOwnerResult;
-  }
-  if (!sendPolicyCommand.mode) {
-    return sessionCommandReply("⚙️ Usage: /send on|off|inherit");
-  }
-  if (params.sessionEntry && params.sessionStore && params.sessionKey) {
-    if (sendPolicyCommand.mode === "inherit") {
-      delete params.sessionEntry.sendPolicy;
-    } else {
-      params.sessionEntry.sendPolicy = sendPolicyCommand.mode;
+export const handleSendPolicyCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/send",
+    match: (body) => {
+      const command = parseSendPolicyCommand(body);
+      return command.hasCommand ? command : null;
+    },
+    ownerOnly: true,
+  },
+  async (params, sendPolicyCommand) => {
+    if (!sendPolicyCommand.mode) {
+      return sessionCommandReply("⚙️ Usage: /send on|off|inherit");
     }
-    if (!(await persistSessionEntry({ ...params, touchedFields: ["sendPolicy"] }))) {
-      return sessionEntryPersistenceConflictReply();
+    if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+      if (sendPolicyCommand.mode === "inherit") {
+        delete params.sessionEntry.sendPolicy;
+      } else {
+        params.sessionEntry.sendPolicy = sendPolicyCommand.mode;
+      }
+      if (!(await persistSessionEntry({ ...params, touchedFields: ["sendPolicy"] }))) {
+        return sessionEntryPersistenceConflictReply();
+      }
     }
-  }
-  const label =
-    sendPolicyCommand.mode === "inherit"
-      ? "inherit"
-      : sendPolicyCommand.mode === "allow"
-        ? "on"
-        : "off";
-  return sessionCommandReply(`⚙️ Send policy set to ${label}.`);
-};
+    const label =
+      sendPolicyCommand.mode === "inherit"
+        ? "inherit"
+        : sendPolicyCommand.mode === "allow"
+          ? "on"
+          : "off";
+    return sessionCommandReply(`⚙️ Send policy set to ${label}.`);
+  },
+);
 
-export const handleUsageCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/usage" && !normalized.startsWith("/usage ")) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /usage from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const rawArgs = normalized === "/usage" ? "" : normalized.slice("/usage".length).trim();
-  const requested = rawArgs ? normalizeUsageDisplay(rawArgs) : undefined;
-  if (normalizeLowercaseStringOrEmpty(rawArgs).startsWith("cost")) {
-    const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-    const sessionAgentId =
-      params.sessionKey && !isUnscopedSessionKeySentinel(params.sessionKey)
-        ? resolveSessionAgentId({
-            sessionKey: params.sessionKey,
-            config: params.cfg,
-            agentId: params.agentId,
-          })
-        : params.agentId;
-    const usageAgentId = sessionAgentId ?? DEFAULT_AGENT_ID;
-    const sessionSummary = await loadSessionCostSummary({
-      sessionId: targetSessionEntry?.sessionId,
-      sessionEntry: targetSessionEntry,
-      ...(targetSessionEntry?.sessionId && params.sessionKey
-        ? {
-            sessionTarget: {
-              agentId: usageAgentId,
-              sessionId: targetSessionEntry.sessionId,
+export const handleUsageCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/usage",
+    match: (body) => matchCommandPrefix(body, "/usage"),
+    silentUnauthorized: true,
+  },
+  async (params, rawArgs) => {
+    const requested = rawArgs ? normalizeUsageDisplay(rawArgs) : undefined;
+    if (normalizeLowercaseStringOrEmpty(rawArgs).startsWith("cost")) {
+      const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+      const sessionAgentId =
+        params.sessionKey && !isUnscopedSessionKeySentinel(params.sessionKey)
+          ? resolveSessionAgentId({
               sessionKey: params.sessionKey,
-              storePath: resolveSessionStorePathForScope({
+              config: params.cfg,
+              agentId: params.agentId,
+            })
+          : params.agentId;
+      const usageAgentId = sessionAgentId ?? DEFAULT_AGENT_ID;
+      const sessionSummary = await loadSessionCostSummary({
+        sessionId: targetSessionEntry?.sessionId,
+        sessionEntry: targetSessionEntry,
+        ...(targetSessionEntry?.sessionId && params.sessionKey
+          ? {
+              sessionTarget: {
                 agentId: usageAgentId,
+                sessionId: targetSessionEntry.sessionId,
                 sessionKey: params.sessionKey,
-                storePath:
-                  params.storePath ??
-                  resolveStorePath(params.cfg.session?.store, { agentId: usageAgentId }),
-              }),
-            },
-          }
-        : {}),
-      config: params.cfg,
-      agentId: usageAgentId,
-    });
-    const summary = await loadCostUsageSummary({
-      config: params.cfg,
-      agentId: usageAgentId,
-    });
+                storePath: resolveSessionStorePathForScope({
+                  agentId: usageAgentId,
+                  sessionKey: params.sessionKey,
+                  storePath:
+                    params.storePath ??
+                    resolveStorePath(params.cfg.session?.store, { agentId: usageAgentId }),
+                }),
+              },
+            }
+          : {}),
+        config: params.cfg,
+        agentId: usageAgentId,
+      });
+      const summary = await loadCostUsageSummary({
+        config: params.cfg,
+        agentId: usageAgentId,
+      });
 
-    const sessionCost = formatUsd(sessionSummary?.totalCost);
-    const sessionTokens = sessionSummary?.totalTokens
-      ? formatTokenCount(sessionSummary.totalTokens)
-      : undefined;
-    const sessionMissing = sessionSummary?.missingCostEntries ?? 0;
-    const sessionSuffix = sessionMissing > 0 ? " (partial)" : "";
-    const sessionLine =
-      sessionCost || sessionTokens
-        ? `Session ${sessionCost ?? "n/a"}${sessionSuffix}${sessionTokens ? ` · ${sessionTokens} tokens` : ""}`
-        : "Session n/a";
+      const sessionCost = formatUsd(sessionSummary?.totalCost);
+      const sessionTokens = sessionSummary?.totalTokens
+        ? formatTokenCount(sessionSummary.totalTokens)
+        : undefined;
+      const sessionMissing = sessionSummary?.missingCostEntries ?? 0;
+      const sessionSuffix = sessionMissing > 0 ? " (partial)" : "";
+      const sessionLine =
+        sessionCost || sessionTokens
+          ? `Session ${sessionCost ?? "n/a"}${sessionSuffix}${sessionTokens ? ` · ${sessionTokens} tokens` : ""}`
+          : "Session n/a";
 
-    const todayKey = new Date().toLocaleDateString("en-CA");
-    const todayEntry = summary.daily.find((entry) => entry.date === todayKey);
-    const todayCost = formatUsd(todayEntry?.totalCost);
-    const todayMissing = todayEntry?.missingCostEntries ?? 0;
-    const todaySuffix = todayMissing > 0 ? " (partial)" : "";
-    const todayLine = `Today ${todayCost ?? "n/a"}${todaySuffix}`;
+      const todayKey = new Date().toLocaleDateString("en-CA");
+      const todayEntry = summary.daily.find((entry) => entry.date === todayKey);
+      const todayCost = formatUsd(todayEntry?.totalCost);
+      const todayMissing = todayEntry?.missingCostEntries ?? 0;
+      const todaySuffix = todayMissing > 0 ? " (partial)" : "";
+      const todayLine = `Today ${todayCost ?? "n/a"}${todaySuffix}`;
 
-    const last30Cost = formatUsd(summary.totals.totalCost);
-    const last30Missing = summary.totals.missingCostEntries;
-    const last30Suffix = last30Missing > 0 ? " (partial)" : "";
-    const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
+      const last30Cost = formatUsd(summary.totals.totalCost);
+      const last30Missing = summary.totals.missingCostEntries;
+      const last30Suffix = last30Missing > 0 ? " (partial)" : "";
+      const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
 
-    return sessionCommandReply(`💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`);
-  }
+      return sessionCommandReply(`💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`);
+    }
 
-  const isReset = rawArgs ? isSessionDefaultDirectiveValue(rawArgs) : false;
+    const isReset = rawArgs ? isSessionDefaultDirectiveValue(rawArgs) : false;
 
-  if (rawArgs && !requested && !isReset) {
-    return sessionCommandReply("⚙️ Usage: /usage off|tokens|full|reset|cost");
-  }
+    if (rawArgs && !requested && !isReset) {
+      return sessionCommandReply("⚙️ Usage: /usage off|tokens|full|reset|cost");
+    }
 
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+    const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
 
-  if (isReset) {
+    if (isReset) {
+      if (targetSessionEntry && params.sessionStore && params.sessionKey) {
+        delete targetSessionEntry.responseUsage;
+        params.sessionStore[params.sessionKey] = targetSessionEntry;
+        if (
+          !(await persistSessionEntry({
+            ...params,
+            sessionEntry: targetSessionEntry,
+            touchedFields: ["responseUsage"],
+          }))
+        ) {
+          return sessionEntryPersistenceConflictReply();
+        }
+      }
+      return sessionCommandReply("⚙️ Usage footer: reset to default.");
+    }
+
+    const replyChannel = params.command.channel;
+    const currentRaw = targetSessionEntry?.responseUsage;
+    const current = resolveEffectiveResponseUsage(
+      currentRaw,
+      params.cfg.messages?.responseUsage,
+      replyChannel,
+    );
+    const next =
+      requested ?? (current === "off" ? "tokens" : current === "tokens" ? "full" : "off");
+
     if (targetSessionEntry && params.sessionStore && params.sessionKey) {
-      delete targetSessionEntry.responseUsage;
+      targetSessionEntry.responseUsage = next;
       params.sessionStore[params.sessionKey] = targetSessionEntry;
       if (
         !(await persistSessionEntry({
@@ -391,115 +401,79 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
         return sessionEntryPersistenceConflictReply();
       }
     }
-    return sessionCommandReply("⚙️ Usage footer: reset to default.");
-  }
 
-  const replyChannel = params.command.channel;
-  const currentRaw = targetSessionEntry?.responseUsage;
-  const current = resolveEffectiveResponseUsage(
-    currentRaw,
-    params.cfg.messages?.responseUsage,
-    replyChannel,
-  );
-  const next = requested ?? (current === "off" ? "tokens" : current === "tokens" ? "full" : "off");
+    return sessionCommandReply(`⚙️ Usage footer: ${next}.`);
+  },
+);
 
-  if (targetSessionEntry && params.sessionStore && params.sessionKey) {
-    targetSessionEntry.responseUsage = next;
-    params.sessionStore[params.sessionKey] = targetSessionEntry;
-    if (
-      !(await persistSessionEntry({
-        ...params,
+export const handleFastCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/fast", match: (body) => matchCommandPrefix(body, "/fast"), silentUnauthorized: true },
+  async (params, rawArgs) => {
+    const rawMode = normalizeLowercaseStringOrEmpty(rawArgs);
+    if (!rawMode || rawMode === "status") {
+      const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+      const sessionAgentId = params.sessionKey
+        ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+        : params.agentId;
+      const state = resolveFastModeState({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        agentId: sessionAgentId,
         sessionEntry: targetSessionEntry,
-        touchedFields: ["responseUsage"],
-      }))
-    ) {
-      return sessionEntryPersistenceConflictReply();
+      });
+      return sessionCommandReply(
+        formatFastModeCurrentStatus({
+          mode: state.mode,
+          source: state.source,
+          fastAutoOnSeconds: state.fastAutoOnSeconds,
+          label: "⚙️ Current fast mode",
+        }),
+      );
     }
-  }
 
-  return sessionCommandReply(`⚙️ Usage footer: ${next}.`);
-};
-
-export const handleFastCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/fast" && !normalized.startsWith("/fast ")) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /fast from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const rawArgs = normalized === "/fast" ? "" : normalized.slice("/fast".length).trim();
-  const rawMode = normalizeLowercaseStringOrEmpty(rawArgs);
-  if (!rawMode || rawMode === "status") {
     const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-    const sessionAgentId = params.sessionKey
-      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
-      : params.agentId;
-    const state = resolveFastModeState({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      agentId: sessionAgentId,
-      sessionEntry: targetSessionEntry,
-    });
-    return sessionCommandReply(
-      formatFastModeCurrentStatus({
-        mode: state.mode,
-        source: state.source,
-        fastAutoOnSeconds: state.fastAutoOnSeconds,
-        label: "⚙️ Current fast mode",
-      }),
-    );
-  }
-
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-  const resetsToDefault = isSessionDefaultDirectiveValue(rawMode);
-  const nextMode = resetsToDefault ? undefined : normalizeFastMode(rawMode);
-  if (nextMode === undefined) {
-    if (resetsToDefault) {
-      if (targetSessionEntry && params.sessionStore && params.sessionKey) {
-        delete targetSessionEntry.fastMode;
-        if (
-          !(await persistSessionEntry({
-            ...params,
-            sessionEntry: targetSessionEntry,
-            touchedFields: ["fastMode"],
-          }))
-        ) {
-          return sessionEntryPersistenceConflictReply();
+    const resetsToDefault = isSessionDefaultDirectiveValue(rawMode);
+    const nextMode = resetsToDefault ? undefined : normalizeFastMode(rawMode);
+    if (nextMode === undefined) {
+      if (resetsToDefault) {
+        if (targetSessionEntry && params.sessionStore && params.sessionKey) {
+          delete targetSessionEntry.fastMode;
+          if (
+            !(await persistSessionEntry({
+              ...params,
+              sessionEntry: targetSessionEntry,
+              touchedFields: ["fastMode"],
+            }))
+          ) {
+            return sessionEntryPersistenceConflictReply();
+          }
         }
+        return sessionCommandReply("⚙️ Fast mode reset to default.");
       }
-      return sessionCommandReply("⚙️ Fast mode reset to default.");
+      return sessionCommandReply("⚙️ Usage: /fast status|auto|on|off|default");
     }
-    return sessionCommandReply("⚙️ Usage: /fast status|auto|on|off|default");
-  }
 
-  if (targetSessionEntry && params.sessionStore && params.sessionKey) {
-    targetSessionEntry.fastMode = nextMode;
-    if (
-      !(await persistSessionEntry({
-        ...params,
-        sessionEntry: targetSessionEntry,
-        touchedFields: ["fastMode"],
-      }))
-    ) {
-      return sessionEntryPersistenceConflictReply();
+    if (targetSessionEntry && params.sessionStore && params.sessionKey) {
+      targetSessionEntry.fastMode = nextMode;
+      if (
+        !(await persistSessionEntry({
+          ...params,
+          sessionEntry: targetSessionEntry,
+          touchedFields: ["fastMode"],
+        }))
+      ) {
+        return sessionEntryPersistenceConflictReply();
+      }
     }
-  }
 
-  return sessionCommandReply(
-    nextMode === "auto"
-      ? "⚙️ Fast mode set to auto."
-      : `⚙️ Fast mode ${nextMode ? "enabled" : "disabled"}.`,
-  );
-};
+    return sessionCommandReply(
+      nextMode === "auto"
+        ? "⚙️ Fast mode set to auto."
+        : `⚙️ Fast mode ${nextMode ? "enabled" : "disabled"}.`,
+    );
+  },
+);
 
 export const handleSessionCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {

--- a/src/auto-reply/reply/commands-setunset-standard.ts
+++ b/src/auto-reply/reply/commands-setunset-standard.ts
@@ -12,11 +12,7 @@ export function parseStandardSetUnsetSlashCommand<T>(params: {
   onError?: (message: string) => T;
 }): T | null {
   return parseSlashCommandWithSetUnset<T>({
-    raw: params.raw,
-    slash: params.slash,
-    invalidMessage: params.invalidMessage,
-    usageMessage: params.usageMessage,
-    onKnownAction: params.onKnownAction,
+    ...params,
     onSet: params.onSet ?? ((path, value) => ({ action: "set", path, value }) as T),
     onUnset: params.onUnset ?? ((path) => ({ action: "unset", path }) as T),
     onError: params.onError ?? ((message) => ({ action: "error", message }) as T),

--- a/src/auto-reply/reply/commands-setunset.ts
+++ b/src/auto-reply/reply/commands-setunset.ts
@@ -2,70 +2,6 @@
 import { parseSlashCommandOrNull } from "./commands-slash-parse.js";
 import { parseConfigValue } from "./config-value.js";
 
-/** Parsed set/unset action or a user-facing parse error. */
-type SetUnsetParseResult =
-  | { kind: "set"; path: string; value: unknown }
-  | { kind: "unset"; path: string }
-  | { kind: "error"; message: string };
-
-/** Parses `set path=value` or `unset path` command arguments. */
-function parseSetUnsetCommand(params: {
-  slash: string;
-  action: "set" | "unset";
-  args: string;
-}): SetUnsetParseResult {
-  const action = params.action;
-  const args = params.args.trim();
-  if (action === "unset") {
-    if (!args) {
-      return { kind: "error", message: `Usage: ${params.slash} unset path` };
-    }
-    return { kind: "unset", path: args };
-  }
-  if (!args) {
-    return { kind: "error", message: `Usage: ${params.slash} set path=value` };
-  }
-  const eqIndex = args.indexOf("=");
-  if (eqIndex <= 0) {
-    return { kind: "error", message: `Usage: ${params.slash} set path=value` };
-  }
-  const path = args.slice(0, eqIndex).trim();
-  const rawValue = args.slice(eqIndex + 1);
-  if (!path) {
-    return { kind: "error", message: `Usage: ${params.slash} set path=value` };
-  }
-  const parsed = parseConfigValue(rawValue);
-  if (parsed.error) {
-    return { kind: "error", message: parsed.error };
-  }
-  return { kind: "set", path, value: parsed.value };
-}
-
-/** Dispatches parsed set/unset action into caller-provided callbacks. */
-function parseSetUnsetCommandAction<T>(params: {
-  slash: string;
-  action: string;
-  args: string;
-  onSet: (path: string, value: unknown) => T;
-  onUnset: (path: string) => T;
-  onError: (message: string) => T;
-}): T | null {
-  if (params.action !== "set" && params.action !== "unset") {
-    return null;
-  }
-  const parsed = parseSetUnsetCommand({
-    slash: params.slash,
-    action: params.action,
-    args: params.args,
-  });
-  if (parsed.kind === "error") {
-    return params.onError(parsed.message);
-  }
-  return parsed.kind === "set"
-    ? params.onSet(parsed.path, parsed.value)
-    : params.onUnset(parsed.path);
-}
-
 /** Parses a slash command whose actions include set/unset plus custom actions. */
 export function parseSlashCommandWithSetUnset<T>(params: {
   raw: string;
@@ -86,17 +22,19 @@ export function parseSlashCommandWithSetUnset<T>(params: {
   if (!parsed.ok) {
     return params.onError(parsed.message);
   }
-  const { action, args } = parsed;
-  const setUnset = parseSetUnsetCommandAction<T>({
-    slash: params.slash,
-    action,
-    args,
-    onSet: params.onSet,
-    onUnset: params.onUnset,
-    onError: params.onError,
-  });
-  if (setUnset) {
-    return setUnset;
+  const { action } = parsed;
+  const args = parsed.args.trim();
+  if (action === "unset") {
+    return args ? params.onUnset(args) : params.onError(`Usage: ${params.slash} unset path`);
+  }
+  if (action === "set") {
+    const equalsIndex = args.indexOf("=");
+    const path = equalsIndex > 0 ? args.slice(0, equalsIndex).trim() : "";
+    if (!path) {
+      return params.onError(`Usage: ${params.slash} set path=value`);
+    }
+    const value = parseConfigValue(args.slice(equalsIndex + 1));
+    return value.error ? params.onError(value.error) : params.onSet(path, value.value);
   }
   const knownAction = params.onKnownAction(action, args);
   if (knownAction) {

--- a/src/auto-reply/reply/commands-steer.ts
+++ b/src/auto-reply/reply/commands-steer.ts
@@ -8,7 +8,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
-import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
   isEmbeddedAgentRunActive,
@@ -106,69 +106,58 @@ function continueWithSteerFallback(
   return { shouldContinue: true };
 }
 
-export const handleSteerCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
+export const handleSteerCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/steer", match: parseSteerMessage },
+  async (params, message) => {
+    if (!message) {
+      return commandReply(STEER_USAGE);
+    }
 
-  const message = parseSteerMessage(params.command.commandBodyNormalized);
-  if (message === null) {
-    return null;
-  }
+    const targetSessionKey = resolveSteerTargetSessionKey(params);
+    if (!targetSessionKey) {
+      return continueWithSteerFallback(
+        params,
+        message,
+        "steer: no current session; continuing with /steer payload as a normal prompt",
+      );
+    }
 
-  const unauthorized = rejectUnauthorizedCommand(params, "/steer");
-  if (unauthorized) {
-    return unauthorized;
-  }
+    const sessionId = resolveSteerSessionId({ commandParams: params, targetSessionKey });
+    if (!sessionId) {
+      return continueWithSteerFallback(
+        params,
+        message,
+        `steer: no active run for ${targetSessionKey}; continuing with /steer payload as a normal prompt`,
+      );
+    }
 
-  if (!message) {
-    return { shouldContinue: false, reply: { text: STEER_USAGE } };
-  }
+    const queueOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(sessionId, message, {
+      steeringMode: "all",
+      isInboundUserMessage: true,
+      debounceMs: 0,
+      ...(params.opts?.sourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode }
+        : {}),
+      taskSuggestionDeliveryMode: params.opts?.taskSuggestionDeliveryMode,
+    }).catch((err: unknown): CommandHandlerResult => {
+      return continueWithSteerFallback(
+        params,
+        message,
+        `steer: active session ${sessionId} threw while steering: ${formatSteerError(err)}; continuing with /steer payload as a normal prompt`,
+      );
+    });
+    if ("shouldContinue" in queueOutcome) {
+      return queueOutcome;
+    }
+    if (!queueOutcome.queued) {
+      const summary = formatEmbeddedAgentQueueFailureSummary(queueOutcome);
+      return continueWithSteerFallback(
+        params,
+        message,
+        `steer: active session ${sessionId} rejected steering injection: ${summary}; continuing with /steer payload as a normal prompt`,
+      );
+    }
 
-  const targetSessionKey = resolveSteerTargetSessionKey(params);
-  if (!targetSessionKey) {
-    return continueWithSteerFallback(
-      params,
-      message,
-      "steer: no current session; continuing with /steer payload as a normal prompt",
-    );
-  }
-
-  const sessionId = resolveSteerSessionId({ commandParams: params, targetSessionKey });
-  if (!sessionId) {
-    return continueWithSteerFallback(
-      params,
-      message,
-      `steer: no active run for ${targetSessionKey}; continuing with /steer payload as a normal prompt`,
-    );
-  }
-
-  const queueOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(sessionId, message, {
-    steeringMode: "all",
-    isInboundUserMessage: true,
-    debounceMs: 0,
-    ...(params.opts?.sourceReplyDeliveryMode
-      ? { sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode }
-      : {}),
-    taskSuggestionDeliveryMode: params.opts?.taskSuggestionDeliveryMode,
-  }).catch((err: unknown): CommandHandlerResult => {
-    return continueWithSteerFallback(
-      params,
-      message,
-      `steer: active session ${sessionId} threw while steering: ${formatSteerError(err)}; continuing with /steer payload as a normal prompt`,
-    );
-  });
-  if ("shouldContinue" in queueOutcome) {
-    return queueOutcome;
-  }
-  if (!queueOutcome.queued) {
-    const summary = formatEmbeddedAgentQueueFailureSummary(queueOutcome);
-    return continueWithSteerFallback(
-      params,
-      message,
-      `steer: active session ${sessionId} rejected steering injection: ${summary}; continuing with /steer payload as a normal prompt`,
-    );
-  }
-
-  return { shouldContinue: false, reply: { text: "steered current session." } };
-};
+    return commandReply("steered current session.");
+  },
+);

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -1,6 +1,6 @@
 // Implements subagent commands for spawn, focus, routing, and status.
-import { logVerbose } from "../../globals.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { defineAuthorizedTextCommand } from "./command-gates.js";
 import {
   resolveHandledPrefix,
   resolveRequesterSessionKey,
@@ -65,60 +65,51 @@ function loadControlRuntime() {
   return controlRuntimeLoader.load();
 }
 
-export const handleSubagentsCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-
-  const normalized = params.command.commandBodyNormalized;
-  const handledPrefix = resolveHandledPrefix(normalized);
-  if (!handledPrefix) {
-    return null;
-  }
-
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring ${handledPrefix} from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const rest = normalized.slice(handledPrefix.length).trim();
-  const restTokens = rest.split(/\s+/).filter(Boolean);
-  const action = resolveSubagentsAction({ handledPrefix, restTokens });
-  if (!action) {
-    return (await loadHelpAction()).handleSubagentsHelpAction();
-  }
-
-  const requesterKey = resolveRequesterSessionKey(params);
-  if (!requesterKey) {
-    return stopWithText("⚠️ Missing session key.");
-  }
-
-  const ctx: SubagentsCommandContext = {
-    params,
-    handledPrefix,
-    requesterKey,
-    runs: (await loadControlRuntime()).listControlledSubagentRuns(requesterKey),
-    restTokens,
-  };
-
-  switch (action) {
-    case "help":
+export const handleSubagentsCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/subagents",
+    match: (body) => resolveHandledPrefix(body) ?? null,
+    silentUnauthorized: true,
+  },
+  async (params, handledPrefix) => {
+    const normalized = params.command.commandBodyNormalized;
+    const rest = normalized.slice(handledPrefix.length).trim();
+    const restTokens = rest.split(/\s+/).filter(Boolean);
+    const action = resolveSubagentsAction({ handledPrefix, restTokens });
+    if (!action) {
       return (await loadHelpAction()).handleSubagentsHelpAction();
-    case "agents":
-      return (await loadAgentsAction()).handleSubagentsAgentsAction(ctx);
-    case "focus":
-      return await (await loadFocusAction()).handleSubagentsFocusAction(ctx);
-    case "unfocus":
-      return await (await loadUnfocusAction()).handleSubagentsUnfocusAction(ctx);
-    case "list":
-      return (await loadListAction()).handleSubagentsListAction(ctx);
-    case "info":
-      return (await loadInfoAction()).handleSubagentsInfoAction(ctx);
-    case "log":
-      return await (await loadLogAction()).handleSubagentsLogAction(ctx);
-    default:
-      return (await loadHelpAction()).handleSubagentsHelpAction();
-  }
-};
+    }
+
+    const requesterKey = resolveRequesterSessionKey(params);
+    if (!requesterKey) {
+      return stopWithText("⚠️ Missing session key.");
+    }
+
+    const ctx: SubagentsCommandContext = {
+      params,
+      handledPrefix,
+      requesterKey,
+      runs: (await loadControlRuntime()).listControlledSubagentRuns(requesterKey),
+      restTokens,
+    };
+
+    switch (action) {
+      case "help":
+        return (await loadHelpAction()).handleSubagentsHelpAction();
+      case "agents":
+        return (await loadAgentsAction()).handleSubagentsAgentsAction(ctx);
+      case "focus":
+        return await (await loadFocusAction()).handleSubagentsFocusAction(ctx);
+      case "unfocus":
+        return await (await loadUnfocusAction()).handleSubagentsUnfocusAction(ctx);
+      case "list":
+        return (await loadListAction()).handleSubagentsListAction(ctx);
+      case "info":
+        return (await loadInfoAction()).handleSubagentsInfoAction(ctx);
+      case "log":
+        return await (await loadLogAction()).handleSubagentsLogAction(ctx);
+      default:
+        return (await loadHelpAction()).handleSubagentsHelpAction();
+    }
+  },
+);

--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -1,6 +1,5 @@
 // Implements task-list commands that route through the current session agent.
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { logVerbose } from "../../globals.js";
 import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
@@ -14,6 +13,7 @@ import {
   formatTaskStatusTitle,
 } from "../../tasks/task-status.js";
 import type { ReplyPayload } from "../types.js";
+import { commandReply, defineAuthorizedTextCommand, matchCommandPrefix } from "./command-gates.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 
 const MAX_VISIBLE_TASKS = 5;
@@ -124,28 +124,14 @@ async function buildTasksReply(params: HandleCommandsParams): Promise<ReplyPaylo
   };
 }
 
-export const handleTasksCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/tasks" && !normalized.startsWith("/tasks ")) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /tasks from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  if (normalized !== "/tasks") {
-    return {
-      shouldContinue: false,
-      reply: { text: "Usage: /tasks" },
-    };
-  }
-  return {
-    shouldContinue: false,
-    reply: await buildTasksReply(params),
-  };
-};
+export const handleTasksCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/tasks",
+    match: (body) => matchCommandPrefix(body, "/tasks"),
+    silentUnauthorized: true,
+  },
+  async (params) =>
+    params.command.commandBodyNormalized === "/tasks"
+      ? { shouldContinue: false, reply: await buildTasksReply(params) }
+      : commandReply("Usage: /tasks"),
+);

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -6,7 +6,6 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { readLatestAssistantTextFromSessionTranscript } from "../../config/sessions.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
-import { logVerbose } from "../../globals.js";
 import {
   isUnscopedSessionKeySentinel,
   resolveAgentIdFromSessionKey,
@@ -39,6 +38,11 @@ import {
 import { isSilentReplyPayloadText } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import {
+  commandReply as stopWithText,
+  defineAuthorizedTextCommand,
+  matchCommandPrefix,
+} from "./command-gates.js";
+import {
   persistSessionEntry,
   sessionEntryPersistenceConflictReply,
 } from "./commands-session-store.js";
@@ -57,17 +61,11 @@ type TtsCommandParams = Parameters<CommandHandler>[0];
 
 function parseTtsCommand(normalized: string): ParsedTtsCommand | null {
   // Accept `/tts` and `/tts <action> [args]` as a single control surface.
-  if (normalized === "/tts") {
-    return { action: "status", args: "" };
-  }
-  if (!normalized.startsWith("/tts ")) {
+  const rest = matchCommandPrefix(normalized, "/tts");
+  if (rest === null) {
     return null;
   }
-  const rest = normalized.slice(5).trim();
-  if (!rest) {
-    return { action: "status", args: "" };
-  }
-  const [action, ...tail] = rest.split(/\s+/);
+  const [action, ...tail] = (rest || "status").split(/\s+/);
   return {
     action: normalizeOptionalLowercaseString(action) ?? "",
     args: normalizeOptionalString(tail.join(" ")) ?? "",
@@ -89,10 +87,6 @@ function formatAttemptDetails(attempts: TtsAttemptDetail[] | undefined): string 
       return `${attempt.provider}:${attempt.outcome}(${reason})${persona}${latency}`;
     })
     .join(", ");
-}
-
-function stopWithText(text: string): CommandHandlerResult {
-  return { shouldContinue: false, reply: { text } };
 }
 
 function ttsUsage(): ReplyPayload {
@@ -329,198 +323,183 @@ function handleTtsStatusAction(
   return stopWithText(lines.join("\n"));
 }
 
-export const handleTtsCommands: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const parsed = parseTtsCommand(params.command.commandBodyNormalized);
-  if (!parsed) {
-    return null;
-  }
-
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring TTS command from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const accountId = params.ctx?.AccountId;
-  const config = resolveTtsConfig(params.cfg, {
-    agentId: params.agentId,
-    channelId: params.command.channel,
-    accountId,
-  });
-  const prefsPath = resolveTtsPrefsPath(config);
-  const action = parsed.action;
-  const args = parsed.args;
-
-  if (action === "help") {
-    return { shouldContinue: false, reply: ttsUsage() };
-  }
-
-  if (action === "on") {
-    setTtsEnabled(prefsPath, true);
-    return stopWithText("🔊 TTS enabled.");
-  }
-
-  if (action === "off") {
-    setTtsEnabled(prefsPath, false);
-    return stopWithText("🔇 TTS disabled.");
-  }
-
-  if (action === "chat") {
-    return handleTtsChatAction(params, args);
-  }
-
-  if (action === "latest" || (action === "read" && args.toLowerCase() === "latest")) {
-    return handleTtsLatestAction(params, accountId, prefsPath);
-  }
-
-  if (action === "audio") {
-    if (!args) {
-      return stopWithText(
-        `🎤 Generate audio from text.\n\n` +
-          `Usage: /tts audio <text>\n` +
-          `Example: /tts audio Hello, this is a test!`,
-      );
-    }
-
-    const audio = await buildTtsAudioReply({
-      text: args,
-      cfg: params.cfg,
-      channel: params.command.channel,
-      accountId,
-      prefsPath,
+export const handleTtsCommands: CommandHandler = defineAuthorizedTextCommand(
+  { label: "TTS command", match: parseTtsCommand, silentUnauthorized: true },
+  async (params, parsed) => {
+    const accountId = params.ctx?.AccountId;
+    const config = resolveTtsConfig(params.cfg, {
       agentId: params.agentId,
+      channelId: params.command.channel,
+      accountId,
     });
-    if (!("error" in audio)) {
-      return { shouldContinue: false, reply: audio.reply };
-    }
-    return stopWithText(`❌ Error generating audio: ${audio.error}`);
-  }
+    const prefsPath = resolveTtsPrefsPath(config);
+    const action = parsed.action;
+    const args = parsed.args;
 
-  if (action === "provider") {
-    const currentProvider = getTtsProvider(config, prefsPath);
-    if (!args) {
-      const providers = listSpeechProviders(params.cfg);
-      return stopWithText(
-        `🎙️ TTS provider\n` +
-          `Primary: ${currentProvider}\n` +
-          providers
-            .map(
-              (provider) =>
-                `${provider.label}: ${
-                  provider.isConfigured({
-                    cfg: params.cfg,
-                    providerConfig: getResolvedSpeechProviderConfig(
-                      config,
-                      provider.id,
-                      params.cfg,
-                    ),
-                    timeoutMs: config.timeoutMs,
-                  })
-                    ? "✅"
-                    : "❌"
-                }`,
-            )
-            .join("\n") +
-          `\nUsage: /tts provider <id>`,
-      );
-    }
-
-    const requested = args.toLowerCase();
-    const resolvedProvider = getSpeechProvider(requested, params.cfg);
-    if (!resolvedProvider) {
+    if (action === "help") {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 
-    const nextProvider = canonicalizeSpeechProviderId(requested, params.cfg) ?? resolvedProvider.id;
-    setTtsProvider(prefsPath, nextProvider);
-    return stopWithText(`✅ TTS provider set to ${nextProvider}.`);
-  }
-
-  if (action === "persona") {
-    const personas = listTtsPersonas(config);
-    const activePersona = getTtsPersona(config, prefsPath);
-    if (!args) {
-      const lines = [
-        "🎭 TTS persona",
-        `Active: ${activePersona?.id ?? "none"}`,
-        personas.length > 0
-          ? personas
-              .map((persona) => {
-                const label = persona.label ? ` (${persona.label})` : "";
-                const provider = persona.provider ? ` provider=${persona.provider}` : "";
-                return `${persona.id}${label}${provider}`;
-              })
-              .join("\n")
-          : "No personas configured.",
-        "Usage: /tts persona <id> | off",
-      ];
-      return stopWithText(lines.join("\n"));
+    if (action === "on" || action === "off") {
+      const enabled = action === "on";
+      setTtsEnabled(prefsPath, enabled);
+      return stopWithText(enabled ? "🔊 TTS enabled." : "🔇 TTS disabled.");
     }
 
-    const requested = args.toLowerCase();
-    if (requested === "off" || requested === "none" || requested === "default") {
-      setTtsPersona(prefsPath, null);
-      return stopWithText("✅ TTS persona disabled.");
+    if (action === "chat") {
+      return handleTtsChatAction(params, args);
     }
-    const persona = personas.find((entry) => entry.id === requested);
-    if (!persona) {
+
+    if (action === "latest" || (action === "read" && args.toLowerCase() === "latest")) {
+      return handleTtsLatestAction(params, accountId, prefsPath);
+    }
+
+    if (action === "audio") {
+      if (!args) {
+        return stopWithText(
+          `🎤 Generate audio from text.\n\n` +
+            `Usage: /tts audio <text>\n` +
+            `Example: /tts audio Hello, this is a test!`,
+        );
+      }
+
+      const audio = await buildTtsAudioReply({
+        text: args,
+        cfg: params.cfg,
+        channel: params.command.channel,
+        accountId,
+        prefsPath,
+        agentId: params.agentId,
+      });
+      if (!("error" in audio)) {
+        return { shouldContinue: false, reply: audio.reply };
+      }
+      return stopWithText(`❌ Error generating audio: ${audio.error}`);
+    }
+
+    if (action === "provider") {
+      const currentProvider = getTtsProvider(config, prefsPath);
+      if (!args) {
+        const providers = listSpeechProviders(params.cfg);
+        return stopWithText(
+          `🎙️ TTS provider\n` +
+            `Primary: ${currentProvider}\n` +
+            providers
+              .map(
+                (provider) =>
+                  `${provider.label}: ${
+                    provider.isConfigured({
+                      cfg: params.cfg,
+                      providerConfig: getResolvedSpeechProviderConfig(
+                        config,
+                        provider.id,
+                        params.cfg,
+                      ),
+                      timeoutMs: config.timeoutMs,
+                    })
+                      ? "✅"
+                      : "❌"
+                  }`,
+              )
+              .join("\n") +
+            `\nUsage: /tts provider <id>`,
+        );
+      }
+
+      const requested = args.toLowerCase();
+      const resolvedProvider = getSpeechProvider(requested, params.cfg);
+      if (!resolvedProvider) {
+        return { shouldContinue: false, reply: ttsUsage() };
+      }
+
+      const nextProvider =
+        canonicalizeSpeechProviderId(requested, params.cfg) ?? resolvedProvider.id;
+      setTtsProvider(prefsPath, nextProvider);
+      return stopWithText(`✅ TTS provider set to ${nextProvider}.`);
+    }
+
+    if (action === "persona") {
+      const personas = listTtsPersonas(config);
+      const activePersona = getTtsPersona(config, prefsPath);
+      if (!args) {
+        const lines = [
+          "🎭 TTS persona",
+          `Active: ${activePersona?.id ?? "none"}`,
+          personas.length > 0
+            ? personas
+                .map((persona) => {
+                  const label = persona.label ? ` (${persona.label})` : "";
+                  const provider = persona.provider ? ` provider=${persona.provider}` : "";
+                  return `${persona.id}${label}${provider}`;
+                })
+                .join("\n")
+            : "No personas configured.",
+          "Usage: /tts persona <id> | off",
+        ];
+        return stopWithText(lines.join("\n"));
+      }
+
+      const requested = args.toLowerCase();
+      if (requested === "off" || requested === "none" || requested === "default") {
+        setTtsPersona(prefsPath, null);
+        return stopWithText("✅ TTS persona disabled.");
+      }
+      const persona = personas.find((entry) => entry.id === requested);
+      if (!persona) {
+        return stopWithText(
+          `❌ Unknown TTS persona: ${requested || args}.\n` +
+            `Use /tts persona to list configured personas.`,
+        );
+      }
+      setTtsPersona(prefsPath, persona.id);
+      return stopWithText(`✅ TTS persona set to ${persona.id}.`);
+    }
+
+    if (action === "limit") {
+      if (!args) {
+        const currentLimit = getTtsMaxLength(prefsPath);
+        return stopWithText(
+          `📏 TTS limit: ${currentLimit} characters.\n\n` +
+            `Text longer than this triggers summary (if enabled).\n` +
+            `Range: 100-4096 chars (Telegram max).\n\n` +
+            `To change: /tts limit <number>\n` +
+            `Example: /tts limit 2000`,
+        );
+      }
+      const next = /^\d+$/.test(args) ? Number(args) : Number.NaN;
+      if (!Number.isSafeInteger(next) || next < 100 || next > 4096) {
+        return stopWithText("❌ Limit must be between 100 and 4096 characters.");
+      }
+      setTtsMaxLength(prefsPath, next);
+      return stopWithText(`✅ TTS limit set to ${next} characters.`);
+    }
+
+    if (action === "summary") {
+      if (!args) {
+        const enabled = isSummarizationEnabled(prefsPath);
+        const maxLen = getTtsMaxLength(prefsPath);
+        return stopWithText(
+          `📝 TTS auto-summary: ${enabled ? "on" : "off"}.\n\n` +
+            `When text exceeds ${maxLen} chars:\n` +
+            `• ON: summarizes text, then generates audio\n` +
+            `• OFF: truncates text, then generates audio\n\n` +
+            `To change: /tts summary on | off`,
+        );
+      }
+      const requested = args.toLowerCase();
+      if (requested !== "on" && requested !== "off") {
+        return { shouldContinue: false, reply: ttsUsage() };
+      }
+      setSummarizationEnabled(prefsPath, requested === "on");
       return stopWithText(
-        `❌ Unknown TTS persona: ${requested || args}.\n` +
-          `Use /tts persona to list configured personas.`,
+        requested === "on" ? "✅ TTS auto-summary enabled." : "❌ TTS auto-summary disabled.",
       );
     }
-    setTtsPersona(prefsPath, persona.id);
-    return stopWithText(`✅ TTS persona set to ${persona.id}.`);
-  }
 
-  if (action === "limit") {
-    if (!args) {
-      const currentLimit = getTtsMaxLength(prefsPath);
-      return stopWithText(
-        `📏 TTS limit: ${currentLimit} characters.\n\n` +
-          `Text longer than this triggers summary (if enabled).\n` +
-          `Range: 100-4096 chars (Telegram max).\n\n` +
-          `To change: /tts limit <number>\n` +
-          `Example: /tts limit 2000`,
-      );
+    if (action === "status") {
+      return handleTtsStatusAction(params, config, prefsPath);
     }
-    const next = /^\d+$/.test(args) ? Number(args) : Number.NaN;
-    if (!Number.isSafeInteger(next) || next < 100 || next > 4096) {
-      return stopWithText("❌ Limit must be between 100 and 4096 characters.");
-    }
-    setTtsMaxLength(prefsPath, next);
-    return stopWithText(`✅ TTS limit set to ${next} characters.`);
-  }
 
-  if (action === "summary") {
-    if (!args) {
-      const enabled = isSummarizationEnabled(prefsPath);
-      const maxLen = getTtsMaxLength(prefsPath);
-      return stopWithText(
-        `📝 TTS auto-summary: ${enabled ? "on" : "off"}.\n\n` +
-          `When text exceeds ${maxLen} chars:\n` +
-          `• ON: summarizes text, then generates audio\n` +
-          `• OFF: truncates text, then generates audio\n\n` +
-          `To change: /tts summary on | off`,
-      );
-    }
-    const requested = args.toLowerCase();
-    if (requested !== "on" && requested !== "off") {
-      return { shouldContinue: false, reply: ttsUsage() };
-    }
-    setSummarizationEnabled(prefsPath, requested === "on");
-    return stopWithText(
-      requested === "on" ? "✅ TTS auto-summary enabled." : "❌ TTS auto-summary disabled.",
-    );
-  }
-
-  if (action === "status") {
-    return handleTtsStatusAction(params, config, prefsPath);
-  }
-
-  return { shouldContinue: false, reply: ttsUsage() };
-};
+    return { shouldContinue: false, reply: ttsUsage() };
+  },
+);

--- a/src/auto-reply/reply/commands-whoami.ts
+++ b/src/auto-reply/reply/commands-whoami.ts
@@ -1,40 +1,35 @@
 /** Handles /whoami identity reporting for authorized command senders. */
-import { logVerbose } from "../../globals.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
 /** Command handler for the /whoami identity diagnostic. */
-export const handleWhoamiCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  if (params.command.commandBodyNormalized !== "/whoami") {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /whoami from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-  const senderId = params.ctx.SenderId ?? "";
-  const senderUsername = params.ctx.SenderUsername ?? "";
-  const lines = ["🧭 Identity", `Channel: ${params.command.channel}`];
-  if (senderId) {
-    lines.push(`User id: ${senderId}`);
-  }
-  if (senderUsername) {
-    const handle = senderUsername.startsWith("@") ? senderUsername : `@${senderUsername}`;
-    lines.push(`Username: ${handle}`);
-  }
-  if (params.ctx.ChatType === "group" && params.ctx.From) {
-    lines.push(`Chat: ${params.ctx.From}`);
-  }
-  if (params.ctx.MessageThreadId != null) {
-    lines.push(`Thread: ${params.ctx.MessageThreadId}`);
-  }
-  const allowFromSender = params.command.senderId ?? "";
-  if (allowFromSender) {
-    lines.push(`AllowFrom: ${allowFromSender}`);
-  }
-  return { shouldContinue: false, reply: { text: lines.join("\n") } };
-};
+export const handleWhoamiCommand: CommandHandler = defineAuthorizedTextCommand(
+  {
+    label: "/whoami",
+    match: (body) => (body === "/whoami" ? true : null),
+    silentUnauthorized: true,
+  },
+  (params) => {
+    const senderId = params.ctx.SenderId ?? "";
+    const senderUsername = params.ctx.SenderUsername ?? "";
+    const lines = ["🧭 Identity", `Channel: ${params.command.channel}`];
+    if (senderId) {
+      lines.push(`User id: ${senderId}`);
+    }
+    if (senderUsername) {
+      const handle = senderUsername.startsWith("@") ? senderUsername : `@${senderUsername}`;
+      lines.push(`Username: ${handle}`);
+    }
+    if (params.ctx.ChatType === "group" && params.ctx.From) {
+      lines.push(`Chat: ${params.ctx.From}`);
+    }
+    if (params.ctx.MessageThreadId != null) {
+      lines.push(`Thread: ${params.ctx.MessageThreadId}`);
+    }
+    const allowFromSender = params.command.senderId ?? "";
+    if (allowFromSender) {
+      lines.push(`AllowFrom: ${allowFromSender}`);
+    }
+    return commandReply(lines.join("\n"));
+  },
+);

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -12,14 +12,8 @@ import {
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
-import {
-  adoptPersistedSessionSnapshot,
-  sessionModelOverrideChangesApplied,
-  sessionSnapshotChangesApplied,
-} from "../../config/sessions/session-snapshot-merge.js";
 import { triggerSessionPatchHook } from "../../gateway/session-patch-hooks.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import {
   applyModelOverrideToSessionEntry,
   isModelSelectionLocked,
@@ -41,6 +35,7 @@ import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handl
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
 import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
 import {
+  applySessionDirectiveFields,
   canPersistSessionDirectiveDefaults,
   formatDirectiveAck,
   formatElevatedRuntimeHint,
@@ -49,13 +44,37 @@ import {
   formatInternalVerboseCurrentReplyOnlyText,
   formatInternalVerbosePersistenceDeniedText,
   enqueueModeSwitchEvents,
+  persistSessionDirectiveSnapshot,
   resolveDirectiveTouchedSessionFields,
   withOptions,
 } from "./directive-handling.shared.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel } from "./directives.js";
+import type { ReasoningLevel, ThinkLevel } from "./directives.js";
 import { refreshQueuedFollowupSession } from "./queue.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
-import { persistReplySessionEntry } from "./session-entry-persistence.js";
+
+const DIRECTIVE_ACK_MESSAGES = {
+  verbose: {
+    off: "Verbose logging disabled.",
+    on: "Verbose logging enabled.",
+    full: "Verbose logging set to full.",
+  },
+  trace: {
+    off: "Trace disabled.",
+    on: "Trace enabled. Warning: trace output may contain sensitive information.",
+    raw: "Trace set to raw. Warning: trace output may contain sensitive information.",
+  },
+  reasoning: {
+    off: "Reasoning visibility disabled.",
+    on: "Reasoning visibility enabled.",
+    stream: "Reasoning stream enabled.",
+  },
+  elevated: {
+    off: "Elevated mode disabled.",
+    on: "Elevated mode set to ask (approvals may still apply).",
+    ask: "Elevated mode set to ask (approvals may still apply).",
+    full: "Elevated mode set to full (auto-approve).",
+  },
+} as const;
 
 /** Handles inline directives that can be acknowledged without a model turn. */
 export async function handleDirectiveOnly(
@@ -107,14 +126,7 @@ export async function handleDirectiveOnly(
     sessionKey: runtimePolicySessionKey,
   }).sandboxed;
   const shouldHintDirectRuntime = directives.hasElevatedDirective && !runtimeIsSandboxed;
-  const allowInternalExecPersistence = canPersistSessionDirectiveDefaults({
-    messageProvider: params.messageProvider,
-    surface: params.surface,
-    gatewayClientScopes: params.gatewayClientScopes,
-    commandAuthorized: params.commandAuthorized,
-    senderIsOwner: params.senderIsOwner,
-  });
-  const allowInternalVerbosePersistence = canPersistSessionDirectiveDefaults({
+  const allowPrivilegedPersistence = canPersistSessionDirectiveDefaults({
     messageProvider: params.messageProvider,
     surface: params.surface,
     gatewayClientScopes: params.gatewayClientScopes,
@@ -232,25 +244,17 @@ export async function handleDirectiveOnly(
     };
   }
   if (directives.hasVerboseDirective && !directives.verboseLevel) {
-    if (!directives.rawVerboseLevel) {
-      const level = currentVerboseLevel ?? "off";
-      return {
-        text: withOptions(`Current verbose level: ${level}.`, "on, full, off"),
-      };
-    }
     return {
-      text: `Unrecognized verbose level "${directives.rawVerboseLevel}". Valid levels: off, on, full.`,
+      text: directives.rawVerboseLevel
+        ? `Unrecognized verbose level "${directives.rawVerboseLevel}". Valid levels: off, on, full.`
+        : withOptions(`Current verbose level: ${currentVerboseLevel ?? "off"}.`, "on, full, off"),
     };
   }
   if (directives.hasTraceDirective && !directives.traceLevel) {
-    if (!directives.rawTraceLevel) {
-      const level = (sessionEntry.traceLevel as "on" | "off" | "raw" | undefined) ?? "off";
-      return {
-        text: withOptions(`Current trace level: ${level}.`, "on, off, raw"),
-      };
-    }
     return {
-      text: `Unrecognized trace level "${directives.rawTraceLevel}". Valid levels: off, on, raw.`,
+      text: directives.rawTraceLevel
+        ? `Unrecognized trace level "${directives.rawTraceLevel}". Valid levels: off, on, raw.`
+        : withOptions(`Current trace level: ${sessionEntry.traceLevel ?? "off"}.`, "on, off, raw"),
     };
   }
   if (
@@ -258,25 +262,22 @@ export async function handleDirectiveOnly(
     directives.fastMode === undefined &&
     !directives.clearFastMode
   ) {
-    if (
-      !directives.rawFastMode ||
-      normalizeLowercaseStringOrEmpty(directives.rawFastMode) === "status"
-    ) {
+    const isFastStatus = normalizeLowercaseStringOrEmpty(directives.rawFastMode) === "status";
+    if (!directives.rawFastMode || isFastStatus) {
       const statusText = formatFastModeCurrentStatus({
         mode: effectiveFastMode,
         source: effectiveFastModeSource,
         fastAutoOnSeconds: fastModeState.fastAutoOnSeconds,
       });
-      if (normalizeLowercaseStringOrEmpty(directives.rawFastMode) === "status") {
-        return { text: statusText };
-      }
       return {
-        text: withOptions(
-          statusText,
-          formatFastModeCommandOptions({
-            fastAutoOnSeconds: fastModeState.fastAutoOnSeconds,
-          }),
-        ),
+        text: isFastStatus
+          ? statusText
+          : withOptions(
+              statusText,
+              formatFastModeCommandOptions({
+                fastAutoOnSeconds: fastModeState.fastAutoOnSeconds,
+              }),
+            ),
       };
     }
     return {
@@ -284,14 +285,13 @@ export async function handleDirectiveOnly(
     };
   }
   if (directives.hasReasoningDirective && !directives.reasoningLevel) {
-    if (!directives.rawReasoningLevel) {
-      const level = currentReasoningLevel ?? "off";
-      return {
-        text: withOptions(`Current reasoning level: ${level}.`, "on, off, stream"),
-      };
-    }
     return {
-      text: `Unrecognized reasoning level "${directives.rawReasoningLevel}". Valid levels: on, off, stream.`,
+      text: directives.rawReasoningLevel
+        ? `Unrecognized reasoning level "${directives.rawReasoningLevel}". Valid levels: on, off, stream.`
+        : withOptions(
+            `Current reasoning level: ${currentReasoningLevel ?? "off"}.`,
+            "on, off, stream",
+          ),
     };
   }
   if (directives.hasElevatedDirective && !directives.elevatedLevel) {
@@ -329,25 +329,17 @@ export async function handleDirectiveOnly(
     };
   }
   if (directives.hasExecDirective) {
-    if (directives.invalidExecHost) {
-      return {
-        text: `Unrecognized exec host "${directives.rawExecHost ?? ""}". Valid hosts: auto, sandbox, gateway, node.`,
-      };
-    }
-    if (directives.invalidExecSecurity) {
-      return {
-        text: `Unrecognized exec security "${directives.rawExecSecurity ?? ""}". Valid: deny, allowlist, full.`,
-      };
-    }
-    if (directives.invalidExecAsk) {
-      return {
-        text: `Unrecognized exec ask "${directives.rawExecAsk ?? ""}". Valid: off, on-miss, always.`,
-      };
-    }
-    if (directives.invalidExecNode) {
-      return {
-        text: "Exec node requires a value.",
-      };
+    const invalidExecMessage = directives.invalidExecHost
+      ? `Unrecognized exec host "${directives.rawExecHost ?? ""}". Valid hosts: auto, sandbox, gateway, node.`
+      : directives.invalidExecSecurity
+        ? `Unrecognized exec security "${directives.rawExecSecurity ?? ""}". Valid: deny, allowlist, full.`
+        : directives.invalidExecAsk
+          ? `Unrecognized exec ask "${directives.rawExecAsk ?? ""}". Valid: off, on-miss, always.`
+          : directives.invalidExecNode
+            ? "Exec node requires a value."
+            : undefined;
+    if (invalidExecMessage) {
+      return { text: invalidExecMessage };
     }
     const unexpectedExecArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
     if (unexpectedExecArguments) {
@@ -426,13 +418,9 @@ export async function handleDirectiveOnly(
   const shouldRemapUnsupportedThinkLevel =
     Boolean(remappedUnsupportedThinkLevel) && remappedUnsupportedThinkLevel !== nextThinkLevel;
 
-  const prevElevatedLevel =
-    currentElevatedLevel ??
-    (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
-    (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
   const prevReasoningLevel =
     currentReasoningLevel ?? (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
-  let elevatedChanged =
+  const elevatedChanged =
     directives.hasElevatedDirective &&
     directives.elevatedLevel !== undefined &&
     elevatedEnabled &&
@@ -440,97 +428,37 @@ export async function handleDirectiveOnly(
   let modelSelectionUpdated = false;
   let modelSelectionApplied = true;
   let sessionChangesApplied = true;
-  let appliedSessionEntry = sessionEntry;
+  const appliedSessionEntry = sessionEntry;
   const touchedSessionFields = resolveDirectiveTouchedSessionFields({
     directives,
-    allowInternalExecPersistence,
-    allowInternalVerbosePersistence,
+    allowPrivilegedPersistence,
   });
   if (shouldRemapUnsupportedThinkLevel && !touchedSessionFields.includes("thinkingLevel")) {
     touchedSessionFields.push("thinkingLevel");
   }
-  const shouldPersistSessionEntry =
-    (directives.hasThinkDirective &&
-      (Boolean(directives.thinkLevel) || directives.clearThinkLevel)) ||
-    (directives.hasFastDirective &&
-      (directives.fastMode !== undefined || directives.clearFastMode)) ||
-    (directives.hasVerboseDirective &&
-      Boolean(directives.verboseLevel) &&
-      allowInternalVerbosePersistence) ||
-    (directives.hasTraceDirective && Boolean(directives.traceLevel)) ||
-    (directives.hasReasoningDirective && Boolean(directives.reasoningLevel)) ||
-    (directives.hasElevatedDirective && Boolean(directives.elevatedLevel)) ||
-    (directives.hasExecDirective && directives.hasExecOptions && allowInternalExecPersistence) ||
-    Boolean(modelSelection) ||
-    directives.hasQueueDirective ||
-    shouldRemapUnsupportedThinkLevel;
+  // Validated, authorized directives have already named every field they can mutate.
+  const shouldPersistSessionEntry = touchedSessionFields.length > 0;
   const fastModeChanged =
     (directives.hasFastDirective &&
       directives.fastMode !== undefined &&
       directives.fastMode !== currentFastMode) ||
     (directives.clearFastMode && currentFastMode !== fastModeState.mode);
-  let reasoningChanged =
-    directives.hasReasoningDirective && directives.reasoningLevel !== undefined;
+  const reasoningChanged =
+    directives.hasReasoningDirective &&
+    directives.reasoningLevel !== undefined &&
+    directives.reasoningLevel !== prevReasoningLevel;
   if (shouldPersistSessionEntry) {
     const initialSessionEntry = { ...sessionEntry };
-    if (directives.clearThinkLevel) {
-      delete sessionEntry.thinkingLevel;
-    } else if (
-      directives.hasThinkDirective &&
-      directives.thinkLevel &&
-      resolvedDirectiveThinkLevel
-    ) {
-      sessionEntry.thinkingLevel = resolvedDirectiveThinkLevel;
-    }
-    if (directives.clearFastMode) {
-      delete sessionEntry.fastMode;
-    } else if (directives.hasFastDirective && directives.fastMode !== undefined) {
-      sessionEntry.fastMode = directives.fastMode;
-    }
+    applySessionDirectiveFields({
+      directives,
+      sessionEntry,
+      allowPrivilegedPersistence,
+      allowTracePersistence: true,
+      allowElevatedPersistence: elevatedEnabled && elevatedAllowed,
+      persistDirectiveOnlyFields: true,
+    });
     if (shouldRemapUnsupportedThinkLevel && remappedUnsupportedThinkLevel) {
       sessionEntry.thinkingLevel = remappedUnsupportedThinkLevel;
-    }
-    if (
-      directives.hasVerboseDirective &&
-      directives.verboseLevel &&
-      allowInternalVerbosePersistence
-    ) {
-      applyVerboseOverride(sessionEntry, directives.verboseLevel);
-    }
-    if (directives.hasTraceDirective && directives.traceLevel) {
-      applyTraceOverride(sessionEntry, directives.traceLevel);
-    }
-    if (directives.hasReasoningDirective && directives.reasoningLevel) {
-      if (directives.reasoningLevel === "off") {
-        // Persist explicit off so it overrides model-capability defaults.
-        sessionEntry.reasoningLevel = "off";
-      } else {
-        sessionEntry.reasoningLevel = directives.reasoningLevel;
-      }
-      reasoningChanged =
-        directives.reasoningLevel !== prevReasoningLevel && directives.reasoningLevel !== undefined;
-    }
-    if (directives.hasElevatedDirective && directives.elevatedLevel) {
-      // Unlike other toggles, elevated defaults can be "on".
-      // Persist "off" explicitly so `/elevated off` actually overrides defaults.
-      sessionEntry.elevatedLevel = directives.elevatedLevel;
-      elevatedChanged =
-        elevatedChanged ||
-        (directives.elevatedLevel !== prevElevatedLevel && directives.elevatedLevel !== undefined);
-    }
-    if (directives.hasExecDirective && directives.hasExecOptions && allowInternalExecPersistence) {
-      if (directives.execHost) {
-        sessionEntry.execHost = directives.execHost;
-      }
-      if (directives.execSecurity) {
-        sessionEntry.execSecurity = directives.execSecurity;
-      }
-      if (directives.execAsk) {
-        sessionEntry.execAsk = directives.execAsk;
-      }
-      if (directives.execNode) {
-        sessionEntry.execNode = directives.execNode;
-      }
     }
     if (modelSelection) {
       const applied = applyModelOverrideToSessionEntry({
@@ -542,68 +470,22 @@ export async function handleDirectiveOnly(
       const appliedRuntime = applyModelRuntimeDirective(sessionEntry, modelRuntimeResolution);
       modelSelectionUpdated = applied.updated || appliedRuntime.updated;
     }
-    if (directives.hasQueueDirective && directives.queueReset) {
-      delete sessionEntry.queueMode;
-      delete sessionEntry.queueDebounceMs;
-      delete sessionEntry.queueCap;
-      delete sessionEntry.queueDrop;
-    } else if (directives.hasQueueDirective) {
-      if (directives.queueMode) {
-        sessionEntry.queueMode = directives.queueMode;
-      }
-      if (typeof directives.debounceMs === "number") {
-        sessionEntry.queueDebounceMs = directives.debounceMs;
-      }
-      if (typeof directives.cap === "number") {
-        sessionEntry.queueCap = directives.cap;
-      }
-      if (directives.dropPolicy) {
-        sessionEntry.queueDrop = directives.dropPolicy;
-      }
-    }
     sessionEntry.updatedAt = Date.now();
     sessionStore[sessionKey] = sessionEntry;
     if (storePath) {
-      const persistence = await persistReplySessionEntry({
+      const persistence = await persistSessionDirectiveSnapshot({
         storePath,
         sessionKey,
         initialEntry: initialSessionEntry,
-        entry: sessionEntry,
+        sessionEntry,
+        sessionStore,
+        hasModelSelection: Boolean(modelSelection),
         reassertLiveModelSwitchPending:
           modelSelectionUpdated && sessionEntry.liveModelSwitchPending === true,
         touchedFields: touchedSessionFields,
       });
-      if (persistence.status === "current") {
-        const persistedEntry = persistence.entry;
-        sessionStore[sessionKey] = persistedEntry;
-        sessionChangesApplied = sessionSnapshotChangesApplied({
-          initial: initialSessionEntry,
-          next: sessionEntry,
-          current: persistedEntry,
-          touchedFields: touchedSessionFields,
-        });
-        if (modelSelection) {
-          modelSelectionApplied =
-            sessionChangesApplied &&
-            sessionModelOverrideChangesApplied({
-              initial: initialSessionEntry,
-              next: sessionEntry,
-              current: persistedEntry,
-              reassertLiveModelSwitchPending:
-                modelSelectionUpdated && sessionEntry.liveModelSwitchPending === true,
-            });
-        }
-        adoptPersistedSessionSnapshot(sessionEntry, persistedEntry);
-        appliedSessionEntry = sessionEntry;
-      } else {
-        if (persistence.entry) {
-          sessionStore[sessionKey] = persistence.entry;
-        }
-        sessionChangesApplied = false;
-        if (modelSelection) {
-          modelSelectionApplied = false;
-        }
-      }
+      sessionChangesApplied = persistence.sessionChangesApplied;
+      modelSelectionApplied = persistence.modelSelectionApplied;
     }
     if (modelSelection && !modelSelectionApplied) {
       sessionChangesApplied = false;
@@ -712,76 +594,40 @@ export async function handleDirectiveOnly(
     );
   }
   if (directives.hasVerboseDirective && directives.verboseLevel) {
-    parts.push(
-      !allowInternalVerbosePersistence
-        ? formatDirectiveAck(formatInternalVerboseCurrentReplyOnlyText())
-        : directives.verboseLevel === "off"
-          ? formatDirectiveAck("Verbose logging disabled.")
-          : directives.verboseLevel === "full"
-            ? formatDirectiveAck("Verbose logging set to full.")
-            : formatDirectiveAck("Verbose logging enabled."),
-    );
+    const message = allowPrivilegedPersistence
+      ? DIRECTIVE_ACK_MESSAGES.verbose[directives.verboseLevel]
+      : formatInternalVerboseCurrentReplyOnlyText();
+    parts.push(formatDirectiveAck(message));
   }
   if (directives.hasTraceDirective && directives.traceLevel) {
-    parts.push(
-      directives.traceLevel === "off"
-        ? formatDirectiveAck("Trace disabled.")
-        : directives.traceLevel === "raw"
-          ? formatDirectiveAck(
-              "Trace set to raw. Warning: trace output may contain sensitive information.",
-            )
-          : formatDirectiveAck(
-              "Trace enabled. Warning: trace output may contain sensitive information.",
-            ),
-    );
+    parts.push(formatDirectiveAck(DIRECTIVE_ACK_MESSAGES.trace[directives.traceLevel]));
   }
-  if (
-    directives.hasVerboseDirective &&
-    directives.verboseLevel &&
-    !allowInternalVerbosePersistence
-  ) {
+  if (directives.hasVerboseDirective && directives.verboseLevel && !allowPrivilegedPersistence) {
     parts.push(formatDirectiveAck(formatInternalVerbosePersistenceDeniedText()));
   }
   if (directives.hasReasoningDirective && directives.reasoningLevel) {
-    parts.push(
-      directives.reasoningLevel === "off"
-        ? formatDirectiveAck("Reasoning visibility disabled.")
-        : directives.reasoningLevel === "stream"
-          ? formatDirectiveAck("Reasoning stream enabled.")
-          : formatDirectiveAck("Reasoning visibility enabled."),
-    );
+    parts.push(formatDirectiveAck(DIRECTIVE_ACK_MESSAGES.reasoning[directives.reasoningLevel]));
   }
   if (directives.hasElevatedDirective && directives.elevatedLevel) {
-    parts.push(
-      directives.elevatedLevel === "off"
-        ? formatDirectiveAck("Elevated mode disabled.")
-        : directives.elevatedLevel === "full"
-          ? formatDirectiveAck("Elevated mode set to full (auto-approve).")
-          : formatDirectiveAck("Elevated mode set to ask (approvals may still apply)."),
-    );
+    parts.push(formatDirectiveAck(DIRECTIVE_ACK_MESSAGES.elevated[directives.elevatedLevel]));
     if (shouldHintDirectRuntime) {
       parts.push(formatElevatedRuntimeHint());
     }
   }
-  if (directives.hasExecDirective && directives.hasExecOptions && allowInternalExecPersistence) {
-    const execParts: string[] = [];
-    if (directives.execHost) {
-      execParts.push(`host=${directives.execHost}`);
-    }
-    if (directives.execSecurity) {
-      execParts.push(`security=${directives.execSecurity}`);
-    }
-    if (directives.execAsk) {
-      execParts.push(`ask=${directives.execAsk}`);
-    }
-    if (directives.execNode) {
-      execParts.push(`node=${directives.execNode}`);
-    }
+  if (directives.hasExecDirective && directives.hasExecOptions && allowPrivilegedPersistence) {
+    const execParts = Object.entries({
+      host: directives.execHost,
+      security: directives.execSecurity,
+      ask: directives.execAsk,
+      node: directives.execNode,
+    })
+      .filter(([, value]) => Boolean(value))
+      .map(([key, value]) => `${key}=${value}`);
     if (execParts.length > 0) {
       parts.push(formatDirectiveAck(`Exec defaults set (${execParts.join(", ")}).`));
     }
   }
-  if (directives.hasExecDirective && directives.hasExecOptions && !allowInternalExecPersistence) {
+  if (directives.hasExecDirective && directives.hasExecOptions && !allowPrivilegedPersistence) {
     parts.push(formatDirectiveAck(formatInternalExecPersistenceDeniedText()));
   }
   if (modelSelection && modelSelectionApplied) {
@@ -845,4 +691,3 @@ export async function handleDirectiveOnly(
   }
   return { text: ack || "OK." };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -120,186 +120,114 @@ export function parseInlineDirectives(
   },
 ): InlineDirectives {
   const nativeCommand = options?.nativeCommand;
+  let cleaned = body;
+  let hasAnyDirective = false;
   const parseScopedDirective = <T extends { cleaned: string; hasDirective: boolean }>(
-    currentBody: string,
     commandName: NativeReplyDirectiveCommand,
     extract: (value: string) => T,
-  ): T =>
-    !nativeCommand || nativeCommand === commandName
-      ? extract(currentBody)
-      : ({ cleaned: currentBody, hasDirective: false } as T);
-  const {
-    cleaned: thinkCleaned,
-    thinkLevel,
-    rawLevel: rawThinkLevel,
-    hasDirective: hasThinkDirective,
-  } = parseScopedDirective(body, "think", (value) =>
+    enabled = true,
+  ): T => {
+    const parsed =
+      enabled && (!nativeCommand || nativeCommand === commandName)
+        ? extract(cleaned)
+        : ({ cleaned, hasDirective: false } as T);
+    cleaned = parsed.cleaned;
+    hasAnyDirective ||= parsed.hasDirective;
+    return parsed;
+  };
+  const think = parseScopedDirective("think", (value) =>
     extractThinkDirective(value, { strict: nativeCommand === "think" }),
   );
-  const {
-    cleaned: verboseCleaned,
-    verboseLevel,
-    rawLevel: rawVerboseLevel,
-    hasDirective: hasVerboseDirective,
-  } = parseScopedDirective(thinkCleaned, "verbose", (value) =>
+  const verbose = parseScopedDirective("verbose", (value) =>
     extractVerboseDirective(value, { strict: nativeCommand === "verbose" }),
   );
-  const {
-    cleaned: traceCleaned,
-    traceLevel,
-    rawLevel: rawTraceLevel,
-    hasDirective: hasTraceDirective,
-  } = parseScopedDirective(verboseCleaned, "trace", (value) =>
+  const trace = parseScopedDirective("trace", (value) =>
     extractTraceDirective(value, { strict: nativeCommand === "trace" }),
   );
-  const {
-    cleaned: fastCleaned,
-    fastMode,
-    rawLevel: rawFastMode,
-    hasDirective: hasFastDirective,
-  } = parseScopedDirective(traceCleaned, "fast", (value) =>
+  const fast = parseScopedDirective("fast", (value) =>
     extractFastDirective(value, { strict: nativeCommand === "fast" }),
   );
-  const {
-    cleaned: reasoningCleaned,
-    reasoningLevel,
-    rawLevel: rawReasoningLevel,
-    hasDirective: hasReasoningDirective,
-  } = parseScopedDirective(fastCleaned, "reasoning", (value) =>
+  const reasoning = parseScopedDirective("reasoning", (value) =>
     extractReasoningDirective(value, { strict: nativeCommand === "reasoning" }),
   );
-  const {
-    cleaned: elevatedCleaned,
-    elevatedLevel,
-    rawLevel: rawElevatedLevel,
-    hasDirective: hasElevatedDirective,
-  } = options?.disableElevated
-    ? {
-        cleaned: reasoningCleaned,
-        elevatedLevel: undefined,
-        rawLevel: undefined,
-        hasDirective: false,
-      }
-    : parseScopedDirective(reasoningCleaned, "elevated", (value) =>
-        extractElevatedDirective(value, { strict: nativeCommand === "elevated" }),
-      );
-  const {
-    cleaned: execCleaned,
-    execHost,
-    execSecurity,
-    execAsk,
-    execNode,
-    rawExecHost,
-    rawExecSecurity,
-    rawExecAsk,
-    rawExecNode,
-    hasExecOptions,
-    invalidHost: invalidExecHost,
-    invalidSecurity: invalidExecSecurity,
-    invalidAsk: invalidExecAsk,
-    invalidNode: invalidExecNode,
-    hasDirective: hasExecDirective,
-  } = parseScopedDirective(elevatedCleaned, "exec", extractExecDirective);
+  const elevated = parseScopedDirective(
+    "elevated",
+    (value) => extractElevatedDirective(value, { strict: nativeCommand === "elevated" }),
+    !options?.disableElevated,
+  );
+  const exec = parseScopedDirective("exec", extractExecDirective);
   const allowStatusDirective = options?.allowStatusDirective !== false && !nativeCommand;
   const { cleaned: statusCleaned, hasDirective: hasStatusDirective } = allowStatusDirective
-    ? extractStatusDirective(execCleaned)
-    : { cleaned: execCleaned, hasDirective: false };
-  const {
-    cleaned: modelCleaned,
-    rawModel,
-    rawProfile,
-    rawRuntime,
-    hasDirective: hasModelDirective,
-  } = parseScopedDirective(statusCleaned, "model", (value) =>
+    ? extractStatusDirective(cleaned)
+    : { cleaned, hasDirective: false };
+  cleaned = statusCleaned;
+  hasAnyDirective ||= hasStatusDirective;
+  const model = parseScopedDirective("model", (value) =>
     extractModelDirective(value, {
       aliases: options?.modelAliases,
     }),
   );
-  const {
-    cleaned: queueCleaned,
-    queueMode,
-    queueReset,
-    rawMode,
-    debounceMs,
-    cap,
-    dropPolicy,
-    rawDebounce,
-    rawCap,
-    rawDrop,
-    hasDirective: hasQueueDirective,
-    hasOptions: hasQueueOptions,
-  } = parseScopedDirective(modelCleaned, "queue", extractQueueDirective);
-  const hasAnyDirective =
-    hasThinkDirective ||
-    hasVerboseDirective ||
-    hasTraceDirective ||
-    hasFastDirective ||
-    hasReasoningDirective ||
-    hasElevatedDirective ||
-    hasExecDirective ||
-    hasStatusDirective ||
-    hasModelDirective ||
-    hasQueueDirective;
+  const queue = parseScopedDirective("queue", extractQueueDirective);
   // Later directives see text cleaned by earlier directives; preserve that ordering.
   return {
-    cleaned: hasAnyDirective ? queueCleaned : body.trim(),
+    cleaned: hasAnyDirective ? cleaned : body.trim(),
     ...(nativeCommand && hasAnyDirective
       ? {
           nativeCommand: {
             name: nativeCommand,
-            ...(queueCleaned ? { unconsumedArguments: queueCleaned } : {}),
+            ...(cleaned ? { unconsumedArguments: cleaned } : {}),
           },
         }
       : {}),
-    hasThinkDirective,
-    thinkLevel,
-    rawThinkLevel,
-    clearThinkLevel: hasThinkDirective && isSessionDefaultDirectiveValue(rawThinkLevel),
-    hasVerboseDirective,
-    verboseLevel,
-    rawVerboseLevel,
-    hasTraceDirective,
-    traceLevel,
-    rawTraceLevel,
-    hasFastDirective,
-    fastMode,
-    rawFastMode,
-    clearFastMode: hasFastDirective && isSessionDefaultDirectiveValue(rawFastMode),
-    hasReasoningDirective,
-    reasoningLevel,
-    rawReasoningLevel,
-    hasElevatedDirective,
-    elevatedLevel,
-    rawElevatedLevel,
-    hasExecDirective,
-    execHost,
-    execSecurity,
-    execAsk,
-    execNode,
-    rawExecHost,
-    rawExecSecurity,
-    rawExecAsk,
-    rawExecNode,
-    hasExecOptions,
-    invalidExecHost,
-    invalidExecSecurity,
-    invalidExecAsk,
-    invalidExecNode,
+    hasThinkDirective: think.hasDirective,
+    thinkLevel: think.thinkLevel,
+    rawThinkLevel: think.rawLevel,
+    clearThinkLevel: think.hasDirective && isSessionDefaultDirectiveValue(think.rawLevel),
+    hasVerboseDirective: verbose.hasDirective,
+    verboseLevel: verbose.verboseLevel,
+    rawVerboseLevel: verbose.rawLevel,
+    hasTraceDirective: trace.hasDirective,
+    traceLevel: trace.traceLevel,
+    rawTraceLevel: trace.rawLevel,
+    hasFastDirective: fast.hasDirective,
+    fastMode: fast.fastMode,
+    rawFastMode: fast.rawLevel,
+    clearFastMode: fast.hasDirective && isSessionDefaultDirectiveValue(fast.rawLevel),
+    hasReasoningDirective: reasoning.hasDirective,
+    reasoningLevel: reasoning.reasoningLevel,
+    rawReasoningLevel: reasoning.rawLevel,
+    hasElevatedDirective: elevated.hasDirective,
+    elevatedLevel: elevated.elevatedLevel,
+    rawElevatedLevel: elevated.rawLevel,
+    hasExecDirective: exec.hasDirective,
+    execHost: exec.execHost,
+    execSecurity: exec.execSecurity,
+    execAsk: exec.execAsk,
+    execNode: exec.execNode,
+    rawExecHost: exec.rawExecHost,
+    rawExecSecurity: exec.rawExecSecurity,
+    rawExecAsk: exec.rawExecAsk,
+    rawExecNode: exec.rawExecNode,
+    hasExecOptions: exec.hasExecOptions,
+    invalidExecHost: exec.invalidHost,
+    invalidExecSecurity: exec.invalidSecurity,
+    invalidExecAsk: exec.invalidAsk,
+    invalidExecNode: exec.invalidNode,
     hasStatusDirective,
-    hasModelDirective,
-    rawModelDirective: rawModel,
-    rawModelProfile: rawProfile,
-    rawModelRuntime: rawRuntime,
-    hasQueueDirective,
-    queueMode,
-    queueReset,
-    rawQueueMode: rawMode,
-    debounceMs,
-    cap,
-    dropPolicy,
-    rawDebounce,
-    rawCap,
-    rawDrop,
-    hasQueueOptions,
+    hasModelDirective: model.hasDirective,
+    rawModelDirective: model.rawModel,
+    rawModelProfile: model.rawProfile,
+    rawModelRuntime: model.rawRuntime,
+    hasQueueDirective: queue.hasDirective,
+    queueMode: queue.queueMode,
+    queueReset: queue.queueReset,
+    rawQueueMode: queue.rawMode,
+    debounceMs: queue.debounceMs,
+    cap: queue.cap,
+    dropPolicy: queue.dropPolicy,
+    rawDebounce: queue.rawDebounce,
+    rawCap: queue.rawCap,
+    rawDrop: queue.rawDrop,
+    hasQueueOptions: queue.hasOptions,
   };
 }

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -10,17 +10,11 @@ import { modelKey, type ModelAliasIndex } from "../../agents/model-selection.js"
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
-import {
-  adoptPersistedSessionSnapshot,
-  sessionModelOverrideChangesApplied,
-  sessionSnapshotChangesApplied,
-} from "../../config/sessions/session-snapshot-merge.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { triggerSessionPatchHook } from "../../gateway/session-patch-hooks.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applySessionModelSelectionToEntry } from "../../model-picker/apply-session-model-selection.js";
-import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import {
   formatThinkingLevels,
   isThinkingLevelSupported,
@@ -33,14 +27,15 @@ import {
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import {
+  applySessionDirectiveFields,
   canPersistSessionDirectiveDefaults,
   enqueueModeSwitchEvents,
+  persistSessionDirectiveSnapshot,
   resolveDirectiveTouchedSessionFields,
 } from "./directive-handling.shared.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel } from "./directives.js";
+import type { ThinkLevel } from "./directives.js";
 import { resolveContextTokens } from "./model-selection.js";
 import { refreshQueuedFollowupSession } from "./queue.js";
-import { persistReplySessionEntry } from "./session-entry-persistence.js";
 
 type PersistedThinkingLevelRemap = {
   from: ThinkLevel;
@@ -107,14 +102,7 @@ export async function persistInlineDirectives(params: {
   let { provider, model } = params;
   let thinkingRemap: PersistedThinkingLevelRemap | undefined;
   let sessionChangesApplied = true;
-  const allowInternalExecPersistence = canPersistSessionDirectiveDefaults({
-    messageProvider: params.messageProvider,
-    surface: params.surface,
-    gatewayClientScopes: params.gatewayClientScopes,
-    commandAuthorized: params.commandAuthorized,
-    senderIsOwner: params.senderIsOwner,
-  });
-  const allowInternalVerbosePersistence = canPersistSessionDirectiveDefaults({
+  const allowPrivilegedPersistence = canPersistSessionDirectiveDefaults({
     messageProvider: params.messageProvider,
     surface: params.surface,
     gatewayClientScopes: params.gatewayClientScopes,
@@ -123,8 +111,7 @@ export async function persistInlineDirectives(params: {
   });
   const touchedSessionFields = resolveDirectiveTouchedSessionFields({
     directives,
-    allowInternalExecPersistence,
-    allowInternalVerbosePersistence,
+    allowPrivilegedPersistence,
   });
   const thinkingCatalog =
     params.thinkingCatalog && params.thinkingCatalog.length > 0
@@ -199,96 +186,22 @@ export async function persistInlineDirectives(params: {
 
   if (!errorText && sessionEntry && sessionStore && sessionKey) {
     const initialSessionEntry = { ...sessionEntry };
-    let appliedSessionEntry = sessionEntry;
-    const prevElevatedLevel =
-      (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
-      (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
-    const prevReasoningLevel = (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
-    let elevatedChanged =
+    const appliedSessionEntry = sessionEntry;
+    const elevatedChanged =
       directives.hasElevatedDirective &&
       directives.elevatedLevel !== undefined &&
       elevatedEnabled &&
       elevatedAllowed;
-    let reasoningChanged =
+    const reasoningChanged =
       directives.hasReasoningDirective && directives.reasoningLevel !== undefined;
-    let updated = false;
-
-    if (directives.clearThinkLevel) {
-      if (sessionEntry.thinkingLevel) {
-        delete sessionEntry.thinkingLevel;
-        updated = true;
-      }
-    } else if (directives.hasThinkDirective && directives.thinkLevel) {
-      sessionEntry.thinkingLevel = directives.thinkLevel;
-      updated = true;
-    }
-    if (directives.clearFastMode) {
-      if (sessionEntry.fastMode !== undefined) {
-        delete sessionEntry.fastMode;
-        updated = true;
-      }
-    }
-    if (
-      directives.hasVerboseDirective &&
-      directives.verboseLevel &&
-      allowInternalVerbosePersistence
-    ) {
-      applyVerboseOverride(sessionEntry, directives.verboseLevel);
-      updated = true;
-    }
-    if (
-      directives.hasTraceDirective &&
-      directives.traceLevel &&
-      (params.senderIsOwner || delegatedTraceAllowed)
-    ) {
-      applyTraceOverride(sessionEntry, directives.traceLevel);
-      updated = true;
-    }
-    if (directives.hasReasoningDirective && directives.reasoningLevel) {
-      if (directives.reasoningLevel === "off") {
-        // Persist explicit off so it overrides model-capability defaults.
-        sessionEntry.reasoningLevel = "off";
-      } else {
-        sessionEntry.reasoningLevel = directives.reasoningLevel;
-      }
-      reasoningChanged =
-        reasoningChanged ||
-        (directives.reasoningLevel !== prevReasoningLevel &&
-          directives.reasoningLevel !== undefined);
-      updated = true;
-    }
-    if (
-      directives.hasElevatedDirective &&
-      directives.elevatedLevel &&
-      elevatedEnabled &&
-      elevatedAllowed
-    ) {
-      // Persist "off" explicitly so inline `/elevated off` overrides defaults.
-      sessionEntry.elevatedLevel = directives.elevatedLevel;
-      elevatedChanged =
-        elevatedChanged ||
-        (directives.elevatedLevel !== prevElevatedLevel && directives.elevatedLevel !== undefined);
-      updated = true;
-    }
-    if (directives.hasExecDirective && directives.hasExecOptions && allowInternalExecPersistence) {
-      if (directives.execHost) {
-        sessionEntry.execHost = directives.execHost;
-        updated = true;
-      }
-      if (directives.execSecurity) {
-        sessionEntry.execSecurity = directives.execSecurity;
-        updated = true;
-      }
-      if (directives.execAsk) {
-        sessionEntry.execAsk = directives.execAsk;
-        updated = true;
-      }
-      if (directives.execNode) {
-        sessionEntry.execNode = directives.execNode;
-        updated = true;
-      }
-    }
+    let updated = applySessionDirectiveFields({
+      directives,
+      sessionEntry,
+      allowPrivilegedPersistence,
+      allowTracePersistence: params.senderIsOwner === true || delegatedTraceAllowed,
+      allowElevatedPersistence: elevatedEnabled && elevatedAllowed,
+      persistDirectiveOnlyFields: false,
+    });
 
     let modelUpdated = false;
     let modelApplied = true;
@@ -360,62 +273,25 @@ export async function persistInlineDirectives(params: {
       // winner check when their value matches the local snapshot.
       updated = true;
     }
-    if (directives.hasQueueDirective && directives.queueReset) {
-      delete sessionEntry.queueMode;
-      delete sessionEntry.queueDebounceMs;
-      delete sessionEntry.queueCap;
-      delete sessionEntry.queueDrop;
-      updated = true;
-    }
-
     if (updated) {
       sessionEntry.updatedAt = Date.now();
       sessionStore[sessionKey] = sessionEntry;
       if (storePath) {
-        const persistence = await persistReplySessionEntry({
+        const persistence = await persistSessionDirectiveSnapshot({
           storePath,
           sessionKey,
           initialEntry: initialSessionEntry,
-          entry: sessionEntry,
+          sessionEntry,
+          sessionStore,
+          hasModelSelection: Boolean(modelDirective),
           reassertLiveModelSwitchPending:
             modelUpdated &&
             params.markLiveSwitchPending === true &&
             sessionEntry.liveModelSwitchPending === true,
           touchedFields: touchedSessionFields,
         });
-        if (persistence.status === "current") {
-          const persistedEntry = persistence.entry;
-          sessionStore[sessionKey] = persistedEntry;
-          sessionChangesApplied = sessionSnapshotChangesApplied({
-            initial: initialSessionEntry,
-            next: sessionEntry,
-            current: persistedEntry,
-            touchedFields: touchedSessionFields,
-          });
-          if (modelDirective) {
-            modelApplied =
-              sessionChangesApplied &&
-              sessionModelOverrideChangesApplied({
-                initial: initialSessionEntry,
-                next: sessionEntry,
-                current: persistedEntry,
-                reassertLiveModelSwitchPending:
-                  modelUpdated &&
-                  params.markLiveSwitchPending === true &&
-                  sessionEntry.liveModelSwitchPending === true,
-              });
-          }
-          adoptPersistedSessionSnapshot(sessionEntry, persistedEntry);
-          appliedSessionEntry = sessionEntry;
-        } else {
-          if (persistence.entry) {
-            sessionStore[sessionKey] = persistence.entry;
-          }
-          sessionChangesApplied = false;
-          if (modelDirective) {
-            modelApplied = false;
-          }
-        }
+        sessionChangesApplied = persistence.sessionChangesApplied;
+        modelApplied = persistence.modelSelectionApplied;
       }
       if (modelDirective && !modelApplied) {
         sessionChangesApplied = false;

--- a/src/auto-reply/reply/directive-handling.shared.ts
+++ b/src/auto-reply/reply/directive-handling.shared.ts
@@ -1,12 +1,19 @@
 // Shared directive parsing helpers used by model and auth directive handlers.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../../cli/command-format.js";
-import { SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS } from "../../config/sessions/session-snapshot-merge.js";
+import {
+  adoptPersistedSessionSnapshot,
+  SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS,
+  sessionModelOverrideChangesApplied,
+  sessionSnapshotChangesApplied,
+} from "../../config/sessions/session-snapshot-merge.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { SYSTEM_MARK, prefixSystemMessage } from "../../infra/system-message.js";
+import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
+import { persistReplySessionEntry } from "./session-entry-persistence.js";
 
 export const formatDirectiveAck = (text: string): string => {
   return prefixSystemMessage(text);
@@ -50,66 +57,204 @@ export function canPersistSessionDirectiveDefaults(params: {
   return params.commandAuthorized === true || params.senderIsOwner === true;
 }
 
+const SESSION_LEVEL_DIRECTIVE_FIELDS = [
+  ["hasThinkDirective", "thinkingLevel"],
+  ["hasFastDirective", "fastMode"],
+  ["hasVerboseDirective", "verboseLevel"],
+  ["hasTraceDirective", "traceLevel"],
+  ["hasReasoningDirective", "reasoningLevel"],
+  ["hasElevatedDirective", "elevatedLevel"],
+] as const satisfies ReadonlyArray<readonly [keyof InlineDirectives, keyof SessionEntry]>;
+
+const SESSION_EXEC_DIRECTIVE_FIELDS = [
+  "execHost",
+  "execSecurity",
+  "execAsk",
+  "execNode",
+] as const satisfies ReadonlyArray<keyof InlineDirectives & keyof SessionEntry>;
+
+const SESSION_QUEUE_DIRECTIVE_FIELDS = [
+  ["queueMode", "queueMode"],
+  ["debounceMs", "queueDebounceMs"],
+  ["cap", "queueCap"],
+  ["dropPolicy", "queueDrop"],
+] as const satisfies ReadonlyArray<readonly [keyof InlineDirectives, keyof SessionEntry]>;
+
 /** Names explicit directive writes that snapshot equality cannot infer. */
 export function resolveDirectiveTouchedSessionFields(params: {
   directives: InlineDirectives;
-  allowInternalExecPersistence: boolean;
-  allowInternalVerbosePersistence: boolean;
+  allowPrivilegedPersistence: boolean;
 }): Array<keyof SessionEntry> {
   const { directives } = params;
   const fields = new Set<keyof SessionEntry>();
-  if (directives.hasThinkDirective) {
-    fields.add("thinkingLevel");
-  }
-  if (directives.hasFastDirective) {
-    fields.add("fastMode");
-  }
-  if (directives.hasVerboseDirective && params.allowInternalVerbosePersistence) {
-    fields.add("verboseLevel");
-  }
-  if (directives.hasTraceDirective) {
-    fields.add("traceLevel");
-  }
-  if (directives.hasReasoningDirective) {
-    fields.add("reasoningLevel");
-  }
-  if (directives.hasElevatedDirective) {
-    fields.add("elevatedLevel");
+  for (const [directiveField, sessionField] of SESSION_LEVEL_DIRECTIVE_FIELDS) {
+    if (
+      directives[directiveField] &&
+      (sessionField !== "verboseLevel" || params.allowPrivilegedPersistence)
+    ) {
+      fields.add(sessionField);
+    }
   }
   if (directives.hasModelDirective) {
     for (const field of SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS) {
       fields.add(field);
     }
   }
-  if (directives.hasExecDirective && params.allowInternalExecPersistence) {
-    if (directives.execHost) {
-      fields.add("execHost");
-    }
-    if (directives.execSecurity) {
-      fields.add("execSecurity");
-    }
-    if (directives.execAsk) {
-      fields.add("execAsk");
-    }
-    if (directives.execNode) {
-      fields.add("execNode");
+  if (directives.hasExecDirective && params.allowPrivilegedPersistence) {
+    for (const field of SESSION_EXEC_DIRECTIVE_FIELDS) {
+      if (directives[field]) {
+        fields.add(field);
+      }
     }
   }
   if (directives.hasQueueDirective) {
-    if (directives.queueReset || directives.queueMode) {
-      fields.add("queueMode");
-    }
-    if (directives.queueReset || typeof directives.debounceMs === "number") {
-      fields.add("queueDebounceMs");
-    }
-    if (directives.queueReset || typeof directives.cap === "number") {
-      fields.add("queueCap");
-    }
-    if (directives.queueReset || directives.dropPolicy) {
-      fields.add("queueDrop");
+    for (const [directiveField, sessionField] of SESSION_QUEUE_DIRECTIVE_FIELDS) {
+      const value = directives[directiveField];
+      if (directives.queueReset || typeof value === "number" || Boolean(value)) {
+        fields.add(sessionField);
+      }
     }
   }
   return [...fields];
+}
+
+/** Applies canonical session settings while each caller retains its authorization boundaries. */
+export function applySessionDirectiveFields(params: {
+  directives: InlineDirectives;
+  sessionEntry: SessionEntry;
+  allowPrivilegedPersistence: boolean;
+  allowTracePersistence: boolean;
+  allowElevatedPersistence: boolean;
+  persistDirectiveOnlyFields: boolean;
+}): boolean {
+  const { directives, sessionEntry } = params;
+  let updated = false;
+  const updateField = <Field extends keyof SessionEntry>(
+    field: Field,
+    value: SessionEntry[Field],
+  ) => {
+    sessionEntry[field] = value;
+    updated = true;
+  };
+
+  if (directives.clearThinkLevel) {
+    if (sessionEntry.thinkingLevel) {
+      delete sessionEntry.thinkingLevel;
+      updated = true;
+    }
+  } else if (directives.hasThinkDirective && directives.thinkLevel) {
+    updateField("thinkingLevel", directives.thinkLevel);
+  }
+  if (directives.clearFastMode) {
+    if (sessionEntry.fastMode !== undefined) {
+      delete sessionEntry.fastMode;
+      updated = true;
+    }
+  } else if (
+    params.persistDirectiveOnlyFields &&
+    directives.hasFastDirective &&
+    directives.fastMode !== undefined
+  ) {
+    updateField("fastMode", directives.fastMode);
+  }
+  if (
+    directives.hasVerboseDirective &&
+    directives.verboseLevel &&
+    params.allowPrivilegedPersistence
+  ) {
+    applyVerboseOverride(sessionEntry, directives.verboseLevel);
+    updated = true;
+  }
+  if (directives.hasTraceDirective && directives.traceLevel && params.allowTracePersistence) {
+    applyTraceOverride(sessionEntry, directives.traceLevel);
+    updated = true;
+  }
+  if (directives.hasReasoningDirective && directives.reasoningLevel) {
+    // Explicit off remains stored so provider defaults cannot re-enable reasoning.
+    updateField("reasoningLevel", directives.reasoningLevel);
+  }
+  if (
+    directives.hasElevatedDirective &&
+    directives.elevatedLevel &&
+    params.allowElevatedPersistence
+  ) {
+    // Elevated defaults can be on, so an explicit off must also remain stored.
+    updateField("elevatedLevel", directives.elevatedLevel);
+  }
+  if (
+    directives.hasExecDirective &&
+    directives.hasExecOptions &&
+    params.allowPrivilegedPersistence
+  ) {
+    for (const field of SESSION_EXEC_DIRECTIVE_FIELDS) {
+      const value = directives[field];
+      if (value) {
+        updateField(field, value);
+      }
+    }
+  }
+  if (directives.hasQueueDirective && directives.queueReset) {
+    for (const [, field] of SESSION_QUEUE_DIRECTIVE_FIELDS) {
+      delete sessionEntry[field];
+    }
+    updated = true;
+  } else if (directives.hasQueueDirective && params.persistDirectiveOnlyFields) {
+    for (const [directiveField, sessionField] of SESSION_QUEUE_DIRECTIVE_FIELDS) {
+      const value = directives[directiveField];
+      if (typeof value === "number" || value) {
+        updateField(sessionField, value);
+      }
+    }
+  }
+  return updated;
+}
+
+/** Commits a directive snapshot only when its touched fields still win the session transaction. */
+export async function persistSessionDirectiveSnapshot(params: {
+  storePath: string;
+  sessionKey: string;
+  initialEntry: SessionEntry;
+  sessionEntry: SessionEntry;
+  sessionStore: Record<string, SessionEntry>;
+  touchedFields: Array<keyof SessionEntry>;
+  hasModelSelection: boolean;
+  reassertLiveModelSwitchPending: boolean;
+}): Promise<{ sessionChangesApplied: boolean; modelSelectionApplied: boolean }> {
+  const { sessionEntry, sessionKey, sessionStore } = params;
+  const persistence = await persistReplySessionEntry({
+    storePath: params.storePath,
+    sessionKey,
+    initialEntry: params.initialEntry,
+    entry: sessionEntry,
+    reassertLiveModelSwitchPending: params.reassertLiveModelSwitchPending,
+    touchedFields: params.touchedFields,
+  });
+  if (persistence.status !== "current") {
+    if (persistence.entry) {
+      sessionStore[sessionKey] = persistence.entry;
+    }
+    return { sessionChangesApplied: false, modelSelectionApplied: false };
+  }
+
+  const persistedEntry = persistence.entry;
+  sessionStore[sessionKey] = persistedEntry;
+  const sessionChangesApplied = sessionSnapshotChangesApplied({
+    initial: params.initialEntry,
+    next: sessionEntry,
+    current: persistedEntry,
+    touchedFields: params.touchedFields,
+  });
+  const modelSelectionApplied =
+    !params.hasModelSelection ||
+    (sessionChangesApplied &&
+      sessionModelOverrideChangesApplied({
+        initial: params.initialEntry,
+        next: sessionEntry,
+        current: persistedEntry,
+        reassertLiveModelSwitchPending: params.reassertLiveModelSwitchPending,
+      }));
+  adoptPersistedSessionSnapshot(sessionEntry, persistedEntry);
+  return { sessionChangesApplied, modelSelectionApplied };
 }
 
 const formatElevatedEvent = (level: ElevatedLevel) => {

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -1,5 +1,4 @@
 // Defines reply directive parsing constants and text-matching helpers.
-import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import { escapeRegExp } from "../../utils.js";
 import type { ReasoningLevel, TraceLevel } from "../thinking.js";
 import {
@@ -30,12 +29,6 @@ const compileDirectivePattern = (names: readonly string[], suffix = ""): RegExp 
   return new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)${suffix}`, "i");
 };
 
-const THINK_DIRECTIVE_PATTERN = compileDirectivePattern(["thinking", "think", "t"]);
-const VERBOSE_DIRECTIVE_PATTERN = compileDirectivePattern(["verbose", "v"]);
-const TRACE_DIRECTIVE_PATTERN = compileDirectivePattern(["trace"]);
-const FAST_DIRECTIVE_PATTERN = compileDirectivePattern(["fast"]);
-const ELEVATED_DIRECTIVE_PATTERN = compileDirectivePattern(["elevated", "elev"]);
-const REASONING_DIRECTIVE_PATTERN = compileDirectivePattern(["reasoning", "reason"]);
 const STATUS_DIRECTIVE_PATTERN = compileDirectivePattern(["status"], `(?:\\s*:\\s*)?`);
 
 const matchLevelDirective = (
@@ -49,8 +42,7 @@ const matchLevelDirective = (
     return null;
   }
   const start = match.index;
-  const directiveEnd = match.index + match[0].length;
-  let i = directiveEnd;
+  let i = match.index + match[0].length;
   while (i < body.length && /\s/.test(body.charAt(i))) {
     i += 1;
   }
@@ -89,10 +81,7 @@ const extractLevelDirective = <T>(
   }
   const rawLevel = match.rawLevel;
   const level = normalize(rawLevel);
-  const cleaned = body
-    .slice(0, match.start)
-    .concat(" ")
-    .concat(body.slice(match.end))
+  const cleaned = `${body.slice(0, match.start)} ${body.slice(match.end)}`
     .replace(/\s+/g, " ")
     .trim();
   return {
@@ -103,168 +92,60 @@ const extractLevelDirective = <T>(
   };
 };
 
-const extractSimpleDirective = (
-  body: string,
-  pattern: RegExp,
-): { cleaned: string; hasDirective: boolean } => {
-  const match = body.match(pattern);
-  const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
-  return {
-    cleaned,
-    hasDirective: Boolean(match),
-  };
+type NamedLevelDirective<T, Field extends string> = Omit<ExtractedLevel<T>, "level"> & {
+  [Key in Field]?: T;
 };
 
-export function extractThinkDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  thinkLevel?: ThinkLevel;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(
-    body,
-    THINK_DIRECTIVE_PATTERN,
-    normalizeThinkLevel,
-    options,
-  );
-  return {
-    cleaned: extracted.cleaned,
-    thinkLevel: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
+function createLevelDirectiveExtractor<T, Field extends string>(
+  names: readonly string[],
+  field: Field,
+  normalize: (raw?: string) => T | undefined,
+): (body?: string, options?: LevelDirectiveParseOptions) => NamedLevelDirective<T, Field> {
+  const pattern = compileDirectivePattern(names);
+  return (body, options) => {
+    if (!body) {
+      return { cleaned: "", hasDirective: false } as NamedLevelDirective<T, Field>;
+    }
+    const { cleaned, level, rawLevel, hasDirective } = extractLevelDirective(
+      body,
+      pattern,
+      normalize,
+      options,
+    );
+    return { cleaned, [field]: level, rawLevel, hasDirective } as NamedLevelDirective<T, Field>;
   };
 }
 
-export function extractVerboseDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  verboseLevel?: VerboseLevel;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(
-    body,
-    VERBOSE_DIRECTIVE_PATTERN,
-    normalizeVerboseLevel,
-    options,
-  );
-  return {
-    cleaned: extracted.cleaned,
-    verboseLevel: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
-  };
-}
-
-export function extractTraceDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  traceLevel?: TraceLevel;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(
-    body,
-    TRACE_DIRECTIVE_PATTERN,
-    normalizeTraceLevel,
-    options,
-  );
-  return {
-    cleaned: extracted.cleaned,
-    traceLevel: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
-  };
-}
-
-export function extractFastDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  fastMode?: FastMode;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(body, FAST_DIRECTIVE_PATTERN, normalizeFastMode, options);
-  return {
-    cleaned: extracted.cleaned,
-    fastMode: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
-  };
-}
-
-export function extractElevatedDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  elevatedLevel?: ElevatedLevel;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(
-    body,
-    ELEVATED_DIRECTIVE_PATTERN,
-    normalizeElevatedLevel,
-    options,
-  );
-  return {
-    cleaned: extracted.cleaned,
-    elevatedLevel: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
-  };
-}
-
-export function extractReasoningDirective(
-  body?: string,
-  options?: LevelDirectiveParseOptions,
-): {
-  cleaned: string;
-  reasoningLevel?: ReasoningLevel;
-  rawLevel?: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const extracted = extractLevelDirective(
-    body,
-    REASONING_DIRECTIVE_PATTERN,
-    normalizeReasoningLevel,
-    options,
-  );
-  return {
-    cleaned: extracted.cleaned,
-    reasoningLevel: extracted.level,
-    rawLevel: extracted.rawLevel,
-    hasDirective: extracted.hasDirective,
-  };
-}
+export const extractThinkDirective = createLevelDirectiveExtractor(
+  ["thinking", "think", "t"],
+  "thinkLevel",
+  normalizeThinkLevel,
+);
+export const extractVerboseDirective = createLevelDirectiveExtractor(
+  ["verbose", "v"],
+  "verboseLevel",
+  normalizeVerboseLevel,
+);
+export const extractTraceDirective = createLevelDirectiveExtractor(
+  ["trace"],
+  "traceLevel",
+  normalizeTraceLevel,
+);
+export const extractFastDirective = createLevelDirectiveExtractor(
+  ["fast"],
+  "fastMode",
+  normalizeFastMode,
+);
+export const extractElevatedDirective = createLevelDirectiveExtractor(
+  ["elevated", "elev"],
+  "elevatedLevel",
+  normalizeElevatedLevel,
+);
+export const extractReasoningDirective = createLevelDirectiveExtractor(
+  ["reasoning", "reason"],
+  "reasoningLevel",
+  normalizeReasoningLevel,
+);
 
 export function extractStatusDirective(body?: string): {
   cleaned: string;
@@ -273,7 +154,11 @@ export function extractStatusDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  return extractSimpleDirective(body, STATUS_DIRECTIVE_PATTERN);
+  const match = body.match(STATUS_DIRECTIVE_PATTERN);
+  return {
+    cleaned: match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim(),
+    hasDirective: Boolean(match),
+  };
 }
 
 export type { ElevatedLevel, ReasoningLevel, ThinkLevel, TraceLevel, VerboseLevel };


### PR DESCRIPTION
## What Problem This Solves

Slash-command metadata, authorization, parsing, and directive persistence had accumulated competing owners and repeated implementations. That duplication made aliases, plugin precedence, native-command validation, owner checks, and channel behavior harder to keep consistent.

## Why This Change Was Made

Consolidate built-in command descriptors into one typed registry, share one command matching and authorization owner, derive alias detection from the same registry snapshot, and use canonical directive extraction, session mutation, and transactional persistence owners. Preserve all existing command names, aliases, precedence, authorization boundaries, browser-safe imports, native argument handling, plugin behavior, and channel contracts.

## User Impact

No intended user-visible behavior change. All 51 existing built-in slash commands and their aliases remain available, plugin commands retain precedence, owner and administrator protections stay enforced, and command responses and channel-native behavior remain unchanged.

## Evidence

- Handwritten production code: 2,471 lines added and 3,985 removed, for 1,514 fewer production lines; test code unchanged.
- Built-in command registry: 1,079 to 672 lines. Directive-only owner: 848 to 693 lines. Removed both now-unnecessary oversized-file suppressions and their exact shrink-only baseline entries; max-lines ratchet passes with 1,016 remaining grandfathered entries.
- Exhaustive before/after parity for all 51 built-in commands: definition order, text/native aliases, scopes, categories, tiers, arguments, formatters, browser-safe imports, and dynamic thinking/fast choices.
- Blacksmith Testbox: tbx_01kyxdpm920vs28qy78ghs087s; run https://github.com/openclaw/openclaw/actions/runs/30677141429.
- Command/directive/auth regression suite: 26 test files and 498 passing tests, including malformed native arguments, explicit owner authorization, unresolved SecretRef fail-closed behavior, private MCP routing, sensitive config redaction, allowlists, TTS, sessions, and all touched handler families.
- Gateway/browser/plugin/channel integration: 7 test files and 201 passing tests across gateway command discovery, browser-safe imports, plugin command precedence, Telegram native/group authorization, Discord native plugin dispatch, and Slack slash commands.
- Final exact-patch command control, authorization gating, and /btw regressions: 85 additional passing tests.
- Full changed gate (CI=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm check:changed): core production/test types, lint, format, architecture, dead exports, and shrink-only guards passed (including all full-repository lint shards, script lint, production/test typechecks, formatting, boundary guards, import-cycle checks, and database/schema guards).
- Fresh structured autoreview: clean; no accepted or actionable findings.
### Real behavior proof: exact reviewed head

Blacksmith Testbox checked out exact head 58fcb230f10bccf99515d50668c86a7b4557118f. Every observation below came from a real ephemeral Gateway process, the real auto-reply and session-persistence owners, a local mock OpenAI provider, and either qa-channel or the real Telegram plugin against Crabline's local Telegram-shaped API. No live credentials or production channels were used.

Synthetic-channel lane: three scenarios passed, zero failed:

```
pnpm openclaw qa suite --provider-mode mock-openai \
  --scenario channel-sender-allowlist \
  --scenario luna-thinking-visibility-switch \
  --scenario session-reset-payload-preservation \
  --concurrency 2 --output-dir .artifacts/qa-e2e/pr-117143-qa-channel
```

Observed operator-visible results:

- Non-allowlisted group sender: no outbound reply; allowlisted sender: QA-ALLOWLIST-OVERRIDE-OK.
- Reasoning directive: Reasoning visibility enabled.
- Thinking off: Thinking disabled.; subsequent reply: THINKING-OFF-OK.
- Thinking medium: Thinking level set to medium.; subsequent reply: THINKING-MAX-OK; actual mock-provider request reasoning.effort=medium.
- Session reset: lifecycle revision changed, durable session identity remained stable, exact multiline user payload reached the provider once, the /new command prefix was stripped, and the visible reply was QA-RESET-PAYLOAD-OK.

Telegram native-command lane: four scenarios passed, zero failed:

```
pnpm openclaw qa suite --provider-mode mock-openai \
  --channel-driver crabline --channel telegram \
  --scenario telegram-repeated-command-authorization \
  --scenario native-command-session-target \
  --scenario telegram-help-command \
  --scenario telegram-commands-command \
  --concurrency 1 --output-dir .artifacts/qa-e2e/pr-117143-native-telegram
```

Observed operator-visible results:

- Native /status while removed from the Telegram group allowlist: You are not authorized to use this command.
- After restoring the allowlist, repeated native /status, /help, and /commands all succeeded without reopening authorization.
- Native /help advertised /new and /commands for full list; /commands included /stop plus /think (/thinking, /t).
- Native /stop interrupted the active routed conversation: Agent was aborted.; next user turn: QA-NATIVE-STOP-RECOVERY-OK.

Additional direct real-gateway verdict, proving mixed directive persistence and unauthorized no-op against the same exact head:

```json
{
  "verdict": "PASS",
  "head": "58fcb230f10bccf99515d50668c86a7b4557118f",
  "channel": "qa-channel",
  "gateway": "ephemeral-child",
  "provider": "mock-openai",
  "unauthorizedNativeBlocked": true,
  "authorizedNativeStatusContainsSession": true,
  "mixedDirective": "/reasoning on /think medium",
  "directiveAck": "Thinking level set to medium. Reasoning visibility enabled.",
  "persisted": {
    "reasoningLevel": "on",
    "thinkingLevel": "medium"
  },
  "nextTurnReply": "QA-MIXED-DIRECTIVE-OK",
  "providerReasoningEffort": "medium",
  "unauthorizedMixedDirectiveNoOp": true
}
```

Artifacts: .artifacts/qa-e2e/pr-117143-qa-channel/{qa-suite-summary.json,qa-evidence.json,qa-suite-report.md} and .artifacts/qa-e2e/pr-117143-native-telegram/{qa-suite-summary.json,qa-evidence.json,qa-suite-report.md}; linked Testbox run: https://github.com/openclaw/openclaw/actions/runs/30677141429.

### ClawSweeper rank-up moves

- Publish exact-head regression output: resolved by 784 passing focused regressions, the complete passing changed gate, seven passing operator-visible real-Gateway scenarios, and the exact-head mixed-directive verdict above.
- Add redacted runtime proof for representative text/native authorization and directive persistence: resolved by the qa-channel and Telegram/Crabline observations plus persisted session and actual provider-request evidence above.
- Refresh the branch against current main: intentionally skipped under the explicit maintainer instruction not to fetch or rebase and to preserve the exact already-reviewed and fully proven head. GitHub currently reports this exact head mergeable against main; the maintainer owns any final integration-time base refresh.
