### PR TITLE
fix(openai): preserve authoritative image token usage

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -81,10 +81,11 @@ vi.mock("openclaw/plugin-sdk/logging-core", () => ({
   })),
 }));
 
-function mockGeneratedPngResponse() {
+function mockGeneratedPngResponse(usage?: Record<string, unknown>) {
   const response = {
     json: async () => ({
       data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
+      ...(usage === undefined ? {} : { usage }),
     }),
   };
   postJsonRequestMock.mockResolvedValue({
@@ -675,6 +676,110 @@ describe("openai image generation provider", () => {
       size: "3840x2160",
     });
     expect(result.images).toHaveLength(1);
+  });
+
+  it.each([
+    { name: "generation", inputImages: undefined },
+    {
+      name: "multipart edit",
+      inputImages: [{ buffer: Buffer.from("reference-image"), mimeType: "image/png" }],
+    },
+  ])("preserves bounded token usage for direct $name responses", async ({ inputImages }) => {
+    mockGeneratedPngResponse({
+      input_tokens: 41,
+      output_tokens: 92,
+      total_tokens: 133,
+      input_tokens_details: {
+        text_tokens: 0,
+        image_tokens: 34,
+        cached_tokens: 7,
+        cache_write_tokens: 0,
+      },
+      output_tokens_details: { image_tokens: 92, text_tokens: 0 },
+    });
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-1",
+      prompt: "Draw an image with auditable token accounting",
+      cfg: {},
+      ...(inputImages ? { inputImages } : {}),
+    });
+
+    expect(result.metadata).toEqual({
+      usage: {
+        input_tokens: 41,
+        output_tokens: 92,
+        total_tokens: 133,
+        input_tokens_details: {
+          text_tokens: 0,
+          image_tokens: 34,
+        },
+        output_tokens_details: { image_tokens: 92, text_tokens: 0 },
+      },
+    });
+  });
+
+  it("merges zero-valued image usage with existing normalized-size metadata", async () => {
+    mockGeneratedPngResponse({
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      input_tokens_details: { text_tokens: 0, image_tokens: 0, cached_tokens: 0 },
+      output_tokens_details: { image_tokens: 0, text_tokens: 0 },
+    });
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-1",
+      prompt: "Draw an image with zero token usage",
+      cfg: {},
+      size: "2048x1152",
+    });
+
+    expect(result.metadata).toEqual({
+      requestedSize: "2048x1152",
+      normalizedSize: "1536x1024",
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+        input_tokens_details: { text_tokens: 0, image_tokens: 0 },
+        output_tokens_details: { image_tokens: 0, text_tokens: 0 },
+      },
+    });
+  });
+
+  it("drops unsafe counts and unknown provider fields from image-usage metadata", async () => {
+    mockGeneratedPngResponse({
+      input_tokens: -1,
+      output_tokens: 1.5,
+      total_tokens: Number.MAX_SAFE_INTEGER + 1,
+      unbounded_provider_metadata: "x".repeat(4_096),
+      input_tokens_details: {
+        image_tokens: 9,
+        text_tokens: 0,
+        cached_tokens: 2,
+        cache_write_tokens: -1,
+        unbounded_provider_metadata: "x".repeat(4_096),
+      },
+      output_tokens_details: { image_tokens: 3, text_tokens: 0 },
+    });
+
+    const result = await buildOpenAIImageGenerationProvider().generateImage({
+      provider: "openai",
+      model: "gpt-image-1",
+      prompt: "Draw an image without leaking provider metadata",
+      cfg: {},
+    });
+
+    expect(result.metadata).toEqual({
+      usage: {
+        input_tokens_details: { image_tokens: 9, text_tokens: 0 },
+        output_tokens_details: { image_tokens: 3, text_tokens: 0 },
+      },
+    });
+    expect(JSON.stringify(result.metadata).length).toBeLessThan(256);
   });
 
   it("normalizes legacy gpt-image-1 sizes before native OpenAI generation", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -35,6 +35,7 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
+import { asOptionalRecord, asSafeIntegerInRange } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   canonicalizeCodexResponsesBaseUrl,
@@ -127,6 +128,35 @@ function resolveOpenAIImageCount(count: number | undefined): number {
     return 1;
   }
   return Math.max(1, Math.min(OPENAI_MAX_IMAGE_RESULTS, Math.trunc(count)));
+}
+
+function resolveOpenAIImageUsage(payload: unknown): Record<string, unknown> | undefined {
+  const usage = asOptionalRecord(asOptionalRecord(payload)?.usage);
+  if (!usage) {
+    return undefined;
+  }
+
+  const projectTokenCounts = (record: Record<string, unknown>, fields: readonly string[]) =>
+    Object.fromEntries(
+      fields.flatMap((field) => {
+        const count = asSafeIntegerInRange(record[field], { min: 0 });
+        return count === undefined ? [] : [[field, count]];
+      }),
+    );
+  const fields = ["input_tokens", "output_tokens", "total_tokens"];
+  const counts: Record<string, number | Record<string, number>> = projectTokenCounts(usage, fields);
+  const detailFields = ["text_tokens", "image_tokens"];
+  for (const field of ["input_tokens_details", "output_tokens_details"]) {
+    const details = asOptionalRecord(usage[field]);
+    if (!details) {
+      continue;
+    }
+    const normalizedDetails = projectTokenCounts(details, detailFields);
+    if (Object.keys(normalizedDetails).length > 0) {
+      counts[field] = normalizedDetails;
+    }
+  }
+  return Object.keys(counts).length > 0 ? counts : undefined;
 }
 
 function isPublicOpenAIImageBaseUrl(baseUrl: string): boolean {
@@ -1095,10 +1125,15 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
           );
         }
 
+        const usage = resolveOpenAIImageUsage(data);
+        const metadata = {
+          ...sizeResolution.metadata,
+          ...(usage ? { usage } : {}),
+        };
         return {
           images,
           model,
-          ...(sizeResolution.metadata ? { metadata: sizeResolution.metadata } : {}),
+          ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
         };
       } finally {
         await release();


### PR DESCRIPTION
## What Problem This Solves

Successful OpenAI image generation and image editing returned images but silently discarded the same response's authoritative token-usage details. Operators and agents could not see image input, output, total, or documented text/image token breakdowns, including valid zero-valued counts.

## Why This Change Was Made

The private OpenAI image-provider owner now projects only the token fields documented by the installed OpenAI SDK and Azure image API. Existing canonical record and safe-integer helpers reject malformed values and unsupported fields before metadata becomes model-visible.

Generation, multipart editing, normalized image-size metadata, no-usage responses, authentication, transport cleanup, and the separate Codex image route retain their existing behavior.

## User Impact

- Image generation and edits expose accurate input, output, and total token usage.
- Documented text/image breakdowns retain zero-valued counts.
- Unsupported cache fields, arbitrary provider metadata, negative/fractional counts, and unsafe integers never enter agent context.
- Existing normalized-size metadata remains available alongside usage.

## Evidence

- Frozen baseline: `7e78de747b8a64d52f30aee948b697bf4c528691`.
- Immutable reviewed candidate: `92fcf8a987d91c6cd67ca8255310d2ae01c2dcb6`.
- Latest-main merge checked against `4fb19fb8c586b2d7801d1c512a4ac21e4d826505`; synthetic merge tree `51961401154367f8e5f8155e131c2c53832b77ba`. Personally inspected adjacent ChatGPT Responses/Codex changes and direct sibling Codex protocol/images usage contracts; image owner, provider registration, runtime metadata passthrough, and model-visible image-tool metadata are unchanged.
- Directly inspected installed SDK contract: `node_modules/openai/src/resources/images.ts:450`; sibling Codex image response: `../codex/codex-rs/codex-api/src/endpoint/images.rs:145`.
- Actual installed `openai@6.49.0` SDK and production provider independently executed **10 real localhost HTTP requests** covering generation, multipart edit, zero usage, hostile provider metadata, and no-usage control.
- Full hosted production `pnpm tsgo:extensions`, extension-test `pnpm tsgo:extensions:test`, and type-aware owner/test lint all passed.
- **175/175 hosted tests passed**: OpenAI image owner 96, image runtime 14, generic compatible image owner 8, and image tool 57.
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/30682128755
- Genuine full-branch `gpt-5.6-sol` / `high` autoreview through **P3**: zero findings, confidence 0.98.
- Two fresh independent blind reviews: zero findings, confidence 0.99 and 0.94.
- Exactly two reviewed files; root cause count: **1**.

## Risk / Scope

The production increase is explicitly approved because copying raw usage would allow arbitrary provider data into model-visible metadata. The owner instead uses a bounded, documented-field projector with a precisely typed number-or-nested-number accumulator.

No public SDK, configuration, provider routing, authentication, SSRF, wire protocol, persistence, or SQLite changes.
