### PR TITLE
fix(ui): retire stale Gateway event-log observers

### DIFF
--- a/ui/src/app/gateway-store.observers.test.ts
+++ b/ui/src/app/gateway-store.observers.test.ts
@@ -193,6 +193,58 @@ describe("application gateway observer ownership", () => {
     expect(third).toHaveBeenCalledExactlyOnceWith(gateway.eventLog);
   });
 
+  it.each(["replace", "stop"] as const)(
+    "retires remaining event-log observers when the first observer %ss its client",
+    (action) => {
+      const { gateway, clients, current } = createGatewayStore();
+      const stale = vi.fn();
+      const delivered = vi.fn();
+      gateway.subscribeEventLog(() => {
+        if (action === "replace") {
+          gateway.connect();
+        } else {
+          gateway.stop();
+        }
+      });
+      gateway.subscribeEventLog(stale);
+      gateway.subscribeEvents(delivered);
+      gateway.start();
+      const retired = current();
+      retired.opts.onHello?.(HELLO);
+
+      retired.opts.onEvent?.(createGatewayEvent(1));
+
+      expect(stale).not.toHaveBeenCalled();
+      expect(delivered).not.toHaveBeenCalled();
+      expect(gateway.eventLog).toHaveLength(1);
+      expect(clients).toHaveLength(action === "replace" ? 2 : 1);
+      expect(gateway.snapshot.phase).toBe(action === "replace" ? "reconnecting" : "stopped");
+    },
+  );
+
+  it("retires an older event-log snapshot after a reentrant event is recorded", () => {
+    const { gateway, current } = createGatewayStore();
+    const observed: number[] = [];
+    let nested = false;
+    gateway.subscribeEventLog(() => {
+      if (!nested) {
+        nested = true;
+        current().opts.onEvent?.(createGatewayEvent(2));
+      }
+    });
+    gateway.subscribeEventLog((events) => observed.push(events.length));
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+
+    current().opts.onEvent?.(createGatewayEvent(1));
+
+    expect(observed).toEqual([2]);
+    expect(gateway.eventLog.map((event) => event.payload)).toEqual([
+      { text: "event-2" },
+      { text: "event-1" },
+    ]);
+  });
+
   it("never logs a presence event after its snapshot observer replaces the client", () => {
     const { gateway, current } = createGatewayStore();
     const logged = vi.fn();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -235,6 +235,7 @@ export function createApplicationGateway(
     settings = patchSettings(patch, { selectGateway });
   };
   const recordGatewayEvent = (event: Parameters<GatewayEventListener>[0]) => {
+    const eventClient = client;
     if (event.event === "presence") {
       const entries = readPresenceEntries(event.payload);
       if (entries) {
@@ -242,7 +243,6 @@ export function createApplicationGateway(
         // A live connection owns its authenticated identity until onClose. Older
         // gateways can omit still-connected clients after presence TTL pruning.
         if (selfUser && !sameSelfUser(snapshot.selfUser, selfUser)) {
-          const eventClient = client;
           setSnapshot({ ...snapshot, selfUser });
           // A presence observer can replace its client before this event reaches the log.
           if (!isCurrentClient(eventClient)) {
@@ -255,7 +255,9 @@ export function createApplicationGateway(
       0,
       250,
     );
-    notifyGatewayObservers(eventLogListeners, eventLog, "event");
+    const ownsEventLog = (current: readonly EventLogEntry[]) =>
+      current === eventLog && isCurrentClient(eventClient);
+    notifyGatewayObservers(eventLogListeners, eventLog, "event", ownsEventLog);
   };
 
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {


### PR DESCRIPTION
## Summary

- Refactor the private Gateway event-log owner to retire observer delivery whenever its socket is replaced/stopped or a nested event supersedes the published log.
- Reuse the existing canonical observer-publication predicate; preserve retained history, listener membership snapshots, failure isolation, raw events, presence ownership, and healthy Debug updates.

## Root cause

`recordGatewayEvent` was the only application Gateway publication that omitted the canonical `notifyGatewayObservers` ownership predicate. A synchronous first subscriber could reconnect or stop its originating client while later log subscribers, including Debug, still received the retired event. A reentrant event likewise published the newest snapshot and then rolled Debug back to its obsolete older snapshot. Capturing the producing client once at the existing owner and fencing delivery to both the current client and exact current log snapshot fixes this owner-boundary invariant without a consumer-side workaround, public API change, compatibility shim, or new dependency.

Production delta: `ui/src/app/gateway-store.ts` **+4/-2 (net +2)**; one root cause, with three precise regressions. No protocol, configuration, authentication, security, persistence, or SDK surface changes.

## Exact baseline RED

Frozen baseline `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12` with production untouched: `node scripts/run-vitest.mjs ui/src/app/gateway-store.observers.test.ts` produced **3 new failures and 10 existing passes**:

1. A second log observer received an event after the first observer replaced its Gateway client.
2. A second log observer received an event after the first observer stopped its Gateway client.
3. A reentrant event delivered histories `[2, 1]` instead of the authoritative `[2]`.

## Verification

- Blacksmith Testbox `tbx_01kyxj1dsfygk7dtrh7pjsjha8`: **120/120 focused tests passed**, zero failed, across Gateway owner/observers, app-host lineage and shell, Debug/source replacement, and bootstrap; two Vitest shards.
- The reusable Testbox preserves its workflow Git HEAD and syncs branch changes as a working-tree patch. Before executing any tests, the remote command verified frozen-baseline ancestry and the exact immutable `eeffb08840ec43acaaaa4e92e68220b9b7980653` Git blob for **both** changed files: owner `5a12523b09e7540a2b21037658322537eb1cdf2d`; observer tests `6709f64d6899d5b2c5c4c60b04ae67f9cc68e40a`. This is patch-identical source proof, not a claim that the workflow checkout HEAD equals the private commit.
- Exact-source remote type-aware oxlint: **0 warnings / 0 errors**; oxfmt and `git diff --check` clean. Remote timing JSON `exitCode=0`; the lease was stopped and independently verified **completed**.
- Independent actual **Google Chrome 150** used the real production Gateway store, **14 genuine challenge/device-authenticated WebSocket hellos**, **16 sequenced real Gateway frames**, and the rendered Debug DOM: baseline RED → immutable candidate GREEN, **26/26 assertions**, zero uncaught page errors. Coverage includes replacement, stop, nested delivery, retained history, healthy events, raw-event isolation, and failing-observer isolation.
- Two independent strict whole-owner P0–P3 reviews: **zero findings**, confidence **0.99** and **0.98**; both inspected callers, presence/snapshot/raw-event siblings, listener lifecycle, and Debug consumers.
- Genuine full-branch Codex autoreview against exact frozen baseline through **P3**: **zero findings**, overall confidence **0.93**, TruffleHog clean.

## Agent transcript

- Read the current complete root and scoped UI ownership guides; inspected the existing Gateway owner, sibling publications, presence path, historical changes, actual Debug consumers, and existing regression tests.
- Froze `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`, authored three focused tests first, and captured the genuine baseline RED before changing production.
- Refactored only the existing owner-boundary guard, froze immutable candidate `eeffb08840ec43acaaaa4e92e68220b9b7980653`, and had separate agents independently verify real browser/WebSocket behavior and whole-owner P0–P3 correctness.
- Used one lazily acquired, branch-scoped Testbox, verified both exact immutable source blobs before execution, completed focused proof, and stopped/verified the lease.
