### PR TITLE
fix(plugins): load packaged TypeScript plugins consistently

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -34,6 +34,7 @@ on:
       - "scripts/plugin-npm-release-check.ts"
       - "scripts/plugin-npm-release-plan.ts"
       - "scripts/verify-plugin-npm-published-runtime.mts"
+      - "src/plugins/package-entrypoints.ts"
   workflow_dispatch:
     inputs:
       publish_scope:

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -45,8 +45,11 @@ built entries:
   entry; OpenClaw does not silently fall back to source.
 - Without an explicit runtime entry, package discovery through
   `plugins.load.paths` or global roots looks for matching JavaScript peers under
-  `dist/` first, then beside the TypeScript source entry, trying `.js`, `.mjs`,
-  and `.cjs` in that order at each location.
+  `dist/` first, then beside the TypeScript source entry. For `src/` entries,
+  it checks both flattened `dist/` output and output retaining `dist/src/`.
+  At each location, `.mts` prefers `.mjs` and `.cts` prefers `.cjs`; `.ts` and
+  `.tsx` try `.js`, `.mjs`, then `.cjs`. Installation, discovery, setup, runtime
+  loading, and published-package verification use the same candidate order.
 - A `plugins.load.paths` entry that resolves inside the host's own bundled
   plugin tree is discovered as that bundled plugin, so it keeps the bundled
   entry point and bundled provenance whether or not compiled output exists

--- a/scripts/lib/plugin-publication-candidates.ts
+++ b/scripts/lib/plugin-publication-candidates.ts
@@ -39,6 +39,7 @@ export const PLUGIN_NPM_RELEASE_AUTHORITY_PATHS = [
   "scripts/release-tooling-identity.d.mts",
   "scripts/release-tooling-identity.mjs",
   "scripts/verify-plugin-npm-published-runtime.mts",
+  "src/plugins/package-entrypoints.ts",
 ] as const;
 
 function hasAuthorityPathChanges(

--- a/scripts/verify-plugin-npm-published-runtime.mts
+++ b/scripts/verify-plugin-npm-published-runtime.mts
@@ -9,6 +9,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import * as tar from "tar";
+import {
+  isTypeScriptPackageEntry,
+  listBuiltRuntimeEntryCandidates,
+} from "../src/plugins/package-entrypoints.js";
 import { readPositiveIntEnv } from "./e2e/lib/env-limits.mjs";
 import { sleep } from "./lib/sleep.mjs";
 
@@ -59,33 +63,6 @@ function normalizePackagePath(value: string) {
     .replace(/\\/g, "/")
     .replace(/^package\//u, "")
     .replace(/^\.\//u, "");
-}
-
-function isTypeScriptPackageEntry(entryPath: string) {
-  return [".ts", ".mts", ".cts"].includes(path.extname(entryPath).toLowerCase());
-}
-
-function listBuiltRuntimeEntryCandidates(entryPath: string) {
-  if (!isTypeScriptPackageEntry(entryPath)) {
-    return [];
-  }
-  const normalized = entryPath.replace(/\\/g, "/");
-  const withoutExtension = normalized.replace(/\.[^.]+$/u, "");
-  const normalizedRelative = normalized.replace(/^\.\//u, "");
-  const distWithoutExtension = normalizedRelative.startsWith("src/")
-    ? `./dist/${normalizedRelative.slice("src/".length).replace(/\.[^.]+$/u, "")}`
-    : `./dist/${withoutExtension.replace(/^\.\//u, "")}`;
-  const withJavaScriptExtensions = (basePath: string) => [
-    `${basePath}.js`,
-    `${basePath}.mjs`,
-    `${basePath}.cjs`,
-  ];
-  return [
-    ...new Set([
-      ...withJavaScriptExtensions(distWithoutExtension),
-      ...withJavaScriptExtensions(withoutExtension),
-    ]),
-  ].filter((candidate) => candidate !== normalized);
 }
 
 function hasPackedFile(packageFiles: Set<string>, entryPath: string) {

--- a/src/plugins/package-entry-resolution.runtime.test.ts
+++ b/src/plugins/package-entry-resolution.runtime.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PackageManifest } from "./manifest.js";
+import {
+  resolvePackageRuntimeExtensionSources,
+  resolvePackageSetupSource,
+  validatePackageExtensionEntriesForInstall,
+} from "./package-entry-resolution.js";
+import {
+  clearPluginRuntimeArtifactResolutionMemo,
+  resolvePluginRuntimeArtifact,
+} from "./plugin-runtime-artifact-resolution.js";
+
+const packageRoots: string[] = [];
+
+function createPackageFixture(params: {
+  sourceExtension: string;
+  runtimeOutputs?: string[];
+  includeSource?: boolean;
+}): { packageDir: string; sourceEntry: string; manifest: PackageManifest } {
+  const packageDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-runtime-entry-")),
+  );
+  packageRoots.push(packageDir);
+  const sourceEntry = `./src/entry${params.sourceExtension}`;
+  if (params.includeSource !== false) {
+    fs.mkdirSync(path.join(packageDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(packageDir, sourceEntry), "export default {};\n");
+  }
+  for (const relativeOutput of params.runtimeOutputs ?? []) {
+    const outputPath = path.join(packageDir, relativeOutput);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, "export default {};\n");
+  }
+  return {
+    packageDir,
+    sourceEntry,
+    manifest: {
+      name: "runtime-entry-fixture",
+      version: "1.0.0",
+      openclaw: { extensions: [sourceEntry], setupEntry: sourceEntry },
+    },
+  };
+}
+
+afterEach(() => {
+  clearPluginRuntimeArtifactResolutionMemo();
+  for (const packageRoot of packageRoots.splice(0)) {
+    fs.rmSync(packageRoot, { recursive: true, force: true });
+  }
+});
+
+describe("canonical installed package runtime entries", () => {
+  it.each([
+    {
+      name: "TSX source with its flat JavaScript build",
+      sourceExtension: ".tsx",
+      runtimeOutputs: ["dist/entry.js"],
+      expectedRuntime: "dist/entry.js",
+    },
+    {
+      name: "TSX source omitted from a published package",
+      sourceExtension: ".tsx",
+      runtimeOutputs: ["dist/entry.js"],
+      includeSource: false,
+      expectedRuntime: "dist/entry.js",
+    },
+    {
+      name: "TypeScript compiler output that preserves the src directory",
+      sourceExtension: ".ts",
+      runtimeOutputs: ["dist/src/entry.js"],
+      expectedRuntime: "dist/src/entry.js",
+    },
+    {
+      name: "ES module TypeScript output ahead of an unrelated .js artifact",
+      sourceExtension: ".mts",
+      runtimeOutputs: ["dist/entry.js", "dist/entry.mjs"],
+      expectedRuntime: "dist/entry.mjs",
+    },
+    {
+      name: "CommonJS TypeScript output ahead of an unrelated .js artifact",
+      sourceExtension: ".cts",
+      runtimeOutputs: ["dist/entry.js", "dist/entry.cjs"],
+      expectedRuntime: "dist/entry.cjs",
+    },
+  ])("keeps install, discovery, setup, and loading aligned for $name", async (scenario) => {
+    const { packageDir, sourceEntry, manifest } = createPackageFixture(scenario);
+    const installResult = await validatePackageExtensionEntriesForInstall({
+      packageDir,
+      extensions: [sourceEntry],
+      manifest,
+    });
+    const diagnostics: Parameters<typeof resolvePackageRuntimeExtensionSources>[0]["diagnostics"] =
+      [];
+    const runtimeSources = resolvePackageRuntimeExtensionSources({
+      packageDir,
+      manifest,
+      extensions: [sourceEntry],
+      origin: "global",
+      sourceLabel: packageDir,
+      diagnostics,
+    });
+    const setupSource = resolvePackageSetupSource({
+      packageDir,
+      manifest,
+      origin: "global",
+      sourceLabel: packageDir,
+      diagnostics,
+    });
+    const artifact = resolvePluginRuntimeArtifact({
+      pluginId: "runtime-entry-fixture",
+      entryKind: "runtime",
+      source: path.join(packageDir, sourceEntry),
+      rootDir: packageDir,
+      origin: "global",
+      preferBuiltPluginArtifacts: true,
+    });
+    const expectedSource = fs.realpathSync(path.join(packageDir, scenario.expectedRuntime));
+
+    expect(installResult).toEqual({ ok: true });
+    expect(runtimeSources).toEqual([expectedSource]);
+    expect(setupSource).toBe(expectedSource);
+    expect(artifact.source).toBe(expectedSource);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it.each([".ts", ".tsx", ".mts", ".cts"])(
+    "rejects published source-only %s entries while allowing linked source checkouts",
+    async (sourceExtension) => {
+      const { packageDir, sourceEntry, manifest } = createPackageFixture({ sourceExtension });
+      const installResult = await validatePackageExtensionEntriesForInstall({
+        packageDir,
+        extensions: [sourceEntry],
+        manifest,
+      });
+      const linkedInstallResult = await validatePackageExtensionEntriesForInstall({
+        packageDir,
+        extensions: [sourceEntry],
+        manifest,
+        allowSourceTypeScriptEntries: true,
+      });
+      const diagnostics: Parameters<
+        typeof resolvePackageRuntimeExtensionSources
+      >[0]["diagnostics"] = [];
+
+      expect(installResult).toEqual({
+        ok: false,
+        error: expect.stringContaining("requires compiled runtime output"),
+      });
+      expect(linkedInstallResult).toEqual({ ok: true });
+      expect(
+        resolvePackageRuntimeExtensionSources({
+          packageDir,
+          manifest,
+          extensions: [sourceEntry],
+          origin: "global",
+          sourceLabel: packageDir,
+          diagnostics,
+        }),
+      ).toEqual([]);
+      expect(diagnostics).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining("requires compiled runtime output"),
+        }),
+      ]);
+      expect(
+        resolvePackageRuntimeExtensionSources({
+          packageDir,
+          manifest,
+          extensions: [sourceEntry],
+          origin: "global",
+          requireBuiltRuntimeEntry: false,
+          sourceLabel: packageDir,
+          diagnostics: [],
+        }),
+      ).toEqual([fs.realpathSync(path.join(packageDir, sourceEntry))]);
+    },
+  );
+});

--- a/src/plugins/package-entrypoints.ts
+++ b/src/plugins/package-entrypoints.ts
@@ -4,7 +4,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 
 /** True when a package entrypoint needs built JavaScript candidates. */
 export function isTypeScriptPackageEntry(entryPath: string): boolean {
-  return [".ts", ".mts", ".cts"].includes(path.extname(entryPath).toLowerCase());
+  return [".ts", ".tsx", ".mts", ".cts"].includes(path.extname(entryPath).toLowerCase());
 }
 
 /** Lists built runtime entry candidates for a TypeScript package entrypoint. */
@@ -14,18 +14,25 @@ export function listBuiltRuntimeEntryCandidates(entryPath: string): string[] {
   }
   const normalized = entryPath.replace(/\\/g, "/");
   const withoutExtension = normalized.replace(/\.[^.]+$/u, "");
-  const normalizedRelative = normalized.replace(/^\.\//u, "");
+  const normalizedRelative = withoutExtension.replace(/^\.\//u, "");
   const distWithoutExtension = normalizedRelative.startsWith("src/")
-    ? `./dist/${normalizedRelative.slice("src/".length).replace(/\.[^.]+$/u, "")}`
-    : `./dist/${withoutExtension.replace(/^\.\//u, "")}`;
-  const withJavaScriptExtensions = (basePath: string) => [
-    `${basePath}.js`,
-    `${basePath}.mjs`,
-    `${basePath}.cjs`,
+    ? `./dist/${normalizedRelative.slice("src/".length)}`
+    : `./dist/${normalizedRelative}`;
+  const sourceExtension = path.extname(normalized).toLowerCase();
+  // TypeScript preserves module format for .mts/.cts, and rootDir can retain src/ in dist/.
+  const outputExtensions =
+    sourceExtension === ".mts"
+      ? [".mjs", ".js", ".cjs"]
+      : sourceExtension === ".cts"
+        ? [".cjs", ".js", ".mjs"]
+        : [".js", ".mjs", ".cjs"];
+  const outputBases = [
+    distWithoutExtension,
+    ...(normalizedRelative.startsWith("src/") ? [`./dist/${normalizedRelative}`] : []),
+    withoutExtension,
   ];
-  const candidates = [
-    ...withJavaScriptExtensions(distWithoutExtension),
-    ...withJavaScriptExtensions(withoutExtension),
-  ];
+  const candidates = outputBases.flatMap((basePath) =>
+    outputExtensions.map((extension) => `${basePath}${extension}`),
+  );
   return uniqueStrings(candidates).filter((candidate) => candidate !== normalized);
 }

--- a/src/plugins/package-entrypoints.ts
+++ b/src/plugins/package-entrypoints.ts
@@ -4,7 +4,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 
 /** True when a package entrypoint needs built JavaScript candidates. */
 export function isTypeScriptPackageEntry(entryPath: string): boolean {
-  return [".ts", ".mts", ".cts"].includes(path.extname(entryPath).toLowerCase());
+  return [".ts", ".tsx", ".mts", ".cts"].includes(path.extname(entryPath).toLowerCase());
 }
 
 /** Lists built runtime entry candidates for a TypeScript package entrypoint. */
@@ -14,18 +14,23 @@ export function listBuiltRuntimeEntryCandidates(entryPath: string): string[] {
   }
   const normalized = entryPath.replace(/\\/g, "/");
   const withoutExtension = normalized.replace(/\.[^.]+$/u, "");
-  const normalizedRelative = normalized.replace(/^\.\//u, "");
+  const normalizedRelative = withoutExtension.replace(/^\.\//u, "");
   const distWithoutExtension = normalizedRelative.startsWith("src/")
-    ? `./dist/${normalizedRelative.slice("src/".length).replace(/\.[^.]+$/u, "")}`
-    : `./dist/${withoutExtension.replace(/^\.\//u, "")}`;
-  const withJavaScriptExtensions = (basePath: string) => [
-    `${basePath}.js`,
-    `${basePath}.mjs`,
-    `${basePath}.cjs`,
+    ? `./dist/${normalizedRelative.slice("src/".length)}`
+    : `./dist/${normalizedRelative}`;
+  const sourceExtension = path.extname(normalized).toLowerCase();
+  const outputExtensions = sourceExtension.startsWith(".mts")
+    ? [".mjs", ".js", ".cjs"]
+    : sourceExtension.startsWith(".cts")
+      ? [".cjs", ".js", ".mjs"]
+      : [".js", ".mjs", ".cjs"];
+  const outputBases = [
+    distWithoutExtension,
+    ...(normalizedRelative.startsWith("src/") ? [`./dist/${normalizedRelative}`] : []),
+    withoutExtension,
   ];
-  const candidates = [
-    ...withJavaScriptExtensions(distWithoutExtension),
-    ...withJavaScriptExtensions(withoutExtension),
-  ];
+  const candidates = outputBases.flatMap((basePath) =>
+    outputExtensions.map((extension) => `${basePath}${extension}`),
+  );
   return uniqueStrings(candidates).filter((candidate) => candidate !== normalized);
 }

--- a/src/plugins/plugin-runtime-artifact-resolution.test.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.test.ts
@@ -66,6 +66,15 @@ afterEach(() => {
 });
 
 describe("resolvePluginRuntimeArtifact", () => {
+  it("keeps the bundled root build ahead of adjacent source output", () => {
+    const fixture = createBundledPluginFixture();
+    fs.writeFileSync(path.join(fixture.rootDir, "index.js"), 'module.exports = { id: "stale" };\n');
+
+    expect(resolveFixture({ ...fixture, preferBuiltPluginArtifacts: true }).source).toBe(
+      fixture.builtSource,
+    );
+  });
+
   it.each([
     { firstPreference: false, firstArtifact: "source" },
     { firstPreference: true, firstArtifact: "built" },

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -2,6 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawPackageManifest } from "./manifest.js";
+import {
+  isTypeScriptPackageEntry,
+  listBuiltRuntimeEntryCandidates,
+} from "./package-entrypoints.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
 type ResolvedPluginRuntimeArtifact = { source: string; rootDir: string };
@@ -39,69 +43,21 @@ function rewriteBundledRuntimeArtifactRelativePath(relativePath: string): string
   return relativePath.replace(/\.[^.]+$/u, ".js");
 }
 
-function listPackageLocalRuntimeArtifactOutputExtensions(sourceExt: string): string[] {
-  switch (sourceExt) {
-    case ".mts":
-    case ".mjs":
-      return [".mjs", ".js", ".cjs"];
-    case ".cts":
-    case ".cjs":
-      return [".cjs", ".js", ".mjs"];
-    default:
-      return [".js", ".mjs", ".cjs"];
-  }
-}
-
-function listPackageLocalRuntimeArtifactRelativePathBases(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const withoutExt = ext ? relativePath.slice(0, -ext.length) : relativePath;
-  if (!withoutExt.startsWith(`src${path.sep}`) && !withoutExt.startsWith("src/")) {
-    return [withoutExt];
-  }
-  return [withoutExt.slice(4), withoutExt];
-}
-
-function listPackageLocalDistRuntimeArtifactRelativePaths(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const candidates = new Set<string>();
-  for (const base of listPackageLocalRuntimeArtifactRelativePathBases(relativePath)) {
-    for (const outputExt of listPackageLocalRuntimeArtifactOutputExtensions(ext)) {
-      candidates.add(`${base}${outputExt}`);
-    }
-  }
-  return [...candidates];
-}
-
-function shouldPreferPackageLocalDistRuntimeArtifact(source: string): boolean {
-  switch (path.extname(source).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-      return true;
-    default:
-      return false;
-  }
-}
-
 function resolvePackageLocalDistRuntimeArtifact(params: {
   source: string;
   rootDir: string;
 }): string | null {
   const relativeSource = path.relative(params.rootDir, params.source);
   if (
-    !shouldPreferPackageLocalDistRuntimeArtifact(relativeSource) ||
+    !isTypeScriptPackageEntry(relativeSource) ||
     relativeSource === "" ||
     relativeSource.startsWith("..") ||
     path.isAbsolute(relativeSource)
   ) {
     return null;
   }
-  const artifactRoot = path.join(params.rootDir, "dist");
-  for (const artifactRelativePath of listPackageLocalDistRuntimeArtifactRelativePaths(
-    relativeSource,
-  )) {
-    const artifactSource = path.join(artifactRoot, artifactRelativePath);
+  for (const artifactRelativePath of listBuiltRuntimeEntryCandidates(relativeSource)) {
+    const artifactSource = path.resolve(params.rootDir, artifactRelativePath);
     if (fs.existsSync(artifactSource)) {
       return safeRealpathOrResolve(artifactSource);
     }

--- a/src/plugins/plugin-runtime-artifact-selection.ts
+++ b/src/plugins/plugin-runtime-artifact-selection.ts
@@ -1,6 +1,10 @@
 /** Selects built plugin artifacts without importing active runtime state. */
 import path from "node:path";
 import type { OpenClawPackageManifest } from "./manifest.js";
+import {
+  isTypeScriptPackageEntry,
+  listBuiltRuntimeEntryCandidates,
+} from "./package-entrypoints.js";
 import { pluginCacheExistsSync, pluginCacheRealpathSync } from "./plugin-cache-files.js";
 import { getPluginCacheRoot } from "./plugin-cache.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -9,69 +13,26 @@ function rewriteBundledRuntimeArtifactRelativePath(relativePath: string): string
   return relativePath.replace(/\.[^.]+$/u, ".js");
 }
 
-function listPackageLocalRuntimeArtifactOutputExtensions(sourceExt: string): string[] {
-  switch (sourceExt) {
-    case ".mts":
-    case ".mjs":
-      return [".mjs", ".js", ".cjs"];
-    case ".cts":
-    case ".cjs":
-      return [".cjs", ".js", ".mjs"];
-    default:
-      return [".js", ".mjs", ".cjs"];
-  }
-}
-
-function listPackageLocalRuntimeArtifactRelativePathBases(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const withoutExt = ext ? relativePath.slice(0, -ext.length) : relativePath;
-  if (!withoutExt.startsWith(`src${path.sep}`) && !withoutExt.startsWith("src/")) {
-    return [withoutExt];
-  }
-  return [withoutExt.slice(4), withoutExt];
-}
-
-function listPackageLocalDistRuntimeArtifactRelativePaths(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const candidates = new Set<string>();
-  for (const base of listPackageLocalRuntimeArtifactRelativePathBases(relativePath)) {
-    for (const outputExt of listPackageLocalRuntimeArtifactOutputExtensions(ext)) {
-      candidates.add(`${base}${outputExt}`);
-    }
-  }
-  return [...candidates];
-}
-
-function shouldPreferPackageLocalDistRuntimeArtifact(source: string): boolean {
-  switch (path.extname(source).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-      return true;
-    default:
-      return false;
-  }
-}
-
 function resolvePackageLocalDistRuntimeArtifact(params: {
   source: string;
   rootDir: string;
+  origin: PluginOrigin;
 }): string | null {
   const relativeSource = path.relative(params.rootDir, params.source);
   if (
-    !shouldPreferPackageLocalDistRuntimeArtifact(relativeSource) ||
+    !isTypeScriptPackageEntry(relativeSource) ||
     relativeSource === "" ||
     relativeSource.startsWith("..") ||
     path.isAbsolute(relativeSource)
   ) {
     return null;
   }
-  const artifactRoot = path.join(params.rootDir, "dist");
-  for (const artifactRelativePath of listPackageLocalDistRuntimeArtifactRelativePaths(
-    relativeSource,
-  )) {
-    const artifactSource = path.join(artifactRoot, artifactRelativePath);
+  for (const artifactRelativePath of listBuiltRuntimeEntryCandidates(relativeSource)) {
+    // Bundled source peers must not shadow the canonical root build below.
+    if (params.origin === "bundled" && !artifactRelativePath.startsWith("./dist/")) {
+      continue;
+    }
+    const artifactSource = path.resolve(params.rootDir, artifactRelativePath);
     if (pluginCacheExistsSync(artifactSource)) {
       return pluginCacheRealpathSync(artifactSource) ?? path.resolve(artifactSource);
     }
@@ -158,7 +119,7 @@ export function resolvePreferredBuiltRuntimeArtifact(params: {
     return { source, rootDir };
   }
   if (params.origin !== "bundled") {
-    const artifactSource = resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
+    const artifactSource = resolvePackageLocalDistRuntimeArtifact({ ...params, source, rootDir });
     return artifactSource ? { source: artifactSource, rootDir } : { source, rootDir };
   }
   // Source-external plugins keep source authoritative over package-local output;
@@ -166,7 +127,7 @@ export function resolvePreferredBuiltRuntimeArtifact(params: {
   const sourceExternal = params.packageManifest?.build?.bundledDist === false;
   const packageLocalArtifactSource = sourceExternal
     ? null
-    : resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
+    : resolvePackageLocalDistRuntimeArtifact({ ...params, source, rootDir });
   if (packageLocalArtifactSource) {
     return { source: packageLocalArtifactSource, rootDir };
   }

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -836,6 +836,7 @@ describe("collectPluginNpmGitRangeSelection", () => {
     "scripts/lib/tsx-cli-shim.mjs",
     "scripts/tsx.mjs",
     "scripts/plugin-npm-release-plan.ts",
+    "src/plugins/package-entrypoints.ts",
   ])("selects all publishable plugins for an authority-only %s change", (changedPath) => {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-range-");
     const absolutePath = join(repoDir, changedPath);

--- a/test/scripts/verify-plugin-npm-published-runtime.test.ts
+++ b/test/scripts/verify-plugin-npm-published-runtime.test.ts
@@ -128,6 +128,50 @@ describe("plugin npm publish verifier command limits", () => {
 });
 
 describe("collectPluginNpmPublishedRuntimeErrors", () => {
+  it.each([".ts", ".tsx", ".mts", ".cts"])(
+    "rejects source-only %s runtime and setup entries",
+    (extension) => {
+      const errors = collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "entry-fixture",
+          openclaw: {
+            extensions: [`./src/index${extension}`],
+            setupEntry: `./src/setup${extension}`,
+          },
+        },
+        files: ["openclaw.plugin.json", `src/index${extension}`, `src/setup${extension}`],
+      });
+      expect(errors).toEqual([
+        expect.stringContaining(
+          `compiled runtime output for TypeScript entry ./src/index${extension}`,
+        ),
+        expect.stringContaining(
+          `compiled runtime output for TypeScript entry ./src/setup${extension}`,
+        ),
+      ]);
+    },
+  );
+
+  it.each([
+    [".ts", ".js"],
+    [".tsx", ".js"],
+    [".mts", ".mjs"],
+    [".cts", ".cjs"],
+  ])("accepts nested compiler output for %s entries without source", (source, output) => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "entry-fixture",
+          openclaw: {
+            extensions: [`./src/index${source}`],
+            setupEntry: `./src/setup${source}`,
+          },
+        },
+        files: ["openclaw.plugin.json", `dist/src/index${output}`, `dist/src/setup${output}`],
+      }),
+    ).toEqual([]);
+  });
+
   it("flags published plugin packages with TypeScript entries and no compiled runtime output", () => {
     expect(
       collectPluginNpmPublishedRuntimeErrors({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installing or updating a packaged plugin could reject valid compiled output, choose the wrong module format, or accept source-only TSX despite the compiled-runtime requirement. Packages that omit their TypeScript source or preserve `src/` under `dist/` were affected.

## Why This Change Was Made

Package installation, discovery/setup, runtime artifact selection, and npm release verification now share the same compiled-entry candidate owner. The owner recognizes `.ts`, `.tsx`, `.mts`, and `.cts`, searches both flattened and nested compiler output, and prefers `.mjs` for `.mts` and `.cjs` for `.cts` as specified by [TypeScript 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html).

The refresh retains current main's registry-scoped artifact memo, process-stable filesystem cache, source-external plugin ownership, and containment checks. Bundled adjacent source peers cannot shadow the canonical root build. The shared helper is also included in release change detection so future helper-only corrections trigger validation. It removes the duplicate runtime and release-verifier candidate policies: production runtime is net -32 lines, release tooling net -22, release workflow +1, tests +235, and docs net +3.

## User Impact

Supported compiled plugin layouts resolve consistently through installation, setup, discovery, and runtime loading after an upgrade. Managed source-only TypeScript packages fail with an actionable compiled-output error; linked source development remains supported.

Release note: Plugin installs: align packaged runtime entry resolution for TSX, nested compiler output, and native ESM/CommonJS extensions. Thanks @steipete.

## Evidence

Before the repair, the original lifecycle regression matrix failed 6 of 9 cases, the expanded release-verifier matrix failed 5 of 32 cases, and the bundled-adjacent precedence regression failed. The complete repaired focused suite passes 290 tests across install/discovery/setup, runtime identity/cache, artifact selection, and npm verification.

```sh
node scripts/run-vitest.mjs src/plugins/package-entry-resolution.runtime.test.ts src/plugins/plugin-runtime-artifact-resolution.test.ts src/plugins/plugin-runtime-artifact-identity.test.ts src/plugins/install.test.ts src/plugins/discovery.test.ts test/scripts/verify-plugin-npm-published-runtime.test.ts
```

Codex review of the adapted branch completed with no actionable findings at the requested P0 threshold. Both Rank-up moves from the latest ClawSweeper review are addressed: the standalone verifier shares the canonical candidate contract with TSX/nested-output coverage, and the branch preserves the current runtime ownership safeguards after refresh.

On hydrated Linux Blacksmith Testbox `tbx_01m1b3mc7q7pz9dre2qp71fb6g` ([run](https://github.com/openclaw/openclaw/actions/runs/33359598254)), `pnpm build` completed successfully. A synthetic npm-pack install/overwrite sequence then passed through the built CLI: direct JavaScript v1 → source-omitted nested TSX v2 → native MJS v3 → native CJS v4. Every version reported `loaded` through `plugins inspect --runtime --json` and executed its versioned CLI sentinel. MTS/CTS packages also contained a throwing `.js` decoy, proving native-extension priority. A final source-only TSX replacement was rejected with the compiled-output error, and v4 still executed. Temporary package/state directories were removed.

The local shared-dependency checkout could not complete the broad gates: the build lacked `shiki/wasm`, and core typecheck reported six unchanged logging `Logger.settings`/`attachTransport` errors. The clean Linux build and real CLI proof passed. The final changed-file gate passed in full on a fresh [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33360924030), with the comparison pinned to this PR's actual base (terminal exit 0, 18m56s). Hosted CI and the required `openclaw/ci-gate` passed on exact head `2e956681bd6291771c480fcbbe060436c1bc6165` ([CI run](https://github.com/openclaw/openclaw/actions/runs/33361533105)).

The helper-only Git-range selection regression failed before the release-authority follow-through; the repaired release-selection and workflow suites pass 64 tests.

A separate independent Codex review of final head `2e956681bd6291771c480fcbbe060436c1bc6165` found no actionable issues. Its earlier release-authority finding is addressed by the two dependency scope entries and the regression above.

Compatibility disposition: native MTS→MJS and CTS→CJS precedence was the original PR’s documented intent and matches the existing runtime owner and TypeScript contract. This repair applies that same contract consistently to installation, discovery, setup, and verification. Packages that need a different artifact can continue to select it with explicit runtime entry fields. The precedence repair is within the requested autonomous fix-and-land scope; no new configuration, schema, or product-policy surface is introduced.
