### PR TITLE
fix(cli): surface degraded auxiliary health diagnostics

### DIFF
--- a/src/commands/health-diagnostics.ts
+++ b/src/commands/health-diagnostics.ts
@@ -1,0 +1,96 @@
+// Canonical gateway health degradation shared by text health and status output.
+import type { HealthSummary } from "../gateway/health/types.js";
+import { formatDurationHuman } from "../infra/format-time/format-duration.js";
+
+type GatewayHealthDiagnostic = {
+  item: "Context engine" | "Delivery queue" | "Config hot reload";
+  detail: string;
+};
+
+function buildContextEngineHealthDiagnostic(
+  summary: HealthSummary,
+): GatewayHealthDiagnostic | null {
+  const quarantined = summary.contextEngines?.quarantined ?? [];
+  if (quarantined.length === 0) {
+    return null;
+  }
+  const engines = quarantined.map((entry) => entry.engineId).join(", ");
+  return {
+    item: "Context engine",
+    detail: `warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`,
+  };
+}
+
+function buildDeliveryQueueHealthDiagnostic(
+  summary: HealthSummary,
+  now: number,
+): GatewayHealthDiagnostic | null {
+  const failed = summary.deliveryQueues?.failed ?? [];
+  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
+  if (failed.length === 0 && ingressFailed.length === 0) {
+    return null;
+  }
+  const counts = [
+    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
+    ...ingressFailed.map(
+      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
+    ),
+  ].join(", ");
+  const oldest = [...failed, ...ingressFailed]
+    .map((queue) => queue.oldestFailedAt)
+    .filter((value): value is number => typeof value === "number");
+  const oldestNote =
+    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
+  return {
+    item: "Delivery queue",
+    detail: `warning (dead-lettered entries — ${counts}${oldestNote})`,
+  };
+}
+
+function buildConfigReloadHealthDiagnostic(summary: HealthSummary): GatewayHealthDiagnostic | null {
+  if (summary.configReload?.hotReloadStatus !== "disabled") {
+    return null;
+  }
+  return {
+    item: "Config hot reload",
+    detail: "disabled (watcher retries exhausted; restart the gateway to restore it)",
+  };
+}
+
+/** Collects gateway-owned operational failures for text health and status output. */
+export function collectGatewayHealthDiagnostics(
+  summary: HealthSummary,
+  now = Date.now(),
+): GatewayHealthDiagnostic[] {
+  return [
+    buildContextEngineHealthDiagnostic(summary),
+    buildDeliveryQueueHealthDiagnostic(summary, now),
+    buildConfigReloadHealthDiagnostic(summary),
+  ].filter((diagnostic): diagnostic is GatewayHealthDiagnostic => diagnostic !== null);
+}
+
+/** Preserves the canonical `Item: detail` wording used by text health output. */
+export function formatGatewayHealthDiagnostic(diagnostic: GatewayHealthDiagnostic): string {
+  return `${diagnostic.item}: ${diagnostic.detail}`;
+}
+
+/** Formats context engine quarantine state for text health output. */
+export function formatContextEngineHealthLine(summary: HealthSummary): string | null {
+  const diagnostic = buildContextEngineHealthDiagnostic(summary);
+  return diagnostic ? formatGatewayHealthDiagnostic(diagnostic) : null;
+}
+
+/** Formats dead-lettered delivery queue entries for text health output. */
+export function formatDeliveryQueueHealthLine(
+  summary: HealthSummary,
+  now = Date.now(),
+): string | null {
+  const diagnostic = buildDeliveryQueueHealthDiagnostic(summary, now);
+  return diagnostic ? formatGatewayHealthDiagnostic(diagnostic) : null;
+}
+
+/** Formats config hot-reload watcher degradation for text health output. */
+export function formatConfigReloadHealthLine(summary: HealthSummary): string | null {
+  const diagnostic = buildConfigReloadHealthDiagnostic(summary);
+  return diagnostic ? formatGatewayHealthDiagnostic(diagnostic) : null;
+}

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -26,7 +26,6 @@ import type { AgentHealthSummary, HealthSummary } from "../gateway/health/types.
 import { info } from "../globals.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { formatDurationHuman } from "../infra/format-time/format-duration.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
@@ -36,8 +35,17 @@ import {
   GATEWAY_HEALTH_REACHABLE_LINE,
   gatewayProbeResultSawGateway,
 } from "./gateway-health-auth-diagnostic.js";
+import {
+  collectGatewayHealthDiagnostics,
+  formatGatewayHealthDiagnostic,
+} from "./health-diagnostics.js";
 import { formatHealthChannelLines } from "./health-format.js";
 import { logGatewayConnectionDetails } from "./status.gateway-connection.js";
+export {
+  formatConfigReloadHealthLine,
+  formatContextEngineHealthLine,
+  formatDeliveryQueueHealthLine,
+} from "./health-diagnostics.js";
 export { formatHealthChannelLines } from "./health-format.js";
 export type { HealthSummary } from "../gateway/health/types.js";
 
@@ -145,48 +153,6 @@ function formatEventLoopHealthLine(summary: HealthSummary): string | null {
   )}ms p99=${Math.round(eventLoop.delayP99Ms)}ms util=${eventLoop.utilization} cpu=${
     eventLoop.cpuCoreRatio
   }`;
-}
-
-/** Formats context engine quarantine state for text health output. */
-export function formatContextEngineHealthLine(summary: HealthSummary): string | null {
-  const quarantined = summary.contextEngines?.quarantined ?? [];
-  if (quarantined.length === 0) {
-    return null;
-  }
-  const engines = quarantined.map((entry) => entry.engineId).join(", ");
-  return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
-}
-
-/** Formats dead-lettered delivery queue entries for text health output. */
-export function formatDeliveryQueueHealthLine(
-  summary: HealthSummary,
-  now = Date.now(),
-): string | null {
-  const failed = summary.deliveryQueues?.failed ?? [];
-  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
-  if (failed.length === 0 && ingressFailed.length === 0) {
-    return null;
-  }
-  const counts = [
-    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
-    ...ingressFailed.map(
-      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
-    ),
-  ].join(", ");
-  const oldest = [...failed, ...ingressFailed]
-    .map((queue) => queue.oldestFailedAt)
-    .filter((value): value is number => typeof value === "number");
-  const oldestNote =
-    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
-  return `Delivery queue: warning (dead-lettered entries — ${counts}${oldestNote})`;
-}
-
-/** Formats config hot-reload watcher degradation for text health output. */
-export function formatConfigReloadHealthLine(summary: HealthSummary): string | null {
-  if (summary.configReload?.hotReloadStatus !== "disabled") {
-    return null;
-  }
-  return "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)";
 }
 
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
@@ -399,17 +365,8 @@ export async function healthCommand(
     if (eventLoopLine) {
       runtime.log(styleHealthChannelLine(eventLoopLine, rich));
     }
-    const contextEngineLine = formatContextEngineHealthLine(summary);
-    if (contextEngineLine) {
-      runtime.log(styleHealthChannelLine(contextEngineLine, rich));
-    }
-    const deliveryQueueLine = formatDeliveryQueueHealthLine(summary);
-    if (deliveryQueueLine) {
-      runtime.log(styleHealthChannelLine(deliveryQueueLine, rich));
-    }
-    const configReloadLine = formatConfigReloadHealthLine(summary);
-    if (configReloadLine) {
-      runtime.log(styleHealthChannelLine(configReloadLine, rich));
+    for (const diagnostic of collectGatewayHealthDiagnostics(summary)) {
+      runtime.log(styleHealthChannelLine(formatGatewayHealthDiagnostic(diagnostic), rich));
     }
     for (const plugin of displayPlugins) {
       const channelSummary = summary.channels?.[plugin.id];

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -14,6 +14,22 @@ import {
   statusHealthColumns,
 } from "./status.command-sections.ts";
 
+function createStatusHealthSummary(overrides: Partial<HealthSummary> = {}): HealthSummary {
+  return {
+    ok: true,
+    ts: 1_700_000_000_000,
+    durationMs: 42,
+    channels: {},
+    channelOrder: [],
+    channelLabels: {},
+    heartbeatSeconds: 60,
+    defaultAgentId: "main",
+    agents: [],
+    sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+    ...overrides,
+  };
+}
+
 describe("status.command-sections", () => {
   it("formats security audit lines with finding caps and follow-up commands", () => {
     const lines = buildStatusSecurityAuditLines({
@@ -210,7 +226,7 @@ describe("status.command-sections", () => {
 
   it("maps health channel detail lines into status rows", () => {
     const rows = buildStatusHealthRows({
-      health: { durationMs: 42 } as HealthSummary,
+      health: createStatusHealthSummary(),
       formatHealthChannelLines: () => [
         "QuietChat: OK · ready",
         "WorkChat: failed · auth",
@@ -235,8 +251,7 @@ describe("status.command-sections", () => {
 
   it("adds degraded event-loop health to status rows", () => {
     const rows = buildStatusHealthRows({
-      health: {
-        durationMs: 42,
+      health: createStatusHealthSummary({
         eventLoop: {
           degraded: true,
           reasons: ["event_loop_delay"],
@@ -246,7 +261,7 @@ describe("status.command-sections", () => {
           utilization: 1,
           cpuCoreRatio: 1,
         },
-      } as HealthSummary,
+      }),
       formatHealthChannelLines: () => [],
       ok: (value) => `ok(${value})`,
       warn: (value) => `warn(${value})`,
@@ -261,6 +276,69 @@ describe("status.command-sections", () => {
         Detail: "reasons event_loop_delay · max 62000ms · p99 61000ms · util 1 · cpu 1",
       },
     ]);
+  });
+
+  it("surfaces gateway-owned context, delivery, and config-reload degradation", () => {
+    const rows = buildStatusHealthRows({
+      health: createStatusHealthSummary({
+        contextEngines: {
+          quarantined: [
+            {
+              engineId: "lossless-claw",
+              owner: "plugin:lossless-claw",
+              operation: "assemble",
+              reason: "database corrupt",
+              failedAt: 1_700_000_000_000,
+            },
+          ],
+        },
+        deliveryQueues: {
+          failed: [{ queueName: "outbound", count: 2 }],
+          ingressFailed: [{ channelId: "telegram", accountId: "ops", count: 1 }],
+        },
+        configReload: { hotReloadStatus: "disabled" },
+      }),
+      formatHealthChannelLines: () => ["QuietChat: OK · ready"],
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toEqual([
+      { Item: "Gateway", Status: "ok(reachable)", Detail: "42ms" },
+      { Item: "QuietChat", Status: "ok(OK)", Detail: "OK · ready" },
+      {
+        Item: "Context engine",
+        Status: "warn(WARN)",
+        Detail: "warning (1 quarantined; downgraded to legacy: lossless-claw)",
+      },
+      {
+        Item: "Delivery queue",
+        Status: "warn(WARN)",
+        Detail: "warning (dead-lettered entries — outbound: 2, inbound telegram/ops: 1)",
+      },
+      {
+        Item: "Config hot reload",
+        Status: "warn(WARN)",
+        Detail: "disabled (watcher retries exhausted; restart the gateway to restore it)",
+      },
+    ]);
+  });
+
+  it("omits healthy context, delivery, and config-reload state", () => {
+    const rows = buildStatusHealthRows({
+      health: createStatusHealthSummary({
+        contextEngines: { quarantined: [] },
+        deliveryQueues: { failed: [], ingressFailed: [] },
+        configReload: { hotReloadStatus: "active" },
+      }),
+      formatHealthChannelLines: () => [],
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toEqual([{ Item: "Gateway", Status: "ok(reachable)", Detail: "42ms" }]);
   });
 
   it("builds footer lines from update and reachability state", () => {

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -12,6 +12,7 @@ import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.j
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import type { Tone } from "../memory-host-sdk/status.js";
 import type { SessionStatus, StatusSummary } from "../status/types.js";
+import { collectGatewayHealthDiagnostics } from "./health-diagnostics.js";
 import type { HealthSummary } from "./health.js";
 import type { AgentLocalStatus } from "./status.agent-local.js";
 import type { MemoryStatusSnapshot, MemoryPluginStatus } from "./status.scan.shared.js";
@@ -309,6 +310,13 @@ export function buildStatusHealthRows(params: {
                 ? params.warn("UNLINKED")
                 : params.warn("WARN");
     rows.push({ Item: item, Status: status, Detail: detail });
+  }
+  for (const diagnostic of collectGatewayHealthDiagnostics(params.health)) {
+    rows.push({
+      Item: diagnostic.item,
+      Status: params.warn("WARN"),
+      Detail: diagnostic.detail,
+    });
   }
   return rows;
 }


### PR DESCRIPTION
## Problem

`openclaw status --deep` could report the Gateway as reachable while silently discarding gateway-recorded context-engine quarantine, inbound/outbound dead-lettered messages, and disabled config hot reload. The same snapshot already produced actionable warnings in `openclaw health`.

## Root-cause fix

- Extract one typed, CLI-owned operational-health projection shared by human health output and deep status rows.
- Surface quarantined context engines, outbound/inbound dead letters, and disabled hot reload as `WARN` rows; suppress healthy states.
- Preserve existing health wording, ordering, named formatter exports, JSON, gateway ownership, and plugin/config/protocol contracts.

## Verification

- Shipped `v2026.7.1` and current-main real-shaped owner reproduction: baseline missing all three warnings; focused baseline RED 1 failure / 9 passes.
- 64 existing/focused tests passing across status rows, status report assembly/rendering, health CLI, gateway health snapshots, and plugin health.
- Actual production `buildStatusCommandReportData` produces three `WARN` rows for one genuine gateway health snapshot; healthy context/queues/reloader stay silent.
- Formatting and `git diff --check` clean; latest main 982add961804097f5a6b0b94255c5c855e8ad863 synthetic merge clean; composes cleanly with separately reviewed immutable channel-health formatter fix 0cb6f686e832b70ff08e4f807e5f3f0db5832b49.
- Exact immutable Codex P0–P3 structured autoreview clean (confidence 0.97; TruffleHog clean); three independent exact-SHA P0–P3 reviews clean.
- No config, protocol, SDK, schema, persistent-state, channel transport, or plugin-owner changes.
