### PR TITLE
fix(codex): preserve authoritative turn completion and final output

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -2141,6 +2141,64 @@ describe("codex conversation binding", () => {
     await expect(readTestConversationBinding(sessionFile)).resolves.toBeUndefined();
   });
 
+  it("retains a pre-start final after a saturated commentary stream", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeTestConversationBinding(sessionFile, {
+      threadId: "thread-1",
+      cwd: tempDir,
+    });
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string) => {
+        if (method !== "turn/start") {
+          throw new Error(`unexpected method: ${method}`);
+        }
+        for (let index = 0; index < 100; index += 1) {
+          notificationHandler?.({
+            method: "item/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              item: {
+                type: "agentMessage",
+                id: `commentary-${index}`,
+                text: `progress ${index}`,
+                phase: "commentary",
+              },
+            },
+          });
+        }
+        notificationHandler?.({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: { type: "agentMessage", id: "answer", text: "authoritative answer" },
+          },
+        });
+        notificationHandler?.({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null, items: [] },
+          },
+        });
+        return { turn: { id: "turn-1" } };
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+    const { event, ctx } = boundConversationClaim(sessionFile);
+
+    await expect(handleCodexConversationInboundClaim(event, ctx)).resolves.toEqual({
+      handled: true,
+      reply: { text: "authoritative answer" },
+    });
+  });
+
   it("reports an interrupted bound turn as cancellation instead of a partial reply", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await writeTestConversationBinding(sessionFile, {

--- a/extensions/codex/src/conversation-turn-collector.test.ts
+++ b/extensions/codex/src/conversation-turn-collector.test.ts
@@ -70,6 +70,269 @@ describe("codex conversation turn collector", () => {
     });
   });
 
+  it("retains the terminal outcome after a full pre-start assistant stream", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    for (let index = 0; index < 101; index += 1) {
+      collector.handleNotification({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "answer", delta: "." },
+      });
+    }
+    collector.handleNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "answer", text: "authoritative answer" }],
+        },
+      },
+    });
+    collector.setTurnId("turn-1");
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "authoritative answer",
+    });
+  });
+
+  it("does not let completed commentary replace or impersonate a final answer", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    collector.setTurnId("turn-1");
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "answer", text: "real answer", phase: "final_answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "progress", delta: "progress" },
+    });
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "agentMessage",
+          id: "completed-progress",
+          text: "completed progress",
+          phase: "commentary",
+        },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            { type: "agentMessage", id: "progress", text: "late progress", phase: "commentary" },
+          ],
+        },
+      },
+    });
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "real answer",
+    });
+  });
+
+  it("retains commentary completion after the pre-start notification buffer fills", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    for (let index = 0; index < 100; index += 1) {
+      collector.handleNotification({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "progress", delta: "." },
+      });
+    }
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "progress", text: "progress", phase: "commentary" },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+    });
+    collector.setTurnId("turn-1");
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({ replyText: "" });
+  });
+
+  it("retains a final completion over a full buffer of commentary completions", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    for (let index = 0; index < 100; index += 1) {
+      collector.handleNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "agentMessage",
+            id: `commentary-${index}`,
+            text: `progress ${index}`,
+            phase: "commentary",
+          },
+        },
+      });
+    }
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "answer", text: "authoritative answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+    });
+    collector.setTurnId("turn-1");
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "authoritative answer",
+    });
+  });
+
+  it("retains the newest final completion when the pre-start buffer is full", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    for (let index = 0; index < 100; index += 1) {
+      collector.handleNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: `answer-${index}`, text: `answer ${index}` },
+        },
+      });
+    }
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "newest", text: "newest answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+    });
+    collector.setTurnId("turn-1");
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "newest answer",
+    });
+  });
+
+  it("does not let unrelated tool completion evict the final assistant message", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    for (let index = 0; index < 100; index += 1) {
+      collector.handleNotification({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "answer", delta: "." },
+      });
+      collector.handleNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "commandExecution", id: `command-${index}` },
+        },
+      });
+    }
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "answer", text: "authoritative answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+    });
+    collector.setTurnId("turn-1");
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "authoritative answer",
+    });
+  });
+
+  it("returns the last completed final answer when the terminal summary is empty", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    collector.setTurnId("turn-1");
+    const completedAnswers: Array<{ id: string; text: string }> = [
+      { id: "first", text: "first answer" },
+      { id: "second", text: "second answer" },
+    ];
+    for (const { id, text } of completedAnswers) {
+      collector.handleNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id, text, phase: "final_answer" },
+        },
+      });
+    }
+    collector.handleNotification({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+    });
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "second answer",
+    });
+  });
+
+  it("lets the terminal final answer supersede later streamed completions", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    collector.setTurnId("turn-1");
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "answer", text: "earlier answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "agentMessage", id: "later", text: "later answer" },
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "answer", text: "terminal answer" }],
+        },
+      },
+    });
+
+    await expect(collector.wait({ timeoutMs: 100 })).resolves.toEqual({
+      replyText: "terminal answer",
+    });
+  });
+
   it("uses completed agent message items when deltas are absent", async () => {
     const collector = createCodexConversationTurnCollector("thread-1");
     collector.setTurnId("turn-1");
@@ -231,6 +494,33 @@ describe("codex conversation turn collector", () => {
     });
 
     await expect(completion).rejects.toThrow("codex app-server turn interrupted");
+  });
+
+  it("rejects a non-terminal status instead of returning streamed partial text", async () => {
+    const collector = createCodexConversationTurnCollector("thread-1");
+    collector.setTurnId("turn-1");
+    const completion = collector.wait({ timeoutMs: 1_000 });
+
+    collector.handleNotification({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-1",
+        delta: "unfinished answer",
+      },
+    });
+    collector.handleNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: { id: "turn-1", status: "inProgress", error: null, items: [] },
+      },
+    });
+
+    await expect(completion).rejects.toThrow(
+      "codex app-server turn completed without a valid terminal status",
+    );
   });
 
   it("confirms a terminal notification that arrives after the bound turn times out", async () => {

--- a/extensions/codex/src/conversation-turn-collector.ts
+++ b/extensions/codex/src/conversation-turn-collector.ts
@@ -1,7 +1,9 @@
 // Codex plugin module implements conversation turn collector behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { asOptionalRecord as readRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isAssistantCommentaryCompletionNotification } from "./app-server/attempt-notifications.js";
 import {
+  isCodexNotificationForTurn,
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./app-server/notification-correlation.js";
@@ -28,21 +30,13 @@ export function createCodexConversationTurnCollector(threadId: string) {
   let failedError: string | undefined;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const assistantTextByItem = new Map<string, string>();
-  const assistantOrder: string[] = [];
   const pendingNotificationsByTurnId = new Map<string, CodexServerNotification[]>();
   let resolveCompletion: ((value: { replyText: string }) => void) | undefined;
   let rejectCompletion: ((error: Error) => void) | undefined;
   let resolveTerminal: (() => void) | undefined;
 
-  const rememberItem = (itemId: string) => {
-    if (!assistantOrder.includes(itemId)) {
-      assistantOrder.push(itemId);
-    }
-  };
   const collectReplyText = (): string => {
-    const texts = assistantOrder
-      .map((itemId) => assistantTextByItem.get(itemId)?.trim())
-      .filter((text): text is string => Boolean(text));
+    const texts = [...assistantTextByItem.values()].map((text) => text.trim()).filter(Boolean);
     return texts.at(-1) ?? "";
   };
   const clearWaitState = () => {
@@ -72,17 +66,29 @@ export function createCodexConversationTurnCollector(threadId: string) {
       return;
     }
     if (!turnId) {
-      const pendingTurnId = readNotificationTurnId(params);
+      const pendingTurnId = readCodexNotificationTurnId(params);
       if (pendingTurnId) {
         const pending = pendingNotificationsByTurnId.get(pendingTurnId) ?? [];
-        if (pending.length < MAX_PENDING_NOTIFICATIONS_PER_TURN) {
-          pending.push(notification);
-          pendingNotificationsByTurnId.set(pendingTurnId, pending);
+        if (pending.length === MAX_PENDING_NOTIFICATIONS_PER_TURN) {
+          const incomingPriority = pendingNotificationPriority(notification);
+          // Keep the facts that classify assistant output and terminate the turn;
+          // otherwise retained progress deltas can impersonate a final answer.
+          const expiredPriority = Math.min(...pending.map(pendingNotificationPriority));
+          const maxReplaceablePriority = incomingPriority >= 2 ? 2 : incomingPriority - 1;
+          if (expiredPriority > maxReplaceablePriority) {
+            return;
+          }
+          pending.splice(
+            pending.findIndex((item) => pendingNotificationPriority(item) === expiredPriority),
+            1,
+          );
         }
+        pending.push(notification);
+        pendingNotificationsByTurnId.set(pendingTurnId, pending);
       }
       return;
     }
-    if (!isNotificationForTurn(params, threadId, turnId)) {
+    if (!isCodexNotificationForTurn(params, threadId, turnId)) {
       return;
     }
     if (notification.method === "item/agentMessage/delta") {
@@ -91,7 +97,6 @@ export function createCodexConversationTurnCollector(threadId: string) {
       if (!delta) {
         return;
       }
-      rememberItem(itemId);
       assistantTextByItem.set(itemId, `${assistantTextByItem.get(itemId) ?? ""}${delta}`);
       return;
     }
@@ -99,9 +104,12 @@ export function createCodexConversationTurnCollector(threadId: string) {
       const item = isJsonObject(params.item) ? params.item : undefined;
       if (item?.type === "agentMessage") {
         const itemId = readString(item, "id") ?? readString(params, "itemId") ?? "assistant";
+        assistantTextByItem.delete(itemId);
+        if (isAssistantCommentaryCompletionNotification(notification)) {
+          return;
+        }
         const text = readTextString(item, "text");
-        if (text) {
-          rememberItem(itemId);
+        if (text?.trim()) {
           assistantTextByItem.set(itemId, text);
         }
       }
@@ -119,17 +127,21 @@ export function createCodexConversationTurnCollector(threadId: string) {
         // Codex reports an interrupted turn as a terminal completion without a
         // final answer; streamed partial text must not become a successful reply.
         failedError = "codex app-server turn interrupted";
+      } else if (status !== "completed") {
+        failedError = "codex app-server turn completed without a valid terminal status";
       }
-      const items = Array.isArray(turn?.items) ? turn.items : [];
-      for (const item of items) {
-        if (!isJsonObject(item) || item.type !== "agentMessage") {
-          continue;
-        }
-        const itemId = readString(item, "id") ?? `assistant-${assistantOrder.length + 1}`;
-        const text = readTextString(item, "text");
-        if (text) {
-          rememberItem(itemId);
-          assistantTextByItem.set(itemId, text);
+      if (status === "completed") {
+        const items = Array.isArray(turn?.items) ? turn.items : [];
+        for (const item of items) {
+          if (!isJsonObject(item) || item.type !== "agentMessage") {
+            continue;
+          }
+          const itemId = readString(item, "id") ?? `assistant-${assistantTextByItem.size + 1}`;
+          assistantTextByItem.delete(itemId);
+          const text = item.phase === "commentary" ? undefined : readTextString(item, "text");
+          if (text?.trim()) {
+            assistantTextByItem.set(itemId, text);
+          }
         }
       }
       finish();
@@ -189,27 +201,15 @@ export function createCodexConversationTurnCollector(threadId: string) {
   };
 }
 
-function isNotificationForTurn(
-  params: JsonObject,
-  threadId: string,
-  turnId: string | undefined,
-): boolean {
-  if (readCodexNotificationThreadId(params) !== threadId) {
-    return false;
+function pendingNotificationPriority(notification: CodexServerNotification) {
+  if (notification.method === "turn/completed") {
+    return 3;
   }
-  if (!turnId) {
-    return true;
+  const item = readRecord(readRecord(notification.params)?.item);
+  if (notification.method !== "item/completed" || item?.type !== "agentMessage") {
+    return 0;
   }
-  const directTurnId = readString(params, "turnId");
-  if (directTurnId) {
-    return directTurnId === turnId;
-  }
-  const turn = isJsonObject(params.turn) ? params.turn : undefined;
-  return readString(turn, "id") === turnId;
-}
-
-function readNotificationTurnId(params: JsonObject): string | undefined {
-  return readCodexNotificationTurnId(params);
+  return isAssistantCommentaryCompletionNotification(notification) ? 1 : 2;
 }
 
 function readString(record: Record<string, unknown> | JsonObject | undefined, key: string) {


### PR DESCRIPTION
# fix(codex): preserve authoritative conversation outcomes

## What Problem This Solves

The Codex conversation-turn collector had five owner-boundary failures:

1. `turn/completed` with `status: "interrupted"` could resolve successfully with partial assistant output.
2. Completed `phase: "commentary"` messages could replace or impersonate the final answer.
3. More than 100 notifications arriving before the `turn/start` response could evict the terminal notification and leave a finished turn timing out.
4. A saturated delta buffer could evict the commentary completion, retain its deltas, and misreport progress as the answer.
5. A buffer containing 100 commentary completions could discard the following authoritative final or legacy-unphased completion, then resolve an empty terminal summary with no reply.

These failures are shipped in `v2026.7.2-beta.1` through `.5`.

## Canonical Fix

The collector owns correlation of native Codex lifecycle notifications into one OpenClaw reply. This rewrite:

- preserves the timeout and interruption lifecycle semantics from #116012
- ranks bounded pre-start events as transient, commentary, final/legacy-unphased, then terminal
- lets newer final completions replace older final completions so the last answer remains authoritative
- excludes explicit commentary while preserving legacy unphased assistant completions
- lets only `status: "completed"` terminal items supersede streamed completions
- rejects failed, interrupted, and invalid non-terminal outcomes
- removes duplicate turn-correlation and assistant-order bookkeeping

Production delta: **+46/-46 (net zero)**. Tests: **+348/-0**.

Enlarging or unbounding the buffer would only defer the failure. Relying exclusively on terminal items would regress Codex `0.144.x` and `0.145.0`, whose completed turns could carry an empty terminal item list. A downstream conversation-binding guard would repair the wrong owner.

## Direct Upstream Codex Contract Inspection

Maintainer reviewers personally inspected sibling `../codex` at the `rust-v0.146.0` dereferenced commit `e363b08c9175ac1cbe5893615dd2cb9ddf95043b` (annotated tag object `be449751a978f02e5bbba886999662956c7f38f5`) and the terminal-summary producer change `80f3c3141e4dd421c861408a87703bad0cb09874`:

- [`codex-rs/app-server-protocol/src/protocol/v2/turn.rs:30-35`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L30-L35): `Completed`, `Interrupted`, `Failed`, and `InProgress`.
- [`codex-rs/app-server-protocol/src/protocol/v2/item.rs:243-248`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L243-L248): agent-message text plus optional phase.
- [`codex-rs/protocol/src/models.rs:756-769`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/protocol/src/models.rs#L756-L769): missing phase is legacy/unknown; commentary and final answer are distinct.
- [`codex-rs/app-server/src/thread_state.rs:158-170`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server/src/thread_state.rs#L158-L170): only nonempty final or legacy-unphased messages become the authoritative last assistant message.
- [`codex-rs/app-server/src/bespoke_event_handling.rs:1270-1295`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server/src/bespoke_event_handling.rs#L1270-L1295): terminal turns carry zero or one authoritative final item.
- [`codex-rs/app-server/src/bespoke_event_handling.rs:1463-1515`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server/src/bespoke_event_handling.rs#L1463-L1515): successful completion uses the last final message; interruption carries no final item.
- [`codex-rs/app-server/src/request_processors/turn_processor.rs:567-617`](https://github.com/openai/codex/blob/e363b08c9175ac1cbe5893615dd2cb9ddf95043b/codex-rs/app-server/src/request_processors/turn_processor.rs#L567-L617): input is submitted before `turn/start` returns, proving the pre-response notification race.

The same phase and terminal contracts were checked at shipped Codex tags `0.144.4` and `0.145.0`.

## Exact-Head Native Stdio Proof

The real authenticated repository-pinned `codex-cli 0.146.0` app-server was run over native stdio against signed PR head `ff523ac316965f04f86fa9df35161428b7267a1a`. It used an ephemeral thread, `approvalPolicy: "never"`, and a read-only sandbox.

The successful flow required exactly `OPENCLAW_QA_NATIVE_FINAL`. The interrupt flow waited for a real `commandExecution` running `sleep 30`, then sent `turn/interrupt`. This is the complete redacted proof output; it contains no paths, thread/item identifiers, accounts, endpoints, or credentials:

```json
{
  "head": "ff523ac316965f04f86fa9df35161428b7267a1a",
  "binary": "codex-cli 0.146.0",
  "transport": "stdio",
  "successfulFinal": {
    "turnIdPresent": true,
    "phases": ["final_answer"],
    "exactFinalSeen": true,
    "terminal": {
      "status": "completed",
      "itemPhases": ["final_answer"]
    },
    "collectorReply": "OPENCLAW_QA_NATIVE_FINAL"
  },
  "interruptedTurn": {
    "turnIdPresent": true,
    "terminal": {
      "status": "interrupted",
      "itemPhases": []
    },
    "collectorError": "codex app-server turn interrupted"
  }
}
```

A separate stock-native saturation probe requested a deterministic 200-line answer. Across four authenticated `codex-cli 0.146.0` trials, each turn emitted 1,016 notifications, including 999 agent-message deltas, and returned the complete first and last lines. All four observed zero notifications before the `turn/start` response. That proves the real producer can exceed the collector cap, but stock Codex exposes no deterministic control that forces provider output before the much shorter start response. The exact saturated pre-response ordering therefore remains covered by the production-handler binding replay rather than a patched or proxied binary.

## Validation

- collector tests: **23/23**
- conversation-binding tests: **47/47**
- exact-head binding replay: **1/1**
  - registers the production notification handler
  - emits 100 commentary completions, one legacy-unphased final completion, and an empty completed terminal before mocked `turn/start` returns
  - proves the delivered reply is `authoritative answer` only after `setTurnId` replays the buffered stream
- formatting and `git diff --check`: clean
- full-branch P0/P1 autoreview: no findings, confidence **0.91**
- independent owner/caller/sibling review: clean
- TruffleHog: clean
- exact-head GitHub CI: **green** (`openclaw/ci-gate`, real-behavior proof, and all applicable checks): [`30689051957`](https://github.com/openclaw/openclaw/actions/runs/30689051957)
- canonical changed gate: infrastructure blocked before tests
  - Blacksmith scheduler initially returned HTTP 429
  - AWS hydration failed because `typescript` was absent during repository postinstall
  - Blacksmith full sync timed out, then workflow dispatch returned HTTP 500
  - affected Blacksmith run: [`30688153879`](https://github.com/openclaw/openclaw/actions/runs/30688153879)

## User Impact

Successful conversations return the authoritative final answer. Cancelled or invalid conversations fail visibly. Commentary cannot impersonate an answer, a saturated pre-start stream cannot hide terminal completion, and a full commentary buffer cannot discard the following final answer. No authentication, configuration, persistence, public SDK, protocol, snapshot, or reasoning-projection files change.
