### PR TITLE
fix(feishu): preserve canonical outbound delivery lifecycle

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -310,16 +310,21 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       adapter,
       proofs: {
         text: async () => {
+          const onDeliveryResult = vi.fn();
           const result = await adapterSendText({
             cfg: emptyConfig,
             to: "chat:chat-1",
             text: "hello",
             accountId: "default",
+            onDeliveryResult,
           });
           expect(sendMessageCall()?.to).toBe("chat:chat-1");
           expect(sendMessageCall()?.text).toBe("hello");
           expect(sendMessageCall()?.accountId).toBe("default");
           expect(result.receipt.platformMessageIds).toEqual(["feishu-text-1"]);
+          expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
+            "feishu-text-1",
+          ]);
         },
         media: async () => {
           const onDeliveryResult = vi.fn();
@@ -567,6 +572,29 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     }
   });
 
+  it("does not send fallback text when accepted local-image progress cannot be persisted", async () => {
+    const { dir, file } = await createTmpImage();
+    const onDeliveryResult = vi.fn().mockRejectedValueOnce(new Error("progress write failed"));
+
+    try {
+      await expect(
+        sendText({
+          cfg: emptyConfig,
+          to: "chat_1",
+          text: file,
+          accountId: "main",
+          mediaLocalRoots: [dir],
+          onDeliveryResult,
+        }),
+      ).rejects.toThrow("progress write failed");
+      expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(onDeliveryResult).toHaveBeenCalledOnce();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("uses markdown cards when renderMode=card", async () => {
     const result = await sendText({
       cfg: cardRenderConfig,
@@ -650,6 +678,52 @@ describe("feishuOutbound.sendPayload native cards", () => {
     await fs.writeFile(file, "image-data");
     return { dir, file };
   }
+
+  it("records delegated post subchunks once without duplicating parent receipts", async () => {
+    sendMessageFeishuMock.mockImplementation(async () => ({
+      messageId: `chunk_${sendMessageFeishuMock.mock.calls.length}`,
+    }));
+    const onDeliveryResult = vi.fn();
+    const text = Array.from({ length: 2_200 }, () => "a").join("\n");
+
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text },
+      onDeliveryResult,
+    });
+
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual(
+      sendMessageFeishuMock.mock.calls.map((_call, index) => `chunk_${index + 1}`),
+    );
+  });
+
+  it("records separate fallback media and each expanded text chunk once", async () => {
+    sendMessageFeishuMock.mockImplementation(async () => ({
+      messageId: `chunk_${sendMessageFeishuMock.mock.calls.length}`,
+    }));
+    const onDeliveryResult = vi.fn();
+    const text = Array.from({ length: 2_200 }, () => "a").join("\n");
+
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text, mediaUrl: "https://example.com/image.png" },
+      onDeliveryResult,
+    });
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "media_msg",
+      ...sendMessageFeishuMock.mock.calls.map((_call, index) => `chunk_${index + 1}`),
+    ]);
+  });
 
   it("renders presentation-only payloads into Feishu channelData cards for core delivery", async () => {
     const presentation: MessagePresentation = {
@@ -2315,6 +2389,82 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
     }
   });
 
+  it("keeps explicit first-mode replies sticky across expanded post-md chunks", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+      replyToId: "om_explicit_reply",
+      replyToIdSource: "explicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    for (const [params] of sendMessageFeishuMock.mock.calls) {
+      expect(params.replyToMessageId).toBe("om_explicit_reply");
+    }
+  });
+
+  it("records each accepted expanded text chunk before the next send", async () => {
+    sendMessageFeishuMock.mockImplementation(async () => ({
+      messageId: `chunk_${sendMessageFeishuMock.mock.calls.length}`,
+    }));
+    const onDeliveryResult = vi.fn();
+
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+      accountId: "main",
+      onDeliveryResult,
+    });
+
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual(
+      sendMessageFeishuMock.mock.calls.map((_call, index) => `chunk_${index + 1}`),
+    );
+  });
+
+  it("preserves the first accepted text chunk when the following send fails", async () => {
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "accepted_chunk" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendText({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "accepted_chunk",
+    ]);
+  });
+
+  it("stops text fanout immediately when accepted delivery cannot be persisted", async () => {
+    const onDeliveryResult = vi.fn().mockRejectedValueOnce(new Error("progress write failed"));
+
+    await expect(
+      sendText({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("progress write failed");
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+  });
+
   it("re-chunks expanded post-md text at the selected account limit", async () => {
     await sendText({
       cfg: {
@@ -2378,6 +2528,26 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
 describe("feishuOutbound.sendMedia replyToId forwarding", () => {
   beforeEach(() => {
     resetOutboundMocks();
+  });
+
+  it("sends and records text-only media requests exactly once", async () => {
+    const onDeliveryResult = vi.fn();
+
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "text without an attachment",
+      replyToId: "om_reply_target",
+      accountId: "main",
+      onDeliveryResult,
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(onDeliveryResult.mock.calls.map(([delivery]) => delivery.messageId)).toEqual([
+      "text_msg",
+    ]);
+    expectFeishuResult(result, "text_msg");
   });
 
   it("forwards replyToId to sendMediaFeishu", async () => {
@@ -2483,6 +2653,25 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
 
     expect(sendMessageCall()?.replyToMessageId).toBe("om_reply_target");
     expect(sendMediaCall()?.replyToMessageId).toBe("om_reply_target");
+  });
+
+  it("keeps explicit first-mode targets sticky across every caption chunk and attachment", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "om_explicit_reply",
+      replyToIdSource: "explicit",
+      replyToMode: "first",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    for (const [params] of sendMessageFeishuMock.mock.calls) {
+      expect(params.replyToMessageId).toBe("om_explicit_reply");
+    }
+    expect(sendMediaCall()?.replyToMessageId).toBe("om_explicit_reply");
   });
 
   it("keeps native topic roots sticky across captions, attachments, and fallback", async () => {
@@ -2649,6 +2838,71 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
       "fallback_msg",
     ]);
     expectFeishuResult(result, "fallback_msg");
+  });
+
+  it("records every accepted caption chunk before recording its attachment", async () => {
+    sendMessageFeishuMock.mockImplementation(async () => ({
+      messageId: `caption_${sendMessageFeishuMock.mock.calls.length}`,
+    }));
+    const onDeliveryResult = vi.fn();
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+      mediaUrl: "https://example.com/image.png",
+      accountId: "main",
+      onDeliveryResult,
+    });
+
+    expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      ...sendMessageFeishuMock.mock.calls.map((_call, index) => `caption_${index + 1}`),
+      "media_msg",
+    ]);
+  });
+
+  it("preserves accepted caption chunks when a later chunk fails before media", async () => {
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "accepted_caption" })
+      .mockRejectedValueOnce(new Error("second caption failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+        mediaUrl: "https://example.com/image.png",
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second caption failed");
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "accepted_caption",
+    ]);
+  });
+
+  it("stops before later caption chunks and media when delivery persistence fails", async () => {
+    const onDeliveryResult = vi.fn().mockRejectedValueOnce(new Error("progress write failed"));
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: Array.from({ length: 2_200 }, () => "a").join("\n"),
+        mediaUrl: "https://example.com/image.png",
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("progress write failed");
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
   });
 
   it("does not send fallback text after an accepted media send loses its receipt", async () => {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -150,6 +150,15 @@ type FeishuOutboundPayload = Parameters<
   NonNullable<ChannelOutboundAdapter["sendPayload"]>
 >[0]["payload"];
 type FeishuSendPayloadContext = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0];
+type FeishuSendTextContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
+
+async function reportFeishuOutboundDelivery<T extends { messageId: string }>(
+  result: T,
+  onDeliveryResult: FeishuSendTextContext["onDeliveryResult"],
+): Promise<T> {
+  await onDeliveryResult?.(attachChannelToResult("feishu", result));
+  return result;
+}
 
 function consumeFeishuPresentationFallbackMarker(payload: FeishuOutboundPayload): {
   payload: FeishuOutboundPayload;
@@ -390,8 +399,11 @@ async function sendOutboundText(params: {
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
+  replyToIdSource?: FeishuSendTextContext["replyToIdSource"];
+  replyToMode?: FeishuSendTextContext["replyToMode"];
+  onDeliveryResult?: FeishuSendTextContext["onDeliveryResult"];
 }) {
-  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
+  const { cfg, to, text, accountId, replyToMessageId, replyInThread, onDeliveryResult } = params;
   const commentResult = await sendCommentThreadReply({
     cfg,
     to,
@@ -400,7 +412,7 @@ async function sendOutboundText(params: {
     accountId,
   });
   if (commentResult) {
-    return commentResult;
+    return await reportFeishuOutboundDelivery(commentResult, onDeliveryResult);
   }
 
   const account = resolveFeishuAccount({ cfg, accountId });
@@ -410,14 +422,17 @@ async function sendOutboundText(params: {
   // modified by post-md newline normalization. Only the post path below
   // materializes CommonMark soft breaks for Feishu rendering.
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({
-      cfg,
-      to,
-      text,
-      accountId,
-      replyToMessageId,
-      replyInThread,
-    });
+    return await reportFeishuOutboundDelivery(
+      await sendMarkdownCardFeishu({
+        cfg,
+        to,
+        text,
+        accountId,
+        replyToMessageId,
+        replyInThread,
+      }),
+      onDeliveryResult,
+    );
   }
 
   // Tables need contiguous source rows, so convert them before the parser
@@ -436,30 +451,26 @@ async function sendOutboundText(params: {
     limit: postLimit,
     mode: resolveChunkMode(cfg, "feishu", accountId),
   });
-  if (subChunks.length <= 1) {
-    return sendMessageFeishu({
-      cfg,
-      to,
-      text: subChunks[0] ?? normalizedText,
-      accountId,
-      replyToMessageId,
-      replyInThread,
-    });
-  }
-
   let lastResult: Awaited<ReturnType<typeof sendMessageFeishu>> | undefined;
   const preserveThread = replyInThread === true;
-  for (const [i, chunk] of subChunks.entries()) {
-    // Thread roots must accompany every chunk. Ordinary quoted replies remain
-    // first-chunk-only so implicit reply ids are consumed once per fanout.
-    lastResult = await sendMessageFeishu({
-      cfg,
-      to,
-      text: chunk,
-      accountId,
-      replyToMessageId: preserveThread || i === 0 ? replyToMessageId : undefined,
-      replyInThread: preserveThread ? true : i === 0 ? replyInThread : undefined,
-    });
+  const nextReplyToMessageId = createReplyToFanout({
+    replyToId: replyToMessageId,
+    replyToIdSource: params.replyToIdSource,
+    replyToMode: params.replyToMode ?? "first",
+  });
+  for (const [i, chunk] of (subChunks.length ? subChunks : [normalizedText]).entries()) {
+    // Explicit replies and native topic roots stay sticky; implicit first replies do not.
+    lastResult = await reportFeishuOutboundDelivery(
+      await sendMessageFeishu({
+        cfg,
+        to,
+        text: chunk,
+        accountId,
+        replyToMessageId: preserveThread ? replyToMessageId : nextReplyToMessageId(),
+        replyInThread: preserveThread ? true : i === 0 ? replyInThread : undefined,
+      }),
+      onDeliveryResult,
+    );
   }
   return lastResult!;
 }
@@ -508,18 +519,14 @@ async function sendFeishuFallbackPayload(params: {
       mediaUrl,
       replyToId: nextReplyToId(),
       audioAsVoice: params.payload.audioAsVoice ?? ctx.audioAsVoice,
-      onDeliveryResult: undefined,
     });
-    await ctx.onDeliveryResult?.(lastResult);
   }
   for (const chunk of textChunks) {
     lastResult = await sendText({
       ...ctx,
       text: chunk,
       replyToId: nextReplyToId(),
-      onDeliveryResult: undefined,
     });
-    await ctx.onDeliveryResult?.(lastResult);
   }
   return lastResult!;
 }
@@ -562,9 +569,7 @@ async function sendFeishuTtsSupplementPayload(params: {
         ...ctx,
         text: chunk,
         replyToId: nextReplyToId(),
-        onDeliveryResult: undefined,
       });
-      await ctx.onDeliveryResult?.(lastResult);
     }
   }
 
@@ -774,21 +779,26 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       text,
       accountId,
       replyToId,
+      replyToIdSource,
+      replyToMode,
       threadId,
       mediaLocalRoots,
       identity,
+      onDeliveryResult,
     }) => {
       const { replyToMessageId, replyInThread } = resolveFeishuReplyMode({
         replyToId,
         threadId,
       });
+      const deliveryOptions = { replyToIdSource, replyToMode, onDeliveryResult };
       // Scheme A compatibility shim:
       // when upstream accidentally returns a local image path as plain text,
       // auto-upload and send as Feishu image message instead of leaking path text.
       const localImagePath = normalizePossibleLocalImagePath(text);
       if (localImagePath) {
+        let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
         try {
-          return await sendMediaFeishu({
+          mediaResult = await sendMediaFeishu({
             cfg,
             to,
             mediaUrl: localImagePath,
@@ -810,8 +820,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
             replyToMessageId,
             replyInThread,
+            ...deliveryOptions,
           });
         }
+        return await reportFeishuOutboundDelivery(mediaResult, onDeliveryResult);
       }
 
       if (parseFeishuCommentTarget(to)) {
@@ -822,20 +834,24 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           accountId: accountId ?? undefined,
           replyToMessageId,
           replyInThread,
+          ...deliveryOptions,
         });
       }
 
       const card = readNativeFeishuCardJson(text);
       if (card) {
         assertFeishuCardWithinEnvelope(card, "Feishu native card");
-        return await sendCardFeishu({
-          cfg,
-          to,
-          card: markRenderedFeishuCard(card),
-          accountId: accountId ?? undefined,
-          replyToMessageId,
-          replyInThread,
-        });
+        return await reportFeishuOutboundDelivery(
+          await sendCardFeishu({
+            cfg,
+            to,
+            card: markRenderedFeishuCard(card),
+            accountId: accountId ?? undefined,
+            replyToMessageId,
+            replyInThread,
+          }),
+          onDeliveryResult,
+        );
       }
 
       const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
@@ -848,15 +864,18 @@ export const feishuOutbound: ChannelOutboundAdapter = {
               template: "blue" as const,
             }
           : undefined;
-        return await sendStructuredCardFeishu({
-          cfg,
-          to,
-          text,
-          replyToMessageId,
-          replyInThread,
-          accountId: accountId ?? undefined,
-          header: header?.title ? header : undefined,
-        });
+        return await reportFeishuOutboundDelivery(
+          await sendStructuredCardFeishu({
+            cfg,
+            to,
+            text,
+            replyToMessageId,
+            replyInThread,
+            accountId: accountId ?? undefined,
+            header: header?.title ? header : undefined,
+          }),
+          onDeliveryResult,
+        );
       }
       return await sendOutboundText({
         cfg,
@@ -865,6 +884,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         accountId: accountId ?? undefined,
         replyToMessageId,
         replyInThread,
+        ...deliveryOptions,
       });
     },
     sendMedia: async ({
@@ -897,8 +917,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { replyToMessageId, replyInThread };
       };
-      const commentTarget = parseFeishuCommentTarget(to);
-      if (commentTarget) {
+      const deliveryOptions = { replyToIdSource, replyToMode, onDeliveryResult };
+      if (parseFeishuCommentTarget(to)) {
         const commentText = mediaUrl?.trim()
           ? await buildFeishuMediaFallbackText({
               text,
@@ -912,94 +932,86 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text: commentText,
           accountId: accountId ?? undefined,
           ...nextReplyMode(),
+          ...deliveryOptions,
         });
       }
 
-      const suppressTextForVoiceMedia =
-        mediaUrl !== undefined &&
-        shouldSuppressFeishuTextForVoiceMedia({
-          mediaUrl,
-          audioAsVoice,
+      if (!mediaUrl) {
+        return await sendOutboundText({
+          cfg,
+          to,
+          text: text ?? "",
+          accountId: accountId ?? undefined,
+          ...nextReplyMode(),
+          ...deliveryOptions,
         });
-      const reportDelivery = async (result: Awaited<ReturnType<typeof sendOutboundText>>) => {
-        await onDeliveryResult?.(attachChannelToResult("feishu", result));
-      };
+      }
+
+      const suppressTextForVoiceMedia = shouldSuppressFeishuTextForVoiceMedia({
+        mediaUrl,
+        audioAsVoice,
+      });
       let textSent = false;
 
       // Send text first if provided, except for Feishu native voice bubbles.
       if (text?.trim() && !suppressTextForVoiceMedia) {
-        const textResult = await sendOutboundText({
+        await sendOutboundText({
           cfg,
           to,
           text,
           accountId: accountId ?? undefined,
           ...nextReplyMode(),
+          ...deliveryOptions,
         });
         textSent = true;
-        await reportDelivery(textResult);
       }
 
-      // Upload and send media if URL or local path provided
-      if (mediaUrl) {
-        let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
-        const mediaReplyMode = nextReplyMode();
-        try {
-          mediaResult = await sendMediaFeishu({
-            cfg,
-            to,
-            mediaUrl,
-            accountId: accountId ?? undefined,
-            mediaLocalRoots,
-            ...mediaReplyMode,
-            ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
-          });
-        } catch (err) {
-          if (isChannelPartialDeliveryError(err)) {
-            // Accepted media is not an upload failure and must never trigger a second send.
-            throw err;
-          }
-          // Log the error for debugging
-          console.error(`[feishu] sendMediaFeishu failed:`, err);
-          const fallbackText = await buildFeishuMediaFallbackText({
-            text: textSent ? undefined : text,
-            mediaUrl,
-          });
-          const fallbackResult = await sendOutboundText({
-            cfg,
-            to,
-            text: fallbackText,
-            accountId: accountId ?? undefined,
-            // A rejected upload never delivered its attempted reply target.
-            ...(textSent ? nextReplyMode() : mediaReplyMode),
-          });
-          await reportDelivery(fallbackResult);
-          return fallbackResult;
+      let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
+      const mediaReplyMode = nextReplyMode();
+      try {
+        mediaResult = await sendMediaFeishu({
+          cfg,
+          to,
+          mediaUrl,
+          accountId: accountId ?? undefined,
+          mediaLocalRoots,
+          ...mediaReplyMode,
+          ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
+        });
+      } catch (err) {
+        if (isChannelPartialDeliveryError(err)) {
+          // Accepted media is not an upload failure and must never trigger a second send.
+          throw err;
         }
-
-        // Upload fallback applies only to the platform send. Persistence and
-        // follow-up failures must not resend an attachment already accepted by Feishu.
-        await onDeliveryResult?.(attachChannelToResult("feishu", mediaResult));
-        if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
-          const textResult = await sendOutboundText({
-            cfg,
-            to,
-            text,
-            accountId: accountId ?? undefined,
-            ...nextReplyMode(),
-          });
-          await reportDelivery(textResult);
-        }
-        return mediaResult;
+        console.error(`[feishu] sendMediaFeishu failed:`, err);
+        const fallbackText = await buildFeishuMediaFallbackText({
+          text: textSent ? undefined : text,
+          mediaUrl,
+        });
+        return await sendOutboundText({
+          cfg,
+          to,
+          text: fallbackText,
+          accountId: accountId ?? undefined,
+          // A rejected upload never delivered its attempted reply target.
+          ...(textSent ? nextReplyMode() : mediaReplyMode),
+          ...deliveryOptions,
+        });
       }
 
-      // No media URL, just return text result
-      return await sendOutboundText({
-        cfg,
-        to,
-        text: text ?? "",
-        accountId: accountId ?? undefined,
-        ...nextReplyMode(),
-      });
+      // Persist the accepted attachment before any later fallible text action.
+      await reportFeishuOutboundDelivery(mediaResult, onDeliveryResult);
+      if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
+        await sendOutboundText({
+          cfg,
+          to,
+          text,
+          accountId: accountId ?? undefined,
+          ...nextReplyMode(),
+          ...deliveryOptions,
+        });
+      }
+      return mediaResult;
     },
   }),
 };


### PR DESCRIPTION
## What Problem This Solves

- Refactor the private Feishu outbound owner around one canonical per-provider-delivery lifecycle.
- Prevent duplicate text-only media sends, persist every accepted expanded text or attachment before later fallible work, and retain explicit reply targets across provider-generated chunks.
- Preserve implicit one-shot replies, sticky topics, degraded voice, visible attachment fallbacks, and existing public plugin/configuration contracts.

## Why This Change Was Made

One private outbound owner is responsible for all three reproduced root causes: duplicated text-only media requests, accepted provider chunks lost before later work fails, and explicitly chosen reply targets lost during provider-expanded Markdown fanout. A bounded refactor establishes one canonical per-platform-delivery path instead of adding independent special-case repairs. The existing Feishu-only production owner grows by 12 lines; no plugin SDK, public config, dependency, authentication, protocol, database schema, or other channel changes.

## User Impact

Feishu operators see one text-only message instead of two, retain durable evidence for every accepted text/attachment before a later failure or retry, and keep explicit replies anchored through every expanded chunk. Existing implicit first-only replies, native topic roots, visible upload-failure fallback, degraded voice, original attachment behavior, and account isolation remain intact.

## Evidence

- Exact reviewed head: `67abd59475a3a2c1b8fa2a1bda26c8ce17694117`; tree: `761f4925dbe80b3c90111684d9515015cf902f0d`; current main: `4fb19fb8c586b2d7801d1c512a4ac21e4d826505`; clean synthetic merge tree: `c0510bf04d85a27731420a0855a7d8a8a7881f9a`.
- Blacksmith hosted production and extension-test TypeScript gates, targeted type-aware lint, formatting, and `git diff --check`: passed.
- Complete Feishu suite excluding one independently confirmed unrelated baseline-red doctor file: **92 files, 1,429 tests passed**.
- Actual installed `@larksuiteoapi/node-sdk@1.71.1` with real localhost HTTP/auth/upload/message requests: **13/13 scenarios passed**, including accepted-chunk persistence, later provider HTTP 400, receipt persistence failure, explicit/implicit replies, topic threads, upload fallback, and degraded voice.
- Four independent blind P0–P3 reviews and full immutable-branch autoreview: clean.
- One dedicated hosted lease completed and was stopped: `tbx_01kyxs681x92k629djyy15fjmw`.

`extensions/feishu/src/doctor.test.ts` already fails identically on both this change's frozen base `b521ce626bfb479ba39e7919445c76e40d1d21aa` and the actually tested then-current `main` `618f3298c7dc00a41549e4dec41d8412f651624b`; every relevant doctor/session-owner path remains byte-identical on current `main` `4fb19fb8c586b2d7801d1c512a4ac21e4d826505`. Its existing test helper attempts to write `agent:codex:acp:binding:feishu:default:abc123` into the `agent:main` SQLite session store, which the unchanged canonical owner rejects with `SESSION_CANONICAL_KEY_MIGRATION_REQUIRED`; the other 12 tests in that existing file pass. This PR changes neither the doctor nor session-owner paths.
