### PR TITLE
fix(cli): update plugins doctor clean message (#115073)

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -508,7 +508,7 @@ The `--json` flag outputs a machine-readable report suitable for scripting and a
 openclaw plugins doctor
 ```
 
-`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `No plugin issues detected.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
+`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
 
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -508,7 +508,7 @@ The `--json` flag outputs a machine-readable report suitable for scripting and a
 openclaw plugins doctor
 ```
 
-`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
+`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. It loads plugin modules without activating plugins and does not query the running Gateway. When these local checks pass, it prints `Plugin discovery, module loading, compatibility, and configuration checks passed. Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.` The [health command](/cli/health) reads current runtime quarantine and fallback state from the Gateway. If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
 
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -508,7 +508,7 @@ The `--json` flag outputs a machine-readable report suitable for scripting and a
 openclaw plugins doctor
 ```
 
-`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
+`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
 
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -93,7 +93,9 @@ describe("plugins cli list", () => {
     await runPluginsCommand(["plugins", "doctor"]);
 
     expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith({ config: {}, effectiveOnly: true });
-    expect(runtimeLogs).toContain("No plugin issues detected.");
+    expect(runtimeLogs).toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports stale plugin config in doctor output without claiming full plugin health", async () => {
@@ -145,7 +147,9 @@ describe("plugins cli list", () => {
     expect(output).toContain(
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports missing configured Codex runtime plugin in doctor output", async () => {
@@ -191,7 +195,9 @@ describe("plugins cli list", () => {
     expect(output).toContain(
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports missing configured ACPX runtime plugin in doctor output", async () => {
@@ -213,7 +219,9 @@ describe("plugins cli list", () => {
     expect(output).toContain('Configured runtime "acpx" requires the ACPX Runtime plugin');
     expect(output).toContain("openclaw doctor --fix");
     expect(output).toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports blocked configured ACPX runtime with ACP-specific guidance", async () => {
@@ -241,7 +249,9 @@ describe("plugins cli list", () => {
     expect(output).toContain("disable ACP/acpx in acp config");
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports disabled configured ACPX runtime with ACP-specific guidance", async () => {
@@ -264,7 +274,9 @@ describe("plugins cli list", () => {
     expect(output).toContain("disable ACP/acpx in acp config");
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("does not report implicit OpenAI Codex preference as configured runtime", async () => {
@@ -285,7 +297,9 @@ describe("plugins cli list", () => {
 
     const output = runtimeLogs.join("\n");
     expect(output).not.toContain('Configured runtime "codex"');
-    expect(output).toContain("No plugin issues detected.");
+    expect(output).toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("does not report configured Codex runtime when the plugin is enabled", async () => {
@@ -308,7 +322,9 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(runtimeLogs).toContain("No plugin issues detected.");
+    expect(runtimeLogs).toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports configured Codex runtime when the plugin record is disabled", async () => {
@@ -336,7 +352,9 @@ describe("plugins cli list", () => {
     expect(output).toContain('but "codex" is disabled');
     expect(output).toContain('Enable the "codex" plugin');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports blocked configured Codex runtime without install advice", async () => {
@@ -368,7 +386,9 @@ describe("plugins cli list", () => {
     expect(output).toContain('Remove "codex" from plugins.deny');
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports disabled configured Codex runtime entry without install advice", async () => {
@@ -402,7 +422,9 @@ describe("plugins cli list", () => {
     expect(output).toContain("Set plugins.entries.codex.enabled=true");
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain("No plugin issues detected.");
+    expect(output).not.toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports config-selected plugin source shadowing in doctor output", async () => {
@@ -462,7 +484,9 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(runtimeLogs).toContain("No plugin issues detected.");
+    expect(runtimeLogs).toContain(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
   });
 
   it("reports persisted plugin registry state without refreshing", async () => {

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -94,7 +94,7 @@ describe("plugins cli list", () => {
 
     expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith({ config: {}, effectiveOnly: true });
     expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -148,7 +148,7 @@ describe("plugins cli list", () => {
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -196,7 +196,7 @@ describe("plugins cli list", () => {
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -220,7 +220,7 @@ describe("plugins cli list", () => {
     expect(output).toContain("openclaw doctor --fix");
     expect(output).toContain("openclaw plugins install @openclaw/acpx");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -250,7 +250,7 @@ describe("plugins cli list", () => {
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -275,7 +275,7 @@ describe("plugins cli list", () => {
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -298,7 +298,7 @@ describe("plugins cli list", () => {
     const output = runtimeLogs.join("\n");
     expect(output).not.toContain('Configured runtime "codex"');
     expect(output).toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -323,7 +323,7 @@ describe("plugins cli list", () => {
     await runPluginsCommand(["plugins", "doctor"]);
 
     expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -353,7 +353,7 @@ describe("plugins cli list", () => {
     expect(output).toContain('Enable the "codex" plugin');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -387,7 +387,7 @@ describe("plugins cli list", () => {
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -423,7 +423,7 @@ describe("plugins cli list", () => {
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
     expect(output).not.toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 
@@ -485,7 +485,7 @@ describe("plugins cli list", () => {
     await runPluginsCommand(["plugins", "doctor"]);
 
     expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
   });
 

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -22,6 +22,10 @@ const workshopMocks = vi.hoisted(() => ({
   detectToolPolicyDiagnostic: vi.fn(),
 }));
 
+const cleanDoctorMessage =
+  "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
+  'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.';
+
 vi.mock("../skills/workshop/tool-policy-diagnostic.js", () => ({
   detectSkillWorkshopToolPolicyDiagnostic: workshopMocks.detectToolPolicyDiagnostic,
 }));
@@ -93,9 +97,7 @@ describe("plugins cli list", () => {
     await runPluginsCommand(["plugins", "doctor"]);
 
     expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith({ config: {}, effectiveOnly: true });
-    expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(runtimeLogs).toContain(cleanDoctorMessage);
   });
 
   it("reports stale plugin config in doctor output without claiming full plugin health", async () => {
@@ -147,9 +149,7 @@ describe("plugins cli list", () => {
     expect(output).toContain(
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports missing configured Codex runtime plugin in doctor output", async () => {
@@ -195,9 +195,7 @@ describe("plugins cli list", () => {
     expect(output).toContain(
       "No plugin install-tree issues detected; configuration warnings remain.",
     );
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports missing configured ACPX runtime plugin in doctor output", async () => {
@@ -219,9 +217,7 @@ describe("plugins cli list", () => {
     expect(output).toContain('Configured runtime "acpx" requires the ACPX Runtime plugin');
     expect(output).toContain("openclaw doctor --fix");
     expect(output).toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports blocked configured ACPX runtime with ACP-specific guidance", async () => {
@@ -249,9 +245,7 @@ describe("plugins cli list", () => {
     expect(output).toContain("disable ACP/acpx in acp config");
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports disabled configured ACPX runtime with ACP-specific guidance", async () => {
@@ -274,9 +268,7 @@ describe("plugins cli list", () => {
     expect(output).toContain("disable ACP/acpx in acp config");
     expect(output).not.toContain('runtime policy to "openclaw"');
     expect(output).not.toContain("openclaw plugins install @openclaw/acpx");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("does not report implicit OpenAI Codex preference as configured runtime", async () => {
@@ -297,9 +289,7 @@ describe("plugins cli list", () => {
 
     const output = runtimeLogs.join("\n");
     expect(output).not.toContain('Configured runtime "codex"');
-    expect(output).toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).toContain(cleanDoctorMessage);
   });
 
   it("does not report configured Codex runtime when the plugin is enabled", async () => {
@@ -322,9 +312,7 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(runtimeLogs).toContain(cleanDoctorMessage);
   });
 
   it("reports configured Codex runtime when the plugin record is disabled", async () => {
@@ -352,9 +340,7 @@ describe("plugins cli list", () => {
     expect(output).toContain('but "codex" is disabled');
     expect(output).toContain('Enable the "codex" plugin');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports blocked configured Codex runtime without install advice", async () => {
@@ -386,9 +372,7 @@ describe("plugins cli list", () => {
     expect(output).toContain('Remove "codex" from plugins.deny');
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports disabled configured Codex runtime entry without install advice", async () => {
@@ -422,9 +406,7 @@ describe("plugins cli list", () => {
     expect(output).toContain("Set plugins.entries.codex.enabled=true");
     expect(output).not.toContain('Run "openclaw doctor --fix" to install');
     expect(output).not.toContain("openclaw plugins install @openclaw/codex");
-    expect(output).not.toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(output).not.toContain(cleanDoctorMessage);
   });
 
   it("reports config-selected plugin source shadowing in doctor output", async () => {
@@ -484,9 +466,7 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(runtimeLogs).toContain(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
-    );
+    expect(runtimeLogs).toContain(cleanDoctorMessage);
   });
 
   it("reports persisted plugin registry state without refreshing", async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -397,7 +397,7 @@ export async function runPluginsDoctorCommand(): Promise<void> {
 
   if (!hasInstallTreeIssues && pluginConfigWarnings.length === 0) {
     defaultRuntime.log(
-      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
     );
     return;
   }

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -396,7 +396,9 @@ export async function runPluginsDoctorCommand(): Promise<void> {
   const pluginConfigWarnings = [...stalePluginConfigWarnings, ...configuredRuntimePluginWarnings];
 
   if (!hasInstallTreeIssues && pluginConfigWarnings.length === 0) {
-    defaultRuntime.log("No plugin issues detected.");
+    defaultRuntime.log(
+      'Static plugin checks passed. Direct operators to "openclaw health" for active runtime quarantine/fallback status.',
+    );
     return;
   }
 

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -397,7 +397,8 @@ export async function runPluginsDoctorCommand(): Promise<void> {
 
   if (!hasInstallTreeIssues && pluginConfigWarnings.length === 0) {
     defaultRuntime.log(
-      'Static plugin checks passed. Run "openclaw health" to check active runtime quarantine/fallback status.',
+      "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
+        'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.',
     );
     return;
   }


### PR DESCRIPTION
Fixes #115073

### What Problem This Solves

`openclaw plugins doctor` previously printed `No plugin issues detected.` when plugin discovery, module loading, compatibility, and configuration checks passed. That wording implied runtime health even though the command does not query the running Gateway.

This PR makes the boundary explicit:

- `openclaw plugins doctor` reports its local plugin checks.
- `openclaw health` reports the running Gateway's runtime quarantines and fallbacks.

### User Impact

Operators now receive a truthful success message with the correct next command for runtime diagnosis:

```text
Plugin discovery, module loading, compatibility, and configuration checks passed. Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.
```

The plugin CLI documentation explains the same control-plane/runtime boundary.

### Evidence

- `node scripts/run-vitest.mjs src/cli/plugins-cli.list.test.ts` - 20 tests passed
- `pnpm docs:check-mdx docs/cli/plugins.md` - passed
- `pnpm docs:check-links` - 6,348 internal links checked, 0 broken
- targeted `oxfmt --check` - passed
- `git diff --check origin/main...HEAD` - passed
- autoreview through P1 - clean, confidence 0.99

### AI-Assisted PR Disclosure

The original contribution was authored with Antigravity AI. The maintainer repair tightened the operator copy, documentation, and regression-test contract without widening the runtime behavior.
