### PR TITLE
fix(doctor): keep repaired session rows readable

### DIFF
--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { listSessionEntries } from "../config/sessions/session-accessor.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -56,6 +57,14 @@ function readEntryJson(env: NodeJS.ProcessEnv, sessionKey: string): string {
     .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
     .get(sessionKey) as { entry_json: string };
   return row.entry_json;
+}
+
+function readEntryValidity(env: NodeJS.ProcessEnv, sessionKey: string): number {
+  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  const row = database.db
+    .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+    .get(sessionKey) as { entry_valid: number };
+  return row.entry_valid;
 }
 
 describe("doctor canonical session delivery state", () => {
@@ -125,6 +134,37 @@ describe("doctor canonical session delivery state", () => {
         accountId: "current-bot",
       });
     }
+  });
+
+  it("keeps rewritten delivery rows valid for normal session reads", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-delivery-validity-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionKey = "agent:main:delivery-validity";
+    insertSessionRow(env, sessionKey, {
+      sessionId: "delivery-validity-session",
+      updatedAt: 10,
+      deliveryContext: { channel: "telegram", to: "recipient" },
+    });
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    database.db
+      .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+      .run(sessionKey);
+
+    expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env })).toEqual({
+      found: 1,
+      repaired: 1,
+      scannedStores: 1,
+    });
+    expect(readEntryValidity(env, sessionKey)).toBe(1);
+    closeOpenClawAgentDatabasesForTest();
+    expect(listSessionEntries({ agentId: "main", env })).toMatchObject([
+      { sessionKey, entry: { sessionId: "delivery-validity-session", updatedAt: 10 } },
+    ]);
+    expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env })).toEqual({
+      found: 0,
+      repaired: 0,
+      scannedStores: 1,
+    });
   });
 
   it("preserves shipped last-route precedence over stale explicit context", () => {
@@ -261,11 +301,15 @@ describe("doctor canonical session delivery state", () => {
       updatedAt: 10,
       deliveryContext: { channel: "telegram", to: "-1001" },
     });
-    openOpenClawAgentDatabase({ agentId: "main", env })
-      .db.prepare(
-        "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
-      )
-      .run("agent:main:invalid", "invalid-session", "null", 20);
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    const insertInvalid = database.db.prepare(
+      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+    );
+    insertInvalid.run("agent:main:invalid", "invalid-session", "null", 20);
+    const invalidObjectJson = JSON.stringify({
+      deliveryContext: { channel: "telegram", to: "recipient" },
+    });
+    insertInvalid.run("agent:main:invalid-object", "invalid-object-session", invalidObjectJson, 30);
 
     expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env })).toEqual({
       found: 1,
@@ -273,6 +317,8 @@ describe("doctor canonical session delivery state", () => {
       scannedStores: 1,
     });
     expect(readEntryJson(env, "agent:main:invalid")).toBe("null");
+    expect(readEntryJson(env, "agent:main:invalid-object")).toBe(invalidObjectJson);
+    expect(readEntryValidity(env, "agent:main:invalid-object")).toBe(0);
   });
 
   it("migrates a copied realistic store without touching the source or canonical row bytes", () => {

--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -28,6 +28,9 @@ function insertSessionRow(
       "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
     )
     .run(sessionKey, String(entry.sessionId), JSON.stringify(entry), Number(entry.updatedAt));
+  database.db
+    .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+    .run(sessionKey);
   const legacyContext = entry.deliveryContext as Record<string, unknown> | undefined;
   database.db
     .prepare(
@@ -319,6 +322,10 @@ describe("doctor canonical session delivery state", () => {
     expect(readEntryJson(env, "agent:main:invalid")).toBe("null");
     expect(readEntryJson(env, "agent:main:invalid-object")).toBe(invalidObjectJson);
     expect(readEntryValidity(env, "agent:main:invalid-object")).toBe(0);
+    closeOpenClawAgentDatabasesForTest();
+    expect(() => listSessionEntries({ agentId: "main", env })).toThrow(
+      /invalid persisted session row requires repair/u,
+    );
   });
 
   it("migrates a copied realistic store without touching the source or canonical row bytes", () => {
@@ -397,6 +404,8 @@ describe("doctor canonical session delivery state", () => {
       repaired: 3,
       scannedStores: 1,
     });
+    closeOpenClawAgentDatabasesForTest();
+    expect(listSessionEntries({ agentId: "main", env: copiedEnv })).toHaveLength(4);
     expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env: copiedEnv })).toEqual({
       found: 0,
       repaired: 0,

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
+import { parseSqliteSessionEntryRecord } from "../config/sessions/session-entry-json.js";
 import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -95,22 +96,20 @@ function collectDeliveryRewrites(database: DatabaseSync): DeliveryRewrite[] {
   const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
   const rows = executeSqliteQuerySync(
     database,
-    db.selectFrom("session_nodes").select(["session_key", "current_session_id", "entry_json"]),
+    db
+      .selectFrom("session_nodes")
+      .select(["session_key", "current_session_id", "entry_json", "updated_at"]),
   ).rows;
   return rows.flatMap((row) => {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(row.entry_json);
-    } catch {
-      return [];
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const parsed = parseSqliteSessionEntryRecord(row);
+    if (!parsed) {
       return [];
     }
     const entry = parsed as SessionEntry;
     const normalizedEntry = normalizeLegacySessionEntryDelivery(entry);
     const entryJson = JSON.stringify(normalizedEntry);
-    return entryJson === row.entry_json
+    return entryJson === row.entry_json ||
+      !parseSqliteSessionEntryRecord({ ...row, entry_json: entryJson })
       ? []
       : [
           {
@@ -133,6 +132,15 @@ function applyDeliveryRewrites(database: DatabaseSync): number {
       db
         .updateTable("session_nodes")
         .set({ entry_json: rewrite.entryJson })
+        .where("session_key", "=", rewrite.sessionKey),
+    );
+    // Updating entry_json resets the validity projection to pending. Settle the proven-valid
+    // rewrite in a second statement so strict runtime readers can consume doctor's output.
+    executeSqliteQuerySync(
+      database,
+      db
+        .updateTable("session_nodes")
+        .set({ entry_valid: 1 })
         .where("session_key", "=", rewrite.sessionKey),
     );
     executeSqliteQuerySync(

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -18,6 +18,10 @@ import {
   sessionDeliveryChannel,
 } from "../utils/delivery-context.shared.js";
 import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
+import {
+  type DoctorSessionEntryRow,
+  writeValidatedDoctorSessionEntryJson,
+} from "./doctor-session-entry-rewrite.js";
 import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 
 export type SessionDeliveryStateRepairReport = {
@@ -31,7 +35,7 @@ type DeliveryRewrite = {
   channel: string | null;
   currentSessionId: string;
   entryJson: string;
-  sessionKey: string;
+  row: DoctorSessionEntryRow;
 };
 
 /** Scan or rewrite legacy delivery fields inside existing session row JSON. */
@@ -117,7 +121,7 @@ function collectDeliveryRewrites(database: DatabaseSync): DeliveryRewrite[] {
             channel: sessionDeliveryChannel(normalizedEntry) ?? null,
             currentSessionId: row.current_session_id,
             entryJson,
-            sessionKey: row.session_key,
+            row,
           },
         ];
   });
@@ -127,22 +131,7 @@ function applyDeliveryRewrites(database: DatabaseSync): number {
   const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
   const rewrites = collectDeliveryRewrites(database);
   for (const rewrite of rewrites) {
-    executeSqliteQuerySync(
-      database,
-      db
-        .updateTable("session_nodes")
-        .set({ entry_json: rewrite.entryJson })
-        .where("session_key", "=", rewrite.sessionKey),
-    );
-    // Updating entry_json resets the validity projection to pending. Settle the proven-valid
-    // rewrite in a second statement so strict runtime readers can consume doctor's output.
-    executeSqliteQuerySync(
-      database,
-      db
-        .updateTable("session_nodes")
-        .set({ entry_valid: 1 })
-        .where("session_key", "=", rewrite.sessionKey),
-    );
+    writeValidatedDoctorSessionEntryJson(database, rewrite.row, rewrite.entryJson);
     executeSqliteQuerySync(
       database,
       db

--- a/src/commands/doctor-session-entry-rewrite.ts
+++ b/src/commands/doctor-session-entry-rewrite.ts
@@ -1,0 +1,39 @@
+import type { DatabaseSync } from "node:sqlite";
+import { parseSqliteSessionEntryRecord } from "../config/sessions/session-entry-json.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+
+export type DoctorSessionEntryRow = {
+  current_session_id: string;
+  entry_json: string;
+  session_key: string;
+  updated_at: number;
+};
+
+/** Persist a doctor-proven entry rewrite and settle the schema-owned validity projection. */
+export function writeValidatedDoctorSessionEntryJson(
+  database: DatabaseSync,
+  row: DoctorSessionEntryRow,
+  entryJson: string,
+): void {
+  if (!parseSqliteSessionEntryRecord({ ...row, entry_json: entryJson })) {
+    throw new Error(`Refusing invalid SQLite session entry rewrite for ${row.session_key}`);
+  }
+  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
+  executeSqliteQuerySync(
+    database,
+    db
+      .updateTable("session_nodes")
+      .set({ entry_json: entryJson })
+      .where("session_key", "=", row.session_key),
+  );
+  // The entry_json trigger marks every rewrite pending, including a value already validated
+  // above. Settle it separately so the next strict reader does not reject doctor's output.
+  executeSqliteQuerySync(
+    database,
+    db
+      .updateTable("session_nodes")
+      .set({ entry_valid: 1 })
+      .where("session_key", "=", row.session_key),
+  );
+}

--- a/src/commands/doctor-session-incognito-key-repair.test.ts
+++ b/src/commands/doctor-session-incognito-key-repair.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { listSessionEntries } from "../config/sessions/session-accessor.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -38,6 +39,7 @@ describe("doctor reserved incognito session key repair", () => {
     try {
       const entryJson = JSON.stringify({
         sessionId: "session-old",
+        updatedAt: 1,
         parentSessionKey: oldKey,
         spawnedBy: oldKey,
         completionOwnerSessionKey: oldKey,
@@ -81,10 +83,22 @@ describe("doctor reserved incognito session key repair", () => {
           "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, parent_session_key, spawned_by) VALUES ('agent:work:dashboard:regular', 'session-work', ?, 1, ?, ?)",
         )
         .run(
-          JSON.stringify({ sessionId: "session-work", completionOwnerSessionKey: oldKey }),
+          JSON.stringify({
+            sessionId: "session-work",
+            updatedAt: 1,
+            parentSessionKey: oldKey,
+            spawnedBy: oldKey,
+            completionOwnerSessionKey: oldKey,
+          }),
           oldKey,
           oldKey,
         );
+      database.db
+        .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+        .run(oldKey);
+      secondaryDatabase.db
+        .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+        .run("agent:work:dashboard:regular");
       secondaryDatabase.db
         .prepare(
           "INSERT INTO session_windows (session_id, session_key, session_scope, created_at, updated_at, parent_session_key, spawned_by) VALUES ('session-work', 'agent:work:dashboard:regular', 'conversation', 1, 1, ?, ?)",
@@ -206,6 +220,26 @@ describe("doctor reserved incognito session key repair", () => {
         systemPromptReport: { sessionKey: newKey },
         pluginExtensions: { test: { label: oldKey } },
       });
+      expect(
+        database.db
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get(newKey),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        secondaryDatabase.db
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:work:dashboard:regular"),
+      ).toEqual({ entry_valid: 1 });
+      closeOpenClawAgentDatabasesForTest();
+      expect(listSessionEntries({ agentId: "main", env })).toMatchObject([
+        { sessionKey: newKey, entry: { sessionId: "session-old", updatedAt: 1 } },
+      ]);
+      expect(listSessionEntries({ agentId: "work", env })).toMatchObject([
+        {
+          sessionKey: "agent:work:dashboard:regular",
+          entry: { sessionId: "session-work", updatedAt: 1 },
+        },
+      ]);
       expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
         found: 0,
         repaired: 0,

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -16,6 +16,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
+import { writeValidatedDoctorSessionEntryJson } from "./doctor-session-entry-rewrite.js";
 import {
   collectSharedStateSessionKeys,
   deleteRepairJournal,
@@ -357,7 +358,9 @@ function rewriteSessionEntryJsonReferences(
   const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
   const rows = executeSqliteQuerySync(
     database,
-    db.selectFrom("session_nodes").select(["session_key", "entry_json"]),
+    db
+      .selectFrom("session_nodes")
+      .select(["session_key", "current_session_id", "entry_json", "updated_at"]),
   ).rows;
   for (const row of rows) {
     let parsed: unknown;
@@ -371,13 +374,7 @@ function rewriteSessionEntryJsonReferences(
     if (entryJson === row.entry_json) {
       continue;
     }
-    executeSqliteQuerySync(
-      database,
-      db
-        .updateTable("session_nodes")
-        .set({ entry_json: entryJson })
-        .where("session_key", "=", row.session_key),
-    );
+    writeValidatedDoctorSessionEntryJson(database, row, entryJson);
   }
 }
 


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` could rewrite canonical SQLite session JSON and leave the same row marked invalid. The next strict session read then rejected doctor's own output, which could abort doctor or update finalization.

This PR now repairs the shared doctor write invariant for both direct `session_nodes.entry_json` writers:

- delivery-state normalization
- reserved incognito-key repair

Both paths validate the prospective canonical row before writing, then restore `entry_valid = 1` after the schema trigger resets it.

## What Problem This Solves

Doctor repair could report success and then make its own repaired session rows unreadable. Affected operators could see doctor or `openclaw update` finalization fail immediately after legacy session metadata was normalized.

The original patch fixed only delivery-state repair. Deep review found the same defect in reserved incognito-key repair, which runs earlier in the same doctor sequence and could still leave a row unreadable.

## Root Cause

`session_nodes` has an `AFTER UPDATE OF entry_json` trigger that sets `entry_valid = 0`. Canonical runtime writers follow their JSON update with a separate validity update. The two doctor repair paths bypassed that owner boundary and updated `entry_json` directly without settling validity.

The strict validity projection landed on `main` in #116703 after `v2026.7.2-beta.6` was cut. Neither `v2026.7.2-beta.5` nor `v2026.7.2-beta.6` contains that projection, so this is a current-`main` release blocker rather than a regression shipped in those beta tags.

## Canonical Fix

A doctor-owned rewrite helper now:

1. parses the prospective JSON through the canonical SQLite session-entry parser,
2. refuses structurally invalid rewrites,
3. updates `entry_json`, and
4. marks the row valid in a second statement after the trigger fires.

Strict readers remain strict. There is no runtime fallback, retry, schema-version bump, or configuration change.

## Evidence

Baseline reproduction against current `main` with the regression tests retained:

```text
Test Files  1 failed | 1 passed
Tests       3 failed | 9 passed
```

The failures proved:

- delivery repair persisted `entry_valid = 0`
- incognito-key repair persisted `entry_valid = 0`
- delivery repair accepted an invalid object row as a candidate

Exact repaired head:

```text
node scripts/run-vitest.mjs \
  src/commands/doctor-session-delivery-state.test.ts \
  src/commands/doctor-session-incognito-key-repair.test.ts

Test Files  2 passed
Tests       12 passed
```

Coverage includes:

- real schema-trigger behavior
- copied-store close/reopen through strict `listSessionEntries`
- repeated repair idempotence
- malformed-row fail-closed behavior
- delivery and incognito sibling writers

Also passed:

- targeted `oxlint`
- targeted `oxfmt --check`
- `git diff --check`
- fresh local autoreview with no accepted or actionable findings

Blacksmith Testbox was attempted for the changed gate, but checkout sync timed out before any repository command ran. The permitted local fallback then stopped at the dependency-status guard because this Codex GWT must not reconcile its shared `node_modules`. Clean exact-head GitHub CI is therefore the heavy proof lane.

## Scope

Production delta: `+59/-26` across the two repair paths and one shared helper. Tests: `+95/-6`.

The positive production delta establishes one canonical validation/write boundary and removes duplicate trigger-settlement policy from both doctor writers.

AI-assisted: yes. Maintainer review traced the producer, trigger, strict reader, sibling writer, doctor order, update finalization path, tag provenance, and focused failure/reopen behavior.
