### PR TITLE
fix(telegram): record authoritative topic delivery correlation

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1117,12 +1117,37 @@ describe("handleTelegramAction", () => {
     endUserRequest();
   });
 
-  it("marks topic room-event delivery when send uses a separate thread id", async () => {
+  it.each([
+    {
+      label: "a separate forum topic",
+      to: "-100123",
+      threadId: 77,
+      expectedTarget: "-100123:topic:77",
+    },
+    {
+      label: "an explicit forum topic instead of a stale embedded topic",
+      to: "-100123:topic:271",
+      threadId: 404,
+      expectedTarget: "-100123:topic:404",
+    },
+    {
+      label: "an explicit private-chat topic instead of a stale embedded topic",
+      to: "123:topic:7",
+      threadId: 11,
+      expectedTarget: "123:topic:11",
+    },
+    {
+      label: "an explicitly selected General forum topic",
+      to: "-100123:topic:271",
+      threadId: 1,
+      expectedTarget: "-100123:topic:1",
+    },
+  ])("marks topic room-event delivery for $label", async ({ to, threadId, expectedTarget }) => {
     let count = 0;
     const end = telegramInboundEventDelivery.begin(
       "telegram-session",
       {
-        outboundTo: "-100123:topic:77",
+        outboundTo: expectedTarget,
         markInboundEventDelivered: () => {
           count += 1;
         },
@@ -1133,14 +1158,16 @@ describe("handleTelegramAction", () => {
     await handleTelegramAction(
       {
         action: "sendMessage",
-        to: "-100123",
-        threadId: 77,
+        to,
+        threadId,
         content: "Hello from a room event topic",
       },
       telegramConfig(),
       { sessionKey: "telegram-session", inboundEventKind: "room_event" },
     );
 
+    const sent = mockCall(sendMessageTelegram, 0, "room event topic send");
+    expect(requireRecord(sent[2], "room event topic options").messageThreadId).toBe(threadId);
     expect(count).toBe(1);
     end();
   });

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1204,7 +1204,8 @@ describe("handleTelegramAction", () => {
       name: "poll",
       params: {
         action: "poll",
-        to: "@testchannel",
+        to: "-100123:topic:271",
+        threadId: 404,
         question: "Ready?",
         answers: ["Yes", "No"],
       },
@@ -1214,17 +1215,18 @@ describe("handleTelegramAction", () => {
       name: "sticker",
       params: {
         action: "sendSticker",
-        to: "@testchannel",
+        to: "-100123:topic:271",
+        threadId: 404,
         fileId: "sticker-1",
       },
       cfg: telegramConfig({ actions: { sticker: true } }),
     },
-  ])("marks room-event delivery after successful $name actions", async ({ params, cfg }) => {
+  ])("marks room-event delivery after successful $name actions", async ({ name, params, cfg }) => {
     let count = 0;
     const end = telegramInboundEventDelivery.begin(
       "telegram-session",
       {
-        outboundTo: "@testchannel",
+        outboundTo: "-100123:topic:404",
         markInboundEventDelivered: () => {
           count += 1;
         },
@@ -1237,6 +1239,11 @@ describe("handleTelegramAction", () => {
       inboundEventKind: "room_event",
     });
 
+    const sent =
+      name === "poll"
+        ? mockCall(sendPollTelegram, 0, "room event topic poll")
+        : mockCall(sendStickerTelegram, 0, "room event topic sticker");
+    expect(requireRecord(sent[2], "room event topic options").messageThreadId).toBe(404);
     expect(count).toBe(1);
     end();
   });

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -161,7 +161,7 @@ function resolveActionTopicNameCacheScope(cfg: OpenClawConfig, accountId?: strin
 
 function formatTelegramDeliveryTarget(to: string, messageThreadId?: number | null): string {
   const parsed = parseTelegramTarget(to);
-  const topicId = parsed.messageThreadId ?? messageThreadId;
+  const topicId = messageThreadId ?? parsed.messageThreadId;
   if (topicId == null) {
     return to;
   }


### PR DESCRIPTION
## What Problem This Solves

A Telegram message, poll, or sticker action can successfully send to an explicitly selected topic while delivery correlation reports a different stale topic embedded in the target. The topic-specific inbound event then remains falsely undelivered even though the visible Telegram send succeeded.

## Why This Change Was Made

The Telegram send owner already prioritizes explicit `messageThreadId`. The delivery-target formatter now records the same explicit topic. Correlation matching, account/session isolation, and Telegram send behavior stay unchanged.

## User Impact

Successful Telegram actions mark the topic they actually used. Forum General-topic semantics remain intact: topic 1 can be omitted from the Bot API wire while correlation still records topic 1. Private-chat topics remain explicit.

## Evidence

- Exact head `2159cfb369c`; rebased onto `1cf1af4aed3` current main at review time.
- Production delta: `+1/-1` (net zero). Test delta: `+42/-8`. No config, protocol, storage, dependency, or default changes.
- Current-main failure remains at `extensions/telegram/src/action-runtime.ts`: embedded `parsed.messageThreadId` wins over explicit `messageThreadId`; the real send resolver does the opposite.
- Focused owner suite: `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts` -> **107 passed, 0 failed**. Coverage includes conflicting stale/explicit topics for message, poll, and sticker, plus private-chat and General-topic cases.
- Exact changed gate passed locally: formatting, extension production/test typechecks, extension lint, import cycles, plugin boundaries, dead exports, dependency guards, and ratchets. Remote routing was unavailable because the installed Crabbox binary failed its version/help sanity check.

### Real Telegram userbot proof

Run with `$telegram-e2e-userbot`, a fresh ephemeral Gateway, deterministic provider, and two temporary forum topics. No Mantis path was used.

```json
{
  "inboundTopic": 48050,
  "staleTopicEmbeddedInActionTarget": 48049,
  "explicitActionTopic": 48050,
  "providerRequests": 2,
  "gatewaySend": {
    "operation": "sendMessage",
    "messageId": 48052,
    "threadId": 48050
  },
  "userbotTranscript": {
    "ok": true,
    "sender": "sut-bot",
    "text": "OPENCLAW_E2E_TOPIC_ACTION",
    "threadId": 48050
  },
  "temporaryTopicsDeleted": true
}
```

Gateway evidence: `Inbound message telegram:group:<redacted>:topic:48050`, followed by `outbound send ok ... messageId=48052 ... threadId=48050`. The real Telegram user transcript independently observed the SUT message in topic `48050`. The runner's probe selector returned exit 1 despite placing that same matching SUT message in its `observed` array; the post-run userbot transcript returned `ok: true`. This is a harness-selector false negative, not a product-send failure.

The committed correlation assertion covers the internal half of the same action: expected topic 404, stale embedded topic 271, explicit topic 404, actual send option 404, delivery mark count 1. Poll and sticker run the identical conflict case.

### Review passes

- `$prreview`: best narrow owner-boundary fix; P1 because a visible success can leave a false undelivered state.
- `$distill`: removes divergent precedence without adding a path or state.
- `$greybeard`: identical parse/branch/allocation cost; production net zero.
- `$autoreview`: helper preflight and TruffleHog passed, but the review engine could not start because no supported review CLI (`codex`, Claude, Pi, or alternatives) is installed on this box. No clean autoreview result is claimed.