### PR TITLE
fix(ci): stop blocking dependency-only removals

### DIFF
--- a/scripts/github/dependency-guard.d.mts
+++ b/scripts/github/dependency-guard.d.mts
@@ -17,6 +17,11 @@ type PullRequest = {
 };
 
 type ActorCandidate = { login: string; source: string };
+type DependencyGraphChange = {
+  change_type: string;
+  manifest?: string | null;
+  name?: string | null;
+};
 
 export function isDependencyFile(filename: string): boolean;
 export function isDependencyManifest(filename: string): boolean;
@@ -25,6 +30,9 @@ export function dependencyFieldChanges(
   baseManifest: Record<string, unknown>,
   headManifest: Record<string, unknown>,
 ): string[];
+export function isRemovalOnlyDependencyGraphChange(
+  changes: readonly DependencyGraphChange[],
+): boolean;
 export function shouldAutoscrubDependencyLockfiles(options: {
   dependencyFiles?: string[];
   lockfileChanges: unknown[];
@@ -75,6 +83,10 @@ export function renderAuthorizedDependencyComment(override: Record<string, unkno
 export function renderTrustedDependencyComment(options: {
   actor: { login: string; reason: string };
   headSha: string;
+}): string;
+export function renderRemovalOnlyDependencyComment(options: {
+  dependencyGraphChanges: readonly DependencyGraphChange[];
+  headSha?: string;
 }): string;
 export function renderAutoscrubbedDependencyComment(options: {
   baseBranch: string;

--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -54,7 +54,6 @@ const dependencyManifestFields = [
   "cpu",
   "libc",
 ];
-
 export function isDependencyFile(filename) {
   return (
     filename.endsWith("package-lock.json") ||
@@ -80,6 +79,10 @@ export function dependencyFieldChanges(baseManifest, headManifest) {
     }
   }
   return changes;
+}
+
+export function isRemovalOnlyDependencyGraphChange(changes) {
+  return changes.length > 0 && changes.every((change) => change.change_type === "removed");
 }
 
 export function shouldAutoscrubDependencyLockfiles({
@@ -305,6 +308,26 @@ export function renderTrustedDependencyComment({ actor, headSha }) {
     `- Trusted role: ${markdownCode(actor.reason)}`,
     "",
     "Security review is still recommended before merge when the dependency graph change is intentional.",
+  ].join("\n");
+}
+
+export function renderRemovalOnlyDependencyComment({ dependencyGraphChanges, headSha }) {
+  const removalLines = dependencyGraphChanges.map(
+    (change) =>
+      `- Removed ${markdownCode(change.name ?? "<unknown dependency>")} from ${markdownCode(change.manifest ?? "<unknown manifest>")}.`,
+  );
+  return [
+    dependencyGraphGuardMarker,
+    "",
+    "### Dependency removals noted",
+    "",
+    "This PR only removes dependencies from the dependency graph, so the dependency guard is informational and does not require `/allow-dependencies-change`.",
+    "",
+    ...removalLines,
+    "",
+    `- Current SHA: ${markdownCode(headSha ?? "<head-sha>")}`,
+    "",
+    "A later push that adds or changes dependency graph entries will require a fresh security approval.",
   ].join("\n");
 }
 
@@ -534,12 +557,12 @@ async function readBase64FileAtRef(api, { owner, repo, path, ref }) {
 }
 
 async function collectDependencyManifestChanges(api, { owner, repo, pullRequest, files }) {
-  const manifestPaths = files
-    .map((file) => file.filename)
-    .filter((filename) => typeof filename === "string" && isDependencyManifest(filename))
-    .toSorted((left, right) => left.localeCompare(right));
+  const manifestFiles = files
+    .filter((file) => typeof file.filename === "string" && isDependencyManifest(file.filename))
+    .toSorted((left, right) => left.filename.localeCompare(right.filename));
   const changes = [];
-  for (const path of manifestPaths) {
+  for (const file of manifestFiles) {
+    const path = file.filename;
     const [baseManifest, headManifest] = await Promise.all([
       readJsonFileAtRef(api, {
         owner,
@@ -722,6 +745,27 @@ async function main() {
         renderClearedDependencyGuardComment({ headSha: pullRequest.head?.sha }),
       );
     }
+    return;
+  }
+
+  const dependencyGraphChanges = await api.paginate(
+    `/repos/${owner}/${repo}/dependency-graph/compare/${pullRequest.base?.sha}...${pullRequest.head?.sha}`,
+  );
+  if (isRemovalOnlyDependencyGraphChange(dependencyGraphChanges)) {
+    if (mode === "detect") {
+      await setOutput("autoscrub", "false");
+    }
+    await upsertComment(
+      existingGuardComment,
+      renderRemovalOnlyDependencyComment({
+        dependencyGraphChanges,
+        headSha: pullRequest.head?.sha,
+      }),
+    );
+    await writeSummary(
+      "## Dependency Guard\n\nDependency removals are informational and do not require security approval.",
+    );
+    console.log("Dependency removals detected; guard is informational.");
     return;
   }
 

--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -54,6 +54,7 @@ const dependencyManifestFields = [
   "cpu",
   "libc",
 ];
+
 export function isDependencyFile(filename) {
   return (
     filename.endsWith("package-lock.json") ||
@@ -557,12 +558,12 @@ async function readBase64FileAtRef(api, { owner, repo, path, ref }) {
 }
 
 async function collectDependencyManifestChanges(api, { owner, repo, pullRequest, files }) {
-  const manifestFiles = files
-    .filter((file) => typeof file.filename === "string" && isDependencyManifest(file.filename))
-    .toSorted((left, right) => left.filename.localeCompare(right.filename));
+  const manifestPaths = files
+    .map((file) => file.filename)
+    .filter((filename) => typeof filename === "string" && isDependencyManifest(filename))
+    .toSorted((left, right) => left.localeCompare(right));
   const changes = [];
-  for (const file of manifestFiles) {
-    const path = file.filename;
+  for (const path of manifestPaths) {
     const [baseManifest, headManifest] = await Promise.all([
       readJsonFileAtRef(api, {
         owner,

--- a/test/scripts/dependency-guard-script.test.ts
+++ b/test/scripts/dependency-guard-script.test.ts
@@ -21,11 +21,13 @@ import {
   isDependencyManifest,
   isDependencyGuardTrustedForHead,
   isPackageLockfile,
+  isRemovalOnlyDependencyGraphChange,
   readBoundedGitHubErrorText,
   renderAuthorizedDependencyComment,
   renderAutoscrubbedDependencyComment,
   renderBlockedDependencyComment,
   renderClearedDependencyGuardComment,
+  renderRemovalOnlyDependencyComment,
   renderTrustedDependencyComment,
   sanitizeDisplayValue,
   securityApproverSet,
@@ -91,6 +93,43 @@ describe("dependency guard script", () => {
         },
       ),
     ).toEqual(["optionalDependencies", "peerDependencies", "overrides", "packageManager", "pnpm"]);
+  });
+
+  it("allows only dependency graph removals without approval", () => {
+    expect(
+      isRemovalOnlyDependencyGraphChange([
+        { change_type: "removed", name: "a" },
+        { change_type: "removed", name: "b" },
+      ]),
+    ).toBe(true);
+    expect(
+      isRemovalOnlyDependencyGraphChange([
+        { change_type: "removed", name: "a" },
+        { change_type: "added", name: "b" },
+      ]),
+    ).toBe(false);
+    expect(isRemovalOnlyDependencyGraphChange([{ change_type: "changed", name: "a" }])).toBe(false);
+    expect(isRemovalOnlyDependencyGraphChange([])).toBe(false);
+  });
+
+  it("renders dependency removals as informational", () => {
+    const body = renderRemovalOnlyDependencyComment({
+      dependencyGraphChanges: [
+        {
+          change_type: "removed",
+          manifest: "extensions/example/package.json",
+          name: "example-dependency",
+        },
+      ],
+      headSha,
+    });
+
+    expect(body).toContain("Dependency removals noted");
+    expect(body).toContain("does not require `/allow-dependencies-change`");
+    expect(body).toContain("Removed `example-dependency`");
+    expect(body).toContain("`extensions/example/package.json`");
+    expect(body).toContain(headSha);
+    expect(body).not.toContain("changes are blocked");
   });
 
   it("accepts only security-member override commands for the current head sha", () => {

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -221,6 +221,15 @@ describe("dependency guard workflow", () => {
     expect(script).toContain("process.exitCode = 1");
   });
 
+  it("keeps removal-only dependency changes informational", () => {
+    const script = readFileSync("scripts/github/dependency-guard.mjs", "utf8");
+
+    expect(script).toContain("isRemovalOnlyDependencyGraphChange");
+    expect(script).toContain("Dependency removals detected; guard is informational.");
+    expect(script).toContain("/dependency-graph/compare/");
+    expect(script).toContain('change.change_type === "removed"');
+  });
+
   it("cleans dependency label and guard comment after successful autoscrub", () => {
     const script = readFileSync("scripts/github/dependency-guard.mjs", "utf8");
     const autoscrubCommitIndex = script.indexOf("const commit = await createAutoscrubCommit");


### PR DESCRIPTION
Related: #116300

## What Problem This Solves

Fixes an issue where pull requests that only remove dependencies are blocked by the dependency guard until an admin or `@openclaw/openclaw-secops` member approves the exact head, even though the change cannot introduce a new package into the resolved graph.

## Why This Change Was Made

The guard now queries GitHub's dependency-graph compare endpoint for the PR's exact base and head SHAs. A non-empty comparison containing only `removed` entries is informational; any `added` entry still follows the existing exact-head admin/secops approval path. API errors, empty comparisons, and unexpected response entries remain fail-closed.

The policy surface remains CODEOWNED by `@openclaw/openclaw-secops`, so this PR still requires their review.

## User Impact

Contributors can remove obsolete dependencies without waiting for a security override. Dependency additions and version changes remain blocked until an authorized reviewer approves the current head SHA.

## Evidence

- Live GitHub API proof against #116300 returned HTTP 200 with exactly one entry: `change_type=removed`, `name=@openclaw/plugin-sdk`, `manifest=extensions/tencent/package.json`.
- GitHub's documented response contract exposes `change_type` as `added` or `removed`; version changes include an `added` entry and therefore remain blocked: https://docs.github.com/en/rest/dependency-graph/dependency-review?apiVersion=2022-11-28#compare-two-commits
- `node scripts/run-vitest.mjs test/scripts/dependency-guard-script.test.ts test/scripts/dependency-guard-workflow.test.ts` — 2 files, 44 tests passed.
- `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs` — passed on Blacksmith Testbox, including script/test typechecks, lint, formatting, declaration contracts, and guard checks.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
