### PR TITLE
fix(imessage): preserve accepted attachment delivery custody

### DIFF
--- a/extensions/imessage/src/channel.runtime.test.ts
+++ b/extensions/imessage/src/channel.runtime.test.ts
@@ -145,4 +145,40 @@ describe("sendIMessageOutbound approval identity", () => {
       expect.objectContaining({ conversationReadOrigin: "delegated" }),
     );
   });
+
+  it("forwards accepted attachment progress before a later native caption failure", async () => {
+    const receipt = {
+      primaryPlatformMessageId: "p:0/accepted-attachment",
+      platformMessageIds: ["p:0/accepted-attachment"],
+      parts: [{ platformMessageId: "p:0/accepted-attachment", kind: "media" as const, index: 0 }],
+      sentAt: 1_000,
+    };
+    const accepted = {
+      content: "",
+      messageId: "p:0/accepted-attachment",
+      messageIds: ["p:0/accepted-attachment"],
+      sentText: "",
+      receipt,
+      visibleReplySent: true as const,
+    };
+    const captionError = new Error("caption failed after accepted attachment");
+    const send = vi.fn(async (_to, _text, options) => {
+      await options.onDeliveryResult?.(accepted);
+      throw captionError;
+    });
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendIMessageOutbound({
+        cfg: {} as never,
+        to: "+15551230000",
+        text: "caption",
+        mediaUrl: "/tmp/report.pdf",
+        deps: { imessage: send },
+        onDeliveryResult,
+      }),
+    ).rejects.toBe(captionError);
+
+    expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(accepted);
+  });
 });

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -22,6 +22,7 @@ export async function sendIMessageOutbound(params: {
   deps?: { [channelId: string]: unknown };
   replyToId?: string;
   conversationReadOrigin?: "delegated" | "direct-operator";
+  onDeliveryResult?: NonNullable<Parameters<IMessageSendFn>[2]["onDeliveryResult"]>;
 }) {
   const send =
     resolveOutboundSendDep<IMessageSendFn>(params.deps, "imessage", {
@@ -43,6 +44,7 @@ export async function sendIMessageOutbound(params: {
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
     conversationReadOrigin: params.conversationReadOrigin,
+    ...(params.onDeliveryResult ? { onDeliveryResult: params.onDeliveryResult } : {}),
   });
   const meta = {
     ...(result as typeof result & { meta?: Record<string, unknown> }).meta,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -173,6 +173,19 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         replyToId: ctx.replyToId ?? undefined,
         conversationReadOrigin: (ctx as typeof ctx & IMessageMessageContextExtras)
           .conversationReadOrigin,
+        ...(ctx.onDeliveryResult
+          ? {
+              onDeliveryResult: async (acceptedResult) => {
+                await ctx.onDeliveryResult?.(
+                  toIMessageMessageSendResult(
+                    acceptedResult,
+                    ctx.audioAsVoice ? "voice" : "media",
+                    ctx.replyToId,
+                  ),
+                );
+              },
+            }
+          : {}),
       });
       return toIMessageMessageSendResult(
         result,
@@ -457,6 +470,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
           accountId,
           deps,
           replyToId,
+          onDeliveryResult,
         }) =>
           await (
             await loadIMessageChannelRuntime()
@@ -470,6 +484,21 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
             accountId: accountId ?? undefined,
             deps,
             replyToId: replyToId ?? undefined,
+            ...(onDeliveryResult
+              ? {
+                  onDeliveryResult: async (result) => {
+                    await onDeliveryResult({
+                      channel: "imessage",
+                      ...toIMessageMessageSendResult(
+                        result,
+                        audioAsVoice ? "voice" : "media",
+                        replyToId,
+                      ),
+                      messageId: result.messageId,
+                    });
+                  },
+                }
+              : {}),
           }),
       },
     },

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IMessageRpcClient } from "./client.js";
@@ -93,6 +94,12 @@ describe("sendMessageIMessage receipts", () => {
     vi.useRealTimers();
     await openClawState.cleanup();
   });
+
+  function createOutboundMediaFile(filename: string, contents: Buffer): string {
+    const sourcePath = openClawState.path(filename);
+    fs.writeFileSync(sourcePath, contents);
+    return sourcePath;
+  }
 
   it("attaches a text receipt for native send ids", async () => {
     const client = createClient({ guid: "p:0/imsg-1" });
@@ -560,6 +567,71 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it.each([
+    { kind: "document", filename: "quarterly-report.pdf", audioAsVoice: false },
+    { kind: "voice", filename: "spoken-reply.mp3", audioAsVoice: true },
+  ] as const)(
+    "preserves the original $kind filename through the real media store and native CLI provider",
+    async ({ filename, audioAsVoice }) => {
+      const attachmentBytes = Buffer.from(`actual-provider-attachment-${filename}`);
+      const sourcePath = createOutboundMediaFile(filename, attachmentBytes);
+      const deliveredPaths: string[] = [];
+      const runCliJson = vi.fn(async (args: readonly string[]) => {
+        const attachmentPath = args[args.indexOf("--file") + 1];
+        expect(attachmentPath).toBeDefined();
+        deliveredPaths.push(attachmentPath!);
+        expect(fs.readFileSync(attachmentPath!)).toEqual(attachmentBytes);
+        return { messageId: "p:0/provider-accepted-media" };
+      });
+
+      await sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        mediaUrl: sourcePath,
+        mediaLocalRoots: [openClawState.root],
+        audioAsVoice,
+        runCliJson,
+      });
+
+      expect(deliveredPaths.map((attachmentPath) => path.basename(attachmentPath))).toEqual([
+        filename,
+      ]);
+      expect(fs.existsSync(deliveredPaths[0]!)).toBe(false);
+      const storedFilenames = fs.readdirSync(openClawState.statePath("media", "outbound"));
+      expect(storedFilenames).toHaveLength(1);
+      expect(storedFilenames[0]).toMatch(/---[a-f\d-]{36}\./iu);
+      expect(
+        fs.readFileSync(openClawState.statePath("media", "outbound", storedFilenames[0]!)),
+      ).toEqual(attachmentBytes);
+      expect(fs.existsSync(sourcePath)).toBe(true);
+    },
+  );
+
+  it("cleans an original-name CLI attachment workspace when the native provider rejects it", async () => {
+    const filename = "rejected-report.pdf";
+    const sourcePath = createOutboundMediaFile(filename, Buffer.from("provider rejection bytes"));
+    let deliveredPath: string | undefined;
+    const providerError = new Error("native attachment rejected");
+    const runCliJson = vi.fn(async (args: readonly string[]) => {
+      deliveredPath = args[args.indexOf("--file") + 1];
+      expect(path.basename(deliveredPath!)).toBe(filename);
+      expect(fs.existsSync(deliveredPath!)).toBe(true);
+      throw providerError;
+    });
+
+    await expect(
+      sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        mediaUrl: sourcePath,
+        mediaLocalRoots: [openClawState.root],
+        runCliJson,
+      }),
+    ).rejects.toBe(providerError);
+
+    expect(deliveredPath).toBeDefined();
+    expect(fs.existsSync(deliveredPath!)).toBe(false);
+    expect(fs.readdirSync(openClawState.statePath("media", "outbound"))).toHaveLength(1);
+  });
+
   it("sends audioAsVoice media through send-attachment audio transport", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });
@@ -1009,6 +1081,44 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  it("preserves staged filenames across native RPC sends and their unthreaded retry", async () => {
+    const filename = "threaded-review.pdf";
+    const attachmentBytes = Buffer.from("actual native rpc provider bytes");
+    const sourcePath = createOutboundMediaFile(filename, attachmentBytes);
+    const deliveredPaths: string[] = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        const attachmentPath = params.file as string;
+        deliveredPaths.push(attachmentPath);
+        expect(fs.readFileSync(attachmentPath)).toEqual(attachmentBytes);
+        if (params.reply_to) {
+          throw new Error(
+            "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+          );
+        }
+        return { guid: "p:0/provider-accepted-rpc" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_id:42", "caption", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      conversationReadOrigin: "direct-operator",
+      replyToId: "p:0/thread-root",
+      mediaUrl: sourcePath,
+      mediaLocalRoots: [openClawState.root],
+    });
+
+    expect(result.messageId).toBe("p:0/provider-accepted-rpc");
+    expect(deliveredPaths.map((attachmentPath) => path.basename(attachmentPath))).toEqual([
+      filename,
+      filename,
+    ]);
+    expect(deliveredPaths.every((attachmentPath) => !fs.existsSync(attachmentPath))).toBe(true);
+    expect(fs.readdirSync(openClawState.statePath("media", "outbound"))).toHaveLength(1);
+  });
+
   it("sends DM handle media captions as attachment plus follow-up text", async () => {
     const client = createClient({ guid: "p:0/caption-guid" });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
@@ -1046,8 +1156,68 @@ describe("sendMessageIMessage receipts", () => {
   });
 
   it("does not persist caption text when the caption follow-up send fails", async () => {
-    const client = createRejectingClient(new Error("caption failed"));
+    const captionError = new Error("caption failed");
+    const client = createRejectingClient(captionError);
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
+    const onDeliveryResult = vi.fn();
+
+    let observedError: unknown;
+    try {
+      await sendMessageIMessage("imessage:+15550004567", "caption", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        mediaUrl: "/tmp/image.png",
+        resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+        runCliJson,
+        onDeliveryResult,
+      });
+    } catch (error) {
+      observedError = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observedError)).toBe(true);
+    expect(observedError).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      cause: captionError,
+      sentBeforeError: true,
+      visibleReplySent: true,
+      deliveryResult: {
+        content: "",
+        messageIds: ["p:0/dm-media-guid"],
+        receipt: {
+          primaryPlatformMessageId: "p:0/dm-media-guid",
+          platformMessageIds: ["p:0/dm-media-guid"],
+          parts: [expect.objectContaining({ kind: "media" })],
+        },
+        visibleReplySent: true,
+      },
+    });
+    expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        content: "",
+        messageId: "p:0/dm-media-guid",
+        messageIds: ["p:0/dm-media-guid"],
+        visibleReplySent: true,
+        receipt: expect.objectContaining({
+          platformMessageIds: ["p:0/dm-media-guid"],
+        }),
+      }),
+    );
+    const scope = "default:imessage:+15550004567";
+    expect(hasPersistedIMessageEcho({ scope, text: "caption" })).toBe(false);
+    expect(
+      hasPersistedIMessageEcho({ scope, media: { contentType: "image/png", kind: "image" } }),
+    ).toBe(true);
+    expect(hasPersistedIMessageEcho({ scope, messageId: "p:0/dm-media-guid" })).toBe(true);
+  });
+
+  it("stops before a caption when accepted attachment custody cannot be recorded", async () => {
+    const custodyError = new Error("accepted attachment custody failed");
+    const client = createClient({ guid: "p:0/caption-guid" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
+    const onDeliveryResult = vi.fn(async () => {
+      throw custodyError;
+    });
 
     await expect(
       sendMessageIMessage("imessage:+15550004567", "caption", {
@@ -1056,14 +1226,24 @@ describe("sendMessageIMessage receipts", () => {
         mediaUrl: "/tmp/image.png",
         resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
         runCliJson,
+        onDeliveryResult,
       }),
-    ).rejects.toThrow("caption failed");
-    const scope = "default:imessage:+15550004567";
-    expect(hasPersistedIMessageEcho({ scope, text: "caption" })).toBe(false);
-    expect(
-      hasPersistedIMessageEcho({ scope, media: { contentType: "image/png", kind: "image" } }),
-    ).toBe(true);
-    expect(hasPersistedIMessageEcho({ scope, messageId: "p:0/dm-media-guid" })).toBe(true);
+    ).rejects.toBe(custodyError);
+
+    expect(isChannelPartialDeliveryError(custodyError)).toBe(false);
+    expect(runCliJson).toHaveBeenCalledOnce();
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+    expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        content: "",
+        messageId: "p:0/dm-media-guid",
+        messageIds: ["p:0/dm-media-guid"],
+        receipt: expect.objectContaining({
+          platformMessageIds: ["p:0/dm-media-guid"],
+        }),
+        visibleReplySent: true,
+      }),
+    );
   });
 
   it("returns the caption message id when captioned attachment only has a placeholder id", async () => {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,6 +1,10 @@
 // Imessage plugin module implements send behavior.
 import { constants, accessSync } from "node:fs";
-import type { MediaPlaceholderTextFact } from "openclaw/plugin-sdk/channel-inbound";
+import { basename } from "node:path";
+import {
+  createChannelPartialDeliveryError,
+  type MediaPlaceholderTextFact,
+} from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -9,10 +13,15 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-import { kindFromMime, resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
+import {
+  extractOriginalFilename,
+  kindFromMime,
+  resolveOutboundAttachmentFromUrl,
+} from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import {
@@ -79,6 +88,7 @@ type IMessageSendOpts = {
   ) => Promise<{ path: string; contentType?: string }>;
   createClient?: (params: { cliPath: string; dbPath?: string }) => Promise<IMessageRpcClient>;
   runCliJson?: (args: readonly string[]) => Promise<Record<string, unknown>>;
+  onDeliveryResult?: (result: IMessageDeliveryProgress) => Promise<void> | void;
   resolveMessageGuidImpl?: (params: {
     dbPath?: string;
     messageId: string;
@@ -115,6 +125,13 @@ type IMessageSendResult = {
   echoText?: string;
   echoMedia?: MediaPlaceholderTextFact;
   receipt: MessageReceipt;
+};
+
+type IMessageDeliveryProgress = IMessageSendResult & {
+  content: string;
+  messageIds: string[];
+  visibleReplySent: true;
+  replyToId?: string;
 };
 
 function resolveMessageId(result: Record<string, unknown> | null | undefined): string | null {
@@ -433,6 +450,22 @@ function isConcreteIMessageMessageId(messageId: string | undefined): boolean {
   return Boolean(trimmed && trimmed !== "unknown" && trimmed !== "ok");
 }
 
+async function withOriginalIMessageAttachmentPath<T>(
+  filePath: string,
+  send: (attachmentPath: string) => Promise<T>,
+): Promise<T> {
+  const filename = extractOriginalFilename(filePath);
+  if (basename(filePath) === filename) {
+    return await send(filePath);
+  }
+  // The bridge exposes this basename and copies its bytes before returning;
+  // keep the UUID-backed media-store file intact while its private alias is live.
+  return await withTempWorkspace(
+    { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-imessage-outbound-" },
+    async (workspace) => await send(await workspace.copyIn(filename, filePath)),
+  );
+}
+
 function canSynthesizeAttachmentChatHandle(raw: string): boolean {
   const trimmed = raw.trim();
   return trimmed.includes("@") || trimmed.startsWith("+");
@@ -611,18 +644,20 @@ async function trySendAttachmentForTarget(params: {
         pending: true,
       });
     }
-    result = await params.runCliJson([
-      "send-attachment",
-      "--chat",
-      attachmentChatTarget,
-      "--file",
-      params.filePath,
-      ...(params.audioAsVoice ? ["--audio"] : []),
-      ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
-      "--transport",
-      // One-shot imsg names its private-API transport dylib; JSON-RPC calls it bridge.
-      params.sendTransport === "bridge" ? "dylib" : params.sendTransport,
-    ]);
+    result = await withOriginalIMessageAttachmentPath(params.filePath, async (attachmentPath) =>
+      params.runCliJson([
+        "send-attachment",
+        "--chat",
+        attachmentChatTarget,
+        "--file",
+        attachmentPath,
+        ...(params.audioAsVoice ? ["--audio"] : []),
+        ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
+        "--transport",
+        // One-shot imsg names its private-API transport dylib; JSON-RPC calls it bridge.
+        params.sendTransport === "bridge" ? "dylib" : params.sendTransport,
+      ]),
+    );
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);
     if (!params.audioAsVoice && isAttachmentCommandFallbackError(error)) {
@@ -812,11 +847,34 @@ export async function sendMessageIMessage(
       if (!message.trim()) {
         return attachmentResult;
       }
-      const captionResult = await sendMessageIMessage(to, text, {
-        ...opts,
-        ...(opts.client ? { client: opts.client } : {}),
-        mediaUrl: undefined,
+      // Persist canonical provider facts before any later native send can run.
+      // A failed custody callback must stop the caption and keep its own error.
+      await opts.onDeliveryResult?.({
+        ...attachmentResult,
+        content: "",
+        messageIds: attachmentResult.receipt.platformMessageIds,
+        visibleReplySent: true,
+        ...(attachmentResult.receipt.replyToId
+          ? { replyToId: attachmentResult.receipt.replyToId }
+          : {}),
       });
+      let captionResult: IMessageSendResult;
+      try {
+        captionResult = await sendMessageIMessage(to, text, {
+          ...opts,
+          ...(opts.client ? { client: opts.client } : {}),
+          mediaUrl: undefined,
+          onDeliveryResult: undefined,
+        });
+      } catch (error: unknown) {
+        // Only the attachment was visible; never attribute the failed caption to it.
+        throw createChannelPartialDeliveryError(error, {
+          content: "",
+          messageIds: attachmentResult.receipt.platformMessageIds,
+          receipt: attachmentResult.receipt,
+          visibleReplySent: true,
+        });
+      }
       const messageId = isConcreteIMessageMessageId(attachmentResult.messageId)
         ? attachmentResult.messageId
         : captionResult.messageId;
@@ -880,9 +938,13 @@ export async function sendMessageIMessage(
     await client.stop();
   };
   const requestSuccessfulSend = async (sendParams: Record<string, unknown>) => {
-    const response = await client.request<Record<string, unknown>>("send", sendParams, {
-      timeoutMs,
-    });
+    const request = async (nativeParams: Record<string, unknown>) =>
+      await client.request<Record<string, unknown>>("send", nativeParams, { timeoutMs });
+    const response = filePath
+      ? await withOriginalIMessageAttachmentPath(filePath, async (attachmentPath) =>
+          request({ ...sendParams, file: attachmentPath }),
+        )
+      : await request(sendParams);
     const failure = resolveIMessageSendFailure(response);
     if (failure) {
       throw new Error(failure);

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -1,23 +1,35 @@
 // Imessage tests cover test plugin plugin behavior.
+import fs from "node:fs";
+import path from "node:path";
 import { buildTypedExecApprovalPendingReplyPayload } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
   createMessageReceiptFromOutboundResults,
+  sendDurableMessageBatch,
   verifyChannelMessageAdapterCapabilityProofs,
   verifyDurableFinalCapabilityProofs,
 } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createTestRegistry,
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 import {
   listImportedBundledPluginFacadeIds,
   resetFacadeRuntimeStateForTest,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearIMessageApprovalReactionTargetsForTest,
   resolveIMessageApprovalReactionTargetWithPersistence,
 } from "./approval-reactions.js";
 import { imessagePlugin } from "./channel.js";
+import type { IMessageRpcClient } from "./client.js";
 import { createIMessageTestPlugin } from "./imessage.test-plugin.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
+import { sendMessageIMessage } from "./send.js";
 
 beforeEach(() => {
   resetFacadeRuntimeStateForTest();
@@ -391,6 +403,144 @@ describe("createIMessageTestPlugin", () => {
       imessageMessageGuid: "p:0/stable-guid",
       imessageVisibleText: "hello",
     });
+  });
+
+  it("preserves provider-accepted attachment progress through actual durable core without replay", async () => {
+    const cfg = {
+      channels: { imessage: { accounts: { default: {} } } },
+    } as OpenClawConfig;
+    const captionError = new Error("caption failed after native attachment acceptance");
+    const captionClient = {
+      request: vi.fn(async () => {
+        throw captionError;
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+    const attachmentBytes = Buffer.from("%PDF-1.4\n% actual durable native attachment\n");
+    const runCliJson = vi.fn(async (args: readonly string[]) => {
+      const attachmentPath = args[args.indexOf("--file") + 1];
+      expect(attachmentPath).toBeDefined();
+      expect(fs.readFileSync(attachmentPath!)).toEqual(attachmentBytes);
+      return { messageId: "p:0/durable-accepted-attachment" };
+    });
+    const nativeSend: typeof sendMessageIMessage = async (to, text, options) =>
+      await sendMessageIMessage(to, text, {
+        ...options,
+        client: captionClient,
+        runCliJson,
+      });
+    const onDeliveryResult = vi.fn();
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "imessage", plugin: imessagePlugin, source: "test" }]),
+    );
+    try {
+      await withStateDirEnv("openclaw-imessage-durable-attachment-", async ({ stateDir }) => {
+        const sourcePath = path.join(stateDir, "quarterly-report.pdf");
+        fs.writeFileSync(sourcePath, attachmentBytes);
+
+        const result = await sendDurableMessageBatch({
+          cfg,
+          channel: "imessage",
+          to: "imessage:+15550004567",
+          durability: "required",
+          mediaAccess: { localRoots: [stateDir] },
+          deps: { imessage: nativeSend },
+          onDeliveryResult,
+          payloads: [{ text: "undelivered caption", mediaUrl: sourcePath }],
+        });
+
+        if (result.status === "failed") {
+          throw result.error;
+        }
+        expect(result).toMatchObject({
+          status: "partial_failed",
+          sentBeforeError: true,
+          receipt: { platformMessageIds: ["p:0/durable-accepted-attachment"] },
+          results: [
+            {
+              channel: "imessage",
+              messageId: "p:0/durable-accepted-attachment",
+            },
+          ],
+          payloadOutcomes: [{ status: "failed", sentBeforeError: true }],
+        });
+        expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            channel: "imessage",
+            messageId: "p:0/durable-accepted-attachment",
+          }),
+        );
+
+        await drainPendingDeliveries({
+          drainKey: "imessage:default",
+          logLabel: "iMessage accepted attachment recovery",
+          cfg,
+          stateDir,
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+          selectEntry: (entry) => ({ match: entry.channel === "imessage" }),
+        });
+        expect(runCliJson).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      releasePinnedPluginChannelRegistry();
+    }
+  });
+
+  it("halts native caption delivery when actual durable progress custody rejects", async () => {
+    const cfg = {
+      channels: { imessage: { accounts: { default: {} } } },
+    } as OpenClawConfig;
+    const custodyError = new Error("durable accepted-attachment custody rejected");
+    const captionRequest = vi.fn(async () => ({ guid: "p:0/caption-must-not-send" }));
+    const captionClient = {
+      request: captionRequest,
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+    const attachmentBytes = Buffer.from("%PDF-1.4\n% actual durable custody failure\n");
+    const runCliJson = vi.fn(async () => ({ messageId: "p:0/durable-custody-attachment" }));
+    const nativeSend: typeof sendMessageIMessage = async (to, text, options) =>
+      await sendMessageIMessage(to, text, { ...options, client: captionClient, runCliJson });
+    const onDeliveryResult = vi.fn(async () => {
+      throw custodyError;
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "imessage", plugin: imessagePlugin, source: "test" }]),
+    );
+    try {
+      await withStateDirEnv("openclaw-imessage-durable-custody-", async ({ stateDir }) => {
+        const sourcePath = path.join(stateDir, "custody-report.pdf");
+        fs.writeFileSync(sourcePath, attachmentBytes);
+
+        const result = await sendDurableMessageBatch({
+          cfg,
+          channel: "imessage",
+          to: "imessage:+15550004567",
+          durability: "required",
+          mediaAccess: { localRoots: [stateDir] },
+          deps: { imessage: nativeSend },
+          onDeliveryResult,
+          payloads: [{ text: "caption must not send", mediaUrl: sourcePath }],
+        });
+
+        expect(result).toMatchObject({
+          status: "partial_failed",
+          sentBeforeError: true,
+          results: [
+            {
+              channel: "imessage",
+              messageId: "p:0/durable-custody-attachment",
+            },
+          ],
+        });
+        expect(onDeliveryResult).toHaveBeenCalledOnce();
+        expect(runCliJson).toHaveBeenCalledOnce();
+        expect(captionRequest).not.toHaveBeenCalled();
+      });
+    } finally {
+      releasePinnedPluginChannelRegistry();
+    }
   });
 
   it("exposes seeded private API actions for binding contract tests", () => {


### PR DESCRIPTION
## What Problem This Solves

iMessage's ordinary outbound owner passed UUID-bearing OpenClaw media-store paths directly to its native one-shot CLI and JSON-RPC transports. The native Swift provider copies the source basename into the recipient-visible attachment, exposing names such as `quarterly-report---UUID.pdf` instead of `quarterly-report.pdf`, including threaded fallback and voice notes.

The same owner accepted attachments before attempting separate captions, but did not report accepted provider facts through either real outbound adapter before the later caption send. A failed caption consequently discarded the accepted provider receipt, misrepresented visible content, and could replay an already-delivered attachment from the durable SQLite queue.

## Why This Change Was Made

Refactor both native attachment transports through one private, owner-local original-filename lifecycle. Reuse the existing public SDK filename extractor and identity-safe private temporary workspace; copy the canonical stored bytes under the original basename only for the awaited native provider call, preserving the source and reliably removing the private alias on success, failure, and retry.

Publish one typed, canonical accepted-attachment result through the actual primary message adapter and attached-results adapter **before** attempting the caption. The result carries the original provider receipt, provider message IDs, empty visible text, visibility, and reply metadata. Durability/custody failures propagate their exact original error and prevent a second provider send. Only an actual later caption failure becomes the existing canonical partial-delivery error, retaining the accepted receipt and correctly reporting empty visible text.

## User Impact

Recipients see the intended iMessage document and voice attachment filename on both native transports and threaded retries. If an attachment arrives but its caption fails, OpenClaw preserves the actual accepted provider identity and does not silently replay the attachment. If accepted-delivery custody cannot be recorded, the caption is never sent and the original persistence failure remains diagnosable.

## Evidence

- Immutable reviewed commit `005287aaf182329959f0914ade85ae1a78f35874`, tree `0fa79906380de1664bb6ff1473fb6f30934966ce`, sole parent `618f3298c7dc00a41549e4dec41d8412f651624b`; exactly six existing iMessage plugin/owner test files.
- Current authoritative `main` `947886e7649ca0172f7e0f643c35f9e6283ebe5b` leaves all iMessage, outbound delivery, channel lifecycle, message, and Plugin SDK owner paths unchanged; exact clean synthetic merge tree `88141b928e63e0f21fad329084a7c97bc1ac25a1`.
- Authentic frozen-production baseline reproduces leaked document/voice filenames, native failure cleanup, RPC threaded/unthreaded names, and lost accepted receipts. A separate genuine baseline runs the actual registered iMessage plugin, native provider callback, core durable producer, and SQLite queue: accepted attachment followed by caption failure **fails** and loses authoritative delivery custody.
- Corrected real SQLite-backed integration tests prove both accepted-attachment/caption-failure receipt preservation with no recovery replay and rejected accepted-delivery custody with **no caption provider call**. Focused native-owner tests independently prove canonical accepted progress, preserved original error, and truthful empty-content partial delivery.
- Full hosted iMessage owner suite: **919/919 tests across 52 files**. Hosted production extension typecheck, extension-test typecheck, type-aware lint, formatting, and diff gates **all passed** on then-authoritative runner `main` `4fb19fb8c586b2d7801d1c512a4ac21e4d826505` while the local checkout HEAD remained frozen at `4751365ee66a0820549702c93f175fc9acc2dadc`; all six final `005287aaf182329959f0914ade85ae1a78f35874` source blobs were individually hash-verified, and current `947886e7649ca0172f7e0f643c35f9e6283ebe5b` leaves every affected owner and caller unchanged. The durable integration tests use the canonical `mediaAccess.localRoots` owner contract.
- One authorized Blacksmith Testbox lease `tbx_01kyxvzs7z16rmgp37pv7yc5mm`: https://github.com/openclaw/openclaw/actions/runs/30685502142. The final timing JSON reports `exitCode: 0`; the lease was explicitly stopped before the final immutable commit, and direct independent status confirmed `completed`.
- Pinned native `imsg` Swift commit `e22dfad8e54ef5ae9ef8b64a3db05f0ce25cd52c`, `MessageSender.swift:122-146`, confirms the source basename is user-visible and provider copying completes before return. Direct inspection of installed `@openclaw/fs-safe` confirms private copy permissions and guaranteed post-send cleanup.
- Genuine full-branch Codex `gpt-5.6-sol` high-reasoning autoreview through **P0/P1/P2/P3**: zero findings, confidence **0.97**. Four fresh independently hostile exact-commit reviewers separately inspected both adapter seams, actual durable SQLite custody and replay, native Swift/provider copy lifetime, reply/thread/voice behavior, and dependency contracts.
- Production delta **+114/-21 = +93 lines**, limited to three existing iMessage owner files. The growth expresses the single shared native filename lifetime and typed, canonical, custody-first receipt propagation through both existing adapter seams; no new owner, fallback, public SDK/config surface, dependency, storage, schema, auth, or provider routing is introduced.
