### PR TITLE
fix(whatsapp): canonicalize accepted group participant lifecycle

### DIFF
--- a/extensions/whatsapp/src/inbound/group-metadata-cache.ts
+++ b/extensions/whatsapp/src/inbound/group-metadata-cache.ts
@@ -5,6 +5,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import {
+  readWhatsAppBaileysCacheEntry,
   rememberWhatsAppBaileysCacheEntry,
   type WhatsAppBaileysGroupMetadataCache,
 } from "./baileys-cache.js";
@@ -153,10 +154,24 @@ export function createWhatsAppGroupMetadataCacheOwner(params: GroupMetadataCache
       return cached;
     }
     try {
-      const meta = await (params.getCurrentSock() ?? params.sock).groupMetadata(jid);
-      rememberWhatsAppBaileysCacheEntry(params.baileysCache, jid, meta, GROUP_META_TTL_MS);
+      const hydratedEntry = params.baileysCache?.get(jid);
+      const providerMetadata = params.baileysCache
+        ? readWhatsAppBaileysCacheEntry(params.baileysCache, jid)
+        : undefined;
+      const hydratedMetadata = providerMetadata?.participants?.length
+        ? providerMetadata
+        : undefined;
+      const meta =
+        hydratedMetadata ?? (await (params.getCurrentSock() ?? params.sock).groupMetadata(jid));
+      if (!hydratedMetadata) {
+        rememberWhatsAppBaileysCacheEntry(params.baileysCache, jid, meta, GROUP_META_TTL_MS);
+      }
       publishedJids.add(jid);
       const entry = await summarize(meta);
+      if (hydratedMetadata && hydratedEntry) {
+        // Reusing provider-owned membership must not extend its authoritative freshness window.
+        entry.expires = hydratedEntry.expiresAt;
+      }
       rememberGroupMetadataCacheEntry(reconnectCache, jid, {
         subject: entry.subject,
         expires: entry.expires,

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -622,6 +622,147 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("group metadata cache reuses hydrated participant identities without querying WhatsApp again", async () => {
+    const participantLid = "277038292303944@lid";
+    const participantPhone = "15551234567@s.whatsapp.net";
+    const sock = getSock();
+    sock.groupFetchAllParticipating.mockResolvedValueOnce({
+      "123@g.us": {
+        id: "123@g.us",
+        subject: "Hydrated Group",
+        owner: undefined,
+        participants: [{ id: participantLid, phoneNumber: participantPhone }],
+      },
+    });
+    sock.signalRepository.lidMapping.getPNForLID.mockResolvedValue(participantPhone);
+
+    const { listener, baileysCache } = await startInboxMonitorWithBaileysCache();
+    try {
+      await vi.waitFor(() => {
+        expect(baileysCache.baileysGroupMetaCache.has("123@g.us")).toBe(true);
+      });
+      sock.groupMetadata.mockRejectedValue(new Error("408 timed out"));
+
+      await listener.sendMessage("123@g.us", "ping @+15551234567");
+
+      expect(sock.groupMetadata).not.toHaveBeenCalled();
+      expect(sock.sendMessage).toHaveBeenCalledWith("123@g.us", {
+        text: "ping @277038292303944",
+        mentions: [participantLid],
+      });
+    } finally {
+      await listener.close();
+    }
+  });
+
+  it("group metadata cache refreshes provider snapshots that omit participant identities", async () => {
+    const sock = getSock();
+    sock.groupFetchAllParticipating.mockResolvedValueOnce({
+      "123@g.us": groupMetadata({ subject: "Incomplete Group", participants: [] }),
+    });
+    sock.groupMetadata.mockResolvedValueOnce(
+      groupMetadata({
+        subject: "Complete Group",
+        participants: ["15551234567@s.whatsapp.net"],
+      }),
+    );
+
+    const { listener, baileysCache } = await startInboxMonitorWithBaileysCache();
+    try {
+      await vi.waitFor(() => {
+        expect(baileysCache.baileysGroupMetaCache.get("123@g.us")?.value.participants).toEqual([]);
+      });
+
+      await listener.sendMessage("123@g.us", "recovered @15551234567");
+
+      expect(sock.groupMetadata).toHaveBeenCalledOnce();
+      expect(sock.sendMessage).toHaveBeenCalledWith("123@g.us", {
+        text: "recovered @15551234567",
+        mentions: ["15551234567@s.whatsapp.net"],
+      });
+      await expectCachedGroupMetadata(baileysCache, {
+        id: "123@g.us",
+        subject: "Complete Group",
+        participants: [{ id: "15551234567@s.whatsapp.net" }],
+      });
+    } finally {
+      await listener.close();
+    }
+  });
+
+  it("group metadata cache never extends hydrated participant identities beyond their provider expiry", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const sock = getSock();
+    sock.groupFetchAllParticipating.mockResolvedValueOnce({
+      "123@g.us": groupMetadata({
+        subject: "Expiring Group",
+        participants: ["15551234567@s.whatsapp.net"],
+      }),
+    });
+    sock.groupMetadata.mockRejectedValue(new Error("408 timed out"));
+
+    const { listener, baileysCache } = await startInboxMonitorWithBaileysCache();
+    try {
+      await vi.waitFor(() => {
+        expect(baileysCache.baileysGroupMetaCache.get("123@g.us")?.expiresAt).toBe(
+          1_700_000_300_000,
+        );
+      });
+
+      dateNow.mockReturnValue(1_700_000_299_000);
+      await listener.sendMessage("123@g.us", "fresh @15551234567");
+
+      dateNow.mockReturnValue(1_700_000_300_001);
+      await listener.sendMessage("123@g.us", "expired @15551234567");
+
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(1, "123@g.us", {
+        text: "fresh @15551234567",
+        mentions: ["15551234567@s.whatsapp.net"],
+      });
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(2, "123@g.us", {
+        text: "expired @15551234567",
+      });
+      expect(sock.groupMetadata).toHaveBeenCalledTimes(1);
+      expect(baileysCache.baileysGroupMetaCache.has("123@g.us")).toBe(false);
+    } finally {
+      dateNow.mockRestore();
+      await listener.close();
+    }
+  });
+
+  it("group metadata cache drops hydrated local participants when membership changes", async () => {
+    const sock = getSock();
+    sock.groupFetchAllParticipating.mockResolvedValueOnce({
+      "123@g.us": groupMetadata({
+        subject: "Changing Group",
+        participants: ["15551234567@s.whatsapp.net"],
+      }),
+    });
+    const { listener, baileysCache } = await startInboxMonitorWithBaileysCache();
+    try {
+      await vi.waitFor(() => {
+        expect(baileysCache.baileysGroupMetaCache.has("123@g.us")).toBe(true);
+      });
+      await listener.sendMessage("123@g.us", "before @15551234567");
+      sock.groupMetadata.mockRejectedValue(new Error("408 timed out"));
+
+      sock.ev.emit("group-participants.update", { id: "123@g.us" });
+      await listener.sendMessage("123@g.us", "after @15551234567");
+
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(1, "123@g.us", {
+        text: "before @15551234567",
+        mentions: ["15551234567@s.whatsapp.net"],
+      });
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(2, "123@g.us", {
+        text: "after @15551234567",
+      });
+      expect(sock.groupMetadata).toHaveBeenCalledTimes(1);
+      expect(baileysCache.baileysGroupMetaCache.has("123@g.us")).toBe(false);
+    } finally {
+      await listener.close();
+    }
+  });
+
   it("group metadata cache invalidates partial group and participant updates", async () => {
     const groupMetadataCache: NonNullable<InboxMonitorOptions["groupMetadataCache"]> = new Map();
     const { listener, sock, baileysCache } = await startInboxMonitorWithBaileysCache({


### PR DESCRIPTION
## What Problem This Solves

WhatsApp already loads complete group-participant metadata during startup, but inbound normalization and outbound mentions discarded that provider-owned snapshot and retried the network. When the redundant request timed out, incoming participant context disappeared and otherwise-valid LID mentions were silently omitted from text and media replies.

## Why This Change Was Made

Make the existing group-metadata lifecycle owner reuse its account-scoped Baileys snapshot only when it contains actual participant identities. Keep the provider's original expiration deadline, refresh genuinely incomplete snapshots from WhatsApp, and preserve group-update invalidation and subject-only reconnect state. Four focused regressions cover hydrated LID mentions, empty participant snapshots, authoritative expiry, and membership removal.

## User Impact

WhatsApp group replies now deliver native mentions and inbound participant context even when a redundant metadata query would have failed. Valid cached groups avoid an unnecessary provider round trip; expired, incomplete, changed, cross-account, and reconnect-only data never acquire additional access.

## Evidence

- Immutable candidate: c3bf61d15f048fda493abde690114af11a8df7e1; tree: 50d9658e7fa0c3b0fff5ae8541fcb0b4b1481402; parent: 618f3298c7dc00a41549e4dec41d8412f651624b.
- Latest reviewed main: 4fb19fb8c586b2d7801d1c512a4ac21e4d826505; conflict-free synthetic merge tree: bcd6456bc1fa9ac938f4b6af01c6c6403c74c2d0.
- Actual installed Baileys 7.0.0-rc13 provider parsing and generated WhatsApp message wire: 12/12 scenarios pass, including hydrated LID text/media mentions, empty-snapshot network recovery, provider-owned expiry, group invalidation, account isolation, and subject-only reconnect privacy.
- Hosted Blacksmith Testbox tbx_01kyxv6h4x1dqsj49sfat8j6j6: targeted WhatsApp owner and sibling suites 155/155 passing; full extension production typecheck passing; full extension test typecheck passing; changed-file type-aware lint and formatting passing. https://github.com/openclaw/openclaw/actions/runs/30685053231
- Full WhatsApp sweep passed 1,258/1,259 tests; its only failure was an unchanged asynchronous outbound-log fixture race, which passed when rerun independently on the exact candidate.
- Independent full-priority Codex review: no findings; real TruffleHog scan clean; three hostile independent reviews found no remaining P0/P1/P2/P3 issues.
