### PR TITLE
fix(ui): keep canvas leases lifecycle-owned and timer-safe

### DIFF
--- a/ui/src/app/canvas-surface-lease.runtime.ts
+++ b/ui/src/app/canvas-surface-lease.runtime.ts
@@ -1,4 +1,6 @@
 // Loaded after hello so capability renewal does not inflate the startup chunk.
+import { resolveSafeTimeoutDelayMs } from "@openclaw/gateway-client/browser";
+
 const RENEWAL_LEAD_MS = 15_000;
 const MIN_RENEWAL_DELAY_MS = 1_000;
 // Used only when a refresh response omits expiry; an early one-minute refresh
@@ -45,6 +47,7 @@ export function createCanvasSurfaceLease<
   let consecutiveFailures = 0;
   let generation = 0;
   let started = false;
+  const ownsGeneration = (expected: number) => started && generation === expected;
 
   const clearScheduledRenewal = () => {
     if (timer !== null) {
@@ -54,17 +57,24 @@ export function createCanvasSurfaceLease<
   };
 
   const schedule = (delayMs: number, expectedGeneration: number) => {
+    if (!ownsGeneration(expectedGeneration)) {
+      return;
+    }
     clearScheduledRenewal();
-    timer = setTimer(() => {
-      timer = null;
-      if (started && generation === expectedGeneration) {
+    timer = setTimer(
+      () => {
+        if (!ownsGeneration(expectedGeneration)) {
+          return;
+        }
+        timer = null;
         renew(expectedGeneration);
-      }
-    }, delayMs);
+      },
+      resolveSafeTimeoutDelayMs(delayMs, { minMs: MIN_RENEWAL_DELAY_MS }),
+    );
   };
 
   const handleFailure = (expectedGeneration: number) => {
-    if (!started || generation !== expectedGeneration) {
+    if (!ownsGeneration(expectedGeneration)) {
       return;
     }
     consecutiveFailures += 1;
@@ -75,8 +85,7 @@ export function createCanvasSurfaceLease<
   const renew = (expectedGeneration: number) => {
     if (
       inFlight?.generation === expectedGeneration ||
-      !started ||
-      generation !== expectedGeneration ||
+      !ownsGeneration(expectedGeneration) ||
       !currentUrl
     ) {
       return;
@@ -85,7 +94,7 @@ export function createCanvasSurfaceLease<
     const request = Promise.resolve()
       .then(() => params.request("plugin.surface.refresh", { surface: "canvas", observedUrl }))
       .then((response) => {
-        if (!started || generation !== expectedGeneration || currentUrl !== observedUrl) {
+        if (!ownsGeneration(expectedGeneration) || currentUrl !== observedUrl) {
           return;
         }
         const refreshed = parseCanvasSurfaceRefresh(response);

--- a/ui/src/app/canvas-surface-lease.test.ts
+++ b/ui/src/app/canvas-surface-lease.test.ts
@@ -185,6 +185,96 @@ describe("createCanvasSurfaceLease", () => {
     expect(clock.nextDelayMs).toBe(60_000);
   });
 
+  it.each(["stops", "reconnects without a canvas"] as const)(
+    "does not schedule a retired generation when publishing a refreshed URL %s",
+    async (transition) => {
+      const clock = new FakeClock();
+      const changes: Array<string | null> = [];
+      const request = vi.fn(async () => ({
+        surface: "canvas",
+        pluginSurfaceUrls: { canvas: "https://canvas.test/__openclaw__/cap/refreshed" },
+        expiresAtMs: 120_000,
+      }));
+      const lease = createCanvasSurfaceLease({
+        request,
+        onChange: (url) => {
+          changes.push(url);
+          if (url === "https://canvas.test/__openclaw__/cap/refreshed") {
+            if (transition === "stops") {
+              lease.stop();
+            } else {
+              lease.start(undefined);
+            }
+          }
+        },
+        now: clock.now,
+        setTimer: clock.setTimer,
+        clearTimer: clock.clearTimer,
+      });
+
+      lease.start("https://canvas.test/__openclaw__/cap/original");
+      await flushPromises();
+
+      expect(request).toHaveBeenCalledOnce();
+      expect(changes).toEqual([
+        "https://canvas.test/__openclaw__/cap/original",
+        "https://canvas.test/__openclaw__/cap/refreshed",
+        null,
+      ]);
+      expect(clock.pendingCount).toBe(0);
+    },
+  );
+
+  it("keeps the reconnect renewal owned when a retired timer callback arrives late", async () => {
+    const request = vi
+      .fn<(method: string, params: unknown) => Promise<unknown>>()
+      .mockResolvedValueOnce({
+        surface: "canvas",
+        pluginSurfaceUrls: { canvas: "https://canvas.test/__openclaw__/cap/first" },
+        expiresAtMs: 120_000,
+      })
+      .mockResolvedValueOnce({
+        surface: "canvas",
+        pluginSurfaceUrls: { canvas: "https://canvas.test/__openclaw__/cap/reconnected" },
+        expiresAtMs: 180_000,
+      });
+    const { clock, lease } = createLeaseHarness(request);
+
+    lease.start("https://canvas.test/__openclaw__/cap/original");
+    await flushPromises();
+    const retiredCallback = clock.takeNextCallback();
+    expect(retiredCallback).toBeDefined();
+
+    lease.stop();
+    lease.start("https://canvas.test/__openclaw__/cap/reconnect");
+    await flushPromises();
+    expect(clock.pendingCount).toBe(1);
+
+    retiredCallback?.();
+    expect(request).toHaveBeenCalledTimes(2);
+    lease.stop();
+
+    expect(clock.pendingCount).toBe(0);
+  });
+
+  it.each([Number.MAX_SAFE_INTEGER, 2 ** 32 + 115_000])(
+    "clamps an advertised canvas expiry of %d to a browser-safe native timer",
+    async (expiresAtMs) => {
+      const request = vi.fn(async () => ({
+        surface: "canvas",
+        pluginSurfaceUrls: { canvas: "https://canvas.test/__openclaw__/cap/refreshed" },
+        expiresAtMs,
+      }));
+      const { clock, lease } = createLeaseHarness(request);
+
+      lease.start("https://canvas.test/__openclaw__/cap/original");
+      await flushPromises();
+
+      expect(clock.nextDelayMs).toBe(2_147_483_647);
+      lease.stop();
+    },
+  );
+
   it("stop clears timers, ignores an in-flight result, and publishes null once", async () => {
     const pending = deferred<unknown>();
     const { changes, clock, connectionChanges, lease } = createLeaseHarness(() => pending.promise);


### PR DESCRIPTION
## What Problem This Solves

Control UI canvas capability renewal had two independent lifecycle defects in its private scheduler:

1. A refreshed-URL observer can synchronously stop or reconnect the gateway, but the retired generation still installed a renewal timer. A late retired timer callback could also discard the current reconnect generation's timer handle, leaving the live renewal orphaned.
2. A legitimate safe-integer capability expiry beyond the native browser timer maximum was passed directly to `setTimeout`. Chromium converts delays above 2,147,483,647 ms into immediate callbacks, producing a real RPC storm.

On frozen current main `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`, independent Google Chrome 150 plus the full production `createApplicationGateway`, genuine device-authenticated WebSocket challenge, and actual canvas refresh RPCs produced **123 server requests and 122 URL rotations in 120 ms**. The same browser proof reproduced a timer being installed after stop and an active reconnect timer being orphaned.

## Why This Change Was Made

The existing canvas lease owns both the generation and its renewal timer, so both repairs belong in that one private scheduler. A canonical generation predicate now guards scheduling and checks stale callbacks **before** they mutate the active timer handle. All duplicate lifecycle checks reuse that predicate.

Every native delay goes through the existing exported browser-safe `resolveSafeTimeoutDelayMs` helper; normal expiry, minimum delay, retry backoff, missing-expiry renewal, and single-flight behavior stay unchanged.

Only one existing private production owner and its colocated tests change. There are no protocol, authentication, security, public configuration, persistence, dependency, or package-surface changes.

## User Impact

- Long-lived canvas widgets no longer overload the gateway with continuous capability-refresh requests.
- Disconnects and reconnects leave no retired or orphaned renewal timers.
- Canvas capability rotation still performs the initial refresh and preserves all normal retry behavior.

## Verification

Frozen base: `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`.

Immutable candidate: `e65158e7e953858ce3041159eb13831f51c817c6`.

- Dedicated Blacksmith Testbox exact production **and test blob** guards, six real UI owner/caller/browser/widget suites: **132/132 passing**, six files, no failures.
- Type-aware `oxlint --type-aware --type-check`, targeted `oxfmt --check`, and `git diff --check` all passed.
- Independent real Chrome 150 + complete production application gateway + real device-authenticated WebSocket: **15/15 assertions**, **123 refresh requests → exactly one**, safe 2,147,483,647-ms delay, zero retired timers after stop, current reconnect timer remains owned, zero browser errors.
- Two independent complete-owner/caller/dependency/history reviews: **zero P0/P1/P2/P3 findings**, confidence **0.99** each.
- Genuine full-branch P3 autoreview: TruffleHog clean, **zero findings**, patch correct, confidence **0.97**.

Native timer contracts: [Node.js timers](https://nodejs.org/api/timers.html#settimeoutcallback-delay-args) and [browser maximum timer delay](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value).
