### PR TITLE
fix(embeddings): reject malformed and empty provider vectors

### DIFF
--- a/packages/memory-host-sdk/src/host/batch-output.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-output.test.ts
@@ -173,6 +173,39 @@ describe("applyEmbeddingBatchOutputLine", () => {
     expect(byCustomId.get("req-1")).toEqual([0.1, 0.2]);
   });
 
+  it.each([
+    { name: "non-array", embedding: "poison" },
+    { name: "array-like object", embedding: { length: 1 } },
+    { name: "boolean", embedding: false },
+    { name: "string coordinate", embedding: ["poison"] },
+    { name: "null coordinate", embedding: [null] },
+    { name: "NaN coordinate", embedding: [Number.NaN] },
+    { name: "positive infinity coordinate", embedding: [Number.POSITIVE_INFINITY] },
+    { name: "negative infinity coordinate", embedding: [Number.NEGATIVE_INFINITY] },
+  ])("rejects a $name instead of storing it as a valid vector", ({ embedding }) => {
+    const remaining = new Set(["req-invalid"]);
+    const errors: string[] = [];
+    const byCustomId = new Map<string, number[]>();
+
+    applyEmbeddingBatchOutputLine({
+      line: {
+        custom_id: "req-invalid",
+        response: {
+          status_code: 200,
+          body: { data: [{ embedding: embedding as unknown as number[] }] },
+        },
+      },
+      remaining,
+      errors,
+      byCustomId,
+    });
+
+    expect(remaining.has("req-invalid")).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/^req-invalid: (?:empty|invalid) embedding$/);
+    expect(byCustomId.size).toBe(0);
+  });
+
   it("records provider error from line.error", () => {
     const remaining = new Set(["req-2"]);
     const errors: string[] = [];

--- a/packages/memory-host-sdk/src/host/batch-output.ts
+++ b/packages/memory-host-sdk/src/host/batch-output.ts
@@ -174,8 +174,8 @@ export function applyEmbeddingBatchOutputLine(params: {
   const data =
     response?.body && typeof response.body === "object" ? (response.body.data ?? []) : [];
   const embedding = data[0]?.embedding ?? [];
-  if (embedding.length === 0) {
-    params.errors.push(`${customId}: empty embedding`);
+  if (!Array.isArray(embedding) || embedding.length === 0 || !embedding.every(Number.isFinite)) {
+    params.errors.push(`${customId}: ${embedding?.length ? "invalid" : "empty"} embedding`);
     return;
   }
   params.byCustomId.set(customId, embedding);

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
@@ -124,6 +124,39 @@ describe("fetchRemoteEmbeddingVectors", () => {
     ).rejects.toThrow("embedding fetch failed: malformed JSON response");
   });
 
+  it.each([
+    { name: "query", input: ["query"], data: [{ embedding: [] }] },
+    {
+      name: "document batch",
+      input: ["first", "second"],
+      data: [{ embedding: [0.1] }, { embedding: [] }],
+    },
+  ])("rejects empty vectors in a $name response", async ({ input, data }) => {
+    postJsonMock.mockImplementationOnce(async (params) => await params.parse({ data }));
+
+    await expect(
+      fetchRemoteEmbeddingVectors({
+        url: "https://memory.example/v1/embeddings",
+        headers: {},
+        body: { input },
+        errorPrefix: "embedding fetch failed",
+      }),
+    ).rejects.toThrow("embedding fetch failed: malformed JSON response");
+  });
+
+  it("preserves an empty response for an empty submitted input batch", async () => {
+    postJsonMock.mockImplementationOnce(async (params) => await params.parse({ data: [] }));
+
+    await expect(
+      fetchRemoteEmbeddingVectors({
+        url: "https://memory.example/v1/embeddings",
+        headers: {},
+        body: { input: [] },
+        errorPrefix: "embedding fetch failed",
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it("rejects wrong nested embedding vector types", async () => {
     postJsonMock.mockImplementationOnce(async (params) => {
       return await params.parse({ data: [{ embedding: [0.1, "bad"] }] });

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -18,7 +18,7 @@ function malformedEmbeddingResponse(errorPrefix: string): Error {
 
 /** Validate and return one finite embedding vector. */
 function readEmbeddingVector(value: unknown, errorPrefix: string): number[] {
-  if (!Array.isArray(value)) {
+  if (!Array.isArray(value) || value.length === 0) {
     throw malformedEmbeddingResponse(errorPrefix);
   }
   for (const entry of value) {


### PR DESCRIPTION
## Summary

- Reject empty embedding vectors in the existing shared direct-response producer instead of silently returning unusable query or document embeddings.
- Reject non-array, nonnumeric, and nonfinite embedding vectors in the existing shared streamed-batch producer for both OpenAI and Voyage.
- Preserve zero-valued coordinates, valid SDK responses, zero-input batches, existing provider errors, and all public contracts with **zero net production lines**.

## Root causes

1. `readEmbeddingVector` accepted empty arrays for nonempty requests, allowing direct embedding calls to return zero-dimensional vectors successfully.
2. `applyEmbeddingBatchOutputLine` trusted `.length` without checking array shape or finite numeric coordinates, allowing both OpenAI and Voyage batch output to store malformed values as embedding vectors.

## Verification

- Real localhost baseline: direct calls accepted `[[]]`; full OpenAI and Voyage multipart-upload/batch/output pipelines each accepted `["poison"]`.
- Real localhost candidate: direct query/document calls fail visibly; both provider pipelines reject malformed output; the official installed `openai@6.49.0` SDK returns a valid `[0.25]`, valid `[[0]]` is preserved, and zero-input batches still return `[]`.
- Blacksmith Testbox: `pnpm tsgo:core`, `pnpm tsgo:test:packages`, exact-four-path type-aware lint, **98/98 owner/OpenAI/Voyage/plugin tests across five shards**, and the **11-request official-SDK localhost proof** all passed.
- Full `gpt-5.6-sol` high-reasoning structured autoreview through P3: zero findings, confidence 0.99.
- Three fresh independent full-owner blind reviews: CLEAN (0.99, 0.99, 0.98).
- Reviewed original/candidate blob guards, exact-four-path guards, unchanged package lockfile, and synthetic merge against `982add961804097f5a6b0b94255c5c855e8ad863` all passed.
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/30682347608
