### PR TITLE
fix(plugins): hash loader cache keys so plugin config never leaks into diagnostics

### DIFF
--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -152,16 +152,6 @@ function buildActivationMetadataHash(params: {
     .digest("hex");
 }
 
-function redactPluginConfigForCacheKey(plugins: NormalizedPluginsConfig): NormalizedPluginsConfig {
-  const entries = Object.fromEntries(
-    Object.entries(plugins.entries).map(([pluginId, entry]) => [
-      pluginId,
-      "config" in entry ? { ...entry, config: "<plugin-config>" } : entry,
-    ]),
-  );
-  return { ...plugins, entries };
-}
-
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
@@ -227,15 +217,18 @@ function buildCacheKey(params: {
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
   const activationMode = params.activate === false ? "snapshot" : "active";
-  return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
-    bundledPackage,
-    devSourceRoot: params.devSourceRoot ?? "",
-    discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
-    ...params.plugins,
-    installs,
-    loadPaths,
-    activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
+  const cacheIdentity = `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify(
+    {
+      bundledPackage,
+      devSourceRoot: params.devSourceRoot ?? "",
+      discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
+      ...params.plugins,
+      installs,
+      loadPaths,
+      activationMetadataKey: params.activationMetadataKey ?? "",
+    },
+  )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
+  return createHash("sha256").update(cacheIdentity).digest("hex");
 }
 
 export function resolveRuntimeSubagentMode(
@@ -384,9 +377,7 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const devSourceRoot = resolveOpenClawDevSourceRoot(env);
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
-    plugins: shouldResolveRawConfigEnvVars
-      ? redactPluginConfigForCacheKey(trustNormalized)
-      : trustNormalized,
+    plugins: trustNormalized,
     activationMetadataKey: buildActivationMetadataHash({
       activationSource,
       autoEnabledReasons: options.autoEnabledReasons ?? {},

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -23,6 +23,7 @@ import {
   clearPluginInteractiveHandlers,
   resolvePluginInteractiveNamespaceMatch,
 } from "./interactive-registry.js";
+import { resolvePluginRegistryLoadCacheKey } from "./loader-cache.js";
 import { loadOpenClawPlugins, resolveRuntimePluginRegistry } from "./loader.js";
 import {
   EMPTY_PLUGIN_SCHEMA,
@@ -1384,9 +1385,10 @@ describe("loadOpenClawPlugins", () => {
       },
     },
     {
-      label: "fails loudly when a plugin reenters the same snapshot load during register",
+      label: "does not expose plugin config in cache keys or reentry diagnostics",
       run: () => {
         useNoBundledPlugins();
+        const pluginConfigSentinel = "hunter2-sentinel";
         const marker = "__openclaw_loader_reentry_error";
         const reenterFnMarker = "__openclaw_loader_reentry_fn";
         Reflect.deleteProperty(globalThis, marker);
@@ -1405,6 +1407,9 @@ describe("loadOpenClawPlugins", () => {
             plugins: {
               load: { paths: [pluginFile] },
               allow: ["reentrant-snapshot"],
+              entries: {
+                "reentrant-snapshot": { config: { token: pluginConfigSentinel } },
+              },
             },
           },
         } satisfies Parameters<typeof loadOpenClawPlugins>[0];
@@ -1412,6 +1417,11 @@ describe("loadOpenClawPlugins", () => {
           id: "reentrant-snapshot",
           dir: pluginDir,
           filename: "reentrant-snapshot.cjs",
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: { token: { type: "string" } },
+          },
           body: `module.exports = {
     id: "reentrant-snapshot",
     register() {
@@ -1428,6 +1438,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
+        const cacheKey = resolvePluginRegistryLoadCacheKey(nestedOptions);
+        expect(cacheKey).toMatch(/^[a-f0-9]{64}$/);
+        expect(cacheKey).not.toContain(pluginConfigSentinel);
         const registry = loadOpenClawPlugins(nestedOptions);
 
         try {
@@ -1435,10 +1448,14 @@ describe("loadOpenClawPlugins", () => {
             | { name?: unknown; message?: unknown }
             | undefined;
           expect(reentryError?.name).toBe("PluginLoadReentryError");
-          expect(String(reentryError?.message)).toContain("plugin load reentry detected");
+          expect(reentryError?.message).toBe(
+            `plugin load reentry detected for cache key: ${cacheKey}`,
+          );
+          expect(String(reentryError?.message)).not.toContain(pluginConfigSentinel);
           const record = registry.plugins.find((entry) => entry.id === "reentrant-snapshot");
           expect(record?.status).toBe("error");
-          expect(record?.error).toContain("plugin load reentry detected");
+          expect(record?.error).toContain(cacheKey);
+          expect(record?.error).not.toContain(pluginConfigSentinel);
           expect(record?.failurePhase).toBe("register");
         } finally {
           Reflect.deleteProperty(globalThis, marker);


### PR DESCRIPTION
## What Problem This Solves

Plugin-registry cache keys embed the full JSON-serialized normalized plugins config — including arbitrary per-plugin `entries[<id>].config` values — via `buildCacheKey` in `src/plugins/loader-load-context.ts`. That key is interpolated verbatim into `PluginLoadReentryError` ("plugin load reentry detected for cache key: …"), which lands in `registry.plugins[].error` and is therefore reachable from plugin status/diagnostics output. Anything an operator put in plugin config (tokens, URLs, internal names) could surface in diagnostics.

A partial redaction helper existed but only applied on the `resolveRawConfigEnvVars` path — every other load path serialized config into the key unredacted.

## Why This Change Was Made

The key's only consumers compare it for equality (cache lookup, active-registry compatibility matching re-derives keys through the same builder). Nothing parses its structure. So the complete cache identity is now SHA-256 hashed: identical inputs produce identical keys, and no configuration bytes can appear in any key, error message, or status output. The now-redundant partial redaction helper is deleted rather than kept "just in case" — hashing supersedes it, and the raw-env path it guarded already had registry caching disabled.

## User Impact

Plugin configuration values can no longer leak into error messages, logs, or `openclaw plugins` status output via loader cache keys. No behavior change to caching: hit/miss semantics are identical for identical inputs.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts` — 179/179 pass (verified independently by reviewer session); full loader family run by implementation session: 8 files, 221 tests.
- New regression test: a sentinel config value (`hunter2-sentinel`) is asserted absent from the cache key, the reentry error message, and the plugin status error; the key is asserted to be a 64-char hex digest; the reentry assertion upgraded from substring to exact-message equality.
- Structured autoreview (Codex, gpt-5.6-sol, high): clean, no actionable findings.
- Prod diff is net -9 LOC (redaction helper deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Runtime proof (added post-review)

Redacted terminal transcript triggering the real reentry path through the built dist loader, with a sentinel in plugin config: the emitted `PluginLoadReentryError` and `registry.plugins[].error` contain only the 64-char SHA-256 digest; the sentinel is absent from the error and from the entire serialized registry. Full transcript: https://github.com/openclaw/openclaw/pull/117237#issuecomment-5150039447

Live gateway on an integration build including this change: 3 plugins load in 1.0s, `/readyz` reports ready, clean 44ms shutdown — no caching behavior change.
