### PR TITLE
fix(ui): scope model provider catalogs to the selected agent

### DIFF
--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -3,13 +3,17 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { loadModelProvidersData } from "./load.ts";
 
 describe("loadModelProvidersData", () => {
-  it("scopes only credential status to the selected agent", async () => {
+  it("keeps selected-agent provider models separate from global default models", async () => {
+    const globalModels = [{ id: "main-default", name: "Main Default", provider: "openai" }];
+    const workerModels = [{ id: "worker-private", name: "Worker Private", provider: "anthropic" }];
     const request = vi.fn(async (method: string, _params?: unknown) => {
       switch (method) {
         case "models.authStatus":
           return { ts: 1, providers: [] };
+        case "chat.metadata":
+          return { models: workerModels };
         case "models.list":
-          return { models: [] };
+          return { models: globalModels };
         case "config.get":
           return { config: {}, hash: "hash" };
         case "usage.status":
@@ -22,16 +26,48 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    await loadModelProvidersData(client, { refresh: true, agentId: "writer" });
+    const result = await loadModelProvidersData(client, { refresh: true, agentId: "writer" });
 
     expect(request).toHaveBeenCalledWith("models.authStatus", {
       refresh: true,
       agentId: "writer",
     });
+    expect(request).toHaveBeenCalledWith("chat.metadata", { agentId: "writer" });
+    expect(result.models).toEqual(globalModels);
+    expect(result.agentModels).toEqual(workerModels);
     expect(request).toHaveBeenCalledWith("usage.status");
     const sessionUsageCall = request.mock.calls.find(([method]) => method === "sessions.usage");
     expect(sessionUsageCall?.[1]).not.toHaveProperty("agentId");
     expect(sessionUsageCall?.[1]).toHaveProperty("agentScope", "all");
+  });
+
+  it("never substitutes another agent's catalog when selected-agent metadata fails", async () => {
+    const globalModels = [{ id: "main-default", name: "Main Default", provider: "openai" }];
+    const request = vi.fn(async (method: string) => {
+      switch (method) {
+        case "chat.metadata":
+          throw new Error("worker metadata unavailable");
+        case "models.authStatus":
+          return { ts: 1, providers: [] };
+        case "models.list":
+          return { models: globalModels };
+        case "config.get":
+          return { config: {}, hash: "hash" };
+        case "usage.status":
+          return { updatedAt: 1, providers: [] };
+        case "sessions.usage":
+          return { aggregates: { byProvider: [] } };
+        default:
+          return {};
+      }
+    });
+
+    const result = await loadModelProvidersData({ request } as unknown as GatewayBrowserClient, {
+      agentId: "writer",
+    });
+
+    expect(result.models).toEqual(globalModels);
+    expect(result.agentModels).toBeNull();
   });
 
   it("degrades an invalid auth-status response without discarding other provider data", async () => {
@@ -57,6 +93,7 @@ describe("loadModelProvidersData", () => {
 
     expect(result.authStatus).toBeNull();
     expect(result.models).toEqual([]);
+    expect(result.agentModels).toEqual([]);
     expect(result.catalogModels).toEqual([]);
     expect(result.config).toEqual({});
     expect(result.providerUsage).toEqual({ updatedAt: 1, providers: [] });

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -19,7 +19,10 @@ export const MODEL_PROVIDERS_COST_DAYS = 30;
 
 export type ModelProvidersData = {
   authStatus: ModelAuthStatusResult | null;
+  /** Global configured catalog used only by default-model selectors. */
   models: ModelCatalogEntry[] | null;
+  /** Selected agent's private configured catalog for provider-card readiness. */
+  agentModels: ModelCatalogEntry[] | null;
   catalogModels: ModelCatalogEntry[] | null;
   config: Record<string, unknown> | null;
   providerUsage: UsageSummary | null;
@@ -31,6 +34,7 @@ export type ModelProvidersData = {
 export const EMPTY_MODEL_PROVIDERS_DATA: ModelProvidersData = {
   authStatus: null,
   models: null,
+  agentModels: null,
   catalogModels: null,
   config: null,
   providerUsage: null,
@@ -65,13 +69,19 @@ export async function loadModelProvidersData(
       : params === undefined
         ? client.request<T>(method)
         : client.request<T>(method, params);
-  const [authStatus, models, catalogModels, config, providerUsage, costByProvider] =
+  const globalModels = loadModels(client, opts).catch(() => null);
+  const [authStatus, models, agentModels, catalogModels, config, providerUsage, costByProvider] =
     await Promise.all([
       loadModelAuthStatus(client, opts).then(
         (result) => ({ ok: true as const, result }),
         (error: unknown) => ({ ok: false as const, error }),
       ),
-      loadModels(client, opts).catch(() => null),
+      globalModels,
+      opts?.agentId
+        ? request<{ models?: ModelCatalogEntry[] }>("chat.metadata", { agentId: opts.agentId })
+            .then((result) => (Array.isArray(result?.models) ? result.models : null))
+            .catch(() => null)
+        : globalModels,
       request<{ models?: ModelCatalogEntry[] }>("models.list", {
         view: "all",
         includeProviderCapabilities: true,
@@ -95,6 +105,7 @@ export async function loadModelProvidersData(
     authStatus:
       authStatus.ok && Array.isArray(authStatus.result?.providers) ? authStatus.result : null,
     models,
+    agentModels,
     catalogModels,
     config,
     providerUsage,

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -49,7 +49,7 @@ function createHarness(initialScopeId: string) {
     });
     return () => releaseAuthStatus?.();
   };
-  const request = vi.fn(async (method: string): Promise<unknown> => {
+  const request = vi.fn(async (method: string, _params?: unknown): Promise<unknown> => {
     switch (method) {
       case "models.authStatus": {
         if (pendingAuthStatus) {
@@ -173,6 +173,72 @@ afterEach(() => {
 });
 
 describe("ModelProvidersPage agent scope", () => {
+  it("shows private worker model readiness without replacing global model defaults", async () => {
+    const { context, request } = createHarness("writer");
+    const globalModels = [
+      { id: "main-default", name: "Main Default", provider: "openai", available: true },
+    ];
+    const workerModels = [
+      { id: "worker-private", name: "Worker Private", provider: "anthropic", available: true },
+    ];
+    request.mockImplementation(async (method, params) => {
+      switch (method) {
+        case "models.authStatus":
+          return {
+            ts: 1,
+            providers: [
+              {
+                provider: "anthropic",
+                displayName: "Anthropic",
+                status: "ok",
+                profiles: [{ profileId: "anthropic:writer", type: "api_key", status: "ok" }],
+              },
+            ],
+          };
+        case "chat.metadata":
+          return { models: workerModels };
+        case "models.list":
+          return {
+            models:
+              (params as { view?: string } | undefined)?.view === "configured"
+                ? globalModels
+                : [...globalModels, ...workerModels],
+          };
+        case "config.get":
+          return {
+            config: { agents: { defaults: { model: { primary: "openai/main-default" } } } },
+            hash: "hash",
+          };
+        case "usage.status":
+          return { updatedAt: 1, providers: [] };
+        case "sessions.usage":
+          return { aggregates: { byProvider: [] } };
+        default:
+          return {};
+      }
+    });
+    const page = appendPage(context);
+
+    await vi.waitFor(() => {
+      const workerCard = page.querySelector('[data-provider-id="anthropic"]');
+      expect(workerCard?.textContent).toContain("1 model");
+      expect(workerCard?.textContent).toContain("Ready");
+    });
+
+    const primaryModel = page.querySelector<HTMLSelectElement>(".model-providers__defaults select");
+    expect([...primaryModel!.options].map((option) => option.value)).toContain(
+      "openai/main-default",
+    );
+    expect([...primaryModel!.options].map((option) => option.value)).not.toContain(
+      "anthropic/worker-private",
+    );
+    expect(request).toHaveBeenCalledWith(
+      "chat.metadata",
+      { agentId: "writer" },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
   it("links the page subtitle to the model providers guide", async () => {
     const { context } = createHarness("main");
     const page = appendPage(context);

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -611,6 +611,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     const configBusy = this.configBusy();
     const cards = buildModelProviderCards({
       ...data,
+      models: data.agentModels,
       configProviderIds: config.providerIds,
       configApiKeyProviderIds: config.apiKeyProviderIds,
       configProviderAuthModes: config.providerAuthModes,


### PR DESCRIPTION
## What Problem This Solves

Model Provider cards correctly queried the selected worker’s authentication status but calculated available model counts and readiness from the default agent’s global `models.list`. A worker with valid private provider credentials therefore appeared to have zero models or be unavailable, while default-agent models could appear on another agent’s cards.

## Why This Change Was Made

Use the already-shipped, read-scoped `chat.metadata {agentId}` projection for the selected agent’s card catalog, while retaining the existing global `models.list` catalog for global default-model selectors. Model discovery remains scoped, abortable, and fail-closed: failure never silently substitutes a different agent’s catalog.

## User Impact

Provider cards now show the actual selected agent’s configured models and readiness. Global default model selection still reflects the global/default agent. No credentials, profile secrets, or additional privileges are exposed.

## Evidence

- Exact parent: `618f3298c7dc00a41549e4dec41d8412f651624b`; exact immutable commit: `7acb88c02402bf8944736251f2f2165bb62591d3`.
- Actual isolated production Gateway with real token-authenticated WebSocket, operator.read scope and per-agent SQLite credential fixtures: `models.list` contained only default-agent `qa-main`; selected worker `chat.metadata` contained private `qa-worker`; previous worker card readiness/count incorrectly reported zero. Credential scans found no secret fields in metadata.
- Authentic owner/UI RED: four failures before the fix; scoped worker cards, global default-model selector preservation, failure-null/no cross-agent substitution and cancellation all pass afterward.
- Focused existing loader/page and adjacent model-provider sibling suites: **68/68 tests passed**. Targeted oxlint, oxfmt and `git diff --check` clean.
- Genuine full-branch P0–P3 Codex review: **zero findings**, confidence **0.88**, TruffleHog clean. Three independent hostile owner/Gateway/privacy reviews: **zero findings**, confidences **0.99**, **0.98**, and **0.98**.
- Production: **14 lines added / 2 removed / net +12**; exactly four existing approved owner/test files; no auth, public config, Gateway protocol, provider credentials, SDK, storage schema, or generated changes.
- Current canonical main: `4fb19fb8c586b2d7801d1c512a4ac21e4d826505`; exact conflict-free synthetic merge tree: `3d7e62cb7761fd60c07fa1165ebe5781dce7220b`. Full owner/caller/sibling source and Gateway contract re-audited; no semantic overlap with intervening main changes.
