### PR TITLE
fix(plugins): plugins doctor reports healthy while the selected context engine is quarantined

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -510,6 +510,8 @@ openclaw plugins doctor
 
 `doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `No plugin issues detected.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
 
+`doctor` also lists context engines quarantined at runtime under `Runtime quarantines:`. A plugin engine that loads fine but throws during a session is quarantined for that process and replaced by `legacy`, so a plugin can be healthy on disk while the engine you configured is not the one running. The same records appear in `/status` plugin health and in gateway health.
+
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 
 For module-shape failures such as missing `register`/`activate` exports, rerun with `OPENCLAW_PLUGIN_LOAD_DEBUG=1` to include a compact export-shape summary in the diagnostic output.

--- a/src/cli/plugins-cli.doctor-quarantine.test.ts
+++ b/src/cli/plugins-cli.doctor-quarantine.test.ts
@@ -1,0 +1,93 @@
+// Plugins doctor tests cover runtime context-engine quarantine reporting.
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ensureContextEnginesInitialized } from "../context-engine/init.js";
+import { registerContextEngineForOwner, resolveContextEngine } from "../context-engine/registry.js";
+import {
+  captureContextEngineRegistryStateForTests,
+  resetContextEngineRuntimeQuarantineForTests,
+} from "../context-engine/registry.test-support.js";
+import {
+  resetPluginsCliTestState,
+  runPluginsCommand,
+  runtimeLogs,
+} from "./plugins-cli-test-helpers.js";
+
+const ENGINE_ID = "lossless-claw";
+const BOOTSTRAP_ERROR = "ENOENT: no such file or directory, stat 'agent:main:main'";
+
+// Drives the shipped quarantine path: a plugin-owned engine is selected, its
+// bootstrap throws, and the registry quarantines it and falls back to legacy.
+async function quarantineSelectedContextEngine(): Promise<void> {
+  registerContextEngineForOwner(
+    ENGINE_ID,
+    () => ({
+      info: { id: "lcm", name: "Lossless Context Manager" },
+      async bootstrap() {
+        throw new Error(BOOTSTRAP_ERROR);
+      },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }: { messages: AgentMessage[] }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+    }),
+    `plugin:${ENGINE_ID}`,
+    { allowSameOwnerRefresh: true },
+  );
+
+  const engine = await resolveContextEngine({
+    plugins: { slots: { contextEngine: ENGINE_ID } },
+  });
+  const result = await engine.bootstrap?.({
+    sessionId: "main",
+    sessionKey: "agent:main:main",
+    sessionFile: "/tmp/openclaw-sessions/main.jsonl",
+  });
+
+  expect(result?.bootstrapped).toBe(false);
+  expect(engine.info.id).toBe("legacy");
+}
+
+let restoreContextEngineRegistry = () => {};
+
+beforeAll(() => {
+  restoreContextEngineRegistry = captureContextEngineRegistryStateForTests();
+  // Registers the built-in legacy engine exactly as runtime startup does, so the
+  // quarantine fallback resolves the same engine operators end up running on.
+  ensureContextEnginesInitialized();
+});
+
+afterAll(() => {
+  restoreContextEngineRegistry();
+});
+
+describe("plugins doctor runtime quarantines", () => {
+  beforeEach(() => {
+    resetPluginsCliTestState();
+    resetContextEngineRuntimeQuarantineForTests();
+  });
+
+  it("reports a quarantined context engine instead of a clean bill of health", async () => {
+    await quarantineSelectedContextEngine();
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    const output = runtimeLogs.join("\n");
+    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).toContain(`context engine "${ENGINE_ID}"`);
+    expect(output).toContain(`plugin:${ENGINE_ID}`);
+    expect(output).toContain(BOOTSTRAP_ERROR);
+    expect(output).toContain("legacy");
+  });
+
+  it("still reports a clean bill of health when nothing is quarantined", async () => {
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    expect(runtimeLogs).toContain("No plugin issues detected.");
+  });
+});

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -368,6 +368,11 @@ export async function runPluginsDoctorCommand(): Promise<void> {
     isStalePluginAutoRepairBlocked,
     scanStalePluginConfig,
   } = await import("../commands/doctor/shared/stale-plugin-config.js");
+  // Static discovery cannot see an engine that loaded and then failed at runtime, so read the
+  // same quarantine record gateway health and /status read; without it doctor calls a silently
+  // downgraded engine healthy.
+  const { listContextEngineQuarantines } = await import("../context-engine/registry.js");
+  const { defaultSlotIdForKey } = await import("../plugins/slots.js");
   const cfg = getRuntimeConfig();
   const configSnapshot = await readConfigFileSnapshot().catch(() => null);
   const sourceCfg = (configSnapshot?.sourceConfig ?? configSnapshot?.config ?? cfg) as
@@ -391,11 +396,13 @@ export async function runPluginsDoctorCommand(): Promise<void> {
     env: process.env,
     plugins: report.plugins,
   });
+  const contextEngineQuarantines = listContextEngineQuarantines();
+  const hasRuntimeQuarantines = contextEngineQuarantines.length > 0;
   const hasInstallTreeIssues =
     errors.length > 0 || diags.length > 0 || shadowed.length > 0 || compatibility.length > 0;
   const pluginConfigWarnings = [...stalePluginConfigWarnings, ...configuredRuntimePluginWarnings];
 
-  if (!hasInstallTreeIssues && pluginConfigWarnings.length === 0) {
+  if (!hasInstallTreeIssues && !hasRuntimeQuarantines && pluginConfigWarnings.length === 0) {
     defaultRuntime.log("No plugin issues detected.");
     return;
   }
@@ -407,6 +414,22 @@ export async function runPluginsDoctorCommand(): Promise<void> {
       const phase = entry.failurePhase ? ` [${entry.failurePhase}]` : "";
       lines.push(`- ${entry.id}${phase}: ${entry.error ?? "failed to load"} (${entry.source})`);
     }
+  }
+  if (hasRuntimeQuarantines) {
+    if (lines.length > 0) {
+      lines.push("");
+    }
+    const fallbackEngineId = defaultSlotIdForKey("contextEngine");
+    lines.push(theme.error("Runtime quarantines:"));
+    for (const entry of contextEngineQuarantines) {
+      const owner = entry.owner ? ` (${entry.owner})` : "";
+      lines.push(
+        `- context engine "${entry.engineId}"${owner} failed during ${entry.operation} and was replaced by "${fallbackEngineId}": ${entry.reason}`,
+      );
+    }
+    lines.push(
+      `  ${theme.muted("Repair:")} fix or disable the owning plugin, then ${theme.command("openclaw gateway restart --force")}`,
+    );
   }
   if (diags.length > 0) {
     if (lines.length > 0) {


### PR DESCRIPTION
Closes #115073

## What Problem This Solves

Fixes an issue where operators running `openclaw plugins doctor` are told `No plugin issues detected.` while the context engine they configured has been quarantined at runtime and silently replaced by `legacy`. The plugin still looks loaded and healthy in the inventory, so the only trace of the swap is a line in the gateway log:

```
[context-engine] Context engine "lossless-claw" owner=plugin:lossless-claw failed during bootstrap: ENOENT: no such file or directory, stat 'agent:main:main'; quarantining it for this process and falling back to default engine "legacy".
```

Two defects had to be fixed for the reported workflow to work:

1. **`plugins doctor` never looked.** It was static-only — plugin diagnostics report, compatibility notices, stale-plugin-config scan (`src/cli/plugins-cli.runtime.ts:360`). None of those can see an engine that loaded fine and then failed during a session.
2. **The shared runtime-health store dropped the record off Linux.** `plugins doctor` runs in a separate process from the gateway that recorded the quarantine, and sibling records were verified with `getProcessStartTime`, which returns `null` on every non-Linux platform (`src/shared/pid-alive.ts:82-88`). On the reporter's macOS the record was discarded before any surface could read it. Fixing only (1) would have left the reported macOS workflow broken — as ClawSweeper's P1 finding on the first revision of this PR pointed out.

## Why This Change Was Made

**Doctor reads the record that already exists.** Three health surfaces already consume it via `listContextEngineQuarantines()`:

- `src/gateway/health/collector.ts:60`
- `src/gateway/server-methods/health.ts:125`
- `src/status/status-plugin-health.runtime.ts:171`

`plugins doctor` was the only plugin health surface that never looked. It now reads the same reader and prints a `Runtime quarantines:` section. No new contract, no new config or env surface, no second aggregation path.

**The health store now uses the repo's own cross-platform process identity.** `getFileLockProcessStartTime` (`src/shared/pid-alive.ts:108`) resolves a process incarnation on Linux *and* Darwin, and it is what every other lock and lease in the repo already uses — gateway-lock, session-write-lock, sessions/storage-lock, worktrees/run-lease, plugin-sdk/file-lock, openclaw-agent-db-lease, startup-migration-checkpoint, stale-lock-file, mcp-oauth-lock. `runtime-health-store.ts` was the single remaining production consumer of the Linux-only `getProcessStartTime`. This is an alignment fix, not a new mechanism.

The fail-closed property is unchanged: an unverifiable identity still drops the record, so a recycled PID can never resurrect a stale failure. What changes is that macOS now *has* a verifiable identity instead of always failing closed. Writer and reader are deliberately kept on one function — the units are platform-specific (Linux `/proc` ticks vs Darwin epoch seconds) and are only ever compared locally.

Because the envelope is shared, runtime tool-schema quarantines (`src/agents/tool-schema-quarantine-health.ts`, read by `/status`) get the same cross-process repair on macOS. Same invariant, same owner, same change.

Scope notes:

- `plugins doctor` surfaces context-engine quarantines only. Tool-schema quarantines are filtered against the live runtime plugin registry (`status-plugin-health.runtime.ts:142`), and doctor runs with `loadPlugins: "never"`, so that filter would silently drop plugin-owned entries here. Core `openclaw doctor` already covers runtime tool schemas via `core/doctor/runtime-tool-schemas` (#88760).
- Reading quarantines does not create or migrate the state database. Verified below.

## User Impact

`openclaw plugins doctor` now names a quarantined engine, what replaced it, why, and what to do next — including when the gateway recorded it in another process, on Linux and macOS alike:

```
Runtime quarantines:
- context engine "lossless-claw" (plugin:lossless-claw) failed during bootstrap and was replaced by "legacy": ENOENT: no such file or directory, stat 'agent:main:main'
  Repair: fix or disable the owning plugin, then openclaw gateway restart --force

Docs: https://docs.openclaw.ai/plugin
```

`No plugin issues detected.` is unchanged when nothing is quarantined.

## Evidence

Focused proof command:

```bash
node scripts/run-vitest.mjs src/cli/plugins-cli.doctor-quarantine.test.ts
```

### 1. Doctor reports the quarantine (in-process, real production path)

The test registers a plugin-owned engine, resolves it through `resolveContextEngine`, and calls `bootstrap`, which throws. The real registry quarantines it and falls back to `legacy`. Then it runs the real `plugins doctor` command through the CLI dispatcher. No state is hand-written into any store.

RED, before the doctor change — the production quarantine fires and doctor still reports clean:

```
[context-engine] Context engine "lossless-claw" owner=plugin:lossless-claw failed during bootstrap: ENOENT: no such file or directory, stat 'agent:main:main'; quarantining it for this process and falling back to default engine "legacy".

 FAIL  src/cli/plugins-cli.doctor-quarantine.test.ts > reports a quarantined context engine instead of a clean bill of health
AssertionError: expected 'No plugin issues detected.' not to contain 'No plugin issues detected.'

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

GREEN: `Test Files 1 passed (1) / Tests 2 passed (2)`.

### 2. Gateway-to-CLI visibility on macOS (the reported workflow)

Two real OS processes on macOS 27.0 arm64, sharing one `OPENCLAW_STATE_DIR`. The recorder drives the real registry quarantine path and stays alive, standing in for the gateway; a separate process then reads through the production reader.

**Negative control — upstream `runtime-health-store.ts`:**

```
CHILD_READY pid=89934
PARENT pid=89971 sees: []
```

**With this change:**

```
CHILD_READY pid=89881
[context-engine] Context engine "lossless-claw" owner=plugin:lossless-claw failed during bootstrap: ENOENT: no such file or directory, stat 'agent:main:main'; quarantining it for this process and falling back to default engine "legacy".

PARENT pid=89919
[
  {
    "engineId": "lossless-claw",
    "operation": "bootstrap",
    "reason": "ENOENT: no such file or directory, stat 'agent:main:main'",
    "failedAt": "2026-08-01T05:25:08.506Z",
    "owner": "plugin:lossless-claw"
  }
]
```

### 3. Sibling-visibility tests now run on macOS

`src/context-engine/quarantine-health.test.ts` gated its cross-process coverage on `process.platform === "linux"`. That gate is now derived from whether the identity source resolves, so the same tests execute on Darwin. On this macOS host:

```
before:  Test Files 1 passed (1)   Tests 4 passed | 3 skipped (7)
after:   Test Files 1 passed (1)   Tests 8 passed (8)
```

The added test pins writer and reader to one identity function — the split that would silently drop every sibling record.

### 4. No state-database side effect

A probe against a fresh empty `OPENCLAW_STATE_DIR` confirmed the new read neither creates the state DB nor leaves files behind:

```
PROBE before=false after=false entries=0 files=[]
```

### Blast radius

```
node scripts/run-vitest.mjs src/context-engine   ->   9 files,  93 passed, 0 skipped   (was 85 passed | 6 skipped)
node scripts/run-vitest.mjs src/plugin-state     ->   4 files,  75 passed
node scripts/run-vitest.mjs src/status           ->  11 files, 120 passed
node scripts/run-vitest.mjs src/cli/plugins-cli  ->  10 files, 297 passed (+1 e2e file, 3 passed)
```

Also green locally: `run-tsgo -p tsconfig.core.json`, `run-tsgo -p test/tsconfig/tsconfig.core.test.json`, `oxfmt --check`, `git diff --check`.

Production diff: +23 net lines in `src/cli/plugins-cli.runtime.ts`, +18 net in `src/plugin-state/runtime-health-store.ts`.

### Honest limits

- **Darwin identity resolution is 1-second granular.** `ps -o lstart=` has no sub-second field, so a PID recycled within the same second as its predecessor could pass the incarnation check. This is the same tradeoff every other lock and lease in the repo already accepts through `getFileLockProcessStartTime`; this change does not make it better or worse, it just stops the health store from being the one surface that opted out entirely.
- **Darwin resolution spawns `ps`.** `list()` memoizes per PID for the pass, and own-PID records short-circuit on the process token without touching the OS, so a health read costs at most one `ps` per distinct recorder PID.
- **Records written by an older build on macOS carry `processStartTime: null`** and are dropped after upgrade. That is the intended fail-closed direction, and quarantines are per-process runtime state with no persistence contract.
- The cross-process evidence in section 2 was captured by hand rather than in CI; the committed tests cover the identity check and the writer/reader symmetry, not a spawned-process round trip.

---

AI-assisted: written with Claude Code, reviewed and validated locally by the author.
