### PR TITLE
fix(agents): cap DeepSeek DSML recovery buffer at 256 KB

### DIFF
--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -884,6 +884,10 @@ const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
 const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
+const DEEPSEEK_DSML_TOOL_MAX_BOUNDARY_TOKEN_LEN = Math.max(
+  DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN,
+  ...DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.map((token) => token.length),
+);
 
 // Match MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES / MAX_POST_TOOL_CALL_BUFFER_BYTES.
 const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
@@ -891,10 +895,39 @@ const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
 function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
   let bufferBytes = 0;
+  let discardDepth = 0;
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
     while (buffer) {
+      if (discardDepth > 0) {
+        const boundary = findEarliestDeepSeekDsmlToolBoundary(buffer);
+        if (!boundary) {
+          if (final) {
+            buffer = "";
+            discardDepth = 0;
+            return output;
+          }
+          const keep = longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(buffer);
+          buffer = keep > 0 ? buffer.slice(-keep) : "";
+          return output;
+        }
+
+        buffer = buffer.slice(boundary.index + boundary.token.length);
+        if (boundary.kind === "open") {
+          discardDepth += 1;
+        } else {
+          discardDepth -= 1;
+          if (discardDepth === 0) {
+            // The text filter saw the oversized opening block. Give it only
+            // the outer close so both parsers resume at the same boundary.
+            output.push({ kind: "text", text: boundary.token });
+            bufferBytes = Buffer.byteLength(buffer, "utf8");
+          }
+        }
+        continue;
+      }
+
       const open = findEarliestStringToken(buffer, DEEPSEEK_DSML_TOOL_OPEN_TOKENS);
       if (!open) {
         if (final) {
@@ -922,20 +955,40 @@ function createDeepSeekDsmlToolCallRecoverer() {
       }
 
       const afterOpen = buffer.slice(open.token.length);
-      const close = findEarliestStringToken(afterOpen, DEEPSEEK_DSML_TOOL_CLOSE_TOKENS);
-      if (!close) {
-        // Unterminated DSML: discard as text when the stream ends or the
-        // buffer exceeds the shared 256 KB UTF-8 cap (DoS guard).
-        if (final || bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
+      const blockScan = scanDeepSeekDsmlToolBlock(afterOpen);
+      if (!blockScan.close) {
+        if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
+          bufferBytes = 0;
+          return output;
+        }
+        if (bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
+          // Keep framing state after releasing the oversized buffer. Nested
+          // DSML must remain inert until the original outer block closes.
+          discardDepth = blockScan.depth;
+          output.push({ kind: "text", text: open.token });
+          const keep = longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(afterOpen);
+          buffer = keep > 0 ? afterOpen.slice(-keep) : "";
           bufferBytes = 0;
         }
         return output;
       }
 
-      const body = afterOpen.slice(0, close.index);
-      const blockText = buffer.slice(0, open.token.length + close.index + close.token.length);
+      const body = afterOpen.slice(0, blockScan.close.index);
+      const blockText = buffer.slice(
+        0,
+        open.token.length + blockScan.close.index + blockScan.close.token.length,
+      );
+      const blockBytes = Buffer.byteLength(blockText, "utf8");
+      if (blockBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
+        // A close arriving in the chunk that crosses the cap must not make an
+        // otherwise oversized block eligible for tool-call recovery.
+        output.push({ kind: "text", text: open.token + blockScan.close.token });
+        bufferBytes -= blockBytes;
+        buffer = buffer.slice(blockText.length);
+        continue;
+      }
       const recoveredToolCalls = parseDeepSeekDsmlToolCallBlock(body);
       if (recoveredToolCalls.length > 0) {
         output.push(...recoveredToolCalls);
@@ -950,8 +1003,10 @@ function createDeepSeekDsmlToolCallRecoverer() {
 
   return {
     push(chunk: string) {
+      if (discardDepth === 0) {
+        bufferBytes += utf8ByteLengthForAppend(buffer, chunk);
+      }
       buffer += chunk;
-      bufferBytes += Buffer.byteLength(chunk, "utf8");
       return consume(false);
     },
     flush() {
@@ -1057,10 +1112,10 @@ function decodeDeepSeekDsmlText(value: string): string {
     .replaceAll("&amp;", "&");
 }
 
-function findEarliestStringToken(text: string, tokens: readonly string[]) {
+function findEarliestStringToken(text: string, tokens: readonly string[], fromIndex = 0) {
   let best: { index: number; token: string } | null = null;
   for (const token of tokens) {
-    const index = text.indexOf(token);
+    const index = text.indexOf(token, fromIndex);
     if (index !== -1 && (!best || index < best.index)) {
       best = { index, token };
     }
@@ -1068,11 +1123,78 @@ function findEarliestStringToken(text: string, tokens: readonly string[]) {
   return best;
 }
 
+function findEarliestDeepSeekDsmlToolBoundary(text: string, fromIndex = 0) {
+  const open = findEarliestStringToken(text, DEEPSEEK_DSML_TOOL_OPEN_TOKENS, fromIndex);
+  const close = findEarliestStringToken(text, DEEPSEEK_DSML_TOOL_CLOSE_TOKENS, fromIndex);
+  if (!open) {
+    return close ? { kind: "close" as const, ...close } : null;
+  }
+  if (!close || open.index < close.index) {
+    return { kind: "open" as const, ...open };
+  }
+  return { kind: "close" as const, ...close };
+}
+
+function scanDeepSeekDsmlToolBlock(text: string) {
+  let depth = 1;
+  let offset = 0;
+  while (offset < text.length) {
+    const boundary = findEarliestDeepSeekDsmlToolBoundary(text, offset);
+    if (!boundary) {
+      break;
+    }
+    const index = boundary.index;
+    if (boundary.kind === "open") {
+      depth += 1;
+    } else {
+      depth -= 1;
+      if (depth === 0) {
+        return { close: { index, token: boundary.token }, depth };
+      }
+    }
+    offset = index + boundary.token.length;
+  }
+  return { close: null, depth };
+}
+
+function utf8ByteLengthForAppend(buffer: string, chunk: string) {
+  let bytes = Buffer.byteLength(chunk, "utf8");
+  if (!buffer || !chunk) {
+    return bytes;
+  }
+  const previousCodeUnit = buffer.charCodeAt(buffer.length - 1);
+  const nextCodeUnit = chunk.charCodeAt(0);
+  if (
+    previousCodeUnit >= 0xd800 &&
+    previousCodeUnit <= 0xdbff &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
+  ) {
+    // Each isolated surrogate counts as three UTF-8 bytes; the joined scalar is four.
+    bytes -= 2;
+  }
+  return bytes;
+}
+
 function longestDeepSeekDsmlToolOpenPrefixSuffixLength(text: string) {
   const maxLength = Math.min(text.length, DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN - 1);
   for (let length = maxLength; length > 0; length -= 1) {
     const suffix = text.slice(text.length - length);
     if (DEEPSEEK_DSML_TOOL_OPEN_TOKENS.some((token) => token.startsWith(suffix))) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+function longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(text: string) {
+  const maxLength = Math.min(text.length, DEEPSEEK_DSML_TOOL_MAX_BOUNDARY_TOKEN_LEN - 1);
+  for (let length = maxLength; length > 0; length -= 1) {
+    const suffix = text.slice(text.length - length);
+    if (
+      DEEPSEEK_DSML_TOOL_OPEN_TOKENS.some((token) => token.startsWith(suffix)) ||
+      DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.some((token) => token.startsWith(suffix))
+    ) {
       return length;
     }
   }

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -1210,7 +1210,7 @@ function scanDeepSeekDsmlToolBlock(
       invokeOpen ? { kind: "invoke-open" as const, ...invokeOpen } : null,
     ]
       .filter((candidate) => candidate !== null)
-      .sort((left, right) => left.index - right.index)[0];
+      .toSorted((left, right) => left.index - right.index)[0];
     if (!next) {
       state.offset = Math.max(
         contentStartIndex,

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -885,8 +885,12 @@ const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
 
+// Match MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES / MAX_POST_TOOL_CALL_BUFFER_BYTES.
+const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
+
 function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
+  let bufferBytes = 0;
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
@@ -896,41 +900,50 @@ function createDeepSeekDsmlToolCallRecoverer() {
         if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
+          bufferBytes = 0;
           return output;
         }
         const keep = longestDeepSeekDsmlToolOpenPrefixSuffixLength(buffer);
         const emitLength = buffer.length - keep;
         if (emitLength > 0) {
-          output.push({ kind: "text", text: buffer.slice(0, emitLength) });
-          buffer = buffer.slice(emitLength);
+          const emitted = buffer.slice(0, emitLength);
+          output.push({ kind: "text", text: emitted });
+          bufferBytes -= Buffer.byteLength(emitted, "utf8");
+          buffer = buffer.slice(emitted.length);
         }
         return output;
       }
 
       if (open.index > 0) {
-        output.push({ kind: "text", text: buffer.slice(0, open.index) });
-        buffer = buffer.slice(open.index);
+        const prefix = buffer.slice(0, open.index);
+        output.push({ kind: "text", text: prefix });
+        bufferBytes -= Buffer.byteLength(prefix, "utf8");
+        buffer = buffer.slice(prefix.length);
       }
 
       const afterOpen = buffer.slice(open.token.length);
       const close = findEarliestStringToken(afterOpen, DEEPSEEK_DSML_TOOL_CLOSE_TOKENS);
       if (!close) {
-        if (final) {
+        // Unterminated DSML: discard as text when the stream ends or the
+        // buffer exceeds the shared 256 KB UTF-8 cap (DoS guard).
+        if (final || bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
+          bufferBytes = 0;
         }
         return output;
       }
 
       const body = afterOpen.slice(0, close.index);
-      const blockLength = open.token.length + close.index + close.token.length;
+      const blockText = buffer.slice(0, open.token.length + close.index + close.token.length);
       const recoveredToolCalls = parseDeepSeekDsmlToolCallBlock(body);
       if (recoveredToolCalls.length > 0) {
         output.push(...recoveredToolCalls);
       } else {
-        output.push({ kind: "text", text: buffer.slice(0, blockLength) });
+        output.push({ kind: "text", text: blockText });
       }
-      buffer = buffer.slice(blockLength);
+      bufferBytes -= Buffer.byteLength(blockText, "utf8");
+      buffer = buffer.slice(blockText.length);
     }
     return output;
   };
@@ -938,6 +951,7 @@ function createDeepSeekDsmlToolCallRecoverer() {
   return {
     push(chunk: string) {
       buffer += chunk;
+      bufferBytes += Buffer.byteLength(chunk, "utf8");
       return consume(false);
     },
     flush() {

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -884,8 +884,7 @@ const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
 const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
-const DEEPSEEK_DSML_TOOL_MAX_BOUNDARY_TOKEN_LEN = Math.max(
-  DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN,
+const DEEPSEEK_DSML_TOOL_MAX_CLOSE_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.map((token) => token.length),
 );
 
@@ -895,41 +894,14 @@ const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
 function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
   let bufferBytes = 0;
-  let discardDepth = 0;
+  let closeSearchOffset = 0;
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
     while (buffer) {
-      if (discardDepth > 0) {
-        const boundary = findEarliestDeepSeekDsmlToolBoundary(buffer);
-        if (!boundary) {
-          if (final) {
-            buffer = "";
-            discardDepth = 0;
-            return output;
-          }
-          const keep = longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(buffer);
-          buffer = keep > 0 ? buffer.slice(-keep) : "";
-          return output;
-        }
-
-        buffer = buffer.slice(boundary.index + boundary.token.length);
-        if (boundary.kind === "open") {
-          discardDepth += 1;
-        } else {
-          discardDepth -= 1;
-          if (discardDepth === 0) {
-            // The text filter saw the oversized opening block. Give it only
-            // the outer close so both parsers resume at the same boundary.
-            output.push({ kind: "text", text: boundary.token });
-            bufferBytes = Buffer.byteLength(buffer, "utf8");
-          }
-        }
-        continue;
-      }
-
       const open = findEarliestStringToken(buffer, DEEPSEEK_DSML_TOOL_OPEN_TOKENS);
       if (!open) {
+        closeSearchOffset = 0;
         if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
@@ -952,11 +924,16 @@ function createDeepSeekDsmlToolCallRecoverer() {
         output.push({ kind: "text", text: prefix });
         bufferBytes -= Buffer.byteLength(prefix, "utf8");
         buffer = buffer.slice(prefix.length);
+        closeSearchOffset = 0;
       }
 
       const afterOpen = buffer.slice(open.token.length);
-      const blockScan = scanDeepSeekDsmlToolBlock(afterOpen);
-      if (!blockScan.close) {
+      const close = findEarliestStringToken(
+        afterOpen,
+        DEEPSEEK_DSML_TOOL_CLOSE_TOKENS,
+        closeSearchOffset,
+      );
+      if (!close) {
         if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
@@ -964,30 +941,21 @@ function createDeepSeekDsmlToolCallRecoverer() {
           return output;
         }
         if (bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
-          // Keep framing state after releasing the oversized buffer. Nested
-          // DSML must remain inert until the original outer block closes.
-          discardDepth = blockScan.depth;
-          output.push({ kind: "text", text: open.token });
-          const keep = longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(afterOpen);
-          buffer = keep > 0 ? afterOpen.slice(-keep) : "";
-          bufferBytes = 0;
+          throw new Error("Exceeded DeepSeek DSML recovery buffer limit");
         }
+        closeSearchOffset = Math.max(
+          0,
+          afterOpen.length - DEEPSEEK_DSML_TOOL_MAX_CLOSE_TOKEN_LEN + 1,
+        );
         return output;
       }
 
-      const body = afterOpen.slice(0, blockScan.close.index);
-      const blockText = buffer.slice(
-        0,
-        open.token.length + blockScan.close.index + blockScan.close.token.length,
-      );
+      closeSearchOffset = 0;
+      const body = afterOpen.slice(0, close.index);
+      const blockText = buffer.slice(0, open.token.length + close.index + close.token.length);
       const blockBytes = Buffer.byteLength(blockText, "utf8");
       if (blockBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
-        // A close arriving in the chunk that crosses the cap must not make an
-        // otherwise oversized block eligible for tool-call recovery.
-        output.push({ kind: "text", text: open.token + blockScan.close.token });
-        bufferBytes -= blockBytes;
-        buffer = buffer.slice(blockText.length);
-        continue;
+        throw new Error("Exceeded DeepSeek DSML recovery buffer limit");
       }
       const recoveredToolCalls = parseDeepSeekDsmlToolCallBlock(body);
       if (recoveredToolCalls.length > 0) {
@@ -1003,9 +971,7 @@ function createDeepSeekDsmlToolCallRecoverer() {
 
   return {
     push(chunk: string) {
-      if (discardDepth === 0) {
-        bufferBytes += utf8ByteLengthForAppend(buffer, chunk);
-      }
+      bufferBytes += utf8ByteLengthForAppend(buffer, chunk);
       buffer += chunk;
       return consume(false);
     },
@@ -1123,40 +1089,6 @@ function findEarliestStringToken(text: string, tokens: readonly string[], fromIn
   return best;
 }
 
-function findEarliestDeepSeekDsmlToolBoundary(text: string, fromIndex = 0) {
-  const open = findEarliestStringToken(text, DEEPSEEK_DSML_TOOL_OPEN_TOKENS, fromIndex);
-  const close = findEarliestStringToken(text, DEEPSEEK_DSML_TOOL_CLOSE_TOKENS, fromIndex);
-  if (!open) {
-    return close ? { kind: "close" as const, ...close } : null;
-  }
-  if (!close || open.index < close.index) {
-    return { kind: "open" as const, ...open };
-  }
-  return { kind: "close" as const, ...close };
-}
-
-function scanDeepSeekDsmlToolBlock(text: string) {
-  let depth = 1;
-  let offset = 0;
-  while (offset < text.length) {
-    const boundary = findEarliestDeepSeekDsmlToolBoundary(text, offset);
-    if (!boundary) {
-      break;
-    }
-    const index = boundary.index;
-    if (boundary.kind === "open") {
-      depth += 1;
-    } else {
-      depth -= 1;
-      if (depth === 0) {
-        return { close: { index, token: boundary.token }, depth };
-      }
-    }
-    offset = index + boundary.token.length;
-  }
-  return { close: null, depth };
-}
-
 function utf8ByteLengthForAppend(buffer: string, chunk: string) {
   let bytes = Buffer.byteLength(chunk, "utf8");
   if (!buffer || !chunk) {
@@ -1181,20 +1113,6 @@ function longestDeepSeekDsmlToolOpenPrefixSuffixLength(text: string) {
   for (let length = maxLength; length > 0; length -= 1) {
     const suffix = text.slice(text.length - length);
     if (DEEPSEEK_DSML_TOOL_OPEN_TOKENS.some((token) => token.startsWith(suffix))) {
-      return length;
-    }
-  }
-  return 0;
-}
-
-function longestDeepSeekDsmlToolBoundaryPrefixSuffixLength(text: string) {
-  const maxLength = Math.min(text.length, DEEPSEEK_DSML_TOOL_MAX_BOUNDARY_TOKEN_LEN - 1);
-  for (let length = maxLength; length > 0; length -= 1) {
-    const suffix = text.slice(text.length - length);
-    if (
-      DEEPSEEK_DSML_TOOL_OPEN_TOKENS.some((token) => token.startsWith(suffix)) ||
-      DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.some((token) => token.startsWith(suffix))
-    ) {
       return length;
     }
   }

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -881,31 +881,62 @@ const DEEPSEEK_DSML_TOOL_OPEN_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
 const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
   DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
 );
+const DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES = DEEPSEEK_DSML_BARS.map(
+  (bar) => `<${bar}DSML${bar}invoke`,
+);
+const DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.map(
+  (bar) => `</${bar}DSML${bar}invoke>`,
+);
 const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
-const DEEPSEEK_DSML_TOOL_MAX_CLOSE_TOKEN_LEN = Math.max(
+const DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN = Math.max(
+  ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
   ...DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.map((token) => token.length),
+  ...DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES.map((token) => token.length),
+  ...DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS.map((token) => token.length),
 );
 
 // Match MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES / MAX_POST_TOOL_CALL_BUFFER_BYTES.
 const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
+const DEEPSEEK_DSML_SCAN_BATCH_CHARS = 64 * 1_024;
+
+type DeepSeekDsmlToolBlockScanState = {
+  offset: number;
+  mode: "outer" | "invoke-open" | "invoke-body";
+  invokeOpenStart: number;
+};
 
 function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
   let bufferBytes = 0;
-  let closeSearchOffset = 0;
+  let bufferEndsWithHighSurrogate = false;
+  let pendingScanChars = 0;
+  let activeOpenToken: string | null = null;
+  let blockScanState: DeepSeekDsmlToolBlockScanState = {
+    offset: 0,
+    mode: "outer",
+    invokeOpenStart: -1,
+  };
+  const resetBlockScan = () => {
+    activeOpenToken = null;
+    pendingScanChars = 0;
+    blockScanState = { offset: 0, mode: "outer", invokeOpenStart: -1 };
+  };
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
     while (buffer) {
-      const open = findEarliestStringToken(buffer, DEEPSEEK_DSML_TOOL_OPEN_TOKENS);
+      const open = activeOpenToken
+        ? { index: 0, token: activeOpenToken }
+        : findEarliestStringToken(buffer, DEEPSEEK_DSML_TOOL_OPEN_TOKENS);
       if (!open) {
-        closeSearchOffset = 0;
+        resetBlockScan();
         if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
           bufferBytes = 0;
+          bufferEndsWithHighSurrogate = false;
           return output;
         }
         const keep = longestDeepSeekDsmlToolOpenPrefixSuffixLength(buffer);
@@ -915,6 +946,9 @@ function createDeepSeekDsmlToolCallRecoverer() {
           output.push({ kind: "text", text: emitted });
           bufferBytes -= Buffer.byteLength(emitted, "utf8");
           buffer = buffer.slice(emitted.length);
+          if (!buffer) {
+            bufferEndsWithHighSurrogate = false;
+          }
         }
         return output;
       }
@@ -924,35 +958,40 @@ function createDeepSeekDsmlToolCallRecoverer() {
         output.push({ kind: "text", text: prefix });
         bufferBytes -= Buffer.byteLength(prefix, "utf8");
         buffer = buffer.slice(prefix.length);
-        closeSearchOffset = 0;
+        resetBlockScan();
       }
 
-      const afterOpen = buffer.slice(open.token.length);
-      const close = findEarliestStringToken(
-        afterOpen,
-        DEEPSEEK_DSML_TOOL_CLOSE_TOKENS,
-        closeSearchOffset,
+      activeOpenToken = open.token;
+      if (blockScanState.offset === 0) {
+        blockScanState.offset = open.token.length;
+      }
+      const blockScan = scanDeepSeekDsmlToolBlock(
+        buffer,
+        open.token.replace("<", "</"),
+        open.token.length,
+        blockScanState,
       );
+      if (blockScan.kind === "nested-open") {
+        throw new Error("Nested DeepSeek DSML recovery wrappers are not supported");
+      }
+      const close = blockScan.kind === "close" ? blockScan : null;
       if (!close) {
         if (final) {
           output.push({ kind: "text", text: buffer });
           buffer = "";
           bufferBytes = 0;
+          bufferEndsWithHighSurrogate = false;
           return output;
         }
         if (bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
           throw new Error("Exceeded DeepSeek DSML recovery buffer limit");
         }
-        closeSearchOffset = Math.max(
-          0,
-          afterOpen.length - DEEPSEEK_DSML_TOOL_MAX_CLOSE_TOKEN_LEN + 1,
-        );
         return output;
       }
 
-      closeSearchOffset = 0;
-      const body = afterOpen.slice(0, close.index);
-      const blockText = buffer.slice(0, open.token.length + close.index + close.token.length);
+      resetBlockScan();
+      const body = buffer.slice(open.token.length, close.index);
+      const blockText = buffer.slice(0, close.index + close.token.length);
       const blockBytes = Buffer.byteLength(blockText, "utf8");
       if (blockBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
         throw new Error("Exceeded DeepSeek DSML recovery buffer limit");
@@ -965,14 +1004,30 @@ function createDeepSeekDsmlToolCallRecoverer() {
       }
       bufferBytes -= Buffer.byteLength(blockText, "utf8");
       buffer = buffer.slice(blockText.length);
+      if (!buffer) {
+        bufferEndsWithHighSurrogate = false;
+      }
     }
     return output;
   };
 
   return {
     push(chunk: string) {
-      bufferBytes += utf8ByteLengthForAppend(buffer, chunk);
+      const append = utf8ByteLengthForAppend(bufferEndsWithHighSurrogate, chunk);
+      bufferBytes += append.bytes;
+      bufferEndsWithHighSurrogate = append.endsWithHighSurrogate;
       buffer += chunk;
+      pendingScanChars += chunk.length;
+      if (
+        activeOpenToken &&
+        pendingScanChars < DEEPSEEK_DSML_SCAN_BATCH_CHARS &&
+        !chunk.includes("<") &&
+        !chunk.includes(">") &&
+        bufferBytes <= MAX_DSML_RECOVERY_BUFFER_BYTES
+      ) {
+        return [];
+      }
+      pendingScanChars = 0;
       return consume(false);
     },
     flush() {
@@ -983,23 +1038,23 @@ function createDeepSeekDsmlToolCallRecoverer() {
 
 function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlToolCall[] {
   const toolCalls: RecoveredDeepSeekDsmlToolCall[] = [];
-  const invokeOpenRegex = /<[|｜]DSML[|｜]invoke\b([^>]*)>/g;
+  const invokeOpenRegex = /<[|｜]DSML[|｜]invoke\b([^<>]*)>/g;
   let openMatch: RegExpExecArray | null;
   while ((openMatch = invokeOpenRegex.exec(body)) !== null) {
-    const invokeName = parseXmlAttribute(openMatch[1] ?? "", "name");
-    if (!invokeName) {
-      continue;
-    }
     const invokeBodyStart = openMatch.index + openMatch[0].length;
     const invokeClose = findEarliestStringToken(body.slice(invokeBodyStart), [
       "</|DSML|invoke>",
       "</｜DSML｜invoke>",
     ]);
     if (!invokeClose) {
-      continue;
+      break;
     }
     const invokeBody = body.slice(invokeBodyStart, invokeBodyStart + invokeClose.index);
     invokeOpenRegex.lastIndex = invokeBodyStart + invokeClose.index + invokeClose.token.length;
+    const invokeName = parseXmlAttribute(openMatch[1] ?? "", "name");
+    if (!invokeName) {
+      continue;
+    }
     const parsedArguments = parseDeepSeekDsmlInvokeArguments(invokeBody);
     if (!parsedArguments) {
       continue;
@@ -1089,23 +1144,106 @@ function findEarliestStringToken(text: string, tokens: readonly string[], fromIn
   return best;
 }
 
-function utf8ByteLengthForAppend(buffer: string, chunk: string) {
-  let bytes = Buffer.byteLength(chunk, "utf8");
-  if (!buffer || !chunk) {
-    return bytes;
+function scanDeepSeekDsmlToolBlock(
+  text: string,
+  closeToken: string,
+  contentStartIndex: number,
+  state: DeepSeekDsmlToolBlockScanState,
+):
+  | { kind: "close"; index: number; token: string }
+  | { kind: "nested-open"; index: number; token: string }
+  | { kind: "incomplete" } {
+  while (state.offset < text.length) {
+    if (state.mode === "invoke-open") {
+      const nextOpen = text.indexOf("<", state.offset);
+      const nextClose = text.indexOf(">", state.offset);
+      if (nextClose === -1 && nextOpen === -1) {
+        state.offset = text.length;
+        return { kind: "incomplete" };
+      }
+      if (nextOpen !== -1 && (nextClose === -1 || nextOpen < nextClose)) {
+        state.mode = "outer";
+        state.offset = nextOpen;
+        state.invokeOpenStart = -1;
+        continue;
+      }
+      const invokeOpenTag = text.slice(state.invokeOpenStart, nextClose + 1);
+      if (!/^<[|｜]DSML[|｜]invoke\b[^<>]*>$/.test(invokeOpenTag)) {
+        state.mode = "outer";
+        state.offset = state.invokeOpenStart + 1;
+        state.invokeOpenStart = -1;
+        continue;
+      }
+      state.mode = "invoke-body";
+      state.offset = nextClose + 1;
+      state.invokeOpenStart = -1;
+      continue;
+    }
+
+    if (state.mode === "invoke-body") {
+      const invokeClose = findEarliestStringToken(
+        text,
+        DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS,
+        state.offset,
+      );
+      if (!invokeClose) {
+        state.offset = Math.max(0, text.length - DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN + 1);
+        return { kind: "incomplete" };
+      }
+      state.mode = "outer";
+      state.offset = invokeClose.index + invokeClose.token.length;
+      continue;
+    }
+
+    const toolOpen = findEarliestStringToken(text, DEEPSEEK_DSML_TOOL_OPEN_TOKENS, state.offset);
+    const toolCloseIndex = text.indexOf(closeToken, state.offset);
+    const invokeOpen = findEarliestStringToken(
+      text,
+      DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES,
+      state.offset,
+    );
+    const next = [
+      toolOpen ? { kind: "nested-open" as const, ...toolOpen } : null,
+      toolCloseIndex === -1
+        ? null
+        : { kind: "close" as const, index: toolCloseIndex, token: closeToken },
+      invokeOpen ? { kind: "invoke-open" as const, ...invokeOpen } : null,
+    ]
+      .filter((candidate) => candidate !== null)
+      .sort((left, right) => left.index - right.index)[0];
+    if (!next) {
+      state.offset = Math.max(
+        contentStartIndex,
+        text.length - DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN + 1,
+      );
+      return { kind: "incomplete" };
+    }
+    if (next.kind === "invoke-open") {
+      state.mode = "invoke-open";
+      state.invokeOpenStart = next.index;
+      state.offset = next.index + next.token.length;
+      continue;
+    }
+    return next;
   }
-  const previousCodeUnit = buffer.charCodeAt(buffer.length - 1);
+  return { kind: "incomplete" };
+}
+
+function utf8ByteLengthForAppend(bufferEndsWithHighSurrogate: boolean, chunk: string) {
+  let bytes = Buffer.byteLength(chunk, "utf8");
+  if (!chunk) {
+    return { bytes, endsWithHighSurrogate: bufferEndsWithHighSurrogate };
+  }
   const nextCodeUnit = chunk.charCodeAt(0);
-  if (
-    previousCodeUnit >= 0xd800 &&
-    previousCodeUnit <= 0xdbff &&
-    nextCodeUnit >= 0xdc00 &&
-    nextCodeUnit <= 0xdfff
-  ) {
+  if (bufferEndsWithHighSurrogate && nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
     // Each isolated surrogate counts as three UTF-8 bytes; the joined scalar is four.
     bytes -= 2;
   }
-  return bytes;
+  const finalCodeUnit = chunk.charCodeAt(chunk.length - 1);
+  return {
+    bytes,
+    endsWithHighSurrogate: finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff,
+  };
 }
 
 function longestDeepSeekDsmlToolOpenPrefixSuffixLength(text: string) {

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -465,6 +465,105 @@ describe("openai transport stream", () => {
     ).rejects.toThrow("Exceeded DeepSeek DSML recovery buffer limit");
   });
 
+  it("does not carry surrogate accounting across emitted visible text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks([
+          makeCompletionsChunk({ content: "\ud83d" }),
+          makeCompletionsChunk({ content: "\ude00" }),
+          makeCompletionsChunk({
+            content: "<|DSML|tool_calls>" + "x".repeat(256_001),
+          }),
+          makeCompletionsChunk({}, "stop"),
+        ]),
+        output,
+        model,
+        { push() {} },
+      ),
+    ).rejects.toThrow("Exceeded DeepSeek DSML recovery buffer limit");
+  });
+
+  it("rejects a nested DSML wrapper before the original outer close", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: Array<{ type: string }> = [];
+
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks([
+          makeCompletionsChunk({ content: "<|DSML|tool_calls><|DSML|tool_" }),
+          makeCompletionsChunk({
+            content:
+              'calls><|DSML|invoke name="read">{"path":"/tmp/nested.md"}</|DSML|invoke></|DSML|tool_calls>',
+          }),
+          makeCompletionsChunk({ content: "</|DSML|tool_calls>" }, "stop"),
+        ]),
+        output,
+        model,
+        {
+          push(event) {
+            events.push(event);
+          },
+        },
+      ),
+    ).rejects.toThrow("Nested DeepSeek DSML recovery wrappers are not supported");
+    expect(events.filter((event) => event.type.startsWith("toolcall_"))).toEqual([]);
+    expect(output.content.some((part) => part.type === "toolCall")).toBe(false);
+  });
+
+  it("does not accept a different DSML wrapper kind as the outer close", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          content:
+            '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/mismatch.md"}</|DSML|invoke></|DSML|function_calls>',
+        }),
+        makeCompletionsChunk({}, "stop"),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content.some((part) => part.type === "toolCall")).toBe(false);
+  });
+
+  it("does not rewind across the outer opener after a short first body chunk", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ content: "<|DSML|tool_calls>\n" }),
+        makeCompletionsChunk({
+          content:
+            '<|DSML|invoke name="read">{"path":"/tmp/fragmented.md"}</|DSML|invoke></|DSML|tool_calls>',
+        }),
+        makeCompletionsChunk({}, "stop"),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "read",
+        arguments: { path: "/tmp/fragmented.md" },
+      },
+    ]);
+  });
+
   it("treats DSML-looking text inside a parameter value as payload", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
@@ -473,6 +572,86 @@ describe("openai transport stream", () => {
       '<｜DSML｜parameter name="text" string="true">' +
       "literal <｜DSML｜tool_calls> marker" +
       "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>";
+
+    const chunks = [...content].map((char) => makeCompletionsChunk({ content: char }));
+    chunks.push(makeCompletionsChunk({}, "stop"));
+    await testing.processOpenAICompletionsStream(streamChunks(chunks), output, model, {
+      push() {},
+    });
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "message",
+        arguments: { text: "literal <｜DSML｜tool_calls> marker" },
+      },
+    ]);
+  });
+
+  it("ignores an incomplete invoke-like prefix before a valid invoke", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const content =
+      "<|DSML|tool_calls>literal <|DSML|invoke marker " +
+      '<|DSML|invoke name="read">{"path":"/tmp/valid.md"}</|DSML|invoke>' +
+      "</|DSML|tool_calls>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks(
+        [...content]
+          .map((char) => makeCompletionsChunk({ content: char }))
+          .concat([makeCompletionsChunk({}, "stop")]),
+      ),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "read",
+        arguments: { path: "/tmp/valid.md" },
+      },
+    ]);
+  });
+
+  it("does not recover a nested call hidden inside a nameless invoke", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: Array<{ type: string }> = [];
+    const content =
+      "<|DSML|tool_calls><|DSML|invoke><|DSML|tool_calls>" +
+      '<|DSML|invoke name="read">{"path":"/tmp/bypass"}</|DSML|invoke>' +
+      "</|DSML|tool_calls>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([makeCompletionsChunk({ content }), makeCompletionsChunk({}, "stop")]),
+      output,
+      model,
+      {
+        push(event) {
+          events.push(event);
+        },
+      },
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(events.filter((event) => event.type.startsWith("toolcall_"))).toEqual([]);
+    expect(output.content.some((part) => part.type === "toolCall")).toBe(false);
+  });
+
+  it("treats DSML-looking text inside JSON arguments as payload", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const content =
+      '<|DSML|tool_calls><|DSML|invoke name="message">' +
+      '{"text":"literal <|DSML|tool_calls> marker"}' +
+      "</|DSML|invoke></|DSML|tool_calls>";
 
     await testing.processOpenAICompletionsStream(
       streamChunks([makeCompletionsChunk({ content }, "stop")]),
@@ -487,7 +666,7 @@ describe("openai transport stream", () => {
         type: "toolCall",
         id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
         name: "message",
-        arguments: { text: "literal <｜DSML｜tool_calls> marker" },
+        arguments: { text: "literal <|DSML|tool_calls> marker" },
       },
     ]);
   });

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -489,7 +489,7 @@ describe("openai transport stream", () => {
   it("rejects a nested DSML wrapper before the original outer close", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
-    const events: Array<{ type: string }> = [];
+    const events: CapturedStreamEvent[] = [];
 
     await expect(
       testing.processOpenAICompletionsStream(
@@ -505,7 +505,7 @@ describe("openai transport stream", () => {
         model,
         {
           push(event) {
-            events.push(event);
+            events.push(event as CapturedStreamEvent);
           },
         },
       ),
@@ -573,7 +573,7 @@ describe("openai transport stream", () => {
       "literal <｜DSML｜tool_calls> marker" +
       "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>";
 
-    const chunks = [...content].map((char) => makeCompletionsChunk({ content: char }));
+    const chunks = Array.from(content, (char) => makeCompletionsChunk({ content: char }));
     chunks.push(makeCompletionsChunk({}, "stop"));
     await testing.processOpenAICompletionsStream(streamChunks(chunks), output, model, {
       push() {},
@@ -600,9 +600,9 @@ describe("openai transport stream", () => {
 
     await testing.processOpenAICompletionsStream(
       streamChunks(
-        [...content]
-          .map((char) => makeCompletionsChunk({ content: char }))
-          .concat([makeCompletionsChunk({}, "stop")]),
+        Array.from(content, (char) => makeCompletionsChunk({ content: char })).concat([
+          makeCompletionsChunk({}, "stop"),
+        ]),
       ),
       output,
       model,
@@ -623,7 +623,7 @@ describe("openai transport stream", () => {
   it("does not recover a nested call hidden inside a nameless invoke", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
-    const events: Array<{ type: string }> = [];
+    const events: CapturedStreamEvent[] = [];
     const content =
       "<|DSML|tool_calls><|DSML|invoke><|DSML|tool_calls>" +
       '<|DSML|invoke name="read">{"path":"/tmp/bypass"}</|DSML|invoke>' +
@@ -635,7 +635,7 @@ describe("openai transport stream", () => {
       model,
       {
         push(event) {
-          events.push(event);
+          events.push(event as CapturedStreamEvent);
         },
       },
     );

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -289,26 +289,25 @@ describe("openai transport stream", () => {
       content.slice(index * 4096, (index + 1) * 4096),
     );
 
-    await testing.processOpenAICompletionsStream(
-      streamChunks(
-        chunks.map((contentChunk, index) =>
-          makeCompletionsChunk(
-            { content: contentChunk },
-            index === chunks.length - 1 ? "stop" : null,
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks(
+          chunks.map((contentChunk, index) =>
+            makeCompletionsChunk(
+              { content: contentChunk },
+              index === chunks.length - 1 ? "stop" : null,
+            ),
           ),
         ),
+        output,
+        model,
+        { push: (event) => events.push(event as CapturedStreamEvent) },
       ),
-      output,
-      model,
-      { push: (event) => events.push(event as CapturedStreamEvent) },
-    );
-
-    expect(output.stopReason).toBe("stop");
-    expect(output.content).toEqual([{ type: "text", text: " after" }]);
+    ).rejects.toThrow("Exceeded DeepSeek DSML recovery buffer limit");
     expect(events.filter((event) => event.type?.startsWith("toolcall_"))).toEqual([]);
   });
 
-  it("discards oversized DeepSeek DSML recovery buffer with multibyte UTF-8 text", async () => {
+  it("rejects an oversized DeepSeek DSML recovery buffer using UTF-8 bytes", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
 
@@ -318,21 +317,21 @@ describe("openai transport stream", () => {
       "\u00E9".repeat(200_000) +
       "</｜DSML｜parameter></｜DSML｜invoke>";
 
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "<｜DSML｜tool_calls>" + multibyteBody,
-          },
-          "stop",
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks([
+          makeCompletionsChunk(
+            {
+              content: "<｜DSML｜tool_calls>" + multibyteBody,
+            },
+            "stop",
+          ),
+        ]),
+        output,
+        model,
+        { push() {} },
+      ),
+    ).rejects.toThrow("Exceeded DeepSeek DSML recovery buffer limit");
   });
 
   it("counts split surrogate pairs exactly at the DeepSeek DSML recovery cap", async () => {
@@ -371,11 +370,7 @@ describe("openai transport stream", () => {
     ]);
   });
 
-  it("discards nested DSML over SSE until the split outer close, then resumes recovery", async () => {
-    const nestedCall = (name: string) =>
-      `<|DSML|tool_calls><|DSML|invoke name="${name}">{"value":"nested"}</|DSML|invoke></|DSML|tool_calls>`;
-    const finalCall =
-      '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/final.md"}</|DSML|invoke></|DSML|tool_calls>';
+  it("surfaces an oversized DeepSeek DSML recovery buffer as a transport error", async () => {
     const server = createServer((req, res) => {
       req.resume();
       req.on("end", () => {
@@ -388,15 +383,7 @@ describe("openai transport stream", () => {
           makeCompletionsChunk({
             content: "<|DSML|tool_calls>" + "x".repeat(300_000),
           }),
-          makeCompletionsChunk({
-            content:
-              nestedCall("nested_one") +
-              "<|DSML|tool_use_error>ignored</|DSML|tool_use_error>" +
-              nestedCall("nested_two") +
-              "</|DSML|tool_",
-          }),
-          makeCompletionsChunk({ content: "calls> after " + finalCall }),
-          makeCompletionsChunk({}, "tool_calls"),
+          makeCompletionsChunk({}, "stop"),
         ]) {
           res.write(`data: ${JSON.stringify(chunk)}\n\n`);
         }
@@ -428,41 +415,81 @@ describe("openai transport stream", () => {
 
       const events: Array<{
         type: string;
-        delta?: string;
         reason?: string;
-        message?: {
-          content?: Array<{
-            type?: string;
-            text?: string;
-            name?: string;
-            arguments?: Record<string, unknown>;
-          }>;
-        };
+        error?: { errorMessage?: string; content?: unknown[] };
       }> = [];
       for await (const event of stream as AsyncIterable<(typeof events)[number]>) {
         events.push(event);
       }
 
-      const done = events.find((event) => event.type === "done");
-      expect(done?.reason).toBe("toolUse");
-      expect(done?.message?.content).toEqual([
-        expect.objectContaining({ type: "text", text: " after " }),
+      expect(events).toContainEqual(
         expect.objectContaining({
-          type: "toolCall",
-          name: "read",
-          arguments: { path: "/tmp/final.md" },
+          type: "error",
+          reason: "error",
+          error: expect.objectContaining({
+            errorMessage: "Exceeded DeepSeek DSML recovery buffer limit",
+            content: [],
+          }),
         }),
-      ]);
-      expect(events.filter((event) => event.type === "toolcall_start")).toHaveLength(1);
-      expect(events.filter((event) => event.type === "toolcall_delta")).toHaveLength(1);
-      expect(JSON.stringify(events)).not.toContain("nested_one");
-      expect(JSON.stringify(events)).not.toContain("nested_two");
-      expect(JSON.stringify(events)).not.toContain("DSML");
+      );
+      expect(events.filter((event) => event.type === "toolcall_start")).toEqual([]);
+      expect(events.filter((event) => event.type === "toolcall_delta")).toEqual([]);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       });
     }
+  });
+
+  it("fails before a later DSML call after overflow can be authorized", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const laterCall =
+      '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls>';
+
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks([
+          makeCompletionsChunk({
+            content: "<|DSML|tool_calls>" + "x".repeat(256_001),
+          }),
+          makeCompletionsChunk({
+            content: "</|DSML|function_calls> after " + laterCall,
+          }),
+          makeCompletionsChunk({}, "tool_calls"),
+        ]),
+        output,
+        model,
+        { push() {} },
+      ),
+    ).rejects.toThrow("Exceeded DeepSeek DSML recovery buffer limit");
+  });
+
+  it("treats DSML-looking text inside a parameter value as payload", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const content =
+      '<｜DSML｜tool_calls><｜DSML｜invoke name="message">' +
+      '<｜DSML｜parameter name="text" string="true">' +
+      "literal <｜DSML｜tool_calls> marker" +
+      "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([makeCompletionsChunk({ content }, "stop")]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "message",
+        arguments: { text: "literal <｜DSML｜tool_calls> marker" },
+      },
+    ]);
   });
 
   it.each([

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -275,35 +275,37 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
-  it("discards oversized DeepSeek DSML recovery buffer as text", async () => {
+  it("rejects an oversized DeepSeek DSML block when the crossing chunk contains its close", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
 
-    // Unterminated body well above the 256 KB recovery cap.
-    const hugeBody =
-      '<｜DSML｜invoke name="session_status"><｜DSML｜parameter name="key" string="true">' +
-      "x".repeat(300_000) +
-      "</｜DSML｜parameter></｜DSML｜invoke>";
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk({
-          content: "<｜DSML｜tool_calls>" + hugeBody,
-        }),
-        makeCompletionsChunk(
-          {
-            content: "</｜DSML｜tool_calls>",
-          },
-          "stop",
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
+    const prefix = '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"';
+    const suffix = '"}</|DSML|invoke></|DSML|tool_calls>';
+    const padding = "x".repeat(256_001 - Buffer.byteLength(prefix + suffix, "utf8"));
+    const content = prefix + padding + suffix + " after";
+    expect(Buffer.byteLength(prefix + padding + suffix, "utf8")).toBe(256_001);
+    const chunks = Array.from({ length: Math.ceil(content.length / 4096) }, (_, index) =>
+      content.slice(index * 4096, (index + 1) * 4096),
     );
 
-    // Cap discards the open block as text; no tool calls recovered.
-    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+    await testing.processOpenAICompletionsStream(
+      streamChunks(
+        chunks.map((contentChunk, index) =>
+          makeCompletionsChunk(
+            { content: contentChunk },
+            index === chunks.length - 1 ? "stop" : null,
+          ),
+        ),
+      ),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toEqual([{ type: "text", text: " after" }]);
+    expect(events.filter((event) => event.type?.startsWith("toolcall_"))).toEqual([]);
   });
 
   it("discards oversized DeepSeek DSML recovery buffer with multibyte UTF-8 text", async () => {
@@ -318,12 +320,9 @@ describe("openai transport stream", () => {
 
     await testing.processOpenAICompletionsStream(
       streamChunks([
-        makeCompletionsChunk({
-          content: "<｜DSML｜tool_calls>" + multibyteBody,
-        }),
         makeCompletionsChunk(
           {
-            content: "</｜DSML｜tool_calls>",
+            content: "<｜DSML｜tool_calls>" + multibyteBody,
           },
           "stop",
         ),
@@ -334,6 +333,136 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+  });
+
+  it("counts split surrogate pairs exactly at the DeepSeek DSML recovery cap", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const prefix = '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"';
+    const suffix = '"}</|DSML|invoke>';
+    const outerClose = "</|DSML|tool_calls>";
+    const emoji = "\u{1f600}";
+    const padding = "x".repeat(
+      256_000 - Buffer.byteLength(prefix + emoji + suffix + outerClose, "utf8"),
+    );
+    const beforeSplit = prefix + padding + "\uD83D";
+    const afterSplit = "\uDE00" + suffix;
+    expect(Buffer.byteLength(beforeSplit + afterSplit + outerClose, "utf8")).toBe(256_000);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ content: beforeSplit }),
+        makeCompletionsChunk({ content: afterSplit }),
+        makeCompletionsChunk({ content: outerClose }, "stop"),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "read",
+        arguments: { path: padding + emoji },
+      },
+    ]);
+  });
+
+  it("discards nested DSML over SSE until the split outer close, then resumes recovery", async () => {
+    const nestedCall = (name: string) =>
+      `<|DSML|tool_calls><|DSML|invoke name="${name}">{"value":"nested"}</|DSML|invoke></|DSML|tool_calls>`;
+    const finalCall =
+      '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/final.md"}</|DSML|invoke></|DSML|tool_calls>';
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of [
+          makeCompletionsChunk({
+            content: "<|DSML|tool_calls>" + "x".repeat(300_000),
+          }),
+          makeCompletionsChunk({
+            content:
+              nestedCall("nested_one") +
+              "<|DSML|tool_use_error>ignored</|DSML|tool_use_error>" +
+              nestedCall("nested_two") +
+              "</|DSML|tool_",
+          }),
+          makeCompletionsChunk({ content: "calls> after " + finalCall }),
+          makeCompletionsChunk({}, "tool_calls"),
+        ]) {
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        }
+        res.end("data: [DONE]\n\n");
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = makeCompletionsModel({
+        ...createDeepSeekCompletionsModel(),
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      });
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Read the file", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      const events: Array<{
+        type: string;
+        delta?: string;
+        reason?: string;
+        message?: {
+          content?: Array<{
+            type?: string;
+            text?: string;
+            name?: string;
+            arguments?: Record<string, unknown>;
+          }>;
+        };
+      }> = [];
+      for await (const event of stream as AsyncIterable<(typeof events)[number]>) {
+        events.push(event);
+      }
+
+      const done = events.find((event) => event.type === "done");
+      expect(done?.reason).toBe("toolUse");
+      expect(done?.message?.content).toEqual([
+        expect.objectContaining({ type: "text", text: " after " }),
+        expect.objectContaining({
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "/tmp/final.md" },
+        }),
+      ]);
+      expect(events.filter((event) => event.type === "toolcall_start")).toHaveLength(1);
+      expect(events.filter((event) => event.type === "toolcall_delta")).toHaveLength(1);
+      expect(JSON.stringify(events)).not.toContain("nested_one");
+      expect(JSON.stringify(events)).not.toContain("nested_two");
+      expect(JSON.stringify(events)).not.toContain("DSML");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it.each([

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -510,7 +510,7 @@ describe("openai transport stream", () => {
         },
       ),
     ).rejects.toThrow("Nested DeepSeek DSML recovery wrappers are not supported");
-    expect(events.filter((event) => event.type.startsWith("toolcall_"))).toEqual([]);
+    expect(events.filter((event) => event.type?.startsWith("toolcall_") === true)).toEqual([]);
     expect(output.content.some((part) => part.type === "toolCall")).toBe(false);
   });
 
@@ -641,7 +641,7 @@ describe("openai transport stream", () => {
     );
 
     expect(output.stopReason).toBe("stop");
-    expect(events.filter((event) => event.type.startsWith("toolcall_"))).toEqual([]);
+    expect(events.filter((event) => event.type?.startsWith("toolcall_") === true)).toEqual([]);
     expect(output.content.some((part) => part.type === "toolCall")).toBe(false);
   });
 

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -275,6 +275,67 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
+  it("discards oversized DeepSeek DSML recovery buffer as text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    // Unterminated body well above the 256 KB recovery cap.
+    const hugeBody =
+      '<｜DSML｜invoke name="session_status"><｜DSML｜parameter name="key" string="true">' +
+      "x".repeat(300_000) +
+      "</｜DSML｜parameter></｜DSML｜invoke>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          content: "<｜DSML｜tool_calls>" + hugeBody,
+        }),
+        makeCompletionsChunk(
+          {
+            content: "</｜DSML｜tool_calls>",
+          },
+          "stop",
+        ),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    // Cap discards the open block as text; no tool calls recovered.
+    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+  });
+
+  it("discards oversized DeepSeek DSML recovery buffer with multibyte UTF-8 text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    // 200k "é": .length under 256k string units, UTF-8 bytes over 256k.
+    const multibyteBody =
+      '<｜DSML｜invoke name="session_status"><｜DSML｜parameter name="key" string="true">' +
+      "\u00E9".repeat(200_000) +
+      "</｜DSML｜parameter></｜DSML｜invoke>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          content: "<｜DSML｜tool_calls>" + multibyteBody,
+        }),
+        makeCompletionsChunk(
+          {
+            content: "</｜DSML｜tool_calls>",
+          },
+          "stop",
+        ),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+  });
+
   it.each([
     { finishReason: "length", stopReason: "length" },
     { finishReason: "content_filter", stopReason: "error" },


### PR DESCRIPTION
Fixes #90015

Recreates closed #86637 (barnacle inactivity auto-close) on current main.

## What Problem This Solves

DeepSeek-compatible providers can stream textual DSML tool-call markup. An unterminated outer DSML block previously grew the recovery buffer without a bound, allowing a buggy or hostile stream to consume memory for the lifetime of the response.

## Why This Change Was Made

The DSML recovery owner now enforces a 256 KB UTF-8 limit, matching the existing native tool-call argument and post-tool text limits.

- Closing-token search resumes from the unscanned suffix instead of rescanning the accumulated block on every streamed chunk.
- A block over the limit fails immediately with `Exceeded DeepSeek DSML recovery buffer limit`.
- Outer wrapper kinds must close exactly, and nested wrappers fail closed before any tool event is authorized.
- Complete invoke bodies remain opaque to structural wrapper scanning, while nameless or malformed invokes cannot expose nested executable calls.
- Overflow cannot authorize a later textual tool call.
- DSML-looking text inside a valid parameter value remains payload data rather than parser structure.
- Split surrogate pairs retain exact UTF-8 byte accounting without leaking accounting state across emitted text.

The explicit transport error is intentional: it gives the operator and retry layer a visible outcome instead of silently discarding the remainder of the response or guessing where nested recovery can resume.

No config, protocol, or public API surface changes.

## User Impact

Malformed or malicious DeepSeek DSML streams can no longer grow recovery memory without bound. Valid DSML calls at or below the limit continue to recover normally. Valid textual DSML blocks above 256 KB now fail visibly; maintainers accept that compatibility tradeoff because it matches the existing native tool-call safety envelope.

## Evidence

Exact repaired head: `440804456395c8bbcfb319e93c4cccc9e3d86e11`

### Sanitized exact-head AWS proof

- Provider: direct AWS Crabbox, public networking, no Tailscale, empty instance profile, no credential hydration
- Focused tests: https://crabbox.openclaw.ai/portal/runs/run_0178e6747612
- Standalone production-transport runtime: https://crabbox.openclaw.ai/portal/runs/run_e3baa07ab8fe

```console
$ pnpm test src/agents/openai-transport-stream.deepseek-and-shaping.test.ts src/agents/deepseek-text-filter.test.ts
Test Files  2 passed (2)
Tests       65 passed (65)
```

The standalone script used `createOpenAICompletionsTransportStreamFn()` directly against a loopback OpenAI-compatible SSE endpoint, without Vitest or test-support imports:

```json
{"exactHead":"440804456395c8bbcfb319e93c4cccc9e3d86e11","oversized":{"terminal":"error","reason":"error","errorMessage":"Exceeded DeepSeek DSML recovery buffer limit","toolEvents":0},"nested":{"terminal":"error","reason":"error","errorMessage":"Nested DeepSeek DSML recovery wrappers are not supported","toolEvents":0},"namelessInvoke":{"terminal":"done","reason":"stop","toolEvents":0},"valid":{"terminal":"done","reason":"toolUse","toolName":"message","arguments":{"text":"literal <｜DSML｜tool_calls> marker"}}}
```

Coverage includes:

- a 256,001-byte block whose closing token arrives in the cap-crossing chunk
- multibyte overflow and exact-cap split-surrogate accounting
- a later textual call after overflow remaining unauthorized
- nested wrappers, mismatched closes, malformed invoke prefixes, and nameless-invoke nesting remaining unauthorized
- valid raw parameter and JSON payloads containing DSML-looking markers
- character-by-character canonical full-width DSML fragmentation
- production HTTP/SSE transport error propagation
- existing ordinary, split, repeated, malformed, native-call, text-filter, and terminal-safety behavior

### Review and static proof

- `git diff --check`: pass
- `oxfmt --check` on both changed files: pass
- fresh exact-head autoreview: clean, patch correct, confidence `0.99`
- production delta from the original uncapped parent: `+195/-17` (`+178` net); tests: `+363/-28`

The positive production delta is the bounded structural scanner and byte-accounting owner needed to prevent provider text from crossing into executable tool-call events through malformed wrapper boundaries.

- GitHub CI attempt 2: pass after rerunning the `check-lint` job that was terminated by runner shutdown on attempt 1
- Required gate: https://github.com/openclaw/openclaw/actions/runs/30694129719/job/91355636987
- Exact-head ClawSweeper: no findings, proof sufficient, platinum readiness: https://github.com/openclaw/openclaw/pull/117175#issuecomment-5149461336
