### PR TITLE
feat(plugins): expose outbound session key to channel adapters

### DIFF
--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -22,6 +22,7 @@ export type ChannelOutboundContext = {
   cfg: OpenClawConfig;
   to: string;
   text: string;
+  sessionKey?: string;
   mediaUrl?: string;
   audioAsVoice?: boolean;
   mediaAccess?: OutboundMediaAccess;

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -478,6 +478,7 @@ function normalizeChannelMessageSendResult(
 const createChannelOutboundContextBase = (params: ChannelHandlerParams) => ({
   cfg: params.cfg,
   to: params.to,
+  sessionKey: params.session?.key,
   accountId: params.accountId,
   replyToId: params.replyToId,
   replyToIdSource: undefined,

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -133,6 +133,7 @@ export type ChannelHandlerParams = {
   mediaAccess?: OutboundMediaAccess;
   gatewayClientScopes?: readonly string[];
   conversationReadOrigin?: "delegated" | "direct-operator";
+  session?: OutboundSessionContext;
   deliveryQueueId?: string;
   preparedMessageId?: string;
   requiredUnknownSendReconciliation?: boolean;

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -87,6 +87,7 @@ export async function deliverOutboundPayloadsCore(
       mediaAccess: resolveMediaAccess(mediaSources),
       gatewayClientScopes: params.gatewayClientScopes,
       conversationReadOrigin: params.conversationReadOrigin,
+      session: params.session,
       deliveryQueueId: params.deliveryQueueId,
       preparedMessageId: params.preparedMessageId,
       requiredUnknownSendReconciliation: params.requiredUnknownSendReconciliation,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -539,6 +539,19 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
   });
 
+  it("forwards the canonical session key to plugin outbound adapters", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "m1" });
+    setTestOutbound({ sendText });
+
+    await deliverMatrix({
+      session: { key: "agent:main:matrix:room:ops" },
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: "agent:main:matrix:room:ops" }),
+    );
+  });
+
   it("reports unsupported durable final delivery when required capabilities are missing", async () => {
     setTestOutbound({
       deliveryMode: "direct",


### PR DESCRIPTION
Related: #117210

## What Problem This Solves

Plugin outbound adapters cannot correlate a send with the canonical agent session even though the delivery pipeline already carries that session context. Plugins currently have to reconstruct or omit that relationship.

## Why This Change Was Made

This adds an optional `sessionKey` to `ChannelOutboundContext` and forwards `OutboundSessionContext.key` through the existing channel-handler boundary. The field is additive and omitted when no session is present, so existing adapters and callers keep their current behavior.

## User Impact

Plugin authors can make session-aware outbound decisions and correlate sends with the originating session without deriving identity from unrelated fields. Existing channel adapters remain source-compatible.

## Evidence

- Regression test: `forwards the canonical session key to plugin outbound adapters`
- Focused regression test passes under Node 25.9.0.
- `pnpm build` passes under Node 25.9.0.
- Full `deliver.test.ts` result improved from 3 failures before the implementation to 2 pre-existing media-staging failures after it; the new regression changed from red to green.
- Static diff scan found no environment-specific literals or credential values.

AI-assisted: Yes. The contributor reviewed the implementation, test results, and final diff.
