### PR TITLE
fix(gateway): clamp discovery advertise timeout

### DIFF
--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -223,6 +223,41 @@ describe("startGatewayDiscovery", () => {
     vi.useRealTimers();
   });
 
+  it("waits for delayed discovery when the configured timeout exceeds Node's timer range", async () => {
+    useDevelopmentDiscoveryEnv();
+    process.env.OPENCLAW_GATEWAY_DISCOVERY_ADVERTISE_TIMEOUT_MS = "2147483648";
+
+    const stop = vi.fn();
+    const service = makeDiscoveryService({
+      id: "slow-discovery",
+      advertise: vi.fn(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 50);
+        });
+        return { stop };
+      }),
+    });
+    const logs = makeLogs();
+
+    const startedAt = Date.now();
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "off",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [service],
+      logDiscovery: logs,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    await result.bonjourStop?.();
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(25);
+    expect(logs.warn).not.toHaveBeenCalled();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("skips local discovery services when mDNS mode is off", async () => {
     process.env.NODE_ENV = "development";
     delete process.env.VITEST;

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -1,7 +1,7 @@
 // Gateway discovery runtime.
 // Starts local mDNS plugin discovery and optional wide-area DNS-SD publishing.
 import { isTruthyEnvValue } from "../infra/env.js";
-import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { clampTimerTimeoutMs, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { resolveWideAreaDiscoveryDomain, writeWideAreaGatewayZone } from "../infra/widearea-dns.js";
@@ -23,7 +23,7 @@ function resolveDiscoveryAdvertiseTimeoutMs(env: NodeJS.ProcessEnv): number {
   if (parsed === undefined) {
     return DEFAULT_DISCOVERY_ADVERTISE_TIMEOUT_MS;
   }
-  return parsed;
+  return clampTimerTimeoutMs(parsed) ?? DEFAULT_DISCOVERY_ADVERTISE_TIMEOUT_MS;
 }
 
 /** Start configured Gateway discovery publishers and return their shutdown hook. */


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where Gateway startup could treat a configured discovery advertise timeout above Node's timer ceiling as approximately 1ms. A discovery service that needed only 50ms could therefore be reported as timed out almost immediately.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The parsed discovery timeout is now passed through the project's existing timer clamp before it reaches `setTimeout`. Values up to the project timer ceiling keep their configured duration, oversized values are capped consistently with other timers, and invalid values still use the existing default.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Operators can use a large positive discovery advertise timeout without triggering `TimeoutOverflowWarning` or accidentally shortening Gateway startup tolerance to about 1ms.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

Fresh reproduction on latest `main` (`c50237e37df`) with a 50ms discovery advertiser:

```text
DF_LATEST_MAIN trigger configured_timeout_ms=2147483648 advertise_delay_ms=50
TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
DF_LATEST_MAIN transition warning_log=gateway discovery service timed out after 2147483648ms; continuing startup
DF_LATEST_MAIN transition startup_returned elapsed_ms=4
DF_LATEST_MAIN transition advertise_completed elapsed_ms=50
DF_LATEST_MAIN outcome problem_present premature_timeout=true overflow_warning=true discovery_timeout_log=true advertise_completed=true
```

After the fix, an isolated real Gateway loaded a manifest-backed discovery plugin with the same timeout and delay:

```text
DF_LIVE trigger plugin=daily-fix-discovery-delay timeout_env=2147483648 configured_delay_ms=50 gateway_port=19051
DF_LIVE transition advertise_completed elapsed_ms=60
[gateway] http server listening (1 plugin: daily-fix-discovery-delay; 118.7s)
[gateway] ready
DF_LIVE_GATEWAY gateway ready listening port=19051
DF_LIVE_PROOF outcome advertise_completed_before_gateway_ready elapsed_ms=60 overflow_warning_count=0 discovery_timeout_log_count=0
```

Focused verification:

- `node scripts/run-vitest.mjs run src/gateway/server-discovery-runtime.test.ts` — 11 tests passed.
- `pnpm exec oxfmt --check src/gateway/server-discovery-runtime.ts src/gateway/server-discovery-runtime.test.ts` — both changed files passed.
