### PR TITLE
fix(agents): prevent fallback after stale lifecycle abort

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -3,6 +3,7 @@
  * Exercises raw error coercion, remediation hints, timeout/auth/billing/rate-limit cases.
  */
 import { describe, expect, it } from "vitest";
+import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { classifyFailoverSignal } from "./embedded-agent-helpers/errors.js";
 import {
   buildFailoverRemediationHint,
@@ -1416,6 +1417,17 @@ describe("failover-error", () => {
       ).toBe(true);
     });
 
+    it("returns true for stale gateway lifecycle ownership loss", () => {
+      const staleLifecycle = createAgentRunStaleLifecycleError();
+      expect(isNonProviderRuntimeCoordinationError(staleLifecycle)).toBe(true);
+      expect(
+        isNonProviderRuntimeCoordinationError(new Error("wrapper", { cause: staleLifecycle })),
+      ).toBe(true);
+      const abortWrapper = new Error("request was aborted", { cause: staleLifecycle });
+      abortWrapper.name = "AbortError";
+      expect(isNonProviderRuntimeCoordinationError(abortWrapper)).toBe(true);
+    });
+
     it("returns true when the coordination error is nested via cause", () => {
       const wrapped = new Error("wrapper", { cause: makeSessionLockError() });
       expect(isNonProviderRuntimeCoordinationError(wrapped)).toBe(true);
@@ -1457,6 +1469,13 @@ describe("failover-error", () => {
           status: 503,
           message: "upstream overloaded",
           cause: { result: { reason: "missing_tool_result" } },
+        }),
+      ).toBe(false);
+      expect(
+        isNonProviderRuntimeCoordinationError({
+          status: 503,
+          message: "upstream overloaded",
+          cause: createAgentRunStaleLifecycleError(),
         }),
       ).toBe(false);
       expect(isNonProviderRuntimeCoordinationError(null)).toBe(false);

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -5,6 +5,7 @@
  */
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { formatCliCommand } from "../cli/command-format.js";
+import { isAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverSignal,
@@ -496,6 +497,22 @@ function hasMissingToolResultFailure(err: unknown): boolean {
   return findErrorProperty(err, readMissingToolResultMarker) === true;
 }
 
+function hasStaleAgentRunLifecycleFailure(err: unknown): boolean {
+  return (
+    findErrorProperty(err, (candidate) =>
+      isAgentRunStaleLifecycleError(candidate) ? true : undefined,
+    ) === true
+  );
+}
+
+function hasDirectProviderFailureIdentity(err: unknown): boolean {
+  if (isFailoverError(err)) {
+    return true;
+  }
+  const signal = normalizeDirectErrorSignal(err);
+  return Boolean(signal.status || signal.code || signal.errorType || signal.provider);
+}
+
 /**
  * True when the error is a local runtime coordination/tool-execution error
  * rather than a provider/model failure. The model fallback chain must abort on
@@ -899,6 +916,13 @@ export function resolveModelFallbackError(
   if (err instanceof AgentHarnessSessionSupersededError) {
     return { kind: "coordination", error: err };
   }
+  const staleLifecycleFailure = hasStaleAgentRunLifecycleFailure(err);
+  if (
+    staleLifecycleFailure &&
+    (isAgentRunStaleLifecycleError(err) || !hasDirectProviderFailureIdentity(err))
+  ) {
+    return { kind: "coordination", error: err };
+  }
   // A direct takeover remains a coordination failure unless the dedicated
   // cleanup wrapper owns a preserved prompt error. Its message alone must not
   // reclassify session-state loss as a provider failure.
@@ -912,7 +936,8 @@ export function resolveModelFallbackError(
   if (
     hasSessionWriteLockContention(err) ||
     hasEmbeddedAttemptSessionTakeover(err) ||
-    hasMissingToolResultFailure(err)
+    hasMissingToolResultFailure(err) ||
+    staleLifecycleFailure
   ) {
     return { kind: "coordination", error: err };
   }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptNotContinuableError } from "../../packages/agent-core/src/errors.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import {
   onTrustedInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -1925,6 +1926,38 @@ describe("runWithModelFallback", () => {
       }),
     ).rejects.toBe(lockError);
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the fallback chain on stale gateway lifecycle errors (#116418)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "ollama/qwen3:0.6b",
+            fallbacks: ["minimax/MiniMax-M3"],
+          },
+        },
+      },
+    });
+    const lifecycleError = createAgentRunStaleLifecycleError();
+    const wrappedLifecycleError = new Error("request was aborted", { cause: lifecycleError });
+    wrappedLifecycleError.name = "AbortError";
+    const run = vi.fn().mockRejectedValue(wrappedLifecycleError);
+    const onFallbackStep = vi.fn();
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "ollama",
+        model: "qwen3:0.6b",
+        run,
+        onFallbackStep,
+      }),
+    ).rejects.toBe(wrappedLifecycleError);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onFallbackStep).not.toHaveBeenCalledWith(
+      expect.objectContaining({ decision: "candidate_failed" }),
+    );
   });
 
   it("aborts the fallback chain on transcript continuation failures without candidate_failed attribution", async () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -4,8 +4,8 @@ import { randomUUID } from "node:crypto";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
-import { createAbortError } from "./abort-signal.js";
 import { hasInvalidLifecycleStartTimestamp } from "./agent-event-lifecycle.js";
+import { createAgentRunStaleLifecycleError } from "./agent-lifecycle-error.js";
 import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 /** Approval event phase for request/resolution transitions. */
@@ -194,7 +194,7 @@ export function assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration: st
   if (isAgentEventLifecycleGenerationCurrent(lifecycleGeneration)) {
     return;
   }
-  throw createAbortError("Agent run belongs to a stale gateway lifecycle");
+  throw createAgentRunStaleLifecycleError();
 }
 
 /** Captures immutable lifecycle ownership for one admitted execution. */

--- a/src/infra/agent-lifecycle-error.ts
+++ b/src/infra/agent-lifecycle-error.ts
@@ -1,0 +1,21 @@
+const AGENT_RUN_STALE_LIFECYCLE_ERROR = "Agent run belongs to a stale gateway lifecycle";
+const AGENT_RUN_STALE_LIFECYCLE_ERROR_CODE = "ERR_STALE_GATEWAY_LIFECYCLE";
+
+export function createAgentRunStaleLifecycleError(): Error {
+  const error = new Error(AGENT_RUN_STALE_LIFECYCLE_ERROR) as Error & { code: string };
+  error.name = "AbortError";
+  error.code = AGENT_RUN_STALE_LIFECYCLE_ERROR_CODE;
+  return error;
+}
+
+export function isAgentRunStaleLifecycleError(value: unknown): boolean {
+  try {
+    return (
+      value instanceof Error &&
+      "code" in value &&
+      value.code === AGENT_RUN_STALE_LIFECYCLE_ERROR_CODE
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #116418

## What Problem This Solves

Fixes an issue where users selecting an Ollama or other primary model could be silently routed to a configured fallback when the primary attempt was aborted because it belonged to a stale Gateway lifecycle.

## Why This Change Was Made

Stale lifecycle ownership is a local coordination failure, not a provider failure. This change gives that abort a stable internal identity and stops model fallback before another provider is invoked, including when a generic timeout-shaped `AbortError` wraps the lifecycle error. Explicit provider failure metadata remains authoritative.

## User Impact

Gateway lifecycle failures now surface on the requested run instead of silently invoking a cloud fallback. This preserves the user's provider choice and avoids unexpected remote usage or charges.

Thanks @Myer66 for the corrected lifecycle trace and reproducible routing evidence.

## Evidence

- `node scripts/run-vitest.mjs src/agents/failover-error.test.ts` — 106 passed
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts` — 138 passed
- Live isolated Ollama route reached `provider=ollama`, `api=ollama`, `endpoint=local`, model `llama3.2:3b`; the small model later made an unrelated invalid `sessions_yield` call.
- Formatting, targeted oxlint, import-cycle, env-var budget, conflict-marker, max-lines, and `git diff --check` checks passed.
- Two Codex autoreview passes reported no accepted/actionable findings.
- Full changed-check delegation was unavailable because the configured Blacksmith/Crabbox backend was not ready. Local `tsgo` also encounters the unchanged `packages/terminal-core/src/ansi.ts` TS2554 baseline failure; the linked sparse install cannot resolve `@openclaw/session-url-contract/parse`. Exact-head CI remains the authoritative broad gate.

AI-assisted implementation; the maintainer reviewed the code path, tests, and live proof.
