### PR TITLE
fix(google): preserve canonical replay and provider error ownership

### DIFF
--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -201,6 +201,27 @@ describe("google-shared convertMessages", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "text",
+      block: { type: "text", text: "", textSignature: "c2lnbmVk" },
+      part: { text: "", thoughtSignature: "c2lnbmVk" },
+    },
+    {
+      label: "thinking",
+      block: { type: "thinking", thinking: "", thinkingSignature: "c2lnbmVk" },
+      part: { thought: true, text: "", thoughtSignature: "c2lnbmVk" },
+    },
+  ])("preserves the empty content field of a signed $label part", ({ block, part }) => {
+    const model = makeModel("gemini-3-flash");
+
+    const contents = convertMessagesForTest(model, {
+      messages: [makeGoogleAssistantMessage(model.id, [block])],
+    } as Context);
+
+    expect(contents).toEqual([{ role: "model", parts: [part] }]);
+  });
+
   it("supplies the documented Gemini 3 thought-signature placeholder for unsigned calls", () => {
     const model = makeModel("gemini-3-flash");
     const contents = convertMessagesForTest(model, {

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -168,6 +168,23 @@ describe("google-shared convertTools", () => {
 
 describe("google-shared convertMessages", () => {
   it.each([
+    { label: "serialized object", value: '{"query":"cats"}', expected: { query: "cats" } },
+    { label: "malformed JSON", value: "{not valid json", expected: {} },
+    { label: "JSON array", value: ["not", "an", "object"], expected: {} },
+  ])("coerces $label tool-call arguments to the SDK object contract", ({ value, expected }) => {
+    const model = makeModel("gemini-3-flash");
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "call_1", name: "lookup", arguments: value },
+        ]),
+      ],
+    } as Context);
+
+    expect(contents[0]?.parts?.[0]?.functionCall?.args).toEqual(expected);
+  });
+
+  it.each([
     { label: "empty user text", messages: [{ role: "user", content: "" }] },
     {
       label: "empty user text part",
@@ -196,6 +213,183 @@ describe("google-shared convertMessages", () => {
 
     expect(contents[0]?.parts?.[0]?.thoughtSignature).toBe("skip_thought_signature_validator");
   });
+
+  it("keeps unsigned parallel Gemini 3 calls exactly as the provider issued them", () => {
+    const model = makeModel("gemini-3-flash");
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "signed",
+            arguments: {},
+            thoughtSignature: "c2lnbmVk",
+          },
+          { type: "toolCall", id: "call_2", name: "unsigned", arguments: {} },
+        ]),
+      ],
+    } as Context);
+
+    expect(contents[0]?.parts).toEqual([
+      { functionCall: { name: "signed", args: {} }, thoughtSignature: "c2lnbmVk" },
+      { functionCall: { name: "unsigned", args: {} } },
+    ]);
+  });
+
+  it.each([
+    { label: "identical arguments", first: { q: "cats" }, second: { q: "cats" } },
+    {
+      label: "reordered nested arguments",
+      first: { first: 1, nested: { alpha: 2, beta: 3 } },
+      second: { nested: { beta: 3, alpha: 2 }, first: 1 },
+    },
+    {
+      label: "canonically distinct Unicode keys",
+      first: { é: 1, "e\u0301": 2 },
+      second: { "e\u0301": 2, é: 1 },
+    },
+  ])(
+    "keeps an earlier Gemini tool-call signature on its original $label part",
+    ({ first, second }) => {
+      const model = makeModel("gemini-3-flash");
+      const toolCall = { type: "toolCall", id: "call_1", name: "lookup" };
+      const contents = convertMessagesForTest(model, {
+        messages: [
+          makeGoogleAssistantMessage(model.id, [
+            { ...toolCall, arguments: first, thoughtSignature: "c2lnbmVk" },
+          ]),
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "cats" }],
+            isError: false,
+            timestamp: 0,
+          },
+          makeGoogleAssistantMessage(model.id, [{ ...toolCall, arguments: second }]),
+        ],
+      } as Context);
+
+      const signatures = contents
+        .flatMap((content) => content.parts ?? [])
+        .filter((part) => part.functionCall)
+        .map((part) => part.thoughtSignature);
+      expect(signatures).toEqual(["c2lnbmVk", "skip_thought_signature_validator"]);
+    },
+  );
+
+  it("never replays a cached signature onto a later parallel Gemini function call", () => {
+    const model = makeModel("gemini-3-flash");
+    const cachedCall = { type: "toolCall", id: "call_1", name: "lookup", arguments: {} };
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [{ ...cachedCall, thoughtSignature: "c2lnbmVk" }]),
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: 0,
+        },
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "other", name: "different", arguments: {} },
+          cachedCall,
+        ]),
+      ],
+    } as Context);
+
+    const signatures = contents
+      .flatMap((content) => content.parts ?? [])
+      .filter((part) => part.functionCall)
+      .map((part) => part.thoughtSignature);
+    expect(signatures).toEqual(["c2lnbmVk", "skip_thought_signature_validator", undefined]);
+  });
+
+  it.each(["google-vertex", "openai-responses"])(
+    "never replays a Gemini tool-call signature onto the foreign %s API route",
+    (api) => {
+      const model = makeModel("gemini-3-flash");
+      const toolCall = { type: "toolCall", id: "call_1", name: "lookup", arguments: {} };
+      const contents = convertMessagesForTest(model, {
+        messages: [
+          makeGoogleAssistantMessage(model.id, [{ ...toolCall, thoughtSignature: "c2lnbmVk" }]),
+          {
+            ...makeGoogleAssistantMessage(model.id, [toolCall]),
+            api,
+          },
+        ],
+      } as Context);
+
+      const signatures = contents
+        .flatMap((content) => content.parts ?? [])
+        .filter((part) => part.functionCall)
+        .map((part) => part.thoughtSignature);
+      expect(signatures).toEqual(["c2lnbmVk", "skip_thought_signature_validator"]);
+    },
+  );
+
+  it("never replays a prior user turn's Gemini tool-call signature", () => {
+    const model = makeModel("gemini-3-flash");
+    const toolCall = { type: "toolCall", id: "call_1", name: "lookup", arguments: {} };
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [{ ...toolCall, thoughtSignature: "c2lnbmVk" }]),
+        { role: "user", content: "a new question", timestamp: 1 },
+        makeGoogleAssistantMessage(model.id, [toolCall]),
+      ],
+    } as Context);
+
+    const signatures = contents
+      .flatMap((content) => content.parts ?? [])
+      .filter((part) => part.functionCall)
+      .map((part) => part.thoughtSignature);
+    expect(signatures).toEqual(["c2lnbmVk", "skip_thought_signature_validator"]);
+  });
+
+  it("resets signature replay for runtime-context carriers emitted as Google user turns", () => {
+    const model = makeModel("gemini-3-flash");
+    const toolCall = { type: "toolCall", id: "call_1", name: "lookup", arguments: {} };
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [{ ...toolCall, thoughtSignature: "c2lnbmVk" }]),
+        {
+          role: "user",
+          content: "volatile runtime context",
+          runtimeContextCarrier: true,
+          timestamp: 1,
+        },
+        makeGoogleAssistantMessage(model.id, [toolCall]),
+      ],
+    } as Context);
+
+    const signatures = contents
+      .flatMap((content) => content.parts ?? [])
+      .filter((part) => part.functionCall)
+      .map((part) => part.thoughtSignature);
+    expect(signatures).toEqual(["c2lnbmVk", "skip_thought_signature_validator"]);
+  });
+
+  it.each(["gemini-2.5-pro", "claude-3-opus"])(
+    "does not replay thought signatures for the unsupported %s model",
+    (modelId) => {
+      const model = makeModel(modelId);
+      const toolCall = { type: "toolCall", id: "call_1", name: "lookup", arguments: {} };
+      const contents = convertMessagesForTest(model, {
+        messages: [
+          makeGoogleAssistantMessage(model.id, [{ ...toolCall, thoughtSignature: "c2lnbmVk" }]),
+          makeGoogleAssistantMessage(model.id, [toolCall]),
+        ],
+      } as Context);
+
+      const signatures = contents
+        .flatMap((content) => content.parts ?? [])
+        .filter((part) => part.functionCall)
+        .map((part) => part.thoughtSignature);
+      expect(signatures).toEqual(["c2lnbmVk", undefined]);
+    },
+  );
 
   function expectConsecutiveMessagesNotMerged(params: {
     modelId: string;

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -500,7 +500,14 @@ describe("consumeGoogleGenerateContentStream", () => {
 
     expect(output.content).toEqual(content);
     expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "" }));
-    expect(convertMessages(model, { messages: [output] })).toEqual([{ role: "model", parts }]);
+    expect(convertMessages(model, { messages: [output] })).toEqual([
+      {
+        role: "model",
+        parts: parts.map((part) =>
+          "thoughtSignature" in part && !("text" in part) ? { ...part, text: "" } : part,
+        ),
+      },
+    ]);
   });
 
   it("keeps an explicit signature-only thought separate from the preceding tool call", async () => {

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -1,5 +1,5 @@
 // Google shared provider tests cover response conversion and finish reasons.
-import { FinishReason, GoogleGenAI, type GenerateContentResponse } from "@google/genai";
+import { ApiError, FinishReason, GoogleGenAI, type GenerateContentResponse } from "@google/genai";
 import { describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, Model } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -7,6 +7,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-bound
 import {
   buildGoogleGenerateContentParams,
   buildGoogleSimpleThinking,
+  convertMessages,
   consumeGoogleGenerateContentStream,
   runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
@@ -446,6 +447,276 @@ describe("consumeGoogleGenerateContentStream", () => {
       },
     ]);
   });
+
+  it.each([
+    {
+      label: "the first thinking delta",
+      parts: [
+        { thoughtSignature: "c2lnXzE=" },
+        { thought: true, text: "draft" },
+        { text: "answer" },
+      ],
+      content: [
+        { type: "text", text: "", textSignature: "c2lnXzE=" },
+        { type: "thinking", thinking: "draft", thinkingSignature: undefined },
+        { type: "text", text: "answer", textSignature: undefined },
+      ],
+    },
+    {
+      label: "a later thinking delta",
+      parts: [
+        { thought: true, text: "draft", thoughtSignature: "c2lnXzE=" },
+        { thoughtSignature: "c2lnXzI=" },
+        { text: "answer" },
+      ],
+      content: [
+        { type: "thinking", thinking: "draft", thinkingSignature: "c2lnXzE=" },
+        { type: "text", text: "", textSignature: "c2lnXzI=" },
+        { type: "text", text: "answer", textSignature: undefined },
+      ],
+    },
+  ])("retains a standalone thought signature beside $label", async ({ parts, content }) => {
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+    const events: Array<{ type: string; delta?: string }> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event);
+      }
+    })();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [{ content: { parts }, finishReason: FinishReason.STOP }],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream,
+      nextToolCallId: () => "generated-lookup",
+    });
+    await collect;
+
+    expect(output.content).toEqual(content);
+    expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "" }));
+    expect(convertMessages(model, { messages: [output] })).toEqual([{ role: "model", parts }]);
+  });
+
+  it("keeps an explicit signature-only thought separate from the preceding tool call", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
+                  { thought: true, thoughtSignature: "dGhvdWdodF9zaWc=" },
+                  { thought: true, text: "draft" },
+                ],
+              },
+              finishReason: FinishReason.STOP,
+            },
+          ],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "generated-lookup",
+    });
+
+    expect(output.content).toEqual([
+      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      { type: "thinking", thinking: "", thinkingSignature: "dGhvdWdodF9zaWc=" },
+      { type: "thinking", thinking: "draft", thinkingSignature: undefined },
+    ]);
+  });
+
+  it.each([
+    { label: "different", signature: "c2lnXzI=" },
+    { label: "identical", signature: "c2lnXzE=" },
+  ])(
+    "never overwrites a signed tool call with a separate $label provider signature part",
+    async ({ signature }) => {
+      const output = createOutput();
+
+      await consumeGoogleGenerateContentStream({
+        chunks: chunks([
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: { id: "call_1", name: "lookup", args: {} },
+                      thoughtSignature: "c2lnXzE=",
+                    },
+                    { thoughtSignature: signature },
+                  ],
+                },
+                finishReason: FinishReason.STOP,
+              },
+            ],
+          } as GenerateContentResponse,
+        ]),
+        model,
+        output,
+        stream: new AssistantMessageEventStream(),
+        nextToolCallId: () => "generated-lookup",
+      });
+
+      expect(output.content).toEqual([
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "lookup",
+          arguments: {},
+          thoughtSignature: "c2lnXzE=",
+        },
+        { type: "text", text: "", textSignature: signature },
+      ]);
+    },
+  );
+
+  it("never attaches a signed media Part to the preceding unsigned tool call", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
+                  {
+                    inlineData: { mimeType: "image/png", data: "aW1hZ2U=" },
+                    thoughtSignature: "c2lnXzE=",
+                  },
+                ],
+              },
+              finishReason: FinishReason.STOP,
+            },
+          ],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "generated-lookup",
+    });
+
+    expect(output.content).toEqual([
+      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+    ]);
+  });
+
+  it("keeps a same-candidate standalone signature separate from an unsigned tool call", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
+                  { thoughtSignature: "c2lnXzE=" },
+                ],
+              },
+              finishReason: FinishReason.STOP,
+            },
+          ],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "generated-lookup",
+    });
+
+    expect(output.content).toEqual([
+      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      { type: "text", text: "", textSignature: "c2lnXzE=" },
+    ]);
+  });
+
+  it.each([
+    {
+      label: "signed text followed by unsigned text",
+      parts: [{ text: "signed", thoughtSignature: "c2lnXzE=" }, { text: "unsigned" }],
+      content: [
+        { type: "text", text: "signed", textSignature: "c2lnXzE=" },
+        { type: "text", text: "unsigned", textSignature: undefined },
+      ],
+    },
+    {
+      label: "signed thinking followed by unsigned thinking",
+      parts: [
+        { thought: true, text: "signed", thoughtSignature: "c2lnXzE=" },
+        { thought: true, text: "unsigned" },
+      ],
+      content: [
+        { type: "thinking", thinking: "signed", thinkingSignature: "c2lnXzE=" },
+        { type: "thinking", thinking: "unsigned", thinkingSignature: undefined },
+      ],
+    },
+    {
+      label: "separately signed text parts",
+      parts: [
+        { text: "first", thoughtSignature: "c2lnXzE=" },
+        { text: "second", thoughtSignature: "c2lnXzI=" },
+      ],
+      content: [
+        { type: "text", text: "first", textSignature: "c2lnXzE=" },
+        { type: "text", text: "second", textSignature: "c2lnXzI=" },
+      ],
+    },
+    {
+      label: "separately signed text parts with the same signature",
+      parts: [
+        { text: "first", thoughtSignature: "c2lnXzE=" },
+        { text: "second", thoughtSignature: "c2lnXzE=" },
+      ],
+      content: [
+        { type: "text", text: "first", textSignature: "c2lnXzE=" },
+        { type: "text", text: "second", textSignature: "c2lnXzE=" },
+      ],
+    },
+    {
+      label: "separately signed thought parts with the same signature",
+      parts: [
+        { thought: true, text: "first", thoughtSignature: "c2lnXzE=" },
+        { thought: true, text: "second", thoughtSignature: "c2lnXzE=" },
+      ],
+      content: [
+        { type: "thinking", thinking: "first", thinkingSignature: "c2lnXzE=" },
+        { type: "thinking", thinking: "second", thinkingSignature: "c2lnXzE=" },
+      ],
+    },
+  ])("keeps exact provider part ownership for $label", async ({ parts, content }) => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [{ content: { parts }, finishReason: FinishReason.STOP }],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "generated-lookup",
+    });
+
+    expect(output.content).toEqual(content);
+    expect(convertMessages(model, { messages: [output] })).toEqual([{ role: "model", parts }]);
+  });
 });
 
 describe("runGoogleGenerateContentLifecycle", () => {
@@ -604,9 +875,36 @@ describe("runGoogleGenerateContentLifecycle", () => {
 
     expect(await stream.result()).toMatchObject({
       stopReason: "aborted",
+      errorCode: "GATEWAY_RESTART",
       errorMessage: "Google run restarted",
     });
-    expect(output.errorCode).toBeUndefined();
+    expect(output.errorCode).toBe("GATEWAY_RESTART");
+  });
+
+  it.each([429, 503])("preserves the official Google SDK's %s API error status", async (status) => {
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+
+    await runGoogleGenerateContentLifecycle({
+      stream,
+      model,
+      output,
+      createClient: () => ({
+        models: {
+          generateContentStream: async () => {
+            throw new ApiError({ status, message: "Google quota exceeded" });
+          },
+        },
+      }),
+      buildParams: () => ({ model: model.id, contents: [] }),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(await stream.result()).toMatchObject({
+      stopReason: "error",
+      errorCode: String(status),
+      errorMessage: `${status}: Google quota exceeded`,
+    });
   });
 
   it("preserves the typed Gemini finish reason when the official SDK omits finishMessage", async () => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -462,7 +462,11 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
     } else {
       output.errorMessage = formattedError;
     }
-    stream.push({ type: "error", reason: output.stopReason, error: output });
+    stream.push({
+      type: "error",
+      reason: output.stopReason === "aborted" ? "aborted" : "error",
+      error: output,
+    });
     stream.end();
   }
 }
@@ -827,12 +831,13 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
     }
     if (candidate?.content?.parts) {
       for (const [partIndex, part] of candidate.content.parts.entries()) {
-        const hasText = typeof part.text === "string";
+        const text = part.text;
+        const hasText = typeof text === "string";
         const hasThoughtSignature =
           typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
         const signatureOnly =
           hasThoughtSignature &&
-          (!hasText || part.text.length === 0) &&
+          (!hasText || text.length === 0) &&
           Object.keys(part).every(
             (key) => key === "thought" || key === "thoughtSignature" || key === "text",
           );
@@ -896,7 +901,7 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
               });
             }
           }
-          const delta = hasText ? part.text : "";
+          const delta = hasText ? text : "";
           if (currentBlock.type === "thinking") {
             currentBlock.thinking += delta;
             currentBlock.thinkingSignature = retainThoughtSignature(

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -237,7 +237,7 @@ export function convertMessages<T extends GoogleApiType>(
             continue;
           }
           parts.push({
-            ...(block.text && { text: sanitizeSurrogates(block.text) }),
+            text: sanitizeSurrogates(block.text),
             ...(thoughtSignature && { thoughtSignature }),
           });
         } else if (block.type === "thinking") {
@@ -253,7 +253,7 @@ export function convertMessages<T extends GoogleApiType>(
           if (isSameProviderAndModel) {
             parts.push({
               thought: true,
-              ...(block.thinking && { text: sanitizeSurrogates(block.thinking) }),
+              text: sanitizeSurrogates(block.thinking),
               ...(thoughtSignature && { thoughtSignature }),
             });
           } else {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -14,7 +14,11 @@ import {
   ThinkingLevel,
 } from "@google/genai";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import {
+  assignTransportErrorDetails,
+  coerceTransportToolCallArguments,
+  transportAbortError,
+} from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -173,6 +177,9 @@ export function convertMessages<T extends GoogleApiType>(
   };
 
   const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+  const requiresToolCallThoughtSignature =
+    model.provider !== "google-gemini-cli" &&
+    (isGemini3ProModel(model) || isGemini3FlashModel(model));
   // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
   // live inside functionResponse, so hold them until the consecutive result run ends.
   const pendingToolResultImageTurns: Content[] = [];
@@ -215,38 +222,38 @@ export function convertMessages<T extends GoogleApiType>(
       }
     } else if (msg.role === "assistant") {
       const parts: Part[] = [];
+      let sawFunctionCall = false;
       // Check if message is from same provider and model - only then keep thinking blocks
-      const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+      const isSameProviderAndModel =
+        msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
 
       for (const block of msg.content) {
         if (block.type === "text") {
-          // Skip empty text blocks
-          if (!block.text || block.text.trim() === "") {
-            continue;
-          }
           const thoughtSignature = resolveThoughtSignature(
             isSameProviderAndModel,
             block.textSignature,
           );
+          if ((!block.text || block.text.trim() === "") && !thoughtSignature) {
+            continue;
+          }
           parts.push({
-            text: sanitizeSurrogates(block.text),
+            ...(block.text && { text: sanitizeSurrogates(block.text) }),
             ...(thoughtSignature && { thoughtSignature }),
           });
         } else if (block.type === "thinking") {
-          // Skip empty thinking blocks
-          if (!block.thinking || block.thinking.trim() === "") {
+          const thoughtSignature = resolveThoughtSignature(
+            isSameProviderAndModel,
+            block.thinkingSignature,
+          );
+          if ((!block.thinking || block.thinking.trim() === "") && !thoughtSignature) {
             continue;
           }
           // Only keep as thinking block if same provider AND same model
           // Otherwise convert to plain text (no tags to avoid model mimicking them)
           if (isSameProviderAndModel) {
-            const thoughtSignature = resolveThoughtSignature(
-              isSameProviderAndModel,
-              block.thinkingSignature,
-            );
             parts.push({
               thought: true,
-              text: sanitizeSurrogates(block.thinking),
+              ...(block.thinking && { text: sanitizeSurrogates(block.thinking) }),
               ...(thoughtSignature && { thoughtSignature }),
             });
           } else {
@@ -255,16 +262,21 @@ export function convertMessages<T extends GoogleApiType>(
             });
           }
         } else if (block.type === "toolCall") {
+          const args = coerceTransportToolCallArguments(block.arguments);
+          const ownSignature = resolveThoughtSignature(
+            isSameProviderAndModel,
+            block.thoughtSignature,
+          );
           const thoughtSignature =
-            resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature) ??
-            (model.provider !== "google-gemini-cli" &&
-            (isGemini3ProModel(model) || isGemini3FlashModel(model))
+            ownSignature ??
+            (!sawFunctionCall && requiresToolCallThoughtSignature
               ? "skip_thought_signature_validator"
               : undefined);
+          sawFunctionCall = true;
           const part: Part = {
             functionCall: {
               name: block.name,
-              args: block.arguments ?? {},
+              args,
               ...(requiresToolCallId(model.id) ? { id: block.id } : {}),
             },
             ...(thoughtSignature && { thoughtSignature }),
@@ -438,8 +450,18 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
         delete (block as { index?: number }).index;
       }
     }
-    output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-    output.errorMessage = formatProviderError(error);
+    const failure = options?.signal?.aborted ? transportAbortError(options.signal) : error;
+    assignTransportErrorDetails(output, failure, options?.signal);
+    const formattedError = formatProviderError(failure);
+    const status = failure instanceof Error && "status" in failure ? failure.status : undefined;
+    if (typeof status === "number" && Number.isFinite(status)) {
+      output.errorCode ||= String(status);
+      output.errorMessage = formattedError.startsWith(`${status}:`)
+        ? formattedError
+        : `${status}: ${formattedError}`;
+    } else {
+      output.errorMessage = formattedError;
+    }
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();
   }
@@ -804,18 +826,51 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
       );
     }
     if (candidate?.content?.parts) {
-      for (const part of candidate.content.parts) {
-        if (part.text === undefined && !part.functionCall && part.thought !== true) {
-          const latestBlock = blocks.at(-1);
-          if (latestBlock?.type === "toolCall" && part.thoughtSignature) {
-            latestBlock.thoughtSignature = retainThoughtSignature(
-              latestBlock.thoughtSignature,
-              part.thoughtSignature,
-            );
-            continue;
+      for (const [partIndex, part] of candidate.content.parts.entries()) {
+        const hasText = typeof part.text === "string";
+        const hasThoughtSignature =
+          typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
+        const signatureOnly =
+          hasThoughtSignature &&
+          (!hasText || part.text.length === 0) &&
+          Object.keys(part).every(
+            (key) => key === "thought" || key === "thoughtSignature" || key === "text",
+          );
+        if (signatureOnly) {
+          if (!hasText && part.thought !== true) {
+            const latestBlock = blocks.at(-1);
+            if (
+              partIndex === 0 &&
+              latestBlock?.type === "toolCall" &&
+              !latestBlock.thoughtSignature
+            ) {
+              latestBlock.thoughtSignature = retainThoughtSignature(
+                latestBlock.thoughtSignature,
+                part.thoughtSignature,
+              );
+              continue;
+            }
           }
+          // Empty signed Parts have their own wire identity; merging moves an opaque signature.
+          endCurrentBlock();
         }
-        if (part.text !== undefined) {
+
+        if (hasText || signatureOnly) {
+          if (currentBlock && (hasThoughtSignature || partIndex > 0)) {
+            const currentSignature =
+              currentBlock.type === "thinking"
+                ? currentBlock.thinkingSignature
+                : currentBlock.textSignature;
+            const currentText =
+              currentBlock.type === "thinking" ? currentBlock.thinking : currentBlock.text;
+            if (
+              currentText.length > 0 &&
+              (currentSignature !== part.thoughtSignature ||
+                (partIndex > 0 && (currentSignature || hasThoughtSignature)))
+            ) {
+              endCurrentBlock();
+            }
+          }
           const isThinking = isThinkingPart(part);
           if (
             !currentBlock ||
@@ -841,8 +896,9 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
               });
             }
           }
+          const delta = hasText ? part.text : "";
           if (currentBlock.type === "thinking") {
-            currentBlock.thinking += part.text;
+            currentBlock.thinking += delta;
             currentBlock.thinkingSignature = retainThoughtSignature(
               currentBlock.thinkingSignature,
               part.thoughtSignature,
@@ -850,11 +906,11 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
             params.stream.push({
               type: "thinking_delta",
               contentIndex: blockIndex(),
-              delta: part.text,
+              delta,
               partial: params.output,
             });
           } else {
-            currentBlock.text += part.text;
+            currentBlock.text += delta;
             currentBlock.textSignature = retainThoughtSignature(
               currentBlock.textSignature,
               part.thoughtSignature,
@@ -862,9 +918,12 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
             params.stream.push({
               type: "text_delta",
               contentIndex: blockIndex(),
-              delta: part.text,
+              delta,
               partial: params.output,
             });
+          }
+          if (signatureOnly) {
+            endCurrentBlock();
           }
         }
 


### PR DESCRIPTION
# fix(google): preserve Gemini signatures and actionable SDK failures

## Root causes repaired

1. Preserve the exact Google/Vertex provider Part owning every thought signature across streamed text, thinking, tools, standalone signature carriers, and next-turn replay; retain the mandatory empty `text: ""` discriminator on signed empty Parts.
2. Normalize malformed, array-shaped, and JSON-serialized historical function-call arguments through the existing shared transport coercion owner.
3. Apply the documented Gemini 3 fallback signature only to the first unsigned parallel function call in each assistant step, preserving authentic provider signatures and avoiding cross-provider replay.
4. Preserve real Google SDK HTTP status codes and caller-provided coded abort causes so existing quota/failover classification remains actionable.

## Dependency and safety evidence

- Current official Google thought-signature documentation requires exact original Part ownership, signs only the first parallel Gemini 3 function call, and documents signatures arriving on empty streamed text Parts.
- Installed `@google/genai` 2.13.0 `Part` requires exactly one content discriminator; its actual serializer retains `text: ""` but does not invent it when missing. Both signed-empty text and signed-empty thinking regressions fail on the original branch and now pass.
- Google streams expose no stable Part identity across SSE chunks; ordinary same-Part deltas remain merged, matching Google's own SDK merge implementation. No speculative chunk-boundary workaround or compatibility layer is introduced.
- Private package owner only: no provider configuration, public plugin SDK, authentication policy, protocol, sanitizer, or security boundary changes. Production +97/-33 (net +64) is justified by exact opaque-Part ownership, SDK argument/HTTP-error contracts, and elimination of unsafe signature replay; tests +522/-2.

## Actual authenticated provider proof (no mocked fetch)

Executed the exact corrected OpenClaw `streamGoogle` owner and installed official `@google/genai@2.13.0` against a real authenticated localhost HTTP/SSE Gemini server using native, unmodified Node fetch. Four actual `POST /v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse` requests carried a real `x-goog-api-key` header (redacted); no fetch, SSRF guard, or provider was mocked.

```json
{
  "baseline": {
    "head": "b521ce626bfb479ba39e7919445c76e40d1d21aa",
    "nextRequestModelTurn": null,
    "dropsBothSignedEmptyParts": true
  },
  "corrected": {
    "head": "bb5fe2796e6da6571ba475c77e071de13a82dfd0",
    "nextRequestModelTurn": {
      "role": "model",
      "parts": [
        { "text": "", "thoughtSignature": "c2lnbmVkLWVtcHR5LXRleHQ=" },
        { "text": "", "thought": true, "thoughtSignature": "c2lnbmVkLWVtcHR5LXRoaW5raW5n" }
      ]
    }
  },
  "actualHttp429": { "stopReason": "error", "errorCode": "429", "message": "Proof-only quota exhausted" },
  "authenticatedHttpRequests": 4,
  "mockedFetch": false,
  "mockedGuard": false,
  "assertions": "ALL PASS"
}
```

Raw redacted transcript: `/private/tmp/openclaw-qa400-google-package-live-proof.txt`; reproducible driver: `/private/tmp/openclaw-qa400-google-package-live-proof.mjs`. Current official [Google thought-signature contract](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures) documents signatures on empty streamed text Parts and exact Part replay.

## Full verification

- Blacksmith Testbox completed successfully: `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:test:packages`, and full `pnpm lint:core`.
- `node scripts/run-vitest.mjs packages/ai/src/providers/google-shared.convert.test.ts packages/ai/src/providers/google-shared.test.ts`: **83 passed**.
- Genuine exact committed-branch P0–P3 automated review: clean, confidence 0.94, TruffleHog clean; three independent full-context owner/dependency reviews: clean.
- Reviewed base `b521ce626bfb479ba39e7919445c76e40d1d21aa`; current main `618f3298c7dc00a41549e4dec41d8412f651624b`; exact clean synthetic merge `0028d8caa8b9f5150eee73176de1422c3ca9f923`.
- Existing branch `codex/qa400-google-canonical-owner`; corrected immutable commit `bb5fe2796e6da6571ba475c77e071de13a82dfd0`.
- Repository-wide `check:changed` also exposes an unrelated existing main budget ratchet (`OPENCLAW_* count 515 below budget 517`); the complete affected production/test type and lint lanes above were therefore verified directly on Testbox.
