### PR TITLE
fix(google): preserve authoritative stream terminal outcomes

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -666,6 +666,33 @@ describe("google transport stream", () => {
     },
   );
 
+  it("cancels an open Google response when its prefetched first event blocks the prompt", async () => {
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      buildOpenRawSseResponse({
+        sse: 'data: {"promptFeedback":{"blockReason":"SAFETY"}}\n\n',
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+    const controller = new AbortController();
+    const removeAbortListener = vi.spyOn(controller.signal, "removeEventListener");
+
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({ id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" }),
+      options: { apiKey: "gemini-api-key", signal: controller.signal },
+    });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorCode: "SAFETY",
+      errorType: "google_prompt_blocked",
+    });
+    expect(cancelCalled).toBe(true);
+    expect(removeAbortListener).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+
   it.each(["google", "google-vertex"] as const)(
     "rejects an unfinished %s stream instead of silently completing partial output",
     async (provider) => {
@@ -785,6 +812,52 @@ describe("google transport stream", () => {
       { "x-goog-api-key": "gemini-key-2" },
     );
   });
+
+  it.each([
+    "quota exceeded",
+    "Your daily usage limit was reached",
+    "You exceeded your current quota, please check your plan and billing details.",
+    "Resource has been exhausted (e.g. check quota).",
+  ])(
+    "rotates Gemini LLM API keys when the first SSE event is rate limited: %s",
+    async (message) => {
+      vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+      vi.stubEnv("GEMINI_API_KEYS", "gemini-key-2");
+      guardedFetchMock
+        .mockResolvedValueOnce(
+          buildSseResponse([
+            {
+              error: {
+                code: 429,
+                status: "RESOURCE_EXHAUSTED",
+                message,
+              },
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          buildSseResponse([
+            {
+              candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+            },
+          ]),
+        );
+
+      const result = await runGeminiStreamResult({ options: { apiKey: "gemini-key-1" } });
+
+      expect(result.stopReason).toBe("stop");
+      expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+      expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+      expectHeaders(
+        requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
+        { "x-goog-api-key": "gemini-key-1" },
+      );
+      expectHeaders(
+        requireRequestInit(requireMockCall(guardedFetchMock, 1, "guarded fetch"), "guarded fetch"),
+        { "x-goog-api-key": "gemini-key-2" },
+      );
+    },
+  );
 
   it.each([
     {
@@ -1084,6 +1157,106 @@ describe("google transport stream", () => {
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
   });
 
+  it.each([
+    {
+      label: "JSON content type",
+      headers: { "content-type": "application/json" },
+      prefix: "",
+      fragmented: false,
+      terminated: false,
+    },
+    {
+      label: "delimiter-terminated JSON content type",
+      headers: { "content-type": "application/json" },
+      prefix: "",
+      fragmented: false,
+      terminated: true,
+    },
+    {
+      label: "fragmented body without content type",
+      headers: {},
+      prefix: "",
+      fragmented: true,
+      terminated: false,
+    },
+    {
+      label: "naked error after a completed SSE event",
+      headers: { "content-type": "text/event-stream" },
+      prefix: 'data: {"candidates":[{"finishReason":"STOP"}]}\n\n',
+      fragmented: false,
+      terminated: false,
+    },
+    {
+      label: "delimiter-terminated naked error after a completed SSE event",
+      headers: { "content-type": "text/event-stream" },
+      prefix: 'data: {"candidates":[{"finishReason":"STOP"}]}\n\n',
+      fragmented: false,
+      terminated: true,
+    },
+  ])(
+    "surfaces a naked Google provider error from $label",
+    async ({ headers, prefix, fragmented, terminated }) => {
+      const providerError = JSON.stringify({
+        error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "quota exceeded" },
+      });
+      const segments = fragmented
+        ? [providerError.slice(0, 12), providerError.slice(12)]
+        : [`${providerError}${terminated ? "\n\n" : ""}`];
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          if (prefix) {
+            controller.enqueue(encoder.encode(prefix));
+          }
+          for (const segment of segments) {
+            controller.enqueue(encoder.encode(segment));
+          }
+          controller.close();
+        },
+      });
+      guardedFetchMock.mockResolvedValueOnce(new Response(body, { status: 200, headers }));
+
+      const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "RESOURCE_EXHAUSTED",
+        errorType: "google_stream_failed",
+        errorMessage: "quota exceeded",
+      });
+    },
+  );
+
+  it("parses a heavily fragmented naked Google provider error only after plausible closing braces", async () => {
+    const providerError = JSON.stringify({
+      error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "quota exceeded" },
+    });
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const character of providerError) {
+          controller.enqueue(encoder.encode(character));
+        }
+        controller.close();
+      },
+    });
+    guardedFetchMock.mockResolvedValueOnce(new Response(body, { status: 200 }));
+    const parse = vi.spyOn(JSON, "parse");
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorCode: "RESOURCE_EXHAUSTED",
+      errorMessage: "quota exceeded",
+    });
+    expect(
+      parse.mock.calls.filter(
+        ([candidate]) => typeof candidate === "string" && candidate.startsWith('{"error":'),
+      ),
+    ).toHaveLength(2);
+  });
+
   it("rejects an incomplete SSE frame after an otherwise terminal Google response", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildRawSseResponse(
@@ -1115,7 +1288,8 @@ describe("google transport stream", () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildRawSseResponse(
         'data: {"candidates":[{"finishReason":"STOP"}]}\n\n' +
-          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exceeded"}}\n\n',
+          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota exceeded"}}\n\n' +
+          "data: [DONE]\n\n",
       ),
     );
 
@@ -1195,6 +1369,64 @@ describe("google transport stream", () => {
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
     expect(cancelCalled).toBe(true);
+  });
+
+  it("finishes and cancels an open Gemini response after its terminal SSE marker", async () => {
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      buildOpenRawSseResponse({
+        sse:
+          'data: {"candidates":[{"content":{"parts":[{"text":"complete"}]},"finishReason":"STOP"}]}\n\n' +
+          "data: [DONE]\n\n",
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+    const controller = new AbortController();
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+        { apiKey: "gemini-api-key", signal: controller.signal } as never,
+      ),
+    );
+    const pendingResult = stream.result();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      pendingResult,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), 50);
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (!result) {
+      controller.abort(new Error("terminal marker test cleanup"));
+      await pendingResult;
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "complete" }],
+    });
+    expect(cancelCalled).toBe(true);
+  });
+
+  it("treats the Google terminal SSE marker as definitive despite later provider data", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(
+        'data: {"candidates":[{"finishReason":"STOP"}]}\n\n' +
+          "data: [DONE]\n\n" +
+          'data: {"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"late"}}\n\n',
+      ),
+    );
+
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+    expect(result.stopReason).toBe("stop");
   });
 
   it("retries Gemini 3 requests with lean thinking when the first attempt has no first response", async () => {
@@ -1299,6 +1531,61 @@ describe("google transport stream", () => {
 
     expect(result.content).toEqual([{ type: "text", text: "first second" }]);
     expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries Gemini 3 when a usage-only first SSE event never produces a response", async () => {
+    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
+    vi.useFakeTimers();
+    guardedFetchMock
+      .mockImplementationOnce((_url: string, init?: RequestInit) => {
+        const encoder = new TextEncoder();
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode('data: {"usageMetadata":{"promptTokenCount":100}}\n\n'),
+            );
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                controller.error(init.signal?.reason ?? new Error("aborted"));
+              },
+              { once: true },
+            );
+          },
+        });
+        return Promise.resolve(
+          new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+        );
+      })
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+    const controller = new AbortController();
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({ id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" }),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+        { apiKey: "gemini-api-key", reasoning: "high", signal: controller.signal } as never,
+      ),
+    );
+    const pendingResult = stream.result();
+    await vi.advanceTimersByTimeAsync(20);
+    const fetchCount = guardedFetchMock.mock.calls.length;
+    if (fetchCount !== 2) {
+      controller.abort(new Error("usage-only first response test cleanup"));
+      await pendingResult;
+    }
+
+    expect(fetchCount).toBe(2);
+    expect(await pendingResult).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "recovered" }],
+    });
   });
 
   it("uses bearer auth when the Google api key is an OAuth JSON payload", async () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1214,7 +1214,13 @@ describe("google transport stream", () => {
           controller.close();
         },
       });
-      guardedFetchMock.mockResolvedValueOnce(new Response(body, { status: 200, headers }));
+      const contentType = headers["content-type"];
+      guardedFetchMock.mockResolvedValueOnce(
+        new Response(body, {
+          status: 200,
+          headers: contentType ? { "content-type": contentType } : undefined,
+        }),
+      );
 
       const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
 

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -999,9 +999,11 @@ function createChildSignal(parent: AbortSignal | undefined, timeoutMs: number) {
 function iteratorToAsyncGenerator<T>(
   iterator: AsyncIterator<T>,
   cleanup?: () => void,
+  prefetched: readonly T[] = [],
 ): AsyncGenerator<T> {
   return (async function* () {
     try {
+      yield* prefetched;
       for (;;) {
         const next = await iterator.next();
         if (next.done) {
@@ -1019,10 +1021,19 @@ function iteratorToAsyncGenerator<T>(
 type GoogleSseAttempt =
   | {
       type: "ready";
-      firstChunk?: GoogleSseChunk;
       chunks: AsyncGenerator<GoogleSseChunk>;
     }
   | { type: "timeout" };
+
+function hasGoogleFirstResponseActivity(chunk: GoogleSseChunk): boolean {
+  return Boolean(
+    chunk.promptFeedback ||
+    chunk.candidates?.some(
+      (candidate) =>
+        typeof candidate.finishReason === "string" || (candidate.content?.parts?.length ?? 0) > 0,
+    ),
+  );
+}
 
 async function openGoogleSseAttempt(params: {
   guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
@@ -1050,18 +1061,27 @@ async function openGoogleSseAttempt(params: {
     }
     const chunks = parseGoogleSseChunks(response, signal);
     const iterator = chunks[Symbol.asyncIterator]();
-    const first = await iterator.next();
-    attemptSignal?.clearDeadline();
-    if (first.done) {
-      return {
-        type: "ready",
-        chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
-      };
+    const prefetched: GoogleSseChunk[] = [];
+    for (;;) {
+      const first = await iterator.next();
+      if (attemptSignal?.timedOut() && !params.parentSignal?.aborted) {
+        attemptSignal.cleanup();
+        await iterator.return?.();
+        return { type: "timeout" };
+      }
+      if (first.done) {
+        break;
+      }
+      prefetched.push(first.value);
+      // Usage and response IDs do not prove that Gemini has begun generating.
+      if (!attemptSignal || hasGoogleFirstResponseActivity(first.value)) {
+        break;
+      }
     }
+    attemptSignal?.clearDeadline();
     return {
       type: "ready",
-      firstChunk: first.value,
-      chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
+      chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup, prefetched),
     };
   } catch (error) {
     attemptSignal?.cleanup();
@@ -1085,23 +1105,9 @@ async function openGoogleSseChunks(params: {
     params.kind === "google-vertex"
       ? "Google Vertex AI API error"
       : "Google Generative AI API error";
-  if (!shouldRetryGoogleGemini3FirstResponse({ kind: params.kind, model: params.model })) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
-      headers: params.headers,
-      body: JSON.stringify(params.request),
-      signal: params.options?.signal,
-    });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
-    return {
-      type: "ready",
-      chunks: parseGoogleSseChunks(response, params.options?.signal),
-    };
-  }
-
-  const retryMs = resolveGoogleGemini3FirstResponseRetryMs();
+  const retryMs = shouldRetryGoogleGemini3FirstResponse({ kind: params.kind, model: params.model })
+    ? resolveGoogleGemini3FirstResponseRetryMs()
+    : 0;
   const retryRequest =
     retryMs > 0
       ? buildGoogleGemini3FirstResponseRetryParams({
@@ -1109,33 +1115,21 @@ async function openGoogleSseChunks(params: {
           request: params.request,
         })
       : undefined;
-  if (!retryRequest) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
-      headers: params.headers,
-      body: JSON.stringify(params.request),
-      signal: params.options?.signal,
-    });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
-    return {
-      type: "ready",
-      chunks: parseGoogleSseChunks(response, params.options?.signal),
-    };
-  }
-
+  // Keep the first provider frame inside API-key rotation and first-response retry ownership.
   const firstAttempt = await openGoogleSseAttempt({
     guardedFetch: params.guardedFetch,
     url: params.url,
     headers: params.headers,
     request: params.request,
     parentSignal: params.options?.signal,
-    firstResponseTimeoutMs: retryMs,
+    firstResponseTimeoutMs: retryRequest ? retryMs : 0,
     errorPrefix,
   });
   if (firstAttempt.type === "ready") {
     return firstAttempt;
+  }
+  if (!retryRequest) {
+    throw new Error("Google Gemini first response timed out without a retry request");
   }
 
   const retryAttempt = await openGoogleSseAttempt({
@@ -1170,6 +1164,63 @@ async function buildGoogleTransportHeaders(params: {
     : buildGoogleHeaders(params.model, params.apiKey, params.optionHeaders);
 }
 
+function throwGoogleProviderStreamError(chunk: unknown): void {
+  if (!isRecord(chunk) || !isRecord(chunk.error)) {
+    return;
+  }
+  const providerError = chunk.error;
+  const code = normalizeOptionalString(providerError.status) ?? "GOOGLE_STREAM_ERROR";
+  const status = typeof providerError.code === "number" ? providerError.code : undefined;
+  // Preserve the user-facing provider message while exposing authoritative retry facts.
+  const cause = { ...(status === undefined ? {} : { status }), code };
+  throw Object.assign(
+    new Error(normalizeOptionalString(providerError.message) ?? "Google stream failed", { cause }),
+    {
+      code,
+      status,
+      type: "google_stream_failed",
+    },
+  );
+}
+
+function throwUnframedGoogleProviderStreamError(buffer: string): void {
+  const candidate = buffer.trim();
+  if (!candidate.startsWith("{") || !candidate.endsWith("}")) {
+    return;
+  }
+  let chunk: unknown;
+  try {
+    chunk = JSON.parse(candidate);
+  } catch {
+    // Naked provider errors can span arbitrary HTTP body chunks.
+    return;
+  }
+  throwGoogleProviderStreamError(chunk);
+}
+
+function readGoogleSseEvent(rawEvent: string): GoogleSseChunk | "[DONE]" | undefined {
+  const data = rawEvent
+    .split(/\r\n|\n|\r/u)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .join("\n");
+  if (!data) {
+    throwUnframedGoogleProviderStreamError(rawEvent);
+    return undefined;
+  }
+  if (data === "[DONE]") {
+    return data;
+  }
+  let chunk: unknown;
+  try {
+    chunk = JSON.parse(data);
+  } catch {
+    throw new Error("Google SSE stream returned malformed JSON");
+  }
+  throwGoogleProviderStreamError(chunk);
+  return chunk as GoogleSseChunk;
+}
+
 async function* parseGoogleSseChunks(
   response: Response,
   signal?: AbortSignal,
@@ -1193,6 +1244,7 @@ async function* parseGoogleSseChunks(
       const { done, value } = await reader.read();
       if (done) {
         buffer += decoder.decode();
+        throwUnframedGoogleProviderStreamError(buffer);
         if (
           buffer
             .split(/\r\n|\n|\r/u)
@@ -1209,33 +1261,17 @@ async function* parseGoogleSseChunks(
         const rawEvent = buffer.slice(0, boundary.index);
         buffer = buffer.slice(boundary.index + boundary[0].length);
         boundary = GOOGLE_SSE_EVENT_BOUNDARY_RE.exec(buffer);
-        const data = rawEvent
-          .split(/\r\n|\n|\r/u)
-          .filter((line) => line.startsWith("data:"))
-          .map((line) => line.slice(5).trim())
-          .join("\n");
-        if (!data || data === "[DONE]") {
+        const chunk = readGoogleSseEvent(rawEvent);
+        if (!chunk) {
           continue;
         }
-        let chunk: unknown;
-        try {
-          chunk = JSON.parse(data);
-        } catch {
-          throw new Error("Google SSE stream returned malformed JSON");
+        if (chunk === "[DONE]") {
+          // The definitive marker ends the stream without waiting on an open provider body.
+          return;
         }
-        if (isRecord(chunk) && isRecord(chunk.error)) {
-          const providerError = chunk.error;
-          throw Object.assign(
-            new Error(normalizeOptionalString(providerError.message) ?? "Google stream failed"),
-            {
-              code: normalizeOptionalString(providerError.status) ?? "GOOGLE_STREAM_ERROR",
-              status: typeof providerError.code === "number" ? providerError.code : undefined,
-              type: "google_stream_failed",
-            },
-          );
-        }
-        yield chunk as GoogleSseChunk;
+        yield chunk;
       }
+      throwUnframedGoogleProviderStreamError(buffer);
     }
   } finally {
     signal?.removeEventListener("abort", abortHandler);
@@ -1380,14 +1416,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           string,
           Extract<GoogleTransportContentBlock, { type: "toolCall" }>
         >();
-        const chunks =
-          sse.firstChunk === undefined
-            ? sse.chunks
-            : (async function* (firstChunk: GoogleSseChunk) {
-                yield firstChunk;
-                yield* sse.chunks;
-              })(sse.firstChunk);
-        for await (const chunk of chunks) {
+        for await (const chunk of sse.chunks) {
           output.responseId ||= chunk.responseId;
           updateUsage(output, model, chunk, knownUsage);
           const candidate = chunk.candidates?.[0];

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1066,7 +1066,7 @@ async function openGoogleSseAttempt(params: {
       const first = await iterator.next();
       if (attemptSignal?.timedOut() && !params.parentSignal?.aborted) {
         attemptSignal.cleanup();
-        await iterator.return?.();
+        await iterator.return?.(undefined);
         return { type: "timeout" };
       }
       if (first.done) {

--- a/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
@@ -366,25 +366,6 @@ export function describeGoogleProviderRuntimeContract(load: ProviderRuntimeContr
       });
     });
 
-    it("owns usage-token parsing", async () => {
-      const provider = requireProviderContractProvider("google-gemini-cli");
-      await expect(
-        provider.resolveUsageAuth?.({
-          config: {} as never,
-          env: {} as NodeJS.ProcessEnv,
-          provider: "google-gemini-cli",
-          resolveApiKeyFromConfigAndStore: () => undefined,
-          resolveOAuthToken: async () => ({
-            token: '{"token":"google-oauth-token"}',
-            accountId: "google-account",
-          }),
-        }),
-      ).resolves.toEqual({
-        token: "google-oauth-token",
-        accountId: "google-account",
-      });
-    });
-
     it("owns OAuth auth-profile formatting", () => {
       const provider = requireProviderContractProvider("google-gemini-cli");
 
@@ -398,38 +379,6 @@ export function describeGoogleProviderRuntimeContract(load: ProviderRuntimeContr
           projectId: "proj-123",
         }),
       ).toBe('{"token":"google-oauth-token","projectId":"proj-123"}');
-    });
-
-    it("owns usage snapshot fetching", async () => {
-      const provider = requireProviderContractProvider("google-gemini-cli");
-      const mockFetch = createProviderUsageFetch(async (url) => {
-        if (url.includes("cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota")) {
-          return makeResponse(200, {
-            buckets: [
-              { modelId: "gemini-3.1-pro-preview", remainingFraction: 0.4 },
-              { modelId: "gemini-3.1-flash-preview", remainingFraction: 0.8 },
-            ],
-          });
-        }
-        return makeResponse(404, "not found");
-      });
-
-      const snapshot = await provider.fetchUsageSnapshot?.({
-        config: {} as never,
-        env: {} as NodeJS.ProcessEnv,
-        provider: "google-gemini-cli",
-        token: "google-oauth-token",
-        timeoutMs: 5_000,
-        fetchFn: mockFetch as unknown as typeof fetch,
-      });
-
-      expectFields(snapshot, {
-        provider: "google-gemini-cli",
-        displayName: "Gemini",
-      });
-      expect(snapshot?.windows[0]).toEqual({ label: "Pro", usedPercent: 60 });
-      expect(snapshot?.windows[1]?.label).toBe("Flash");
-      expect(snapshot?.windows[1]?.usedPercent).toBeCloseTo(20);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Keep Google and Vertex first streamed provider events inside existing API-key rotation and Gemini first-response retry ownership; expose actionable framed/naked provider failures and authoritative quota status without changing security policy.
- Honor Google's definitive `[DONE]` marker, cancel open response bodies, release abort listeners, and reject metadata-only Gemini preludes as first-response activity.
- Rebase onto the post-#117167 Google OAuth retirement and remove exactly two obsolete Google-only runtime assertions for usage hooks intentionally deleted by that landed change; preserve OAuth profile formatting and every other provider contract.
- Fix strict Google AsyncGenerator and test HeadersInit types that broke the original hosted checks.

## Verification

- Actual Blacksmith Testbox completed successfully (`exitCode: 0`): `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions:test`, `pnpm lint:core`, `pnpm lint:extensions`.
- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts extensions/google/provider-runtime.contract.test.ts`: **133 passed** (130 Google streaming cases; 3 remaining Google runtime-contract cases).
- Genuine committed-branch Codex P0–P3 autoreview: clean, confidence 0.92; TruffleHog clean. Three independent full-context owner/dependency reviews: clean.
- Root-current main `0cd33bad88c7af167d4a907955c4795b264d5a77`; exact clean synthetic merge tree `5fecf77ea90342c9e1f92ba110240f375a1bd9d3`. The Google owner/helper dependency blobs are unchanged from the frozen reviewed base.
- Repository-wide `check:changed` additionally hits an unrelated pre-existing baseline ratchet (`OPENCLAW_* count 515 below budget 517`); the complete affected production/test type and lint lanes above were executed directly instead.

## Actual authenticated Gemini SSE first-frame failover (no mocked fetch/guard)

Executed the actual bundled Google plugin transport owner through its production guarded fetch/SSRF policy against a real TLS Gemini SSE server reached through an actual localhost HTTP CONNECT proxy. The baseline and corrected requests both carry real API-key authentication; the first decoded event is a real quota-error SSE frame. No fetch, guard, or provider was mocked.

```json
{
  "installedGoogleSdk": "@google/genai@2.13.0",
  "baseline": {
    "authenticatedRequests": ["[PRIMARY_REDACTED]"],
    "firstDecodedSseError": "RESOURCE_EXHAUSTED",
    "stopReason": "error",
    "content": []
  },
  "corrected": {
    "authenticatedRequests": ["[PRIMARY_REDACTED]", "[ROTATED_REDACTED]"],
    "stopReason": "stop",
    "generatedText": "rotated live Gemini response",
    "usage": { "input": 7, "output": 4, "totalTokens": 11 }
  },
  "realTlsAndConnectProxy": true,
  "productionFetchUnmocked": true,
  "assertions": "ALL PASS"
}
```

Raw redacted rotation transcript: `/private/tmp/openclaw-qa400-google-stream-key-rotation-live-proof.txt`; reproducible driver: `/private/tmp/openclaw-qa400-google-stream-proof/key-rotation-live.mts`.

## Actual authenticated Gemini SSE terminal proof (no mocked fetch/guard)

Executed both the real pre-fix OpenClaw Google transport owner and corrected exact head against an actual authenticated localhost Gemini SSE endpoint. The production owner performed real guarded HTTP `POST /v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse` calls with an `x-goog-api-key` header (redacted). The server sent a real candidate with `finishReason: STOP`, then `data: [DONE]`, and intentionally never closed its response body.

```json
{
  "installedGoogleSdk": "@google/genai@2.13.0",
  "baseline": {
    "ownerBlob": "e5e982b75ae4bfb63f87db55929b42ce24124f35",
    "terminal": "timed_out",
    "responseStillOpenAfterDoneMs": 163,
    "tcpSocketStillOpen": true
  },
  "corrected": {
    "head": "b4fd27b3a09a0f52faf98a8ba0977dd4cabbee8f",
    "terminal": "completed",
    "responseClosedAfterDoneMs": 5,
    "tcpSocketClosedAfterDoneMs": 5,
    "stopReason": "stop",
    "generatedText": "localhost provider proof"
  },
  "mockedFetch": false,
  "mockedGuard": false
}
```

Raw redacted transcript: `/private/tmp/openclaw-qa400-google-stream-done-live-proof.txt`; reproducible driver: `/private/tmp/openclaw-qa400-google-stream-done-live-proof.mjs`.

## Scope

- Maintainer restored this branch to the independently reviewed exact head after an unrelated, unreviewed cross-provider API-key-rotation commit was externally added. That broader provider-runtime change is intentionally **not** part of this PR; scope remains the private Google stream owner and the two obsolete Google-only runtime-contract cases.
- Branch: `codex/qa400-google-stream-lifecycle`; corrected commit: `b4fd27b3a09a0f52faf98a8ba0977dd4cabbee8f`; reviewed base: `b521ce626bfb479ba39e7919445c76e40d1d21aa`.
- Production `extensions/google/transport-stream.ts`: +104/-75. Google owner regression tests: +294/-1. Private runtime-contract helper: -51 lines, deleting only the two retired Google OAuth usage assertions.
- No public SDK, protocol, provider configuration, credential, sanitizer, security, or storage changes.
