### PR TITLE
fix(ui): preserve workboard session capture ownership

### DIFF
--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { matchesAgentScope } from "../../pages/workboard/agent-filter.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   addWorkboardCardComment,
@@ -2941,10 +2942,109 @@ describe("workboard controller", () => {
       ].join("\n"),
       status: "review",
       priority: "normal",
-      agentId: "",
+      agentId: "main",
       sessionKey: sampleSession.key,
     });
     expect(getWorkboardState(host).cards[0]).toMatchObject({ sessionKey: sampleSession.key });
+  });
+
+  it("keeps captured worker sessions visible and executes them with their owning agent", async () => {
+    state.loaded = true;
+    const session = createGatewaySession({
+      key: "agent:writer:dashboard:captured",
+      label: "Writer follow-up",
+      status: "done",
+      hasActiveRun: false,
+    });
+    const runSessionKey = "agent:writer:subagent:workboard-default-writer-card";
+    let storedCard: WorkboardCard | undefined;
+    const client = createClient((method, params) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "workboard.cards.create") {
+        const input = params as { agentId: string; sessionKey: string; title: string };
+        storedCard = createWorkboardCard({
+          id: "writer-card",
+          title: input.title,
+          status: "review",
+          sessionKey: input.sessionKey,
+          ...(input.agentId ? { agentId: input.agentId } : {}),
+        });
+        return { card: storedCard };
+      }
+      if (method === "workboard.cards.update") {
+        const input = params as { patch: Partial<WorkboardCard> };
+        storedCard = { ...storedCard!, ...input.patch };
+        return { card: storedCard };
+      }
+      if (method === "agent") {
+        return { sessionKey: runSessionKey, runId: "writer-run" };
+      }
+      if (method === "tasks.list") {
+        return {
+          tasks: [
+            createWorkboardTask({
+              id: "writer-task",
+              taskId: "writer-task",
+              agentId: "writer",
+              childSessionKey: runSessionKey,
+              runId: "writer-run",
+            }),
+          ],
+        };
+      }
+      return {};
+    });
+
+    const captured = await captureSessionToWorkboard({ host, client, session });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "workboard.cards.create",
+      expect.objectContaining({ agentId: "writer", sessionKey: session.key }),
+    );
+    expect(captured).not.toBeNull();
+    expect(
+      matchesAgentScope(
+        captured!,
+        {
+          defaultId: "main",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [{ id: "main" }, { id: "writer" }],
+        },
+        "writer",
+      ),
+    ).toBe(true);
+
+    await expect(startWorkboardCard({ host, client, card: captured! })).resolves.toBe(
+      runSessionKey,
+    );
+    expect(client.request).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({ agentId: "writer", sessionKey: runSessionKey }),
+    );
+  });
+
+  it("keeps genuinely unscoped captured sessions assigned to the configured default", async () => {
+    state.loaded = true;
+    const session = createGatewaySession({ key: "legacy-dashboard-session" });
+    const client = createClient((method) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "workboard.cards.create") {
+        return { card: createWorkboardCard({ sessionKey: session.key }) };
+      }
+      return {};
+    });
+
+    await captureSessionToWorkboard({ host, client, session });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "workboard.cards.create",
+      expect.objectContaining({ agentId: "", sessionKey: session.key }),
+    );
   });
 
   it("captures a session on the selected named board", async () => {

--- a/ui/src/lib/workboard/session-capture.ts
+++ b/ui/src/lib/workboard/session-capture.ts
@@ -1,6 +1,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { parseAgentSessionKey } from "../sessions/session-key.ts";
 import {
   isActiveWorkboardCard,
   isFailedSessionStatus,
@@ -220,7 +221,9 @@ export async function captureSessionToWorkboard(params: {
       }),
       status: sessionCaptureStatus(params.session),
       priority: "normal",
-      agentId: "",
+      // Preserve the source thread's owner; only genuinely unscoped legacy
+      // sessions stay unassigned and resolve through the configured default.
+      agentId: parseAgentSessionKey(params.session.key)?.agentId ?? "",
       sessionKey: params.session.key,
       ...selectedWorkboardBoardParams(state),
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes captured worker sessions appearing under the default agent instead of their owning agent in Workboard.

## User Impact

New session captures appear in the correct agent view even when the caller omits or leaves the owner empty. Default-agent and genuinely unscoped/global captures keep their existing behavior. Existing card assignments are not migrated.

## Why This Change Was Made

The original UI capture module has been retired. The current-source repair derives ownership at the capture API/store boundary using the supported session identity helpers, accepts compatible explicit owners, and rejects contradictory owners before mutation. It preserves workspace access checks, capture identity, concurrent winner handling, archived restoration, and the linked-card start guard.

Original contribution: Peter Steinberger (@steipete). Contributor ancestry is retained in the pending local merge.

**Candidate status:** the current-source repair is validated locally but remains unpublished; the branch is still at `06ae626ff63797c36ac8cacde80449dec2515776`. Independent review is quota-blocked until September 21, 2026, 23:35 UTC. No reviewer switch, commit, push, or landing has occurred. Originating-chat image delivery, independent review, and exact-head CI/native landing must complete before merge.

## Evidence

- 240 focused store/API/browser tests passed, including two independent SQLite-host capture/restore races; 6 Doctor-contract tests also passed.
- Extension production/test types, formatting, line-cap ratchets, lint (zero warnings/errors in an isolated physical checkout), and all selected repository guards passed.
- Real disposable Gateway and built browser: writer capture persisted in SQLite and appeared under Writer rather than Main, with default/unscoped/global controls.
- Actual authenticated read-only capture denial and write-scoped workspace denial, including forged workspace authority; contradictory owners, repeated capture, and archived restore verified.
- Current manual-start consumer using real Gateway RPCs: linked cards reject both start modes without sending a request; explicit unlink then manual session creation preserves Writer with the existing compare-and-swap update. No model run was started.
- Disposable acceptance state was cleaned. Screenshots use synthetic data and were inspected before upload.

### Before: captured writer task is missing from Writer

![Before: Writer scope is empty after capturing a writer session](https://github.com/user-attachments/assets/053ac430-3613-45a7-be06-f99aa331a1fe)

### After: captured writer task appears under Writer

![After: Writer scope contains the captured writer task](https://github.com/user-attachments/assets/350e5501-c62f-476e-ace5-03eaae274e20)
