### PR TITLE
fix(qa): restore subagent fanout catalog validation

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -71,32 +71,24 @@ describe("qa scenario catalog channel contracts", () => {
     expect(subagentFanout.execution.suiteIsolation).toBe("isolated");
   });
 
-  it("uses durable subagent completion evidence before accepting fanout", () => {
+  it("uses public parent history and durable task records before accepting fanout", () => {
     const scenario = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));
     const flow = JSON.stringify(scenario.execution.flow);
-    const completionWait = flow.indexOf('"saveAs":"completedFanout"');
-    const storeReads = [...flow.matchAll(/readRawQaSessionStore/gu)].map((match) => match.index);
 
     expect(flow).toContain('"call":"startAgentRun"');
     expect(flow).not.toContain('"call":"runAgentPrompt"');
     expect(flow).toContain('"taskTracking":false');
     expect(flow).toContain('"saveAs":"parentOutbound"');
-    expect(flow).toContain("messages.slice(parentOutboundStartIndex)");
-    expect(flow).not.toContain("waitForAgentHistoryReply");
+    expect(flow).toContain("waitForAgentHistoryReply");
     expect(flow).not.toContain('"call":"waitForOutboundMessage"');
     expect(flow).not.toContain("childCompletionMarker");
-    expect(flow).toContain("entry.spawnedBy === sessionKey");
-    expect(flow).toContain(
-      "timeoutSawAlpha && timeoutSawBeta && timeoutAlphaOk && timeoutBetaOk && (!env.mock || timeoutSpawnRequests.length >= 2)",
-    );
-    expect(flow).toContain("Boolean(env.mock) ? config.expectedChildCompletionMarkers[0] : 'ok'");
-    expect(flow).toContain('saveAs":"timeoutEvidence');
-    expect(flow).toContain('saveAs":"recoveredParentOutbound');
+    expect(flow).toContain("['tasks', 'list', '--json', '--runtime', 'subagent']");
+    expect(flow).toContain("task.requesterSessionKey === sessionKey");
+    expect(flow).toContain("task?.status === 'succeeded'");
+    expect(flow).toContain("task.deliveryStatus === 'delivered'");
+    expect(flow).not.toContain("readRawQaSessionStore");
+    expect(flow).not.toContain("readSessionTranscriptSummary");
     expect(flow).not.toContain('"value":"subagent-1: ok\\nsubagent-2: ok"');
-    expect(flow).toContain("Promise.all([readSessionTranscriptSummary");
-    expect(completionWait).toBeGreaterThan(-1);
-    expect(storeReads).toHaveLength(2);
-    expect(completionWait).toBeLessThan(storeReads[0] ?? -1);
   });
 
   it("keeps channel streaming evidence portable across QA Channel and Crabline Telegram", () => {


### PR DESCRIPTION
Related: #116832\n\n## What Problem This Solves\n\nResolves a problem where the QA scenario catalog test on current main rejected the subagent fanout scenario after its evidence path moved to public parent history and durable task records.\n\n## Why This Change Was Made\n\nThe catalog contract now validates the public history/task-record boundary introduced by #116832 and removes assertions for the retired private session-store and transcript readers. Production behavior is unchanged.\n\n## User Impact\n\nNo user-visible runtime change. QA catalog validation again reflects the scenario that current main actually runs.\n\n## Evidence\n\n- 
 RUN  v4.1.10 /Users/dallin/Documents/code/openclaw/openclaw.maturity-scorecard-jul-16


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  12:14:17
   Duration  757ms (transform 228ms, setup 188ms, import 149ms, tests 347ms, environment 0ms) — 8/8 passed\n-  — passed\n- Fresh autoreview — clean (0.99)