### PR TITLE
fix(clickclack): thread replies stop being answered past the 100-reply thread window

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -26,9 +26,7 @@ const mocks = vi.hoisted(() => ({
     events: vi.fn(),
     eventPage: vi.fn(),
     websocket: vi.fn(),
-    channelMessages: vi.fn(),
-    directMessages: vi.fn(),
-    thread: vi.fn(),
+    message: vi.fn(),
     setBotCommands: vi.fn(),
   },
   handleClickClackInbound: vi.fn(),
@@ -139,26 +137,24 @@ describe("ClickClack gateway", () => {
       commandAuthorized: true,
     });
     mocks.resolveWorkspaceId.mockResolvedValue("workspace-1");
-    mocks.client.channelMessages.mockResolvedValue([
-      {
-        id: "msg-1",
-        workspace_id: "workspace-1",
-        channel_id: "chan-1",
-        author_id: "human-1",
-        thread_root_id: "msg-1",
-        body: "hello",
-        body_format: "markdown",
+    mocks.client.message.mockResolvedValue({
+      id: "msg-1",
+      workspace_id: "workspace-1",
+      channel_id: "chan-1",
+      author_id: "human-1",
+      thread_root_id: "msg-1",
+      body: "hello",
+      body_format: "markdown",
+      created_at: "2026-01-01T00:00:00.000Z",
+      author: {
+        id: "human-1",
+        kind: "human",
+        display_name: "Human",
+        handle: "human",
+        avatar_url: "",
         created_at: "2026-01-01T00:00:00.000Z",
-        author: {
-          id: "human-1",
-          kind: "human",
-          display_name: "Human",
-          handle: "human",
-          avatar_url: "",
-          created_at: "2026-01-01T00:00:00.000Z",
-        },
       },
-    ]);
+    });
   });
 
   it("uses the private API base for REST and realtime startup", async () => {
@@ -523,7 +519,7 @@ describe("ClickClack gateway", () => {
       token: "test-token",
       correlationId: "fakeco.case_1",
     });
-    expect(mocks.client.channelMessages).toHaveBeenCalledWith("chan-1", 1, 10);
+    expect(mocks.client.message).toHaveBeenCalledWith("msg-1");
     expect(mocks.handleClickClackInbound).toHaveBeenCalledWith(
       expect.objectContaining({ correlationId: "fakeco.case_1" }),
     );

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -38,11 +38,15 @@ vi.mock("./access.js", () => ({
   resolveClickClackInboundAccess: mocks.resolveClickClackInboundAccess,
 }));
 
-vi.mock("./http-client.js", () => ({
-  createClickClackClient: mocks.createClickClackClient,
-  normalizeClickClackCorrelationId: (value: unknown) =>
-    typeof value === "string" && /^[A-Za-z0-9._:-]{1,128}$/u.test(value) ? value : undefined,
-}));
+vi.mock("./http-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./http-client.js")>();
+  return {
+    ClickClackHttpError: actual.ClickClackHttpError,
+    createClickClackClient: mocks.createClickClackClient,
+    normalizeClickClackCorrelationId: (value: unknown) =>
+      typeof value === "string" && /^[A-Za-z0-9._:-]{1,128}$/u.test(value) ? value : undefined,
+  };
+});
 
 vi.mock("./inbound.js", () => ({
   handleClickClackInbound: mocks.handleClickClackInbound,
@@ -426,6 +430,41 @@ describe("ClickClack gateway", () => {
     expect(mocks.client.websocket).toHaveBeenLastCalledWith("workspace-1", "cursor-2");
     expect(ctx.log?.warn).toHaveBeenCalledWith(
       "[default] ClickClack event processing failed; reconnecting: dispatch failed",
+    );
+
+    abort.abort();
+    await run;
+  });
+
+  it("replays a transient authoritative message fetch before committing its cursor", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const event = createBacklogEvent(1, "message.created");
+    mocks.client.eventPage
+      .mockResolvedValueOnce({ events: [], tailCursor: "" })
+      .mockResolvedValueOnce({ events: [event] })
+      .mockResolvedValueOnce({ events: [] });
+    mocks.client.websocket.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
+    mocks.client.message.mockRejectedValueOnce(new Error("message fetch failed"));
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await waitForGatewayState(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    emitMessageEvent(firstSocket, 1);
+
+    await waitForGatewayState(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(2));
+    expect(mocks.client.message).toHaveBeenCalledTimes(2);
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledOnce();
+    expect(firstSocket.close).toHaveBeenCalledOnce();
+    expect(mocks.client.eventPage).toHaveBeenNthCalledWith(2, "workspace-1", {
+      afterCursor: "",
+      limit: 500,
+    });
+    expect(mocks.client.websocket).toHaveBeenLastCalledWith("workspace-1", "cursor-1");
+    expect(ctx.log?.warn).toHaveBeenCalledWith(
+      "[default] ClickClack event processing failed; reconnecting: message fetch failed",
     );
 
     abort.abort();

--- a/extensions/clickclack/src/gateway.thread-reply-window.test.ts
+++ b/extensions/clickclack/src/gateway.thread-reply-window.test.ts
@@ -266,9 +266,20 @@ function createGatewayContext(
 
 describe("ClickClack gateway thread reply resolution", () => {
   let testServer: ClickClackTestServer;
+  let abort: AbortController | undefined;
+  let run: Promise<void> | undefined;
+
+  function startGateway(): ChannelGatewayContext<ResolvedClickClackAccount> {
+    abort = new AbortController();
+    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
+    run = startClickClackGatewayAccount(ctx);
+    return ctx;
+  }
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    abort = undefined;
+    run = undefined;
     mocks.resolveClickClackInboundAccess.mockResolvedValue({
       shouldDispatch: true,
       commandAuthorized: true,
@@ -277,13 +288,18 @@ describe("ClickClack gateway thread reply resolution", () => {
   });
 
   afterEach(async () => {
-    await testServer.close();
+    try {
+      abort?.abort();
+      if (run) {
+        await run;
+      }
+    } finally {
+      await testServer.close();
+    }
   });
 
   it("dispatches a thread reply past the server thread-reply window", async () => {
-    const abort = new AbortController();
-    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
-    const run = startClickClackGatewayAccount(ctx);
+    const ctx = startGateway();
 
     await testServer.emitThreadReplyEvent("msg-101");
     await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
@@ -295,15 +311,10 @@ describe("ClickClack gateway thread reply resolution", () => {
     );
     expect(testServer.requestPaths).toContain("GET /api/messages/msg-101");
     expect(ctx.log?.warn).not.toHaveBeenCalled();
-
-    abort.abort();
-    await run;
   });
 
   it("dispatches a DM thread reply that never enters the root DM timeline", async () => {
-    const abort = new AbortController();
-    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
-    const run = startClickClackGatewayAccount(ctx);
+    startGateway();
 
     await testServer.emitThreadReplyEvent("msg_dm_reply", {
       direct_conversation_id: "dmc_1",
@@ -317,16 +328,11 @@ describe("ClickClack gateway thread reply resolution", () => {
       }),
     );
     expect(testServer.requestPaths).toContain("GET /api/messages/msg_dm_reply");
-
-    abort.abort();
-    await run;
   });
 
   it("records a warning instead of silently handling an unreadable event message", async () => {
     testServer.missingMessageIds.add("msg-101");
-    const abort = new AbortController();
-    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
-    const run = startClickClackGatewayAccount(ctx);
+    const ctx = startGateway();
 
     await testServer.emitThreadReplyEvent("msg-101");
     await vi.waitFor(() =>
@@ -336,8 +342,5 @@ describe("ClickClack gateway thread reply resolution", () => {
     );
 
     expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
-
-    abort.abort();
-    await run;
   });
 });

--- a/extensions/clickclack/src/gateway.thread-reply-window.test.ts
+++ b/extensions/clickclack/src/gateway.thread-reply-window.test.ts
@@ -1,0 +1,343 @@
+import { createServer } from "node:http";
+import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import type { ClickClackMessage, ResolvedClickClackAccount } from "./types.js";
+
+const CLICKCLACK_THREAD_DEFAULT_LIMIT = 100;
+
+const mocks = vi.hoisted(() => ({
+  handleClickClackInbound: vi.fn(),
+  resolveClickClackInboundAccess: vi.fn(),
+}));
+
+vi.mock("./inbound.js", () => ({
+  handleClickClackInbound: mocks.handleClickClackInbound,
+}));
+
+vi.mock("./access.js", () => ({
+  resolveClickClackInboundAccess: mocks.resolveClickClackInboundAccess,
+}));
+
+const { startClickClackGatewayAccount } = await import("./gateway.js");
+
+function threadReply(index: number): ClickClackMessage {
+  return {
+    id: `msg-${index}`,
+    workspace_id: "wsp_1",
+    channel_id: "chn_1",
+    author_id: "usr_human",
+    parent_message_id: "msg_root",
+    thread_root_id: "msg_root",
+    thread_seq: index,
+    body: `reply ${index}`,
+    body_format: "markdown",
+    created_at: "2026-01-01T00:00:00.000Z",
+    author: {
+      id: "usr_human",
+      kind: "human",
+      display_name: "Human",
+      handle: "human",
+      avatar_url: "",
+      created_at: "2026-01-01T00:00:00.000Z",
+    },
+  };
+}
+
+const THREAD_ROOT: ClickClackMessage = {
+  id: "msg_root",
+  workspace_id: "wsp_1",
+  channel_id: "chn_1",
+  author_id: "usr_human",
+  thread_root_id: "msg_root",
+  channel_seq: 1,
+  body: "root",
+  body_format: "markdown",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const ALL_REPLIES = Array.from({ length: 101 }, (_, index) => threadReply(index + 1));
+const LATEST_REPLY = ALL_REPLIES[ALL_REPLIES.length - 1];
+
+const DM_ROOT: ClickClackMessage = {
+  id: "msg_dm_root",
+  workspace_id: "wsp_1",
+  direct_conversation_id: "dmc_1",
+  author_id: "usr_human",
+  thread_root_id: "msg_dm_root",
+  channel_seq: 1,
+  body: "dm root",
+  body_format: "markdown",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const DM_THREAD_REPLY: ClickClackMessage = {
+  id: "msg_dm_reply",
+  workspace_id: "wsp_1",
+  direct_conversation_id: "dmc_1",
+  author_id: "usr_human",
+  parent_message_id: "msg_dm_root",
+  thread_root_id: "msg_dm_root",
+  thread_seq: 1,
+  body: "dm thread reply",
+  body_format: "markdown",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const RESOLVABLE_MESSAGES = [...ALL_REPLIES, DM_THREAD_REPLY];
+
+type ClickClackTestServer = {
+  apiBaseUrl: string;
+  requestPaths: string[];
+  emitThreadReplyEvent: (messageId: string, payload?: Record<string, string>) => Promise<void>;
+  close: () => Promise<void>;
+  missingMessageIds: Set<string>;
+};
+
+async function startClickClackTestServer(): Promise<ClickClackTestServer> {
+  const requestPaths: string[] = [];
+  const missingMessageIds = new Set<string>();
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requestPaths.push(`${req.method} ${url.pathname}${url.search}`);
+    const json = (status: number, body: unknown) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    if (url.pathname === "/api/me") {
+      json(200, {
+        user: {
+          id: "usr_bot",
+          kind: "bot",
+          display_name: "Bot",
+          handle: "bot",
+          avatar_url: "",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      });
+      return;
+    }
+    if (url.pathname === "/api/workspaces") {
+      json(200, {
+        workspaces: [
+          {
+            id: "wsp_1",
+            route_id: "rt_1",
+            name: "Main",
+            slug: "main",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+      return;
+    }
+    if (url.pathname === "/api/realtime/events") {
+      json(200, { events: [], tail_cursor: "cursor-0" });
+      return;
+    }
+    const threadMatch = url.pathname.match(/^\/api\/messages\/([^/]+)\/thread$/u);
+    if (threadMatch) {
+      const requestedLimit = Number(url.searchParams.get("limit"));
+      const limit =
+        Number.isSafeInteger(requestedLimit) && requestedLimit > 0
+          ? Math.min(requestedLimit, 200)
+          : CLICKCLACK_THREAD_DEFAULT_LIMIT;
+      const window =
+        url.searchParams.get("latest") === "true"
+          ? ALL_REPLIES.slice(-limit)
+          : ALL_REPLIES.slice(0, limit);
+      json(200, {
+        root: THREAD_ROOT,
+        replies: window,
+        thread_state: {
+          root_message_id: "msg_root",
+          reply_count: ALL_REPLIES.length,
+          last_reply_at: LATEST_REPLY?.created_at,
+          last_reply_author_ids: ["usr_human"],
+        },
+      });
+      return;
+    }
+    if (/^\/api\/dms\/[^/]+\/messages$/u.test(url.pathname)) {
+      json(200, { messages: [DM_ROOT], oldest_seq: 1, has_older: false });
+      return;
+    }
+    const messageMatch = url.pathname.match(/^\/api\/messages\/([^/]+)$/u);
+    if (messageMatch) {
+      const messageId = decodeURIComponent(messageMatch[1] ?? "");
+      const message = missingMessageIds.has(messageId)
+        ? undefined
+        : RESOLVABLE_MESSAGES.find((candidate) => candidate.id === messageId);
+      if (!message) {
+        json(404, { error: "message not found" });
+        return;
+      }
+      json(200, { message });
+      return;
+    }
+    json(404, { error: `unhandled ${url.pathname}` });
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+  const wss = new WebSocketServer({ server, path: "/api/realtime/ws" });
+  const sockets = new Set<import("ws").WebSocket>();
+  wss.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  return {
+    apiBaseUrl: `http://127.0.0.1:${port}`,
+    requestPaths,
+    missingMessageIds,
+    emitThreadReplyEvent: async (messageId: string, payload: Record<string, string> = {}) => {
+      await vi.waitFor(() => expect(sockets.size).toBe(1));
+      const frame = JSON.stringify({
+        id: "evt-1",
+        cursor: "cursor-1",
+        type: "thread.reply_created",
+        workspace_id: "wsp_1",
+        channel_id: "chn_1",
+        seq: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+        payload: {
+          message_id: messageId,
+          root_message_id: "msg_root",
+          author_id: "usr_human",
+          ...payload,
+        },
+      });
+      for (const socket of sockets) {
+        socket.send(frame);
+      }
+    },
+    close: async () => {
+      for (const socket of sockets) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function createGatewayContext(
+  apiBaseUrl: string,
+  abortSignal: AbortSignal,
+): ChannelGatewayContext<ResolvedClickClackAccount> {
+  return {
+    cfg: {
+      channels: {
+        clickclack: {
+          baseUrl: "https://clickclack.example",
+          apiBaseUrl,
+          token: "test-token",
+          workspace: "main",
+          reconnectMs: 5,
+          commandMenu: false,
+        },
+      },
+    } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],
+    accountId: "default",
+    account: {} as ResolvedClickClackAccount,
+    runtime: {} as ChannelGatewayContext<ResolvedClickClackAccount>["runtime"],
+    abortSignal,
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getStatus: () =>
+      ({ accountId: "default" }) as ReturnType<
+        ChannelGatewayContext<ResolvedClickClackAccount>["getStatus"]
+      >,
+    setStatus: vi.fn(),
+  };
+}
+
+describe("ClickClack gateway thread reply resolution", () => {
+  let testServer: ClickClackTestServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: true,
+      commandAuthorized: true,
+    });
+    testServer = await startClickClackTestServer();
+  });
+
+  afterEach(async () => {
+    await testServer.close();
+  });
+
+  it("dispatches a thread reply past the server thread-reply window", async () => {
+    const abort = new AbortController();
+    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await testServer.emitThreadReplyEvent("msg-101");
+    await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
+
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ id: "msg-101", body: "reply 101" }),
+      }),
+    );
+    expect(testServer.requestPaths).toContain("GET /api/messages/msg-101");
+    expect(ctx.log?.warn).not.toHaveBeenCalled();
+
+    abort.abort();
+    await run;
+  });
+
+  it("dispatches a DM thread reply that never enters the root DM timeline", async () => {
+    const abort = new AbortController();
+    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await testServer.emitThreadReplyEvent("msg_dm_reply", {
+      direct_conversation_id: "dmc_1",
+      root_message_id: "msg_dm_root",
+    });
+    await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
+
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ id: "msg_dm_reply", body: "dm thread reply" }),
+      }),
+    );
+    expect(testServer.requestPaths).toContain("GET /api/messages/msg_dm_reply");
+
+    abort.abort();
+    await run;
+  });
+
+  it("records a warning instead of silently handling an unreadable event message", async () => {
+    testServer.missingMessageIds.add("msg-101");
+    const abort = new AbortController();
+    const ctx = createGatewayContext(testServer.apiBaseUrl, abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await testServer.emitThreadReplyEvent("msg-101");
+    await vi.waitFor(() =>
+      expect(ctx.log?.warn).toHaveBeenCalledWith(
+        expect.stringContaining("skipped unreadable ClickClack message before agent dispatch"),
+      ),
+    );
+
+    expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
+
+    abort.abort();
+    await run;
+  });
+});

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -9,7 +9,11 @@ import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
 import { resolveClickClackAccount } from "./accounts.js";
 import { syncClickClackCommandMenu } from "./command-menu.js";
-import { createClickClackClient, normalizeClickClackCorrelationId } from "./http-client.js";
+import {
+  ClickClackHttpError,
+  createClickClackClient,
+  normalizeClickClackCorrelationId,
+} from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
 import { resolveWorkspaceId } from "./resolve.js";
 import type {
@@ -38,34 +42,14 @@ async function resolveEventMessage(params: {
   if (!messageId) {
     return null;
   }
-  const directConversationId = payloadString(params.event, "direct_conversation_id");
-  if (directConversationId && typeof params.event.seq === "number") {
-    // ClickClack event payloads carry ids and cursors; fetch a narrow window
-    // around the sequence so the message body/author fields stay authoritative.
-    const messages = await params.client.directMessages(
-      directConversationId,
-      params.event.seq - 1,
-      10,
-    );
-    return messages.find((message) => message.id === messageId) ?? null;
-  }
-  if (params.event.type === "thread.reply_created") {
-    const rootId = payloadString(params.event, "root_message_id");
-    if (!rootId) {
+  try {
+    return await params.client.message(messageId);
+  } catch (error) {
+    if (error instanceof ClickClackHttpError && error.status === 404) {
       return null;
     }
-    const thread = await params.client.thread(rootId);
-    return thread.replies.find((message) => message.id === messageId) ?? null;
+    throw error;
   }
-  if (params.event.channel_id && typeof params.event.seq === "number") {
-    const messages = await params.client.channelMessages(
-      params.event.channel_id,
-      params.event.seq - 1,
-      10,
-    );
-    return messages.find((message) => message.id === messageId) ?? null;
-  }
-  return null;
 }
 
 function decodeSocketMessage(data: RawData): string {
@@ -95,7 +79,7 @@ async function processEvent(params: {
   client: ReturnType<typeof createClickClackClient>;
   event: ClickClackEvent;
   botUserId: string;
-  log?: { info: (message: string) => void };
+  log?: { info: (message: string) => void; warn?: (message: string) => void };
 }) {
   if (params.event.type !== "message.created" && params.event.type !== "thread.reply_created") {
     return;
@@ -114,7 +98,14 @@ async function processEvent(params: {
       })
     : params.client;
   const message = await resolveEventMessage({ client: messageClient, event: params.event });
-  if (!message || message.author_id === params.botUserId) {
+  if (!message) {
+    params.log?.warn?.(
+      `[${params.account.accountId}] skipped unreadable ClickClack message before agent dispatch: ` +
+        `type=${params.event.type} messageId=${payloadString(params.event, "message_id") || "unknown"}`,
+    );
+    return;
+  }
+  if (message.author_id === params.botUserId) {
     return;
   }
   if (message.author?.kind === "bot") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where people replying in a busy ClickClack thread get no answer at all once that thread passes 100 replies. From reply 101 onward the bot stops responding in that thread permanently: no reply, no transcript entry, no warning in the gateway log, and no failed-ingress record. The thread simply looks like the bot went deaf, while every other channel and every younger thread keeps working.

The trigger is only thread length, so it hits the most active threads in a workspace, and it is not recoverable by restarting the gateway.

## Why This Change Was Made

The ClickClack gateway treats a realtime event as a routing hint and re-fetches the authoritative message before dispatching agent work. For `thread.reply_created` it did that by pulling the whole thread and searching the reply list:

```ts
// before, extensions/clickclack/src/gateway.ts
if (params.event.type === "thread.reply_created") {
  const rootId = payloadString(params.event, "root_message_id");
  if (!rootId) {
    return null;
  }
  const thread = await params.client.thread(rootId);
  return thread.replies.find((message) => message.id === messageId) ?? null;
}
```

`client.thread()` requests `/api/messages/<root>/thread` with no query parameters, and the ClickClack thread contract caps that response. From `openclaw/clickclack` `docs/features/threads.md`:

> `"replies": Message[], // ordered by thread_seq asc, capped 1..200 (default 100)`
> Replies are ordered by `thread_seq` ascending. `limit` is clamped to `1..200` (default 100). By default clients fetch the earliest replies. Passing `latest=true` returns the latest bounded window, still in ascending order. There is no general `after_seq` pagination parameter yet; clients use realtime events for new replies.

So for reply 101 the response contains replies 1 to 100, `find()` returns `null`, and `processEvent()` returns as if the event were handled. The websocket cursor then advances past that event, and reconnect resumes after it, so the reply is never replayed. That is silent data loss on a default path.

Raising `limit` or passing `latest=true` only moves the cliff to 201, because the endpoint is a bounded window with no reply pagination. The server document points clients at realtime events plus a single-message read instead, and this plugin already has that read: `client.message()` hits `GET /api/messages/<id>`, which the server documents as returning one message visible to the current user. `extensions/clickclack/src/outbound.ts:141` already depends on it, so this adds no new server requirement.

The change resolves the event's own `message_id` through that authoritative endpoint, which also collapses the three separate window heuristics in `resolveEventMessage` into one canonical path:

```ts
// after, extensions/clickclack/src/gateway.ts
const messageId = payloadString(params.event, "message_id");
if (!messageId) {
  return null;
}
try {
  return await params.client.message(messageId);
} catch (error) {
  if (error instanceof ClickClackHttpError && error.status === 404) {
    return null;
  }
  throw error;
}
```

A transient failure (5xx, timeout, network) still propagates, so the existing reconnect-and-replay path retries it and the cursor is not committed. Only a `404` resolves to "not readable", and that case now records an operator warning instead of counting as a handled event, so an event with a `message_id` can no longer end in nothing with nothing explaining why.

Boundaries and non-goals:

- Routing all branches through the single-message read also fixes a worse sibling. The DM branch was checked before the thread branch, so a thread reply in a DM thread resolved through `client.directMessages()`, which pages the root DM timeline. From `openclaw/clickclack` `docs/features/dms.md`: "DM root messages support the same one-level thread model as channel messages. Thread replies carry `direct_conversation_id`, use `thread_seq`, and do not appear in the root DM timeline or unread root-message sequence." A DM thread reply therefore never appeared in that page at all, so every DM thread reply was dropped, not only the ones past 100. This PR covers that surface and adds a regression test for it. The channel branch resolves `message.created` roots, which do carry `channel_seq`, so it was not losing messages; it now shares the same canonical path, and a 10-message window scan becomes a 1-message read at the same request count.
- Visibility is not weakened. The window fetches scoped reads client-side; `GET /api/messages/<id>` is scoped server-side and requires direct conversation membership for DM messages.
- `client.thread()`, `client.channelMessages()`, and `client.directMessages()` stay on the client. `createClickClackClient` is exported as public plugin API from `extensions/clickclack/api.ts` and `runtime-api.ts`, so removing methods would break third-party plugins. They are simply no longer used to resolve realtime events. The discussions read path keeps its own thread request, which already passes an explicit `limit` and fails closed on a truncated reply list.

## User Impact

Thread replies are answered no matter how long the thread is. A workspace's most active threads stop being the ones where the bot mysteriously goes quiet. Operators also get a log line naming the event type and message id whenever a realtime event cannot be read, instead of a silent skip. No configuration changes, no new server requirement.

## Evidence

The proof drives the exported gateway entry point `startClickClackGatewayAccount` against a real loopback ClickClack server: a real `node:http` server plus a real `ws` `WebSocketServer` serving the documented contract, reached over real HTTP and a real websocket by the unmodified `extensions/clickclack/src/http-client.ts`. The server returns the 100 earliest replies for a 101-reply thread, exactly as ClickClack's thread endpoint does. Identical inputs on both runs, differing only by the patch.

## Real behavior proof

Behavior addressed: ClickClack thread replies past the server's 100-reply thread window were never answered, with no reply, no warning, and no replay, because the gateway searched a truncated thread response for the event's message.
Real environment tested: The exported ClickClack gateway account loop driven over real HTTP and a real websocket against a loopback ClickClack server that serves the documented thread contract, on pristine main 618f3298c7dc00a41549e4dec41d8412f651624b and on the patched tree. The gateway loop, its cursor handling, and the real `http-client.ts` REST/websocket client all stay real; only the downstream agent-dispatch and access-decision modules are substituted so the dispatch can be observed without a full agent runtime.
Exact steps or command run after this patch: Start the loopback ClickClack server, run `startClickClackGatewayAccount` against it, deliver a `thread.reply_created` frame for `msg-101` of a 101-reply thread, then close the socket so the gateway reconnects, and record the server-observed HTTP/websocket transcript with the dispatch outcome.
Evidence after fix:
```
# BEFORE (pristine main 618f3298c7dc00a41549e4dec41d8412f651624b)
ClickClack thread has 101 replies. Server returns the 100 earliest per its thread contract.
Human posts reply 101; ClickClack emits thread.reply_created for msg-101.

live HTTP/WS transcript observed by the ClickClack server:
  GET /api/workspaces
  GET /api/me
  GET /api/realtime/events?workspace_id=wsp_1&include_tail=true
  WS CONNECT ?workspace_id=wsp_1&after_cursor=cursor-0
  GET /api/messages/msg_root/thread
  GET /api/realtime/events?workspace_id=wsp_1&after_cursor=cursor-1&limit=500
  WS CONNECT ?workspace_id=wsp_1&after_cursor=cursor-1

agent dispatch for msg-101: NONE
operator warning recorded: NONE

# AFTER (this patch, identical inputs)
ClickClack thread has 101 replies. Server returns the 100 earliest per its thread contract.
Human posts reply 101; ClickClack emits thread.reply_created for msg-101.

live HTTP/WS transcript observed by the ClickClack server:
  GET /api/workspaces
  GET /api/me
  GET /api/realtime/events?workspace_id=wsp_1&include_tail=true
  WS CONNECT ?workspace_id=wsp_1&after_cursor=cursor-0
  GET /api/messages/msg-101
  GET /api/realtime/events?workspace_id=wsp_1&after_cursor=cursor-1&limit=500
  WS CONNECT ?workspace_id=wsp_1&after_cursor=cursor-1

agent dispatch for msg-101: body="reply 101"
operator warning recorded: NONE
```
Observed result after fix: One line of the live transcript moves, from the truncated thread read `GET /api/messages/msg_root/thread` to the authoritative `GET /api/messages/msg-101`, and reply 101 goes from never reaching agent dispatch to being dispatched with its real body while the resumed cursor is unchanged, which shows the reply was previously lost with no replay left.
What was not tested: No live ClickClack server instance was used; the loopback server implements the documented thread and single-message contract rather than running ClickClack itself. No agent model turn was executed, so this shows the reply reaching dispatch, not the text the agent produces. Full `pnpm build` was not run because no dynamic imports, packaging, or published surfaces changed.

## Validation

Run from the PR worktree with the repo wrappers:

- `node scripts/run-vitest.mjs extensions/clickclack` - 27 files, 310 tests passed.
- `node scripts/run-vitest.mjs extensions/clickclack/src/gateway.test.ts extensions/clickclack/src/gateway.thread-reply-window.test.ts` - 25 tests passed, including transient fetch reconnect and replay before cursor commit.
- `node scripts/run-vitest.mjs extensions/clickclack/src/gateway.thread-reply-window.test.ts` - 3 tests passed with the patch. All 3 fail on pristine `origin/main` with the production file reverted: the channel thread reply and the DM thread reply both report `expected "vi.fn()" to be called 1 times, but got 0 times` for agent dispatch, and the unreadable-message case records 0 warnings.
- `node scripts/run-oxlint.mjs` on the changed files - clean.
- `./node_modules/.bin/oxfmt --check` on the changed files - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` and `-p test/tsconfig/tsconfig.extensions.test.json` - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` - clean.

`extensions/clickclack/src/gateway.test.ts` moves its client stub from `channelMessages` to `message` because event resolution now has one canonical path.

Production diff is net negative: 19 insertions, 28 deletions in `extensions/clickclack/src/gateway.ts`.

The ClickClack dependency contract was re-audited at `openclaw/clickclackafe2e8eb6bcfeba947496feae3db72e6f659`: the single-message endpoint enforces workspace visibility plus DM scope/membership, while thread replies remain a bounded window.

## Novelty

Searched open and closed issues and PRs for ClickClack thread replies, `resolveEventMessage`, thread truncation, 100-reply windows, authoritative message fetches, dropped messages, and cursor advancement. No existing report covers this.

- #102486 (merged) changed startup cursor behavior via `tail_cursor` and did not touch `resolveEventMessage`.
- #108570 (closed) covered reconnect skipping in-flight websocket events, a different mechanism from thread-response truncation.
- The open PRs touching this plugin (#104006 REST timeouts, #111692 stalled-request recovery, #116683 native agent progress) do not change `resolveEventMessage` or the thread fetch.

