### PR TITLE
fix(agents): classify credential-file ENOENT as auth for failover (#112226)

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -141,3 +141,41 @@ describe("isLikelyContextOverflowError", () => {
     ).toBe(true);
   });
 });
+
+describe("credential-file ENOENT failover classification (#112226)", () => {
+  it("classifies a missing credentials file as an auth failure so fallback models are tried", () => {
+    expect(
+      classifyFailoverReason(
+        "ENOENT: no such file or directory, open '/Users/alice/.claude/.credentials.json'",
+      ),
+    ).toBe("auth");
+    expect(
+      classifyFailoverReason(
+        "ENOENT: no such file or directory, open '/Users/alice/.openclaw/credentials/anthropic.json'",
+      ),
+    ).toBe("auth");
+    expect(
+      classifyFailoverReason(
+        "ENOENT: no such file or directory, open '/Users/alice/.openclaw/agents/demo/agent/auth-profiles.json'",
+      ),
+    ).toBe("auth");
+  });
+
+  it("does not classify unrelated local ENOENT failures as auth", () => {
+    expect(
+      classifyFailoverReason(
+        "ENOENT: no such file or directory, open '/tmp/openclaw-agent-exec/log.txt'",
+      ),
+    ).toBeNull();
+    expect(
+      classifyFailoverReason(
+        "ENOENT: no such file or directory, open '/Users/alice/.openclaw/state/openclaw.sqlite'",
+      ),
+    ).toBeNull();
+  });
+
+  it("requires both the ENOENT signal and a credential path", () => {
+    expect(classifyFailoverReason("credentials are configured")).toBeNull();
+    expect(classifyFailoverReason("ENOENT: no such file or directory")).toBeNull();
+  });
+});

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -30,6 +30,7 @@ import {
   isReasoningConstraintErrorMessage,
 } from "./context-overflow.js";
 import {
+  isAuthCredentialFileEnoentError,
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
@@ -978,6 +979,9 @@ function classifyFailoverClassificationFromMessage(
   // Auth classifiers run before the broad isJsonApiInternalServerError check so that
   // provider errors like {"type":"api_error","message":"invalid api key"} are
   // correctly classified as "auth" rather than "timeout".
+  if (isAuthCredentialFileEnoentError(raw)) {
+    return toReasonClassification("auth");
+  }
   if (isClaudeCliLoggedOutError(raw, provider)) {
     return toReasonClassification("auth");
   }

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -365,6 +365,22 @@ export function isAuthErrorMessage(raw: string): boolean {
   ]);
 }
 
+const AUTH_CREDENTIAL_FILE_PATH_PATTERNS = [
+  /credentials/i,
+  /auth[_-]?profiles/i,
+] as const satisfies readonly ErrorPattern[];
+
+export function isAuthCredentialFileEnoentError(raw: string): boolean {
+  const value = normalizeLowercaseStringOrEmpty(raw);
+  if (!value || !value.includes("enoent")) {
+    return false;
+  }
+  // Require both a filesystem-missing signal (ENOENT) and credential/auth-file
+  // path semantics so unrelated local ENOENT failures (caches, temp files) stay
+  // unclassified instead of being treated as auth outages.
+  return matchesErrorPatterns(value, AUTH_CREDENTIAL_FILE_PATH_PATTERNS);
+}
+
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
 }


### PR DESCRIPTION
## What Problem This Solves

A provider credentials file missing during a token-refresh window (`~/.claude/.credentials.json`) surfaces as a raw filesystem `ENOENT` error. Because the message contains no auth keyword, the shared failover classifier returns `null` (`failoverReason: null`, `providerRuntimeFailureKind: "unclassified"`), so the configured model fallback chain is never consulted. Every inbound turn during the outage dies with a user-facing `"LLM request failed."` — silently dropping messages even while 9 healthy fallback models across 3 other providers are available.

## Why This Change Was Made

Missing/unreadable provider credentials are functionally an auth failure for that provider and should behave like a 401/403: trigger the model fallback chain. The existing classifier already maps structured auth errors (`ProviderAuthError`, `MissingProviderAuthError`, HTTP 401/403, "no credentials found" text) to `"auth"` — but a raw `ENOENT` from `fs.readFile` bypasses all of them.

The fix adds one narrow matcher at the shared classification boundary: an error is classified as `"auth"` only when **both** a filesystem-missing signal (`ENOENT`) **and** credential/auth-file path semantics (`credentials`, `auth-profiles`) are present. This follows the classification gap guidance on #112226 — a broad "any ENOENT/unclassified preflight is auth" rule would wrongly replay non-credential local failures, so the check is intentionally scoped.

## User Impact

- Missing/unreadable provider credential files now classify as `"auth"` and trigger the configured model fallback chain instead of silently failing every turn.
- Unrelated local `ENOENT` failures (logs, caches, sqlite state) remain unclassified and are unaffected.
- No existing auth, billing, rate-limit, or timeout classification behavior changes.

## Evidence

### Classification regression tests

Added to `src/agents/embedded-agent-helpers/errors.test.ts` (`credential-file ENOENT failover classification (#112226)`), exercising the real production path `classifyFailoverReason` → `classifyFailoverSignal` → `classifyFailoverClassificationFromMessage`:

- `ENOENT ... .claude/.credentials.json` → `"auth"` (the reported carrier)
- `ENOENT ... /credentials/anthropic.json` → `"auth"`
- `ENOENT ... /auth-profiles.json` → `"auth"`
- `ENOENT ... /tmp/log.txt` → `null` (no false positive)
- `ENOENT ... /state/openclaw.sqlite` → `null`
- `"credentials are configured"` (no ENOENT) → `null`
- bare `"ENOENT: no such file or directory"` (no credential path) → `null`

### Test run

Focused suites pass (no regressions):

- `errors.test.ts` + `failover-matches.test.ts`: 39 + 11 passed
- `errors-provider-structured-signals.test.ts` + `provider-error-patterns.test.ts`: 61 passed
- `failover-error.test.ts` + `failover-policy.test.ts`: 152 passed

`git diff --check` clean; `oxlint` clean on changed files; `oxfmt` applied.

Closes #112226
