### PR TITLE
fix(agents): deliver Claude CLI ask_user prompts

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1535,6 +1535,7 @@ describe("runCliAgent reliability", () => {
         throw new Error("Expected internal source reply capture");
       }
       updateMcpLoopbackToolCallCapture(captureHandle, {
+        toolCallId: "mcp-pending-internal-source-reply",
         toolName: "message",
         args: {
           action: "send",
@@ -1594,6 +1595,7 @@ describe("runCliAgent reliability", () => {
         throw new Error("Expected external session reply capture");
       }
       updateMcpLoopbackToolCallCapture(captureHandle, {
+        toolCallId: "mcp-pending-external-session-reply",
         toolName: "message",
         args: {
           action: "send",
@@ -1678,6 +1680,7 @@ describe("runCliAgent reliability", () => {
         throw new Error("Expected message delivery capture");
       }
       updateMcpLoopbackToolCallCapture(captureHandle, {
+        toolCallId: "mcp-possibly-sent",
         toolName: "message",
         args: {
           action: "send",
@@ -1837,6 +1840,7 @@ describe("runCliAgent reliability", () => {
         },
       });
       updateMcpLoopbackToolCallCapture(captureHandle, {
+        toolCallId: "mcp-dry-run-preview",
         toolName: "message",
         args: {
           action: "send",

--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -4,7 +4,28 @@
 import fs from "node:fs/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { BundleMcpConfig } from "../../plugins/bundle-mcp.js";
 import { withOpenClawMcpCaptureHeader } from "./bundle-mcp-runtime.js";
+
+const CLAUDE_MCP_TOOL_CALL_TIMEOUT_MS = 3_610_000;
+
+/** Give Claude's external MCP request enough time for ask_user's maximum wait plus RPC grace. */
+export function applyClaudeLoopbackToolTimeout(config: BundleMcpConfig): BundleMcpConfig {
+  const server = config.mcpServers.openclaw;
+  if (
+    !server ||
+    typeof server.url !== "string" ||
+    !/^http:\/\/(?:127\.0\.0\.1|localhost|\[::1\]):\d+\/mcp$/.test(server.url.trim())
+  ) {
+    return config;
+  }
+  return {
+    mcpServers: {
+      ...config.mcpServers,
+      openclaw: { ...server, timeout: CLAUDE_MCP_TOOL_CALL_TIMEOUT_MS },
+    },
+  };
+}
 
 /** Find existing Claude `--mcp-config` argument values. */
 export function findClaudeMcpConfigPaths(args?: string[]): string[] {

--- a/src/agents/cli-runner/bundle-mcp.codex.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.codex.test.ts
@@ -1,5 +1,6 @@
 /** Tests Codex CLI bundle-MCP config override generation. */
 import { describe, expect, it } from "vitest";
+import { createMcpLoopbackServerConfig } from "../../gateway/mcp-http.loopback-runtime.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 
 describe("prepareCliBundleMcpConfig codex", () => {
@@ -81,5 +82,20 @@ describe("prepareCliBundleMcpConfig codex", () => {
       'mcp_servers={ openclaw = { url = "http://127.0.0.1:23119/mcp", default_tools_approval_mode = "approve", bearer_token_env_var = "OPENCLAW_MCP_TOKEN", env_http_headers = { x-session-key = "OPENCLAW_MCP_SESSION_KEY", x-openclaw-cli-capture-key = "OPENCLAW_MCP_CLI_CAPTURE_KEY" } } }',
     ]);
     expect(prepared.cleanup).toBeUndefined();
+  });
+
+  it("keeps the Claude request timeout out of Codex loopback overrides", async () => {
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "codex-config-overrides",
+      backend: { command: "codex", args: ["exec"] },
+      workspaceDir: "/tmp/openclaw-bundle-mcp-codex-timeout",
+      config: { plugins: { enabled: false } },
+      additionalConfig: createMcpLoopbackServerConfig(23119),
+    });
+
+    expect(prepared.backend.args?.find((arg) => arg.startsWith("mcp_servers="))).not.toContain(
+      "timeout",
+    );
   });
 });

--- a/src/agents/cli-runner/bundle-mcp.gemini.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.gemini.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createMcpLoopbackServerConfig } from "../../gateway/mcp-http.loopback-runtime.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 
 describe("prepareCliBundleMcpConfig gemini", () => {
@@ -77,6 +78,26 @@ describe("prepareCliBundleMcpConfig gemini", () => {
     expect(raw.tools?.exclude).toEqual(["google_web_search"]);
 
     await prepared.cleanup?.();
+  });
+
+  it("keeps the Claude request timeout out of Gemini loopback settings", async () => {
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: { command: "gemini" },
+      workspaceDir: "/tmp/openclaw-bundle-mcp-gemini-timeout",
+      config: { plugins: { enabled: false } },
+      additionalConfig: createMcpLoopbackServerConfig(23119),
+    });
+
+    try {
+      const raw = JSON.parse(
+        await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+      ) as { mcpServers?: Record<string, { timeout?: number }> };
+      expect(raw.mcpServers?.openclaw?.timeout).toBeUndefined();
+    } finally {
+      await prepared.cleanup?.();
+    }
   });
 
   it("translates user mcp.servers transport fields in Gemini system settings", async () => {

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createMcpLoopbackServerConfig } from "../../gateway/mcp-http.loopback-runtime.js";
 import { writeClaudeBundleManifest } from "../../plugins/bundle-mcp.test-support.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import {
@@ -105,6 +106,34 @@ describe("prepareCliBundleMcpConfig", () => {
     expect(prepared.mcpConfigHash).toMatch(/^[0-9a-f]{64}$/);
     expect(prepared.mcpResumeHash).toMatch(/^[0-9a-f]{64}$/);
 
+    await prepared.cleanup?.();
+  });
+
+  it("preserves the loopback tool timeout through Claude capture config rewriting", async () => {
+    const workspaceDir = await cliBundleMcpHarness.tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-timeout-",
+    );
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir,
+      config: { plugins: { enabled: false } },
+      additionalConfig: createMcpLoopbackServerConfig(23119),
+    });
+    const generatedConfigPath = requireMcpConfigPath(prepared.backend.args);
+
+    await prepareCliBundleMcpCaptureAttempt({
+      mode: "claude-config-file",
+      backend: prepared.backend,
+      env: prepared.env,
+      captureKey: "capture-timeout",
+    });
+
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath, "utf-8")) as {
+      mcpServers?: Record<string, { timeout?: number }>;
+    };
+    expect(raw.mcpServers?.openclaw?.timeout).toBe(3_610_000);
     await prepared.cleanup?.();
   });
 

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -24,6 +24,7 @@ import { isRecord } from "../bundle-mcp-adapter.js";
 import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "../bundle-mcp-config.js";
 import { resolveMcpBearerBundleConfig } from "../mcp-auth-profile.js";
 import {
+  applyClaudeLoopbackToolTimeout,
   findClaudeMcpConfigPaths,
   injectClaudeMcpConfigArgs,
   injectClaudeWebSearchDisabledArgs,
@@ -206,27 +207,31 @@ async function prepareModeSpecificBundleMcpConfig(params: {
 }): Promise<PreparedCliBundleMcpConfig> {
   const mcpToolsDeny = normalizeMcpToolDenials(params.mcpToolsDeny);
   const webSearchDisabled = params.webSearchEnabled === false;
+  const projectedConfig =
+    params.mode === "claude-config-file"
+      ? applyClaudeLoopbackToolTimeout(params.mergedConfig)
+      : params.mergedConfig;
   const configHashInput =
     mcpToolsDeny || webSearchDisabled
-      ? { config: params.mergedConfig, mcpToolsDeny, webSearchDisabled }
-      : params.mergedConfig;
+      ? { config: projectedConfig, mcpToolsDeny, webSearchDisabled }
+      : projectedConfig;
   const serializedConfig = `${JSON.stringify(configHashInput, null, 2)}\n`;
   const mcpConfigHash = crypto.createHash("sha256").update(serializedConfig).digest("hex");
   const serializedResumeConfig = `${JSON.stringify(
     mcpToolsDeny || webSearchDisabled
       ? {
-          config: canonicalizeBundleMcpConfigForResume(params.mergedConfig),
+          config: canonicalizeBundleMcpConfigForResume(projectedConfig),
           mcpToolsDeny,
           webSearchDisabled,
         }
-      : canonicalizeBundleMcpConfigForResume(params.mergedConfig),
+      : canonicalizeBundleMcpConfigForResume(projectedConfig),
     null,
     2,
   )}\n`;
   const mcpResumeHash = crypto.createHash("sha256").update(serializedResumeConfig).digest("hex");
 
   if (params.mode === "codex-config-overrides") {
-    const codexConfig = applyCodexMcpToolDenials(params.mergedConfig, mcpToolsDeny);
+    const codexConfig = applyCodexMcpToolDenials(projectedConfig, mcpToolsDeny);
     return {
       backend: injectBundleMcpBackendArgs(params.backend, (args) =>
         webSearchDisabled
@@ -241,7 +246,7 @@ async function prepareModeSpecificBundleMcpConfig(params: {
 
   if (params.mode === "gemini-system-settings") {
     const settings = await writeGeminiSystemSettings(
-      params.mergedConfig,
+      projectedConfig,
       params.env,
       mcpToolsDeny,
       params.webSearchEnabled,
@@ -256,7 +261,7 @@ async function prepareModeSpecificBundleMcpConfig(params: {
   }
 
   const runtimeConfig = resolveOpenClawMcpEnvTemplates(
-    params.mergedConfig,
+    projectedConfig,
     params.env,
   ) as BundleMcpConfig;
   const temporary = await writeTemporaryBundleMcpJson(

--- a/src/agents/cli-runner/execute-tool-tracking.ask-user.test.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ask-user.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  markMcpLoopbackToolCallFinished,
+  markMcpLoopbackToolCallStarted,
+  updateMcpLoopbackToolCallCapture,
+} from "../../gateway/mcp-http.loopback-runtime.js";
+import { createAskUserTool } from "../tools/ask-user-tool.js";
+import { resetPendingAskUserQuestionsForTest } from "../tools/ask-user-tool.test-support.js";
+import { createCliToolTracking } from "./execute-tool-tracking.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+const args = {
+  questions: [
+    {
+      id: "deploy_target",
+      header: "Target",
+      question: "Where should this deploy?",
+      options: [{ label: "Staging" }, { label: "Production" }],
+    },
+  ],
+};
+
+type GatewayCall = NonNullable<Parameters<typeof createAskUserTool>[0]["gatewayCall"]>;
+
+function buildContext(params: {
+  runId: string;
+  sessionKey: string;
+  onAskUserPrompt: NonNullable<PreparedCliRunContext["params"]["onAskUserPrompt"]>;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: [],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    serialize: true,
+  };
+  return {
+    params: {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: params.sessionKey,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "ask",
+      provider: "claude-cli",
+      model: "claude-sonnet-4-5",
+      timeoutMs: 60_000,
+      runId: params.runId,
+      onAskUserPrompt: params.onAskUserPrompt,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: { id: "claude-cli", config: backend, bundleMcp: true },
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "claude-sonnet-4-5",
+    normalizedModel: "claude-sonnet-4-5",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 1,
+  } as PreparedCliRunContext;
+}
+
+function prepareCapturedAskUser(params: {
+  context: PreparedCliRunContext;
+  captureKey: string;
+  toolCallId: string;
+  toolArgs?: typeof args;
+}) {
+  const tracking = createCliToolTracking(params.context);
+  tracking.beginGatewayCapture(params.captureKey);
+  const callArgs = params.toolArgs ?? args;
+  const captureHandle = markMcpLoopbackToolCallStarted({
+    captureKey: params.captureKey,
+    toolName: "ask_user",
+    args: callArgs,
+  });
+  if (!captureHandle) {
+    throw new Error("expected ask_user capture");
+  }
+  updateMcpLoopbackToolCallCapture(captureHandle, {
+    toolCallId: params.toolCallId,
+    toolName: "ask_user",
+    args: callArgs,
+  });
+  return { captureHandle, tracking };
+}
+
+function createGatewayStub() {
+  let finishWait: ((value: unknown) => void) | undefined;
+  const mock = vi.fn(async (method: string, _opts: unknown, params: Record<string, unknown>) => {
+    if (method === "question.request") {
+      return { id: params.id };
+    }
+    if (method === "question.waitAnswer") {
+      return await new Promise((resolve) => {
+        finishWait = resolve;
+      });
+    }
+    if (method === "question.resolve") {
+      finishWait?.({ status: "cancelled" });
+      return { status: "cancelled" };
+    }
+    throw new Error(`unexpected method ${method}`);
+  });
+  return {
+    call: mock as unknown as GatewayCall,
+    answer: (value: string) =>
+      finishWait?.({
+        status: "answered",
+        answers: { answers: { deploy_target: [value] } },
+      }),
+  };
+}
+
+afterEach(() => {
+  resetPendingAskUserQuestionsForTest();
+});
+
+describe("CLI loopback ask_user presentation", () => {
+  it("presents and answers the exact prepared MCP tool call", async () => {
+    const runId = "run-cli-ask-answer";
+    const sessionKey = "agent:main:cli-ask-answer";
+    const gateway = createGatewayStub();
+    const onAskUserPrompt = vi.fn(async () => {
+      gateway.answer("Production");
+    });
+    const context = buildContext({ runId, sessionKey, onAskUserPrompt });
+    const { captureHandle, tracking } = prepareCapturedAskUser({
+      context,
+      captureKey: "capture-cli-ask-answer",
+      toolCallId: "mcp-cli-ask-answer",
+    });
+
+    try {
+      const result = await createAskUserTool({
+        sessionKey,
+        runId,
+        gatewayCall: gateway.call,
+      }).execute("mcp-cli-ask-answer", args);
+
+      expect(onAskUserPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelData: { askUser: { questionId: expect.stringMatching(/^ask_/) } },
+        }),
+      );
+      expect(result).toMatchObject({
+        details: {
+          status: "answered",
+          answers: { answers: { deploy_target: ["Production"] } },
+        },
+      });
+    } finally {
+      markMcpLoopbackToolCallFinished(captureHandle);
+      tracking.finalizeCapture(() => {});
+    }
+  });
+
+  it("propagates prompt delivery errors and releases the session slot", async () => {
+    const runId = "run-cli-ask-error";
+    const sessionKey = "agent:main:cli-ask-error";
+    const gateway = createGatewayStub();
+    const context = buildContext({
+      runId,
+      sessionKey,
+      onAskUserPrompt: async () => {
+        throw new Error("channel unavailable");
+      },
+    });
+    const { captureHandle, tracking } = prepareCapturedAskUser({
+      context,
+      captureKey: "capture-cli-ask-error",
+      toolCallId: "mcp-cli-ask-error",
+    });
+
+    try {
+      await expect(
+        createAskUserTool({ sessionKey, runId, gatewayCall: gateway.call }).execute(
+          "mcp-cli-ask-error",
+          args,
+        ),
+      ).rejects.toThrow("ask_user prompt delivery failed");
+    } finally {
+      markMcpLoopbackToolCallFinished(captureHandle);
+      tracking.finalizeCapture(() => {});
+    }
+
+    const retry = prepareCapturedAskUser({
+      context,
+      captureKey: "capture-cli-ask-retry",
+      toolCallId: "mcp-cli-ask-retry",
+    });
+    markMcpLoopbackToolCallFinished(retry.captureHandle);
+    retry.tracking.finalizeCapture(() => {});
+  });
+
+  it("keeps concurrent prepared calls to one visible prompt per session", async () => {
+    const runId = "run-cli-ask-concurrent";
+    const sessionKey = "agent:main:cli-ask-concurrent";
+    const gateway = createGatewayStub();
+    const onAskUserPrompt = vi.fn(async () => {
+      gateway.answer("Staging");
+    });
+    const context = buildContext({ runId, sessionKey, onAskUserPrompt });
+    const first = prepareCapturedAskUser({
+      context,
+      captureKey: "capture-cli-ask-first",
+      toolCallId: "mcp-cli-ask-first",
+    });
+    const second = prepareCapturedAskUser({
+      context,
+      captureKey: "capture-cli-ask-second",
+      toolCallId: "mcp-cli-ask-second",
+    });
+
+    try {
+      await createAskUserTool({ sessionKey, runId, gatewayCall: gateway.call }).execute(
+        "mcp-cli-ask-first",
+        args,
+      );
+      expect(onAskUserPrompt).toHaveBeenCalledTimes(1);
+    } finally {
+      markMcpLoopbackToolCallFinished(first.captureHandle);
+      first.tracking.finalizeCapture(() => {});
+      markMcpLoopbackToolCallFinished(second.captureHandle);
+      second.tracking.finalizeCapture(() => {});
+    }
+  });
+});

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -25,6 +25,10 @@ import {
   extractMessagingToolSendResult,
   extractMessagingToolSourceReplyPayload,
 } from "../embedded-agent-subscribe.tools.js";
+import {
+  reserveAskUserPrompt,
+  type AskUserPromptDeliveryReservation,
+} from "../tools/ask-user-prompt-delivery.js";
 import { rotateClaudeLiveMcpCaptureKeyForContext } from "./claude-live-session.js";
 import { attachCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import {
@@ -70,6 +74,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   let inFlightUnclassifiedMcpRequests = 0;
   let inFlightMessagingToolCalls = 0;
   const inFlightPreparedMessagingCalls = new Set<McpLoopbackToolCallStart>();
+  const askUserPromptReservations = new Map<string, AskUserPromptDeliveryReservation>();
   const pendingMessagingCalls = new Map<
     string,
     { toolName: string; args: Record<string, unknown>; target?: MessagingToolSend }
@@ -355,6 +360,22 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         return matched?.[0];
       },
       onToolCallUpdate: ({ previous, current }) => {
+        if (
+          normalizeCliMessagingToolName(current.toolName) === "ask_user" &&
+          context.params.onAskUserPrompt
+        ) {
+          const reservation = reserveAskUserPrompt({
+            toolCallId: current.toolCallId,
+            sessionKey: context.params.sessionKey,
+            runId: context.params.runId,
+            args: current.args,
+            deliver: context.params.onAskUserPrompt,
+          });
+          if (reservation) {
+            askUserPromptReservations.set(current.toolCallId, reservation);
+            reservation.deliver();
+          }
+        }
         const candidates = cliLoopbackCalls.filter((candidate) =>
           matchesCliLoopbackCall(previous.toolName, previous.args, candidate.current),
         );
@@ -378,6 +399,10 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         }
       },
       onToolCallFinish: (call, { prepared }) => {
+        if ("toolCallId" in call) {
+          askUserPromptReservations.get(call.toolCallId)?.cancel();
+          askUserPromptReservations.delete(call.toolCallId);
+        }
         const isDelivery = prepared
           ? isPreparedDelivery(call.toolName, call.args)
           : isPotentialDelivery(call.toolName);

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -47,6 +47,7 @@ import type {
 } from "../embedded-agent-runner/run/params.js";
 import type { ExecPolicyOverrides } from "../exec-defaults.js";
 import type { FastModeAutoProgressState } from "../fast-mode.js";
+import type { AgentHarnessQuestionPromptPayload } from "../harness/user-input-bridge.js";
 import type { ScheduledToolPolicyContext } from "../scheduled-tool-policy.js";
 import type { SessionManager } from "../sessions/index.js";
 import type { SilentReplyPromptMode } from "../system-prompt.types.js";
@@ -219,6 +220,8 @@ export type RunCliAgentParams = {
   };
   disableTools?: boolean;
   abortSignal?: AbortSignal;
+  /** Presents an OpenClaw ask_user prompt for bundle-MCP CLI runtimes. */
+  onAskUserPrompt?: (payload: AgentHarnessQuestionPromptPayload) => Promise<void> | void;
   onExecutionStarted?: () => void;
   onExecutionPhase?: (info: {
     phase: EmbeddedAgentExecutionPhase;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -88,7 +88,6 @@ import {
 } from "./embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
-import { buildAgentHarnessQuestionPromptPayload } from "./harness/user-input-bridge.js";
 import { readMcpAppChannelView } from "./mcp-ui-resource.js";
 import type { AgentEvent } from "./runtime/index.js";
 import {
@@ -99,13 +98,8 @@ import { buildToolMutationState } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { readToolResultDetails } from "./tool-result-error.js";
 import { createToolTerminalObserver } from "./tool-terminal-outcome.js";
-import {
-  cancelAskUserPromptDelivery,
-  normalizeAskUserParams,
-  reserveAskUserPromptDelivery,
-  settleAskUserPromptDelivery,
-  waitForAskUserPromptReady,
-} from "./tools/ask-user-tool.js";
+import { reserveAskUserPrompt } from "./tools/ask-user-prompt-delivery.js";
+import { cancelAskUserPromptDelivery } from "./tools/ask-user-tool.js";
 import { isAutomationsToolName } from "./tools/automations-tool-name.js";
 
 type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
@@ -152,31 +146,6 @@ function readUpdatePlanResult(
   const steps = normalizeAgentPlanSteps(details.plan) ?? [];
   const explanation = readStringValue(details.explanation);
   return { ...(explanation ? { explanation } : {}), steps };
-}
-
-function buildAskUserPromptPayload(
-  toolCallId: string,
-  sessionKey: string | undefined,
-  runId: string,
-  args: unknown,
-) {
-  try {
-    const { questions, timeoutSeconds } = normalizeAskUserParams(args);
-    const reservation = reserveAskUserPromptDelivery({
-      toolCallId,
-      sessionKey,
-      runId,
-      questions,
-      timeoutSeconds,
-    });
-    if (!reservation) {
-      return undefined;
-    }
-    return reservation;
-  } catch {
-    // Argument validation owns malformed calls; do not deliver an unusable prompt first.
-    return undefined;
-  }
 }
 
 function isMiddlewareToolResultError(result: unknown): boolean {
@@ -1003,12 +972,19 @@ export function handleToolExecutionStart(
   const startToolName = normalizeToolName(evt.toolName);
   const askUserPromptReservation =
     startToolName === "ask_user" && ctx.params.onToolResult
-      ? buildAskUserPromptPayload(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId, evt.args)
+      ? reserveAskUserPrompt({
+          toolCallId: evt.toolCallId,
+          sessionKey: ctx.params.sessionKey,
+          runId: ctx.params.runId,
+          args: evt.args,
+          deliver: ctx.params.onToolResult,
+          onDeliveryError: (error) => {
+            ctx.log.warn(`failed to deliver ask_user prompt: ${String(error)}`);
+          },
+        })
       : undefined;
   const cancelAskUserPromptReservation = () => {
-    if (askUserPromptReservation) {
-      cancelAskUserPromptDelivery(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId);
-    }
+    askUserPromptReservation?.cancel();
   };
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     let onBlockReplyFlushResult: void | Promise<void>;
@@ -1241,36 +1217,7 @@ export function handleToolExecutionStart(
         }
       }
     }
-
-    if (toolName === "ask_user" && ctx.params.onToolResult) {
-      const payload = askUserPromptReservation;
-      if (payload) {
-        const questionId = payload.questionId;
-        void waitForAskUserPromptReady(questionId)
-          .then((questions) => {
-            if (!questions) {
-              return;
-            }
-            return ctx.params.onToolResult?.(
-              buildAgentHarnessQuestionPromptPayload({
-                questionId,
-                questions: questions.map(({ questionId: id, ...question }) => ({
-                  ...question,
-                  id,
-                })),
-                options: { intro: "Question for you:" },
-              }),
-            );
-          })
-          .then(
-            () => settleAskUserPromptDelivery(questionId),
-            (error: unknown) => {
-              settleAskUserPromptDelivery(questionId, error);
-              ctx.log.warn(`failed to deliver ask_user prompt: ${String(error)}`);
-            },
-          );
-      }
-    }
+    askUserPromptReservation?.deliver();
   };
 
   // Flush pending block replies to preserve message boundaries before tool execution.

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -28,7 +28,7 @@ export type AgentHarnessUserInputPromptOptions = {
   presentation?: MessagePresentation;
 };
 
-type AgentHarnessQuestionPromptPayload = {
+export type AgentHarnessQuestionPromptPayload = {
   text: string;
   presentation?: MessagePresentation;
   presentationTextMode?: "fallback";

--- a/src/agents/tools/ask-user-prompt-delivery.ts
+++ b/src/agents/tools/ask-user-prompt-delivery.ts
@@ -1,0 +1,85 @@
+import {
+  buildAgentHarnessQuestionPromptPayload,
+  type AgentHarnessQuestionPromptPayload,
+} from "../harness/user-input-bridge.js";
+import {
+  cancelAskUserPromptDelivery,
+  normalizeAskUserParams,
+  reserveAskUserPromptDelivery,
+  settleAskUserPromptDelivery,
+  waitForAskUserPromptReady,
+} from "./ask-user-tool.js";
+
+export type AskUserPromptDeliveryReservation = {
+  questionId: string;
+  deliver: () => void;
+  cancel: () => void;
+};
+
+/**
+ * Reserves an ask_user prompt synchronously, then presents it once the Gateway
+ * question is answerable. Tool execution waits for the delivery settlement.
+ */
+export function reserveAskUserPrompt(params: {
+  toolCallId: string;
+  sessionKey?: string;
+  runId: string;
+  args: unknown;
+  deliver: (payload: AgentHarnessQuestionPromptPayload) => Promise<void> | void;
+  onDeliveryError?: (error: unknown) => void;
+}): AskUserPromptDeliveryReservation | undefined {
+  let reservation: { questionId: string } | undefined;
+  try {
+    const { questions, timeoutSeconds } = normalizeAskUserParams(params.args);
+    reservation = reserveAskUserPromptDelivery({
+      toolCallId: params.toolCallId,
+      sessionKey: params.sessionKey,
+      runId: params.runId,
+      questions,
+      timeoutSeconds,
+    });
+  } catch {
+    // Tool argument validation owns malformed calls; do not expose an unusable prompt.
+    return undefined;
+  }
+  if (!reservation) {
+    return undefined;
+  }
+
+  const { questionId } = reservation;
+  let deliveryStarted = false;
+
+  return {
+    questionId,
+    deliver: () => {
+      if (deliveryStarted) {
+        return;
+      }
+      deliveryStarted = true;
+      void waitForAskUserPromptReady(questionId)
+        .then(async (questions) => {
+          if (!questions) {
+            return;
+          }
+          await params.deliver(
+            buildAgentHarnessQuestionPromptPayload({
+              questionId,
+              questions: questions.map(({ questionId: id, ...question }) => ({
+                ...question,
+                id,
+              })),
+              options: { intro: "Question for you:" },
+            }),
+          );
+        })
+        .then(
+          () => settleAskUserPromptDelivery(questionId),
+          (error: unknown) => {
+            settleAskUserPromptDelivery(questionId, error);
+            params.onDeliveryError?.(error);
+          },
+        );
+    },
+    cancel: () => cancelAskUserPromptDelivery(params.toolCallId, params.sessionKey, params.runId),
+  };
+}

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -403,6 +403,7 @@ export async function runCliFallbackCandidate(params: {
             toolsAllow: turn.opts?.toolsAllow,
             disableTools: turn.opts?.disableTools,
             abortSignal: params.runAbortSignal,
+            onAskUserPrompt: turn.opts?.onToolResult,
             onExecutionPhase: params.signalExecutionPhaseForTyping,
             replyOperation: turn.replyOperation,
           },

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -71,7 +71,11 @@ export async function handleMcpJsonRpc(params: {
       args: Record<string, unknown>;
     } & McpLoopbackToolCallOutcome,
   ) => void;
-  onToolCallPrepared?: (call: { toolName: string; args: Record<string, unknown> }) => void;
+  onToolCallPrepared?: (call: {
+    toolCallId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+  }) => void;
 }): Promise<object | null> {
   const { id, method, params: methodParams } = params.message;
 
@@ -187,7 +191,7 @@ export async function handleMcpJsonRpc(params: {
           hookResult.params;
         executedToolArgs = finalizedToolArgs as Record<string, unknown>;
         try {
-          params.onToolCallPrepared?.({ toolName, args: executedToolArgs });
+          params.onToolCallPrepared?.({ toolCallId, toolName, args: executedToolArgs });
         } catch {
           // Observability callbacks must never alter the tool result returned to the MCP client.
         }

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -20,6 +20,7 @@ type McpLoopbackToolCallResult = {
 } & McpLoopbackToolCallOutcome;
 
 export type McpLoopbackToolCallStart = Pick<McpLoopbackToolCallResult, "toolName" | "args">;
+type McpLoopbackPreparedToolCall = McpLoopbackToolCallStart & { toolCallId: string };
 
 type McpLoopbackToolCallCapture = {
   generation: number;
@@ -30,9 +31,12 @@ type McpLoopbackToolCallCapture = {
   onToolCallStart?: (call: McpLoopbackToolCallStart) => string | void;
   onToolCallUpdate?: (calls: {
     previous: McpLoopbackToolCallStart;
-    current: McpLoopbackToolCallStart;
+    current: McpLoopbackPreparedToolCall;
   }) => void;
-  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
+  onToolCallFinish?: (
+    call: McpLoopbackToolCallStart | McpLoopbackPreparedToolCall,
+    state: { prepared: boolean },
+  ) => void;
   onToolCallResult: (call: McpLoopbackToolCallResult) => void;
   inFlight: number;
   activityVersion: number;
@@ -47,7 +51,7 @@ type McpLoopbackRequestCaptureHandle = {
 
 type McpLoopbackToolCallCaptureHandle = {
   capture: McpLoopbackToolCallCapture;
-  call: McpLoopbackToolCallStart;
+  call: McpLoopbackToolCallStart | McpLoopbackPreparedToolCall;
   correlationId?: string;
   prepared: boolean;
   finished: boolean;
@@ -87,9 +91,12 @@ export function beginMcpLoopbackToolCallCapture(params: {
   onToolCallStart?: (call: McpLoopbackToolCallStart) => string | void;
   onToolCallUpdate?: (calls: {
     previous: McpLoopbackToolCallStart;
-    current: McpLoopbackToolCallStart;
+    current: McpLoopbackPreparedToolCall;
   }) => void;
-  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
+  onToolCallFinish?: (
+    call: McpLoopbackToolCallStart | McpLoopbackPreparedToolCall,
+    state: { prepared: boolean },
+  ) => void;
   onToolCallResult: (call: McpLoopbackToolCallResult) => void;
 }): void {
   const captureKey = params.captureKey.trim();
@@ -217,7 +224,7 @@ export function markMcpLoopbackToolCallStarted(params: {
 /** Update an admitted call with the final arguments produced by gateway hooks. */
 export function updateMcpLoopbackToolCallCapture(
   captureHandle: McpLoopbackToolCallCaptureHandle | undefined,
-  call: McpLoopbackToolCallStart,
+  call: McpLoopbackPreparedToolCall,
 ): void {
   if (!captureHandle || captureHandle.finished) {
     return;

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2388,6 +2388,7 @@ describe("mcp loopback server", () => {
         args: { action: "react", target: "original-target" },
       },
       current: {
+        toolCallId: expect.stringMatching(/^mcp-/),
         toolName: "message",
         args: {
           action: "send",
@@ -2398,6 +2399,7 @@ describe("mcp loopback server", () => {
     });
     expect(finishedCalls).toHaveBeenCalledWith(
       {
+        toolCallId: expect.stringMatching(/^mcp-/),
         toolName: "message",
         args: {
           action: "send",
@@ -2813,7 +2815,11 @@ describe("mcp loopback server", () => {
       privateState: "preserved",
     };
     expect(execute).toHaveBeenCalledWith(expect.stringMatching(/^mcp-/), finalArgs, undefined);
-    expect(onToolCallPrepared).toHaveBeenCalledWith({ toolName: "message", args: finalArgs });
+    expect(onToolCallPrepared).toHaveBeenCalledWith({
+      toolCallId: expect.stringMatching(/^mcp-/),
+      toolName: "message",
+      args: finalArgs,
+    });
     expect(onToolCallResult).toHaveBeenCalledWith(
       expect.objectContaining({ toolName: "message", args: finalArgs, outcome: "completed" }),
     );

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -376,8 +376,9 @@ async function startMcpLoopbackServer(port = 0): Promise<{
               signal: requestAbort.signal,
               authorizeToolCall,
               onToolCallPrepared: cliCaptureHandle
-                ? ({ toolName: preparedToolName, args }) => {
+                ? ({ toolCallId, toolName: preparedToolName, args }) => {
                     updateMcpLoopbackToolCallCapture(cliCaptureHandle, {
+                      toolCallId,
                       toolName: preparedToolName,
                       args,
                     });


### PR DESCRIPTION
Fixes #116554

## What Problem This Solves

Fixes an issue where users running Claude CLI-backed agents could reach `ask_user`, block waiting for an answer, and never receive the question in the originating channel. Long question waits could also outlive Claude Code's default external MCP request timeout.

## Why This Change Was Made

Claude CLI loopback calls now reserve and present `ask_user` through the same conversation-aware delivery lifecycle as embedded agents, keyed by the exact prepared MCP tool-call id. The generated Claude config-file projection also covers the full supported question timeout plus Gateway RPC grace; shared loopback, Codex, and Gemini configuration shapes remain unchanged.

## User Impact

Claude CLI-backed agents can present structured questions in the active channel, receive answers, propagate delivery failures, and preserve the documented long-wait behavior.

## Evidence

- 173 focused `ask_user` and embedded delivery tests passed.
- 82 focused CLI, bundle, Gateway, answer, error, cancel, timeout, and concurrency tests passed on the first complete head.
- After ClawSweeper's timeout-scope finding, 14 Claude/Codex/Gemini/Gateway projection tests passed on final head `43da850d08bc61025b2c6cad65ff6caff5b379d7`; targeted formatting, `git diff --check`, and the full dead-export scan also passed.
- The complete changed-files Testbox gate passed before the isolated timeout-scope follow-up: typecheck, test types, lint, format, dead exports, plugin boundaries, import cycles, and repository guards.
- Final-head Testbox run https://github.com/openclaw/openclaw/actions/runs/30679014415 stayed in-progress without command output for 33 minutes and was stopped; the trusted local fallback then queued behind another session's long-running shared oxlint lock. This is recorded as an infrastructure gap, not a green result.
- ClawSweeper reviewed final head with no actionable findings: https://github.com/openclaw/openclaw/pull/117152#issuecomment-5148936030
- Claude Code 2.1.220 config contract inspected directly: per-server `timeout` is milliseconds and applies to external MCP calls.
- Codex sibling source inspected directly: request ids remain stable through app-server input and MCP tool-call start/end; this change does not alter the Codex bridge.
- A legacy Gateway drain timing test fails identically on frozen base `4f7fbcb34da23e93b7a2cc050db893f18fd9da5a` and this branch (`closeSettled` after 20 ms / `ECONNRESET`); no changed hunk touches that lifecycle.
- Real Claude CLI launch reached the installed binary but live channel proof is externally blocked because the local Claude OAuth session is expired and `claude auth status` reports logged out.