### PR TITLE
fix(whatsapp): preserve accepted delivery and partial receipt ownership

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -1,4 +1,5 @@
 // Whatsapp tests cover deliver reply plugin behavior.
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   listMessageReceiptPlatformIds,
@@ -232,6 +233,29 @@ describe("deliverWebReply", () => {
   beforeAll(async () => {
     ({ createWhatsAppReplyTransportContext, deliverWebReply } = await import("./deliver-reply.js"));
     ({ whatsappOutbound } = await import("../outbound-adapter.js"));
+  });
+
+  it("does not resend an accepted reply when its transport reports a disconnect afterward", async () => {
+    const msg = makeMsg();
+    const acceptedFailure = createChannelPartialDeliveryError(new Error("connection closed"), {
+      messageIds: ["reply-already-accepted"],
+      visibleReplySent: true,
+    });
+    vi.mocked(msg.platform.reply).mockRejectedValue(acceptedFailure);
+
+    const failure = await runWithFakeTimers(() =>
+      deliverWebReply({
+        replyResult: { text: "already delivered" },
+        transport: createWhatsAppReplyTransportContext(msg),
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        skipLog: true,
+      }).catch((caught: unknown) => caught),
+    );
+
+    expect(failure).toBe(acceptedFailure);
+    expect(msg.platform.reply).toHaveBeenCalledOnce();
   });
 
   it("suppresses payloads flagged as reasoning", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage } from "baileys";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { prepareWhatsAppOutboundMedia } from "../outbound-media-contract.js";
@@ -470,6 +471,104 @@ describe("createWebSendApi", () => {
       "voice-1",
       "voice-text-1",
     ]);
+  });
+
+  it("preserves the accepted voice receipt when its visible caption send disconnects", async () => {
+    const captionError = new Error("connection closed while sending the voice caption");
+    sendMessage
+      .mockResolvedValueOnce({ key: { id: "voice-accepted-1" } })
+      .mockRejectedValueOnce(captionError);
+
+    const failure = await api
+      .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
+      .catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted voice delivery did not preserve its partial receipt");
+    }
+    expect(failure.deliveryResult.visibleReplySent).toBe(true);
+    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-1"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["voice-accepted-1"]);
+    expect(failure).toHaveProperty("cause", captionError);
+  });
+
+  it("preserves the accepted voice receipt when caption mention resolution fails", async () => {
+    const mentionError = new Error("group metadata lookup disconnected");
+    api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      resolveOutboundMentions: vi.fn().mockRejectedValue(mentionError),
+    });
+    sendMessage.mockResolvedValueOnce({ key: { id: "voice-accepted-2" } });
+
+    const failure = await api
+      .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
+      .catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted voice delivery was lost during mention resolution");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-2"]);
+    expect(failure).toHaveProperty("cause", mentionError);
+  });
+
+  it.each([
+    {
+      kind: "text",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) => sendApi.sendMessage("+1555", "hello"),
+    },
+    {
+      kind: "poll",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) =>
+        sendApi.sendPoll("+1555", { question: "Q?", options: ["a", "b"] }),
+    },
+  ])("retains the accepted $kind receipt when activity recording fails", async ({ kind, send }) => {
+    const activityError = new Error("channel activity bookkeeping disconnected");
+    sendMessage.mockResolvedValueOnce({ key: { id: `${kind}-accepted` } });
+    recordChannelActivity.mockImplementationOnce(() => {
+      throw activityError;
+    });
+
+    const failure = await send(api).catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted provider delivery was lost during activity bookkeeping");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual([`${kind}-accepted`]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([`${kind}-accepted`]);
+    expect(failure).toHaveProperty("cause", activityError);
+  });
+
+  it("retains both accepted voice receipts when later activity recording fails", async () => {
+    const activityError = new Error("channel activity bookkeeping disconnected");
+    sendMessage
+      .mockResolvedValueOnce({ key: { id: "voice-accepted-3" } })
+      .mockResolvedValueOnce({ key: { id: "caption-accepted-3" } });
+    recordChannelActivity.mockImplementationOnce(() => {
+      throw activityError;
+    });
+
+    const failure = await api
+      .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
+      .catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted voice and caption deliveries were lost");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-3", "caption-accepted-3"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "voice-accepted-3",
+      "caption-accepted-3",
+    ]);
+    expect(failure).toHaveProperty("cause", activityError);
   });
 
   it("supports video media and gifPlayback option", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -6,6 +6,7 @@ import type {
   WAPresence,
 } from "baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveWhatsAppDocumentFileName } from "../document-filename.js";
 import { addWhatsAppImagePreviewFields } from "../image-preview.js";
 import { isWhatsAppNewsletterJid } from "../normalize.js";
@@ -17,6 +18,7 @@ import {
 } from "./outbound-mentions.js";
 import {
   combineWhatsAppSendResults,
+  listWhatsAppSendResultMessageIds,
   normalizeWhatsAppSendResult,
   type WhatsAppSendKind,
   type WhatsAppSendResult,
@@ -82,15 +84,43 @@ export function createWebSendApi(params: {
     params.resolveOutboundMentions
       ? await params.resolveOutboundMentions({ jid, text })
       : { text, mentionedJids: [] };
+  const runAcceptedSend = async (
+    kind: WhatsAppSendKind,
+    accountId: string,
+    send: (
+      capture: (result: WAMessage | undefined, kind: WhatsAppSendKind) => void,
+    ) => Promise<void>,
+  ): Promise<WhatsAppSendResult> => {
+    const results: WhatsAppSendResult[] = [];
+    try {
+      // Baileys resolves only after relay acceptance; capture that fact before any later work.
+      await send((result, sendKind) => {
+        results.push(normalizeWhatsAppSendResult(result, sendKind));
+      });
+      recordWhatsAppOutbound(accountId);
+      return combineWhatsAppSendResults(kind, results);
+    } catch (error) {
+      const accepted = results.filter((result) => result.providerAccepted);
+      if (accepted.length === 0) {
+        throw error;
+      }
+      const delivered = combineWhatsAppSendResults(kind, accepted);
+      throw createChannelPartialDeliveryError(error, {
+        messageIds: listWhatsAppSendResultMessageIds(delivered),
+        receipt: delivered.receipt,
+        visibleReplySent: true,
+      });
+    }
+  };
   const sendStructuredMessage = async (
     to: string,
     content: AnyMessageContent,
     kind: WhatsAppSendKind,
   ): Promise<WhatsAppSendResult> => {
     const jid = resolveOutboundJid(to);
-    const result = await params.sock.sendMessage(jid, content);
-    recordWhatsAppOutbound(params.defaultAccountId);
-    return normalizeWhatsAppSendResult(result, kind);
+    return await runAcceptedSend(kind, params.defaultAccountId, async (capture) => {
+      capture(await params.sock.sendMessage(jid, content), kind);
+    });
   };
 
   return {
@@ -165,24 +195,23 @@ export function createWebSendApi(params: {
         messageText: sendOptions?.quotedMessageKey?.messageText,
         media: sendOptions?.quotedMessageKey?.media,
       });
-      const result = quotedOpts
-        ? await params.sock.sendMessage(jid, payload, quotedOpts)
-        : await params.sock.sendMessage(jid, payload);
-      const results = [normalizeWhatsAppSendResult(result, mediaBuffer ? "media" : "text")];
-      if (shouldSendAudioText) {
-        const resolvedAudioText = await resolveMentions(jid, text);
-        const textPayload = addWhatsAppOutboundMentionsToContent(
-          { text: resolvedAudioText.text },
-          resolvedAudioText.mentionedJids,
-        );
-        const textResult = quotedOpts
-          ? await params.sock.sendMessage(jid, textPayload, quotedOpts)
-          : await params.sock.sendMessage(jid, textPayload);
-        results.push(normalizeWhatsAppSendResult(textResult, "text"));
-      }
+      const kind = mediaBuffer ? "media" : "text";
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
-      recordWhatsAppOutbound(accountId);
-      return combineWhatsAppSendResults(mediaBuffer ? "media" : "text", results);
+      return await runAcceptedSend(kind, accountId, async (capture) => {
+        const sendPayload = async (content: AnyMessageContent) =>
+          quotedOpts
+            ? await params.sock.sendMessage(jid, content, quotedOpts)
+            : await params.sock.sendMessage(jid, content);
+        capture(await sendPayload(payload), kind);
+        if (shouldSendAudioText) {
+          const resolvedAudioText = await resolveMentions(jid, text);
+          const textPayload = addWhatsAppOutboundMentionsToContent(
+            { text: resolvedAudioText.text },
+            resolvedAudioText.mentionedJids,
+          );
+          capture(await sendPayload(textPayload), "text");
+        }
+      });
     },
     sendPoll: async (
       to: string,

--- a/extensions/whatsapp/src/outbound-retry.test.ts
+++ b/extensions/whatsapp/src/outbound-retry.test.ts
@@ -1,4 +1,5 @@
 // WhatsApp tests cover outbound retry behavior.
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it, vi } from "vitest";
 import { sendWhatsAppOutboundWithRetry } from "./outbound-retry.js";
 import { withWhatsAppSocketOperationTimeout } from "./socket-timing.js";
@@ -72,6 +73,23 @@ describe("sendWhatsAppOutboundWithRetry", () => {
       name: "WhatsAppSocketOperationTimeoutError",
       deliveryState: "unknown",
     });
+    expect(send).toHaveBeenCalledOnce();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("never replays a send whose disconnect error already carries an accepted receipt", async () => {
+    const acceptedFailure = createChannelPartialDeliveryError(new Error("connection closed"), {
+      messageIds: ["accepted-1"],
+      visibleReplySent: true,
+    });
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(acceptedFailure);
+    const onRetry = vi.fn();
+
+    const failure = await runWithFakeTimers(() =>
+      sendWhatsAppOutboundWithRetry({ send, onRetry }).catch((caught: unknown) => caught),
+    );
+
+    expect(failure).toBe(acceptedFailure);
     expect(send).toHaveBeenCalledOnce();
     expect(onRetry).not.toHaveBeenCalled();
   });

--- a/extensions/whatsapp/src/outbound-retry.ts
+++ b/extensions/whatsapp/src/outbound-retry.ts
@@ -1,4 +1,5 @@
 // WhatsApp plugin module implements outbound retry behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { formatError } from "./session-errors.js";
 import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
@@ -17,7 +18,7 @@ class WhatsAppOutboundRetryError extends Error {
 function isRetryableWhatsAppOutboundError(error: unknown): boolean {
   // Outbound sends surface direct failures; inspecting wrappers or causes can
   // replay a non-idempotent send. A direct local timeout may have delivered it.
-  if (isWhatsAppSocketOperationTimeoutError(error)) {
+  if (isChannelPartialDeliveryError(error) || isWhatsAppSocketOperationTimeoutError(error)) {
     return false;
   }
   return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(formatError(error));


### PR DESCRIPTION
## What Problem This Solves

WhatsApp could already accept and deliver a message, then report a later caption-send, group-mention-resolution, or activity-bookkeeping failure without preserving the accepted provider receipt. The existing retry owner also interpreted accepted partial-delivery disconnects as ordinary retryable failures and resent the same user-visible reply up to three times.

## Why This Change Was Made

Fix both failures at their existing architectural owners. One private WhatsApp accepted-send lifecycle captures the real Baileys message key immediately after the awaited provider relay, preserves every accepted voice/caption/text/poll receipt through subsequent failures, and surfaces the original cause in the canonical partial-delivery envelope. Ordinary and structured sends share that lifecycle. The existing retry owner checks the canonical accepted-delivery state before matching disconnect text, without changing legitimate pre-accept retries or unknown-timeout policy.

This is a bounded owner refactor, not a second send path, a wider retry policy, or a public SDK/configuration change. The production delta is 51 additions and 21 deletions, net 30 lines, and removes repeated quoted-send dispatch decisions.

## User Impact

Accepted WhatsApp messages and voice notes remain visible and retain their actual provider message IDs even if a caption, group mention lookup, poll activity update, or later bookkeeping step fails. Accepted replies are never resent merely because that later error contains a disconnect phrase, preventing duplicate user-visible WhatsApp messages while retaining normal retries for genuine pre-delivery socket failures.

## Evidence

- Frozen baseline: fdcb321bfaaadb5a1e7d123b6be7a934980f8b12; immutable candidate: 34356babbe0da3df078126229e47bfa4e61e4c2c; exact candidate tree: 77501ebf9bb54c37033cd608030e10f2f6acac8e.
- Current-main compatibility: 7e78de747b8a64d52f30aee948b697bf4c528691 leaves the complete WhatsApp plugin, shared partial-delivery contract, Plugin SDK, package manifest, and lockfile byte-identical; clean synthetic merge tree 0f82de6b0bfd6136fcda8fae3b29c4744559ef04.
- Seven genuine frozen-baseline RED scenarios prove accepted voice-caption disconnect, accepted voice mention failure, accepted canonical retry replay, actual auto-reply transport replay, ordinary text bookkeeping failure, structured poll bookkeeping failure, and combined voice+caption bookkeeping failure.
- Focused real owner/retry/auto-reply boundary suite: 85/85 passed; corrected activity regression subset: 3/3 passed.
- Isolated exact-head Linux Blacksmith Testbox: 101 WhatsApp test files and 1,262/1,262 tests passed, plus full extension production tsgo, full extension test tsgo, normal type-aware oxlint, and oxfmt. Exact-head proof run: https://github.com/openclaw/openclaw/actions/runs/30681035863. Wrapper exited 0, owned lease was stopped, and direct status was verified completed.
- The real pinned Baileys 7.0.0-rc13 generated a real provider WAMessage without credentials; its installed sendMessage source awaits relayMessage before returning the accepted fullMsg, directly proving the lifecycle boundary used by this refactor.
- Fresh full-branch genuine Codex Sol-high autoreview through P3: zero accepted findings, confidence 0.94. Three freshly refreshed, independent blind reviewers each returned P0=0/P1=0/P2=0/P3=0.

No authentication, security, public SDK, configuration, protocol, persistent-state, database, or migration changes.
