### PR TITLE
fix(whatsapp): normalize provider self-echo identity ownership

### DIFF
--- a/extensions/whatsapp/src/inbound/dedupe.ts
+++ b/extensions/whatsapp/src/inbound/dedupe.ts
@@ -1,4 +1,12 @@
 // Whatsapp plugin module implements dedupe behavior.
+import {
+  isHostedLidUser,
+  isHostedPnUser,
+  isJidGroup,
+  jidDecode,
+  jidEncode,
+  jidNormalizedUser,
+} from "baileys";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 
 const RECENT_OUTBOUND_MESSAGE_TTL_MS = 20 * 60_000;
@@ -14,7 +22,19 @@ function buildMessageKey(params: {
   messageId: string;
 }): string | null {
   const accountId = params.accountId.trim();
-  const remoteJid = params.remoteJid.trim();
+  const rawRemoteJid = params.remoteJid.trim();
+  const hostedPhone = isHostedPnUser(rawRemoteJid);
+  // Match Baileys cleanMessage: hosted domains collapse before device stripping.
+  let remoteJid: string;
+  if (hostedPhone || isHostedLidUser(rawRemoteJid)) {
+    const decodedJid = jidDecode(rawRemoteJid);
+    if (!decodedJid) {
+      return null;
+    }
+    remoteJid = jidEncode(decodedJid.user, hostedPhone ? "s.whatsapp.net" : "lid");
+  } else {
+    remoteJid = jidNormalizedUser(rawRemoteJid);
+  }
   const messageId = params.messageId.trim();
   if (!accountId || !remoteJid || !messageId || messageId === "unknown") {
     return null;
@@ -41,11 +61,23 @@ export function rememberRecentOutboundMessage(params: {
 export function isRecentOutboundMessage(params: {
   accountId: string;
   remoteJid: string;
+  alternateRemoteJid?: string;
   messageId: string;
 }): boolean {
   const key = buildMessageKey(params);
   if (!key) {
     return false;
   }
-  return recentOutboundMessages.peek(key);
+  if (recentOutboundMessages.peek(key)) {
+    return true;
+  }
+  // Baileys exposes phone/LID aliases for direct chats only; never cross groups.
+  if (!params.alternateRemoteJid || isJidGroup(params.remoteJid)) {
+    return false;
+  }
+  const alternateKey = buildMessageKey({
+    ...params,
+    remoteJid: params.alternateRemoteJid,
+  });
+  return alternateKey !== null && recentOutboundMessages.peek(alternateKey);
 }

--- a/extensions/whatsapp/src/inbound/message-normalization.ts
+++ b/extensions/whatsapp/src/inbound/message-normalization.ts
@@ -45,6 +45,7 @@ export function createWhatsAppInboundMessageNormalizer(options: {
       !isRecentOutboundMessage({
         accountId: options.accountId,
         remoteJid,
+        alternateRemoteJid: msg.key?.remoteJidAlt,
         messageId: id,
       })
     ) {

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
@@ -1,6 +1,8 @@
 // Whatsapp plugin module implements monitor inbox.allows messages from senders allowfrom list support behavior.
 import "./monitor-inbox.test-harness.js";
+import { cleanMessage } from "baileys";
 import { describe, expect, it, vi } from "vitest";
+import { isRecentOutboundMessage } from "./inbound/dedupe.js";
 import {
   buildNotifyMessageUpsert,
   expectPairingPromptSent,
@@ -411,6 +413,135 @@ describe("web monitor inbox", () => {
 
     expect(onMessage).not.toHaveBeenCalled();
     expectOnlyOutboundChannelActivity();
+
+    await listener.close();
+  });
+
+  it.each([
+    {
+      name: "device-qualified phone JIDs",
+      outboundJid: "123:7@s.whatsapp.net",
+      echoedJid: "123@s.whatsapp.net",
+    },
+    {
+      name: "legacy c.us phone JIDs",
+      outboundJid: "123@c.us",
+      echoedJid: "123@s.whatsapp.net",
+    },
+    {
+      name: "hosted phone JIDs",
+      outboundJid: "123:7@hosted",
+      echoedJid: "123:7@hosted",
+    },
+    {
+      name: "hosted LID JIDs",
+      outboundJid: "777:2@hosted.lid",
+      echoedJid: "777:2@hosted.lid",
+    },
+    {
+      name: "phone aliases carried alongside direct LID echoes",
+      outboundJid: "123@s.whatsapp.net",
+      echoedJid: "777@lid",
+      echoedAlternateJid: "123:8@s.whatsapp.net",
+    },
+    {
+      name: "LID aliases carried alongside direct phone echoes",
+      outboundJid: "777@lid",
+      echoedJid: "123@s.whatsapp.net",
+      echoedAlternateJid: "777:3@lid",
+    },
+  ])(
+    "filters provider-normalized outbound self echoes for $name",
+    async ({ outboundJid, echoedJid, echoedAlternateJid }) => {
+      mockLoadConfig.mockReturnValue({
+        channels: {
+          whatsapp: {
+            selfChatMode: true,
+            allowFrom: ["+123"],
+          },
+        },
+        messages: DEFAULT_MESSAGES_CFG,
+      });
+
+      const onMessage = vi.fn();
+      const { listener, sock } = await startInboxMonitor(onMessage);
+      sock.signalRepository.lidMapping.getPNForLID.mockImplementation(async (jid: string) =>
+        jid.startsWith("777@") ? "123@s.whatsapp.net" : null,
+      );
+      const messageId = `bot-provider-echo-${outboundJid}`;
+      sock.sendMessage.mockResolvedValueOnce({ key: { id: messageId } });
+      await listener.sendMessage(outboundJid, "gateway self echo");
+
+      const echoedMessage = {
+        key: {
+          id: messageId,
+          fromMe: true,
+          remoteJid: echoedJid,
+          ...(echoedAlternateJid ? { remoteJidAlt: echoedAlternateJid } : {}),
+        },
+        message: { conversation: "gateway self echo" },
+        messageTimestamp: nowSeconds(),
+      };
+      cleanMessage(echoedMessage, "123@s.whatsapp.net", "777@lid");
+
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [echoedMessage],
+      });
+      await settleInboundWork();
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expectOnlyOutboundChannelActivity();
+      await listener.close();
+    },
+  );
+
+  it("keeps provider-normalized echo matches scoped to their account and message", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          allowFrom: ["+123"],
+        },
+      },
+      messages: DEFAULT_MESSAGES_CFG,
+    });
+
+    const { listener, sock } = await startInboxMonitor(vi.fn());
+    sock.sendMessage.mockResolvedValueOnce({ key: { id: "scoped-hosted-echo" } });
+    await listener.sendMessage("123:7@hosted", "gateway self echo");
+
+    expect(
+      isRecentOutboundMessage({
+        accountId: "other-account",
+        remoteJid: "123@s.whatsapp.net",
+        messageId: "scoped-hosted-echo",
+      }),
+    ).toBe(false);
+    expect(
+      isRecentOutboundMessage({
+        accountId: "default",
+        remoteJid: "123@s.whatsapp.net",
+        messageId: "other-message",
+      }),
+    ).toBe(false);
+
+    await listener.close();
+  });
+
+  it("never treats another group as an alternate direct-chat echo", async () => {
+    const { listener, sock } = await startInboxMonitor(vi.fn());
+    sock.sendMessage.mockResolvedValueOnce({ key: { id: "group-alias-control" } });
+    await listener.sendMessage("12345@g.us", "gateway group message");
+
+    expect(
+      isRecentOutboundMessage({
+        accountId: "default",
+        remoteJid: "67890@g.us",
+        alternateRemoteJid: "12345@g.us",
+        messageId: "group-alias-control",
+      }),
+    ).toBe(false);
 
     await listener.close();
   });


### PR DESCRIPTION
## What Problem This Solves

WhatsApp gateway-originated messages can return as apparent new inbound messages when the provider changes their conversation identity. Device-qualified numbers, legacy `@c.us` identifiers, hosted phone/LID domains, and equivalent direct-message phone/LID aliases previously bypassed the outbound-echo cache and could trigger incorrect pairing, replies, or duplicate work.

## Why This Change Was Made

The existing private dedupe owner stored destination JIDs verbatim even though pinned `baileys@7.0.0-rc13` normalizes incoming JIDs and exposes direct-chat aliases through `remoteJidAlt`. The fix applies the provider's actual canonicalization rules at the owning boundary, narrows decoded hosted users correctly for strict TypeScript, and restricts alternate identity matching to direct conversations.

## User Impact

Gateway-originated WhatsApp self echoes are suppressed consistently across real provider identity representations. Account and message isolation, ordinary human-authored group commands, group participant aliases, access policy, and the existing cache lifetime remain unchanged.

## Evidence

- Actual pinned Baileys `cleanMessage` and `decodeMessageNode`: six frozen-baseline failures become six passing final-production scenarios, including hosted PN/LID domains and direct phone/LID aliases.
- Provider-boundary controls verify cross-account and message-ID isolation, reject cross-group alias matches, and preserve human group messages.
- Dedicated immutable Blacksmith Testbox: **99 WhatsApp test files and 1,263 tests passed**, including the real inbound-monitor regressions.
- Full production extension TypeScript, full extension-test TypeScript, strict owner/provider declaration compatibility, normal type-aware lint, and formatting all passed.
- Four independent hostile reviews and a genuine Sol-high `autoreview --max-priority P3` report zero P0/P1/P2/P3 findings.
- Dedicated Testbox `tbx_01kyxvfbrdt85nfmjysfteyyry` was stopped and verified completed after the successful immutable run: https://github.com/openclaw/openclaw/actions/runs/30685210696.
