### PR TITLE
fix(agents): preserve tools on verified completion wakes

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -461,7 +461,16 @@ describe("Codex app-server dynamic tool build", () => {
       sourceTool: "subagent_announce",
     };
     params.config = {};
-    params.trustedInternalHandoff = true;
+    const trustedInternalHandoff: NonNullable<EmbeddedRunAttemptParams["trustedInternalHandoff"]> =
+      {
+        kind: "subagent-completion",
+        sourceSessionKey: "agent:main:subagent:codex-child",
+        targetSessionKey: "agent:main:session-1",
+        targetSessionId: "session-1",
+        provider: "codex",
+        model: "gpt-5.4-codex",
+      };
+    params.trustedInternalHandoff = trustedInternalHandoff;
     params.scheduledToolPolicy = {
       version: 1,
       mode: "account",
@@ -478,13 +487,13 @@ describe("Codex app-server dynamic tool build", () => {
 
     expect(receivedOptions).toMatchObject({
       inputProvenance: params.inputProvenance,
-      trustedInternalHandoff: true,
+      trustedInternalHandoff,
       scheduledToolPolicy: params.scheduledToolPolicy,
     });
     expect(hoisted.resolveWebSearchToolPolicy).toHaveBeenCalledWith(
       expect.objectContaining({
         inputProvenance: params.inputProvenance,
-        trustedInternalHandoff: true,
+        trustedInternalHandoff,
         scheduledToolPolicy: params.scheduledToolPolicy,
       }),
     );

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -818,21 +818,55 @@ describe("createOpenClawCodingTools", () => {
       runtimeToolAllowlist: ["message"],
       expected: false,
     },
-  ])("limits $name to the source only when its trusted grant is exact", (testCase) => {
-    vi.mocked(createOpenClawTools).mockClear();
-    createOpenClawCodingTools({
-      config: testConfig,
-      trustedInternalHandoff: testCase.trustedInternalHandoff,
-      inputProvenance: {
-        kind: "inter_session",
-        sourceSessionKey: "agent:main:subagent:child",
-        sourceTool: testCase.sourceTool,
-      },
-      sourceReplyDeliveryMode: testCase.sourceReplyDeliveryMode,
-      runtimeToolAllowlist: testCase.runtimeToolAllowlist,
-    });
+  ])("limits $name to the source only when its trusted grant is exact", async (testCase) => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-source-reply-only-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      const sessionKey = "agent:main:direct:requester";
+      const sessionId = "requester-session";
+      const childSessionKey = "agent:main:subagent:child";
+      await writeSessionStore(storeTemplate, "main", {
+        [childSessionKey]: {
+          sessionId: "child-session",
+          updatedAt: Date.now(),
+          spawnedBy: sessionKey,
+          spawnDepth: 1,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+          inheritedToolPolicyVersion: 1,
+        },
+      });
+      vi.mocked(createOpenClawTools).mockClear();
+      createOpenClawCodingTools({
+        config: { session: { store: storeTemplate } },
+        sessionKey,
+        sessionId,
+        modelProvider: "openai",
+        modelId: "gpt-5.4",
+        trustedInternalHandoff: testCase.trustedInternalHandoff
+          ? {
+              kind: "subagent-completion",
+              sourceSessionKey: childSessionKey,
+              sourceSessionId: "child-session",
+              targetSessionKey: sessionKey,
+              targetSessionId: sessionId,
+              provider: "openai",
+              model: "gpt-5.4",
+            }
+          : undefined,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceTool: testCase.sourceTool,
+        },
+        sourceReplyDeliveryMode: testCase.sourceReplyDeliveryMode,
+        runtimeToolAllowlist: testCase.runtimeToolAllowlist,
+      });
 
-    expect(latestCreateOpenClawToolsOptions().sourceReplyOnly).toBe(testCase.expected);
+      expect(latestCreateOpenClawToolsOptions().sourceReplyOnly).toBe(testCase.expected);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("passes configured filesystem policy to OpenClaw tool construction", () => {

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -808,7 +808,7 @@ describe("createOpenClawCodingTools", () => {
       sourceTool: "subagent_announce",
       sourceReplyDeliveryMode: "message_tool_only" as const,
       runtimeToolAllowlist: ["message", "read"],
-      expected: false,
+      expected: true,
     },
     {
       name: "automatic completion delivery",
@@ -818,7 +818,7 @@ describe("createOpenClawCodingTools", () => {
       runtimeToolAllowlist: ["message"],
       expected: false,
     },
-  ])("limits $name to the source only when its trusted grant is exact", async (testCase) => {
+  ])("limits $name to the source only for verified completion delivery", async (testCase) => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-source-reply-only-"));
     try {
       const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -563,7 +563,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   // Trusted ingress plus its exact one-tool cap prevent ordinary private turns from narrowing.
   const sourceReplyOnly =
     capabilityProfile.policy.requesterPolicySource === "completion-handoff" &&
-    options.inputProvenance?.kind === "inter_session" &&
+    options?.inputProvenance?.kind === "inter_session" &&
     options.inputProvenance.sourceTool === "subagent_announce" &&
     options.sourceReplyDeliveryMode === "message_tool_only" &&
     options.runtimeToolAllowlist?.length === 1 &&

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -559,15 +559,13 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     const normalized = normalizeToolName(toolName);
     return normalized === "*" || normalized === "message";
   });
-  // Frozen child output may use only the parent's existing source-delivery grant.
-  // Trusted ingress plus its exact one-tool cap prevent ordinary private turns from narrowing.
+  // A verified completion may retain parent tools, but its mandatory delivery
+  // grant stays bound to the current source regardless of allowlist width.
   const sourceReplyOnly =
     capabilityProfile.policy.requesterPolicySource === "completion-handoff" &&
     options?.inputProvenance?.kind === "inter_session" &&
     options.inputProvenance.sourceTool === "subagent_announce" &&
-    options.sourceReplyDeliveryMode === "message_tool_only" &&
-    options.runtimeToolAllowlist?.length === 1 &&
-    normalizeToolName(options.runtimeToolAllowlist[0] ?? "") === "message";
+    options.sourceReplyDeliveryMode === "message_tool_only";
   const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
     toolNames: capabilityProfile.policy.explicitToolOverrideAllowlist,
     forceMessageTool: options?.forceMessageTool,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -97,6 +97,7 @@ import {
 } from "./sandbox/workspace-mounts.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
 import { createCodingTools, createReadTool } from "./sessions/index.js";
+import type { TrustedSubagentCompletionHandoff } from "./subagent-announce-handoff.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
@@ -468,8 +469,8 @@ type OpenClawCodingToolsOptions = {
   /** Prepared conversation-scoped facts for callers that already resolved this run context. */
   conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
   inputProvenance?: InputProvenance;
-  /** Trusted in-process completion handoff; never derived from model-facing input. */
-  trustedInternalHandoff?: boolean;
+  /** Consumed in-process completion capability; never derived from model-facing input. */
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */
   scheduledToolPolicy?: ScheduledToolPolicyContext;
 };
@@ -561,7 +562,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   // Frozen child output may use only the parent's existing source-delivery grant.
   // Trusted ingress plus its exact one-tool cap prevent ordinary private turns from narrowing.
   const sourceReplyOnly =
-    options?.trustedInternalHandoff === true &&
+    capabilityProfile.policy.requesterPolicySource === "completion-handoff" &&
     options.inputProvenance?.kind === "inter_session" &&
     options.inputProvenance.sourceTool === "subagent_announce" &&
     options.sourceReplyDeliveryMode === "message_tool_only" &&

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -835,6 +835,7 @@ export async function runBtwSideQuestion(
   ): Promise<BtwHarnessSideQuestionDispatch> => {
     const toolsAllow = resolvePluginHarnessPolicyToolsAllow({
       config: params.cfg,
+      sessionId,
       sessionKey: params.sessionKey,
       sandboxSessionKey: params.sandboxSessionKey,
       agentId: sessionAgentId,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -40,6 +40,10 @@ const SUBAGENT_ANNOUNCE_REQUESTER_TOOLS = ["read", "exec", "sessions_spawn", "me
 
 function createSubagentAnnounceHandoffOptions(params: {
   sourceReplyDeliveryMode: "automatic" | "message_tool_only";
+  targetSessionKey: string;
+  targetSessionId: string;
+  provider: string;
+  model: string;
   disableMessageTool?: boolean;
   requireExplicitMessageTarget?: boolean;
   modelRun?: boolean;
@@ -54,7 +58,19 @@ function createSubagentAnnounceHandoffOptions(params: {
     ...(params.modelRun ? { modelRun: true } : {}),
     ...(params.promptMode ? { promptMode: params.promptMode } : {}),
     toolsAllow: params.runtimeToolsAllow ?? [...SUBAGENT_ANNOUNCE_REQUESTER_TOOLS],
-    trustedInternalHandoff: params.trustedInternalHandoff ?? true,
+    ...(params.trustedInternalHandoff === false
+      ? {}
+      : {
+          trustedInternalHandoff: {
+            kind: "subagent-completion" as const,
+            sourceSessionKey: SUBAGENT_ANNOUNCE_CHILD_SESSION_KEY,
+            sourceSessionId: "subagent-announce-child",
+            targetSessionKey: params.targetSessionKey,
+            targetSessionId: params.targetSessionId,
+            provider: params.provider,
+            model: params.model,
+          },
+        }),
     inputProvenance: {
       kind: "inter_session",
       sourceSessionKey: SUBAGENT_ANNOUNCE_CHILD_SESSION_KEY,
@@ -66,6 +82,7 @@ function createSubagentAnnounceHandoffOptions(params: {
         type: "task_completion",
         source: "subagent",
         childSessionKey: SUBAGENT_ANNOUNCE_CHILD_SESSION_KEY,
+        childSessionId: "subagent-announce-child",
         announceType: "subagent task",
         taskLabel: "review",
         status: "ok",
@@ -211,7 +228,15 @@ const SUBAGENT_ANNOUNCE_DELIVERY_CASES: readonly SubagentAnnounceDeliveryCase[] 
 ];
 
 const SUBAGENT_ANNOUNCE_EMBEDDED_DELIVERY_CASES: readonly SubagentAnnounceDeliveryCase[] = [
-  ...SUBAGENT_ANNOUNCE_DELIVERY_CASES,
+  ...SUBAGENT_ANNOUNCE_DELIVERY_CASES.map((testCase) =>
+    testCase.name === "automatic source replies"
+      ? {
+          ...testCase,
+          expectedDisableTools: false,
+          expectedToolsAllow: SUBAGENT_ANNOUNCE_REQUESTER_TOOLS,
+        }
+      : testCase,
+  ),
   {
     name: "a raw model run despite message-tool-only delivery",
     sourceReplyDeliveryMode: "message_tool_only",
@@ -471,6 +496,7 @@ describe("CLI attempt execution", () => {
       "inheritedToolAllow" | "inheritedToolDeny"
     >;
     runId?: string;
+    sessionKey?: string;
     body?: string;
     transcriptBody?: string;
     providerOverride?: string;
@@ -479,12 +505,13 @@ describe("CLI attempt execution", () => {
     fallbackRuntimeState?: RunAgentAttemptParams["fallbackRuntimeState"];
     userTurnTranscriptRecorder?: RunAgentAttemptParams["userTurnTranscriptRecorder"];
     sessionEntry?: Partial<SessionEntry>;
+    additionalSessionEntries?: Record<string, Partial<SessionEntry>>;
     configuredAuthProfileId?: string;
     timeoutMs?: number;
     runTimeoutOverrideMs?: number;
   }) {
     const runId = overrides?.runId ?? "run-embedded-live-stream-gate";
-    const sessionKey = `agent:main:direct:${runId}`;
+    const sessionKey = overrides?.sessionKey ?? `agent:main:direct:${runId}`;
     const sessionEntry: SessionEntry = {
       sessionId: `session-${runId}`,
       updatedAt: Date.now(),
@@ -497,6 +524,15 @@ describe("CLI attempt execution", () => {
           overrides.subagentAnnounceEnvelope,
         )
       : { [sessionKey]: sessionEntry };
+    for (const [additionalSessionKey, additionalEntry] of Object.entries(
+      overrides?.additionalSessionEntries ?? {},
+    )) {
+      sessionStore[additionalSessionKey] = {
+        sessionId: `${additionalSessionKey}-session`,
+        updatedAt: Date.now(),
+        ...additionalEntry,
+      } as SessionEntry;
+    }
     await writeSessionStoreSeed(sessionStore);
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
@@ -508,7 +544,7 @@ describe("CLI attempt execution", () => {
       originalProvider: "openai",
       modelOverride: overrides?.modelOverride ?? "gpt-5.4",
       configuredAuthProfileId: overrides?.configuredAuthProfileId,
-      cfg: overrides?.config ?? ({} as OpenClawConfig),
+      cfg: overrides?.config ?? ({ session: { store: storePath } } as OpenClawConfig),
       sessionEntry,
       sessionId: sessionEntry.sessionId,
       sessionKey,
@@ -2848,6 +2884,10 @@ describe("CLI attempt execution", () => {
         runId: "run-cli-announce",
         opts: createSubagentAnnounceHandoffOptions({
           sourceReplyDeliveryMode,
+          targetSessionKey: sessionKey,
+          targetSessionId: sessionEntry.sessionId,
+          provider: "claude-cli",
+          model: "opus",
           disableMessageTool,
           requireExplicitMessageTarget,
           runtimeToolsAllow,
@@ -2895,8 +2935,11 @@ describe("CLI attempt execution", () => {
       expectedDisableTools,
       expectedToolsAllow,
     }) => {
+      const runId = `embedded-announce-${sourceReplyDeliveryMode}-${disableMessageTool}`;
+      const sessionKey = `agent:main:direct:${runId}`;
+      const sessionId = `session-${runId}`;
       const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
-        runId: `embedded-announce-${sourceReplyDeliveryMode}-${disableMessageTool}`,
+        runId,
         body: "A background task finished. Process the completion update now.",
         config: {
           session: { store: storePath },
@@ -2906,6 +2949,10 @@ describe("CLI attempt execution", () => {
         subagentAnnounceEnvelope: { inheritedToolAllow, inheritedToolDeny },
         opts: createSubagentAnnounceHandoffOptions({
           sourceReplyDeliveryMode,
+          targetSessionKey: sessionKey,
+          targetSessionId: sessionId,
+          provider: "openai",
+          model: "gpt-5.4",
           disableMessageTool,
           requireExplicitMessageTarget,
           modelRun,
@@ -2929,6 +2976,97 @@ describe("CLI attempt execution", () => {
       expect(runCliAgentMock).not.toHaveBeenCalled();
     },
   );
+
+  it("keeps trusted CLI completion handoffs tool-free when inherited policy is restricted", async () => {
+    const sessionKey = "agent:main:direct:claude-trusted-announce";
+    const childSessionKey = "agent:openclaw:subagent:child";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-cli-trusted-announce",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: sessionEntry,
+      [childSessionKey]: {
+        sessionId: "child-session-id",
+        updatedAt: Date.now(),
+        spawnedBy: sessionKey,
+        spawnDepth: 1,
+        subagentRole: "orchestrator",
+        subagentControlScope: "children",
+        inheritedToolPolicyVersion: 1,
+        inheritedToolDeny: ["exec"],
+      },
+    };
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("trusted announce"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "A background task finished. Process the completion update now.",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-cli-trusted-announce",
+      opts: {
+        trustedInternalHandoff: {
+          kind: "subagent-completion",
+          sourceSessionKey: childSessionKey,
+          sourceSessionId: "child-session-id",
+          targetSessionKey: sessionKey,
+          targetSessionId: sessionEntry.sessionId,
+          provider: "claude-cli",
+          model: "opus",
+        },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey,
+            childSessionId: "child-session-id",
+            announceType: "subagent task",
+            taskLabel: "review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Relay this completion.",
+          },
+        ],
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "telegram",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expectMockArgFields(runCliAgentMock, {
+      provider: "claude-cli",
+      disableTools: true,
+      allowEmptyAssistantReplyAsSilent: true,
+    });
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
 
   it("stamps CLI prompts with current timestamp context", async () => {
     vi.useFakeTimers();
@@ -3219,6 +3357,225 @@ describe("CLI attempt execution", () => {
     });
 
     expect(embeddedArg.suppressLiveStreamOutput).toBe(true);
+  });
+
+  it("preserves embedded OpenAI-compatible tools for the exact trusted completion", async () => {
+    const runId = "trusted-glm-completion";
+    const childSessionKey = "agent:main:subagent:glm-child";
+    const sessionKey = `agent:main:direct:${runId}`;
+    const sessionId = `session-${runId}`;
+    const trustedInternalHandoff = {
+      kind: "subagent-completion" as const,
+      sourceSessionKey: childSessionKey,
+      sourceSessionId: "glm-child-session",
+      targetSessionKey: sessionKey,
+      targetSessionId: sessionId,
+      provider: "openai",
+      model: "glm-4.5",
+    };
+
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      runId,
+      modelOverride: "glm-4.5",
+      additionalSessionEntries: {
+        [childSessionKey]: {
+          sessionId: "glm-child-session",
+          spawnedBy: sessionKey,
+          spawnDepth: 1,
+          subagentRole: "orchestrator",
+          subagentControlScope: "children",
+          inheritedToolPolicyVersion: 1,
+        },
+      },
+      opts: {
+        trustedInternalHandoff,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey,
+            childSessionId: "glm-child-session",
+            announceType: "subagent task",
+            taskLabel: "review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Review and continue.",
+          },
+        ],
+      },
+    });
+
+    expect(embeddedArg.disableTools).toBe(false);
+    expect(embeddedArg.trustedInternalHandoff).toEqual(trustedInternalHandoff);
+  });
+
+  it("preserves embedded tools for a verified nested subagent completion", async () => {
+    const runId = "trusted-nested-glm-completion";
+    const requesterSessionKey = "agent:main:subagent:parent-child";
+    const childSessionKey = "agent:main:subagent:leaf";
+    const requesterSessionId = "parent-child-session";
+    const childSessionId = "leaf-session";
+    const trustedInternalHandoff = {
+      kind: "subagent-completion" as const,
+      sourceSessionKey: childSessionKey,
+      sourceSessionId: childSessionId,
+      targetSessionKey: requesterSessionKey,
+      targetSessionId: requesterSessionId,
+      provider: "openai",
+      model: "glm-4.5",
+    };
+
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      runId,
+      sessionKey: requesterSessionKey,
+      modelOverride: "glm-4.5",
+      sessionEntry: {
+        sessionId: requesterSessionId,
+        spawnedBy: "agent:main:direct:root",
+        spawnDepth: 1,
+        subagentRole: "orchestrator",
+        subagentControlScope: "children",
+        inheritedToolPolicyVersion: 1,
+        inheritedToolDeny: ["exec"],
+      },
+      additionalSessionEntries: {
+        [childSessionKey]: {
+          sessionId: childSessionId,
+          spawnedBy: requesterSessionKey,
+          spawnDepth: 2,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+          inheritedToolPolicyVersion: 1,
+          inheritedToolDeny: ["exec", "read"],
+        },
+      },
+      opts: {
+        trustedInternalHandoff,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey,
+            childSessionId,
+            announceType: "subagent task",
+            taskLabel: "review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Review and continue.",
+          },
+        ],
+      },
+    });
+
+    expect(embeddedArg.disableTools).toBe(false);
+    expect(embeddedArg.trustedInternalHandoff).toEqual(trustedInternalHandoff);
+  });
+
+  it("keeps duplicate completion events tool-free despite an otherwise exact capability", async () => {
+    const runId = "duplicate-glm-completion";
+    const childSessionKey = "agent:main:subagent:duplicate-child";
+    const sessionKey = `agent:main:direct:${runId}`;
+    const sessionId = `session-${runId}`;
+    const completionEvent = {
+      type: "task_completion" as const,
+      source: "subagent" as const,
+      childSessionKey,
+      childSessionId: "duplicate-child-session",
+      announceType: "subagent task",
+      taskLabel: "review",
+      status: "ok" as const,
+      statusLabel: "completed",
+      result: "child output",
+      replyInstruction: "Review and continue.",
+    };
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      runId,
+      modelOverride: "glm-4.5",
+      additionalSessionEntries: {
+        [childSessionKey]: {
+          sessionId: completionEvent.childSessionId,
+          spawnedBy: sessionKey,
+          spawnDepth: 1,
+          subagentRole: "orchestrator",
+          subagentControlScope: "children",
+          inheritedToolPolicyVersion: 1,
+        },
+      },
+      opts: {
+        trustedInternalHandoff: {
+          kind: "subagent-completion",
+          sourceSessionKey: childSessionKey,
+          sourceSessionId: completionEvent.childSessionId,
+          targetSessionKey: sessionKey,
+          targetSessionId: sessionId,
+          provider: "openai",
+          model: "glm-4.5",
+        },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [completionEvent, completionEvent],
+      },
+    });
+
+    expect(embeddedArg.disableTools).toBe(true);
+    expect(embeddedArg.trustedInternalHandoff).toBeUndefined();
+  });
+
+  it("keeps an exact completion capability tool-free when persisted lineage is missing", async () => {
+    const runId = "missing-lineage-completion";
+    const childSessionKey = "agent:main:subagent:missing";
+    const sessionKey = `agent:main:direct:${runId}`;
+    const sessionId = `session-${runId}`;
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      runId,
+      modelOverride: "glm-4.5",
+      opts: {
+        trustedInternalHandoff: {
+          kind: "subagent-completion",
+          sourceSessionKey: childSessionKey,
+          targetSessionKey: sessionKey,
+          targetSessionId: sessionId,
+          provider: "openai",
+          model: "glm-4.5",
+        },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: childSessionKey,
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey,
+            announceType: "subagent task",
+            taskLabel: "review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Review and continue.",
+          },
+        ],
+      },
+    });
+
+    expect(embeddedArg.disableTools).toBe(true);
+    expect(embeddedArg.trustedInternalHandoff).toBeUndefined();
   });
 
   it("forwards canonical transcript text without replacing embedded image content", async () => {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -140,12 +140,21 @@ const SUBAGENT_ANNOUNCE_DELIVERY_CASES: readonly SubagentAnnounceDeliveryCase[] 
     expectedDisableTools: true,
   },
   {
-    name: "a coding-only parent allowlist",
+    name: "a coding profile with a source-bound message grant",
     sourceReplyDeliveryMode: "message_tool_only",
     disableMessageTool: false,
     inheritedToolAllow: ["read", "exec", "sessions_spawn"],
     operatorTools: { profile: "coding" },
-    expectedDisableTools: true,
+    expectedDisableTools: false,
+    expectedToolsAllow: ["message"],
+  },
+  {
+    name: "an operator allowlist with a source-bound message grant",
+    sourceReplyDeliveryMode: "message_tool_only",
+    disableMessageTool: false,
+    operatorTools: { allow: ["read", "exec"] },
+    expectedDisableTools: false,
+    expectedToolsAllow: ["message"],
   },
   {
     name: "an inherited explicit message deny",

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -228,15 +228,22 @@ const SUBAGENT_ANNOUNCE_DELIVERY_CASES: readonly SubagentAnnounceDeliveryCase[] 
 ];
 
 const SUBAGENT_ANNOUNCE_EMBEDDED_DELIVERY_CASES: readonly SubagentAnnounceDeliveryCase[] = [
-  ...SUBAGENT_ANNOUNCE_DELIVERY_CASES.map((testCase) =>
-    testCase.name === "automatic source replies"
-      ? {
-          ...testCase,
-          expectedDisableTools: false,
-          expectedToolsAllow: SUBAGENT_ANNOUNCE_REQUESTER_TOOLS,
-        }
-      : testCase,
-  ),
+  ...SUBAGENT_ANNOUNCE_DELIVERY_CASES.map((testCase) => {
+    if (testCase.name === "automatic source replies") {
+      return {
+        ...testCase,
+        expectedDisableTools: false,
+        expectedToolsAllow: SUBAGENT_ANNOUNCE_REQUESTER_TOOLS,
+      };
+    }
+    if (!testCase.expectedDisableTools) {
+      return {
+        ...testCase,
+        expectedToolsAllow: testCase.runtimeToolsAllow ?? SUBAGENT_ANNOUNCE_REQUESTER_TOOLS,
+      };
+    }
+    return testCase;
+  }),
   {
     name: "a raw model run despite message-tool-only delivery",
     sourceReplyDeliveryMode: "message_tool_only",

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -651,6 +651,10 @@ export function runAgentAttempt(params: {
     ? resolveConversationToolPolicies({
         capabilityProfile: completionCapabilityProfile,
         additionalProfileAllow: ["message"],
+        // The source-bound delivery grant extends restrictive allowlists only;
+        // explicit denies still win at every policy layer.
+        additionalPolicyAllow: ["message"],
+        additionalInheritedAllow: ["message"],
       })
     : undefined;
   const completionRuntimeRestrictions = params.opts.toolsAllow

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -731,7 +731,10 @@ export function runAgentAttempt(params: {
     trustedSubagentAnnounceHandoff &&
     !isRawModelRun &&
     !isCliExecutionProvider &&
-    !messageToolOwnsVisibleReply(params.opts);
+    (!messageToolOwnsVisibleReply(params.opts) || completionNeedsMessageDelivery);
+  // Message-tool-only delivery constrains the visible reply, not the parent
+  // continuation's verified authority. Keep the inherited cap while requiring
+  // message to survive every applicable policy before enabling any tools.
   // An explicit cap is enforced even when tools are disabled; clear it so a
   // denied completion can finish tool-free and its owner can relay frozen text.
   const runtimeToolsAllow = isSubagentAnnounceHandoff

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -78,6 +78,7 @@ import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
 import { resolveOpenAIRuntimeProvider } from "../openai-routing.js";
+import { hasVerifiedRequesterCompletionHandoff } from "../requester-tool-policy.js";
 import { resolveAgentRunSessionTarget, type AgentRunSessionTarget } from "../run-session-target.js";
 import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
@@ -90,7 +91,10 @@ import {
   resolveSessionWriteLockTargetKey,
 } from "../session-write-lock.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
-import { isSubagentAnnounceCompletionHandoff } from "../subagent-announce-handoff.js";
+import {
+  isSubagentAnnounceCompletionHandoff,
+  isTrustedSubagentCompletionHandoffForRun,
+} from "../subagent-announce-handoff.js";
 import { isToolAllowedByPolicies } from "../tool-policy-match.js";
 import { readToolAllowlistIntersection } from "../tool-policy.js";
 import { DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS } from "../tool-result-limits.js";
@@ -578,17 +582,38 @@ export function runAgentAttempt(params: {
           ? { id: sessionAuthProfileId, source: sessionAuthProfileSource }
           : undefined;
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
-  // A completion handoff relays frozen child output; letting it act with the
-  // requester's tools would turn child text into a new privileged instruction.
+  // A completion handoff relays frozen child output, so only a verified private
+  // capability plus persisted requester lineage may restore its tool surface.
   const isSubagentAnnounceHandoff = isSubagentAnnounceCompletionHandoff({
     inputProvenance: params.opts.inputProvenance,
     internalEvents: params.opts.internalEvents,
   });
-  const completionRequestsMessageDelivery =
+  const exactSubagentAnnounceHandoff =
     isSubagentAnnounceHandoff &&
+    isTrustedSubagentCompletionHandoffForRun({
+      handoff: params.opts.trustedInternalHandoff,
+      inputProvenance: params.opts.inputProvenance,
+      internalEvents: params.opts.internalEvents,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      provider: params.providerOverride,
+      model: params.modelOverride,
+    });
+  const trustedSubagentAnnounceHandoff =
+    exactSubagentAnnounceHandoff &&
+    hasVerifiedRequesterCompletionHandoff({
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      inputProvenance: params.opts.inputProvenance,
+      trustedInternalHandoff: params.opts.trustedInternalHandoff,
+      sessionId: params.sessionId,
+      modelProvider: params.providerOverride,
+      modelId: params.modelOverride,
+    });
+  const completionRequestsMessageDelivery =
+    trustedSubagentAnnounceHandoff &&
     !isRawModelRun &&
     params.opts.disableMessageTool !== true &&
-    params.opts.trustedInternalHandoff === true &&
     messageToolOwnsVisibleReply(params.opts);
   const completionSandboxStatus = completionRequestsMessageDelivery
     ? resolveSandboxRuntimeStatus({
@@ -641,15 +666,6 @@ export function runAgentAttempt(params: {
         (allow) => allow.length > 0 && isToolAllowedByPolicies("message", [{ allow }]),
       ) ??
         false));
-  // An explicit cap is enforced even when tools are disabled; clear it so a
-  // denied completion can finish tool-free and its owner can relay frozen text.
-  const runtimeToolsAllow = isSubagentAnnounceHandoff
-    ? completionNeedsMessageDelivery
-      ? ["message"]
-      : undefined
-    : params.opts.toolsAllow;
-  const disableTools =
-    params.opts.modelRun === true || (isSubagentAnnounceHandoff && !completionNeedsMessageDelivery);
   const claudeCliFallbackPrelude =
     !isRawModelRun &&
     params.isFallbackRetry &&
@@ -710,6 +726,25 @@ export function runAgentAttempt(params: {
   const isCliExecutionProvider = sessionRuntimeOverride
     ? sessionCliRuntime !== undefined
     : isCliProvider(cliExecutionProvider, params.cfg);
+  const completionRetainsRequesterTools =
+    trustedSubagentAnnounceHandoff &&
+    !isRawModelRun &&
+    !isCliExecutionProvider &&
+    !messageToolOwnsVisibleReply(params.opts);
+  // An explicit cap is enforced even when tools are disabled; clear it so a
+  // denied completion can finish tool-free and its owner can relay frozen text.
+  const runtimeToolsAllow = isSubagentAnnounceHandoff
+    ? completionRetainsRequesterTools
+      ? params.opts.toolsAllow
+      : completionNeedsMessageDelivery
+        ? ["message"]
+        : undefined
+    : params.opts.toolsAllow;
+  const disableTools =
+    params.opts.modelRun === true ||
+    (isSubagentAnnounceHandoff &&
+      !completionRetainsRequesterTools &&
+      !completionNeedsMessageDelivery);
   if (params.fallbackRuntimeState && params.fallbackRuntimeState.originRuntime === undefined) {
     params.fallbackRuntimeState.originRuntime =
       !isRawModelRun && isCliExecutionProvider ? "cli" : "embedded";
@@ -1173,7 +1208,9 @@ export function runAgentAttempt(params: {
     bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
     toolsAllow: runtimeToolsAllow,
     runtimePluginToolGrant: params.opts.runtimePluginToolGrant,
-    trustedInternalHandoff: params.opts.trustedInternalHandoff,
+    trustedInternalHandoff: trustedSubagentAnnounceHandoff
+      ? params.opts.trustedInternalHandoff
+      : undefined,
     scheduledToolPolicy: params.opts.scheduledToolPolicy,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -626,6 +626,7 @@ export function runAgentAttempt(params: {
     ? resolveConversationCapabilityProfile({
         config: params.cfg,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         agentId: params.sessionAgentId,
         agentAccountId: params.runContext.accountId,
         messageProvider: params.opts.messageProvider ?? params.messageChannel,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -22,6 +22,7 @@ import type { BootstrapContextRunKind } from "../bootstrap-mode.js";
 import type { CliSessionBindingFacts } from "../cli-runner/types.js";
 import type { MainSessionRecoveryOwnerLease } from "../main-session-recovery-store.js";
 import type { ScheduledToolPolicyContext } from "../scheduled-tool-policy.js";
+import type { TrustedSubagentCompletionHandoff } from "../subagent-announce-handoff.js";
 import type { AgentStreamParams, ClientToolDefinition } from "./shared-types.js";
 
 /** Image content block for Claude API multimodal messages. */
@@ -119,8 +120,8 @@ export type AgentCommandOpts = {
   toolsAllow?: string[];
   /** Trusted owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
-  /** Trusted in-process subagent-completion handoff; never accepted from public RPC params. */
-  trustedInternalHandoff?: boolean;
+  /** Consumed in-process subagent-completion capability; never accepted from public RPC params. */
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   /** Internal marker identifying a server-managed default cap. */
   toolsAllowIsDefault?: boolean;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -23,6 +23,7 @@ import {
 } from "./requester-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
+import type { TrustedSubagentCompletionHandoff } from "./subagent-announce-handoff.js";
 import type { PromptMode } from "./system-prompt.types.js";
 import {
   collectExplicitAllowlist,
@@ -82,8 +83,8 @@ export type ConversationCapabilityProfileParams = {
   inheritRuntimeToolAllowlist?: boolean;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
   inputProvenance?: InputProvenance;
-  /** Trusted in-process completion handoff; public callers cannot set this fact. */
-  trustedInternalHandoff?: boolean;
+  /** Consumed in-process completion capability; public callers cannot set this fact. */
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */
   scheduledToolPolicy?: ScheduledToolPolicyContext;
 };
@@ -229,6 +230,9 @@ export function resolveConversationCapabilityProfile(
     senderE164: params.senderE164,
     inputProvenance: params.inputProvenance,
     trustedInternalHandoff: params.trustedInternalHandoff,
+    sessionId: params.sessionId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
     senderPolicyMode: params.scheduledToolPolicy || isOwnerInternalSession ? "never" : "always",
     groupPolicySessionKey: params.scheduledToolPolicy?.ownerSessionKey,
     requireConfiguredGroupAccount: params.scheduledToolPolicy?.mode === "account",

--- a/src/agents/conversation-tool-policy-pipeline.ts
+++ b/src/agents/conversation-tool-policy-pipeline.ts
@@ -36,6 +36,7 @@ export function resolveConversationToolPolicies(params: {
   capabilityProfile: ResolvedConversationCapabilityProfile;
   additionalProfileAllow?: readonly string[];
   additionalPolicyAllow?: readonly string[];
+  additionalInheritedAllow?: readonly string[];
 }): ResolvedConversationToolPolicies {
   const policy = params.capabilityProfile.policy;
   const profileAllow = [
@@ -64,7 +65,10 @@ export function resolveConversationToolPolicies(params: {
     sandboxPolicy: mergePolicyAllowlist(policy.sandboxPolicy, params.additionalPolicyAllow),
     subagentPolicy: mergePolicyAllowlist(policy.subagentPolicy, params.additionalPolicyAllow),
     runtimeToolPolicy: policy.runtimeToolPolicyForInheritance,
-    inheritedToolPolicy: policy.inheritedToolPolicy,
+    inheritedToolPolicy: mergePolicyAllowlist(
+      policy.inheritedToolPolicy,
+      params.additionalInheritedAllow,
+    ),
   };
 }
 

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -14,6 +14,7 @@ import type { SkillSnapshot } from "../../skills/types.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
 import type { AgentRuntimeAuthPlan, AgentRuntimePlan } from "../runtime-plan/types.js";
+import type { TrustedSubagentCompletionHandoff } from "../subagent-announce-handoff.js";
 
 export type CompactEmbeddedAgentSessionParams = {
   sessionId: string;
@@ -52,8 +53,8 @@ export type CompactEmbeddedAgentSessionParams = {
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
   inputProvenance?: InputProvenance;
-  /** Trusted in-process subagent-completion handoff; never derived from public input. */
-  trustedInternalHandoff?: boolean;
+  /** Consumed in-process subagent-completion capability; never derived from public input. */
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   sessionFile: string;
   /** Optional caller-observed live prompt tokens used for compaction diagnostics. */
   currentTokenCount?: number;

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -47,6 +47,7 @@ import type { AgentRunSessionTarget } from "../../run-session-target.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { ScheduledToolPolicyContext } from "../../scheduled-tool-policy.js";
 import type { SessionManager } from "../../sessions/index.js";
+import type { TrustedSubagentCompletionHandoff } from "../../subagent-announce-handoff.js";
 import type { SilentReplyPromptMode } from "../../system-prompt.types.js";
 import type { PromptMode } from "../../system-prompt.types.js";
 import type { EmbeddedAgentExecutionPhase } from "../execution-phase.js";
@@ -252,8 +253,8 @@ export type RunEmbeddedAgentParams = {
   toolsAllow?: string[];
   /** Owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
-  /** Trusted in-process subagent-completion handoff; never derived from public input. */
-  trustedInternalHandoff?: boolean;
+  /** Consumed in-process subagent-completion capability; never derived from public input. */
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   /** Seen bootstrap truncation warning signatures for this session (once mode dedupe). */

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -134,6 +134,7 @@ type AgentHarnessSelectionDecision = {
 type PluginHarnessToolPolicyContext = Pick<
   EmbeddedRunAttemptParams,
   | "config"
+  | "sessionId"
   | "sessionKey"
   | "sandboxSessionKey"
   | "agentId"
@@ -664,6 +665,7 @@ function resolvePluginHarnessToolPolicies(
   const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
   const capabilityProfile = resolveConversationCapabilityProfile({
     config: params.config,
+    sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     sandboxSessionKey,
     agentId: params.agentId,

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -45,6 +45,23 @@ describe("resolveRequesterToolPolicies", () => {
     };
   }
 
+  function completionHandoffFacts(sourceSessionKey: string, targetSessionKey: string) {
+    const targetSessionId = `${targetSessionKey}-session`;
+    return {
+      trustedInternalHandoff: {
+        kind: "subagent-completion" as const,
+        sourceSessionKey,
+        targetSessionKey,
+        targetSessionId,
+        provider: "openai",
+        model: "gpt-test",
+      },
+      sessionId: targetSessionId,
+      modelProvider: "openai",
+      modelId: "gpt-test",
+    };
+  }
+
   it("resolves exact sender policy for an external requester", () => {
     const result = resolveRequesterToolPolicies({
       config: config(),
@@ -322,7 +339,7 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: requesterSessionKey,
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, requesterSessionKey),
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: childSessionKey,
@@ -344,7 +361,7 @@ describe("resolveRequesterToolPolicies", () => {
       resolveRequesterToolPolicies({
         agentId: "ops",
         sessionKey: "agent:ops:main",
-        trustedInternalHandoff: true,
+        ...completionHandoffFacts("agent:ops:subagent:child", "agent:ops:main"),
         inputProvenance: {
           kind: "inter_session",
           sourceSessionKey: "agent:ops:subagent:child",
@@ -372,7 +389,7 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: completionOwnerSessionKey,
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, completionOwnerSessionKey),
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: childSessionKey,
@@ -389,7 +406,7 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: controllerSessionKey,
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, completionOwnerSessionKey),
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: childSessionKey,
@@ -425,7 +442,7 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: requesterSessionKey,
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(leafSessionKey, requesterSessionKey),
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: leafSessionKey,
@@ -436,6 +453,45 @@ describe("resolveRequesterToolPolicies", () => {
     expect(result.delegated).toBe(true);
     expect(result.requesterPolicySource).toBe("completion-handoff");
     expect(result.inheritedToolPolicy).toEqual({ deny: ["exec"] });
+  });
+
+  it("prioritizes a verified nested completion over the target subagent resume envelope", async () => {
+    const requesterSessionKey = "agent:main:discord:direct:alice";
+    const parentChildSessionKey = "agent:main:subagent:parent-child";
+    const leafSessionKey = "agent:main:subagent:leaf";
+    await writeSession(parentChildSessionKey, {
+      spawnedBy: requesterSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
+      inheritedToolDeny: ["exec"],
+    });
+    await writeSession(leafSessionKey, {
+      spawnedBy: parentChildSessionKey,
+      spawnDepth: 2,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+      inheritedToolPolicyVersion: 1,
+      inheritedToolDeny: ["exec", "read"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: parentChildSessionKey,
+      subagentSessionKey: parentChildSessionKey,
+      ...completionHandoffFacts(leafSessionKey, parentChildSessionKey),
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: leafSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("completion-handoff");
+    expect(result.inheritedToolPolicy).toEqual({ deny: ["exec", "read"] });
   });
 
   it("fails closed for untrusted or mismatched completion handoffs", async () => {
@@ -463,14 +519,14 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: "agent:main:discord:direct:bob",
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, "agent:main:discord:direct:alice"),
       inputProvenance: provenance,
     });
     const mismatchedCompletionOwner = resolveRequesterToolPolicies({
       config: config(),
       agentId: "main",
       sessionKey: "agent:main:main",
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, "agent:main:discord:direct:alice"),
       inputProvenance: provenance,
     });
 
@@ -499,7 +555,7 @@ describe("resolveRequesterToolPolicies", () => {
       config: config(),
       agentId: "main",
       sessionKey: requesterSessionKey,
-      trustedInternalHandoff: true,
+      ...completionHandoffFacts(childSessionKey, requesterSessionKey),
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: childSessionKey,

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -3,7 +3,6 @@
  * Sender-dependent policy resolves once at trusted ingress; verified descendants
  * consume the persisted effective parent projection instead of guessing identity.
  */
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import { normalizeInputProvenance } from "../sessions/input-provenance.js";
@@ -14,6 +13,10 @@ import {
 } from "./agent-tools.policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
+import {
+  isTrustedSubagentCompletionHandoffForRun,
+  type TrustedSubagentCompletionHandoff,
+} from "./subagent-announce-handoff.js";
 import {
   isSubagentEnvelopeSession,
   resolvePersistedSubagentToolPolicyEnvelope,
@@ -58,7 +61,10 @@ type RequesterToolPolicyParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   inputProvenance?: InputProvenance;
-  trustedInternalHandoff?: boolean;
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
+  sessionId?: string;
+  modelProvider?: string;
+  modelId?: string;
   senderPolicyMode?: SenderPolicyMode;
   /** Group session selected by a trusted scheduled authority envelope. */
   groupPolicySessionKey?: string;
@@ -94,6 +100,50 @@ function resolveDelegatedPolicy(
   const hasExternalRequester =
     provenance?.kind === "external_user" ||
     Boolean(params.senderId || params.senderName || params.senderUsername || params.senderE164);
+  const isTrustedCompletionHandoff = isTrustedSubagentCompletionHandoffForRun({
+    handoff: params.trustedInternalHandoff,
+    inputProvenance: provenance,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    provider: params.modelProvider,
+    model: params.modelId,
+  });
+  if (isTrustedCompletionHandoff) {
+    if (!provenance?.sourceSessionKey || !params.sessionKey) {
+      return { delegated: false };
+    }
+    if (!params.config) {
+      throw new Error("Trusted internal handoff policy resolution requires configuration.");
+    }
+    const targetSessionKey = resolveRequesterStoreKey(params.config, params.sessionKey);
+    let currentSessionKey = resolveRequesterStoreKey(params.config, provenance.sourceSessionKey);
+    const visited = new Set<string>();
+    for (let depth = 0; depth < MAX_DELEGATION_LINEAGE_DEPTH; depth += 1) {
+      if (visited.has(currentSessionKey)) {
+        return { delegated: false };
+      }
+      visited.add(currentSessionKey);
+      const envelope = resolvePersistedSubagentToolPolicyEnvelope(currentSessionKey, {
+        cfg: params.config,
+      });
+      if (!envelope) {
+        return { delegated: false };
+      }
+      const parentSessionKey = resolveRequesterStoreKey(params.config, envelope.spawnedBy);
+      const completionOwnerSessionKey = envelope.completionOwnerSessionKey
+        ? resolveRequesterStoreKey(params.config, envelope.completionOwnerSessionKey)
+        : undefined;
+      if ((completionOwnerSessionKey ?? parentSessionKey) === targetSessionKey) {
+        return {
+          delegated: true,
+          source: "completion-handoff",
+          policy: policyFromEnvelope(envelope),
+        };
+      }
+      currentSessionKey = parentSessionKey;
+    }
+    return { delegated: false };
+  }
   if (!hasExternalRequester) {
     const ownEnvelope = resolvePersistedSubagentToolPolicyEnvelope(params.subagentSessionKey, {
       cfg: params.config,
@@ -109,48 +159,24 @@ function resolveDelegatedPolicy(
       };
     }
   }
-  if (!params.trustedInternalHandoff) {
-    return { delegated: false };
-  }
-  if (
-    provenance?.kind !== "inter_session" ||
-    normalizeOptionalLowercaseString(provenance.sourceTool) !== "subagent_announce" ||
-    !provenance.sourceSessionKey ||
-    !params.sessionKey
-  ) {
-    return { delegated: false };
-  }
-  if (!params.config) {
-    throw new Error("Trusted internal handoff policy resolution requires configuration.");
-  }
-  const targetSessionKey = resolveRequesterStoreKey(params.config, params.sessionKey);
-  let currentSessionKey = resolveRequesterStoreKey(params.config, provenance.sourceSessionKey);
-  const visited = new Set<string>();
-  for (let depth = 0; depth < MAX_DELEGATION_LINEAGE_DEPTH; depth += 1) {
-    if (visited.has(currentSessionKey)) {
-      return { delegated: false };
-    }
-    visited.add(currentSessionKey);
-    const envelope = resolvePersistedSubagentToolPolicyEnvelope(currentSessionKey, {
-      cfg: params.config,
-    });
-    if (!envelope) {
-      return { delegated: false };
-    }
-    const parentSessionKey = resolveRequesterStoreKey(params.config, envelope.spawnedBy);
-    const completionOwnerSessionKey = envelope.completionOwnerSessionKey
-      ? resolveRequesterStoreKey(params.config, envelope.completionOwnerSessionKey)
-      : undefined;
-    if ((completionOwnerSessionKey ?? parentSessionKey) === targetSessionKey) {
-      return {
-        delegated: true,
-        source: "completion-handoff",
-        policy: policyFromEnvelope(envelope),
-      };
-    }
-    currentSessionKey = parentSessionKey;
-  }
   return { delegated: false };
+}
+
+/** Confirms that an exact consumed completion capability also owns persisted requester lineage. */
+export function hasVerifiedRequesterCompletionHandoff(
+  params: Pick<
+    RequesterToolPolicyParams,
+    | "config"
+    | "sessionKey"
+    | "inputProvenance"
+    | "trustedInternalHandoff"
+    | "sessionId"
+    | "modelProvider"
+    | "modelId"
+  >,
+): boolean {
+  const delegatedPolicy = resolveDelegatedPolicy(params, undefined);
+  return delegatedPolicy.delegated && delegatedPolicy.source === "completion-handoff";
 }
 
 /** Resolve sender/group policy or a verified inherited projection, never both. */

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1315,6 +1315,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       completionDirectOrigin: slackThreadOrigin,
       directOrigin: slackThreadOrigin,
       sourceSessionKey: "agent:main:subagent:child",
+      internalEvents: taskCompletionEvents({
+        childSessionKey: "agent:main:subagent:child",
+        childSessionId: "child-session-local",
+      }),
       requesterIsSubagent: false,
       expectsCompletionMessage: true,
       bestEffortDeliver: true,
@@ -1335,7 +1339,13 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(dispatchOptions).toMatchObject({
       expectFinal: true,
       forceSyntheticClient: true,
-      delegatedToolPolicyHandoff: true,
+      delegatedToolPolicyHandoff: {
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceSessionId: "child-session-local",
+        targetSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+        targetSessionId: "requester-session-local",
+        idempotencyKey: "announce-local-dispatch",
+      },
       timeoutMs: 120_000,
     });
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -23,7 +23,6 @@ import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isAgentMediatedCompletionSourceTool,
-  normalizeInputProvenance,
   shouldPreserveUserFacingSessionStateForInputProvenance,
 } from "../sessions/input-provenance.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
@@ -52,7 +51,10 @@ import {
 import type { EmbeddedAgentQueueMessageOptions } from "./embedded-agent-runner/run-state.js";
 import type { EmbeddedAgentQueueMessageOutcome } from "./embedded-agent-runner/runs.js";
 import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
-import { hasGeneratedMediaCompletionEvent } from "./internal-event-contract.js";
+import {
+  AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  hasGeneratedMediaCompletionEvent,
+} from "./internal-event-contract.js";
 import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "./internal-events.js";
 import {
   callGateway,
@@ -74,6 +76,7 @@ import {
   runSubagentAnnounceDispatch,
   type SubagentAnnounceDeliveryResult,
 } from "./subagent-announce-dispatch.js";
+import type { SubagentCompletionToolHandoffRegistration } from "./subagent-announce-handoff.js";
 import {
   inferDeliveryTargetChatType,
   resolveCompletionDeliveryOrigins,
@@ -139,10 +142,10 @@ async function resolveQueueEmbeddedAgentMessageOutcome(
 
 async function runAnnounceAgentCall(params: {
   agentParams: Record<string, unknown>;
+  delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   expectFinal?: boolean;
   timeoutMs?: number;
 }): Promise<unknown> {
-  const inputProvenance = normalizeInputProvenance(params.agentParams.inputProvenance);
   return await subagentAnnounceDeliveryDeps.dispatchGatewayMethodInProcess(
     "agent",
     params.agentParams,
@@ -151,10 +154,7 @@ async function runAnnounceAgentCall(params: {
       forceSyntheticClient: shouldPreserveUserFacingSessionStateForInputProvenance(
         params.agentParams.inputProvenance,
       ),
-      delegatedToolPolicyHandoff:
-        inputProvenance?.kind === "inter_session" &&
-        inputProvenance.sourceTool === "subagent_announce" &&
-        Boolean(inputProvenance.sourceSessionKey),
+      delegatedToolPolicyHandoff: params.delegatedToolPolicyHandoff,
       timeoutMs: params.timeoutMs,
     },
   );
@@ -851,6 +851,15 @@ async function sendSubagentAnnounceDirectly(params: {
       normalizeOptionalLowercaseString(params.sourceTool) ??
       (params.expectsCompletionMessage ? "subagent_announce" : "");
     const isSubagentCompletion = sourceToolId === "subagent_announce";
+    const subagentCompletionEvents = params.internalEvents?.filter(
+      (event) =>
+        event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+    );
+    const trustedCompletionEvent =
+      subagentCompletionEvents?.length === 1 &&
+      subagentCompletionEvents[0]?.childSessionKey === params.sourceSessionKey
+        ? subagentCompletionEvents[0]
+        : undefined;
     const agentMediatedCompletion =
       params.expectsCompletionMessage && isAgentMediatedCompletionSourceTool(sourceToolId);
     const completionRouteRequiresMessageToolDelivery =
@@ -1007,6 +1016,21 @@ async function sendSubagentAnnounceDirectly(params: {
         run: async () =>
           await runAnnounceAgentCall({
             agentParams: directAgentParams,
+            delegatedToolPolicyHandoff:
+              isSubagentCompletion &&
+              trustedCompletionEvent &&
+              params.sourceSessionKey &&
+              requesterActivity.sessionId
+                ? {
+                    sourceSessionKey: params.sourceSessionKey,
+                    ...(trustedCompletionEvent.childSessionId
+                      ? { sourceSessionId: trustedCompletionEvent.childSessionId }
+                      : {}),
+                    targetSessionKey: canonicalRequesterSessionKey,
+                    targetSessionId: requesterActivity.sessionId,
+                    idempotencyKey: params.directIdempotencyKey,
+                  }
+                : undefined,
             expectFinal: true,
             timeoutMs: announceTimeoutMs,
           }),

--- a/src/agents/subagent-announce-handoff.test.ts
+++ b/src/agents/subagent-announce-handoff.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
 import type { AgentInternalEvent } from "./internal-events.js";
-import { isSubagentAnnounceCompletionHandoff } from "./subagent-announce-handoff.js";
+import {
+  isSubagentAnnounceCompletionHandoff,
+  isTrustedSubagentCompletionHandoffForRun,
+} from "./subagent-announce-handoff.js";
 
 const announceProvenance = {
   kind: "inter_session",
@@ -14,6 +17,7 @@ const subagentCompletionEvent: AgentInternalEvent = {
   type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
   source: "subagent",
   childSessionKey: "agent:openclaw:subagent:child",
+  childSessionId: "child-session",
   announceType: "subagent task",
   taskLabel: "review",
   status: "ok",
@@ -48,5 +52,66 @@ describe("isSubagentAnnounceCompletionHandoff", () => {
         internalEvents: [],
       }),
     ).toBe(false);
+  });
+
+  it("keeps malformed completion announces in the broad deny class", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [
+          { ...subagentCompletionEvent, childSessionKey: "agent:openclaw:subagent:forged" },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [subagentCompletionEvent, subagentCompletionEvent],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isTrustedSubagentCompletionHandoffForRun", () => {
+  const exact = {
+    handoff: {
+      kind: "subagent-completion",
+      sourceSessionKey: announceProvenance.sourceSessionKey,
+      sourceSessionId: subagentCompletionEvent.childSessionId,
+      targetSessionKey: "agent:main:main",
+      targetSessionId: "requester-session",
+      provider: "openai",
+      model: "glm-4.5",
+    } as const,
+    inputProvenance: announceProvenance,
+    internalEvents: [subagentCompletionEvent],
+    sessionKey: "agent:main:main",
+    sessionId: "requester-session",
+    provider: "openai",
+    model: "glm-4.5",
+  };
+
+  it("accepts only the exact completion attempt", () => {
+    expect(isTrustedSubagentCompletionHandoffForRun(exact)).toBe(true);
+  });
+
+  it.each([
+    ["source", { inputProvenance: { ...announceProvenance, sourceSessionKey: "forged" } }],
+    [
+      "source event",
+      {
+        internalEvents: [
+          { ...subagentCompletionEvent, childSessionKey: "agent:openclaw:subagent:forged" },
+        ],
+      },
+    ],
+    ["source run", { internalEvents: [{ ...subagentCompletionEvent, childSessionId: "forged" }] }],
+    ["duplicate event", { internalEvents: [subagentCompletionEvent, subagentCompletionEvent] }],
+    ["target", { sessionKey: "agent:main:other" }],
+    ["target run", { sessionId: "replacement-session" }],
+    ["provider", { provider: "anthropic" }],
+    ["model", { model: "claude-opus-4-1" }],
+  ])("rejects a cross-%s handoff", (_name, overrides) => {
+    expect(isTrustedSubagentCompletionHandoffForRun({ ...exact, ...overrides })).toBe(false);
   });
 });

--- a/src/agents/subagent-announce-handoff.ts
+++ b/src/agents/subagent-announce-handoff.ts
@@ -2,6 +2,44 @@ import type { InputProvenance } from "../sessions/input-provenance.js";
 import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 
+export type TrustedSubagentCompletionHandoff = {
+  kind: "subagent-completion";
+  sourceSessionKey: string;
+  sourceSessionId?: string;
+  targetSessionKey: string;
+  targetSessionId: string;
+  provider: string;
+  model: string;
+};
+
+export type SubagentCompletionToolHandoffRegistration = {
+  sourceSessionKey: string;
+  sourceSessionId?: string;
+  targetSessionKey: string;
+  targetSessionId: string;
+  idempotencyKey: string;
+};
+
+function resolveExactSubagentCompletionEvent(params: {
+  inputProvenance?: InputProvenance;
+  internalEvents?: AgentInternalEvent[];
+}) {
+  if (
+    params.inputProvenance?.kind !== "inter_session" ||
+    params.inputProvenance.sourceTool !== "subagent_announce"
+  ) {
+    return undefined;
+  }
+  const completionEvents = params.internalEvents?.filter(
+    (event) =>
+      event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+  );
+  const completionEvent = completionEvents?.length === 1 ? completionEvents[0] : undefined;
+  return completionEvent?.childSessionKey === params.inputProvenance.sourceSessionKey
+    ? completionEvent
+    : undefined;
+}
+
 /** Identifies the delivery-only turn that hands a completed subagent result to its requester. */
 export function isSubagentAnnounceCompletionHandoff(params: {
   inputProvenance?: InputProvenance;
@@ -18,5 +56,40 @@ export function isSubagentAnnounceCompletionHandoff(params: {
       (event) =>
         event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
     ) === true
+  );
+}
+
+/** Verify that a consumed in-process handoff still matches this exact model attempt. */
+export function isTrustedSubagentCompletionHandoffForRun(params: {
+  handoff?: TrustedSubagentCompletionHandoff;
+  inputProvenance?: InputProvenance;
+  internalEvents?: AgentInternalEvent[];
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+}): boolean {
+  const handoff = params.handoff;
+  const completionEvent = resolveExactSubagentCompletionEvent({
+    inputProvenance: params.inputProvenance,
+    internalEvents: params.internalEvents,
+  });
+  if (
+    !handoff ||
+    handoff.kind !== "subagent-completion" ||
+    params.inputProvenance?.kind !== "inter_session" ||
+    params.inputProvenance.sourceTool !== "subagent_announce" ||
+    (params.internalEvents !== undefined && !completionEvent)
+  ) {
+    return false;
+  }
+  return (
+    handoff.sourceSessionKey === params.inputProvenance.sourceSessionKey &&
+    (params.internalEvents === undefined ||
+      handoff.sourceSessionId === completionEvent?.childSessionId) &&
+    handoff.targetSessionKey === params.sessionKey &&
+    handoff.targetSessionId === params.sessionId &&
+    handoff.provider === params.provider?.trim().toLowerCase() &&
+    handoff.model === params.model?.trim()
   );
 }

--- a/src/agents/web-search-tool-policy.ts
+++ b/src/agents/web-search-tool-policy.ts
@@ -5,6 +5,7 @@ import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
 import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
+import type { TrustedSubagentCompletionHandoff } from "./subagent-announce-handoff.js";
 import { isToolAllowedByPolicies } from "./tool-policy-match.js";
 import {
   mergeAlsoAllowPolicy,
@@ -19,6 +20,7 @@ export type WebSearchToolPolicyParams = {
   modelId?: string;
   agentId?: string;
   sessionKey?: string;
+  sessionId?: string;
   sandboxToolPolicy?: SandboxToolPolicy;
   messageProvider?: string;
   agentAccountId?: string | null;
@@ -31,7 +33,7 @@ export type WebSearchToolPolicyParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   inputProvenance?: InputProvenance;
-  trustedInternalHandoff?: boolean;
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   runtimeToolAllowlist?: string[];
 };
@@ -96,6 +98,9 @@ export function resolveWebSearchToolPolicy(
     senderE164: params.senderE164,
     inputProvenance: params.inputProvenance,
     trustedInternalHandoff: params.trustedInternalHandoff,
+    sessionId: params.sessionId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
     senderPolicyMode: params.scheduledToolPolicy ? "never" : "always",
     groupPolicySessionKey: params.scheduledToolPolicy?.ownerSessionKey,
     requireConfiguredGroupAccount: params.scheduledToolPolicy?.mode === "account",

--- a/src/gateway/server-methods/agent-run-admission-phase.ts
+++ b/src/gateway/server-methods/agent-run-admission-phase.ts
@@ -5,12 +5,14 @@ import {
   isEmbeddedAgentRunAbortableForRunId,
   retainEmbeddedAgentRunAbortabilityForRunId,
 } from "../../agents/embedded-agent-runner/runs.js";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
 import {
   commitMainSessionRecovery,
   type MainSessionRecoveryPendingTarget,
 } from "../../agents/main-session-recovery-store.js";
 import { resolvePersistedOverrideModelRef } from "../../agents/model-selection.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import type { TrustedSubagentCompletionHandoff } from "../../agents/subagent-announce-handoff.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -20,6 +22,7 @@ import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SessionWorkAdmissionLease } from "../../sessions/session-lifecycle-admission.js";
 import { registerChatAbortController, resolveAgentRunExpiresAtMs } from "../chat-abort.js";
 import { loadSessionEntry, resolveSessionModelRef } from "../session-utils.js";
+import { consumeSubagentCompletionToolHandoff } from "../subagent-completion-tool-handoff.js";
 import { formatForLog } from "../ws-log.js";
 import {
   isPreRegistrationAbortedAgentDedupeEntryForSession,
@@ -44,6 +47,7 @@ export type PreparedAgentRunDispatch = {
   effectiveModelOverride?: string;
   effectiveThinking?: string;
   effectiveAllowModelOverride: boolean;
+  trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   restoredCronContinuationLifecycleRevision?: string;
   lifecycleStorePath: string;
   resolvedThreadId?: string | number;
@@ -271,6 +275,35 @@ export async function prepareAgentRunDispatch(params: {
 
   const resolvedThreadId =
     params.delivery.explicitThreadId ?? params.delivery.deliveryPlan.resolvedThreadId;
+  const completionSourceSessionKey =
+    params.inputProvenance?.kind === "inter_session" &&
+    params.inputProvenance.sourceTool === "subagent_announce"
+      ? params.inputProvenance.sourceSessionKey
+      : undefined;
+  const completionEvents = params.request.internalEvents?.filter(
+    (event) =>
+      event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+  );
+  const completionEvent =
+    completionEvents?.length === 1 &&
+    completionEvents[0]?.childSessionKey === completionSourceSessionKey
+      ? completionEvents[0]
+      : undefined;
+  const trustedInternalHandoff =
+    params.providerOverride === undefined &&
+    params.modelOverride === undefined &&
+    params.restoredCronContinuation === undefined
+      ? consumeSubagentCompletionToolHandoff({
+          handoffId: params.client?.internal?.delegatedToolPolicyHandoffId,
+          sourceSessionKey: completionEvent?.childSessionKey,
+          sourceSessionId: completionEvent?.childSessionId,
+          targetSessionKey: params.resolvedSessionKey,
+          targetSessionId: params.getAdmittedSessionId(),
+          idempotencyKey: params.request.idempotencyKey,
+          provider: activeModel.provider,
+          model: activeModel.model,
+        })
+      : undefined;
   const taskTrackingMode = resolveGatewayAgentTaskTrackingMode({
     client: params.client,
     sessionKey: params.resolvedSessionKey,
@@ -403,6 +436,7 @@ export async function prepareAgentRunDispatch(params: {
     effectiveModelOverride,
     effectiveThinking,
     effectiveAllowModelOverride,
+    trustedInternalHandoff,
     restoredCronContinuationLifecycleRevision: params.restoredCronContinuation?.lifecycleRevision,
     lifecycleStorePath,
     resolvedThreadId,

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -324,11 +324,6 @@ export function startAgentRunExecution(params: {
           params.client.internal.runtimePluginToolGrant?.pluginId
           ? params.client.internal.runtimePluginToolGrant
           : undefined;
-      const trustedInternalHandoff =
-        params.client?.internal?.delegatedToolPolicyHandoff === true &&
-        params.inputProvenance?.kind === "inter_session" &&
-        params.inputProvenance.sourceTool === "subagent_announce";
-
       const restartRecoveryChannelContext = resolveAgentRestartRecoveryChannelContext({
         canUseInternalRuntimeHandoff: params.canUseInternalRuntimeHandoff,
         expectedExistingSessionId: params.request.expectedExistingSessionId,
@@ -398,7 +393,7 @@ export function startAgentRunExecution(params: {
           bootstrapContextRunKind: params.effectiveBootstrapContextRunKind,
           toolsAllow: params.restoredCronContinuation?.toolsAllow,
           runtimePluginToolGrant,
-          trustedInternalHandoff,
+          trustedInternalHandoff: prepared.trustedInternalHandoff,
           toolsAllowIsDefault: params.restoredCronContinuation?.toolsAllowIsDefault,
           scheduledToolPolicy: params.restoredCronContinuation
             ? resolveScheduledToolPolicyContext({

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -10,6 +10,7 @@ import {
 } from "../../infra/gateway-suspend-coordinator.js";
 import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { registerSubagentCompletionToolHandoff } from "../subagent-completion-tool-handoff.js";
 import {
   getAgentTestMocks,
   makeContext,
@@ -421,6 +422,13 @@ describe("gateway agent handler", () => {
 
   it("forwards trusted delegated policy handoffs only from internal client metadata", async () => {
     primeMainAgentRun();
+    const handoffId = registerSubagentCompletionToolHandoff({
+      sourceSessionKey: "agent:main:subagent:child",
+      sourceSessionId: "child-session-id",
+      targetSessionKey: "agent:main:main",
+      targetSessionId: "existing-session-id",
+      idempotencyKey: "delegated-policy-handoff",
+    });
 
     await invokeAgent(
       {
@@ -432,18 +440,46 @@ describe("gateway agent handler", () => {
           sourceSessionKey: "agent:main:subagent:child",
           sourceTool: "subagent_announce",
         },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey: "agent:main:subagent:child",
+            childSessionId: "child-session-id",
+            announceType: "subagent task",
+            taskLabel: "work",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child completed",
+            replyInstruction: "Continue from this result.",
+          },
+        ],
       },
       {
         client: {
           internal: {
-            delegatedToolPolicyHandoff: true,
+            delegatedToolPolicyHandoffId: handoffId,
           },
         } as never,
       },
     );
 
-    const call = await waitForAgentCommandCall<{ trustedInternalHandoff?: boolean }>();
-    expect(call.trustedInternalHandoff).toBe(true);
+    const call = await waitForAgentCommandCall<{
+      trustedInternalHandoff?: {
+        kind: string;
+        sourceSessionKey: string;
+        sourceSessionId?: string;
+        targetSessionKey: string;
+        targetSessionId: string;
+      };
+    }>();
+    expect(call.trustedInternalHandoff).toMatchObject({
+      kind: "subagent-completion",
+      sourceSessionKey: "agent:main:subagent:child",
+      sourceSessionId: "child-session-id",
+      targetSessionKey: "agent:main:main",
+      targetSessionId: "existing-session-id",
+    });
   });
 
   it("does not claim stale pre-existing sessions for plugin runtime cleanup", async () => {

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -101,8 +101,8 @@ export type GatewayClient = {
     internalDeliverySuppressText?: boolean;
     /** Plugin-owned tools authorized for this internal subagent run. */
     runtimePluginToolGrant?: RuntimePluginToolGrant;
-    /** In-process subagent-completion handoff eligible for verified policy inheritance. */
-    delegatedToolPolicyHandoff?: true;
+    /** Opaque in-process subagent-completion capability; never accepted from wire params. */
+    delegatedToolPolicyHandoffId?: string;
   };
 };
 

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -23,7 +23,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   pluginRuntimeOwnerId?: string;
   pluginSubagentRequester?: PluginSubagentRequesterContext;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
-  delegatedToolPolicyHandoff?: boolean;
+  delegatedToolPolicyHandoffId?: string;
   sessionCreation?: TrustedSessionCreation;
   scopes?: string[];
 }): NonNullable<GatewayRequestOptions["client"]> {
@@ -64,8 +64,8 @@ export function createSyntheticPluginRuntimeClient(params?: {
       ...(params?.runtimePluginToolGrant
         ? { runtimePluginToolGrant: params.runtimePluginToolGrant }
         : {}),
-      ...(params?.delegatedToolPolicyHandoff === true
-        ? { delegatedToolPolicyHandoff: true as const }
+      ...(params?.delegatedToolPolicyHandoffId
+        ? { delegatedToolPolicyHandoffId: params.delegatedToolPolicyHandoffId }
         : {}),
     },
   };

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -932,7 +932,7 @@ describe("loadGatewayPlugins", () => {
     serverPluginsModule.setFallbackGatewayContext(createTestContext("delegated-tool-policy"));
     handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
       expect(opts.req.params).not.toHaveProperty("delegatedToolPolicyHandoff");
-      expect(opts.client?.internal?.delegatedToolPolicyHandoff).toBe(true);
+      expect(opts.client?.internal?.delegatedToolPolicyHandoffId).toEqual(expect.any(String));
       opts.respond(true, { status: "ok" });
     });
 
@@ -940,7 +940,15 @@ describe("loadGatewayPlugins", () => {
       serverPluginsModule.dispatchGatewayMethodInProcess(
         "agent",
         { sessionKey: "agent:main:main" },
-        { delegatedToolPolicyHandoff: true, forceSyntheticClient: true },
+        {
+          delegatedToolPolicyHandoff: {
+            sourceSessionKey: "agent:main:subagent:child",
+            targetSessionKey: "agent:main:main",
+            targetSessionId: "requester-session",
+            idempotencyKey: "announce-1",
+          },
+          forceSyntheticClient: true,
+        },
       ),
     ).resolves.toEqual({ status: "ok" });
   });
@@ -1509,7 +1517,7 @@ describe("loadGatewayPlugins", () => {
             pluginId: "other-plugin",
             toolNames: ["other_plugin_tool"],
           },
-          delegatedToolPolicyHandoff: true,
+          delegatedToolPolicyHandoffId: "handoff-old",
         },
       } as unknown as GatewayRequestOptions["client"],
       isWebchatConnect: () => false,
@@ -1526,7 +1534,7 @@ describe("loadGatewayPlugins", () => {
 
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("workboard");
     expect(getLastDispatchedClientInternal().runtimePluginToolGrant).toBeUndefined();
-    expect(getLastDispatchedClientInternal().delegatedToolPolicyHandoff).toBeUndefined();
+    expect(getLastDispatchedClientInternal().delegatedToolPolicyHandoffId).toBeUndefined();
   });
 
   test("forwards lightContext as lightweight bootstrap context on subagent run", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagent-announce-handoff.js";
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -49,6 +50,10 @@ import {
   resolvePluginSubagentRequestedModelRef,
 } from "./server-plugin-subagent-runtime.js";
 import { projectGatewayRuntimeNodes } from "./server-plugins-node-runtime.js";
+import {
+  cancelSubagentCompletionToolHandoff,
+  registerSubagentCompletionToolHandoff,
+} from "./subagent-completion-tool-handoff.js";
 
 export {
   clearFallbackGatewayContext,
@@ -221,7 +226,7 @@ type DispatchGatewayMethodInProcessOptions = {
   pluginRuntimeOwnerId?: string;
   pluginSubagentRequester?: PluginSubagentRequesterContext;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
-  delegatedToolPolicyHandoff?: boolean;
+  delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   sessionCreation?: TrustedSessionCreation;
   requireScopedClient?: boolean;
   syntheticScopes?: string[];
@@ -254,6 +259,9 @@ export async function dispatchGatewayMethodInProcessRaw(
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
       ? options.pluginRuntimeOwnerId.trim()
       : undefined;
+  const delegatedToolPolicyHandoffId = options?.delegatedToolPolicyHandoff
+    ? registerSubagentCompletionToolHandoff(options.delegatedToolPolicyHandoff)
+    : undefined;
   const syntheticClient = createSyntheticPluginRuntimeClient({
     allowModelOverride: options?.allowSyntheticModelOverride === true,
     agentRunTracking: options?.agentRunTracking,
@@ -267,7 +275,7 @@ export async function dispatchGatewayMethodInProcessRaw(
     ...(options?.runtimePluginToolGrant
       ? { runtimePluginToolGrant: options.runtimePluginToolGrant }
       : {}),
-    delegatedToolPolicyHandoff: options?.delegatedToolPolicyHandoff === true,
+    delegatedToolPolicyHandoffId,
     ...(options?.sessionCreation ? { sessionCreation: options.sessionCreation } : {}),
     scopes: options?.syntheticScopes,
   });
@@ -278,7 +286,7 @@ export async function dispatchGatewayMethodInProcessRaw(
       options?.pluginSubagentRequester ||
       options?.runtimePluginToolGrant ||
       options?.delegatedToolPolicyHandoff ||
-      scope?.client?.internal?.delegatedToolPolicyHandoff
+      scope?.client?.internal?.delegatedToolPolicyHandoffId
       ? {
           ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
           ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
@@ -286,27 +294,30 @@ export async function dispatchGatewayMethodInProcessRaw(
             ? { pluginSubagentRequester: options.pluginSubagentRequester }
             : {}),
           runtimePluginToolGrant: options?.runtimePluginToolGrant,
-          delegatedToolPolicyHandoff:
-            options?.delegatedToolPolicyHandoff === true ? (true as const) : undefined,
+          delegatedToolPolicyHandoffId,
         }
       : undefined,
   );
   if (options?.disableSyntheticClient === true && !scopedClient) {
     throw new Error(`In-process gateway dispatch requires a scoped client (method: ${method}).`);
   }
-  return await dispatchGatewayRequestInProcessRaw(method, params, {
-    client:
-      options?.forceSyntheticClient === true
-        ? syntheticClient
-        : (scopedClient ?? (options?.disableSyntheticClient === true ? null : syntheticClient)),
-    context,
-    expectFinal: options?.expectFinal,
-    isWebchatConnect,
-    onAccepted: options?.onAccepted,
-    requestIdPrefix: "plugin-subagent",
-    timeoutMs: options?.timeoutMs,
-    ...(options?.signal ? { signal: options.signal } : {}),
-  });
+  try {
+    return await dispatchGatewayRequestInProcessRaw(method, params, {
+      client:
+        options?.forceSyntheticClient === true
+          ? syntheticClient
+          : (scopedClient ?? (options?.disableSyntheticClient === true ? null : syntheticClient)),
+      context,
+      expectFinal: options?.expectFinal,
+      isWebchatConnect,
+      onAccepted: options?.onAccepted,
+      requestIdPrefix: "plugin-subagent",
+      timeoutMs: options?.timeoutMs,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    });
+  } finally {
+    cancelSubagentCompletionToolHandoff(delegatedToolPolicyHandoffId);
+  }
 }
 
 /** Live request context for trusted built-in tools that need direct runtime state. */

--- a/src/gateway/subagent-completion-tool-handoff.test.ts
+++ b/src/gateway/subagent-completion-tool-handoff.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  cancelSubagentCompletionToolHandoff,
+  consumeSubagentCompletionToolHandoff,
+  registerSubagentCompletionToolHandoff,
+} from "./subagent-completion-tool-handoff.js";
+
+const registration = {
+  sourceSessionKey: "agent:main:subagent:child",
+  sourceSessionId: "child-session",
+  targetSessionKey: "agent:main:main",
+  targetSessionId: "requester-session",
+  idempotencyKey: "announce-1",
+} as const;
+
+function consume(handoffId: string | undefined, overrides: Record<string, unknown> = {}) {
+  return consumeSubagentCompletionToolHandoff({
+    handoffId,
+    ...registration,
+    provider: "openai",
+    model: "glm-4.5",
+    ...overrides,
+  });
+}
+
+describe("subagent completion tool handoff", () => {
+  it("consumes the exact capability once and binds it to the admitted route", () => {
+    const handoffId = registerSubagentCompletionToolHandoff(registration);
+    expect(consume(handoffId)).toEqual({
+      kind: "subagent-completion",
+      sourceSessionKey: registration.sourceSessionKey,
+      sourceSessionId: registration.sourceSessionId,
+      targetSessionKey: registration.targetSessionKey,
+      targetSessionId: registration.targetSessionId,
+      provider: "openai",
+      model: "glm-4.5",
+    });
+    expect(consume(handoffId)).toBeUndefined();
+  });
+
+  it.each([
+    ["source session", { sourceSessionKey: "agent:main:subagent:forged" }],
+    ["source run", { sourceSessionId: "forged-child-session" }],
+    ["target session", { targetSessionKey: "agent:main:other" }],
+    ["target run", { targetSessionId: "replaced-requester-session" }],
+    ["idempotency key", { idempotencyKey: "announce-forged" }],
+  ])("rejects a mismatched %s without burning the valid capability", (_name, overrides) => {
+    const handoffId = registerSubagentCompletionToolHandoff(registration);
+    expect(consume(handoffId, overrides)).toBeUndefined();
+    expect(consume(handoffId)).toBeDefined();
+  });
+
+  it("rejects missing and forged capability ids", () => {
+    expect(consume(undefined)).toBeUndefined();
+    expect(consume("forged")).toBeUndefined();
+  });
+
+  it("expires capabilities and removes cancelled capabilities", () => {
+    const expiredId = registerSubagentCompletionToolHandoff({ ...registration, nowMs: 1_000 });
+    expect(consume(expiredId, { nowMs: 301_001 })).toBeUndefined();
+
+    const cancelledId = registerSubagentCompletionToolHandoff(registration);
+    expect(cancelSubagentCompletionToolHandoff(cancelledId)).toBe(true);
+    expect(consume(cancelledId)).toBeUndefined();
+  });
+
+  it("allows exactly one winner under concurrent consumption", async () => {
+    const handoffId = registerSubagentCompletionToolHandoff(registration);
+    const results = await Promise.all([
+      Promise.resolve().then(() => consume(handoffId)),
+      Promise.resolve().then(() => consume(handoffId)),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/src/gateway/subagent-completion-tool-handoff.ts
+++ b/src/gateway/subagent-completion-tool-handoff.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import {
+  isFutureDateTimestampMs,
+  resolveExpiresAtMsFromDurationMs,
+} from "@openclaw/normalization-core/number-coercion";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type {
+  SubagentCompletionToolHandoffRegistration,
+  TrustedSubagentCompletionHandoff,
+} from "../agents/subagent-announce-handoff.js";
+
+const SUBAGENT_COMPLETION_TOOL_HANDOFF_TTL_MS = 5 * 60 * 1000;
+
+type SubagentCompletionToolHandoffEntry = SubagentCompletionToolHandoffRegistration & {
+  expiresAtMs: number;
+};
+
+const handoffs = new Map<string, SubagentCompletionToolHandoffEntry>();
+
+function normalizeRegistration(
+  params: SubagentCompletionToolHandoffRegistration,
+): SubagentCompletionToolHandoffRegistration | undefined {
+  const sourceSessionKey = normalizeOptionalString(params.sourceSessionKey);
+  const sourceSessionId = normalizeOptionalString(params.sourceSessionId);
+  const targetSessionKey = normalizeOptionalString(params.targetSessionKey);
+  const targetSessionId = normalizeOptionalString(params.targetSessionId);
+  const idempotencyKey = normalizeOptionalString(params.idempotencyKey);
+  if (!sourceSessionKey || !targetSessionKey || !targetSessionId || !idempotencyKey) {
+    return undefined;
+  }
+  return {
+    sourceSessionKey,
+    ...(sourceSessionId ? { sourceSessionId } : {}),
+    targetSessionKey,
+    targetSessionId,
+    idempotencyKey,
+  };
+}
+
+function pruneExpired(nowMs: number): void {
+  for (const [handoffId, entry] of handoffs) {
+    if (!isFutureDateTimestampMs(entry.expiresAtMs, { nowMs })) {
+      handoffs.delete(handoffId);
+    }
+  }
+}
+
+/** Register one short-lived capability for the exact completion delivery request. */
+export function registerSubagentCompletionToolHandoff(
+  params: SubagentCompletionToolHandoffRegistration & { nowMs?: number },
+): string | undefined {
+  const normalized = normalizeRegistration(params);
+  if (!normalized) {
+    return undefined;
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  pruneExpired(nowMs);
+  const expiresAtMs = resolveExpiresAtMsFromDurationMs(SUBAGENT_COMPLETION_TOOL_HANDOFF_TTL_MS, {
+    nowMs,
+  });
+  if (expiresAtMs === undefined) {
+    return undefined;
+  }
+  const handoffId = randomUUID();
+  handoffs.set(handoffId, { ...normalized, expiresAtMs });
+  return handoffId;
+}
+
+/** Remove an unconsumed capability after its in-process dispatch finishes or fails. */
+export function cancelSubagentCompletionToolHandoff(handoffId: string | undefined): boolean {
+  const normalized = normalizeOptionalString(handoffId);
+  return normalized ? handoffs.delete(normalized) : false;
+}
+
+/**
+ * Consume the capability once and bind it to the model route admitted for this run.
+ * Mismatches do not burn the capability; only the exact request may consume it.
+ */
+export function consumeSubagentCompletionToolHandoff(params: {
+  handoffId?: string;
+  sourceSessionKey?: string;
+  sourceSessionId?: string;
+  targetSessionKey?: string;
+  targetSessionId?: string;
+  idempotencyKey?: string;
+  provider?: string;
+  model?: string;
+  nowMs?: number;
+}): TrustedSubagentCompletionHandoff | undefined {
+  const handoffId = normalizeOptionalString(params.handoffId);
+  const sourceSessionKey = normalizeOptionalString(params.sourceSessionKey);
+  const sourceSessionId = normalizeOptionalString(params.sourceSessionId);
+  const targetSessionKey = normalizeOptionalString(params.targetSessionKey);
+  const targetSessionId = normalizeOptionalString(params.targetSessionId);
+  const idempotencyKey = normalizeOptionalString(params.idempotencyKey);
+  const provider = normalizeOptionalString(params.provider)?.toLowerCase();
+  const model = normalizeOptionalString(params.model);
+  if (
+    !handoffId ||
+    !sourceSessionKey ||
+    !targetSessionKey ||
+    !targetSessionId ||
+    !idempotencyKey ||
+    !provider ||
+    !model
+  ) {
+    return undefined;
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  pruneExpired(nowMs);
+  const entry = handoffs.get(handoffId);
+  if (
+    !entry ||
+    entry.sourceSessionKey !== sourceSessionKey ||
+    entry.sourceSessionId !== sourceSessionId ||
+    entry.targetSessionKey !== targetSessionKey ||
+    entry.targetSessionId !== targetSessionId ||
+    entry.idempotencyKey !== idempotencyKey
+  ) {
+    return undefined;
+  }
+  handoffs.delete(handoffId);
+  return {
+    kind: "subagent-completion",
+    sourceSessionKey,
+    ...(sourceSessionId ? { sourceSessionId } : {}),
+    targetSessionKey,
+    targetSessionId,
+    provider,
+    model,
+  };
+}


### PR DESCRIPTION
Fixes #116461

## What Problem This Solves

Fixes the direct child-completion path where a dormant embedded parent resumed without tools. Affected OpenAI-compatible models could emit inert tool markup or reject the continuation instead of continuing the coordinator workflow.

The aggregate "all pending descendants settled" wake is a separate path and remains tool-enabled. This change is limited to the direct completion handoff carrying the private completion event.

## Security Design

Embedded tools are restored only after all of these facts agree:

- one short-lived, process-local, one-shot capability
- exact source child key and completion session id
- exact target requester key and session id
- exact dispatch idempotency key
- admitted provider and model
- one matching private completion event
- persisted requester lineage and inherited policy

The capability is consumed before execution and never crosses the public Gateway protocol. Forged, missing, expired, replayed, duplicate, cross-session, cross-provider, cross-model, mismatched, fallback, CLI-backed, or unverified handoffs remain tool-free. Direct completion delivery can retain the requester's other tools while the `message` grant remains bound to the exact source route.

## Authority Decision

The maintainer authority model was explicitly accepted in https://github.com/openclaw/openclaw/pull/117148#issuecomment-5149375117.

## Exact-Head Evidence

- Signed branch head: `619682ed010f4e6c56c73feb4948fd7265083e10`
- All six commits have valid ED25519 signatures.
- Frozen current-main compatibility target: `78486e27511c945a01c7e719b7e271e437ffb7a2`
- Merge base: `618f3298c7dc00a41549e4dec41d8412f651624b`
- Current-main compatibility: zero touched-file overlap and clean `git merge-tree`; result tree `3929fc51d8076735ad983292732259ca8f974374`.
- Exact-head live Gateway QA passed with `openai/gpt-5.4`: `issue-109025-completion-policy-live`.
  - `parentTools={"sessions_spawn":1,"sessions_yield":1,"exec":1}`
  - unpredictable execution marker: `ISSUE109025_COMPLETION_EXEC_OK:c8400019-49dc-47de-b0f0-cae8be1c19a7`
- Exact-head focused tests: 206 passed.
  - `src/agents/agent-tools.create-openclaw-coding-tools.test.ts`: 94
  - `src/agents/command/attempt-execution.cli.test.ts`: 112
- Exact-head targeted OXLint, formatting, and `git diff --check` passed.
- Earlier branch-wide Testbox proof passed 482 changed-surface tests, production/test type checks, and the changed gates. Exact-head hosted CI is recorded below.
- Zero unresolved review threads.

## Codex Contract Inspection

Direct inspection was refreshed against sibling Codex head `414782450952a196bbb64b1605a458c2531c47b6`:

- `codex-rs/protocol/src/dynamic_tools.rs:10`
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:119`
- `codex-rs/app-server/src/request_processors/thread_processor.rs:878`
- `codex-rs/app-server/src/request_processors/thread_processor.rs:1122`
- `codex-rs/core/src/session/mod.rs:606`
- `codex-rs/core/src/tools/spec_plan.rs:892`
- `codex-rs/core/src/tools/handlers/dynamic.rs:39`
- `codex-rs/core/src/tools/handlers/dynamic.rs:172`
- `codex-rs/app-server/src/bespoke_event_handling.rs:850`
- `codex-rs/app-server/src/dynamic_tools.rs:16`

Contract result: `thread/start` owns and validates dynamic tool declarations, persists them into the session configuration, plans them into runtime handlers, emits calls with the active turn/call identity, and routes the client response back into the active turn. This PR only decides whether OpenClaw supplies its existing tool declarations on the verified completion continuation.

## Autoreview Disposition

Fresh P1 autoreview completed with TruffleHog clean. Its sole finding proposed requiring the persisted child `sessionId` to equal the completion event id before restoring requester policy.

That finding was rejected after full writer/history review:

- the source session key is a freshly minted durable subagent node identity
- `sessionId` is an intentionally rotating run generation
- supported steer/admission rotations merge over the same node and preserve its inherited policy
- reset creates a new generation without the inherited policy version/owner, so policy lookup already fails closed
- authenticated policy mutation does not rotate `sessionId`, so the proposed equality check would not protect that case

The proposed check would reject legitimate node-preserving rotations without closing a supported privilege-escalation path. No code change was retained.

## Hosted Review

- Exact-head CI attempt 2 passed with no failed or pending jobs: https://github.com/openclaw/openclaw/actions/runs/30687665463
  - attempt 1 had one unrelated wall-clock timing miss in `plugin-lifecycle-measure.test.ts` (1202 ms versus a 1000 ms assertion)
  - the PR changes neither that test nor its implementation; the failed job alone passed on rerun at the same SHA
- Exact-head ClawSweeper: https://github.com/openclaw/openclaw/pull/117148#issuecomment-5148926552
  - reviewed `619682ed010f4e6c56c73feb4948fd7265083e10`
  - no concrete source defect found
  - remaining evidence items are answered by the current-head live proof, current-main merge proof, current Codex inspection, and autoreview disposition above

## Landing

Preserve the signed commit series. Do not use GitHub rebase merge or squash; land with a signed two-parent merge commit after the final exact-head gates are green.
