### PR TITLE
refactor(channels): unify bundled setup ownership and remove duplicate paths

### DIFF
--- a/extensions/matrix/src/channel.setup.ts
+++ b/extensions/matrix/src/channel.setup.ts
@@ -10,7 +10,7 @@ const matrixSetupWizard = createMatrixSetupWizardProxy(async () => ({
   matrixSetupWizard: (await import("./setup-surface.js")).matrixSetupWizard,
 }));
 
-export const matrixSetupPlugin: ChannelPlugin<ResolvedMatrixAccount> = {
+export const matrixPluginBase = {
   id: "matrix",
   meta: {
     id: "matrix",
@@ -44,6 +44,13 @@ export const matrixSetupPlugin: ChannelPlugin<ResolvedMatrixAccount> = {
           baseUrl: account.homeserver,
         },
       }),
+  },
+} satisfies ChannelPlugin<ResolvedMatrixAccount>;
+
+export const matrixSetupPlugin: ChannelPlugin<ResolvedMatrixAccount> = {
+  ...matrixPluginBase,
+  config: {
+    ...matrixPluginBase.config,
     hasConfiguredState: ({ cfg }) => resolveMatrixAccount({ cfg }).configured,
   },
 };

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -1,5 +1,4 @@
 // Matrix plugin module implements channel behavior.
-import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import {
   adaptScopedAccountAccessor,
   createScopedDmSecurityResolver,
@@ -45,8 +44,8 @@ import {
 import { matrixMessageActions } from "./actions.js";
 import { matrixApprovalCapability } from "./approval-native.js";
 import { createMatrixPairingText, createMatrixProbeAccount } from "./channel-account-paths.js";
-import { DEFAULT_ACCOUNT_ID, matrixConfigAdapter } from "./config-adapter.js";
-import { MatrixChannelConfigSchema } from "./config-schema.js";
+import { matrixPluginBase } from "./channel.setup.js";
+import { DEFAULT_ACCOUNT_ID } from "./config-adapter.js";
 import {
   legacyConfigRules as MATRIX_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeMatrixCompatibilityConfig,
@@ -76,12 +75,6 @@ import { matrixResolverAdapter } from "./resolver.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMatrixOutboundSessionRoute } from "./session-route.js";
 import {
-  namedAccountPromotionKeys,
-  resolveSingleAccountPromotionTarget,
-  singleAccountKeysToMove,
-} from "./setup-contract.js";
-import { createMatrixSetupWizardProxy, matrixSetupContract } from "./setup-core.js";
-import {
   defaultTopLevelPlacement,
   resolveMatrixInboundConversation,
 } from "./thread-binding-api.js";
@@ -89,28 +82,12 @@ import type { CoreConfig } from "./types.js";
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
 let matrixStartupLock: Promise<void> = Promise.resolve();
 
-const loadMatrixSetupWizard = createLazyRuntimeNamedExport(
-  () => import("./setup-surface.js"),
-  "matrixSetupWizard",
-);
 const loadMatrixChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
   "matrixChannelRuntime",
 );
 
 const loadMatrixDoctorModule = createLazyRuntimeModule(() => import("./doctor.js"));
-
-const meta = {
-  id: "matrix",
-  label: "Matrix",
-  selectionLabel: "Matrix (plugin)",
-  docsPath: "/channels/matrix",
-  docsLabel: "matrix",
-  blurb: "open protocol; configure a homeserver + access token.",
-  order: 70,
-  markdownCapable: true,
-  quickstartAllowFrom: true,
-};
 
 function buildMatrixTrafficStatusSummary(
   snapshot?: {
@@ -439,36 +416,15 @@ const matrixMessageAdapter = createChannelMessageAdapterFromOutbound({
 export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
   createChatChannelPlugin<ResolvedMatrixAccount, MatrixProbe>({
     base: {
-      id: "matrix",
-      meta,
-      setupWizard: createMatrixSetupWizardProxy(async () => ({
-        matrixSetupWizard: await loadMatrixSetupWizard(),
-      })),
+      ...matrixPluginBase,
+      meta: { ...matrixPluginBase.meta, markdownCapable: true },
       capabilities: {
-        chatTypes: ["direct", "group", "thread"],
-        polls: true,
-        reactions: true,
-        threads: true,
-        media: true,
+        ...matrixPluginBase.capabilities,
         tts: {
           voice: {
             synthesisTarget: "voice-note",
           },
         },
-      },
-      reload: { configPrefixes: ["channels.matrix"] },
-      configSchema: MatrixChannelConfigSchema,
-      config: {
-        ...matrixConfigAdapter,
-        isConfigured: (account) => account.configured,
-        describeAccount: (account) =>
-          describeAccountSnapshot({
-            account,
-            configured: account.configured,
-            extra: {
-              baseUrl: account.homeserver,
-            },
-          }),
       },
       approvalCapability: matrixApprovalCapability,
       groups: {
@@ -539,12 +495,6 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
       secrets: {
         secretTargetRegistryEntries,
         collectRuntimeConfigAssignments,
-      },
-      setupContract: {
-        ...matrixSetupContract,
-        singleAccountKeysToMove,
-        namedAccountPromotionKeys,
-        resolveSingleAccountPromotionTarget,
       },
       bindings: {
         compileConfiguredBinding: ({ conversationId }) =>

--- a/extensions/nostr/src/channel.setup.ts
+++ b/extensions/nostr/src/channel.setup.ts
@@ -3,55 +3,26 @@ import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createDelegatedSetupWizardProxy,
-  createStandardChannelSetupStatus,
   DEFAULT_ACCOUNT_ID,
-  createSetupTranslator,
 } from "openclaw/plugin-sdk/setup-runtime";
 import { buildChannelConfigSchema, type ChannelPlugin } from "./channel-api.js";
 import { NostrConfigSchema } from "./config-schema.js";
 import { DEFAULT_RELAYS } from "./default-relays.js";
-import { createNostrSetupAdapter, createNostrSetupContract } from "./setup-adapter.js";
-
-const t = createSetupTranslator();
+import {
+  createNostrSetupAdapter,
+  createNostrSetupContract,
+  createNostrSetupStatus,
+} from "./setup-adapter.js";
+import type { ResolvedNostrAccount } from "./types.js";
 
 const channel = "nostr" as const;
 
-type NostrAccountConfig = {
-  enabled?: boolean;
-  name?: string;
-  defaultAccount?: string;
-  privateKey?: unknown;
-  relays?: string[];
-  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
-  allowFrom?: Array<string | number>;
-  profile?: unknown;
-};
-
-type ResolvedNostrSetupAccount = {
-  accountId: string;
-  name?: string;
-  enabled: boolean;
-  configured: boolean;
-  privateKey: string;
-  publicKey: string;
-  relays: string[];
-  profile?: unknown;
-  config: NostrAccountConfig;
-};
+type NostrAccountConfig = ResolvedNostrAccount["config"];
 
 function getNostrConfig(cfg: OpenClawConfig): NostrAccountConfig | undefined {
   return (cfg.channels as Record<string, unknown> | undefined)?.nostr as
     | NostrAccountConfig
     | undefined;
-}
-
-function listSetupNostrAccountIds(cfg: OpenClawConfig): string[] {
-  const nostrCfg = getNostrConfig(cfg);
-  const privateKey = typeof nostrCfg?.privateKey === "string" ? nostrCfg.privateKey.trim() : "";
-  if (!privateKey) {
-    return [];
-  }
-  return [resolveDefaultSetupNostrAccountId(cfg)];
 }
 
 function resolveDefaultSetupNostrAccountId(cfg: OpenClawConfig): string {
@@ -64,7 +35,7 @@ function resolveDefaultSetupNostrAccountId(cfg: OpenClawConfig): string {
 function resolveSetupNostrAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-}): ResolvedNostrSetupAccount {
+}): ResolvedNostrAccount {
   const nostrCfg = getNostrConfig(params.cfg);
   const accountId = params.accountId?.trim() || resolveDefaultSetupNostrAccountId(params.cfg);
   const privateKey = typeof nostrCfg?.privateKey === "string" ? nostrCfg.privateKey.trim() : "";
@@ -90,47 +61,16 @@ function resolveSetupNostrAccount(params: {
   };
 }
 
-function looksLikeNostrPrivateKey(privateKey: string): boolean {
-  return (
-    privateKey.startsWith("nsec1") ||
-    privateKey.startsWith("NSEC1") ||
-    /^[0-9a-fA-F]{64}$/.test(privateKey)
-  );
-}
-
-const nostrSetupAdapter = createNostrSetupAdapter({
-  resolveAccountId: (cfg, accountId) => accountId?.trim() || resolveDefaultSetupNostrAccountId(cfg),
-  validatePrivateKey: looksLikeNostrPrivateKey,
-});
-const nostrSetupContract = createNostrSetupContract(nostrSetupAdapter);
-
 const nostrSetupWizard = createDelegatedSetupWizardProxy({
   channel,
   loadWizard: async () => (await import("./setup-surface.js")).nostrSetupWizard,
-  status: {
-    ...createStandardChannelSetupStatus({
-      channelLabel: "Nostr",
-      configuredLabel: t("wizard.channels.statusConfigured"),
-      unconfiguredLabel: t("wizard.channels.statusNeedsPrivateKey"),
-      configuredHint: t("wizard.channels.statusConfigured"),
-      unconfiguredHint: t("wizard.channels.statusNeedsPrivateKey"),
-      configuredScore: 1,
-      unconfiguredScore: 0,
-      includeStatusLine: true,
-      resolveConfigured: ({ cfg, accountId }) =>
-        resolveSetupNostrAccount({ cfg, accountId }).configured,
-      resolveExtraStatusLines: ({ cfg }) => {
-        const account = resolveSetupNostrAccount({ cfg });
-        return [`Relays: ${account.relays.length || DEFAULT_RELAYS.length}`];
-      },
-    }),
-  },
+  status: createNostrSetupStatus(resolveSetupNostrAccount),
   resolveShouldPromptAccountIds: () => false,
   delegatePrepare: true,
   delegateFinalize: true,
 });
 
-export const nostrSetupPlugin: ChannelPlugin<ResolvedNostrSetupAccount> = {
+export const nostrSetupPlugin: ChannelPlugin<ResolvedNostrAccount> = {
   id: channel,
   meta: {
     id: channel,
@@ -147,10 +87,17 @@ export const nostrSetupPlugin: ChannelPlugin<ResolvedNostrSetupAccount> = {
   },
   reload: { configPrefixes: ["channels.nostr"] },
   configSchema: buildChannelConfigSchema(NostrConfigSchema),
-  setupContract: nostrSetupContract,
+  setupContract: createNostrSetupContract(
+    createNostrSetupAdapter({
+      resolveAccountId: (cfg, accountId) =>
+        accountId?.trim() || resolveDefaultSetupNostrAccountId(cfg),
+      validatePrivateKey: (privateKey) => /^(?:nsec1|NSEC1)|^[0-9a-fA-F]{64}$/u.test(privateKey),
+    }),
+  ),
   setupWizard: nostrSetupWizard,
   config: {
-    listAccountIds: listSetupNostrAccountIds,
+    listAccountIds: (cfg) =>
+      resolveSetupNostrAccount({ cfg }).configured ? [resolveDefaultSetupNostrAccountId(cfg)] : [],
     resolveAccount: (cfg, accountId) => resolveSetupNostrAccount({ cfg, accountId }),
     defaultAccountId: resolveDefaultSetupNostrAccountId,
     isConfigured: (account) => account.configured,

--- a/extensions/nostr/src/setup-adapter.ts
+++ b/extensions/nostr/src/setup-adapter.ts
@@ -2,18 +2,25 @@
 import {
   defineChannelSetupContract,
   type ChannelSetupAdapter,
-  type ChannelSetupInput,
 } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
-import { patchTopLevelChannelConfigSection, splitSetupEntries } from "openclaw/plugin-sdk/setup";
+import {
+  createSetupTranslator,
+  createStandardChannelSetupStatus,
+  patchTopLevelChannelConfigSection,
+  splitSetupEntries,
+} from "openclaw/plugin-sdk/setup";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { DEFAULT_RELAYS } from "./default-relays.js";
 
 const channel = "nostr" as const;
 
-type NostrSetupInput = ChannelSetupInput & {
+type NostrSetupInput = {
+  name?: string;
   privateKey?: string;
   relayUrls?: string;
+  useEnv?: boolean;
 };
 
 export function buildNostrSetupPatch(accountId: string, patch: Record<string, unknown>) {
@@ -42,7 +49,7 @@ export function parseRelayUrls(raw: string): { relays: string[]; error?: string 
 export function createNostrSetupAdapter(params: {
   resolveAccountId: (cfg: OpenClawConfig, accountId?: string | null) => string;
   validatePrivateKey: (privateKey: string) => boolean;
-}): ChannelSetupAdapter {
+}): ChannelSetupAdapter<NostrSetupInput> {
   return {
     resolveAccountId: ({ cfg, accountId }) => params.resolveAccountId(cfg, accountId),
     applyAccountName: ({ cfg, accountId, name }) =>
@@ -52,9 +59,8 @@ export function createNostrSetupAdapter(params: {
         patch: buildNostrSetupPatch(accountId, name?.trim() ? { name: name.trim() } : {}),
       }),
     validateInput: ({ input }) => {
-      const typedInput = input as NostrSetupInput;
-      if (!typedInput.useEnv) {
-        const privateKey = typedInput.privateKey?.trim();
+      if (!input.useEnv) {
+        const privateKey = input.privateKey?.trim();
         if (!privateKey) {
           return "Nostr requires --private-key or --use-env.";
         }
@@ -62,23 +68,22 @@ export function createNostrSetupAdapter(params: {
           return "Nostr private key must be valid nsec or 64-character hex.";
         }
       }
-      if (typedInput.relayUrls?.trim()) {
-        return parseRelayUrls(typedInput.relayUrls).error ?? null;
+      if (input.relayUrls?.trim()) {
+        return parseRelayUrls(input.relayUrls).error ?? null;
       }
       return null;
     },
     applyAccountConfig: ({ cfg, accountId, input }) => {
-      const typedInput = input as NostrSetupInput;
-      const relayResult = typedInput.relayUrls?.trim()
-        ? parseRelayUrls(typedInput.relayUrls)
+      const relayResult = input.relayUrls?.trim()
+        ? parseRelayUrls(input.relayUrls)
         : { relays: [] };
       return patchTopLevelChannelConfigSection({
         cfg,
         channel,
         enabled: true,
-        clearFields: typedInput.useEnv ? ["privateKey"] : undefined,
+        clearFields: input.useEnv ? ["privateKey"] : undefined,
         patch: buildNostrSetupPatch(accountId, {
-          ...(typedInput.useEnv ? {} : { privateKey: typedInput.privateKey?.trim() }),
+          ...(input.useEnv ? {} : { privateKey: input.privateKey?.trim() }),
           ...(relayResult.relays.length > 0 ? { relays: relayResult.relays } : {}),
         }),
       });
@@ -86,7 +91,7 @@ export function createNostrSetupAdapter(params: {
   };
 }
 
-export function createNostrSetupContract(adapter: ChannelSetupAdapter) {
+export function createNostrSetupContract(adapter: ChannelSetupAdapter<NostrSetupInput>) {
   return defineChannelSetupContract({
     fields: {
       privateKey: {
@@ -103,6 +108,30 @@ export function createNostrSetupContract(adapter: ChannelSetupAdapter) {
         cli: { flags: "--use-env", description: "Use NOSTR_PRIVATE_KEY" },
       },
     },
-    legacyAdapter: adapter,
+    adapter,
+  });
+}
+
+export function createNostrSetupStatus(
+  resolveAccount: (params: { cfg: OpenClawConfig; accountId?: string | null }) => {
+    configured: boolean;
+    relays: string[];
+  },
+) {
+  const t = createSetupTranslator();
+  return createStandardChannelSetupStatus({
+    channelLabel: "Nostr",
+    configuredLabel: t("wizard.channels.statusConfigured"),
+    unconfiguredLabel: t("wizard.channels.statusNeedsPrivateKey"),
+    configuredHint: t("wizard.channels.statusConfigured"),
+    unconfiguredHint: t("wizard.channels.statusNeedsPrivateKey"),
+    configuredScore: 1,
+    unconfiguredScore: 0,
+    includeStatusLine: true,
+    resolveConfigured: ({ cfg, accountId }) => resolveAccount({ cfg, accountId }).configured,
+    resolveExtraStatusLines: ({ cfg }) => {
+      const account = resolveAccount({ cfg });
+      return [`Relays: ${account.relays.length || DEFAULT_RELAYS.length}`];
+    },
   });
 }

--- a/extensions/nostr/src/setup-surface.ts
+++ b/extensions/nostr/src/setup-surface.ts
@@ -7,7 +7,6 @@ import {
 import type { ChannelSetupDmPolicy, ChannelSetupWizard, DmPolicy } from "openclaw/plugin-sdk/setup";
 import {
   createSetupTranslator,
-  createStandardChannelSetupStatus,
   createTopLevelChannelDmPolicy,
   createTopLevelChannelParsedAllowFromPrompt,
   defineTokenCredential,
@@ -23,6 +22,7 @@ import {
   buildNostrSetupPatch,
   createNostrSetupAdapter,
   createNostrSetupContract,
+  createNostrSetupStatus,
   parseRelayUrls,
 } from "./setup-adapter.js";
 import { resolveDefaultNostrAccountId, resolveNostrAccount } from "./types.js";
@@ -96,21 +96,7 @@ export const nostrSetupWizard: ChannelSetupWizard = {
   resolveAccountIdForConfigure: ({ accountOverride, defaultAccountId }) =>
     accountOverride?.trim() || defaultAccountId,
   resolveShouldPromptAccountIds: () => false,
-  status: createStandardChannelSetupStatus({
-    channelLabel: "Nostr",
-    configuredLabel: t("wizard.channels.statusConfigured"),
-    unconfiguredLabel: t("wizard.channels.statusNeedsPrivateKey"),
-    configuredHint: t("wizard.channels.statusConfigured"),
-    unconfiguredHint: t("wizard.channels.statusNeedsPrivateKey"),
-    configuredScore: 1,
-    unconfiguredScore: 0,
-    includeStatusLine: true,
-    resolveConfigured: ({ cfg }) => resolveNostrAccount({ cfg }).configured,
-    resolveExtraStatusLines: ({ cfg }) => {
-      const account = resolveNostrAccount({ cfg });
-      return [`Relays: ${account.relays.length || DEFAULT_RELAYS.length}`];
-    },
-  }),
+  status: createNostrSetupStatus(resolveNostrAccount),
   introNote: {
     title: t("wizard.nostr.setupTitle"),
     lines: NOSTR_SETUP_HELP_LINES,

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -5,12 +5,11 @@ import { isSlackPluginAccountConfigured } from "./account-configured.js";
 import { inspectSlackAccount } from "./account-inspect.js";
 import type { ResolvedSlackAccount } from "./accounts.js";
 import { getChatChannelMeta, type ChannelPlugin } from "./channel-api.js";
+import { slackSetupPlugin } from "./channel.setup.js";
 import { slackBaseConfigAdapter } from "./config-adapter.js";
-import { SlackChannelConfigSchema } from "./config-schema.js";
 import { slackDoctor } from "./doctor.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { slackSecurityAdapter } from "./security.js";
-import { SLACK_CHANNEL } from "./setup-shared.js";
 
 export { SLACK_CHANNEL } from "./setup-shared.js";
 
@@ -42,26 +41,13 @@ export function createSlackPluginBase(params: {
   | "secrets"
 > {
   return {
-    id: SLACK_CHANNEL,
+    ...slackSetupPlugin,
     meta: {
-      ...getChatChannelMeta(SLACK_CHANNEL),
+      ...getChatChannelMeta(slackSetupPlugin.id),
       preferSessionLookupForAnnounceTarget: true,
     },
     setupWizard: params.setupWizard,
     setupContract: params.setupContract,
-    capabilities: {
-      chatTypes: ["direct", "channel", "thread"],
-      reactions: true,
-      threads: true,
-      media: true,
-      nativeCommands: true,
-    },
-    commands: {
-      nativeCommandsAutoEnabled: false,
-      nativeSkillsAutoEnabled: false,
-      resolveNativeCommandName: ({ commandKey, defaultName }) =>
-        commandKey === "status" ? "agentstatus" : defaultName,
-    },
     doctor: slackDoctor,
     agentPrompt: {
       inboundFormattingHints: () => ({
@@ -83,18 +69,10 @@ export function createSlackPluginBase(params: {
         "- Slack Block Kit or presentation text fields are sent as Slack mrkdwn directly; use `*bold*`, `_italic_`, `~strike~`, `<url|label>` links, and avoid Markdown headings or pipe tables there.",
       ],
     },
-    streaming: {
-      blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
-    },
-    reload: { configPrefixes: ["channels.slack"] },
     security: slackSecurityAdapter,
-    configSchema: SlackChannelConfigSchema,
     config: {
+      ...slackSetupPlugin.config,
       ...slackConfigAdapter,
-      hasConfiguredState: ({ env }) =>
-        ["SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "SLACK_USER_TOKEN"].some(
-          (key) => typeof env?.[key] === "string" && env[key]?.trim().length > 0,
-        ),
       isConfigured: (account) => isSlackPluginAccountConfigured(account),
       describeAccount: (account) =>
         describeAccountSnapshot({

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -1,4 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
 /**
  * Channel setup config mutation helpers.
  *
@@ -10,31 +9,26 @@ import { resolveSingleAccountKeysToMove } from "./setup-promotion-helpers.js";
 import type { ChannelSetupAdapter } from "./types.adapters.js";
 import type { ChannelSetupInput } from "./types.core.js";
 
-type ChannelSectionBase = {
+type ChannelSectionBase = Record<string, unknown> & {
   name?: string;
   defaultAccount?: string;
   accounts?: Record<string, Record<string, unknown>>;
 };
 
-function channelHasAccounts(cfg: OpenClawConfig, channelKey: string): boolean {
-  const channels = cfg.channels as Record<string, unknown> | undefined;
-  const base = channels?.[channelKey] as ChannelSectionBase | undefined;
-  return Boolean(base?.accounts && Object.keys(base.accounts).length > 0);
+function getChannelSection(
+  cfg: OpenClawConfig,
+  channelKey: string,
+): ChannelSectionBase | undefined {
+  const section = (cfg.channels as Record<string, unknown> | undefined)?.[channelKey];
+  return section && typeof section === "object" ? (section as ChannelSectionBase) : undefined;
 }
 
-function shouldStoreNameInAccounts(params: {
-  cfg: OpenClawConfig;
-  channelKey: string;
-  accountId: string;
-  alwaysUseAccounts?: boolean;
-}): boolean {
-  if (params.alwaysUseAccounts) {
-    return true;
-  }
-  if (params.accountId !== DEFAULT_ACCOUNT_ID) {
-    return true;
-  }
-  return channelHasAccounts(params.cfg, params.channelKey);
+function writeChannelSection(
+  cfg: OpenClawConfig,
+  channelKey: string,
+  section: ChannelSectionBase,
+): OpenClawConfig {
+  return { ...cfg, channels: { ...cfg.channels, [channelKey]: section } } as OpenClawConfig;
 }
 
 export function applyAccountNameToChannelSection(params: {
@@ -49,51 +43,23 @@ export function applyAccountNameToChannelSection(params: {
     return params.cfg;
   }
   const accountId = normalizeAccountId(params.accountId);
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const baseConfig = channels?.[params.channelKey];
-  const base =
-    typeof baseConfig === "object" && baseConfig ? (baseConfig as ChannelSectionBase) : undefined;
-  const useAccounts = shouldStoreNameInAccounts({
-    cfg: params.cfg,
-    channelKey: params.channelKey,
-    accountId,
-    alwaysUseAccounts: params.alwaysUseAccounts,
-  });
-  if (!useAccounts && accountId === DEFAULT_ACCOUNT_ID) {
-    const safeBase = base ?? {};
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [params.channelKey]: {
-          ...safeBase,
-          name: trimmed,
-        },
-      },
-    } as OpenClawConfig;
+  const base = getChannelSection(params.cfg, params.channelKey);
+  const accounts = base?.accounts ?? {};
+  const useAccounts =
+    params.alwaysUseAccounts ||
+    accountId !== DEFAULT_ACCOUNT_ID ||
+    Object.keys(accounts).length > 0;
+  if (!useAccounts) {
+    return writeChannelSection(params.cfg, params.channelKey, { ...base, name: trimmed });
   }
-  const baseAccounts: Record<string, Record<string, unknown>> = base?.accounts ?? {};
-  const existingAccount = baseAccounts[accountId] ?? {};
   const baseWithoutName =
     accountId === DEFAULT_ACCOUNT_ID
       ? (({ name: _ignored, ...rest }) => rest)(base ?? {})
       : (base ?? {});
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.channelKey]: {
-        ...baseWithoutName,
-        accounts: {
-          ...baseAccounts,
-          [accountId]: {
-            ...existingAccount,
-            name: trimmed,
-          },
-        },
-      },
-    },
-  } as OpenClawConfig;
+  return writeChannelSection(params.cfg, params.channelKey, {
+    ...baseWithoutName,
+    accounts: { ...accounts, [accountId]: { ...accounts[accountId], name: trimmed } },
+  });
 }
 
 /** Moves a root-level channel name into `accounts.default` before adding named accounts. */
@@ -105,8 +71,7 @@ export function migrateBaseNameToDefaultAccount(params: {
   if (params.alwaysUseAccounts) {
     return params.cfg;
   }
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const base = channels?.[params.channelKey] as ChannelSectionBase | undefined;
+  const base = getChannelSection(params.cfg, params.channelKey);
   const baseName = base?.name?.trim();
   if (!baseName) {
     return params.cfg;
@@ -119,16 +84,7 @@ export function migrateBaseNameToDefaultAccount(params: {
     accounts[DEFAULT_ACCOUNT_ID] = { ...defaultAccount, name: baseName };
   }
   const { name: _ignored, ...rest } = base ?? {};
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.channelKey]: {
-        ...rest,
-        accounts,
-      },
-    },
-  } as OpenClawConfig;
+  return writeChannelSection(params.cfg, params.channelKey, { ...rest, accounts });
 }
 
 /** Applies setup-time account naming and optional root-name migration in one step. */
@@ -164,12 +120,7 @@ export function applySetupAccountConfigPatch(params: {
   accountId: string;
   patch: Record<string, unknown>;
 }): OpenClawConfig {
-  return patchScopedAccountConfig({
-    cfg: params.cfg,
-    channelKey: params.channelKey,
-    accountId: params.accountId,
-    patch: params.patch,
-  });
+  return patchScopedAccountConfig(params);
 }
 
 /** Creates a setup adapter that turns validated setup input into an account config patch. */
@@ -301,14 +252,7 @@ export function patchScopedAccountConfig(params: {
   scopeDefaultToAccounts?: boolean;
 }): OpenClawConfig {
   const accountId = normalizeAccountId(params.accountId);
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const channelConfig = channels?.[params.channelKey];
-  const base =
-    typeof channelConfig === "object" && channelConfig
-      ? (channelConfig as Record<string, unknown> & {
-          accounts?: Record<string, Record<string, unknown>>;
-        })
-      : undefined;
+  const base = getChannelSection(params.cfg, params.channelKey);
   const ensureChannelEnabled = params.ensureChannelEnabled ?? true;
   const ensureAccountEnabled = params.ensureAccountEnabled ?? ensureChannelEnabled;
   const patch = params.patch;
@@ -325,102 +269,67 @@ export function patchScopedAccountConfig(params: {
   };
   if (accountId === DEFAULT_ACCOUNT_ID && !params.scopeDefaultToAccounts) {
     // Default accounts historically live at channel root unless the channel opts into accounts.default.
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [params.channelKey]: {
-          ...clearFields(base ?? {}),
-          ...(ensureChannelEnabled ? { enabled: true } : {}),
-          ...patch,
-        },
-      },
-    } as OpenClawConfig;
+    return writeChannelSection(params.cfg, params.channelKey, {
+      ...clearFields(base ?? {}),
+      ...(ensureChannelEnabled ? { enabled: true } : {}),
+      ...patch,
+    });
   }
 
   const accounts = base?.accounts ?? {};
   const existingAccount = clearFields(accounts[accountId] ?? {});
   // Preserve an explicit disabled account while enabling newly created accounts by default.
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.channelKey]: {
-        ...base,
-        ...(ensureChannelEnabled ? { enabled: true } : {}),
-        accounts: {
-          ...accounts,
-          [accountId]: {
-            ...existingAccount,
-            ...(ensureAccountEnabled
-              ? {
-                  enabled:
-                    typeof existingAccount.enabled === "boolean" ? existingAccount.enabled : true,
-                }
-              : {}),
-            ...accountPatch,
-          },
-        },
+  return writeChannelSection(params.cfg, params.channelKey, {
+    ...base,
+    ...(ensureChannelEnabled ? { enabled: true } : {}),
+    accounts: {
+      ...accounts,
+      [accountId]: {
+        ...existingAccount,
+        ...(ensureAccountEnabled
+          ? {
+              enabled:
+                typeof existingAccount.enabled === "boolean" ? existingAccount.enabled : true,
+            }
+          : {}),
+        ...accountPatch,
       },
     },
-  } as OpenClawConfig;
-}
-
-type ChannelSectionRecord = Record<string, unknown> & {
-  accounts?: Record<string, Record<string, unknown>>;
-};
-
-function cloneIfObject<T>(value: T): T {
-  if (value && typeof value === "object") {
-    return structuredClone(value);
-  }
-  return value;
+  });
 }
 
 function moveSingleAccountKeysIntoAccount(params: {
   cfg: OpenClawConfig;
   channelKey: string;
-  channel: ChannelSectionRecord;
+  channel: ChannelSectionBase;
   accounts: Record<string, Record<string, unknown>>;
   keysToMove: string[];
   targetAccountId: string;
   baseAccount?: Record<string, unknown>;
 }): OpenClawConfig {
   const nextAccount: Record<string, unknown> = { ...params.baseAccount };
+  const nextChannel: ChannelSectionBase = { ...params.channel };
   for (const key of params.keysToMove) {
     if (!(key in nextAccount)) {
-      nextAccount[key] = cloneIfObject(params.channel[key]);
+      const value = params.channel[key];
+      nextAccount[key] = value && typeof value === "object" ? structuredClone(value) : value;
     }
-  }
-  const nextChannel: ChannelSectionRecord = { ...params.channel };
-  for (const key of params.keysToMove) {
     delete nextChannel[key];
   }
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.channelKey]: {
-        ...nextChannel,
-        accounts: {
-          ...params.accounts,
-          [params.targetAccountId]: nextAccount,
-        },
-      },
-    },
-  } as OpenClawConfig;
+  return writeChannelSection(params.cfg, params.channelKey, {
+    ...nextChannel,
+    accounts: { ...params.accounts, [params.targetAccountId]: nextAccount },
+  });
 }
 
 function resolveExistingAccountKey(
   accounts: Record<string, Record<string, unknown>>,
   targetAccountId: string,
 ): string {
-  for (const existingKey of Object.keys(accounts)) {
-    if (normalizeAccountId(existingKey) === targetAccountId) {
-      return existingKey;
-    }
-  }
-  return targetAccountId;
+  return (
+    Object.keys(accounts).find((key) => normalizeAccountId(key) === targetAccountId) ??
+    targetAccountId
+  );
 }
 
 function resolveSingleAccountPromotionTarget(params: {
@@ -446,9 +355,7 @@ function resolveSingleAccountPromotionTarget(params: {
     );
   }
   const namedAccounts = Object.keys(accounts).filter(Boolean);
-  return namedAccounts.length === 1
-    ? expectDefined(namedAccounts[0], "named accounts entry at 0")
-    : DEFAULT_ACCOUNT_ID;
+  return namedAccounts.length === 1 ? (namedAccounts[0] ?? DEFAULT_ACCOUNT_ID) : DEFAULT_ACCOUNT_ID;
 }
 
 /**
@@ -459,54 +366,34 @@ export function moveSingleAccountChannelSectionToDefaultAccount(params: {
   channelKey: string;
   setupSurface?: ChannelSetupAdapter;
 }): OpenClawConfig {
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const baseConfig = channels?.[params.channelKey];
-  const base =
-    typeof baseConfig === "object" && baseConfig ? (baseConfig as ChannelSectionRecord) : undefined;
+  const base = getChannelSection(params.cfg, params.channelKey);
   if (!base) {
     return params.cfg;
   }
 
   const accounts = base.accounts ?? {};
-  if (Object.keys(accounts).length > 0) {
-    const keysToMove = resolveSingleAccountKeysToMove({
-      channelKey: params.channelKey,
-      channel: base,
-      setupSurface: params.setupSurface,
-      includeSetupKeys: true,
-    });
-    if (keysToMove.length === 0) {
-      return params.cfg;
-    }
-
-    const targetAccountId = resolveSingleAccountPromotionTarget({
-      channel: base,
-      setupSurface: params.setupSurface,
-    });
-    // Reuse the existing account key spelling so configs like `accounts.Ops` keep their shape.
-    const resolvedTargetAccountKey = resolveExistingAccountKey(accounts, targetAccountId);
-    return moveSingleAccountKeysIntoAccount({
-      cfg: params.cfg,
-      channelKey: params.channelKey,
-      channel: base,
-      accounts,
-      keysToMove,
-      targetAccountId: resolvedTargetAccountKey,
-      baseAccount: accounts[resolvedTargetAccountKey],
-    });
-  }
+  const hasAccounts = Object.keys(accounts).length > 0;
   const keysToMove = resolveSingleAccountKeysToMove({
     channelKey: params.channelKey,
     channel: base,
     setupSurface: params.setupSurface,
     includeSetupKeys: true,
   });
+  if (hasAccounts && keysToMove.length === 0) {
+    return params.cfg;
+  }
+  const targetAccountId = hasAccounts
+    ? resolveSingleAccountPromotionTarget({ channel: base, setupSurface: params.setupSurface })
+    : DEFAULT_ACCOUNT_ID;
+  // Reuse the existing account key spelling so configs like `accounts.Ops` keep their shape.
+  const resolvedTargetAccountKey = resolveExistingAccountKey(accounts, targetAccountId);
   return moveSingleAccountKeysIntoAccount({
     cfg: params.cfg,
     channelKey: params.channelKey,
     channel: base,
     accounts,
     keysToMove,
-    targetAccountId: DEFAULT_ACCOUNT_ID,
+    targetAccountId: resolvedTargetAccountKey,
+    baseAccount: accounts[resolvedTargetAccountKey],
   });
 }

--- a/src/channels/plugins/setup-wizard-proxy.ts
+++ b/src/channels/plugins/setup-wizard-proxy.ts
@@ -9,7 +9,6 @@ import type { ChannelSetupDmPolicy } from "./setup-wizard-types.js";
 import type { ChannelSetupWizard } from "./setup-wizard.js";
 
 type PromptAllowFromParams = Parameters<NonNullable<ChannelSetupDmPolicy["promptAllowFrom"]>>[0];
-type ResolveConfiguredParams = Parameters<ChannelSetupWizard["status"]["resolveConfigured"]>[0];
 type ResolveAllowFromEntriesParams = Parameters<
   NonNullable<ChannelSetupWizard["allowFrom"]>["resolveEntries"]
 >[0];
@@ -19,30 +18,6 @@ type ResolveAllowFromEntriesResult = Awaited<
 type ResolveGroupAllowlistParams = Parameters<
   NonNullable<NonNullable<ChannelSetupWizard["groupAccess"]>["resolveAllowlist"]>
 >[0];
-
-/**
- * Delegates setup configured-state checks to a lazily loaded wizard.
- */
-function createDelegatedResolveConfigured(loadWizard: () => Promise<ChannelSetupWizard>) {
-  return async ({ cfg, accountId }: ResolveConfiguredParams) =>
-    await (await loadWizard()).status.resolveConfigured({ cfg, accountId });
-}
-
-/**
- * Delegates setup preparation to a lazily loaded wizard.
- */
-function createDelegatedPrepare(loadWizard: () => Promise<ChannelSetupWizard>) {
-  return async (params: Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0]) =>
-    await (await loadWizard()).prepare?.(params);
-}
-
-/**
- * Delegates setup finalization to a lazily loaded wizard.
- */
-function createDelegatedFinalize(loadWizard: () => Promise<ChannelSetupWizard>) {
-  return async (params: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]) =>
-    await (await loadWizard()).finalize?.(params);
-}
 
 type DelegatedStatusBase = Omit<
   ChannelSetupWizard["status"],
@@ -70,7 +45,8 @@ export function createDelegatedSetupWizardProxy(params: {
     channel: params.channel,
     status: {
       ...params.status,
-      resolveConfigured: createDelegatedResolveConfigured(params.loadWizard),
+      resolveConfigured: async (statusParams) =>
+        await (await params.loadWizard()).status.resolveConfigured(statusParams),
       ...createDelegatedSetupWizardStatusResolvers(params.loadWizard),
     },
     // Keep static setup metadata available immediately, while expensive
@@ -78,10 +54,22 @@ export function createDelegatedSetupWizardProxy(params: {
     ...(params.resolveShouldPromptAccountIds
       ? { resolveShouldPromptAccountIds: params.resolveShouldPromptAccountIds }
       : {}),
-    ...(params.delegatePrepare ? { prepare: createDelegatedPrepare(params.loadWizard) } : {}),
+    ...(params.delegatePrepare
+      ? {
+          prepare: async (
+            prepareParams: Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0],
+          ) => await (await params.loadWizard()).prepare?.(prepareParams),
+        }
+      : {}),
     credentials: params.credentials ?? [],
     ...(params.textInputs ? { textInputs: params.textInputs } : {}),
-    ...(params.delegateFinalize ? { finalize: createDelegatedFinalize(params.loadWizard) } : {}),
+    ...(params.delegateFinalize
+      ? {
+          finalize: async (
+            finalizeParams: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0],
+          ) => await (await params.loadWizard()).finalize?.(finalizeParams),
+        }
+      : {}),
     ...(params.completionNote ? { completionNote: params.completionNote } : {}),
     ...(params.dmPolicy ? { dmPolicy: params.dmPolicy } : {}),
     ...(params.disable ? { disable: params.disable } : {}),


### PR DESCRIPTION
## What Problem This Solves

Bundled Slack, Matrix, and Nostr channels duplicated setup metadata, account-state handling, status resolvers, and runtime plugin definitions. Core setup account mutation likewise repeated root/named-account writes and promotion paths, increasing drift risk during onboarding and upgrades.

## Why This Change Was Made

Make lightweight setup definitions authoritative for shared channel metadata while keeping heavy runtime functionality lazy and plugin-owned. Reuse canonical account-section reads/writes, one promotion path, typed Nostr setup input, and a shared Nostr status owner. Preserve every shipped external Plugin SDK setup export, released legacy setup/setupWizard adapters, setupContract precedence, CLI flags, account-key spelling, disabled-account semantics, Matrix capability differences, and Slack runtime security/doctor behavior.

Production LOC: **173 added / 401 removed = 228 fewer lines**; zero test deletions and zero public SDK surface changes.

## User Impact

No intended user-visible behavior change. Operators retain existing guided and non-interactive setup, named/default accounts, pairing/allowlist policies, plugin compatibility, and all Slack, Matrix, and Nostr capabilities.

## Evidence

- Remote Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30681190710
- Focused real owner/sibling proof: **14 files, 143 tests, 7 Vitest projects passed**, covering setup helpers, account promotion, import safety, modern/legacy contract precedence, wizard/proxy/binary/legacy policy, channels CLI, channels add, and Slack/Matrix/Nostr setup.
- Full remote `pnpm check:changed` passed: public Plugin SDK API baseline, plugin-boundary guard, dead-export scans, core/core-test/plugin/plugin-test type checks, changed lint, formatting, dependency/security/database guards, and zero runtime import cycles.
- Full remote `pnpm build` passed, including all 148 public Plugin SDK subpaths and bundled-plugin/runtime startup imports.
- Real isolated packaged operator proof passed: `channels add` configured Nostr, Slack, and Matrix; `channels list --json` returned all three installed/configured default accounts; `doctor --non-interactive` completed and preserved security, pairing, and allowlist diagnostics.
- Fresh structured autoreview: `gpt-5.6-sol/high`, clean; confidence **0.99**.
- Compatibility directly verified against shipped `v2026.6.33`, `v2026.7.2-beta.5`, and `docs/plugins/sdk-setup.md` / `docs/plugins/sdk-migration.md`.
- The dedicated Testbox was stopped after proof.