### PR TITLE
fix(openai): validate video binary responses at the owner boundary

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -1,5 +1,7 @@
 // Openai tests cover video generation provider plugin behavior.
 import fs from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -262,6 +264,7 @@ describe("openai video generation provider", () => {
 
   it("downloads an immediately completed OpenAI submission without polling it again", async () => {
     const release = vi.fn(async () => {});
+    const cancel = vi.fn();
     postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
         id: "vid_completed",
@@ -272,10 +275,18 @@ describe("openai video generation provider", () => {
       }),
       release,
     });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      headers: new Headers({ "content-type": "video/mp4" }),
-      arrayBuffer: async () => Buffer.from("completed-video"),
-    });
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("completed-video"));
+            controller.close();
+          },
+          cancel,
+        }),
+        { headers: { "content-type": "video/mp4" } },
+      ),
+    );
 
     const result = await buildOpenAIVideoGenerationProvider().generateVideo({
       provider: "openai",
@@ -290,8 +301,263 @@ describe("openai video generation provider", () => {
       model: "sora-2",
       metadata: { seconds: "4", size: "720x1280", status: "completed", videoId: "vid_completed" },
     });
+    expect(cancel).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    {
+      label: "JSON error",
+      contentType: "application/json",
+      body: JSON.stringify({ error: "not a rendered video" }),
+    },
+    {
+      label: "problem JSON error",
+      contentType: "application/problem+json",
+      body: JSON.stringify({ detail: "render failed" }),
+    },
+    { label: "plain-text error", contentType: "text/plain", body: "render failed" },
+    { label: "HTML error", contentType: "text/html", body: "<html>render failed</html>" },
+    { label: "empty video", contentType: "video/mp4", body: "" },
+  ])(
+    "rejects a successful $label download and releases both requests",
+    async ({ contentType, body }) => {
+      const submissionRelease = vi.fn(async () => {});
+      const downloadRelease = vi.fn(async () => {});
+      postMultipartRequestMock.mockResolvedValueOnce({
+        response: streamedJsonResponse({
+          id: "vid_malformed",
+          model: "sora-2",
+          status: "completed",
+        }),
+        release: submissionRelease,
+      });
+      fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+        response: new Response(body, { headers: { "content-type": contentType } }),
+        finalUrl: "http://127.0.0.1:44080/v1/videos/vid_malformed/content?variant=video",
+        release: downloadRelease,
+      });
+
+      await expect(
+        buildOpenAIVideoGenerationProvider().generateVideo({
+          provider: "openai",
+          model: "sora-2",
+          prompt: "Reject an invalid generated video",
+          cfg: {
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "http://127.0.0.1:44080/v1",
+                  request: { allowPrivateNetwork: true },
+                  models: [],
+                },
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow("OpenAI generated video download: malformed video response");
+
+      expect(pollProviderOperationJsonMock).not.toHaveBeenCalled();
+      expect(submissionRelease).toHaveBeenCalledOnce();
+      expect(downloadRelease).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    { mode: "public", allowPrivateNetwork: false },
+    { mode: "guarded private", allowPrivateNetwork: true },
+  ])(
+    "cancels unread malformed $mode video responses and closes their upstream socket",
+    async ({ allowPrivateNetwork }) => {
+      let notifySocketClosed: ((closed: boolean) => void) | undefined;
+      const socketClosed = new Promise<boolean>((resolve) => {
+        notifySocketClosed = resolve;
+      });
+      const server = createServer((request, response) => {
+        request.socket.once("close", () => notifySocketClosed?.(true));
+        response.writeHead(200, { "content-type": "application/json" });
+        response.write('{"error":"still streaming');
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        postMultipartRequestMock.mockResolvedValueOnce({
+          response: streamedJsonResponse({ id: "vid_unread", status: "completed" }),
+          release: vi.fn(async () => {}),
+        });
+        const { port } = server.address() as AddressInfo;
+        const upstreamUrl = `http://127.0.0.1:${port}/videos/vid_unread/content`;
+        const downloadRelease = vi.fn(async () => {});
+        if (allowPrivateNetwork) {
+          fetchWithTimeoutGuardedMock.mockImplementationOnce(async () => ({
+            response: await fetch(upstreamUrl),
+            finalUrl: upstreamUrl,
+            release: downloadRelease,
+          }));
+        } else {
+          fetchWithTimeoutMock.mockImplementationOnce(async () => await fetch(upstreamUrl));
+        }
+
+        await expect(
+          buildOpenAIVideoGenerationProvider().generateVideo({
+            provider: "openai",
+            model: "sora-2",
+            prompt: "Reject an unending public video error response",
+            cfg: allowPrivateNetwork
+              ? {
+                  models: {
+                    providers: {
+                      openai: {
+                        baseUrl: `http://127.0.0.1:${port}/v1`,
+                        request: { allowPrivateNetwork: true },
+                        models: [],
+                      },
+                    },
+                  },
+                }
+              : {},
+          }),
+        ).rejects.toThrow("OpenAI generated video download: malformed video response");
+
+        await expect(
+          Promise.race([
+            socketClosed,
+            new Promise<boolean>((resolve) => {
+              setTimeout(() => resolve(false), 250);
+            }),
+          ]),
+        ).resolves.toBe(true);
+        if (allowPrivateNetwork) {
+          expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledOnce();
+          expect(downloadRelease).toHaveBeenCalledOnce();
+        } else {
+          expect(fetchWithTimeoutGuardedMock).not.toHaveBeenCalled();
+        }
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+
+  it.each([
+    { mode: "public", allowPrivateNetwork: false },
+    { mode: "guarded private", allowPrivateNetwork: true },
+  ])(
+    "rejects cloned endless $mode video errors without waiting for capture cancellation",
+    async ({ allowPrivateNetwork }) => {
+      const response = new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"error":"still streaming'));
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+      const captureClone = response.clone();
+      const submissionRelease = vi.fn(async () => {});
+      const downloadRelease = vi.fn(async () => {});
+      postMultipartRequestMock.mockResolvedValueOnce({
+        response: streamedJsonResponse({ id: "vid_cloned", status: "completed" }),
+        release: submissionRelease,
+      });
+      if (allowPrivateNetwork) {
+        fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+          response,
+          finalUrl: "http://127.0.0.1:44080/v1/videos/vid_cloned/content",
+          release: downloadRelease,
+        });
+      } else {
+        fetchWithTimeoutMock.mockResolvedValueOnce(response);
+      }
+
+      const generation = buildOpenAIVideoGenerationProvider().generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "Reject a cloned, unending video error",
+        cfg: allowPrivateNetwork
+          ? {
+              models: {
+                providers: {
+                  openai: {
+                    baseUrl: "http://127.0.0.1:44080/v1",
+                    request: { allowPrivateNetwork: true },
+                    models: [],
+                  },
+                },
+              },
+            }
+          : {},
+      });
+      const captureCancellationPending = Symbol("capture cancellation pending");
+
+      try {
+        const result = await Promise.race([
+          generation.then(
+            () => undefined,
+            (error: unknown) => error,
+          ),
+          new Promise<symbol>((resolve) => {
+            setImmediate(() => resolve(captureCancellationPending));
+          }),
+        ]);
+
+        expect(result).not.toBe(captureCancellationPending);
+        expect(result).toMatchObject({
+          message: "OpenAI generated video download: malformed video response",
+        });
+        expect(submissionRelease).toHaveBeenCalledOnce();
+        if (allowPrivateNetwork) {
+          expect(downloadRelease).toHaveBeenCalledOnce();
+        }
+      } finally {
+        void captureClone.body?.cancel().catch(() => undefined);
+        await generation.catch(() => undefined);
+      }
+    },
+  );
+
+  it.each(["application/json", "text/plain"])(
+    "keeps the malformed public video error when %s body cancellation fails",
+    async (contentType) => {
+      const cancel = vi.fn(async () => {
+        throw new Error("upstream cancellation failed");
+      });
+      const submissionRelease = vi.fn(async () => {});
+      postMultipartRequestMock.mockResolvedValueOnce({
+        response: streamedJsonResponse({ id: "vid_cancel_failed", status: "completed" }),
+        release: submissionRelease,
+      });
+      fetchWithTimeoutMock.mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("still streaming"));
+            },
+            cancel,
+          }),
+          { headers: { "content-type": contentType } },
+        ),
+      );
+
+      await expect(
+        buildOpenAIVideoGenerationProvider().generateVideo({
+          provider: "openai",
+          model: "sora-2",
+          prompt: "Preserve the malformed public video response error",
+          cfg: {},
+        }),
+      ).rejects.toThrow("OpenAI generated video download: malformed video response");
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(submissionRelease).toHaveBeenCalledOnce();
+      expect(fetchWithTimeoutGuardedMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postMultipartRequestMock.mockResolvedValueOnce({

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -5,6 +5,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   executeProviderOperationWithRetry,
@@ -260,6 +261,13 @@ async function downloadOpenAIVideo(
     dispatcherPolicy: params.dispatcherPolicy,
   });
   try {
+    try {
+      assertProviderBinaryResponseContent(response, deadline.label, "video");
+    } catch (error) {
+      // Capture can tee this unread body; awaiting its cancellation deadlocks before release.
+      void response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
     const buffer = await readResponseWithLimit(response, params.maxBytes, {
       timeoutMs,
@@ -270,6 +278,9 @@ async function downloadOpenAIVideo(
       onOverflow: ({ maxBytes }) =>
         new Error(`OpenAI generated video download exceeds ${maxBytes} bytes`),
     });
+    if (buffer.byteLength === 0) {
+      throw new Error(`${deadline.label}: malformed video response`);
+    }
     return {
       buffer,
       mimeType,


### PR DESCRIPTION
## Summary

- Reject malformed or empty successful OpenAI video-download responses at the video provider's binary ownership boundary.
- Prevent hanging transport cleanup when debug-proxy capture holds the other branch of an actual `Response.clone()` stream.
- Preserve the exact public overflow error already shipped in `v2026.7.1`: `OpenAI generated video download exceeds <limit> bytes`.
- Match the already-landed OpenAI text-to-speech provider's canonical validation, nonblocking cancellation, bounded-read, and release lifecycle.

## Root Cause and Canonical Repair

OpenAI video downloads previously accepted invalid successful payloads. An earlier revision also awaited cancellation of one branch of a WHATWG tee while a debug-capture `Response.clone()` kept the other branch open, producing a real indefinite cleanup deadlock; its generic bounded-reader adoption changed an already-shipped operator-visible overflow message.

The final provider owner now uses the shared binary content assertion, the existing provider-owned bounded reader with its exact historical overflow callback, explicit empty rejection, fire-and-forget cleanup for invalid cloned bodies, and the existing transport release ordering. The same pattern already landed for the sibling OpenAI audio/TTS provider. No SDK surface, public protocol, config, schema, live-provider access, or auth-policy change is introduced.

## Real Owner / Dependency Proof

- Direct installed Undici and Node WHATWG stream sources show that `Response.clone()` uses a tee whose cancellation promise does not settle until both branches cancel.
- Actual native Fetch reproduction confirms one branch remains unsettled while the cloned capture stays live and settles only after both branches close.
- Existing shipped release `v2026.7.1` confirms the exact original OpenAI video overflow wording; the final regression restores that exact assertion.
- Hosted Blacksmith exact-owner proof: `node scripts/run-vitest.mjs extensions/openai/video-generation-provider.test.ts` — **1 suite, 30/30 passing**.
- The 30 cases include genuine never-ending `Response.clone()` streams for both public and guarded-private fetch, exact shipped overflow text, malformed MIME/JSON/plaintext/HTML/empty bodies, valid binary, and public/private transport release.
- Testbox production/test files were verified byte-for-byte against the final PR; repository/dependency/environment freshness was accepted without stale overrides.
- Full exact-head proof and hashes: https://github.com/openclaw/openclaw/pull/117227#issuecomment-5160192351
- Fresh final `gpt-5.6-sol` high-reasoning P1 structured review: **clean, confidence 0.98**.

Final reviewed head: `48d417e8e3dbd7e964a6942fa65660a6fa8553c1`.

The existing PR was refreshed onto current `main` after its old 1,025-commit-behind base exposed an unrelated TUI PTY failure (`Session transcript parent entry was not persisted`). The new base already contains the exact canonical session fix from #117260; both reviewed OpenAI production/test files retain **identical SHA-256 bytes** after the conflict-free refresh.
