### PR TITLE
fix(qa): keep runner discovery off broad runtime barrels

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1230,12 +1230,13 @@ The minimum adoption bar for a new channel:
 4. Mount the runner as `openclaw qa <runner>` instead of registering a
    competing root command. Runner plugins should declare `qaRunners` in
    `openclaw.plugin.json` and export a matching `qaRunnerCliRegistrations`
-   array from `runtime-api.ts`. Keep `runtime-api.ts` light; lazy CLI and
-   runner execution should stay behind separate entrypoints. An optional
-   `adapterFactory` exposes the transport to shared scenarios without changing
-   the command's existing scenario catalog. Same-channel partitions are serial
-   unless the factory declares that every instance owns isolated credentials or
-   disposable servers, Gateway state, and artifact paths.
+   array from a lightweight `qa-runner-api.ts` surface. Installed plugins using
+   the shipped `runtime-api.ts` contract remain supported through 2026-10-01
+   while authors migrate. Keep runner execution behind lazy entrypoints. An
+   optional `adapterFactory` exposes the transport to shared scenarios without
+   changing the command's existing scenario catalog. Same-channel partitions
+   are serial unless the factory declares that every instance owns isolated
+   credentials or disposable servers, Gateway state, and artifact paths.
 5. Author or adapt YAML scenarios under the themed `qa/scenarios/`
    directories.
 6. Use the generic scenario helpers for new scenarios.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -490,7 +490,9 @@ Planner diagnostics can distinguish explicit activation hints from manifest owne
 Use `qaRunners` when a plugin contributes one or more transport runners beneath
 the shared `openclaw qa` root. Keep this metadata cheap and static; the plugin
 runtime still owns actual CLI registration through a lightweight
-`runtime-api.ts` surface that exports matching `qaRunnerCliRegistrations`. An
+`qa-runner-api.ts` surface that exports matching `qaRunnerCliRegistrations`. For
+plugins using the shipped `runtime-api.ts` contract, that legacy surface remains
+accepted through 2026-10-01 while authors migrate. An
 optional `adapterFactory` exposes the transport to shared QA scenarios without
 changing the registered command's runner.
 

--- a/extensions/buzz/qa-runner-api.ts
+++ b/extensions/buzz/qa-runner-api.ts
@@ -1,0 +1,3 @@
+import { buzzQaCliRegistration } from "./src/qa/cli.js";
+
+export const qaRunnerCliRegistrations = [buzzQaCliRegistration];

--- a/extensions/buzz/runtime-api.ts
+++ b/extensions/buzz/runtime-api.ts
@@ -1,6 +1,2 @@
-import { buzzQaCliRegistration } from "./src/qa/cli.js";
-
 export type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 export type { ChannelPlugin, PluginRuntime } from "openclaw/plugin-sdk/core";
-
-export const qaRunnerCliRegistrations = [buzzQaCliRegistration];

--- a/extensions/msteams/qa-runner-api.ts
+++ b/extensions/msteams/qa-runner-api.ts
@@ -1,0 +1,3 @@
+import { msteamsQaCliRegistration } from "./src/qa/cli.js";
+
+export const qaRunnerCliRegistrations = [msteamsQaCliRegistration];

--- a/extensions/msteams/runtime-api.ts
+++ b/extensions/msteams/runtime-api.ts
@@ -1,8 +1,6 @@
 // Private runtime barrel for the bundled Microsoft Teams extension.
 // Keep this barrel thin and aligned with the local extension surface.
 
-import { msteamsQaCliRegistration } from "./src/qa/cli.js";
-
 export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 export type { AllowlistMatch } from "openclaw/plugin-sdk/allow-from";
 export {
@@ -68,5 +66,3 @@ export { normalizeStringEntries } from "openclaw/plugin-sdk/string-normalization
 export { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 export { DEFAULT_WEBHOOK_MAX_BODY_BYTES } from "openclaw/plugin-sdk/webhook-ingress";
 export { setMSTeamsRuntime } from "./src/runtime.js";
-
-export const qaRunnerCliRegistrations = [msteamsQaCliRegistration];

--- a/src/plugin-sdk/qa-runner-runtime.integration.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.integration.test.ts
@@ -106,6 +106,11 @@ describe("plugin-sdk qa-runner-runtime linked plugin smoke", () => {
     fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n", "utf8");
     fs.writeFileSync(
       path.join(pluginDir, "runtime-api.js"),
+      'throw new Error("general runtime surface must not load during QA discovery");\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "qa-runner-api.js"),
       [
         "export const qaRunnerCliRegistrations = [",
         "  {",
@@ -137,6 +142,78 @@ describe("plugin-sdk qa-runner-runtime linked plugin smoke", () => {
           adapterFactory: expect.objectContaining({
             id: "linked",
           }),
+          register,
+        },
+      },
+    ]);
+  });
+
+  it("loads a legacy runtime-api runner from an installed linked plugin", () => {
+    const stateDir = makeTempDir("openclaw-qa-runner-legacy-state-");
+    const pluginDir = path.join(stateDir, "extensions", "qa-legacy");
+    const configPath = path.join(stateDir, "openclaw.json");
+
+    fs.writeFileSync(configPath, JSON.stringify({ plugins: {} }), "utf8");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "qa-legacy",
+        qaRunners: [{ commandName: "legacy" }],
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/qa-legacy",
+        type: "module",
+        openclaw: {
+          extensions: ["./index.js"],
+          install: {
+            npmSpec: "@openclaw/qa-legacy",
+          },
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n", "utf8");
+    fs.writeFileSync(
+      path.join(pluginDir, "runtime-api.js"),
+      [
+        "export const qaRunnerCliRegistrations = [",
+        "  {",
+        '    commandName: "legacy",',
+        "    register() {}",
+        "  }",
+        "];",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const contributions = listQaRunnerCliContributions();
+    const contribution = contributions[0];
+    expect(contribution?.status).toBe("available");
+    if (!contribution || contribution.status !== "available") {
+      throw new Error("Expected legacy linked QA runner contribution to be available");
+    }
+    const register = contribution.registration["register"];
+    expect(typeof register).toBe("function");
+    expect(contributions).toEqual([
+      {
+        pluginId: "qa-legacy",
+        commandName: "legacy",
+        status: "available",
+        registration: {
+          commandName: "legacy",
           register,
         },
       },

--- a/src/plugin-sdk/qa-runner-runtime.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.test.ts
@@ -175,7 +175,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
     ]);
     expect(loadBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledWith({
       dirName: "qa-example",
-      artifactBasename: "runtime-api.js",
+      artifactBasename: "qa-runner-api.js",
     });
   });
 
@@ -204,22 +204,28 @@ describe("plugin-sdk qa-runner-runtime", () => {
     ]);
   });
 
-  it("keeps shipped registration-only runner contributions available", async () => {
+  it("keeps shipped runtime-api runner contributions available for installed plugins", async () => {
     const register = vi.fn((qa: Command) => qa);
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
           id: "qa-legacy",
-          origin: "bundled",
+          origin: "global",
           qaRunners: [{ commandName: "legacy" }],
           rootDir: "/tmp/qa-legacy",
         },
       ],
       diagnostics: [],
     });
-    loadBundledPluginPublicSurfaceModuleSync.mockReturnValue({
-      qaRunnerCliRegistrations: [{ commandName: "legacy", register }],
-    });
+    tryLoadActivatedBundledPluginPublicSurfaceModuleSync
+      .mockImplementationOnce(() => {
+        throw new Error(
+          "Unable to resolve bundled plugin public surface qa-legacy/qa-runner-api.js",
+        );
+      })
+      .mockReturnValue({
+        qaRunnerCliRegistrations: [{ commandName: "legacy", register }],
+      });
 
     const module = await import("./qa-runner-runtime.js");
 
@@ -231,6 +237,14 @@ describe("plugin-sdk qa-runner-runtime", () => {
         registration: { commandName: "legacy", register },
       },
     ]);
+    expect(tryLoadActivatedBundledPluginPublicSurfaceModuleSync).toHaveBeenNthCalledWith(1, {
+      dirName: "qa-legacy",
+      artifactBasename: "qa-runner-api.js",
+    });
+    expect(tryLoadActivatedBundledPluginPublicSurfaceModuleSync).toHaveBeenNthCalledWith(2, {
+      dirName: "qa-legacy",
+      artifactBasename: "runtime-api.js",
+    });
   });
 
   it("prefers the source bundled tree for private qa discovery in repo checkouts", async () => {
@@ -278,7 +292,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
 
     const publicSurfaceCall = firstPublicSurfaceCall();
     expect(publicSurfaceCall?.dirName).toBe("qa-example");
-    expect(publicSurfaceCall?.artifactBasename).toBe("runtime-api.js");
+    expect(publicSurfaceCall?.artifactBasename).toBe("qa-runner-api.js");
     expect(publicSurfaceCall?.env?.OPENCLAW_ENABLE_PRIVATE_QA_CLI).toBe("1");
     expect(publicSurfaceCall?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR).toBe(
       path.join(sourceRoot, "extensions"),
@@ -338,7 +352,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
     const module = await import("./qa-runner-runtime.js");
 
     expect(() => module.listQaRunnerCliContributions()).toThrow(
-      'QA runner plugin "qa-example" exported "extra" from runtime-api.js but did not declare it in openclaw.plugin.json',
+      'QA runner plugin "qa-example" exported "extra" from its QA runner surface but did not declare it in openclaw.plugin.json',
     );
   });
 });

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -389,9 +389,12 @@ export function createLiveTransportQaCliRegistration(
   };
 }
 
-type QaRunnerRuntimeSurface = {
+type QaRunnerSurface = {
   qaRunnerCliRegistrations?: readonly QaRunnerCliRegistration[];
 };
+
+const QA_RUNNER_API_ARTIFACT_BASENAME = "qa-runner-api.js";
+const LEGACY_QA_RUNNER_API_ARTIFACT_BASENAME = "runtime-api.js";
 
 type QaRuntimeSurface = {
   defaultQaRuntimeModelForMode: (
@@ -500,7 +503,7 @@ function listDeclaredQaRunnerPlugins(
 
 function indexRuntimeRegistrations(
   pluginId: string,
-  surface: QaRunnerRuntimeSurface,
+  surface: QaRunnerSurface,
 ): ReadonlyMap<string, QaRunnerCliRegistration> {
   const registrations = surface.qaRunnerCliRegistrations ?? [];
   const registrationByCommandName = new Map<string, QaRunnerCliRegistration>();
@@ -518,20 +521,38 @@ function indexRuntimeRegistrations(
   return registrationByCommandName;
 }
 
-function loadQaRunnerRuntimeSurface(
+function loadQaRunnerSurface(
   plugin: PluginManifestRecord,
   env?: NodeJS.ProcessEnv,
-): QaRunnerRuntimeSurface | null {
+): QaRunnerSurface | null {
   if (plugin.origin === "bundled") {
-    return loadBundledPluginPublicSurfaceModuleSync<QaRunnerRuntimeSurface>({
+    return loadBundledPluginPublicSurfaceModuleSync<QaRunnerSurface>({
       dirName: plugin.id,
-      artifactBasename: "runtime-api.js",
+      artifactBasename: QA_RUNNER_API_ARTIFACT_BASENAME,
       ...(env ? { env } : {}),
     });
   }
-  return tryLoadActivatedBundledPluginPublicSurfaceModuleSync<QaRunnerRuntimeSurface>({
+  try {
+    return tryLoadActivatedBundledPluginPublicSurfaceModuleSync<QaRunnerSurface>({
+      dirName: plugin.id,
+      artifactBasename: QA_RUNNER_API_ARTIFACT_BASENAME,
+      ...(env ? { env } : {}),
+    });
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      error.message !==
+        `Unable to resolve bundled plugin public surface ${plugin.id}/${QA_RUNNER_API_ARTIFACT_BASENAME}`
+    ) {
+      throw error;
+    }
+  }
+
+  // qaRunners shipped through runtime-api.js in v2026.6.9. Keep activated
+  // installed plugins working until the 2026-10-01 removal review.
+  return tryLoadActivatedBundledPluginPublicSurfaceModuleSync<QaRunnerSurface>({
     dirName: plugin.id,
-    artifactBasename: "runtime-api.js",
+    artifactBasename: LEGACY_QA_RUNNER_API_ARTIFACT_BASENAME,
     ...(env ? { env } : {}),
   });
 }
@@ -542,9 +563,9 @@ export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution
   const contributions = new Map<string, QaRunnerCliContribution>();
 
   for (const plugin of listDeclaredQaRunnerPlugins(env)) {
-    const runtimeSurface = loadQaRunnerRuntimeSurface(plugin, env);
-    const runtimeRegistrationByCommandName = runtimeSurface
-      ? indexRuntimeRegistrations(plugin.id, runtimeSurface)
+    const runnerSurface = loadQaRunnerSurface(plugin, env);
+    const runtimeRegistrationByCommandName = runnerSurface
+      ? indexRuntimeRegistrations(plugin.id, runnerSurface)
       : null;
     const declaredCommandNames = new Set(plugin.qaRunners.map((runner) => runner.commandName));
 
@@ -557,7 +578,7 @@ export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution
       }
 
       const registration = runtimeRegistrationByCommandName?.get(runner.commandName);
-      if (!runtimeSurface) {
+      if (!runnerSurface) {
         contributions.set(runner.commandName, {
           pluginId: plugin.id,
           commandName: runner.commandName,
@@ -568,7 +589,7 @@ export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution
       }
       if (!registration) {
         throw new Error(
-          `QA runner plugin "${plugin.id}" declared "${runner.commandName}" in openclaw.plugin.json but did not export a matching CLI registration`,
+          `QA runner plugin "${plugin.id}" declared "${runner.commandName}" in openclaw.plugin.json but did not export a matching CLI registration from its QA runner surface`,
         );
       }
       const adapterFactory = registration.adapterFactory;
@@ -596,7 +617,7 @@ export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution
     for (const commandName of runtimeRegistrationByCommandName?.keys() ?? []) {
       if (!declaredCommandNames.has(commandName)) {
         throw new Error(
-          `QA runner plugin "${plugin.id}" exported "${commandName}" from runtime-api.js but did not declare it in openclaw.plugin.json`,
+          `QA runner plugin "${plugin.id}" exported "${commandName}" from its QA runner surface but did not declare it in openclaw.plugin.json`,
         );
       }
     }

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -471,6 +471,22 @@ describe("bundled plugin metadata", () => {
     });
   });
 
+  it("keeps QA runner discovery on narrow bundled runtime sidecars", () => {
+    const runnerPlugins = listRepoBundledPluginMetadata().filter(
+      (entry) => (entry.manifest.qaRunners?.length ?? 0) > 0,
+    );
+    expect(runnerPlugins.length).toBeGreaterThan(0);
+
+    for (const plugin of runnerPlugins) {
+      expectArtifactPresence(plugin?.publicSurfaceArtifacts, {
+        contains: ["qa-runner-api.js"],
+      });
+      expectArtifactPresence(plugin?.runtimeSidecarArtifacts, {
+        contains: ["qa-runner-api.js"],
+      });
+    }
+  });
+
   it("loads tlon channel config metadata from the lightweight schema surface", () => {
     const tlonChannelConfig = collectRepoBundledChannelConfigsForTest("tlon")?.tlon as
       | { schema?: { type?: unknown } }

--- a/src/plugins/bundled-plugin-scan.ts
+++ b/src/plugins/bundled-plugin-scan.ts
@@ -8,6 +8,7 @@ import { PUBLIC_SURFACE_SOURCE_EXTENSIONS } from "./public-surface-runtime.js";
 const RUNTIME_SIDECAR_ARTIFACTS = new Set([
   "helper-api.js",
   "light-runtime-api.js",
+  "qa-runner-api.js",
   "runtime-api.js",
   "runtime-setter-api.js",
   "thread-bindings-runtime.js",

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -136,7 +136,6 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";',
     'export { DEFAULT_WEBHOOK_MAX_BODY_BYTES } from "openclaw/plugin-sdk/webhook-ingress";',
     'export { setMSTeamsRuntime } from "./src/runtime.js";',
-    "export const qaRunnerCliRegistrations = [msteamsQaCliRegistration];",
   ],
   [bundledPluginFile({ rootDir: ROOT_DIR, pluginId: "irc", relativePath: "runtime-api.ts" })]: [
     'export { setIrcRuntime } from "./src/runtime.js";',
@@ -356,6 +355,32 @@ describe("runtime api guardrails", () => {
         source,
         `${pluginId} runtime api should use generic sdk subpaths or local exports`,
       ).not.toContain(`'openclaw/plugin-sdk/${pluginId}'`);
+    }
+  });
+
+  it("keeps QA runner registration on narrow plugin facades", () => {
+    const qaRunnerApiFiles: string[] = [];
+
+    for (const [pluginId, rootDir] of getBundledPluginRoots().entries()) {
+      const runtimeApiPath = resolve(rootDir, "runtime-api.ts");
+      if (existsSync(runtimeApiPath)) {
+        expect(
+          readFileSync(runtimeApiPath, "utf8"),
+          `${pluginId} runtime api must not own QA discovery`,
+        ).not.toContain("qaRunnerCliRegistrations");
+      }
+
+      const qaRunnerApiPath = resolve(rootDir, "qa-runner-api.ts");
+      if (existsSync(qaRunnerApiPath)) {
+        qaRunnerApiFiles.push(qaRunnerApiPath);
+      }
+    }
+
+    expect(qaRunnerApiFiles.length).toBeGreaterThan(0);
+    for (const file of qaRunnerApiFiles) {
+      const exports = readExportStatements(file);
+      expect(exports).toHaveLength(1);
+      expect(exports[0]).toMatch(/^export const qaRunnerCliRegistrations = \[/u);
     }
   });
 

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -80,6 +80,13 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).toContain("dist/extensions/codex/cli-metadata.js");
   });
 
+  it("builds narrow QA runner public surfaces", () => {
+    const entries = listBundledPluginBuildEntries();
+
+    expect(entries["extensions/buzz/qa-runner-api"]).toBe("extensions/buzz/qa-runner-api.ts");
+    expect(entries["extensions/msteams/qa-runner-api"]).toBe("extensions/msteams/qa-runner-api.ts");
+  });
+
   it("filters bundled plugin build entries for bounded script lanes", () => {
     const entries = listBundledPluginBuildEntries({
       env: {


### PR DESCRIPTION
Related: #117033

## What Problem This Solves

Fixes an issue where bundled QA runner discovery imported broad plugin runtime barrels, causing cold discovery to become slow enough to time out after the Microsoft Teams QA runner was registered.

## Why This Change Was Made

Moves Buzz and Microsoft Teams registrations to dedicated `qa-runner-api` facades and teaches the shared loader to prefer that narrow surface. Installed non-bundled plugins retain a documented `runtime-api` fallback through October 1, 2026, so existing runner packages are not broken during the migration window.

## User Impact

`openclaw qa` can discover bundled runners without loading unrelated runtime/plugin state. Existing installed runner plugins that still expose registrations from `runtime-api` continue to work during the migration window.

## Evidence

- 54 focused QA runner, Buzz, Microsoft Teams, manifest, and boundary tests passed
- five cold discovery runs completed in 3.97-5.26 seconds
- packaged artifact `8813207658` contains both narrow facades; broad facades export no runner registrations
- packaged bundled discovery finds both runners, and a built legacy installed-plugin fallback succeeds
- exact-head CI run https://github.com/openclaw/openclaw/actions/runs/30683742675 completed successfully on attempt 2
- attempt 1 only had an unrelated lint runner shutdown; the exact failed-job retry passed
- fresh autoreview: clean, no accepted/actionable findings, correctness 0.93
- zero touched-file drift against current `main`; clean synthetic merge tree `17e49c879144abbba9030e701f218ca34dc12b58`
- zero unresolved review threads

## ClawSweeper Rank-up Disposition

- Packaged new-facade discovery: satisfied by artifact `8813207658`.
- Packaged legacy installed-plugin fallback: satisfied by the built fallback proof.
- Temporary compatibility contract: accepted through October 1, 2026, and documented in the changed QA/plugin docs.
- Final exact-head review: exact-head ClawSweeper reports no findings; current exact-head CI is green.