### PR TITLE
fix(imessage): keep fenced role-marker mapping keys out of the outbound stripper

### DIFF
--- a/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
@@ -63,6 +63,27 @@ describe("sanitizeOutboundText", () => {
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");
   });
 
+  it("keeps a bare 'user:' mapping key inside a fenced code block", () => {
+    const text =
+      "```yaml\n- name: ensure account\n  user:\n    name: alice\n    state: present\n```";
+    // The role-turn stripper must not treat a YAML mapping key as a leaked turn
+    // boundary; deleting `user:` silently reparents its children under the item.
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+
+  it("keeps bare 'system:'/'assistant:' mapping keys inside a fenced code block", () => {
+    const text = "```yaml\nsystem:\n  role: primary\nassistant:\n  role: helper\n```";
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+
+  it("still strips a leaked role marker outside a code block while keeping the fenced one", () => {
+    const text = "assistant:\n```yaml\nuser:\n  name: alice\n```";
+    const result = sanitizeOutboundText(text);
+    // Leaked standalone marker in prose is removed; the fenced key survives.
+    expect(result).not.toMatch(/^assistant:$/m);
+    expect(result).toContain("```yaml\nuser:\n  name: alice\n```");
+  });
+
   it("handles combined internal markers in one message", () => {
     const text = "<thinking>step 1</thinking>NO_REPLY +#+#+#+# assistant to=final\n\nActual reply";
     const result = sanitizeOutboundText(text);

--- a/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
@@ -63,25 +63,37 @@ describe("sanitizeOutboundText", () => {
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");
   });
 
-  it("keeps a bare 'user:' mapping key inside a fenced code block", () => {
-    const text =
-      "```yaml\n- name: ensure account\n  user:\n    name: alice\n    state: present\n```";
-    // The role-turn stripper must not treat a YAML mapping key as a leaked turn
-    // boundary; deleting `user:` silently reparents its children under the item.
-    expect(sanitizeOutboundText(text)).toBe(text);
-  });
-
-  it("keeps bare 'system:'/'assistant:' mapping keys inside a fenced code block", () => {
-    const text = "```yaml\nsystem:\n  role: primary\nassistant:\n  role: helper\n```";
-    expect(sanitizeOutboundText(text)).toBe(text);
-  });
-
-  it("still strips a leaked role marker outside a code block while keeping the fenced one", () => {
-    const text = "assistant:\n```yaml\nuser:\n  name: alice\n```";
-    const result = sanitizeOutboundText(text);
-    // Leaked standalone marker in prose is removed; the fenced key survives.
-    expect(result).not.toMatch(/^assistant:$/m);
-    expect(result).toContain("```yaml\nuser:\n  name: alice\n```");
+  it.each([
+    {
+      name: "backtick fence preserves user while stripping prose user",
+      input: "user:\n```yaml\nuser:\n  name: alice\n```",
+      expected: "```yaml\nuser:\n  name: alice\n```",
+    },
+    {
+      name: "tilde fence preserves system while stripping prose system",
+      input: "system:\n~~~yaml\nsystem:\n  enabled: true\n~~~",
+      expected: "~~~yaml\nsystem:\n  enabled: true\n~~~",
+    },
+    {
+      name: "indented code preserves assistant while stripping prose assistant",
+      input: "keep\n\nassistant:\n\n    assistant:\n    enabled: true",
+      expected: "keep\n\n    assistant:\n    enabled: true",
+    },
+    {
+      name: "unterminated fence preserves every marker family after offset shifts",
+      input: [
+        "#+#+#",
+        "assistant to=final",
+        "user:",
+        "```text",
+        "#+#+#",
+        "assistant to=tool",
+        "user:",
+      ].join("\n"),
+      expected: ["```text", "#+#+#", "assistant to=tool", "user:"].join("\n"),
+    },
+  ] as const)("$name", ({ input, expected }) => {
+    expect(sanitizeOutboundText(input)).toBe(expected);
   });
 
   it("handles combined internal markers in one message", () => {

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -1,5 +1,9 @@
 // Imessage plugin module implements sanitize outbound behavior.
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import {
+  findCodeRegions,
+  isInsideCode,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 
 /**
  * Patterns that indicate assistant-internal metadata leaked into text.
@@ -10,6 +14,19 @@ const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
 // Only a standalone role marker on its own line (a leaked turn boundary) — not
 // any line that merely ends with the word "user/system/assistant:" in prose.
 const ROLE_TURN_MARKER_RE = /^[ \t]*(?:user|system|assistant)\s*:\s*$/gm;
+
+/**
+ * Strip an internal-marker pattern from prose while leaving matches that fall
+ * inside a fenced/indented/inline code region untouched: there a bare `user:`
+ * mapping key or `#+#` line is the user's own content, not leaked scaffolding.
+ * Regions are recomputed per call because the prior strip shifted later offsets.
+ */
+function stripMarkerOutsideCode(text: string, marker: RegExp): string {
+  const codeRegions = findCodeRegions(text);
+  return text.replace(marker, (match, offset: number) =>
+    isInsideCode(offset, codeRegions) ? match : "",
+  );
+}
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
@@ -23,9 +40,9 @@ export function sanitizeOutboundText(text: string): string {
 
   let cleaned = sanitizeAssistantVisibleText(text);
 
-  cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
-  cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
-  cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
+  cleaned = stripMarkerOutsideCode(cleaned, INTERNAL_SEPARATOR_RE);
+  cleaned = stripMarkerOutsideCode(cleaned, ASSISTANT_ROLE_MARKER_RE);
+  cleaned = stripMarkerOutsideCode(cleaned, ROLE_TURN_MARKER_RE);
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();


### PR DESCRIPTION
## What Problem This Solves

Every outbound iMessage reply runs through `sanitizeOutboundText`, which strips three
internal-marker patterns. One of them, `ROLE_TURN_MARKER_RE` (`extensions/imessage/src/monitor/sanitize-outbound.ts:12`),
deletes any line that is only `user:`, `system:` or `assistant:` — a leaked turn boundary.
The regex is anchored per line and allows leading whitespace, and it runs with no code-fence
awareness. So a bare YAML mapping key on its own line inside a fenced block matches and is
silently deleted before delivery.

The recipient gets YAML that still parses but now nests the child keys under the wrong parent:

```yaml
- name: ensure account
  user:            # <- this line is deleted
    name: alice    # now a sibling of `- name:`, no longer under `user:`
    state: present
```

Trigger is ordinary technical chat, not an edge case: Ansible `user:` modules, docker-compose
top-level `user:`, cloud-init, netplan, and LLM prompt templates with `system:` / `assistant:`
lines all hit it. The corruption is silent — nothing signals a line was removed. The two sibling
patterns on the same path (`INTERNAL_SEPARATOR_RE`, `ASSISTANT_ROLE_MARKER_RE`) share the blind spot.

Closes #116942.

## Why This Change Was Made

The role-marker strippers exist to remove leaked turn scaffolding from prose. Inside a code
region a bare `user:` mapping key or a `#+#` line is the user's own content, not scaffolding,
so the strip must skip it. The plugin already owns the exact tool: `findCodeRegions` /
`isInsideCode` are exported from `openclaw/plugin-sdk/text-chunking` and the sibling
`extensions/imessage/src/monitor/reflection-guard.ts` on this same channel already uses them to
ignore matches inside code. Core's `assistant-visible-text.ts` uses the identical
recompute-between-passes shape. So this is the established, narrowest boundary — it preserves the
existing "strip leaked markers in prose" contract while restoring fenced content, rather than
weakening or deleting the strip.

Root cause is fully contained in `sanitizeOutboundText`; everything downstream operates on the
already-corrupted text. Fix = one file, one small helper applied to all three patterns; regions
are recomputed per pass because each strip shifts later offsets. Blast radius: `sanitizeOutboundText`
has three callers, all in the iMessage extension (`deliver.ts:39`, `deliver.ts:89`, `channel.ts:412`).
Grep confirms no other channel carries a role-turn stripper, so this is iMessage-only.

## User Impact

Fenced code blocks in iMessage replies are delivered intact. A `user:` / `system:` / `assistant:`
mapping key inside a fence survives, and its children stay correctly nested. Leaked standalone
role markers in prose are still stripped, unchanged.

## Evidence

_AI-assisted._

**Focused regression proof** (also the ClawSweeper-listed acceptance command):

```
node scripts/run-vitest.mjs extensions/imessage/src/monitor.behavior.test.ts
```

Three new cases in `sanitize-outbound.test-support.ts` fail on the unmodified sanitizer and pass
after the fix; full suite 178/178 (185/185 including `deliver.test.ts`).

**Real-behavior proof** — a harness drives the real production delivery transform chain exactly as
`deliver.ts:39-46` composes it (`sanitizeOutboundText` → real `convertMarkdownTables` → real
`chunkTextWithMode`) and captures the exact payload handed to the send boundary. Negative control
on unfixed `main` vs this branch, same command:

```
# BEFORE (unfixed main) — negative control, FAIL
CASE ansible-user-module
  DELIVERED "```yaml\n- name: ensure account\n\n    name: alice\n    state: present\n```"   # user: deleted
CASE compose-top-level-user
  DELIVERED "...\n    image: nginx\n\n  name: alice\n  uid: 1000\n```"                       # user: deleted
CASE system-and-assistant-keys
  DELIVERED "```yaml\n\n  role: primary\n\n  role: helper\n```"                              # both deleted
RESULT: FAIL — BUG SIGNATURE

# AFTER (this branch) — PASS
CASE ansible-user-module
  DELIVERED "```yaml\n- name: ensure account\n  user:\n    name: alice\n    state: present\n```"
CASE compose-top-level-user
  DELIVERED "Your compose file needs a user block:\n\n```yaml\nservices:\n  app:\n    image: nginx\nuser:\n  name: alice\n  uid: 1000\n```"
CASE system-and-assistant-keys
  DELIVERED "```yaml\nsystem:\n  role: primary\nassistant:\n  role: helper\n```"
  [PASS] leaked standalone 'assistant:' marker in prose is still stripped
RESULT: PASS
```

`git diff --check` clean; `oxfmt` clean. Production delta +17 LOC (one helper).

**What was not tested:** the send RPC itself needs a signed-in Mac + imsg bridge, so the harness
stops at the send boundary and captures the pre-send payload — the same limitation the reporter
noted. The corruption is introduced entirely by `sanitizeOutboundText`, upstream of that boundary,
so the captured payload proves it. Typecheck was left to CI (the linked worktree can't run the
tsgo lane locally without a dependency reconcile).


### Maintainer validation

- **Decision:** accept literal marker-shaped text inside Markdown code regions. The repaired sanitizer still strips the same `#+#`, assistant-role, and `user:` / `system:` / `assistant:` markers in prose.
- **Canonical owner:** `extensions/imessage/src/monitor/sanitize-outbound.ts`, where outbound text is corrupted before formatting, chunking, or send. The branch uses the existing public code-region helpers already used by the sibling iMessage reflection guard.
- **Coverage added:** exact-output table cases for `user:`, `system:`, and `assistant:` inside and outside code; backtick fences, tilde fences, indented code, and an unterminated fence with earlier removals that shift offsets.
- **Provenance:** PR #33295 / `adb9234d0375df93d1ec96ce4008107788cc46c2` introduced the sanitizer (`@joelnishanth`, merged by `@vincentkoc`, March 7, 2026). PR #96392 / `770b19f496c1637774e660d31306105b671d1526` (`@ly-wang19`, merged by `@vincentkoc`) narrowed role stripping to standalone lines but did not protect code regions.
- **Release exposure:** `v2026.7.1` and every `v2026.7.2-beta.1` through `v2026.7.2-beta.5` contain sanitizer blob `cd230ee1baef18b3e6ef44669c77bb02ce4d7ff9`.
- **Exact repaired head:** `0bfdf3cbe9034358fa7af67e1019f923a147251a`, rebuilt on `origin/main` `6922ddd936106c95c2f1388812bc49e8f7920dd0`; the empty CI-retrigger commit was removed and contributor authorship was preserved.
- **Focused proof:** `node scripts/run-vitest.mjs extensions/imessage/src/monitor.behavior.test.ts` - 179/179 passed.
- **Changed gate:** Blacksmith Testbox passed all selected ratchets, formatting, extension typechecks, lint, dead-code, plugin-boundary, database-first, sidecar-loader, and import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/30686352634
- **Autoreview:** fresh branch review clean, no accepted/actionable findings, correctness 0.99.
