### PR TITLE
chore(ci): lower environment variable budget

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-517
+515


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the current `main` checkout fails the environment-variable ratchet because production now contains 515 distinct `OPENCLAW_*` names while the recorded budget remains 517.

## Why This Change Was Made

Lowers the ratchet to the exact measured production count. This preserves the guard policy and does not change runtime behavior.

## User Impact

No user-visible behavior changes. Maintainer changed-file validation can pass again on current `main`.

## Evidence

- `node scripts/check-env-var-count.mjs`: `OPENCLAW_* count 515/515`
- `node scripts/run-vitest.mjs test/scripts/check-env-var-count.test.ts`: 9 passed
- `node scripts/check-changed.mjs -- config/env-var-count-budget.txt`: passed on Blacksmith Testbox run 30685508341
- `git diff --check`: clean
- fresh autoreview: clean, correctness 0.99
- exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30685650281

## ClawSweeper Rank-up Disposition

- Exact scanner proof: resolved by the local and Blacksmith Testbox runs above.
- Latest review/rank-up verification: read and resolved; the durable exact-head review reports no findings and identifies this one-line baseline correction as the best fix.