### PR TITLE
fix(feishu): preserve accepted multi-part attachment delivery

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2394,6 +2394,118 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     expect(sendMediaCall()?.replyInThread).toBe(false);
   });
 
+  it("consumes an implicit first-reply target on the caption before sending its attachment", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "om_reply_target",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMessageCall()?.replyToMessageId).toBe("om_reply_target");
+    expect(sendMediaCall()?.replyToMessageId).toBeUndefined();
+  });
+
+  it("does not reuse an implicit first-reply target for the upload-failure fallback", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "om_reply_target",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock.mock.calls[0]?.[0]?.replyToMessageId).toBe("om_reply_target");
+    expect(sendMessageFeishuMock.mock.calls[1]?.[0]?.replyToMessageId).toBeUndefined();
+  });
+
+  it("preserves an unconsumed implicit reply target when the first media upload fails", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "spoken reply",
+      mediaUrl: "https://example.com/reply.mp3",
+      audioAsVoice: true,
+      replyToId: "om_reply_target",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMediaCall()?.replyToMessageId).toBe("om_reply_target");
+    expect(sendMessageCall()?.replyToMessageId).toBe("om_reply_target");
+  });
+
+  it("consumes an implicit first-reply target on degraded voice media before its text", async () => {
+    sendMediaFeishuMock.mockResolvedValueOnce({
+      messageId: "file_msg",
+      voiceIntentDegradedToFile: true,
+    });
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "spoken reply",
+      mediaUrl: "https://example.com/reply.mp3",
+      audioAsVoice: true,
+      replyToId: "om_reply_target",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMediaCall()?.replyToMessageId).toBe("om_reply_target");
+    expect(sendMessageCall()?.replyToMessageId).toBeUndefined();
+  });
+
+  it("keeps explicit first-mode reply targets sticky across captions and media", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "om_reply_target",
+      replyToIdSource: "explicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMessageCall()?.replyToMessageId).toBe("om_reply_target");
+    expect(sendMediaCall()?.replyToMessageId).toBe("om_reply_target");
+  });
+
+  it("keeps native topic roots sticky across captions, attachments, and fallback", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      threadId: "om_topic_root",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMediaCall()?.replyToMessageId).toBe("om_topic_root");
+    expect(sendMediaCall()?.replyInThread).toBe(true);
+    for (const [params] of sendMessageFeishuMock.mock.calls) {
+      expect(params.replyToMessageId).toBe("om_topic_root");
+      expect(params.replyInThread).toBe(true);
+    }
+  });
+
   it("forwards threadId as replyInThread=true to sendMediaFeishu", async () => {
     await feishuOutbound.sendMedia?.({
       cfg: emptyConfig,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -876,13 +876,27 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       accountId,
       mediaLocalRoots,
       replyToId,
+      replyToIdSource,
+      replyToMode,
       threadId,
       onDeliveryResult,
     }) => {
-      const { replyToMessageId, replyInThread } = resolveFeishuReplyMode({
+      const { normalizedReplyToId } = resolveFeishuReplyMode({
         replyToId,
         threadId,
       });
+      const nextReplyToId = createReplyToFanout({
+        replyToId: normalizedReplyToId,
+        replyToIdSource,
+        replyToMode,
+      });
+      const nextReplyMode = () => {
+        const { replyToMessageId, replyInThread } = resolveFeishuReplyMode({
+          replyToId: nextReplyToId(),
+          threadId,
+        });
+        return { replyToMessageId, replyInThread };
+      };
       const commentTarget = parseFeishuCommentTarget(to);
       if (commentTarget) {
         const commentText = mediaUrl?.trim()
@@ -897,8 +911,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text: commentText,
           accountId: accountId ?? undefined,
-          replyToMessageId,
-          replyInThread,
+          ...nextReplyMode(),
         });
       }
 
@@ -920,8 +933,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text,
           accountId: accountId ?? undefined,
-          replyToMessageId,
-          replyInThread,
+          ...nextReplyMode(),
         });
         textSent = true;
         await reportDelivery(textResult);
@@ -930,6 +942,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       // Upload and send media if URL or local path provided
       if (mediaUrl) {
         let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
+        const mediaReplyMode = nextReplyMode();
         try {
           mediaResult = await sendMediaFeishu({
             cfg,
@@ -937,8 +950,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             mediaUrl,
             accountId: accountId ?? undefined,
             mediaLocalRoots,
-            replyToMessageId,
-            replyInThread,
+            ...mediaReplyMode,
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
         } catch (err) {
@@ -957,8 +969,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             to,
             text: fallbackText,
             accountId: accountId ?? undefined,
-            replyToMessageId,
-            replyInThread,
+            // A rejected upload never delivered its attempted reply target.
+            ...(textSent ? nextReplyMode() : mediaReplyMode),
           });
           await reportDelivery(fallbackResult);
           return fallbackResult;
@@ -973,8 +985,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             to,
             text,
             accountId: accountId ?? undefined,
-            replyToMessageId,
-            replyInThread,
+            ...nextReplyMode(),
           });
           await reportDelivery(textResult);
         }
@@ -987,8 +998,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         to,
         text: text ?? "",
         accountId: accountId ?? undefined,
-        replyToMessageId,
-        replyInThread,
+        ...nextReplyMode(),
       });
     },
   }),


### PR DESCRIPTION
## What problem does this solve?

Feishu direct attachment delivery sends several separate platform messages when a payload has a caption, an upload fallback, or a voice attachment that degrades to a normal file. Its private `sendMedia` owner reused one implicit first-only reply ID for every send, so users received multiple unwanted replies to the same quoted message.

This is **one root cause** with three independently reproduced user-visible failure paths:

1. Caption reply followed by image attachment replied to the same source twice.
2. Caption reply followed by a rejected image upload attached recovery text to the same source again.
3. An accepted degraded voice/file reply followed by visible text also replied twice.

The frozen source baseline is `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`; earlier Feishu PR #117023 is already present in this baseline and none of its fixed roots are counted again.

## Why is this the right fix?

The existing shared `createReplyToFanout` contract in `src/infra/outbound/reply-policy.ts` already owns implicit reply consumption, and neighboring Feishu card, TTS, and presentation fallback paths use it. The direct-media owner now uses that same canonical decision for every actual send. An upload rejected before dispatch retains its still-unconsumed reply target; explicit reply targets and native topic roots remain intentionally sticky. Accepted partial deliveries still propagate without replay.

No public configuration, authentication, plugin SDK, protocol, persistence, migration, dependency declaration, or external account behavior changes. Production delta: **+23/-13, net +10 lines**, justified by applying the existing lifecycle owner across captions, media, fallback, degraded voice, and explicit-thread siblings.

## Frozen-source RED regression proof

With production source exactly at `fdcb321bfaaadb5a1e7d123b6be7a934980f8b12`:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/feishu/src/outbound.test.ts \
  -t 'implicit first-reply|explicit first-mode'

FAIL caption -> attachment: expected undefined; received "om_reply_target"
FAIL caption -> upload fallback: expected undefined; received "om_reply_target"
FAIL degraded voice -> visible text: expected undefined; received "om_reply_target"

Test Files  1 failed
Tests       3 failed | 2 passed
```

## Exact-head focused regression proof

Candidate head: `385a4ad86dcf37102e23c2d9313a4be17763a2ed`; tree: `7af5bafa8f5d9c67ef8517f5d4e0becf00a13580`.

The newer canonical main `982add961804097f5a6b0b94255c5c855e8ad863` leaves the complete Feishu subtree, canonical reply fanout/receipt owners, extension type/lint configurations, pinned lockfile, and Lark dependency unchanged. Its generic account-setup simplification and profile install-identity changes do not modify Feishu outbound delivery or account config shapes. A read-only `git merge-tree --write-tree` succeeds without conflicts and yields synthetic merge tree `3e7521a0cda3327517bd430cc5263b87525bedee`; the reviewed candidate identity remains unchanged.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/feishu/src/outbound.test.ts \
  -t 'implicit first-reply|unconsumed implicit reply|explicit first-mode|native topic roots sticky'

Test Files  1 passed
Tests       7 passed | 103 skipped
```

Regression controls explicitly prove a rejected first upload retains its unused target, explicitly selected replies stay sticky, and every native topic reply keeps `reply_in_thread: true`.

## Actual installed Lark SDK + real local HTTP production proof

An external, source-unchanged probe invokes actual production `feishuOutbound.sendMedia`, the actual OpenClaw `loadWebMedia`, and the actual installed `@larksuiteoapi/node-sdk` against a real local HTTP server. The genuine SDK exchanges its tenant token and performs real image/file uploads plus message reply/create requests. No SDK method or provider result is mocked. Placeholder identities are redacted.

```json
{"scenario":"implicit caption then attachment","sdk":"@larksuiteoapi/node-sdk","transport":"real localhost HTTP","events":[{"path":"/open-apis/im/v1/messages/om_redacted_parent/reply","messageType":"post"},{"path":"/open-apis/im/v1/images"},{"path":"/open-apis/im/v1/messages","messageType":"image"}]}
{"scenario":"implicit caption then rejected attachment fallback","sdk":"@larksuiteoapi/node-sdk","transport":"real localhost HTTP","events":[{"path":"/open-apis/im/v1/messages/om_redacted_parent/reply","messageType":"post"},{"path":"/open-apis/im/v1/images","rejected":true},{"path":"/open-apis/im/v1/messages","messageType":"post"}]}
{"scenario":"implicit degraded voice then visible text","sdk":"@larksuiteoapi/node-sdk","transport":"real localhost HTTP","events":[{"path":"/open-apis/im/v1/files"},{"path":"/open-apis/im/v1/messages/om_redacted_parent/reply","messageType":"file"},{"path":"/open-apis/im/v1/messages","messageType":"post"}]}
{"scenario":"explicit reply remains sticky","sdk":"@larksuiteoapi/node-sdk","transport":"real localhost HTTP","events":[{"path":"/open-apis/im/v1/messages/om_redacted_parent/reply","messageType":"post"},{"path":"/open-apis/im/v1/images"},{"path":"/open-apis/im/v1/messages/om_redacted_parent/reply","messageType":"image"}]}
{"scenario":"explicit native topic remains sticky","sdk":"@larksuiteoapi/node-sdk","transport":"real localhost HTTP","events":[{"path":"/open-apis/im/v1/messages/om_redacted_topic/reply","messageType":"post","replyInThread":true},{"path":"/open-apis/im/v1/images"},{"path":"/open-apis/im/v1/messages/om_redacted_topic/reply","messageType":"image","replyInThread":true}]}
```

All five actual network scenarios passed. This is controlled local-provider proof, not a hosted Feishu account claim; no real credentials were used.

## Independent review and remote exact-head validation

Three independent agents reviewed complete Feishu owners, canonical reply lifecycle, all sibling delivery paths, dependency contracts, and exact immutable head: **P0/P1/P2/P3 clean**. The external reviewer independently reran all five real-SDK/local-HTTP scenarios.

A genuine full-branch Codex autoreview explicitly used `--max-priority P3`, model `gpt-5.6-sol`, high reasoning, and a real clean TruffleHog preflight:

```json
{"findings":[],"overall_correctness":"patch is correct","overall_confidence":0.93}
```

One dedicated Blacksmith Testbox imported and checked out the exact commit/tree, refreshed pinned workspace dependencies, and successfully ran exact-head type-aware Feishu lint, extension test types, all nine relevant owner suites, and the actual installed-SDK HTTP probe:

```text
git rev-parse HEAD
385a4ad86dcf37102e23c2d9313a4be17763a2ed

git rev-parse HEAD^{tree}
7af5bafa8f5d9c67ef8517f5d4e0becf00a13580

pnpm install --frozen-lockfile
terminal-core string-width: 8.2.2

node scripts/run-oxlint.mjs --type-aware \
  --tsconfig config/tsconfig/oxlint.extensions.json \
  extensions/feishu/src/outbound.ts extensions/feishu/src/outbound.test.ts
Found 0 warnings and 0 errors.

pnpm tsgo:extensions:test
PASS

OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/feishu/src/outbound.test.ts \
  extensions/feishu/src/outbound-delivery.test.ts \
  extensions/feishu/src/send.reply-fallback.test.ts \
  extensions/feishu/src/send-result.test.ts \
  extensions/feishu/src/media-upload-contract.test.ts \
  extensions/feishu/src/media.test.ts \
  extensions/feishu/src/reply-dispatcher.test.ts \
  extensions/feishu/src/dm-delivery-loopback.test.ts \
  extensions/feishu/src/send.test.ts
PASS

Actual installed Lark SDK + real local HTTP production-owner scenarios
PASS: 5/5

blacksmith run summary ... command=2m55.008s ... exit=0
blacksmith testbox stop --id tbx_01kyxjw8axg3dxvgvzhhzp92we
Testbox tbx_01kyxjw8axg3dxvgvzhhzp92we stopped (completed)
blacksmith testbox status --id tbx_01kyxjw8axg3dxvgvzhhzp92we
STATUS completed
```

The supporting Testbox workflow runs from `main` and may report cancellation after external lease cleanup; it is **not** described as hosted exact-head PR CI. Exact candidate identity is established by the detached Git commit/tree printed above before all successful remote commands.
