### PR TITLE
fix(doctor): session SQLite restore installs an empty session index over the valid archive

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -360,7 +360,12 @@ it writes the local support report and prints a prefilled issue URL.
 `restore` remains the lower-level undo operation. It uses manifest
 `sourcePath -> archivePath` records, moves archived artifacts back only when the
 original path is missing, reports conflicts when both paths exist, and leaves
-the SQLite database in place.
+the SQLite database in place. When several manifests recorded the same original
+path, restore plans all candidates before moving any of them. Identical archives
+are safe duplicates, and one nonempty legacy `sessions.json` may supersede empty
+copies created by older writers. Distinct nonempty indexes, distinct transcript
+archives, invalid archives, and archives missing without a recorded prior
+restore fail closed so restore cannot silently replace or hide recoverable data.
 
 ### Downgrading After Session SQLite Migration
 

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -293,7 +293,10 @@ export function restoreSessionSqliteMigrationRuns(params: {
   trustedTargets: readonly SessionSqliteMigrationTargetInput[];
 }): DoctorSessionSqliteRestoreReport {
   const restoreReport: DoctorSessionSqliteRestoreReport = emptyRestoreReport();
-  for (const manifestPath of listSessionSqliteMigrationManifestPaths(params.env)) {
+  // Oldest run first, so the winner lookup prefers the earliest surviving archive.
+  const manifestPaths = listSessionSqliteMigrationManifestPaths(params.env).toReversed();
+  const winningArchives = resolveWinningRestoreArchives(manifestPaths, params.trustedTargets);
+  for (const manifestPath of manifestPaths) {
     const manifest = readSessionSqliteMigrationManifest(manifestPath);
     if (!manifest) {
       continue;
@@ -307,13 +310,51 @@ export function restoreSessionSqliteMigrationRuns(params: {
       manifestPaths: [manifestPath],
     };
     restoreReport.manifestPaths.push(manifestPath);
-    restoreSessionSqliteMigrationManifest(manifest, targetManifests, manifestRestoreReport);
+    restoreSessionSqliteMigrationManifest(
+      manifest,
+      targetManifests,
+      manifestRestoreReport,
+      winningArchives,
+    );
     restoreReport.conflicts.push(...manifestRestoreReport.conflicts);
     restoreReport.restoredFiles.push(...manifestRestoreReport.restoredFiles);
     restoreReport.skippedFiles.push(...manifestRestoreReport.skippedFiles);
     writeSessionSqliteMigrationManifest({ manifest, manifestPath });
   }
   return restoreReport;
+}
+
+/**
+ * Pick the one archive that may reclaim each destination, keyed by source path.
+ * Several runs can archive the same path once a legacy writer recreates it, and restore refuses to
+ * overwrite an existing source. Without this the iteration order alone decided the winner, so a
+ * recreated empty index could beat the only pre-migration copy. Runs arrive oldest-first, and a
+ * later run can only have archived content created after the earlier run moved the original away.
+ */
+function resolveWinningRestoreArchives(
+  manifestPaths: readonly string[],
+  trustedTargets: readonly SessionSqliteMigrationTargetInput[],
+): Map<string, string> {
+  const winners = new Map<string, string>();
+  for (const manifestPath of manifestPaths) {
+    const manifest = readSessionSqliteMigrationManifest(manifestPath);
+    if (!manifest) {
+      continue;
+    }
+    for (const target of filterRestoreManifestTargets(manifest, trustedTargets)) {
+      for (const move of uniqueRestoreMoves(target)) {
+        // Match what restoreMigrationMove will accept, so an unusable archive cannot claim a
+        // destination and block a later run that still holds a restorable copy.
+        if (
+          !winners.has(move.sourcePath) &&
+          isRegularFileWithoutFollowingSymlinks(move.archivePath)
+        ) {
+          winners.set(move.sourcePath, move.archivePath);
+        }
+      }
+    }
+  }
+  return winners;
 }
 
 export function restoreSessionSqliteMigrationRun(params: {
@@ -342,7 +383,12 @@ export function restoreSessionSqliteMigrationRun(params: {
     });
     return restoreReport;
   }
-  restoreSessionSqliteMigrationManifest(manifest, targetManifests, restoreReport);
+  restoreSessionSqliteMigrationManifest(
+    manifest,
+    targetManifests,
+    restoreReport,
+    resolveWinningRestoreArchives([params.manifestPath], params.trustedTargets),
+  );
   writeSessionSqliteMigrationManifest({ manifest, manifestPath: params.manifestPath });
   return restoreReport;
 }
@@ -499,10 +545,11 @@ function restoreSessionSqliteMigrationManifest(
   manifest: SessionSqliteMigrationManifest,
   targets: readonly SessionSqliteMigrationTargetManifest[],
   restoreReport: DoctorSessionSqliteRestoreReport,
+  winningArchives: ReadonlyMap<string, string>,
 ): void {
   for (const target of targets) {
     for (const move of uniqueRestoreMoves(target)) {
-      restoreMigrationMove(move, restoreReport);
+      restoreMigrationMove(move, restoreReport, winningArchives);
     }
   }
   manifest.restore = {
@@ -527,7 +574,19 @@ function uniqueRestoreMoves(
 function restoreMigrationMove(
   move: SessionSqliteMigrationMove,
   restoreReport: DoctorSessionSqliteRestoreReport,
+  winningArchives: ReadonlyMap<string, string>,
 ): void {
+  const winningArchive = winningArchives.get(move.sourcePath);
+  if (
+    winningArchive !== undefined &&
+    winningArchive !== move.archivePath &&
+    !fs.existsSync(move.archivePath)
+  ) {
+    // Another run's archive owns this destination and this move's archive was already consumed by
+    // an earlier restore, so there is nothing left to recover or to warn about here.
+    restoreReport.skippedFiles.push(move.sourcePath);
+    return;
+  }
   const sourceExists = fs.existsSync(move.sourcePath);
   const archiveExists = fs.existsSync(move.archivePath);
   if (!sourceExists && archiveExists) {

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -71,6 +71,7 @@ export type ActiveSessionSqliteMigrationRun = {
 
 const SESSION_SQLITE_MIGRATION_RUNS_DIR = "session-sqlite-migration-runs";
 const COMPLETED_MIGRATION_RUN_RETENTION = 50;
+const RESTORE_ARCHIVE_HASH_CHUNK_BYTES = 64 * 1024;
 const AbsolutePathSchema = z
   .string()
   .min(1)
@@ -548,6 +549,21 @@ type RestoreArchiveInspection =
   | { state: "invalid"; reason: string }
   | { state: "missing" };
 
+function hashRestoreArchive(fd: number, size: number): string {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(RESTORE_ARCHIVE_HASH_CHUNK_BYTES);
+  let offset = 0;
+  while (offset < size) {
+    const read = fs.readSync(fd, buffer, 0, Math.min(buffer.length, size - offset), offset);
+    if (read === 0) {
+      throw new Error("archive changed while it was inspected");
+    }
+    hash.update(buffer.subarray(0, read));
+    offset += read;
+  }
+  return hash.digest("hex");
+}
+
 function inspectRestoreArchive(move: SessionSqliteMigrationMove): RestoreArchiveInspection {
   if (hasSymbolicLinkInDirectoryPath(path.dirname(move.archivePath))) {
     return { state: "invalid", reason: "archive parent is a symbolic link; refusing restore" };
@@ -583,20 +599,11 @@ function inspectRestoreArchive(move: SessionSqliteMigrationMove): RestoreArchive
         reason: "archive changed while it was inspected; refusing restore",
       };
     }
-    const content = readFileDescriptorBoundedSync(fd, descriptorStat.size);
-    const finalPathStat = fs.lstatSync(move.archivePath);
-    if (
-      finalPathStat.dev !== descriptorStat.dev ||
-      finalPathStat.ino !== descriptorStat.ino ||
-      finalPathStat.size !== descriptorStat.size
-    ) {
-      return {
-        state: "invalid",
-        reason: "archive changed while it was inspected; refusing restore",
-      };
-    }
+    let digest: string;
     let legacyEntryCount: number | undefined;
     if (move.kind === "legacy-store") {
+      const content = readFileDescriptorBoundedSync(fd, descriptorStat.size);
+      digest = createHash("sha256").update(content).digest("hex");
       let parsed: unknown;
       try {
         parsed = JSON.parse(content.toString("utf-8"));
@@ -613,11 +620,26 @@ function inspectRestoreArchive(move: SessionSqliteMigrationMove): RestoreArchive
         };
       }
       legacyEntryCount = Object.keys(parsed).length;
+    } else {
+      // Transcript-like archives can be arbitrarily large. Hash them incrementally so duplicate
+      // planning cannot turn a Doctor restore into a synchronous whole-file allocation.
+      digest = hashRestoreArchive(fd, descriptorStat.size);
+    }
+    const finalPathStat = fs.lstatSync(move.archivePath);
+    if (
+      finalPathStat.dev !== descriptorStat.dev ||
+      finalPathStat.ino !== descriptorStat.ino ||
+      finalPathStat.size !== descriptorStat.size
+    ) {
+      return {
+        state: "invalid",
+        reason: "archive changed while it was inspected; refusing restore",
+      };
     }
     return {
       state: "available",
       snapshot: {
-        digest: createHash("sha256").update(content).digest("hex"),
+        digest,
         ...(legacyEntryCount === undefined ? {} : { legacyEntryCount }),
         size: descriptorStat.size,
       },

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -1,10 +1,12 @@
 /** Manifest and restore helpers for doctor-owned session SQLite migrations. */
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { z } from "zod";
 import { resolveStateDir } from "../config/paths.js";
+import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import * as replaceFile from "../infra/replace-file.js";
 import { VERSION } from "../version.js";
 import type {
@@ -51,6 +53,7 @@ type SessionSqliteMigrationManifest = {
   openClawVersion: string;
   restore?: {
     attemptedAt: string;
+    consumedArchives?: string[];
     conflicts: DoctorSessionSqliteRestoreConflict[];
     restoredFiles: string[];
     skippedFiles: string[];
@@ -139,6 +142,7 @@ const MigrationManifestSchema = z
     restore: z
       .object({
         attemptedAt: z.string().min(1),
+        consumedArchives: z.array(AbsolutePathSchema).optional(),
         conflicts: z.array(RestoreConflictSchema),
         restoredFiles: z.array(AbsolutePathSchema),
         skippedFiles: z.array(AbsolutePathSchema),
@@ -293,18 +297,12 @@ export function restoreSessionSqliteMigrationRuns(params: {
   trustedTargets: readonly SessionSqliteMigrationTargetInput[];
 }): DoctorSessionSqliteRestoreReport {
   const restoreReport: DoctorSessionSqliteRestoreReport = emptyRestoreReport();
-  // Oldest run first, so the winner lookup prefers the earliest surviving archive.
-  const manifestPaths = listSessionSqliteMigrationManifestPaths(params.env).toReversed();
-  const winningArchives = resolveWinningRestoreArchives(manifestPaths, params.trustedTargets);
-  for (const manifestPath of manifestPaths) {
-    const manifest = readSessionSqliteMigrationManifest(manifestPath);
-    if (!manifest) {
-      continue;
-    }
-    const targetManifests = filterRestoreManifestTargets(manifest, params.trustedTargets);
-    if (targetManifests.length === 0) {
-      continue;
-    }
+  const contexts = loadRestoreManifestContexts(
+    listSessionSqliteMigrationManifestPaths(params.env).toReversed(),
+    params.trustedTargets,
+  );
+  const restorePlan = createRestorePlan(contexts);
+  for (const { manifest, manifestPath, targets } of contexts) {
     const manifestRestoreReport: DoctorSessionSqliteRestoreReport = {
       ...emptyRestoreReport(),
       manifestPaths: [manifestPath],
@@ -312,9 +310,10 @@ export function restoreSessionSqliteMigrationRuns(params: {
     restoreReport.manifestPaths.push(manifestPath);
     restoreSessionSqliteMigrationManifest(
       manifest,
-      targetManifests,
+      manifestPath,
+      targets,
       manifestRestoreReport,
-      winningArchives,
+      restorePlan,
     );
     restoreReport.conflicts.push(...manifestRestoreReport.conflicts);
     restoreReport.restoredFiles.push(...manifestRestoreReport.restoredFiles);
@@ -324,37 +323,314 @@ export function restoreSessionSqliteMigrationRuns(params: {
   return restoreReport;
 }
 
-/**
- * Pick the one archive that may reclaim each destination, keyed by source path.
- * Several runs can archive the same path once a legacy writer recreates it, and restore refuses to
- * overwrite an existing source. Without this the iteration order alone decided the winner, so a
- * recreated empty index could beat the only pre-migration copy. Runs arrive oldest-first, and a
- * later run can only have archived content created after the earlier run moved the original away.
- */
-function resolveWinningRestoreArchives(
+type RestoreManifestContext = {
+  manifest: SessionSqliteMigrationManifest;
+  manifestPath: string;
+  targets: SessionSqliteMigrationTargetManifest[];
+};
+
+type RestoreArchiveSnapshot = {
+  digest: string;
+  legacyEntryCount?: number;
+  size: number;
+};
+
+type RestoreMovePlan =
+  | { action: "conflict"; reason: string }
+  | { action: "restore"; snapshot: RestoreArchiveSnapshot }
+  | { action: "skip-consumed" }
+  | { action: "skip-superseded" }
+  | { action: "standard" };
+
+function loadRestoreManifestContexts(
   manifestPaths: readonly string[],
   trustedTargets: readonly SessionSqliteMigrationTargetInput[],
-): Map<string, string> {
-  const winners = new Map<string, string>();
+): RestoreManifestContext[] {
+  const contexts: RestoreManifestContext[] = [];
   for (const manifestPath of manifestPaths) {
     const manifest = readSessionSqliteMigrationManifest(manifestPath);
     if (!manifest) {
       continue;
     }
-    for (const target of filterRestoreManifestTargets(manifest, trustedTargets)) {
+    const targets = filterRestoreManifestTargets(manifest, trustedTargets);
+    if (targets.length > 0) {
+      contexts.push({ manifest, manifestPath, targets });
+    }
+  }
+  return contexts;
+}
+
+/**
+ * Resolve every duplicate destination before moving an archive. A missing archive only disappears
+ * from the conflict set when its own manifest proves that an earlier restore consumed it.
+ */
+function createRestorePlan(
+  contexts: readonly RestoreManifestContext[],
+): Map<string, RestoreMovePlan> {
+  const plan = new Map<string, RestoreMovePlan>();
+  const candidatesBySource = new Map<
+    string,
+    Array<{
+      consumed: boolean;
+      context: RestoreManifestContext;
+      move: SessionSqliteMigrationMove;
+    }>
+  >();
+  for (const context of contexts) {
+    const consumedArchives = collectRecordedConsumedArchives(context.manifest);
+    for (const target of context.targets) {
       for (const move of uniqueRestoreMoves(target)) {
-        // Match what restoreMigrationMove will accept, so an unusable archive cannot claim a
-        // destination and block a later run that still holds a restorable copy.
-        if (
-          !winners.has(move.sourcePath) &&
-          isRegularFileWithoutFollowingSymlinks(move.archivePath)
-        ) {
-          winners.set(move.sourcePath, move.archivePath);
-        }
+        const candidates = candidatesBySource.get(move.sourcePath) ?? [];
+        candidates.push({
+          consumed: consumedArchives.has(move.archivePath),
+          context,
+          move,
+        });
+        candidatesBySource.set(move.sourcePath, candidates);
       }
     }
   }
-  return winners;
+
+  for (const [sourcePath, candidates] of candidatesBySource) {
+    if (fs.existsSync(sourcePath) || candidates.length === 1) {
+      for (const candidate of candidates) {
+        plan.set(restoreMovePlanKey(candidate.context.manifestPath, candidate.move), {
+          action: "standard",
+        });
+      }
+      continue;
+    }
+
+    const available: Array<{
+      context: RestoreManifestContext;
+      move: SessionSqliteMigrationMove;
+      snapshot: RestoreArchiveSnapshot;
+    }> = [];
+    let blocked = false;
+    for (const candidate of candidates) {
+      const key = restoreMovePlanKey(candidate.context.manifestPath, candidate.move);
+      const inspection = inspectRestoreArchive(candidate.move);
+      if (inspection.state === "available") {
+        available.push({ ...candidate, snapshot: inspection.snapshot });
+        continue;
+      }
+      if (inspection.state === "missing" && candidate.consumed) {
+        plan.set(key, { action: "skip-consumed" });
+        continue;
+      }
+      blocked = true;
+      plan.set(key, {
+        action: "conflict",
+        reason:
+          inspection.state === "missing"
+            ? "archive is missing without a recorded prior restore; refusing another candidate"
+            : inspection.reason,
+      });
+    }
+
+    if (blocked) {
+      for (const candidate of available) {
+        plan.set(restoreMovePlanKey(candidate.context.manifestPath, candidate.move), {
+          action: "conflict",
+          reason:
+            "another archive for this source is unavailable without prior restore evidence; refusing automatic selection",
+        });
+      }
+      continue;
+    }
+    if (available.length === 0) {
+      continue;
+    }
+
+    const kinds = new Set(available.map((candidate) => candidate.move.kind));
+    if (kinds.size !== 1) {
+      setRestoreCandidateConflicts(
+        plan,
+        available,
+        "recorded archives disagree on artifact kind; refusing automatic selection",
+      );
+      continue;
+    }
+    const winner = selectRestoreCandidate(available);
+    if (!winner) {
+      setRestoreCandidateConflicts(
+        plan,
+        available,
+        available[0]?.move.kind === "legacy-store"
+          ? "multiple distinct nonempty session indexes require explicit archive selection"
+          : "multiple distinct archives require explicit archive selection",
+      );
+      continue;
+    }
+    for (const candidate of available) {
+      plan.set(
+        restoreMovePlanKey(candidate.context.manifestPath, candidate.move),
+        candidate === winner
+          ? { action: "restore", snapshot: candidate.snapshot }
+          : { action: "skip-superseded" },
+      );
+    }
+  }
+  return plan;
+}
+
+function selectRestoreCandidate<
+  T extends { move: SessionSqliteMigrationMove; snapshot: RestoreArchiveSnapshot },
+>(candidates: readonly T[]): T | undefined {
+  const distinctDigests = new Set(candidates.map((candidate) => candidate.snapshot.digest));
+  if (distinctDigests.size === 1) {
+    return candidates[0];
+  }
+  if (candidates[0]?.move.kind !== "legacy-store") {
+    return undefined;
+  }
+  const nonemptyDigests = new Set(
+    candidates
+      .filter((candidate) => (candidate.snapshot.legacyEntryCount ?? 0) > 0)
+      .map((candidate) => candidate.snapshot.digest),
+  );
+  if (nonemptyDigests.size === 0) {
+    return candidates[0];
+  }
+  return nonemptyDigests.size === 1
+    ? candidates.find((candidate) => (candidate.snapshot.legacyEntryCount ?? 0) > 0)
+    : undefined;
+}
+
+function setRestoreCandidateConflicts(
+  plan: Map<string, RestoreMovePlan>,
+  candidates: ReadonlyArray<{
+    context: RestoreManifestContext;
+    move: SessionSqliteMigrationMove;
+  }>,
+  reason: string,
+): void {
+  for (const candidate of candidates) {
+    plan.set(restoreMovePlanKey(candidate.context.manifestPath, candidate.move), {
+      action: "conflict",
+      reason,
+    });
+  }
+}
+
+function restoreMovePlanKey(manifestPath: string, move: SessionSqliteMigrationMove): string {
+  return `${manifestPath}\u0000${migrationMoveKey(move)}`;
+}
+
+function collectRecordedConsumedArchives(manifest: SessionSqliteMigrationManifest): Set<string> {
+  const consumed = new Set(manifest.restore?.consumedArchives ?? []);
+  const restoredSources = new Set(manifest.restore?.restoredFiles ?? []);
+  if (restoredSources.size === 0) {
+    return consumed;
+  }
+  const movesBySource = new Map<string, SessionSqliteMigrationMove[]>();
+  for (const target of manifest.targets) {
+    for (const move of uniqueRestoreMoves(target)) {
+      const moves = movesBySource.get(move.sourcePath) ?? [];
+      moves.push(move);
+      movesBySource.set(move.sourcePath, moves);
+    }
+  }
+  // Older shipped manifests only recorded restored source paths. Preserve that evidence when the
+  // source identifies exactly one archive, then persist the explicit archive path on this run.
+  for (const sourcePath of restoredSources) {
+    const moves = movesBySource.get(sourcePath);
+    if (moves?.length === 1) {
+      consumed.add(moves[0].archivePath);
+    }
+  }
+  return consumed;
+}
+
+type RestoreArchiveInspection =
+  | { state: "available"; snapshot: RestoreArchiveSnapshot }
+  | { state: "invalid"; reason: string }
+  | { state: "missing" };
+
+function inspectRestoreArchive(move: SessionSqliteMigrationMove): RestoreArchiveInspection {
+  if (hasSymbolicLinkInDirectoryPath(path.dirname(move.archivePath))) {
+    return { state: "invalid", reason: "archive parent is a symbolic link; refusing restore" };
+  }
+  let pathStat: fs.Stats;
+  try {
+    pathStat = fs.lstatSync(move.archivePath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR"
+      ? { state: "missing" }
+      : { state: "invalid", reason: "archive could not be inspected; refusing restore" };
+  }
+  if (!pathStat.isFile()) {
+    return { state: "invalid", reason: "archive is not a regular file; refusing restore" };
+  }
+
+  let fd: number | undefined;
+  try {
+    const flags =
+      process.platform === "win32"
+        ? "r"
+        : fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0);
+    fd = fs.openSync(move.archivePath, flags);
+    const descriptorStat = fs.fstatSync(fd);
+    if (
+      !descriptorStat.isFile() ||
+      descriptorStat.dev !== pathStat.dev ||
+      descriptorStat.ino !== pathStat.ino
+    ) {
+      return {
+        state: "invalid",
+        reason: "archive changed while it was inspected; refusing restore",
+      };
+    }
+    const content = readFileDescriptorBoundedSync(fd, descriptorStat.size);
+    const finalPathStat = fs.lstatSync(move.archivePath);
+    if (
+      finalPathStat.dev !== descriptorStat.dev ||
+      finalPathStat.ino !== descriptorStat.ino ||
+      finalPathStat.size !== descriptorStat.size
+    ) {
+      return {
+        state: "invalid",
+        reason: "archive changed while it was inspected; refusing restore",
+      };
+    }
+    let legacyEntryCount: number | undefined;
+    if (move.kind === "legacy-store") {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content.toString("utf-8"));
+      } catch {
+        return {
+          state: "invalid",
+          reason: "session index archive is not valid JSON; refusing automatic selection",
+        };
+      }
+      if (!isRecord(parsed)) {
+        return {
+          state: "invalid",
+          reason: "session index archive is not a JSON object; refusing automatic selection",
+        };
+      }
+      legacyEntryCount = Object.keys(parsed).length;
+    }
+    return {
+      state: "available",
+      snapshot: {
+        digest: createHash("sha256").update(content).digest("hex"),
+        ...(legacyEntryCount === undefined ? {} : { legacyEntryCount }),
+        size: descriptorStat.size,
+      },
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR"
+      ? { state: "missing" }
+      : { state: "invalid", reason: "archive could not be read safely; refusing restore" };
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
 }
 
 export function restoreSessionSqliteMigrationRun(params: {
@@ -385,9 +661,16 @@ export function restoreSessionSqliteMigrationRun(params: {
   }
   restoreSessionSqliteMigrationManifest(
     manifest,
+    params.manifestPath,
     targetManifests,
     restoreReport,
-    resolveWinningRestoreArchives([params.manifestPath], params.trustedTargets),
+    createRestorePlan([
+      {
+        manifest,
+        manifestPath: params.manifestPath,
+        targets: targetManifests,
+      },
+    ]),
   );
   writeSessionSqliteMigrationManifest({ manifest, manifestPath: params.manifestPath });
   return restoreReport;
@@ -543,17 +826,26 @@ function emptyRestoreReport(): DoctorSessionSqliteRestoreReport {
 
 function restoreSessionSqliteMigrationManifest(
   manifest: SessionSqliteMigrationManifest,
+  manifestPath: string,
   targets: readonly SessionSqliteMigrationTargetManifest[],
   restoreReport: DoctorSessionSqliteRestoreReport,
-  winningArchives: ReadonlyMap<string, string>,
+  restorePlan: ReadonlyMap<string, RestoreMovePlan>,
 ): void {
+  const consumedArchives = collectRecordedConsumedArchives(manifest);
   for (const target of targets) {
     for (const move of uniqueRestoreMoves(target)) {
-      restoreMigrationMove(move, restoreReport, winningArchives);
+      restoreMigrationMove({
+        consumedArchives,
+        manifestPath,
+        move,
+        restorePlan,
+        restoreReport,
+      });
     }
   }
   manifest.restore = {
     attemptedAt: new Date().toISOString(),
+    ...(consumedArchives.size > 0 ? { consumedArchives: [...consumedArchives].toSorted() } : {}),
     conflicts: restoreReport.conflicts,
     restoredFiles: restoreReport.restoredFiles,
     skippedFiles: restoreReport.skippedFiles,
@@ -571,25 +863,48 @@ function uniqueRestoreMoves(
   return [...moves.values()];
 }
 
-function restoreMigrationMove(
-  move: SessionSqliteMigrationMove,
-  restoreReport: DoctorSessionSqliteRestoreReport,
-  winningArchives: ReadonlyMap<string, string>,
-): void {
-  const winningArchive = winningArchives.get(move.sourcePath);
-  if (
-    winningArchive !== undefined &&
-    winningArchive !== move.archivePath &&
-    !fs.existsSync(move.archivePath)
-  ) {
-    // Another run's archive owns this destination and this move's archive was already consumed by
-    // an earlier restore, so there is nothing left to recover or to warn about here.
+function restoreMigrationMove(params: {
+  consumedArchives: Set<string>;
+  manifestPath: string;
+  move: SessionSqliteMigrationMove;
+  restorePlan: ReadonlyMap<string, RestoreMovePlan>;
+  restoreReport: DoctorSessionSqliteRestoreReport;
+}): void {
+  const { consumedArchives, manifestPath, move, restorePlan, restoreReport } = params;
+  const planned = restorePlan.get(restoreMovePlanKey(manifestPath, move)) ?? {
+    action: "standard",
+  };
+  if (planned.action === "conflict") {
+    restoreReport.conflicts.push({
+      archivePath: move.archivePath,
+      reason: planned.reason,
+      sourcePath: move.sourcePath,
+    });
+    return;
+  }
+  if (planned.action === "skip-consumed" || planned.action === "skip-superseded") {
     restoreReport.skippedFiles.push(move.sourcePath);
     return;
   }
   const sourceExists = fs.existsSync(move.sourcePath);
   const archiveExists = fs.existsSync(move.archivePath);
   if (!sourceExists && archiveExists) {
+    if (planned.action === "restore") {
+      const inspection = inspectRestoreArchive(move);
+      if (
+        inspection.state !== "available" ||
+        inspection.snapshot.digest !== planned.snapshot.digest ||
+        inspection.snapshot.size !== planned.snapshot.size ||
+        inspection.snapshot.legacyEntryCount !== planned.snapshot.legacyEntryCount
+      ) {
+        restoreReport.conflicts.push({
+          archivePath: move.archivePath,
+          reason: "archive changed after restore planning; refusing restore",
+          sourcePath: move.sourcePath,
+        });
+        return;
+      }
+    }
     if (!isRegularFileWithoutFollowingSymlinks(move.archivePath)) {
       restoreReport.conflicts.push({
         archivePath: move.archivePath,
@@ -618,6 +933,7 @@ function restoreMigrationMove(
       return;
     }
     fs.renameSync(move.archivePath, move.sourcePath);
+    consumedArchives.add(move.archivePath);
     restoreReport.restoredFiles.push(move.sourcePath);
     return;
   }

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -535,8 +535,9 @@ function collectRecordedConsumedArchives(manifest: SessionSqliteMigrationManifes
   // source identifies exactly one archive, then persist the explicit archive path on this run.
   for (const sourcePath of restoredSources) {
     const moves = movesBySource.get(sourcePath);
-    if (moves?.length === 1) {
-      consumed.add(moves[0].archivePath);
+    const move = moves?.length === 1 ? moves[0] : undefined;
+    if (move) {
+      consumed.add(move.archivePath);
     }
   }
   return consumed;

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1315,6 +1315,95 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(store.trajectoryPath)).toBe(true);
   });
 
+  it("restores the pre-migration session index when several manifests share one store", async () => {
+    const store = createLegacyStore();
+    const preMigrationIndex = fs.readFileSync(store.storePath, "utf-8");
+    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    // Legacy writers recreate an empty index after a migration archived the real one, so later
+    // runs archive that empty file. `persistLegacySessionStore` writes exactly these 3 bytes.
+    for (let laterRun = 0; laterRun < 2; laterRun += 1) {
+      // Run ids and archive names embed Date.now(), so keep the runs in distinct milliseconds.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 2);
+      });
+      fs.writeFileSync(store.storePath, "{}\n", { mode: 0o600 });
+      await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    }
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    expect(fs.readFileSync(store.storePath, "utf-8")).toBe(preMigrationIndex);
+    // The losing archives stay on disk and stay visible as conflicts, so an operator can still see
+    // that other copies existed instead of restore quietly picking one.
+    const conflicts = restore.targets[0]?.restore?.conflicts ?? [];
+    expect(conflicts).toHaveLength(2);
+    for (const conflict of conflicts) {
+      expect(conflict.sourcePath).toBe(canonicalTestPath(store.storePath));
+      expect(conflict.reason).toBe("source and archive both exist; refusing to overwrite source");
+      expect(fs.readFileSync(conflict.archivePath, "utf-8")).toBe("{}\n");
+    }
+  });
+
+  it("keeps a later non-empty archive recoverable instead of dropping it", async () => {
+    const store = createLegacyStore();
+    const preMigrationIndex = fs.readFileSync(store.storePath, "utf-8");
+    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2);
+    });
+    // An older binary can still write real sessions to the legacy store after the migration.
+    const laterIndex = `${JSON.stringify({ "agent:main:later": { channel: "cli", chatType: "direct", sessionFile: "session-2.jsonl", sessionId: "session-2", sessionStartedAt: 3000, updatedAt: 4000 } }, null, 2)}\n`;
+    fs.writeFileSync(store.storePath, laterIndex, { mode: 0o600 });
+    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    expect(fs.readFileSync(store.storePath, "utf-8")).toBe(preMigrationIndex);
+    const storeConflicts = (restore.targets[0]?.restore?.conflicts ?? []).filter(
+      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    );
+    expect(storeConflicts).toHaveLength(1);
+    expect(
+      fs.readFileSync(expectDefined(storeConflicts[0], "store conflict").archivePath, "utf-8"),
+    ).toBe(laterIndex);
+  });
+
+  it("keeps restore clean when a later migration re-archived an already restored path", async () => {
+    const store = createLegacyStore();
+    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    await runDoctorSessionSqlite({ allAgents: true, cfg: {}, env: store.env, mode: "restore" });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2);
+    });
+    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    // The first run's archives were consumed by the first restore, so only the second run can
+    // reclaim these paths. The spent moves must not report as missing-archive failures.
+    expect(restore.targets[0]?.restore?.conflicts).toEqual([]);
+    expect(restore.totals.issues).toBe(0);
+    expect(restore.targets[0]?.restore?.restoredFiles).toContain(
+      canonicalTestPath(store.storePath),
+    );
+    expect(fs.readFileSync(store.storePath, "utf-8")).toContain("agent:main:main");
+  });
+
   it("rejects malformed restore manifests without throwing", () => {
     const store = createLegacyStore();
     const manifestPath = path.join(store.tempDir, "malformed-manifest.json");

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1357,6 +1357,64 @@ describe("runDoctorSessionSqlite", () => {
     }
   });
 
+  it("streams duplicate large transcript archives while selecting an identical restore", async () => {
+    const store = createLegacyStore();
+    const importReport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const firstManifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+    const firstManifest = readMigrationManifest(firstManifestPath);
+    const firstTarget = expectDefined(firstManifest.targets[0], "first migration target");
+    const transcriptMove = expectDefined(
+      firstTarget.plannedMoves.find((move) => move.kind === "transcript"),
+      "transcript archive move",
+    );
+    const largeTranscript = `${JSON.stringify({
+      payload: "x".repeat(4 * 1024 * 1024),
+      type: "event",
+    })}\n`;
+    fs.writeFileSync(transcriptMove.archivePath, largeTranscript, { mode: 0o600 });
+
+    const secondArchivePath = `${transcriptMove.archivePath}.duplicate`;
+    fs.copyFileSync(transcriptMove.archivePath, secondArchivePath);
+    const duplicateManifest = structuredClone(firstManifest);
+    duplicateManifest.runId = `${firstManifest.runId}-duplicate`;
+    duplicateManifest.startedAt = new Date(Date.parse(firstManifest.startedAt) + 1).toISOString();
+    duplicateManifest.targets = [
+      {
+        ...firstTarget,
+        completedMoves: [{ ...transcriptMove, archivePath: secondArchivePath }],
+        plannedMoves: [{ ...transcriptMove, archivePath: secondArchivePath }],
+      },
+    ];
+    const duplicateManifestPath = path.join(
+      path.dirname(firstManifestPath),
+      `${duplicateManifest.runId}.json`,
+    );
+    fs.writeFileSync(duplicateManifestPath, `${JSON.stringify(duplicateManifest, null, 2)}\n`, {
+      mode: 0o600,
+    });
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    const restoreReport = expectDefined(
+      restore.targets.find((target) => target.restore)?.restore,
+      "aggregate restore report",
+    );
+    expect(restoreReport.conflicts).toEqual([]);
+    expect(restore.totals.issues).toBe(0);
+    expect(fs.statSync(store.transcriptPath).size).toBe(Buffer.byteLength(largeTranscript));
+    expect(fs.readFileSync(store.transcriptPath, "utf-8")).toBe(largeTranscript);
+    expect([transcriptMove.archivePath, secondArchivePath].filter(fs.existsSync)).toHaveLength(1);
+  });
+
   it("fails closed when several manifests contain distinct nonempty session indexes", async () => {
     const store = createLegacyStore();
     const preMigrationIndex = fs.readFileSync(store.storePath, "utf-8");

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1319,6 +1319,7 @@ describe("runDoctorSessionSqlite", () => {
     const store = createLegacyStore();
     const preMigrationIndex = fs.readFileSync(store.storePath, "utf-8");
     await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    const emptyArchivePaths: string[] = [];
     // Legacy writers recreate an empty index after a migration archived the real one, so later
     // runs archive that empty file. `persistLegacySessionStore` writes exactly these 3 bytes.
     for (let laterRun = 0; laterRun < 2; laterRun += 1) {
@@ -1327,7 +1328,18 @@ describe("runDoctorSessionSqlite", () => {
         setTimeout(resolve, 2);
       });
       fs.writeFileSync(store.storePath, "{}\n", { mode: 0o600 });
-      await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifest = readMigrationManifest(importReport.migrationRun?.manifestPath);
+      emptyArchivePaths.push(
+        expectDefined(
+          manifest.targets[0]?.plannedMoves.find((move) => move.kind === "legacy-store"),
+          "empty legacy archive move",
+        ).archivePath,
+      );
     }
 
     const restore = await runDoctorSessionSqlite({
@@ -1338,28 +1350,44 @@ describe("runDoctorSessionSqlite", () => {
     });
 
     expect(fs.readFileSync(store.storePath, "utf-8")).toBe(preMigrationIndex);
-    // The losing archives stay on disk and stay visible as conflicts, so an operator can still see
-    // that other copies existed instead of restore quietly picking one.
-    const conflicts = restore.targets[0]?.restore?.conflicts ?? [];
-    expect(conflicts).toHaveLength(2);
-    for (const conflict of conflicts) {
-      expect(conflict.sourcePath).toBe(canonicalTestPath(store.storePath));
-      expect(conflict.reason).toBe("source and archive both exist; refusing to overwrite source");
-      expect(fs.readFileSync(conflict.archivePath, "utf-8")).toBe("{}\n");
+    expect(restore.targets[0]?.restore?.conflicts).toEqual([]);
+    expect(restore.totals.issues).toBe(0);
+    for (const archivePath of emptyArchivePaths) {
+      expect(fs.readFileSync(archivePath, "utf-8")).toBe("{}\n");
     }
   });
 
-  it("keeps a later non-empty archive recoverable instead of dropping it", async () => {
+  it("fails closed when several manifests contain distinct nonempty session indexes", async () => {
     const store = createLegacyStore();
     const preMigrationIndex = fs.readFileSync(store.storePath, "utf-8");
-    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    const firstImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const firstArchive = expectDefined(
+      readMigrationManifest(firstImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "first legacy archive move",
+    ).archivePath;
     await new Promise((resolve) => {
       setTimeout(resolve, 2);
     });
     // An older binary can still write real sessions to the legacy store after the migration.
     const laterIndex = `${JSON.stringify({ "agent:main:later": { channel: "cli", chatType: "direct", sessionFile: "session-2.jsonl", sessionId: "session-2", sessionStartedAt: 3000, updatedAt: 4000 } }, null, 2)}\n`;
     fs.writeFileSync(store.storePath, laterIndex, { mode: 0o600 });
-    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    const secondImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const secondArchive = expectDefined(
+      readMigrationManifest(secondImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "second legacy archive move",
+    ).archivePath;
 
     const restore = await runDoctorSessionSqlite({
       allAgents: true,
@@ -1368,24 +1396,178 @@ describe("runDoctorSessionSqlite", () => {
       mode: "restore",
     });
 
-    expect(fs.readFileSync(store.storePath, "utf-8")).toBe(preMigrationIndex);
-    const storeConflicts = (restore.targets[0]?.restore?.conflicts ?? []).filter(
+    expect(fs.existsSync(store.storePath)).toBe(false);
+    const restoreReport = expectDefined(
+      restore.targets.find((target) => target.restore)?.restore,
+      "aggregate restore report",
+    );
+    const storeConflicts = restoreReport.conflicts.filter(
       (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
     );
-    expect(storeConflicts).toHaveLength(1);
-    expect(
-      fs.readFileSync(expectDefined(storeConflicts[0], "store conflict").archivePath, "utf-8"),
-    ).toBe(laterIndex);
+    expect(storeConflicts).toHaveLength(2);
+    expect(new Set(storeConflicts.map((conflict) => conflict.reason))).toEqual(
+      new Set(["multiple distinct nonempty session indexes require explicit archive selection"]),
+    );
+    expect(fs.readFileSync(firstArchive, "utf-8")).toBe(preMigrationIndex);
+    expect(fs.readFileSync(secondArchive, "utf-8")).toBe(laterIndex);
+    expect(restore.totals.issues).toBeGreaterThan(0);
+  });
+
+  it("does not hide a missing original archive behind a later empty session index", async () => {
+    const store = createLegacyStore();
+    const firstImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const firstArchive = expectDefined(
+      readMigrationManifest(firstImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "first legacy archive move",
+    ).archivePath;
+    fs.rmSync(firstArchive);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2);
+    });
+    fs.writeFileSync(store.storePath, "{}\n", { mode: 0o600 });
+    const secondImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const secondArchive = expectDefined(
+      readMigrationManifest(secondImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "second legacy archive move",
+    ).archivePath;
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    expect(fs.existsSync(store.storePath)).toBe(false);
+    expect(fs.readFileSync(secondArchive, "utf-8")).toBe("{}\n");
+    const restoreReport = expectDefined(
+      restore.targets.find((target) => target.restore)?.restore,
+      "aggregate restore report",
+    );
+    const storeConflicts = restoreReport.conflicts.filter(
+      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    );
+    expect(storeConflicts).toHaveLength(2);
+    expect(storeConflicts.map((conflict) => conflict.reason)).toEqual(
+      expect.arrayContaining([
+        "archive is missing without a recorded prior restore; refusing another candidate",
+        "another archive for this source is unavailable without prior restore evidence; refusing automatic selection",
+      ]),
+    );
+  });
+
+  it("does not replace an invalid original archive with a later empty session index", async () => {
+    const store = createLegacyStore();
+    const firstImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const firstArchive = expectDefined(
+      readMigrationManifest(firstImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "first legacy archive move",
+    ).archivePath;
+    fs.writeFileSync(firstArchive, "{broken", { mode: 0o600 });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2);
+    });
+    fs.writeFileSync(store.storePath, "{}\n", { mode: 0o600 });
+    const secondImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const secondArchive = expectDefined(
+      readMigrationManifest(secondImport.migrationRun?.manifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "second legacy archive move",
+    ).archivePath;
+
+    const restore = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: {},
+      env: store.env,
+      mode: "restore",
+    });
+
+    expect(fs.existsSync(store.storePath)).toBe(false);
+    expect(fs.readFileSync(firstArchive, "utf-8")).toBe("{broken");
+    expect(fs.readFileSync(secondArchive, "utf-8")).toBe("{}\n");
+    const restoreReport = expectDefined(
+      restore.targets.find((target) => target.restore)?.restore,
+      "aggregate restore report",
+    );
+    const storeConflicts = restoreReport.conflicts.filter(
+      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    );
+    expect(storeConflicts).toHaveLength(2);
+    expect(storeConflicts.map((conflict) => conflict.reason)).toEqual(
+      expect.arrayContaining([
+        "session index archive is not valid JSON; refusing automatic selection",
+        "another archive for this source is unavailable without prior restore evidence; refusing automatic selection",
+      ]),
+    );
   });
 
   it("keeps restore clean when a later migration re-archived an already restored path", async () => {
     const store = createLegacyStore();
-    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    const firstImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const firstManifestPath = requireMigrationManifestPath(firstImport.migrationRun?.manifestPath);
+    const firstArchive = expectDefined(
+      readMigrationManifest(firstManifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "first legacy archive move",
+    ).archivePath;
     await runDoctorSessionSqlite({ allAgents: true, cfg: {}, env: store.env, mode: "restore" });
+    expect(readMigrationManifest(firstManifestPath).restore?.consumedArchives).toContain(
+      firstArchive,
+    );
+    // Shipped manifests recorded only restored source paths. Exercise the additive-field upgrade
+    // path instead of relying only on provenance written by this version.
+    const shippedManifest = readMigrationManifest(firstManifestPath);
+    if (shippedManifest.restore) {
+      delete shippedManifest.restore.consumedArchives;
+    }
+    fs.writeFileSync(firstManifestPath, `${JSON.stringify(shippedManifest, null, 2)}\n`, {
+      mode: 0o600,
+    });
     await new Promise((resolve) => {
       setTimeout(resolve, 2);
     });
-    await runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath });
+    const secondImport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const secondManifestPath = requireMigrationManifestPath(
+      secondImport.migrationRun?.manifestPath,
+    );
+    const secondArchive = expectDefined(
+      readMigrationManifest(secondManifestPath).targets[0]?.plannedMoves.find(
+        (move) => move.kind === "legacy-store",
+      ),
+      "second legacy archive move",
+    ).archivePath;
 
     const restore = await runDoctorSessionSqlite({
       allAgents: true,
@@ -1402,6 +1584,12 @@ describe("runDoctorSessionSqlite", () => {
       canonicalTestPath(store.storePath),
     );
     expect(fs.readFileSync(store.storePath, "utf-8")).toContain("agent:main:main");
+    expect(readMigrationManifest(firstManifestPath).restore?.consumedArchives).toContain(
+      firstArchive,
+    );
+    expect(readMigrationManifest(secondManifestPath).restore?.consumedArchives).toContain(
+      secondArchive,
+    );
   });
 
   it("rejects malformed restore manifests without throwing", () => {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1401,8 +1401,8 @@ describe("runDoctorSessionSqlite", () => {
       restore.targets.find((target) => target.restore)?.restore,
       "aggregate restore report",
     );
-    const storeConflicts = restoreReport.conflicts.filter(
-      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    const storeConflicts = restoreReport.conflicts.filter((conflict) =>
+      [firstArchive, secondArchive].includes(conflict.archivePath),
     );
     expect(storeConflicts).toHaveLength(2);
     expect(new Set(storeConflicts.map((conflict) => conflict.reason))).toEqual(
@@ -1456,8 +1456,8 @@ describe("runDoctorSessionSqlite", () => {
       restore.targets.find((target) => target.restore)?.restore,
       "aggregate restore report",
     );
-    const storeConflicts = restoreReport.conflicts.filter(
-      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    const storeConflicts = restoreReport.conflicts.filter((conflict) =>
+      [firstArchive, secondArchive].includes(conflict.archivePath),
     );
     expect(storeConflicts).toHaveLength(2);
     expect(storeConflicts.map((conflict) => conflict.reason)).toEqual(
@@ -1512,8 +1512,8 @@ describe("runDoctorSessionSqlite", () => {
       restore.targets.find((target) => target.restore)?.restore,
       "aggregate restore report",
     );
-    const storeConflicts = restoreReport.conflicts.filter(
-      (conflict) => conflict.sourcePath === canonicalTestPath(store.storePath),
+    const storeConflicts = restoreReport.conflicts.filter((conflict) =>
+      [firstArchive, secondArchive].includes(conflict.archivePath),
     );
     expect(storeConflicts).toHaveLength(2);
     expect(storeConflicts.map((conflict) => conflict.reason)).toEqual(


### PR DESCRIPTION
Fixes #116163

## What Problem This Solves

`openclaw doctor --session-sqlite restore` could install a later recreated empty `sessions.json` instead of the original pre-migration index when several migration runs archived the same destination. The old path processed manifests immediately, so filesystem order became an implicit data-selection policy.

The initial PR reversed that ordering, but still inferred that a missing losing archive had been consumed by an earlier restore. If the original archive had actually been deleted or lost, Doctor could silently install a later empty index and report success.

## Root cause and owner

The violated invariant belongs to the doctor session-SQLite migration-run owner: all archives targeting one destination must be evaluated before any archive is moved, and a missing archive may be suppressed only when durable per-archive evidence proves an earlier restore consumed it.

## Repair

The rewritten restore path now plans every duplicate destination before writes:

- identical archives may select the earliest recorded copy;
- one valid nonempty legacy session index may supersede valid empty-object copies created by older writers;
- distinct nonempty indexes, distinct transcript archives, invalid/unsafe archives, and archives missing without prior-consumption evidence fail closed before rename;
- losing archives remain untouched;
- every successful rename records its exact archive path in additive `restore.consumedArchives` provenance;
- shipped manifests that only have `restore.restoredFiles` are upgraded in place when one restored source maps unambiguously to one archive;
- transcript-like archives are fingerprinted in 64 KiB chunks, avoiding synchronous whole-file allocation during duplicate planning.

This does not change the SQLite schema or schema version, and it does not bump the migration-manifest version. The optional manifest field is backward-readable; runtime session storage remains SQLite-only.

## Operator-visible behavior

The destructive fixtures use the real `import` and `restore` entry points rather than hand-written result objects:

| state | result |
|---|---|
| original nonempty index + later empty indexes | original index restored; empty archives preserved; no conflict |
| two distinct nonempty indexes | destination remains absent; both archives preserved; two explicit conflicts |
| original archive deleted + later empty index | destination remains absent; later empty archive preserved; missing-original conflict remains visible |
| original archive malformed + later empty index | destination remains absent; both archives preserved; invalid-original conflict remains visible |
| restore -> re-import -> restore | exact consumed-archive provenance keeps repeat restore clean, including a shipped manifest without the new field |
| duplicate 4 MiB transcript archives | one identical archive restores intact, the losing archive remains preserved, and planning stays bounded |

Redacted after-fix Doctor transcript from a real built CLI run on Blacksmith Testbox. The fixture performed one import from a nonempty legacy index, two later imports from recreated empty indexes, then restore:

```text
$ openclaw doctor --session-sqlite restore --session-sqlite-all-agents --json
{
  "mode": "restore",
  "targets": [
    {
      "agentId": "main",
      "issues": [],
      "sqliteEntries": 1,
      "storePath": "<fixture>/state/agents/main/sessions/sessions.json",
      "restore": {
        "conflicts": [],
        "manifestPaths": [
          "<fixture>/state/session-sqlite-migration-runs/<run-1>.json",
          "<fixture>/state/session-sqlite-migration-runs/<run-2>.json",
          "<fixture>/state/session-sqlite-migration-runs/<run-3>.json"
        ],
        "restoredFiles": [
          "<fixture>/state/agents/main/sessions/session-1.jsonl",
          "<fixture>/state/agents/main/sessions/sessions.json"
        ],
        "skippedFiles": [
          "<fixture>/state/agents/main/sessions/sessions.json",
          "<fixture>/state/agents/main/sessions/sessions.json"
        ]
      }
    }
  ],
  "totals": {
    "issues": 0,
    "sqliteEntries": 1,
    "targets": 1
  }
}
legacy_index_entries=1
preserved_empty_archives=2
```

## Evidence

Focused destructive, upgrade, and large-archive coverage:

```text
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts
Test Files  1 passed (1)
Tests       83 passed (83)
```

Adjacent callers:

```text
server-startup-session-migration.test.ts   12 passed
register.maintenance.test.ts               32 passed
doctor-session-sqlite-github-issue.test.ts  1 passed
```

Fresh Blacksmith Testbox changed gate on the frozen branch, including core/test typecheck, changed-file lint, dead exports, database-first guard, native schema-version guard, and import-cycle checks:

- Testbox: `tbx_01kyy0t3p6c42jvzr8pzqbpcnq`
- Result: passed
- Run: https://github.com/openclaw/openclaw/actions/runs/30688172850

Remote SQLite flip lifecycle E2E:

```text
sqlite-sessions-transcripts-flip-proof.e2e.test.ts
Test Files  1 passed (1)
Tests       1 passed (1)
```

- Testbox: `tbx_01kyxzrc34f6ec68522fzykpb3`
- Run: https://github.com/openclaw/openclaw/actions/runs/30687590521

Autoreview on exact local head `6e956006605ee5595f8f4125b69bd94658b0a72c` is clean: patch correct `0.91`, no accepted/actionable P0 or P1 findings, secret scan clean.

## ClawSweeper rank-up moves

- [x] durable per-archive consumption provenance
- [x] deleted-earliest-archive regression
- [x] malformed-earliest-archive regression
- [x] fail-closed distinct-data policy
- [x] bounded duplicate transcript fingerprinting
- [x] literal redacted after-fix Doctor report
- [x] remote changed gate and lifecycle E2E

## Scope

Relative to frozen base `1f40646f7e058adb7a796f039e0027eb0052ad83`: production is +398 net lines, tests +335, docs +5. The production growth is the cross-manifest planner, safe archive inspection/fingerprint recheck, and persisted upgrade evidence required to remove the silent data-loss path; no unrelated runtime, provider, channel, config, or SQLite behavior changed.
