### PR TITLE
refactor(reply): unify turn lifecycle state ownership

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -39,22 +39,12 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     completeDispatchReplyOperation,
     ctx,
     deliveryChannel,
-    dispatchHookDispatcher,
     dispatcher,
-    ensureDispatchReplyOperation,
-    finishReplyOperationAbortedDispatch,
-    finishReplyOperationBusyDispatch,
-    getDispatchAbortSignal,
     getPreDispatchAbortSignal,
     hookRunner,
-    inboundAudio,
     isRoutedReplyDelivered,
     markIdle,
     markInboundDedupeReplayUnsafe,
-    maybeApplyTtsWithFinalizationLease,
-    messageIdForHook,
-    normalizeReplyMediaPayload,
-    normalizedCurrentSurface,
     params,
     recordProcessed,
     replyContextAccountId,
@@ -63,23 +53,18 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     routeReplyChannel,
     routeReplyThreadId,
     routeReplyTo,
-    routeReplyToOriginating,
     runWithDispatchLifecycleAdmission,
     sendPayloadAsync,
-    sendPolicy,
     sendPolicyDenied,
     sessionAgentId,
     sessionKey,
     sessionStoreEntry,
     sessionTtsAuto,
-    shouldEmitFullVerboseProgress,
     shouldEmitVerboseProgress,
     shouldRouteToOriginating,
     sourceReplyDeliveryMode,
     suppressAutomaticSourceDelivery,
     suppressDelivery,
-    suppressHookReplyLifecycle,
-    suppressHookUserDelivery,
     traceReplyPhase,
     trackDispatchLifecycleWork,
     turnLedger,
@@ -92,7 +77,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
   const shouldSendToolStartStatuses = false;
   const notifiedSessionMetadataChangeKeys = new Set<string>();
-  let sessionMetadataChangesForResult: CommandSessionMetadataChange[] | undefined;
+  const routeState: { sessionMetadataChangesForResult?: CommandSessionMetadataChange[] } = {};
   const notifySessionMetadataChanges = (
     changes: CommandSessionMetadataChange[] | undefined,
   ): void => {
@@ -111,7 +96,10 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     if (freshChanges.length === 0) {
       return;
     }
-    sessionMetadataChangesForResult = [...(sessionMetadataChangesForResult ?? []), ...freshChanges];
+    routeState.sessionMetadataChangesForResult = [
+      ...(routeState.sessionMetadataChangesForResult ?? []),
+      ...freshChanges,
+    ];
     params.onSessionMetadataChanges?.(freshChanges);
   };
   const shouldDeliverVerboseProgressDespiteSourceSuppression = () =>
@@ -216,7 +204,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   const shouldSuppressMessageToolOnlyTextErrorProgress = (payload: ReplyPayload) => {
     if (
       sourceReplyDeliveryMode !== "message_tool_only" ||
-      shouldEmitFullVerboseProgress() ||
+      state.shouldEmitFullVerboseProgress() ||
       payload.isError !== true
     ) {
       return false;
@@ -300,7 +288,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     routedFinalCount: number;
     dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
   }> => {
-    const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
+    const abortSignal = options.abortSignal ?? state.getDispatchAbortSignal();
     const throwIfFinalDeliveryAborted = () => {
       if (abortSignal?.aborted) {
         throw new DispatchReplyOperationAbortedError();
@@ -334,7 +322,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     const ttsPayload =
       payload.isReasoning === true || payload.isCommentary === true
         ? payload
-        : await maybeApplyTtsWithFinalizationLease({
+        : await state.maybeApplyTtsWithFinalizationLease({
             payload,
             cfg,
             channel: deliveryChannel,
@@ -344,7 +332,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
             accountId: replyRoute.accountId,
           });
     throwIfFinalDeliveryAborted();
-    let normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
+    let normalizedPayload = await state.normalizeReplyMediaPayload(ttsPayload);
     throwIfFinalDeliveryAborted();
     const deliveredAsBlock = await wasReplyDeliveredAsBlock(payload, abortSignal);
     throwIfFinalDeliveryAborted();
@@ -362,7 +350,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
         return { dedupedAgainstBlock: true, queuedFinal: false, routedFinalCount: 0 };
       }
     }
-    const result = await routeReplyToOriginating(normalizedPayload, {
+    const result = await state.routeReplyToOriginating(normalizedPayload, {
       abortSignal,
       kind: "final",
       ...(hasTranscriptOwner ? { mirror: false } : {}),
@@ -388,14 +376,16 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     const transcriptMirrorSessionKey =
       acpDispatchSessionKey ?? sessionStoreEntry.sessionKey ?? sessionKey;
     const transcriptMirrorSourceId =
-      normalizeOptionalString(messageIdForHook) ??
+      normalizeOptionalString(state.messageIdForHook) ??
       normalizeOptionalString(params.replyOptions?.runId);
     const transcriptMirrorSessionBinding = resolvePreparedTranscriptBinding(
       transcriptMirrorSessionKey,
     );
     const transcriptMirror =
       sourceReplyTranscriptMirror ??
-      (normalizedCurrentSurface === "slack" && hasVisibleFinalContent && transcriptMirrorSessionKey
+      (state.normalizedCurrentSurface === "slack" &&
+      hasVisibleFinalContent &&
+      transcriptMirrorSessionKey
         ? transcriptMirrorForDeliveredPayload(
             {
               sessionKey: transcriptMirrorSessionKey,
@@ -479,32 +469,33 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
             () =>
               hookRunner.runBeforeDispatch(
                 {
-                  messageId: state.hookContext.messageId,
-                  content: state.hookContext.content,
-                  body: state.hookContext.bodyForAgent ?? state.hookContext.body,
-                  channel: state.hookContext.channelId,
+                  messageId: state.hookState.hookContext.messageId,
+                  content: state.hookState.hookContext.content,
+                  body:
+                    state.hookState.hookContext.bodyForAgent ?? state.hookState.hookContext.body,
+                  channel: state.hookState.hookContext.channelId,
                   sessionKey: beforeDispatchSessionKey,
-                  senderId: state.hookContext.senderId,
-                  replyToId: state.hookContext.replyToId,
-                  replyToIdFull: state.hookContext.replyToIdFull,
-                  replyToBody: state.hookContext.replyToBody,
-                  replyToSender: state.hookContext.replyToSender,
-                  replyToIsQuote: state.hookContext.replyToIsQuote,
-                  isGroup: state.hookContext.isGroup,
-                  timestamp: state.hookContext.timestamp,
+                  senderId: state.hookState.hookContext.senderId,
+                  replyToId: state.hookState.hookContext.replyToId,
+                  replyToIdFull: state.hookState.hookContext.replyToIdFull,
+                  replyToBody: state.hookState.hookContext.replyToBody,
+                  replyToSender: state.hookState.hookContext.replyToSender,
+                  replyToIsQuote: state.hookState.hookContext.replyToIsQuote,
+                  isGroup: state.hookState.hookContext.isGroup,
+                  timestamp: state.hookState.hookContext.timestamp,
                 },
                 {
-                  messageId: state.hookContext.messageId,
-                  channelId: state.hookContext.channelId,
-                  accountId: state.hookContext.accountId,
-                  conversationId: state.inboundClaimContext.conversationId,
+                  messageId: state.hookState.hookContext.messageId,
+                  channelId: state.hookState.hookContext.channelId,
+                  accountId: state.hookState.hookContext.accountId,
+                  conversationId: state.hookState.inboundClaimContext.conversationId,
                   sessionKey: beforeDispatchSessionKey,
-                  senderId: state.hookContext.senderId,
-                  replyToId: state.hookContext.replyToId,
-                  replyToIdFull: state.hookContext.replyToIdFull,
-                  replyToBody: state.hookContext.replyToBody,
-                  replyToSender: state.hookContext.replyToSender,
-                  replyToIsQuote: state.hookContext.replyToIsQuote,
+                  senderId: state.hookState.hookContext.senderId,
+                  replyToId: state.hookState.hookContext.replyToId,
+                  replyToIdFull: state.hookState.hookContext.replyToIdFull,
+                  replyToBody: state.hookState.hookContext.replyToBody,
+                  replyToSender: state.hookState.hookContext.replyToSender,
+                  replyToIsQuote: state.hookState.hookContext.replyToIsQuote,
                 },
                 pluginSubagentRequester,
               ),
@@ -554,11 +545,11 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
                   sessionKey: acpDispatchSessionKey,
                   toolsAllow: params.replyOptions?.toolsAllow,
                   images: params.replyOptions?.images,
-                  inboundAudio,
+                  inboundAudio: state.inboundAudio,
                   sessionTtsAuto,
                   ttsChannel: deliveryChannel,
-                  suppressUserDelivery: suppressHookUserDelivery,
-                  suppressReplyLifecycle: suppressHookReplyLifecycle,
+                  suppressUserDelivery: state.suppressHookUserDelivery,
+                  suppressReplyLifecycle: state.suppressHookReplyLifecycle,
                   sourceReplyDeliveryMode,
                   shouldRouteToOriginating,
                   originatingChannel: routeReplyChannel,
@@ -567,11 +558,11 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
                   originatingThreadId: routeReplyThreadId,
                   originatingChatType: replyRoute.chatType,
                   shouldSendToolSummaries,
-                  sendPolicy,
+                  sendPolicy: state.sendPolicy,
                 }),
                 {
                   cfg,
-                  dispatcher: dispatchHookDispatcher,
+                  dispatcher: state.dispatchHookDispatcher,
                   abortSignal: getPreDispatchAbortSignal() ?? params.replyOptions?.abortSignal,
                   onReplyStart: params.replyOptions?.onReplyStart,
                   recordProcessed,
@@ -595,48 +586,38 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     }
   }
 
-  const dispatchAcquisition = await ensureDispatchReplyOperation("dispatch");
+  const dispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");
   if (dispatchAcquisition.status === "aborted") {
-    return { status: "complete" as const, result: finishReplyOperationAbortedDispatch() };
+    return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
   }
   if (dispatchAcquisition.status === "busy") {
     return {
       status: "complete" as const,
-      result: finishReplyOperationBusyDispatch({ dedupeDisposition: "release" }),
+      result: state.finishReplyOperationBusyDispatch({ dedupeDisposition: "release" }),
     };
   }
-  const nextState = extendPreparedDispatchState(
-    state,
-    {
-      shouldSuppressDefaultToolProgressMessages,
-      shouldSendVerboseProgressMessages,
-      shouldSendToolSummaries,
-      shouldSendToolStartStatuses,
-      notifySessionMetadataChanges,
-      shouldDeliverVerboseProgressDespiteSourceSuppression,
-      shouldDeliverForcedToolProgressDespiteSourceSuppression,
-      shouldDeliverFastModeAutoProgressDespiteSourceSuppression,
-      hasExecApprovalPayload,
-      hasAskUserPayload,
-      readAskUserQuestionId,
-      shouldSuppressLateTextOnlyToolProgress,
-      flushPendingCommentaryProgress,
-      noteCommentaryProgress,
-      shouldSuppressMessageToolOnlyTextErrorProgress,
-      sendTrackedBlockReply,
-      recordRoutedBlockReplyDelivery,
-      wasReplyDeliveredAsBlock,
-      sendFinalPayload,
-    },
-    {
-      sessionMetadataChangesForResult: {
-        get: () => sessionMetadataChangesForResult,
-        set: (value: typeof sessionMetadataChangesForResult) => {
-          sessionMetadataChangesForResult = value;
-        },
-      },
-    },
-  );
+  const nextState = extendPreparedDispatchState(state, {
+    shouldSuppressDefaultToolProgressMessages,
+    shouldSendVerboseProgressMessages,
+    shouldSendToolSummaries,
+    shouldSendToolStartStatuses,
+    notifySessionMetadataChanges,
+    shouldDeliverVerboseProgressDespiteSourceSuppression,
+    shouldDeliverForcedToolProgressDespiteSourceSuppression,
+    shouldDeliverFastModeAutoProgressDespiteSourceSuppression,
+    hasExecApprovalPayload,
+    hasAskUserPayload,
+    readAskUserQuestionId,
+    shouldSuppressLateTextOnlyToolProgress,
+    flushPendingCommentaryProgress,
+    noteCommentaryProgress,
+    shouldSuppressMessageToolOnlyTextErrorProgress,
+    sendTrackedBlockReply,
+    recordRoutedBlockReplyDelivery,
+    wasReplyDeliveredAsBlock,
+    sendFinalPayload,
+    routeState,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -25,94 +25,41 @@ import { REPLY_OPERATION_RUN_STATE } from "./reply-operation-run-state.js";
 
 export async function executeDispatch(state: PrepareDispatchExecutionReadyState) {
   const {
-    acpDispatchSessionKey,
-    attachSourceReplyDeliveryMode,
-    canForwardSuppressedSourceItemEvents,
     cfg,
     cleanBlockTtsDirectiveText,
     commentaryPayloadsEnabled,
-    completeDispatchReplyOperation,
     ctx,
-    deliverStandaloneCommentaryProgress,
     deliveryChannel,
-    dispatchHookDispatcher,
     dispatcher,
-    ensureDispatchReplyOperation,
-    finishReplyOperationAbortedDispatch,
-    finishReplyOperationBusyDispatch,
     flushPendingCommentaryProgress,
     getDispatchAbortOperation,
     getDispatchAbortSignal,
-    getDispatchReplyOperation,
-    getPreDispatchAbortSignal,
-    getReplyOptions,
     hasAskUserPayload,
-    hasExecApprovalPayload,
-    hasFailedProgressStatus,
     hookRunner,
-    inboundAudio,
     isDispatchOperationAborted,
-    markIdle,
     markInboundDedupeReplayUnsafe,
-    markObservedReplyDelivery,
     markProgress,
     markVisibleToolErrorProgress,
     maybeApplyTtsWithFinalizationLease,
     maybeSendWorkingStatus,
     normalizeReplyMediaPayload,
-    notePreparedSession,
     notifySessionMetadataChanges,
-    onApprovalEventFromReplyOptions,
-    onItemEvent,
-    onPatchSummaryFromReplyOptions,
-    onPlanUpdateFromReplyOptions,
     onToolResultFromReplyOptions,
     params,
-    readAskUserQuestionId,
     reasoningPayloadsEnabled,
     recordAgentDispatchCompleted,
-    recordProcessed,
-    recordRoutedBlockReplyDelivery,
     replyConfig,
-    replyContextAccountId,
-    replyOperationRunState,
-    replyResolver,
     replyRoute,
     resolveToolDeliveryPayload,
-    routeReplyChannel,
-    routeReplyThreadId,
-    routeReplyTo,
     runWithDispatchLifecycleAdmission,
     sendPayloadAsync,
-    sendTrackedBlockReply,
-    sendPlanUpdate,
-    sendPolicy,
-    sendPolicyDenied,
     sessionAgentId,
-    sessionStableSourceReplyDeliveryMode,
     sessionTtsAuto,
-    shouldDeliverFastModeAutoProgressDespiteSourceSuppression,
-    shouldDeliverForcedToolProgressDespiteSourceSuppression,
     shouldForwardProgressCallback,
-    shouldForwardToolResultProgressCallback,
     shouldRouteToOriginating,
-    shouldSendToolSummaries,
     shouldSuppressDefaultToolProgressMessages,
-    shouldSuppressLateTextOnlyToolProgress,
-    shouldSuppressMessageToolOnlyTextErrorProgress,
-    shouldSuppressProgressDelivery,
-    shouldSuppressToolErrorWarnings,
     sourceReplyDeliveryMode,
-    summarizeApprovalLabel,
-    summarizePatchLabel,
-    suppressAutomaticSourceDelivery,
-    suppressDelivery,
-    suppressHookReplyLifecycle,
-    suppressHookUserDelivery,
-    suppressToolErrorWarnings,
-    traceReplyPhase,
     trackDispatchLifecycleWork,
-    turnLedger,
     typing,
     waitForPendingDirectBlockReplyDelivery,
     wrapProgressCallback,
@@ -123,24 +70,24 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       await runWithDispatchAbortSignal(
         getDispatchAbortSignal(),
         () =>
-          traceReplyPhase("reply.run_reply_resolver", () =>
-            replyResolver(
+          state.traceReplyPhase("reply.run_reply_resolver", () =>
+            state.replyResolver(
               ctx,
               {
-                ...getReplyOptions(),
-                [REPLY_OPERATION_RUN_STATE]: replyOperationRunState,
+                ...state.getReplyOptions(),
+                [REPLY_OPERATION_RUN_STATE]: state.replyOperationRunState,
                 sourceReplyDeliveryMode,
-                sessionPromptSourceReplyDeliveryMode: sessionStableSourceReplyDeliveryMode,
+                sessionPromptSourceReplyDeliveryMode: state.sessionStableSourceReplyDeliveryMode,
                 ...({
                   onDeliberateSilentTerminalReply: () => {
                     deliberateSilentTerminalReply = true;
                   },
                   onSessionMetadataChanges: notifySessionMetadataChanges,
-                  onSessionPrepared: notePreparedSession,
+                  onSessionPrepared: state.notePreparedSession,
                 } satisfies InternalReplyResolverOptions),
-                onObservedReplyDelivery: markObservedReplyDelivery,
-                suppressToolErrorWarnings,
-                shouldSuppressToolErrorWarnings,
+                onObservedReplyDelivery: state.markObservedReplyDelivery,
+                suppressToolErrorWarnings: state.suppressToolErrorWarnings,
+                shouldSuppressToolErrorWarnings: state.shouldSuppressToolErrorWarnings,
                 typingPolicy: typing.typingPolicy,
                 suppressTyping: typing.suppressTyping,
                 onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
@@ -163,10 +110,10 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     await flushPendingCommentaryProgress();
                   },
                 }),
-                onItemEvent,
+                onItemEvent: state.onItemEvent,
                 commentaryProgressEnabled:
-                  deliverStandaloneCommentaryProgress ||
-                  canForwardSuppressedSourceItemEvents ||
+                  state.deliverStandaloneCommentaryProgress ||
+                  state.canForwardSuppressedSourceItemEvents ||
                   params.replyOptions?.commentaryProgressEnabled,
                 reasoningPayloadsEnabled,
                 commentaryPayloadsEnabled,
@@ -175,7 +122,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   requiresToolSummaryVisibility: true,
                   waitForDirectBlockReplyDelivery: true,
                   onVisible: (payload) => {
-                    if (hasFailedProgressStatus(payload)) {
+                    if (state.hasFailedProgressStatus(payload)) {
                       markVisibleToolErrorProgress();
                     }
                   },
@@ -195,7 +142,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   waitForDirectBlockReplyDelivery: true,
                 }),
                 onToolResult: (payload: ReplyPayload) => {
-                  getDispatchReplyOperation()?.recordActivity();
+                  state.getDispatchReplyOperation()?.recordActivity();
                   markProgress();
                   const run = async () => {
                     if (isDispatchOperationAborted()) {
@@ -223,10 +170,10 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     const isFastModeAutoProgress = isFastModeAutoProgressPayload(payload);
                     const isFastModeAutoProgressDelivery =
                       isFastModeAutoProgress &&
-                      shouldDeliverFastModeAutoProgressDespiteSourceSuppression();
+                      state.shouldDeliverFastModeAutoProgressDespiteSourceSuppression();
                     const isForcedToolProgress =
-                      shouldDeliverForcedToolProgressDespiteSourceSuppression();
-                    const progressCallbackForwarded = shouldForwardToolResultProgressCallback(
+                      state.shouldDeliverForcedToolProgressDespiteSourceSuppression();
+                    const progressCallbackForwarded = state.shouldForwardToolResultProgressCallback(
                       payload,
                       isFastModeAutoProgress,
                     );
@@ -243,11 +190,11 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     ) {
                       return;
                     }
-                    if (sendPolicyDenied) {
+                    if (state.sendPolicyDenied) {
                       return;
                     }
                     if (
-                      shouldSuppressProgressDelivery() &&
+                      state.shouldSuppressProgressDelivery() &&
                       !isFastModeAutoProgressDelivery &&
                       !isForcedToolProgress &&
                       !hasAskUserPayload(payload)
@@ -280,13 +227,13 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       return;
                     }
                     if (
-                      shouldSuppressLateTextOnlyToolProgress(deliveryPayload) &&
+                      state.shouldSuppressLateTextOnlyToolProgress(deliveryPayload) &&
                       !isFastModeAutoProgressPayload(deliveryPayload) &&
                       !isForcedToolProgress
                     ) {
                       return;
                     }
-                    if (shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
+                    if (state.shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
                       return;
                     }
                     if (
@@ -297,7 +244,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       const hasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
                       if (
                         !hasMedia &&
-                        !hasExecApprovalPayload(deliveryPayload) &&
+                        !state.hasExecApprovalPayload(deliveryPayload) &&
                         !hasAskUserPayload(deliveryPayload)
                       ) {
                         return;
@@ -306,7 +253,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     if (deliveryPayload.isError === true) {
                       markVisibleToolErrorProgress();
                     }
-                    const askUserQuestionId = readAskUserQuestionId(deliveryPayload);
+                    const askUserQuestionId = state.readAskUserQuestionId(deliveryPayload);
                     if (
                       askUserQuestionId !== undefined &&
                       !(await isAskUserPromptPending(askUserQuestionId))
@@ -320,7 +267,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       await sendPayloadAsync(deliveryPayload, undefined, false);
                     } else {
                       markInboundDedupeReplayUnsafe();
-                      const delivered = turnLedger.sendQueued("tool", deliveryPayload).queued;
+                      const delivered = state.turnLedger.sendQueued("tool", deliveryPayload).queued;
                       if (delivered && hasAskUserPayload(deliveryPayload)) {
                         // ask_user blocks until this callback resolves; drain its prompt now
                         // or the answerable UI can remain queued behind the blocked agent run.
@@ -359,7 +306,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       requiresToolSummaryVisibility: true,
                     })
                   ) {
-                    await onPlanUpdateFromReplyOptions?.(normalized);
+                    await state.onPlanUpdateFromReplyOptions?.(normalized);
                   }
                   if (isDispatchOperationAborted()) {
                     return;
@@ -367,7 +314,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   if (payload.phase !== "update" || shouldSuppressDefaultToolProgressMessages()) {
                     return;
                   }
-                  await sendPlanUpdate({
+                  await state.sendPlanUpdate({
                     explanation: normalized.explanation,
                     steps,
                   });
@@ -390,7 +337,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       requiresToolSummaryVisibility: true,
                     })
                   ) {
-                    await onApprovalEventFromReplyOptions?.(payload);
+                    await state.onApprovalEventFromReplyOptions?.(payload);
                   }
                   if (isDispatchOperationAborted()) {
                     return;
@@ -401,7 +348,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   ) {
                     return;
                   }
-                  const label = summarizeApprovalLabel({
+                  const label = state.summarizeApprovalLabel({
                     status: payload.status,
                     command: payload.command,
                     message: payload.message,
@@ -429,7 +376,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       requiresToolSummaryVisibility: true,
                     })
                   ) {
-                    await onPatchSummaryFromReplyOptions?.(payload);
+                    await state.onPatchSummaryFromReplyOptions?.(payload);
                   }
                   if (isDispatchOperationAborted()) {
                     return;
@@ -437,7 +384,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   if (payload.phase !== "end" || shouldSuppressDefaultToolProgressMessages()) {
                     return;
                   }
-                  const label = summarizePatchLabel({
+                  const label = state.summarizePatchLabel({
                     summary: payload.summary,
                     title: payload.title,
                   });
@@ -461,7 +408,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     }
                     // Buffered commentary preceded this block; deliver it first.
                     await flushPendingCommentaryProgress();
-                    if (suppressDelivery) {
+                    if (state.suppressDelivery) {
                       return;
                     }
                     // Durable reasoning is a channel-owned lane; generic channels
@@ -487,15 +434,18 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     ) {
                       const joinsBufferedTtsDirective =
                         cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
-                      if (state.accumulatedBlockText.length > 0) {
-                        state.accumulatedBlockText += "\n";
+                      if (state.progressState.accumulatedBlockText.length > 0) {
+                        state.progressState.accumulatedBlockText += "\n";
                       }
-                      state.accumulatedBlockText += payload.text;
-                      if (state.accumulatedBlockTtsText.length > 0 && !joinsBufferedTtsDirective) {
-                        state.accumulatedBlockTtsText += "\n";
+                      state.progressState.accumulatedBlockText += payload.text;
+                      if (
+                        state.progressState.accumulatedBlockTtsText.length > 0 &&
+                        !joinsBufferedTtsDirective
+                      ) {
+                        state.progressState.accumulatedBlockTtsText += "\n";
                       }
-                      state.accumulatedBlockTtsText += payload.text;
-                      state.blockCount++;
+                      state.progressState.accumulatedBlockTtsText += payload.text;
+                      state.progressState.blockCount++;
                     }
                     const visiblePayload =
                       payload.text &&
@@ -525,7 +475,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                             assistantMessageIndex: payloadMetadata.assistantMessageIndex,
                           }
                         : context;
-                    if (!suppressAutomaticSourceDelivery) {
+                    if (!state.suppressAutomaticSourceDelivery) {
                       await params.replyOptions?.onBlockReplyQueued?.(
                         visiblePayload,
                         queuedContext,
@@ -557,12 +507,12 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                         false,
                         "block",
                       );
-                      recordRoutedBlockReplyDelivery(normalizedPayload, result);
+                      state.recordRoutedBlockReplyDelivery(normalizedPayload, result);
                     } else {
                       markInboundDedupeReplayUnsafe();
-                      const delivered = sendTrackedBlockReply(normalizedPayload);
+                      const delivered = state.sendTrackedBlockReply(normalizedPayload);
                       if (delivered) {
-                        state.hasPendingDirectBlockReplyDelivery = true;
+                        state.progressState.hasPendingDirectBlockReplyDelivery = true;
                       }
                     }
                   };
@@ -577,17 +527,17 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
   );
   const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
   notifySessionMetadataChanges(sessionMetadataChanges);
-  const finalDispatchAcquisition = await ensureDispatchReplyOperation("dispatch");
+  const finalDispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");
   if (finalDispatchAcquisition.status === "aborted") {
-    return { status: "complete" as const, result: finishReplyOperationAbortedDispatch() };
+    return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
   }
   if (finalDispatchAcquisition.status === "busy") {
     return {
       status: "complete" as const,
-      result: finishReplyOperationBusyDispatch({
+      result: state.finishReplyOperationBusyDispatch({
         recordAgentDispatchCompleted: true,
-        ...(state.sessionMetadataChangesForResult
-          ? { sessionMetadataChanges: state.sessionMetadataChangesForResult }
+        ...(state.routeState.sessionMetadataChangesForResult
+          ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
           : {}),
       }),
     };
@@ -607,32 +557,33 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                 createReplyDispatchEvent({
                   ctx,
                   runId: params.replyOptions?.runId,
-                  sessionKey: acpDispatchSessionKey,
+                  sessionKey: state.acpDispatchSessionKey,
                   toolsAllow: params.replyOptions?.toolsAllow,
                   images: params.replyOptions?.images,
-                  inboundAudio,
+                  inboundAudio: state.inboundAudio,
                   sessionTtsAuto,
                   ttsChannel: deliveryChannel,
-                  suppressUserDelivery: suppressHookUserDelivery,
-                  suppressReplyLifecycle: suppressHookReplyLifecycle,
+                  suppressUserDelivery: state.suppressHookUserDelivery,
+                  suppressReplyLifecycle: state.suppressHookReplyLifecycle,
                   sourceReplyDeliveryMode,
                   shouldRouteToOriginating,
-                  originatingChannel: routeReplyChannel,
-                  originatingTo: routeReplyTo,
-                  originatingAccountId: replyContextAccountId,
-                  originatingThreadId: routeReplyThreadId,
+                  originatingChannel: state.routeReplyChannel,
+                  originatingTo: state.routeReplyTo,
+                  originatingAccountId: state.replyContextAccountId,
+                  originatingThreadId: state.routeReplyThreadId,
                   originatingChatType: replyRoute.chatType,
-                  shouldSendToolSummaries,
-                  sendPolicy,
+                  shouldSendToolSummaries: state.shouldSendToolSummaries,
+                  sendPolicy: state.sendPolicy,
                   isTailDispatch: true,
                 }),
                 {
                   cfg,
-                  dispatcher: dispatchHookDispatcher,
-                  abortSignal: getPreDispatchAbortSignal() ?? params.replyOptions?.abortSignal,
+                  dispatcher: state.dispatchHookDispatcher,
+                  abortSignal:
+                    state.getPreDispatchAbortSignal() ?? params.replyOptions?.abortSignal,
                   onReplyStart: params.replyOptions?.onReplyStart,
-                  recordProcessed,
-                  markIdle,
+                  recordProcessed: state.recordProcessed,
+                  markIdle: state.markIdle,
                 },
               ),
             trackDispatchLifecycleWork,
@@ -640,25 +591,24 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       );
       if (tailDispatchResult?.handled) {
         recordAgentDispatchCompleted("completed");
-        completeDispatchReplyOperation();
+        state.completeDispatchReplyOperation();
         return {
           status: "complete" as const,
-          result: attachSourceReplyDeliveryMode({
+          result: state.attachSourceReplyDeliveryMode({
             queuedFinal: tailDispatchResult.queuedFinal,
             counts: tailDispatchResult.counts,
-            ...(state.sessionMetadataChangesForResult
-              ? { sessionMetadataChanges: state.sessionMetadataChangesForResult }
+            ...(state.routeState.sessionMetadataChangesForResult
+              ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
               : {}),
           }),
         };
       }
     }
   }
-  const nextState = extendPreparedDispatchState(
-    state,
-    { deliberateSilentTerminalReply, replyResult },
-    {},
-  );
+  const nextState = extendPreparedDispatchState(state, {
+    deliberateSilentTerminalReply,
+    replyResult,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -24,45 +24,25 @@ import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatcher.js";
 
 export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState) {
   const {
-    acpDispatchSessionKey,
-    attachSourceReplyDeliveryMode,
     cfg,
     chatType,
-    commentaryPayloadsEnabled,
-    commitInboundDedupeIfClaimed,
-    completeDispatchReplyOperation,
     ctx,
     deliveryChannel,
-    deliverySuppressionReason,
     deliberateSilentTerminalReply,
     dispatcher,
     emptyFinalAllowedAsSilent,
-    explicitCommandTurnCtx,
-    flushPendingCommentaryProgress,
     getDispatchAbortSignal,
     getObservedReplyDelivery,
     isRoutedReplyDelivered,
-    markIdle,
     markInboundDedupeReplayUnsafe,
-    maybeApplyTtsWithFinalizationLease,
-    normalizeReplyMediaPayload,
     noVisibleReplyFallbackDirected,
-    preserveProgressCallbackStartOrder,
-    reasoningPayloadsEnabled,
-    recordAgentDispatchCompleted,
-    recordProcessed,
     replyResult,
-    replyOperationRunState,
     replyRoute,
     routeReplyToOriginating,
-    sendFinalPayload,
     sendPolicyDenied,
     sessionAgentId,
     sessionKey,
     sessionStoreEntry,
-    sessionTtsAuto,
-    sourceReplyDeliveryMode,
-    suppressAutomaticSourceDelivery,
     suppressDelivery,
     throwIfDispatchOperationAborted,
     turnLedger,
@@ -84,12 +64,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   });
   // Final delivery is outside the progress wrappers. Wait until every source-ordered callback
   // has at least started so a delayed tool/reasoning transition cannot appear after the final.
-  if (preserveProgressCallbackStartOrder) {
-    await state.progressCallbackStartTail;
+  if (state.preserveProgressCallbackStartOrder) {
+    await state.progressState.progressCallbackStartTail;
   }
   // Backstop: silent/streaming-delivered turns end without a visible final
   // reply; trailing commentary must still land.
-  await flushPendingCommentaryProgress();
+  await state.flushPendingCommentaryProgress();
   const beforeAgentRunBlocked = replies.some(
     (reply) => getReplyPayloadMetadata(reply)?.beforeAgentRunBlocked === true,
   );
@@ -110,27 +90,27 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   // Uses the same helper as the source-reply visibility policy so the bypass
   // and the policy stay aligned.
   const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
-    suppressAutomaticSourceDelivery &&
+    state.suppressAutomaticSourceDelivery &&
     !sendPolicyDenied &&
     getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
-    (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
+    (ctx.InboundEventKind !== "room_event" || state.explicitCommandTurnCtx);
   const sentFinalPayloadDedupeKeys = new Set<string>();
   for (const [replyIndex, reply] of replies.entries()) {
     throwIfDispatchOperationAborted();
     // Durable reasoning is a channel-owned lane; generic channels keep the
     // historical suppression unless they explicitly opt in.
-    if (reply.isReasoning === true && !reasoningPayloadsEnabled) {
+    if (reply.isReasoning === true && !state.reasoningPayloadsEnabled) {
       continue;
     }
-    if (reply.isCommentary === true && !commentaryPayloadsEnabled) {
+    if (reply.isCommentary === true && !state.commentaryPayloadsEnabled) {
       continue;
     }
     if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {
       if (hasOutboundReplyContent(reply, { trimText: true })) {
         logVerbose(
           [
-            `dispatch-from-config: final reply suppressed by ${deliverySuppressionReason || "source delivery policy"}`,
-            `(session=${acpDispatchSessionKey ?? sessionKey ?? "unknown"}`,
+            `dispatch-from-config: final reply suppressed by ${state.deliverySuppressionReason || "source delivery policy"}`,
+            `(session=${state.acpDispatchSessionKey ?? sessionKey ?? "unknown"}`,
             `provider=${ctx.Provider ?? "unknown"}`,
             `surface=${ctx.Surface ?? "unknown"}`,
             `chatType=${chatType ?? "unknown"}`,
@@ -147,7 +127,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       continue;
     }
     sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
-    const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
+    const finalReply = await state.sendFinalPayload(reply, { deliveryId: String(replyIndex) });
     if (finalReply.dedupedAgainstBlock) {
       // The delivering block already settled into the turn ledger.
       continue;
@@ -216,18 +196,18 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     if (
       ttsMode === "final" &&
       replies.length === 0 &&
-      state.blockCount > 0 &&
-      state.accumulatedBlockTtsText.trim()
+      state.progressState.blockCount > 0 &&
+      state.progressState.accumulatedBlockTtsText.trim()
     ) {
       try {
         await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
         throwIfDispatchOperationAborted();
-        const ttsSyntheticReply = await maybeApplyTtsWithFinalizationLease({
-          payload: { text: state.accumulatedBlockTtsText },
+        const ttsSyntheticReply = await state.maybeApplyTtsWithFinalizationLease({
+          payload: { text: state.progressState.accumulatedBlockTtsText },
           cfg,
           channel: deliveryChannel,
           kind: "final",
-          ttsAuto: sessionTtsAuto,
+          ttsAuto: state.sessionTtsAuto,
           agentId: sessionAgentId,
           accountId: replyRoute.accountId,
         });
@@ -240,13 +220,13 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             {
               mediaUrl: ttsSyntheticReply.mediaUrl,
               audioAsVoice: ttsSyntheticReply.audioAsVoice,
-              spokenText: state.accumulatedBlockTtsText,
+              spokenText: state.progressState.accumulatedBlockTtsText,
               trustedLocalMedia: true,
             },
-            state.accumulatedBlockTtsText,
+            state.progressState.accumulatedBlockTtsText,
             { visibleTextAlreadyDelivered: true },
           );
-          const normalizedTtsOnlyPayload = await normalizeReplyMediaPayload(ttsOnlyPayload);
+          const normalizedTtsOnlyPayload = await state.normalizeReplyMediaPayload(ttsOnlyPayload);
           throwIfDispatchOperationAborted();
           const result = await routeReplyToOriginating(normalizedTtsOnlyPayload, {
             abortSignal: getDispatchAbortSignal(),
@@ -285,12 +265,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   // ledger intentionally does not own. Directedness gates both the fallback and
   // eligibility: only a turn that positively addressed the bot may surface a
   // visible failure notice.
-  const replyAcceptedByActiveRun = replyOperationRunState.admission?.status === "accepted";
+  const replyAcceptedByActiveRun = state.replyOperationRunState.admission?.status === "accepted";
   const noVisibleReplyFallbackAllowed = () =>
     noVisibleReplyFallbackDirected &&
     !suppressDelivery &&
     !sendPolicyDenied &&
-    sourceReplyDeliveryMode !== "message_tool_only" &&
+    state.sourceReplyDeliveryMode !== "message_tool_only" &&
     !emptyFinalAllowedAsSilent &&
     !deliberateSilentTerminalReply &&
     !getObservedReplyDelivery() &&
@@ -364,21 +344,23 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     }
   }
   counts.final += routedFinalCount;
-  commitInboundDedupeIfClaimed();
-  recordAgentDispatchCompleted("completed");
-  recordProcessed(
+  state.commitInboundDedupeIfClaimed();
+  state.recordAgentDispatchCompleted("completed");
+  state.recordProcessed(
     "completed",
-    state.pluginFallbackReason ? { reason: state.pluginFallbackReason } : undefined,
+    state.bindingState.pluginFallbackReason
+      ? { reason: state.bindingState.pluginFallbackReason }
+      : undefined,
   );
-  markIdle("message_completed");
-  completeDispatchReplyOperation();
+  state.markIdle("message_completed");
+  state.completeDispatchReplyOperation();
   return {
     status: "complete" as const,
-    result: attachSourceReplyDeliveryMode({
+    result: state.attachSourceReplyDeliveryMode({
       queuedFinal,
       counts,
-      ...(state.sessionMetadataChangesForResult
-        ? { sessionMetadataChanges: state.sessionMetadataChangesForResult }
+      ...(state.routeState.sessionMetadataChangesForResult
+        ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
         : {}),
       ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
       // Eligibility keys off settled visible delivery: a suppressed or cancelled

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -62,7 +62,11 @@ export async function gatherDispatchRequest(
     ? params.ctx
     : finalizeInboundContext(params.ctx);
   const normalizedParams = ctx === params.ctx ? params : { ...params, ctx };
-  const state = { params: normalizedParams, messageAuditTerminal };
+  const state = {
+    params: normalizedParams,
+    messageAuditTerminal,
+    inboundDedupeReplayUnsafe: false,
+  };
   const { cfg, dispatcher } = normalizedParams;
   const replyOperationRunState: ReplyOperationRunState =
     resolveReplyOperationRunState(normalizedParams.replyOptions) ?? {};
@@ -183,9 +187,8 @@ export async function gatherDispatchRequest(
     messageLifecycle.markIdle(reason);
   };
 
-  let inboundDedupeReplayUnsafe = false;
   const markInboundDedupeReplayUnsafe = () => {
-    inboundDedupeReplayUnsafe = true;
+    state.inboundDedupeReplayUnsafe = true;
   };
 
   const boundAcpDispatchSessionKey = resolveBoundAcpDispatchSessionKey({ ctx, cfg });
@@ -383,8 +386,8 @@ export async function gatherDispatchRequest(
       inboundClaimEvent: inboundClaim.event,
     };
   };
-  let { hookContext, inboundClaimContext, inboundClaimEvent } = buildHookState(hookCtx);
-  const { isGroup, groupId } = hookContext;
+  const hookState = buildHookState(hookCtx);
+  const { isGroup, groupId } = hookState.hookContext;
   let hookMediaPrepared = false;
   let hookMediaMetadataStaged = false;
   const prepareHookMediaMetadata = async () => {
@@ -406,11 +409,12 @@ export async function gatherDispatchRequest(
     );
     if (staged) {
       hookMediaMetadataStaged = true;
-      ({ hookContext, inboundClaimContext, inboundClaimEvent } = buildHookState(hookCtx));
+      Object.assign(hookState, buildHookState(hookCtx));
     }
   };
   const buildMessageReceivedHookContext = () => {
     const mediaRemoteHost = normalizeOptionalString(ctx.MediaRemoteHost);
+    const { hookContext } = hookState;
     const hasUnstagedRemoteMediaMetadata = Boolean(hookContext.media?.length);
     if (hookMediaMetadataStaged || !mediaRemoteHost || !hasUnstagedRemoteMediaMetadata) {
       return hookContext;
@@ -433,88 +437,60 @@ export async function gatherDispatchRequest(
       originalMediaTypes: hookContext.mediaTypes,
     };
   };
-  const nextState = extendPreparedDispatchState(
-    state,
-    {
-      ctx,
-      cfg,
-      dispatcher,
-      sessionKey,
-      traceReplyPhase,
-      recordProcessed,
-      recordAgentDispatchStarted,
-      recordAgentDispatchCompleted,
-      markProcessing,
-      markIdle,
-      markInboundDedupeReplayUnsafe,
-      acpDispatchSessionKey,
-      markProgress,
-      sessionStoreEntry,
-      notePreparedSession,
-      resolvePreparedTranscriptBinding,
-      sessionAgentId,
-      shouldEmitVerboseProgress,
-      shouldEmitFullVerboseProgress,
-      replyRoute,
-      routeReplyThreadId,
-      inboundAudio,
-      sessionTtsAuto,
-      workspaceDir,
-      replyOperationRunState,
-      completeDispatchReplyOperation,
-      dispatchHookDispatcher,
-      ensureDispatchReplyOperation,
-      failDispatchReplyOperation,
-      getDispatchAbortOperation,
-      getDispatchAbortSignal,
-      getDispatchReplyOperation,
-      getObservedReplyDelivery,
-      getPreDispatchAbortSignal,
-      getReplyOptions,
-      isDispatchOperationAborted,
-      isPreDispatchOperationAborted,
-      markObservedReplyDelivery,
-      releasePreDispatchLifecycleAdmission,
-      runWithDispatchLifecycleAdmission,
-      throwIfDispatchOperationAborted,
-      trackDispatchLifecycleWork,
-      turnLedger,
-      maybeApplyTtsWithFinalizationLease,
-      hookRunner,
-      timestamp,
-      messageIdForHook,
-      isGroup,
-      groupId,
-      prepareHookMediaMetadata,
-      buildMessageReceivedHookContext,
-    },
-    {
-      inboundDedupeReplayUnsafe: {
-        get: () => inboundDedupeReplayUnsafe,
-        set: (value: boolean) => {
-          inboundDedupeReplayUnsafe = value;
-        },
-      },
-      hookContext: {
-        get: () => hookContext,
-        set: (value: typeof hookContext) => {
-          hookContext = value;
-        },
-      },
-      inboundClaimContext: {
-        get: () => inboundClaimContext,
-        set: (value: typeof inboundClaimContext) => {
-          inboundClaimContext = value;
-        },
-      },
-      inboundClaimEvent: {
-        get: () => inboundClaimEvent,
-        set: (value: typeof inboundClaimEvent) => {
-          inboundClaimEvent = value;
-        },
-      },
-    },
-  );
+  const nextState = extendPreparedDispatchState(state, {
+    ctx,
+    cfg,
+    dispatcher,
+    sessionKey,
+    traceReplyPhase,
+    recordProcessed,
+    recordAgentDispatchStarted,
+    recordAgentDispatchCompleted,
+    markProcessing,
+    markIdle,
+    markInboundDedupeReplayUnsafe,
+    acpDispatchSessionKey,
+    markProgress,
+    sessionStoreEntry,
+    notePreparedSession,
+    resolvePreparedTranscriptBinding,
+    sessionAgentId,
+    shouldEmitVerboseProgress,
+    shouldEmitFullVerboseProgress,
+    replyRoute,
+    routeReplyThreadId,
+    inboundAudio,
+    sessionTtsAuto,
+    workspaceDir,
+    replyOperationRunState,
+    completeDispatchReplyOperation,
+    dispatchHookDispatcher,
+    ensureDispatchReplyOperation,
+    failDispatchReplyOperation,
+    getDispatchAbortOperation,
+    getDispatchAbortSignal,
+    getDispatchReplyOperation,
+    getObservedReplyDelivery,
+    getPreDispatchAbortSignal,
+    getReplyOptions,
+    isDispatchOperationAborted,
+    isPreDispatchOperationAborted,
+    markObservedReplyDelivery,
+    releasePreDispatchLifecycleAdmission,
+    runWithDispatchLifecycleAdmission,
+    throwIfDispatchOperationAborted,
+    trackDispatchLifecycleWork,
+    turnLedger,
+    maybeApplyTtsWithFinalizationLease,
+    hookRunner,
+    timestamp,
+    messageIdForHook,
+    isGroup,
+    groupId,
+    hookState,
+    prepareHookMediaMetadata,
+    buildMessageReceivedHookContext,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.phase-state.ts
+++ b/src/auto-reply/reply/dispatch-from-config.phase-state.ts
@@ -1,29 +1,6 @@
-type PreparedStateBinding = {
-  get: () => unknown;
-  set: (value: never) => void;
-};
-
-type PreparedStateBindingValues<Bindings extends Record<string, PreparedStateBinding>> = {
-  [Key in keyof Bindings]: ReturnType<Bindings[Key]["get"]>;
-};
-
-export function extendPreparedDispatchState<
-  State extends object,
-  Values extends object,
-  Bindings extends Record<string, PreparedStateBinding>,
->(
+export function extendPreparedDispatchState<State extends object, Values extends object>(
   state: State,
   values: Values,
-  bindings: Bindings,
-): State & Values & PreparedStateBindingValues<Bindings> {
-  Object.assign(state, values);
-  for (const [key, binding] of Object.entries(bindings)) {
-    Object.defineProperty(state, key, {
-      configurable: true,
-      enumerable: true,
-      get: binding.get,
-      set: binding.set,
-    });
-  }
-  return state as State & Values & PreparedStateBindingValues<Bindings>;
+): State & Values {
+  return Object.assign(state, values);
 }

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -69,28 +69,18 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     acpDispatchSessionKey,
     buildMessageReceivedHookContext,
     cfg,
-    completeDispatchReplyOperation,
     ctx,
-    deliverBindingPayload,
     dispatcher,
-    getDispatchReplyOperation,
     hookRunner,
     isInternalWebchatTurn,
     markIdle,
-    markProcessing,
     params,
     recordAgentDispatchCompleted,
     recordProcessed,
-    releasePreDispatchLifecycleAdmission,
     replyRoute,
-    routeReplyChannel,
     sessionAgentId,
     sessionKey,
     sessionStoreEntry,
-    shouldRouteToOriginating,
-    shouldSuppressTyping,
-    suppressAcpChildUserDelivery,
-    timestamp,
   } = state;
   const sendBindingNotice = async (
     payload: ReplyPayload,
@@ -100,7 +90,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     if (suppressAutomaticSourceDelivery) {
       return false;
     }
-    return await deliverBindingPayload(payload, mode, transcriptOwner);
+    return await state.deliverBindingPayload(payload, mode, transcriptOwner);
   };
 
   // Hook contexts use transport-native ids (for example Slack `U123`), while
@@ -199,7 +189,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     entry: sessionStoreEntry.entry,
     sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
     channel:
-      (shouldRouteToOriginating ? routeReplyChannel : undefined) ??
+      (state.shouldRouteToOriginating ? state.routeReplyChannel : undefined) ??
       sessionDeliveryChannel(sessionStoreEntry.entry) ??
       replyRoute.channel ??
       ctx.Surface ??
@@ -320,9 +310,9 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     requested: params.replyOptions?.sourceReplyDeliveryMode,
     strictMessageToolOnly: ctx.InboundEventKind === "room_event" && !isInternalWebchatTurn,
     sendPolicy,
-    suppressAcpChildUserDelivery,
+    suppressAcpChildUserDelivery: state.suppressAcpChildUserDelivery,
     explicitSuppressTyping: params.replyOptions?.suppressTyping === true,
-    shouldSuppressTyping,
+    shouldSuppressTyping: state.shouldSuppressTyping,
     messageToolAvailable,
     defaultVisibleReplies: harnessDefaultVisibleReplies,
   });
@@ -423,7 +413,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     recordAgentDispatchCompleted?: boolean;
     sessionMetadataChanges?: DispatchFromConfigResult["sessionMetadataChanges"];
   }): DispatchFromConfigResult => {
-    void releasePreDispatchLifecycleAdmission(() => waitForReplyDispatcherIdle(dispatcher));
+    void state.releasePreDispatchLifecycleAdmission(() => waitForReplyDispatcherIdle(dispatcher));
     if (opts?.recordAgentDispatchCompleted) {
       recordAgentDispatchCompleted("completed", { reason: "reply-operation-active" });
     }
@@ -443,7 +433,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     });
   };
   const finishReplyOperationAbortedDispatch = (): DispatchFromConfigResult => {
-    const operation = getDispatchReplyOperation();
+    const operation = state.getDispatchReplyOperation();
     // Feedback only for pre-run drops: the user never saw output. Finalization or
     // terminal-settle stalls already produced/settled output, so a notice is noise.
     const droppedBeforeOutput =
@@ -460,17 +450,18 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     commitInboundDedupeIfClaimed();
     recordProcessed("completed", { reason: "reply_operation_aborted" });
     markIdle("message_completed");
-    completeDispatchReplyOperation();
+    state.completeDispatchReplyOperation();
     return attachSourceReplyDeliveryMode({
       queuedFinal,
       counts: dispatcher.getQueuedCounts(),
     });
   };
 
-  let pluginFallbackReason:
-    | "plugin-bound-fallback-missing-plugin"
-    | "plugin-bound-fallback-no-handler"
-    | undefined;
+  const bindingState: {
+    pluginFallbackReason?:
+      | "plugin-bound-fallback-missing-plugin"
+      | "plugin-bound-fallback-no-handler";
+  } = {};
   const emitMessageReceivedHooks = () => {
     if (
       ctx.SuppressMessageReceivedHooks !== true &&
@@ -491,14 +482,14 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
         triggerInternalHook(
           createInternalHookEvent("message", "received", sessionKey, {
             ...toInternalMessageReceivedContext(messageReceivedHookContext),
-            timestamp,
+            timestamp: state.timestamp,
           }),
         ),
         "dispatch-from-config: message_received internal hook failed",
       );
     }
   };
-  markProcessing();
+  state.markProcessing();
   if (await capturePendingConversationTurnReply({ cfg, ctx })) {
     emitMessageReceivedHooks();
     commitInboundDedupeIfClaimed();
@@ -513,50 +504,35 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
       }),
     };
   }
-  const nextState = extendPreparedDispatchState(
-    state,
-    {
-      sendBindingNotice,
-      pluginOwnedBinding,
-      persistPluginBindingUserTurn,
-      sendPolicy,
-      chatType,
-      emptyFinalAllowedAsSilent,
-      noVisibleReplyFallbackDirected,
-      sourceReplyPolicy,
-      sourceReplyDeliveryMode,
-      sessionStableSourceReplyDeliveryMode,
-      suppressAutomaticSourceDelivery,
-      suppressDelivery,
-      sendPolicyDenied,
-      deliverySuppressionReason,
-      suppressHookUserDelivery,
-      suppressHookReplyLifecycle,
-      reasoningPayloadsEnabled,
-      commentaryPayloadsEnabled,
-      attachSourceReplyDeliveryMode,
-      explicitCommandTurnCtx,
-      shouldDeliverPluginBindingReply,
-      inboundDedupeClaim,
-      commitInboundDedupeIfClaimed,
-      finishReplyOperationBusyDispatch,
-      finishReplyOperationAbortedDispatch,
-      emitMessageReceivedHooks,
-    },
-    {
-      pluginFallbackReason: {
-        get: () => pluginFallbackReason,
-        set: (
-          value:
-            | "plugin-bound-fallback-missing-plugin"
-            | "plugin-bound-fallback-no-handler"
-            | undefined,
-        ) => {
-          pluginFallbackReason = value;
-        },
-      },
-    },
-  );
+  const nextState = extendPreparedDispatchState(state, {
+    sendBindingNotice,
+    pluginOwnedBinding,
+    persistPluginBindingUserTurn,
+    sendPolicy,
+    chatType,
+    emptyFinalAllowedAsSilent,
+    noVisibleReplyFallbackDirected,
+    sourceReplyPolicy,
+    sourceReplyDeliveryMode,
+    sessionStableSourceReplyDeliveryMode,
+    suppressAutomaticSourceDelivery,
+    suppressDelivery,
+    sendPolicyDenied,
+    deliverySuppressionReason,
+    suppressHookUserDelivery,
+    suppressHookReplyLifecycle,
+    reasoningPayloadsEnabled,
+    commentaryPayloadsEnabled,
+    attachSourceReplyDeliveryMode,
+    explicitCommandTurnCtx,
+    shouldDeliverPluginBindingReply,
+    inboundDedupeClaim,
+    commitInboundDedupeIfClaimed,
+    finishReplyOperationBusyDispatch,
+    finishReplyOperationAbortedDispatch,
+    emitMessageReceivedHooks,
+    bindingState,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
@@ -27,19 +27,13 @@ import { resolveReplyRoutingDecision } from "./routing-policy.js";
 
 export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyState) {
   const {
-    acpDispatchSessionKey,
     cfg,
     ctx,
-    getDispatchAbortSignal,
     groupId,
-    isGroup,
     markInboundDedupeReplayUnsafe,
-    params,
     replyRoute,
-    routeReplyThreadId,
     sessionStoreEntry,
     turnLedger,
-    workspaceDir,
   } = state;
   // Check if we should route replies to originating channel instead of dispatcher.
   // Only route when the originating channel is DIFFERENT from the current surface.
@@ -113,8 +107,8 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     const { createReplyMediaPathNormalizer } = await loadReplyMediaPathsRuntime();
     normalizeReplyMediaPaths = createReplyMediaPathNormalizer({
       cfg,
-      sessionKey: acpDispatchSessionKey,
-      workspaceDir,
+      sessionKey: state.acpDispatchSessionKey,
+      workspaceDir: state.workspaceDir,
       messageProvider: deliveryChannel,
       accountId: replyContextAccountId,
       groupId,
@@ -170,15 +164,15 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
       requesterSenderName: ctx.SenderName,
       requesterSenderUsername: ctx.SenderUsername,
       requesterSenderE164: ctx.SenderE164,
-      threadId: routeReplyThreadId,
+      threadId: state.routeReplyThreadId,
       replyDelivery: routedReplyDelivery,
       cfg,
       abortSignal: options?.abortSignal,
       mirror: options?.mirror,
-      isGroup,
+      isGroup: state.isGroup,
       groupId,
       replyKind: options?.kind ?? "final",
-      runId: params.replyOptions?.runId,
+      runId: state.params.replyOptions?.runId,
       responsePrefixContext: options?.responsePrefixContext,
     });
     // Routed sends settle here: the transport result is the settlement. This is
@@ -206,7 +200,7 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     if (!routeReplyRuntime || !routeReplyChannel || !routeReplyTo) {
       return null;
     }
-    const effectiveAbortSignal = abortSignal ?? getDispatchAbortSignal();
+    const effectiveAbortSignal = abortSignal ?? state.getDispatchAbortSignal();
     if (effectiveAbortSignal?.aborted) {
       return null;
     }
@@ -266,26 +260,22 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
       ? turnLedger.sendQueued("tool", bindingPayload).queued
       : turnLedger.sendQueued("final", bindingPayload).queued;
   };
-  const nextState = extendPreparedDispatchState(
-    state,
-    {
-      suppressAcpChildUserDelivery,
-      normalizedCurrentSurface,
-      isInternalWebchatTurn,
-      routeReplyChannel,
-      shouldRouteToOriginating,
-      shouldSuppressTyping,
-      routeReplyTo,
-      deliveryChannel,
-      replyContextAccountId,
-      normalizeReplyMediaPayload,
-      routeReplyToOriginating,
-      isRoutedReplyDelivered,
-      sendPayloadAsync,
-      deliverBindingPayload,
-    },
-    {},
-  );
+  const nextState = extendPreparedDispatchState(state, {
+    suppressAcpChildUserDelivery,
+    normalizedCurrentSurface,
+    isInternalWebchatTurn,
+    routeReplyChannel,
+    shouldRouteToOriginating,
+    shouldSuppressTyping,
+    routeReplyTo,
+    deliveryChannel,
+    replyContextAccountId,
+    normalizeReplyMediaPayload,
+    routeReplyToOriginating,
+    isRoutedReplyDelivered,
+    sendPayloadAsync,
+    deliverBindingPayload,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -29,37 +29,21 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   const {
     cfg,
     ctx,
-    deliveryChannel,
-    deliverySuppressionReason,
     dispatcher,
-    getDispatchAbortOperation,
-    getDispatchReplyOperation,
-    hasAskUserPayload,
     isDispatchOperationAborted,
     markInboundDedupeReplayUnsafe,
     markProgress,
     noteCommentaryProgress,
     params,
-    recordAgentDispatchStarted,
-    replyRoute,
-    routeReplyChannel,
     sendPayloadAsync,
     sendPolicyDenied,
-    sessionAgentId,
     sessionKey,
-    sessionStoreEntry,
-    sessionTtsAuto,
-    shouldDeliverVerboseProgressDespiteSourceSuppression,
-    shouldEmitFullVerboseProgress,
     shouldEmitVerboseProgress,
     shouldRouteToOriginating,
-    shouldSendToolStartStatuses,
     shouldSendToolSummaries,
     shouldSendVerboseProgressMessages,
-    sourceReplyPolicy,
     suppressAutomaticSourceDelivery,
     suppressDelivery,
-    traceReplyPhase,
     turnLedger,
   } = state;
   // When automatic source delivery is suppressed, still let the agent process
@@ -67,7 +51,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   // outbound source delivery.
   if (suppressDelivery) {
     logVerbose(
-      `Delivery suppressed by ${deliverySuppressionReason} for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"} — agent will still process the message`,
+      `Delivery suppressed by ${state.deliverySuppressionReason} for session ${state.sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"} — agent will still process the message`,
     );
   }
 
@@ -101,7 +85,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     const normalizedLabel = normalizeWorkingLabel(label);
     if (
       !shouldEmitVerboseProgress() ||
-      !shouldSendToolStartStatuses ||
+      !state.shouldSendToolStartStatuses ||
       !normalizedLabel ||
       toolStartStatusCount >= 2 ||
       toolStartStatusesSent.has(normalizedLabel)
@@ -178,15 +162,19 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   // Track accumulated block text for TTS generation after streaming completes.
   // When block streaming succeeds, there's no final reply, so we need to generate
   // TTS audio separately from the accumulated block content.
-  let accumulatedBlockText = "";
-  let accumulatedBlockTtsText = "";
-  let blockCount = 0;
+  const progressState = {
+    accumulatedBlockText: "",
+    accumulatedBlockTtsText: "",
+    blockCount: 0,
+    hasPendingDirectBlockReplyDelivery: false,
+    progressCallbackStartTail: Promise.resolve(),
+  };
   const cleanBlockTtsDirectiveText = shouldCleanTtsDirectiveText({
     cfg,
-    ttsAuto: sessionTtsAuto,
-    agentId: sessionAgentId,
-    channelId: deliveryChannel,
-    accountId: replyRoute.accountId,
+    ttsAuto: state.sessionTtsAuto,
+    agentId: state.sessionAgentId,
+    channelId: state.deliveryChannel,
+    accountId: state.replyRoute.accountId,
   })
     ? createTtsDirectiveTextStreamCleaner()
     : undefined;
@@ -214,7 +202,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     if (execApproval && typeof execApproval === "object" && !Array.isArray(execApproval)) {
       return payload;
     }
-    if (hasAskUserPayload(payload)) {
+    if (state.hasAskUserPayload(payload)) {
       return payload;
     }
     if (isFastModeAutoProgressPayload(payload)) {
@@ -230,16 +218,16 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   };
   const typing = resolveRunTypingPolicy({
     requestedPolicy: params.replyOptions?.typingPolicy,
-    suppressTyping: sourceReplyPolicy.suppressTyping,
-    originatingChannel: routeReplyChannel,
+    suppressTyping: state.sourceReplyPolicy.suppressTyping,
+    originatingChannel: state.routeReplyChannel,
     systemEvent: shouldRouteToOriginating,
   });
   const shouldSuppressProgressDelivery = () =>
     sendPolicyDenied ||
-    (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
+    (suppressDelivery && !state.shouldDeliverVerboseProgressDespiteSourceSuppression());
   const hasVisibleRegularVerboseToolProgress = () =>
     shouldEmitVerboseProgress() &&
-    !shouldEmitFullVerboseProgress() &&
+    !state.shouldEmitFullVerboseProgress() &&
     shouldSendVerboseProgressMessages() &&
     ctx.InboundEventKind !== "room_event" &&
     !shouldSuppressProgressDelivery();
@@ -302,15 +290,14 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     options?.requiresToolSummaryVisibility === true &&
     (params.replyOptions?.suppressDefaultToolProgressMessages === true ||
       options.allowWhenToolSummariesHidden === true);
-  let hasPendingDirectBlockReplyDelivery = false;
   const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
-    if (!hasPendingDirectBlockReplyDelivery) {
+    if (!progressState.hasPendingDirectBlockReplyDelivery) {
       return;
     }
     // Direct block replies are queued asynchronously so lightweight replies do
     // not wait for dispatcher idle. Flush only before later tool/progress
     // callbacks and final completion where external ordering is visible.
-    hasPendingDirectBlockReplyDelivery = false;
+    progressState.hasPendingDirectBlockReplyDelivery = false;
     await waitForReplyDispatcherIdle(dispatcher, abortSignal);
   };
   const shouldForwardProgressCallback = (options?: {
@@ -334,11 +321,10 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   };
   const preserveProgressCallbackStartOrder =
     params.replyOptions?.preserveProgressCallbackStartOrder === true;
-  let progressCallbackStartTail = Promise.resolve();
   const reserveProgressCallbackStart = () => {
-    const previousStart = progressCallbackStartTail;
+    const previousStart = progressState.progressCallbackStartTail;
     let releaseStart: (() => void) | undefined;
-    progressCallbackStartTail = new Promise<void>((resolve) => {
+    progressState.progressCallbackStartTail = new Promise<void>((resolve) => {
       releaseStart = resolve;
     });
     return {
@@ -368,10 +354,12 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
         if (isDispatchOperationAborted()) {
           return undefined;
         }
-        getDispatchReplyOperation()?.recordActivity();
+        state.getDispatchReplyOperation()?.recordActivity();
         markProgress();
         if (options?.waitForDirectBlockReplyDelivery) {
-          await waitForPendingDirectBlockReplyDelivery(getDispatchAbortOperation()?.abortSignal);
+          await waitForPendingDirectBlockReplyDelivery(
+            state.getDispatchAbortOperation()?.abortSignal,
+          );
           if (isDispatchOperationAborted()) {
             return undefined;
           }
@@ -478,8 +466,11 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
 
   const replyResolver =
     params.replyResolver ??
-    (await traceReplyPhase("reply.load_reply_resolver", () => loadGetReplyFromConfigRuntime()))
-      .getReplyFromConfig;
+    (
+      await state.traceReplyPhase("reply.load_reply_resolver", () =>
+        loadGetReplyFromConfigRuntime(),
+      )
+    ).getReplyFromConfig;
   // Channel runtimes can outlive a config reload. Ordinary Gateway turns rebind to the
   // committed model owner; an explicit per-turn projection stays exact to its caller config.
   const publishedRuntimeReplyConfig = getRuntimeConfigSnapshot();
@@ -491,70 +482,36 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     : params.usePublishedModelRuntime || publishedRuntimeReplyConfig
       ? withPublishedRuntimeReplyConfig(runtimeReplyConfig)
       : withFullRuntimeReplyConfig(cfg);
-  recordAgentDispatchStarted();
-  const nextState = extendPreparedDispatchState(
-    state,
-    {
-      maybeSendWorkingStatus,
-      sendPlanUpdate,
-      summarizeApprovalLabel,
-      summarizePatchLabel,
-      cleanBlockTtsDirectiveText,
-      resolveToolDeliveryPayload,
-      typing,
-      shouldSuppressProgressDelivery,
-      markVisibleToolErrorProgress,
-      hasFailedProgressStatus,
-      shouldSuppressToolErrorWarnings,
-      suppressToolErrorWarnings,
-      onToolResultFromReplyOptions,
-      onPlanUpdateFromReplyOptions,
-      onApprovalEventFromReplyOptions,
-      onPatchSummaryFromReplyOptions,
-      shouldForwardToolResultProgressCallback,
-      waitForPendingDirectBlockReplyDelivery,
-      shouldForwardProgressCallback,
-      preserveProgressCallbackStartOrder,
-      wrapProgressCallback,
-      deliverStandaloneCommentaryProgress,
-      canForwardSuppressedSourceItemEvents,
-      onItemEvent,
-      replyResolver,
-      replyConfig,
-    },
-    {
-      accumulatedBlockText: {
-        get: () => accumulatedBlockText,
-        set: (value: string) => {
-          accumulatedBlockText = value;
-        },
-      },
-      accumulatedBlockTtsText: {
-        get: () => accumulatedBlockTtsText,
-        set: (value: string) => {
-          accumulatedBlockTtsText = value;
-        },
-      },
-      blockCount: {
-        get: () => blockCount,
-        set: (value: number) => {
-          blockCount = value;
-        },
-      },
-      hasPendingDirectBlockReplyDelivery: {
-        get: () => hasPendingDirectBlockReplyDelivery,
-        set: (value: boolean) => {
-          hasPendingDirectBlockReplyDelivery = value;
-        },
-      },
-      progressCallbackStartTail: {
-        get: () => progressCallbackStartTail,
-        set: (value: typeof progressCallbackStartTail) => {
-          progressCallbackStartTail = value;
-        },
-      },
-    },
-  );
+  state.recordAgentDispatchStarted();
+  const nextState = extendPreparedDispatchState(state, {
+    maybeSendWorkingStatus,
+    sendPlanUpdate,
+    summarizeApprovalLabel,
+    summarizePatchLabel,
+    cleanBlockTtsDirectiveText,
+    resolveToolDeliveryPayload,
+    typing,
+    shouldSuppressProgressDelivery,
+    markVisibleToolErrorProgress,
+    hasFailedProgressStatus,
+    shouldSuppressToolErrorWarnings,
+    suppressToolErrorWarnings,
+    onToolResultFromReplyOptions,
+    onPlanUpdateFromReplyOptions,
+    onApprovalEventFromReplyOptions,
+    onPatchSummaryFromReplyOptions,
+    shouldForwardToolResultProgressCallback,
+    waitForPendingDirectBlockReplyDelivery,
+    shouldForwardProgressCallback,
+    preserveProgressCallbackStartOrder,
+    wrapProgressCallback,
+    deliverStandaloneCommentaryProgress,
+    canForwardSuppressedSourceItemEvents,
+    onItemEvent,
+    replyResolver,
+    replyConfig,
+    progressState,
+  });
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
@@ -14,7 +14,6 @@ import { getGlobalPluginRegistry } from "../../plugins/hook-runner-global.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import { DispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
-import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import { shouldBypassPluginOwnedBindingForCommand } from "./dispatch-from-config.plugin-binding.js";
 import type { PrepareDispatchOperationContextReadyState } from "./dispatch-from-config.prepare-context.js";
 import {
@@ -31,33 +30,21 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
     commitInboundDedupeIfClaimed,
     completeDispatchReplyOperation,
     ctx,
-    deliverBindingPayload,
     deliverySuppressionReason,
     dispatcher,
     emitMessageReceivedHooks,
-    ensureDispatchReplyOperation,
-    explicitCommandTurnCtx,
     finishReplyOperationAbortedDispatch,
-    finishReplyOperationBusyDispatch,
     hookRunner,
     isPreDispatchOperationAborted,
-    isRoutedReplyDelivered,
     markIdle,
-    markInboundDedupeReplayUnsafe,
     params,
     persistPluginBindingUserTurn,
     pluginOwnedBinding,
-    prepareHookMediaMetadata,
     recordProcessed,
-    routeReplyToOriginating,
-    runWithDispatchLifecycleAdmission,
     sendBindingNotice,
-    sendPolicyDenied,
     sessionAgentId,
     sessionKey,
     sessionStoreEntry,
-    shouldDeliverPluginBindingReply,
-    suppressAutomaticSourceDelivery,
     suppressDelivery,
   } = state;
   const abortRuntime = params.fastAbortResolver ? null : await loadAbortRuntime();
@@ -93,10 +80,10 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       };
       // Routed delivery owns its destination-scoped prefix. Direct dispatchers already own
       // their prefix, so seed that live context only when no cross-channel route is used.
-      const result = await routeReplyToOriginating(fast.payload, { responsePrefixContext });
+      const result = await state.routeReplyToOriginating(fast.payload, { responsePrefixContext });
       if (result) {
         queuedFinal = result.ok;
-        if (isRoutedReplyDelivered(result)) {
+        if (state.isRoutedReplyDelivered(result)) {
           routedFinalCount += 1;
         }
         if (!result.ok) {
@@ -105,7 +92,7 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
           );
         }
       } else {
-        markInboundDedupeReplayUnsafe();
+        state.markInboundDedupeReplayUnsafe();
         params.replyOptions?.onModelSelected?.(modelSelection);
         queuedFinal = dispatcher.sendFinalReply(fast.payload);
       }
@@ -154,14 +141,14 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
   }
   // Own the session before plugin-bound handlers or message hooks can perform
   // work. Fast abort, fast approval, and inbound dedupe remain ahead of this gate.
-  const preDispatchAcquisition = await ensureDispatchReplyOperation("pre_dispatch");
+  const preDispatchAcquisition = await state.ensureDispatchReplyOperation("pre_dispatch");
   if (preDispatchAcquisition.status === "aborted") {
     return { status: "complete" as const, result: finishReplyOperationAbortedDispatch() };
   }
   if (preDispatchAcquisition.status === "busy") {
     return {
       status: "complete" as const,
-      result: finishReplyOperationBusyDispatch({ dedupeDisposition: "release" }),
+      result: state.finishReplyOperationBusyDispatch({ dedupeDisposition: "release" }),
     };
   }
 
@@ -174,7 +161,10 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       logVerbose(
         `plugin-bound inbound command escaped plugin binding (plugin=${pluginOwnedBinding.pluginId} session=${sessionKey ?? "unknown"}); falling through to command processing`,
       );
-    } else if (sendPolicyDenied || (suppressDelivery && !suppressAutomaticSourceDelivery)) {
+    } else if (
+      state.sendPolicyDenied ||
+      (suppressDelivery && !state.suppressAutomaticSourceDelivery)
+    ) {
       // Plugin-bound inbound handlers typically emit outbound replies we
       // cannot rewind. When automatic delivery is explicitly denied, skip the
       // plugin claim and fall through to normal suppressed agent processing.
@@ -196,20 +186,20 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       });
       const targetedClaimOutcome = hookRunner?.runInboundClaimForPluginOutcome
         ? await (async () => {
-            await prepareHookMediaMetadata();
+            await state.prepareHookMediaMetadata();
             if (isPreDispatchOperationAborted()) {
               throw new DispatchReplyOperationAbortedError();
             }
             const authorizedInboundClaimEvent = {
-              ...state.inboundClaimEvent,
+              ...state.hookState.inboundClaimEvent,
               senderIsOwner: bindingAuthorization.senderIsOwner,
             };
-            return await runWithDispatchLifecycleAdmission(
+            return await state.runWithDispatchLifecycleAdmission(
               async () =>
                 await hookRunner.runInboundClaimForPluginOutcome(
                   pluginOwnedBinding.pluginId,
                   authorizedInboundClaimEvent,
-                  { ...state.inboundClaimContext, pluginBinding: pluginOwnedBinding },
+                  { ...state.hookState.inboundClaimContext, pluginBinding: pluginOwnedBinding },
                 ),
             );
           })()
@@ -229,12 +219,12 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       switch (targetedClaimOutcome.status) {
         case "handled": {
           const transcriptOwner = await persistPluginBindingUserTurn();
-          if (targetedClaimOutcome.result.reply && shouldDeliverPluginBindingReply) {
+          if (targetedClaimOutcome.result.reply && state.shouldDeliverPluginBindingReply) {
             // A bound plugin's reply is the explicit output for this claimed turn,
             // not an automatic agent final; message-tool-only suppression must not
             // turn normal user-request bindings into silent channel responses.
             // Ambient room events keep the same privacy guard as final replies.
-            await deliverBindingPayload(
+            await state.deliverBindingPayload(
               targetedClaimOutcome.result.reply,
               "terminal",
               transcriptOwner,
@@ -254,19 +244,19 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
         }
         case "missing_plugin":
         case "no_handler": {
-          state.pluginFallbackReason =
+          state.bindingState.pluginFallbackReason =
             targetedClaimOutcome.status === "missing_plugin"
               ? "plugin-bound-fallback-missing-plugin"
               : "plugin-bound-fallback-no-handler";
           const isUnmentionedGroupFallback =
             (chatType === "group" || chatType === "channel") &&
             ctx.WasMentioned === false &&
-            !explicitCommandTurnCtx;
+            !state.explicitCommandTurnCtx;
           const shouldSuppressUnmentionedFallback =
             isUnmentionedGroupFallback && ctx.GroupRequireMention !== false;
           if (shouldSuppressUnmentionedFallback) {
             markIdle("plugin_binding_fallback_unmentioned");
-            recordProcessed("completed", { reason: state.pluginFallbackReason });
+            recordProcessed("completed", { reason: state.bindingState.pluginFallbackReason });
             commitInboundDedupeIfClaimed();
             completeDispatchReplyOperation();
             return {
@@ -334,8 +324,7 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
   }
 
   emitMessageReceivedHooks();
-  const nextState = extendPreparedDispatchState(state, {}, {});
-  return { status: "ready" as const, state: nextState };
+  return { status: "ready" as const, state };
 }
 
 type PrepareDispatchOperationResult = Awaited<ReturnType<typeof prepareDispatchOperation>>;

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -34,6 +34,10 @@ import {
 } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
+import {
+  createReplySessionEntryHandle,
+  ReplySessionGenerationInvalidatedError as FollowupSessionGenerationInvalidatedError,
+} from "./session-entry-handle.js";
 import type { TypingController } from "./typing.js";
 
 export type FollowupRunnerParams = {
@@ -61,25 +65,11 @@ export async function settleQueuedFollowupPresentation(
   }
 }
 
-type FollowupSessionOwner =
-  | {
-      kind: "detached";
-      current(): SessionEntry | undefined;
-      publish(entry: SessionEntry | undefined): void;
-      adopt(entry: SessionEntry): void;
-    }
-  | {
-      kind: "session";
-      key: string;
-      storePath?: string;
-      current(): SessionEntry | undefined;
-      publish(entry: SessionEntry | undefined): void;
-      adopt(entry: SessionEntry): void;
-    };
-
-type FollowupSessionStoreOwner = FollowupSessionOwner & {
-  clear(): void;
-};
+type FollowupSessionOwner = {
+  current(): SessionEntry | undefined;
+  publish(entry: SessionEntry | undefined): void;
+  adopt(entry: SessionEntry): void;
+} & ({ kind: "detached" } | { kind: "session"; key: string; storePath?: string });
 
 export type AdmittedFollowupTurn = {
   runId: string;
@@ -104,113 +94,6 @@ type FollowupAdmissionResult =
       operation?: ReplyOperation;
     };
 
-class FollowupSessionGenerationInvalidatedError extends Error {}
-
-function createFollowupSessionOwner(params: {
-  admittedSessionId: string;
-  entry?: SessionEntry;
-  expectedStoreEntry?: SessionEntry;
-  key?: string;
-  store?: Record<string, SessionEntry>;
-  storePath?: string;
-}): FollowupSessionStoreOwner {
-  let ownedSessionId = params.admittedSessionId;
-  let ownedLifecycleRevision =
-    params.entry?.sessionId === ownedSessionId ? params.entry.lifecycleRevision : undefined;
-  const matchesGeneration = (entry: SessionEntry | undefined) =>
-    entry?.sessionId === ownedSessionId && entry.lifecycleRevision === ownedLifecycleRevision
-      ? entry
-      : undefined;
-  let currentEntry = matchesGeneration(params.entry);
-  const current = () => {
-    const storedEntry = matchesGeneration(params.key ? params.store?.[params.key] : undefined);
-    if (storedEntry && (!currentEntry || storedEntry.updatedAt >= currentEntry.updatedAt)) {
-      currentEntry = storedEntry;
-    }
-    return currentEntry;
-  };
-  const publish = (entry: SessionEntry | undefined) => {
-    const nextEntry = matchesGeneration(entry);
-    if (nextEntry && (!currentEntry || nextEntry.updatedAt >= currentEntry.updatedAt)) {
-      currentEntry = nextEntry;
-    }
-    if (nextEntry && params.key && params.store) {
-      const storedEntry = params.store[params.key];
-      if (!storedEntry && params.expectedStoreEntry) {
-        return;
-      }
-      if (
-        !storedEntry ||
-        (matchesGeneration(storedEntry) && nextEntry.updatedAt >= storedEntry.updatedAt)
-      ) {
-        params.store[params.key] = nextEntry;
-      }
-    }
-  };
-  const clear = () => {
-    currentEntry = undefined;
-    if (params.key && params.store && matchesGeneration(params.store[params.key])) {
-      delete params.store[params.key];
-    }
-  };
-  const adopt = (entry: SessionEntry) => {
-    const storedEntry = params.key ? params.store?.[params.key] : undefined;
-    const storedMatchesOwnedGeneration = Boolean(matchesGeneration(storedEntry));
-    const storedMatchesAdoptedGeneration = Boolean(
-      storedEntry &&
-      storedEntry.sessionId === entry.sessionId &&
-      storedEntry.lifecycleRevision === entry.lifecycleRevision,
-    );
-    const storedEntryWasDeleted = Boolean(
-      params.key && params.store && !storedEntry && params.expectedStoreEntry,
-    );
-    if (
-      storedEntryWasDeleted ||
-      (storedEntry && !storedMatchesOwnedGeneration && !storedMatchesAdoptedGeneration)
-    ) {
-      throw new FollowupSessionGenerationInvalidatedError(
-        "Follow-up session generation was replaced during admission",
-      );
-    }
-    const adoptedEntry =
-      storedMatchesAdoptedGeneration && storedEntry && storedEntry.updatedAt >= entry.updatedAt
-        ? storedEntry
-        : entry;
-    ownedSessionId = adoptedEntry.sessionId;
-    ownedLifecycleRevision = adoptedEntry.lifecycleRevision;
-    currentEntry = adoptedEntry;
-    if (
-      params.key &&
-      params.store &&
-      (!storedEntry || storedMatchesOwnedGeneration || adoptedEntry !== storedEntry)
-    ) {
-      params.store[params.key] = adoptedEntry;
-    }
-  };
-  if (
-    currentEntry &&
-    params.key &&
-    params.store?.[params.key] &&
-    ((params.store[params.key] === params.expectedStoreEntry &&
-      !matchesGeneration(params.store[params.key])) ||
-      (matchesGeneration(params.store[params.key]) &&
-        currentEntry.updatedAt >= params.store[params.key]!.updatedAt))
-  ) {
-    params.store[params.key] = currentEntry;
-  }
-  return params.key
-    ? {
-        kind: "session",
-        key: params.key,
-        storePath: params.storePath,
-        current,
-        clear,
-        publish,
-        adopt,
-      }
-    : { kind: "detached", current, clear, publish, adopt };
-}
-
 function resolveFollowupCurrentMessageId(queued: FollowupRun): string | undefined {
   return queued.run.inputProvenance?.kind === "internal_system" &&
     queued.run.inputProvenance.sourceTool === "restart-sentinel"
@@ -228,45 +111,6 @@ function isSameSessionGeneration(
     left.sessionId === right.sessionId &&
     left.lifecycleRevision === right.lifecycleRevision,
   );
-}
-
-function createFollowupSessionStoreView(params: {
-  key?: string;
-  owner: FollowupSessionStoreOwner;
-  store?: Record<string, SessionEntry>;
-}): Record<string, SessionEntry> | undefined {
-  if (!params.key) {
-    return params.store;
-  }
-  const view = { ...params.store };
-  Object.defineProperty(view, params.key, {
-    configurable: true,
-    enumerable: true,
-    get: () => params.owner.current(),
-    set: (entry: SessionEntry | undefined) => {
-      if (!entry) {
-        params.owner.clear();
-        return;
-      }
-      const current = params.owner.current();
-      if (!isSameSessionGeneration(entry, current)) {
-        params.owner.adopt(entry);
-        return;
-      }
-      params.owner.publish(entry);
-    },
-  });
-  return new Proxy(view, {
-    deleteProperty: (target, key) => {
-      if (key === params.key) {
-        // CAS failures invalidate only the owned generation; a concurrent replacement
-        // remains in the backing store while this view forgets its stale snapshot.
-        params.owner.clear();
-        return true;
-      }
-      return Reflect.deleteProperty(target, key);
-    },
-  });
 }
 
 /** Resolves one queued item into an immutable admitted turn. */
@@ -290,6 +134,13 @@ export async function admitFollowupTurn(params: {
     initialStoredEntry ??
     (replySessionKey === params.defaults.sessionKey ? params.defaults.sessionEntry : undefined);
   let run = { ...params.queued.run, config };
+  const resolveRunSessionFile = (source: FollowupRun["run"], sessionId: string) =>
+    resolveAdmittedRunSessionFile({
+      agentId: source.agentId,
+      sessionId,
+      sessionKey: replySessionKey,
+      storePath: params.defaults.storePath,
+    }) ?? source.sessionFile;
   const admission = await admitReplyTurn({
     sessionId: params.queued.admissionSessionId ?? run.sessionId,
     sessionKey: replySessionKey ?? "",
@@ -323,13 +174,7 @@ export async function admitFollowupTurn(params: {
       run = {
         ...run,
         sessionId: operation.sessionId,
-        sessionFile:
-          resolveAdmittedRunSessionFile({
-            agentId: run.agentId,
-            sessionId: operation.sessionId,
-            sessionKey: replySessionKey,
-            storePath: params.defaults.storePath,
-          }) ?? run.sessionFile,
+        sessionFile: resolveRunSessionFile(run, operation.sessionId),
         cliSessionBindingFacts: undefined,
         autoFallbackPrimaryProbe: undefined,
         modelSelectionLocked: false,
@@ -388,13 +233,7 @@ export async function admitFollowupTurn(params: {
     if (activeEntry?.sessionId === operation.sessionId) {
       run = {
         ...run,
-        sessionFile:
-          resolveAdmittedRunSessionFile({
-            agentId: run.agentId,
-            sessionId: operation.sessionId,
-            sessionKey: replySessionKey,
-            storePath: params.defaults.storePath,
-          }) ?? run.sessionFile,
+        sessionFile: resolveRunSessionFile(run, operation.sessionId),
         modelSelectionLocked: activeEntry.modelSelectionLocked === true,
         ...(lifecycleRevisionChanged
           ? {
@@ -410,30 +249,38 @@ export async function admitFollowupTurn(params: {
       sessionKey: replySessionKey,
     });
     const queued: FollowupRun = { ...params.queued, run };
-    const session = createFollowupSessionOwner({
-      admittedSessionId: operation.sessionId,
-      entry: activeEntry,
-      expectedStoreEntry: initialStoredEntry,
-      key: replySessionKey,
-      store: params.defaults.sessionStore,
-      storePath: params.defaults.storePath,
+    const sessionEntryHandle = createReplySessionEntryHandle({
+      sessionEntry: activeEntry,
+      sessionKey: replySessionKey,
+      sessionStore: params.defaults.sessionStore,
+      generationFence: {
+        sessionId: operation.sessionId,
+        expectedStoreEntry: initialStoredEntry,
+      },
     });
-    const sessionStore = createFollowupSessionStoreView({
-      key: replySessionKey,
-      owner: session,
-      store: params.defaults.sessionStore,
-    });
-    let sendPolicy = resolveSendPolicy({
-      cfg: config,
-      entry: activeEntry,
-      sessionKey: run.runtimePolicySessionKey ?? replySessionKey,
-      channel:
-        queued.originatingChannel ?? run.messageProvider ?? sessionDeliveryChannel(activeEntry),
-      chatType: normalizeChatType(
-        queued.originatingChatType ?? run.chatType ?? activeEntry?.chatType,
-      ),
-    });
-    let currentInboundContext =
+    const session: FollowupSessionOwner = {
+      ...(replySessionKey
+        ? { kind: "session" as const, key: replySessionKey, storePath: params.defaults.storePath }
+        : { kind: "detached" as const }),
+      current: () => sessionEntryHandle.getCurrent(),
+      publish: (entry) => entry && sessionEntryHandle.replaceCurrent(entry),
+      adopt: (entry) => sessionEntryHandle.adoptCurrent(entry),
+    };
+    const sessionStore = replySessionKey
+      ? sessionEntryHandle.toCompatSessionStore()
+      : params.defaults.sessionStore;
+    const resolveTurnSendPolicy = (entry: SessionEntry | undefined, source: FollowupRun = queued) =>
+      resolveSendPolicy({
+        cfg: config,
+        entry,
+        sessionKey: source.run.runtimePolicySessionKey ?? replySessionKey,
+        channel:
+          source.originatingChannel ?? source.run.messageProvider ?? sessionDeliveryChannel(entry),
+        chatType: normalizeChatType(
+          source.originatingChatType ?? source.run.chatType ?? entry?.chatType,
+        ),
+      });
+    const currentInboundContext =
       params.defaults.opts?.isHeartbeat === true
         ? queued.currentInboundContext
         : refreshActiveGoalContext(queued.currentInboundContext, activeEntry);
@@ -447,30 +294,27 @@ export async function admitFollowupTurn(params: {
       session,
       sessionStore,
       currentInboundContext,
-      sendPolicy,
+      sendPolicy: resolveTurnSendPolicy(activeEntry),
       preflightCompactionApplied: false,
     };
     const refreshTurnSessionState = (entry: SessionEntry | undefined) => {
-      sendPolicy = resolveSendPolicy({
-        cfg: config,
-        entry,
-        sessionKey: turn.queued.run.runtimePolicySessionKey ?? replySessionKey,
-        channel:
-          turn.queued.originatingChannel ??
-          turn.queued.run.messageProvider ??
-          sessionDeliveryChannel(entry),
-        chatType: normalizeChatType(
-          turn.queued.originatingChatType ?? turn.queued.run.chatType ?? entry?.chatType,
-        ),
-      });
-      currentInboundContext =
+      const refreshedInboundContext =
         params.defaults.opts?.isHeartbeat === true
           ? params.queued.currentInboundContext
           : refreshActiveGoalContext(params.queued.currentInboundContext, entry);
-      turn.sendPolicy = sendPolicy;
-      turn.currentInboundContext = currentInboundContext;
-      turn.queued = { ...turn.queued, currentInboundContext };
+      turn.sendPolicy = resolveTurnSendPolicy(entry, turn.queued);
+      turn.currentInboundContext = refreshedInboundContext;
+      turn.queued = { ...turn.queued, currentInboundContext: refreshedInboundContext };
     };
+    const readTurnSessionEntry = () =>
+      replySessionKey && params.defaults.storePath
+        ? loadSessionEntry({
+            storePath: params.defaults.storePath,
+            sessionKey: replySessionKey,
+          })
+        : replySessionKey && params.defaults.sessionStore
+          ? params.defaults.sessionStore[replySessionKey]
+          : session.current();
     const synchronizeTurnGeneration = (
       entry: SessionEntry | undefined,
       previousEntry: SessionEntry | undefined,
@@ -483,13 +327,7 @@ export async function admitFollowupTurn(params: {
           run: {
             ...turn.queued.run,
             sessionId: entry.sessionId,
-            sessionFile:
-              resolveAdmittedRunSessionFile({
-                agentId: turn.queued.run.agentId,
-                sessionId: entry.sessionId,
-                sessionKey: replySessionKey,
-                storePath: params.defaults.storePath,
-              }) ?? turn.queued.run.sessionFile,
+            sessionFile: resolveRunSessionFile(turn.queued.run, entry.sessionId),
             cliSessionBindingFacts: undefined,
             autoFallbackPrimaryProbe: undefined,
             modelSelectionLocked: entry.modelSelectionLocked === true,
@@ -502,7 +340,7 @@ export async function admitFollowupTurn(params: {
     let pendingTerminalCompactionNotice: Exclude<CompactionNoticePhase, "start"> | undefined;
     let compactionNoticeGenerationInvalidated = false;
     const notifyPreflightCompaction =
-      sendPolicy === "allow" &&
+      turn.sendPolicy === "allow" &&
       queued.currentInboundEventKind !== "room_event" &&
       shouldNotifyUserAboutCompaction(config)
         ? async (phase: CompactionNoticePhase) => {
@@ -510,15 +348,7 @@ export async function admitFollowupTurn(params: {
               pendingTerminalCompactionNotice = phase;
               return;
             }
-            const noticeEntry =
-              replySessionKey && params.defaults.storePath
-                ? loadSessionEntry({
-                    storePath: params.defaults.storePath,
-                    sessionKey: replySessionKey,
-                  })
-                : replySessionKey && params.defaults.sessionStore
-                  ? params.defaults.sessionStore[replySessionKey]
-                  : session.current();
+            const noticeEntry = readTurnSessionEntry();
             try {
               assertPersistedGeneration(noticeEntry);
             } catch (error) {
@@ -529,21 +359,7 @@ export async function admitFollowupTurn(params: {
               }
               throw error;
             }
-            const noticeSendPolicy = resolveSendPolicy({
-              cfg: config,
-              entry: noticeEntry,
-              sessionKey: turn.queued.run.runtimePolicySessionKey ?? replySessionKey,
-              channel:
-                turn.queued.originatingChannel ??
-                turn.queued.run.messageProvider ??
-                sessionDeliveryChannel(noticeEntry),
-              chatType: normalizeChatType(
-                turn.queued.originatingChatType ??
-                  turn.queued.run.chatType ??
-                  noticeEntry?.chatType,
-              ),
-            });
-            if (noticeSendPolicy === "deny") {
+            if (resolveTurnSendPolicy(noticeEntry, turn.queued) === "deny") {
               return;
             }
             await params.onCompactionNoticePayload?.(
@@ -577,10 +393,7 @@ export async function admitFollowupTurn(params: {
         );
       }
       if (replySessionKey && params.defaults.storePath) {
-        const persistedEntry = loadSessionEntry({
-          storePath: params.defaults.storePath,
-          sessionKey: replySessionKey,
-        });
+        const persistedEntry = readTurnSessionEntry();
         if (
           (!persistedEntry && preflightEntry) ||
           (persistedEntry &&
@@ -609,15 +422,7 @@ export async function admitFollowupTurn(params: {
       turn.preflightCompactionApplied =
         generationRotated || (activeEntry?.compactionCount ?? 0) > previousCompactionCount;
     } catch (error) {
-      const failureEntry =
-        replySessionKey && params.defaults.storePath
-          ? loadSessionEntry({
-              storePath: params.defaults.storePath,
-              sessionKey: replySessionKey,
-            })
-          : replySessionKey && params.defaults.sessionStore
-            ? params.defaults.sessionStore[replySessionKey]
-            : session.current();
+      const failureEntry = readTurnSessionEntry();
       if (!isSameSessionGeneration(failureEntry, session.current())) {
         assertPersistedGeneration(failureEntry);
       }

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -66,7 +66,7 @@ export async function settleQueuedFollowupPresentation(
 }
 
 type FollowupSessionOwner = {
-  current(): SessionEntry | undefined;
+  current: () => SessionEntry | undefined;
   publish(entry: SessionEntry | undefined): void;
   adopt(entry: SessionEntry): void;
 } & ({ kind: "detached" } | { kind: "session"; key: string; storePath?: string });

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -4,7 +4,6 @@ import {
   buildRestartRecoveryClaimCleanupPatch,
   hasRestartRecoverySourceClaim,
   hasRestartRecoveryTerminalRun,
-  sameRestartRecoveryTerminalRunIds,
 } from "../../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryBeforeAgentReplyState } from "../../config/sessions/restart-recovery-types.js";
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -12,6 +11,7 @@ import type {
   SessionTranscriptTurnExpectedState,
   SessionTranscriptTurnLifecyclePatch,
 } from "../../config/sessions/session-transcript-turn-lifecycle.types.js";
+import { sessionMatchesExpectedTranscriptTurn } from "../../config/sessions/session-transcript-turn-state.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import type {
   UserTurnTranscriptRecorder,
@@ -104,38 +104,6 @@ function buildExpectedSessionState(entry: SessionEntry): SessionTranscriptTurnEx
   };
 }
 
-function matchesExpectedSessionState(
-  entry: SessionEntry,
-  sessionId: string,
-  expected: SessionTranscriptTurnExpectedState,
-): boolean {
-  return (
-    entry.sessionId === sessionId &&
-    entry.abortedLastRun === expected.abortedLastRun &&
-    entry.mainRestartRecovery?.cycleId === expected.mainRestartRecoveryCycleId &&
-    entry.mainRestartRecovery?.revision === expected.mainRestartRecoveryRevision &&
-    entry.restartRecoveryBeforeAgentReplyState === expected.restartRecoveryBeforeAgentReplyState &&
-    entry.restartRecoveryDeliveryReceiptState === expected.restartRecoveryDeliveryReceiptState &&
-    entry.restartRecoveryDeliveryToolCallId === expected.restartRecoveryDeliveryToolCallId &&
-    entry.restartRecoveryDeliveryRequestFingerprint ===
-      expected.restartRecoveryDeliveryRequestFingerprint &&
-    entry.restartRecoveryDeliveryRunId === expected.restartRecoveryDeliveryRunId &&
-    entry.restartRecoveryDeliverySourceRunId === expected.restartRecoveryDeliverySourceRunId &&
-    entry.restartRecoveryRequesterAccountId === expected.restartRecoveryRequesterAccountId &&
-    entry.restartRecoveryRequesterSenderId === expected.restartRecoveryRequesterSenderId &&
-    entry.restartRecoverySameChannelThreadRequired ===
-      expected.restartRecoverySameChannelThreadRequired &&
-    entry.restartRecoverySourceIngress === expected.restartRecoverySourceIngress &&
-    entry.restartRecoverySourceReplyDeliveryMode ===
-      expected.restartRecoverySourceReplyDeliveryMode &&
-    sameRestartRecoveryTerminalRunIds(
-      entry.restartRecoveryTerminalRunIds,
-      expected.restartRecoveryTerminalRunIds,
-    ) &&
-    entry.status === expected.status
-  );
-}
-
 export function createReplyRestartRecoveryClaimController(params: {
   admissionRunId?: unknown;
   getEntry: () => SessionEntry | undefined;
@@ -191,7 +159,10 @@ export function createReplyRestartRecoveryClaimController(params: {
     const persisted = await updateSessionEntry(
       { storePath: options.storePath, sessionKey: options.sessionKey },
       (current) =>
-        matchesExpectedSessionState(current, options.sessionId, expectedSessionState)
+        sessionMatchesExpectedTranscriptTurn(
+          { entry: current },
+          { expectedSessionId: options.sessionId, expectedSessionState },
+        )
           ? options.patch
           : null,
     );

--- a/src/auto-reply/reply/session-entry-handle.ts
+++ b/src/auto-reply/reply/session-entry-handle.ts
@@ -2,6 +2,7 @@
 import type { SessionEntry } from "../../config/sessions.js";
 
 export type ReplySessionEntryHandle = {
+  adoptCurrent(entry: SessionEntry): void;
   clearCurrent(): void;
   get(sessionKey: string): SessionEntry | undefined;
   getCurrent(): SessionEntry | undefined;
@@ -11,40 +12,155 @@ export type ReplySessionEntryHandle = {
   toCompatSessionStore(): Record<string, SessionEntry>;
 };
 
-export function createReplySessionEntryHandle(params: {
-  sessionEntry: SessionEntry;
-  sessionKey: string;
-  sessionStore?: Record<string, SessionEntry>;
-}): ReplySessionEntryHandle {
-  const entries = params.sessionStore ?? { [params.sessionKey]: params.sessionEntry };
-  let currentEntry: SessionEntry | undefined = params.sessionEntry;
-  entries[params.sessionKey] = currentEntry;
+export class ReplySessionGenerationInvalidatedError extends Error {}
 
-  return {
+export function createReplySessionEntryHandle(params: {
+  sessionEntry?: SessionEntry;
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  generationFence?: {
+    sessionId: string;
+    expectedStoreEntry?: SessionEntry;
+  };
+}): ReplySessionEntryHandle {
+  const { generationFence, sessionKey, sessionStore } = params;
+  const entries = sessionStore ?? {};
+  let ownedSessionId = generationFence?.sessionId;
+  let ownedLifecycleRevision =
+    params.sessionEntry && params.sessionEntry.sessionId === ownedSessionId
+      ? params.sessionEntry.lifecycleRevision
+      : undefined;
+  const matchesGeneration = (entry: SessionEntry | undefined): entry is SessionEntry =>
+    entry !== undefined &&
+    (!generationFence ||
+      (entry.sessionId === ownedSessionId && entry.lifecycleRevision === ownedLifecycleRevision));
+  let currentEntry = matchesGeneration(params.sessionEntry) ? params.sessionEntry : undefined;
+
+  if (sessionKey && currentEntry) {
+    const storedEntry = entries[sessionKey];
+    if (
+      !generationFence ||
+      !sessionStore ||
+      (storedEntry &&
+        ((storedEntry === generationFence.expectedStoreEntry && !matchesGeneration(storedEntry)) ||
+          (matchesGeneration(storedEntry) && currentEntry.updatedAt >= storedEntry.updatedAt)))
+    ) {
+      entries[sessionKey] = currentEntry;
+    }
+  }
+
+  const current = (): SessionEntry | undefined => {
+    const storedEntry = sessionKey ? entries[sessionKey] : undefined;
+    if (
+      generationFence &&
+      matchesGeneration(storedEntry) &&
+      (!currentEntry || storedEntry.updatedAt >= currentEntry.updatedAt)
+    ) {
+      currentEntry = storedEntry;
+    }
+    return currentEntry;
+  };
+
+  const replaceCurrent = (entry: SessionEntry, adopt = false): void => {
+    if (!generationFence) {
+      currentEntry = entry;
+      if (sessionKey) {
+        entries[sessionKey] = entry;
+      }
+      return;
+    }
+    const storedEntry = sessionKey ? entries[sessionKey] : undefined;
+    const storedMatchesOwned = matchesGeneration(storedEntry);
+    let nextEntry = entry;
+    if (adopt) {
+      const storedMatchesAdopted = Boolean(
+        storedEntry &&
+        storedEntry.sessionId === entry.sessionId &&
+        storedEntry.lifecycleRevision === entry.lifecycleRevision,
+      );
+      if (
+        (sessionStore && sessionKey && !storedEntry && generationFence.expectedStoreEntry) ||
+        (storedEntry && !storedMatchesOwned && !storedMatchesAdopted)
+      ) {
+        throw new ReplySessionGenerationInvalidatedError(
+          "Follow-up session generation was replaced during admission",
+        );
+      }
+      if (storedMatchesAdopted && storedEntry && storedEntry.updatedAt >= entry.updatedAt) {
+        nextEntry = storedEntry;
+      }
+      ownedSessionId = nextEntry.sessionId;
+      ownedLifecycleRevision = nextEntry.lifecycleRevision;
+    } else if (!matchesGeneration(nextEntry)) {
+      return;
+    }
+    if (adopt || !currentEntry || nextEntry.updatedAt >= currentEntry.updatedAt) {
+      currentEntry = nextEntry;
+    }
+    if (
+      sessionKey &&
+      (adopt
+        ? !storedEntry || storedMatchesOwned || nextEntry !== storedEntry
+        : (!storedEntry && !generationFence.expectedStoreEntry) ||
+          (storedMatchesOwned && storedEntry && nextEntry.updatedAt >= storedEntry.updatedAt))
+    ) {
+      entries[sessionKey] = nextEntry;
+    }
+  };
+
+  const handle: ReplySessionEntryHandle = {
+    adoptCurrent: (entry) => replaceCurrent(entry, true),
     clearCurrent: () => {
       currentEntry = undefined;
-      delete entries[params.sessionKey];
-    },
-    get: (sessionKey) => entries[sessionKey],
-    getCurrent: () => currentEntry,
-    patchCurrent: (patch) => {
-      if (!currentEntry) {
-        return undefined;
+      if (sessionKey && (!generationFence || matchesGeneration(entries[sessionKey]))) {
+        delete entries[sessionKey];
       }
-      currentEntry = { ...currentEntry, ...patch };
-      entries[params.sessionKey] = currentEntry;
+    },
+    get: (key) => entries[key],
+    getCurrent: current,
+    patchCurrent: (patch) => {
+      if (currentEntry) {
+        replaceCurrent({ ...currentEntry, ...patch });
+      }
       return currentEntry;
     },
-    replaceCurrent: (entry) => {
-      currentEntry = entry;
-      entries[params.sessionKey] = entry;
-    },
-    set: (sessionKey, entry) => {
-      entries[sessionKey] = entry;
-      if (sessionKey === params.sessionKey) {
-        currentEntry = entry;
+    replaceCurrent,
+    set: (key, entry) => {
+      if (key === sessionKey) {
+        replaceCurrent(entry);
+      } else {
+        entries[key] = entry;
       }
     },
-    toCompatSessionStore: () => entries,
+    toCompatSessionStore: () => {
+      if (!generationFence || !sessionKey) {
+        return entries;
+      }
+      const view = { ...entries, ...(currentEntry ? { [sessionKey]: currentEntry } : {}) };
+      return new Proxy(view, {
+        get: (target, key) => (key === sessionKey ? current() : Reflect.get(target, key)),
+        set(target, key, entry: SessionEntry | undefined) {
+          if (key !== sessionKey) {
+            return Reflect.set(target, key, entry);
+          }
+          if (!entry) {
+            handle.clearCurrent();
+          } else {
+            replaceCurrent(entry, !matchesGeneration(entry));
+          }
+          return true;
+        },
+        deleteProperty(target, key) {
+          if (key !== sessionKey) {
+            return Reflect.deleteProperty(target, key);
+          }
+          // A stale owner may clear only its generation, never a concurrent replacement.
+          handle.clearCurrent();
+          return true;
+        },
+      });
+    },
   };
+
+  return handle;
 }


### PR DESCRIPTION
## What Problem This Solves

Users rely on replies, queued follow-ups, restart recovery, and intentionally silent turns continuing to behave consistently as session state changes. The auto-reply pipeline previously spread ownership of these invariants across duplicate session handles, dynamic cross-phase accessors, and a second restart-state comparator, making lifecycle regressions and message loss harder to prevent.

## Why This Change Was Made

This maintainer-requested cleanup moves generation-fenced queued-follow-up ownership into the existing canonical reply session handle, replaces cross-phase getter/setter shims with explicit hook, binding, routing, and progress state owners, and reuses the canonical transcript-session comparator for restart recovery. Existing generation fences, cancellation, compaction adoption, intentional silence, delivery settlement, and public reply contracts remain unchanged.

## User Impact

No intended behavior change. Direct and channel replies, queued follow-ups, thread routing, deliberate `NO_REPLY`, restart recovery, and concurrent session replacement remain protected by their existing contracts. Removes **330 handwritten production lines** across 12 production files; no test lines removed.

## Evidence

- Blacksmith Testbox baseline/operator proof: `tbx_01kyxck3ep0490m610vxbpj4h0` ([remote run](https://github.com/openclaw/openclaw/actions/runs/30676368975)); final-head lint, regression, and changed-gate proof: `tbx_01kyxf2ph4eza6wz0bza3vjgn9` ([remote run](https://github.com/openclaw/openclaw/actions/runs/30678043151)).
- Clean baseline: **353 focused tests passed** across reply admission, follow-up delivery, queue draining, restart recovery, and transport settlement.
- Final changed tree: **851 tests passed**, including the complete 311-case dispatch suite, 160 session cases, 92 queue/collect cases, 51 run-registry cases, 47 follow-up-delivery cases, 43 turn-admission cases, and 36 queued-follow-up generation cases. Explicit direct/group `NO_REPLY` regressions passed.
- Generation-owner equivalence: **2,400 deterministic differential transitions** matched the previous implementation exactly across adoption, stale updates, concurrent replacement/deletion, and compatibility-view writes/deletes.
- Real ephemeral Gateway + `qa-channel` + mock OpenAI: **7/7 operator scenarios passed** (`dm-chat-baseline`, `channel-chat-baseline`, `thread-follow-up`, `rewritten-command-single-delivery`, `restart-recovery-memory-flush-lifecycle-proof`, `message-tool-stranded-final-reply`, `qa-channel-reconnect-dedupe`). The run proved direct replies, intentional unmentioned-channel silence, group mentions, threaded placement, exactly-once rewritten-command delivery, forced memory-flush recovery, one-shot stranded-final retry, and a real Gateway restart with no replay.
- Forced memory-flush lifecycle verdict from the actual Gateway/channel run:

  ```json
  {"verdict":"PASS","channel":"qa-channel","provider":"mock-openai","gateway":"ephemeral-child","memoryFlush":{"kind":"succeeded","compactionCount":0},"parent":{"status":"done","abortedLastRun":false},"replyDelivered":true}
  ```

- Stranded final fault/retry: `recovered=1; stranded turns=1; retry delivery turns=1; WARN logged=true`. Gateway restart markers: `before=RECONNECT-FIRST-OK; after=RECONNECT-SECOND-OK`.
- Full remote `corepack pnpm check:changed`: production and test typechecks, lint, formatting, boundary guards, and dead-export checks pass on the final head.
- Exact whole-repository CI lint command `node scripts/run-oxlint-shards.mjs --threads=8` also passes with **zero warnings/errors across 24,197 core, plugin, and script files**, including the unchanged follow-up caller receiving the unbound-safe session getter.
- Fresh independent structured review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; zero accepted/actionable findings.
- Production delta: `+594 / -924 = -330 LOC`; tests: `0 LOC`.

AI-assisted; maintainer-requested architectural cleanup.
