### PR TITLE
test(gateway): pin MCP loopback drain proof to a server-side barrier

### DIFF
--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -3413,13 +3413,22 @@ describe("createMcpLoopbackServerConfig", () => {
     if (!oldRuntime) {
       throw new Error("expected old MCP loopback runtime");
     }
-    let stalledRequest: ReturnType<typeof request> | undefined;
-    let resolveSocketReady: () => void = () => {};
-    let rejectSocketReady: (error: Error) => void = () => {};
-    const socketReady = new Promise<void>((resolve, reject) => {
-      resolveSocketReady = resolve;
-      rejectSocketReady = reject;
+    // Node only exempts a connection from close()'s idle sweep once its parser has
+    // begun a message, so the drain is pinned by the server-side request start, not
+    // by the client-side connect. Capture admission is that server-side signal.
+    const captureKey = "capture-stalled-drain";
+    let resolveRequestStarted: () => void = () => {};
+    let rejectRequestStarted: (error: Error) => void = () => {};
+    const requestStarted = new Promise<void>((resolve, reject) => {
+      resolveRequestStarted = resolve;
+      rejectRequestStarted = reject;
     });
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onRequestStart: () => resolveRequestStarted(),
+      onToolCallResult: vi.fn(),
+    });
+    let stalledRequest: ReturnType<typeof request> | undefined;
     const responsePromise = new Promise<void>((resolve, reject) => {
       const req = request(
         {
@@ -3431,6 +3440,7 @@ describe("createMcpLoopbackServerConfig", () => {
             authorization: `Bearer ${oldRuntime.ownerToken}`,
             connection: "close",
             "content-type": "application/json",
+            "x-openclaw-cli-capture-key": captureKey,
           },
         },
         (res) => {
@@ -3438,15 +3448,8 @@ describe("createMcpLoopbackServerConfig", () => {
           res.once("end", resolve);
         },
       );
-      req.once("socket", (socket) => {
-        if (!socket.connecting) {
-          resolveSocketReady();
-          return;
-        }
-        socket.once("connect", resolveSocketReady);
-      });
       req.once("error", (error) => {
-        rejectSocketReady(error);
+        rejectRequestStarted(error);
         reject(error);
       });
       req.write("{");
@@ -3462,20 +3465,13 @@ describe("createMcpLoopbackServerConfig", () => {
     };
     let oldClose: Promise<void> | undefined;
     try {
-      await socketReady;
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
+      await requestStarted;
 
       let closeSettled = false;
       oldClose = closeMcpLoopbackServer().finally(() => {
         closeSettled = true;
       });
       expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 20);
-      });
-      expect(closeSettled).toBe(false);
 
       const successor = await startLoopbackServerForTest();
       const successorGrant = mintMcpLoopbackClientGrant({
@@ -3487,6 +3483,9 @@ describe("createMcpLoopbackServerConfig", () => {
         runtimeOwnerToken: successor.runtime.ownerToken,
         captureKey: "capture-successor",
       });
+      // The unfinished body still holds the old connection, so the successor was
+      // minted mid-drain: exactly the window where a late close could fence it.
+      expect(closeSettled).toBe(false);
 
       finishStalledRequest();
       await responsePromise;
@@ -3503,6 +3502,7 @@ describe("createMcpLoopbackServerConfig", () => {
         ).status,
       ).toBe(200);
     } finally {
+      clearMcpLoopbackToolCallCapture(captureKey);
       finishStalledRequest();
       await responsePromise.catch(() => undefined);
       await (oldClose ?? oldServer.close()).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

`createMcpLoopbackServerConfig > withdraws a closing runtime before drain without fencing its successor` in `src/gateway/mcp-http.test.ts` fails nondeterministically on unmodified `main`, and the failure rate rises with machine load. Measured on current `main` at `2261a9c5b46`: **3 of 10 runs failed under load.** Failing runs also emit an unhandled `Error: read ECONNRESET` attributed to the same test, which reads as a socket-handling defect rather than a test-timing one.

The production drain path is correct. The invariant the test checks — `close()` withdraws the active runtime *before* draining, so a successor loopback server started during the drain is not fenced by the late-completing old close (`src/gateway/mcp-http.ts:484-504`) — genuinely holds. Only the test's timing assumption is wrong.

Closes #117161.

## Why This Change Was Made

The test opened a POST, wrote a partial body so the request could never complete, waited on a **client-side** barrier (`req.once("socket")` → `socket.once("connect")` → `setImmediate`), called `closeMcpLoopbackServer()`, then slept a fixed 20 ms and asserted the close had not settled.

That barrier proves only that the *client's* TCP connect finished. It does not prove the *server* parsed the request. Node exempts a connection from `close()`'s idle sweep only once its HTTP parser has begun a message — so when the server has not yet read the request line, `closeIdleConnections()` destroys the socket, the client sees `ECONNRESET`, and the drain settles immediately, well inside the 20 ms window.

Verified against Node v24.16.0 with a standalone probe using no OpenClaw code:

| Server-side state when `server.close()` runs | Drain | Client |
| --- | --- | --- |
| Connection accepted, no request parsed | settles in **0 ms** | **ECONNRESET** |
| Headers parsed, body still streaming | **blocked** past 150 ms; settles only when the body completes | clean |

One mechanism explains both symptoms, and it is why raising the 20 ms constant would only narrow the race rather than remove it.

The fix waits on the existing server-side capture admission signal (`onRequestStart`), which fires after the headers are accepted, and moves the assertion to just before the successor is used — so it proves the successor was minted mid-drain rather than inferring it from a sleep. `src/gateway/server-close.test.ts:1370` already asserts this same "close has not settled" shape deterministically, using an explicit barrier that provably blocks the close; this brings the MCP test in line with that pattern.

Test-only by design: no production file is touched, and no configuration, migration, or product decision is involved.

## User Impact

No shipped behavior changes. The cost being removed is CI noise and false attribution: an intermittent red in the `gateway-core` lane that is unrelated to the change under review, plus an unhandled `ECONNRESET` rejection that points reviewers at socket handling instead of at the test's timing assumption. During the investigation an unrelated branch — a pure string-function change under `src/canvas/` — failed this test 1 of 3 runs, which is exactly the misattribution being fixed.

## Evidence

Rebased onto `2261a9c5b46` (current `main`). `src/gateway/mcp-http.ts` and this test file both drifted upstream in the meantime via #116012 (`sourceReplyOnly` plumbing), so the proof below was re-measured on the new base rather than carried forward.

Focused proof command:

```bash
for i in $(seq 1 10); do node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts 2>&1 | grep -E '^ +Tests +'; done
```

**RED — unmodified `main` at `2261a9c5b46`, under background CPU saturation at 2× core count: 3 of 10 runs failed.**

```
main+2xload run  5:       Tests  1 failed | 97 passed (98)
main+2xload run  6:       Tests  1 failed | 97 passed (98)
main+2xload run 10:       Tests  1 failed | 97 passed (98)
(runs 1-4, 7-9 passed)
```

Failing assertion, captured on the same base — same test, same signature as originally reported:

```
× withdraws a closing runtime before drain without fencing its successor 27ms
FAIL |gateway-core| src/gateway/mcp-http.test.ts > createMcpLoopbackServerConfig >
     withdraws a closing runtime before drain without fencing its successor
AssertionError: expected true to be false // Object.is equality
Error: read ECONNRESET
Serialized Error: { errno: -54, code: 'ECONNRESET', syscall: 'read' }
```

**GREEN — this branch, identical load, same session: 0 of 10 runs failed.**

```
fix+2xload run  1..10:    Tests  98 passed (98)
```

Corroborating earlier measurements on older bases: 2 of 6 red on `f455eb76d85`, and 2 of 5 red on `65f3e42f243` with 5 of 5 green on the branch under saturation at 1× core count.

One calibration note worth recording: an initial 5-run control on this base came back 0/5 green, because the machine happened to be *less* loaded than during the original measurement. Doubling the background load reproduced it at 3/10. The failure rate tracks load, so a short green control does not clear this test — it under-samples.

Static checks: `oxfmt --check src/gateway/mcp-http.test.ts` clean; `git diff --check` clean; `tsgo` on `test/tsconfig/tsconfig.test.src.json` exits 0 with zero diagnostics.

Diff is one file, +22/−22 — net-zero, zero production LOC.

Proof limits, stated honestly: the red/green measurement was taken on macOS under Node 24, with background CPU saturation standing in for a loaded CI runner. I have not reproduced the failure on a Linux CI runner directly; the underlying Node `close()` idle-sweep mechanism is platform-independent and was verified by the standalone probe above.

Provenance: the test arrived in `5c260940bdb` (#103822, sandbox-tool-widening fix). The 20 ms sleep has been there since; nothing regressed — the race has always been present and only becomes visible under load.

---

AI-assisted (Claude Opus 5): investigated, reproduced, and root-caused with an agent; the author reviewed and owns the diff. The Node `close()`/idle-sweep mechanism was verified with a standalone probe rather than taken from documentation.
