### PR TITLE
fix(xai): preserve authoritative realtime response outcomes

### DIFF
--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -111,7 +111,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     if (this.intentionallyClosed) {
       return;
     }
-    if (!this.canSubmitToolResult()) {
+    if (!this.canSubmitInput()) {
       if (this.pendingToolResults.length < XAI_REALTIME_MAX_PENDING_TOOL_RESULTS) {
         this.pendingToolResults.push({ callId, result, ...(options ? { options } : {}) });
       } else {
@@ -467,10 +467,6 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
       meta: { provider: "xai", capability: "realtime-voice" },
     });
     ws.send(payload);
-  }
-
-  private canSubmitToolResult(): boolean {
-    return this.connected && this.sessionConfigured && this.ws?.readyState === WebSocket.OPEN;
   }
 
   private canSubmitInput(): boolean {

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -44,6 +44,17 @@ export type XaiRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
   resolveApiKey?: () => Promise<string>;
 };
 
+type XaiRealtimeResponseItem = {
+  id?: string;
+  type?: string;
+  status?: "completed" | "incomplete" | "in_progress";
+  role?: string;
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+  content?: Array<{ type?: string; text?: string; transcript?: string }>;
+};
+
 export type XaiRealtimeEvent = {
   type: string;
   delta?: string;
@@ -59,15 +70,10 @@ export type XaiRealtimeEvent = {
     id?: string;
     status?: string;
     status_details?: unknown;
+    output?: XaiRealtimeResponseItem[];
   };
   conversation?: { id?: string };
-  item?: {
-    id?: string;
-    type?: string;
-    call_id?: string;
-    name?: string;
-    arguments?: string;
-  };
+  item?: XaiRealtimeResponseItem;
   error?: unknown;
 };
 

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -1,5 +1,5 @@
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX,
   XAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR,
@@ -14,6 +14,7 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
   private assistantTranscriptBuffer = "";
   private assistantTranscriptFinalized = false;
   private inputTranscriptReplacements = new Map<string, string>();
+  private completedResponseToolItems: XaiRealtimeEvent["item"][] = [];
 
   protected abstract onSessionUpdated(): void;
 
@@ -38,22 +39,22 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         return;
       }
       case "conversation.item.created":
-      case "conversation.item.added": {
+      case "conversation.item.added":
+      case "response.output_item.done": {
         const item = event.item;
         const callId = normalizeOptionalString(item?.call_id);
         if (item?.type === "function_call_output" && callId) {
           this.pendingToolResultAcks.delete(callId);
           return;
         }
-        if (event.type === "conversation.item.created" && item?.type === "function_call") {
-          // Resumption replays persisted items instead of replaying the original
-          // response event. Re-emit only calls this bridge did not already deliver.
-          this.emitToolCallOnce({
-            itemId: item.id ?? event.item_id,
-            callId: item.call_id,
-            name: item.name,
-            rawArgs: item.arguments,
-          });
+        if (event.type === "response.output_item.done") {
+          // Output items precede their response outcome, so side effects must
+          // wait until response.done confirms this response succeeded.
+          if (item?.type === "function_call" && (!item.status || item.status === "completed")) {
+            this.completedResponseToolItems.push(item);
+          }
+        } else if (event.type === "conversation.item.created") {
+          this.emitCompletedToolCall(item, event);
         }
         return;
       }
@@ -66,6 +67,7 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         this.markQueue = [];
         this.lastAssistantItemId = null;
         this.responseStartTimestamp = null;
+        this.completedResponseToolItems = [];
         this.resetAssistantTranscript();
         return;
       case "response.output_audio.delta": {
@@ -128,13 +130,36 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         this.inputTranscriptReplacements.delete(this.inputTranscriptKey(event));
         this.config.onError?.(new Error(readXaiRealtimeErrorDetail(event.error)));
         return;
-      case "response.done":
-        this.flushAssistantTranscript();
+      case "response.done": {
+        const status = event.response?.status;
+        const output = event.response?.output ?? [];
+        if (status === undefined || status === "completed") {
+          for (const item of [...output, ...this.completedResponseToolItems]) {
+            this.emitCompletedToolCall(item, event);
+          }
+        }
+        this.completedResponseToolItems = [];
+        const terminalTranscript = output
+          .filter((item) => item.type === "message" && item.role === "assistant")
+          .flatMap((item) => item.content ?? [])
+          .map((content) => content.transcript ?? content.text ?? "")
+          .join("");
+        this.flushAssistantTranscript(terminalTranscript);
         this.responseActive = false;
         this.responseCreateInFlight = false;
         this.responseCancelInFlight = false;
+        if (status === "failed" || status === "incomplete") {
+          const details = event.response?.status_details;
+          const error = isRecord(details) ? details.error : undefined;
+          const reason = isRecord(details) ? normalizeOptionalString(details.reason) : undefined;
+          const message = error
+            ? readXaiRealtimeErrorDetail(error)
+            : `xAI realtime voice response ${status}${reason ? `: ${reason}` : ""}`;
+          this.config.onError?.(new Error(message));
+        }
         this.flushPendingResponseCreate();
         return;
+      }
       case "response.function_call_arguments.delta": {
         const key = event.item_id ?? "unknown";
         const existing = this.toolCallBuffers.get(key);
@@ -152,6 +177,8 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
       case "response.function_call_arguments.done": {
         const key = event.item_id ?? "unknown";
         const buffered = this.toolCallBuffers.get(key);
+        // xAI's documented Function Call Flow requires executing finalized
+        // arguments immediately so tool results can continue the response.
         this.emitToolCallOnce({
           itemId: event.item_id,
           callId: buffered?.callId || event.call_id,
@@ -170,6 +197,20 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
 
   protected resetInputTranscripts(): void {
     this.inputTranscriptReplacements.clear();
+    this.completedResponseToolItems = [];
+  }
+
+  private emitCompletedToolCall(item: XaiRealtimeEvent["item"], event: XaiRealtimeEvent): void {
+    if (item?.type === "function_call" && (!item.status || item.status === "completed")) {
+      // Completed items and resumed replay are authoritative; added items can
+      // still be in progress and must not dispatch incomplete arguments.
+      this.emitToolCallOnce({
+        itemId: item.id ?? event.item_id,
+        callId: item.call_id,
+        name: item.name,
+        rawArgs: item.arguments,
+      });
+    }
   }
 
   private appendAssistantTranscriptDelta(delta: string): void {

--- a/extensions/xai/realtime-voice-terminal-outcomes.test.ts
+++ b/extensions/xai/realtime-voice-terminal-outcomes.test.ts
@@ -1,0 +1,265 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import type WebSocket from "ws";
+import { WebSocketServer } from "ws";
+import { buildXaiRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+
+type RealtimeOutcome = {
+  errors: string[];
+  transcripts: Array<{ speaker: string; text: string; final: boolean }>;
+  tools: Array<{ itemId: string; callId: string; name: string; args: unknown }>;
+};
+
+async function captureRealtimeOutcome(
+  eventInput: Record<string, unknown> | Record<string, unknown>[],
+): Promise<RealtimeOutcome> {
+  const events = Array.isArray(eventInput) ? eventInput : [eventInput];
+  const outcome: RealtimeOutcome = { errors: [], transcripts: [], tools: [] };
+  let markServerEventHandled: () => void = () => {};
+  const serverEventHandled = new Promise<void>((resolve) => {
+    markServerEventHandled = resolve;
+  });
+  const server = createServer();
+  const sockets = new Set<WebSocket>();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (request, socket, head) => {
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      sockets.add(ws);
+      ws.on("message", (message) => {
+        if (JSON.parse(Buffer.from(message as Buffer).toString("utf8")).type !== "session.update") {
+          return;
+        }
+        ws.send(JSON.stringify({ type: "session.updated" }));
+        ws.send(JSON.stringify({ type: "response.created", response: { id: "response_1" } }));
+        for (const event of events) {
+          ws.send(JSON.stringify(event));
+        }
+      });
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+    providerConfig: { apiKey: "fixture-value", baseUrl: `http://127.0.0.1:${port}/v1` },
+    onAudio() {},
+    onClearAudio() {},
+    onError: (error) => outcome.errors.push(error.message),
+    onTranscript: (speaker, text, final) => outcome.transcripts.push({ speaker, text, final }),
+    onToolCall: (tool) => outcome.tools.push(tool),
+    onEvent: (observed) => {
+      if (observed.direction === "server" && observed.type === events.at(-1)?.type) {
+        markServerEventHandled();
+      }
+    },
+  });
+
+  try {
+    await bridge.connect();
+    await serverEventHandled;
+    return outcome;
+  } finally {
+    bridge.close();
+    for (const socket of sockets) {
+      socket.terminate();
+    }
+    await new Promise<void>((resolve) => {
+      wss.close(() => resolve());
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+}
+
+const completedTool = {
+  id: "item_tool",
+  type: "function_call",
+  call_id: "call_tool",
+  name: "lookup_weather",
+  arguments: JSON.stringify({ city: "Paris" }),
+};
+const expectedTool = {
+  itemId: "item_tool",
+  callId: "call_tool",
+  name: "lookup_weather",
+  args: { city: "Paris" },
+};
+
+describe("xAI realtime terminal event ownership", () => {
+  it.each([
+    {
+      name: "preserves assistant transcripts carried only by terminal output",
+      event: {
+        type: "response.done",
+        response: {
+          status: "completed",
+          output: [
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_audio", transcript: "terminal answer" }],
+            },
+          ],
+        },
+      },
+      expected: {
+        errors: [],
+        transcripts: [{ speaker: "assistant", text: "terminal answer", final: true }],
+        tools: [],
+      },
+    },
+    {
+      name: "surfaces failed responses with provider error details",
+      event: {
+        type: "response.done",
+        response: { status: "failed", status_details: { error: { code: "rate_limit_exceeded" } } },
+      },
+      expected: { errors: ["rate_limit_exceeded"], transcripts: [], tools: [] },
+    },
+    {
+      name: "surfaces incomplete responses with their authoritative reason",
+      event: {
+        type: "response.done",
+        response: { status: "incomplete", status_details: { reason: "max_output_tokens" } },
+      },
+      expected: {
+        errors: ["xAI realtime voice response incomplete: max_output_tokens"],
+        transcripts: [],
+        tools: [],
+      },
+    },
+    {
+      name: "does not mistake intentional cancellation for a provider failure",
+      event: {
+        type: "response.done",
+        response: { status: "cancelled", status_details: { reason: "client_cancelled" } },
+      },
+      expected: { errors: [], transcripts: [], tools: [] },
+    },
+    {
+      name: "does not dispatch completed output items before their response succeeds",
+      event: { type: "response.output_item.done", item: completedTool },
+      expected: { errors: [], transcripts: [], tools: [] },
+    },
+    {
+      name: "recovers completed output items only after their response succeeds",
+      event: [
+        { type: "response.output_item.done", item: completedTool },
+        { type: "response.done", response: { status: "completed", output: [] } },
+      ],
+      expected: { errors: [], transcripts: [], tools: [expectedTool] },
+    },
+    {
+      name: "deduplicates recovered output items against authoritative terminal output",
+      event: [
+        { type: "response.output_item.done", item: completedTool },
+        { type: "response.done", response: { status: "completed", output: [completedTool] } },
+      ],
+      expected: { errors: [], transcripts: [], tools: [expectedTool] },
+    },
+    ...["incomplete", "in_progress"].map((status) => ({
+      name: `does not dispatch ${status} function-call items`,
+      event: [
+        { type: "response.output_item.done", item: { ...completedTool, status } },
+        { type: "response.done", response: { status: "completed", output: [] } },
+      ],
+      expected: { errors: [], transcripts: [], tools: [] },
+    })),
+    ...["failed", "incomplete", "cancelled"].map((status) => ({
+      name: `discards recovered output items when their response is ${status}`,
+      event: [
+        { type: "response.output_item.done", item: completedTool },
+        { type: "response.done", response: { status, output: [completedTool] } },
+      ],
+      expected: {
+        errors: status === "cancelled" ? [] : [`xAI realtime voice response ${status}`],
+        transcripts: [],
+        tools: [],
+      },
+    })),
+    {
+      name: "does not carry recovered output items into the next response",
+      event: [
+        { type: "response.output_item.done", item: completedTool },
+        { type: "response.created", response: { id: "response_2" } },
+        { type: "response.done", response: { status: "completed", output: [] } },
+      ],
+      expected: { errors: [], transcripts: [], tools: [] },
+    },
+    {
+      name: "retains immediate completed replay delivery for resumed conversations",
+      event: { type: "conversation.item.created", item: completedTool },
+      expected: { errors: [], transcripts: [], tools: [expectedTool] },
+    },
+    {
+      name: "retains immediate authoritative function-call argument completion",
+      event: {
+        type: "response.function_call_arguments.done",
+        item_id: completedTool.id,
+        call_id: completedTool.call_id,
+        name: completedTool.name,
+        arguments: completedTool.arguments,
+      },
+      expected: { errors: [], transcripts: [], tools: [expectedTool] },
+    },
+    {
+      name: "preserves required streamed-call timing when the response later fails",
+      event: [
+        {
+          type: "response.function_call_arguments.done",
+          item_id: completedTool.id,
+          call_id: completedTool.call_id,
+          name: completedTool.name,
+          arguments: completedTool.arguments,
+        },
+        { type: "response.done", response: { status: "failed", output: [] } },
+      ],
+      expected: {
+        errors: ["xAI realtime voice response failed"],
+        transcripts: [],
+        tools: [expectedTool],
+      },
+    },
+    {
+      name: "does not dispatch incomplete replayed function-call items",
+      event: {
+        type: "conversation.item.created",
+        item: { ...completedTool, status: "incomplete" },
+      },
+      expected: { errors: [], transcripts: [], tools: [] },
+    },
+    {
+      name: "recovers completed tool calls from terminal response output",
+      event: {
+        type: "response.done",
+        response: { status: "completed", output: [completedTool] },
+      },
+      expected: { errors: [], transcripts: [], tools: [expectedTool] },
+    },
+    ...["failed", "incomplete", "cancelled"].map((status) => ({
+      name: `does not recover terminal-output tool calls from a ${status} response`,
+      event: {
+        type: "response.done",
+        response: { status, output: [completedTool] },
+      },
+      expected: {
+        errors: status === "cancelled" ? [] : [`xAI realtime voice response ${status}`],
+        transcripts: [],
+        tools: [],
+      },
+    })),
+    {
+      name: "does not dispatch incomplete items from a completed terminal response",
+      event: {
+        type: "response.done",
+        response: { status: "completed", output: [{ ...completedTool, status: "incomplete" }] },
+      },
+      expected: { errors: [], transcripts: [], tools: [] },
+    },
+  ])("$name", async ({ event, expected }) => {
+    expect(await captureRealtimeOutcome(event)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where xAI realtime voice users could lose assistant transcripts present only in the terminal response, receive no actionable explanation for failed or incomplete model turns, and silently miss completed tool calls present only in supported response output.

## Why This Change Was Made

The existing private xAI event owner now consumes authoritative terminal response status, provider error details, assistant output, and completed function-call output. Newly recovered output-item calls wait for a successful terminal response and deduplicate against final output. Existing streamed-argument completion and resumed conversation replay remain immediate, as required by xAI's documented function-call flow. A duplicated bridge-readiness wrapper is removed.

## User Impact

- Final-only assistant speech transcripts remain visible.
- Failed or incomplete xAI turns report actionable provider errors.
- Recovered output-only tool calls execute once after successful completion.
- Existing immediate streamed tool execution, resumed replay, cancellation, and audio handling retain their provider contracts.

## Evidence

- Frozen baseline: `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`.
- Candidate: `a02cc5c8495316bc1b05df9d24d836edbca74917`.
- Actual localhost HTTP/WebSocket frozen-baseline proof: **6 failures / 11 passing controls**; exact candidate: **17/17 passed**.
- Genuine full-branch P3 structured autoreview: **clean, zero findings, 0.86 confidence**.
- Official xAI Function Call Flow requires immediate `response.function_call_arguments.done` execution: https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech.
- Exact immutable Linux full extension production **and** test typechecks passed; normal boundary-preparing type-aware owner lint passed; **77/77 tests across three provider suites passed**, including **22 real HTTP/WebSocket lifecycle regressions**.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/30680040150.
- Production delta +68/-25 (net +43), justified by three missing canonical terminal producer facts, response-state ownership, deduplication, and explicit provider timing invariants; no public SDK, config, auth, protocol, storage, or dependency changes.
