### PR TITLE
fix(qa): own screenshot and recording artifact freshness

### DIFF
--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -281,7 +281,9 @@ jobs:
             )
             pnpm "${args[@]}"
             cp "$desktop_dir/desktop-browser-smoke.png" "$root/$lane/discord-status-reactions-tool-only-desktop.png"
-            cp "$desktop_dir/desktop-browser-smoke.mp4" "$root/$lane/discord-status-reactions-tool-only-desktop.mp4"
+            if [[ -f "$desktop_dir/desktop-browser-smoke.mp4" ]]; then
+              cp "$desktop_dir/desktop-browser-smoke.mp4" "$root/$lane/discord-status-reactions-tool-only-desktop.mp4"
+            fi
           }
 
           capture_desktop_lane baseline
@@ -293,25 +295,22 @@ jobs:
             local output="$root/$lane/discord-status-reactions-tool-only-desktop-preview.gif"
             local clip="$root/$lane/discord-status-reactions-tool-only-desktop-change.mp4"
             local metadata="$root/$lane/discord-status-reactions-tool-only-desktop-preview.json"
-            crabbox media preview \
+            [[ -f "$input" ]] || return 0
+            if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
+              sudo apt-get update && sudo apt-get install -y ffmpeg || true
+            fi
+            if ! crabbox media preview \
               --input "$input" \
               --output "$output" \
               --trimmed-video-output "$clip" \
-              --json > "$metadata"
+              --json > "$metadata"; then
+              rm -f "$output" "$clip" "$metadata"
+              echo "::warning::Could not generate ${lane} desktop preview; keeping its screenshot and full MP4."
+            fi
           }
 
-          if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y ffmpeg || true
-          fi
-          if ! make_desktop_preview baseline || ! make_desktop_preview candidate; then
-            rm -f "$root/baseline/discord-status-reactions-tool-only-desktop-preview.gif"
-            rm -f "$root/candidate/discord-status-reactions-tool-only-desktop-preview.gif"
-            rm -f "$root/baseline/discord-status-reactions-tool-only-desktop-change.mp4"
-            rm -f "$root/candidate/discord-status-reactions-tool-only-desktop-change.mp4"
-            rm -f "$root/baseline/discord-status-reactions-tool-only-desktop-preview.json"
-            rm -f "$root/candidate/discord-status-reactions-tool-only-desktop-preview.json"
-            echo "::warning::Could not generate motion-trimmed desktop previews; continuing with screenshots and full MP4 links."
-          fi
+          make_desktop_preview baseline
+          make_desktop_preview candidate
 
           read_discord_status_reaction_status() {
             local lane="$1"
@@ -359,8 +358,12 @@ jobs:
             if [[ -f "$root/candidate/discord-status-reactions-tool-only-desktop-change.mp4" ]]; then
               echo "- Candidate desktop change clip: \`candidate/discord-status-reactions-tool-only-desktop-change.mp4\`"
             fi
-            echo "- Baseline desktop video: \`baseline/discord-status-reactions-tool-only-desktop.mp4\`"
-            echo "- Candidate desktop video: \`candidate/discord-status-reactions-tool-only-desktop.mp4\`"
+            if [[ -f "$root/baseline/discord-status-reactions-tool-only-desktop.mp4" ]]; then
+              echo "- Baseline desktop video: \`baseline/discord-status-reactions-tool-only-desktop.mp4\`"
+            fi
+            if [[ -f "$root/candidate/discord-status-reactions-tool-only-desktop.mp4" ]]; then
+              echo "- Candidate desktop video: \`candidate/discord-status-reactions-tool-only-desktop.mp4\`"
+            fi
           } > "$root/mantis-report.md"
 
           jq -n \
@@ -389,8 +392,8 @@ jobs:
                 { kind: "motionPreview", lane: "candidate", label: "Candidate motion preview", path: "candidate/discord-status-reactions-tool-only-desktop-preview.gif", targetPath: "candidate-desktop-preview.gif", alt: "Animated candidate desktop preview", width: 420, required: false },
                 { kind: "motionClip", lane: "baseline", label: "Baseline change MP4", path: "baseline/discord-status-reactions-tool-only-desktop-change.mp4", targetPath: "baseline-desktop-change.mp4", required: false },
                 { kind: "motionClip", lane: "candidate", label: "Candidate change MP4", path: "candidate/discord-status-reactions-tool-only-desktop-change.mp4", targetPath: "candidate-desktop-change.mp4", required: false },
-                { kind: "fullVideo", lane: "baseline", label: "Baseline desktop MP4", path: "baseline/discord-status-reactions-tool-only-desktop.mp4", targetPath: "baseline-desktop.mp4" },
-                { kind: "fullVideo", lane: "candidate", label: "Candidate desktop MP4", path: "candidate/discord-status-reactions-tool-only-desktop.mp4", targetPath: "candidate-desktop.mp4" },
+                { kind: "fullVideo", lane: "baseline", label: "Baseline desktop MP4", path: "baseline/discord-status-reactions-tool-only-desktop.mp4", targetPath: "baseline-desktop.mp4", required: false },
+                { kind: "fullVideo", lane: "candidate", label: "Candidate desktop MP4", path: "candidate/discord-status-reactions-tool-only-desktop.mp4", targetPath: "candidate-desktop.mp4", required: false },
                 { kind: "metadata", lane: "baseline", label: "Baseline preview metadata", path: "baseline/discord-status-reactions-tool-only-desktop-preview.json", targetPath: "baseline-desktop-preview.json", required: false },
                 { kind: "metadata", lane: "candidate", label: "Candidate preview metadata", path: "candidate/discord-status-reactions-tool-only-desktop-preview.json", targetPath: "candidate-desktop-preview.json", required: false },
                 { kind: "metadata", lane: "run", label: "Comparison JSON", path: "comparison.json", targetPath: "comparison.json" },

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
@@ -16,6 +16,32 @@ describe("mantis desktop browser smoke runtime", () => {
     await fs.rm(repoRoot, { force: true, recursive: true });
   });
 
+  function createReusedLeaseRunner(copyArtifacts: (outputDir: string) => Promise<void>) {
+    return vi.fn(async (command: string, args: readonly string[]) => {
+      if (command === "/tmp/crabbox" && args[0] === "inspect") {
+        return {
+          stdout: `${JSON.stringify({
+            host: "203.0.113.10",
+            id: "cbx_existing",
+            provider: "hetzner",
+            sshKey: "/tmp/key",
+            sshUser: "crabbox",
+          })}\n`,
+          stderr: "",
+        };
+      }
+      if (command === "rsync") {
+        const outputDir = args.at(-1);
+        if (typeof outputDir !== "string") {
+          throw new Error("rsync output directory is missing");
+        }
+        await fs.mkdir(outputDir, { recursive: true });
+        await copyArtifacts(outputDir);
+      }
+      return { stdout: "", stderr: "" };
+    });
+  }
+
   it("leases a desktop box, runs a visible browser, copies artifacts, and stops on pass", async () => {
     await fs.mkdir(path.join(repoRoot, "qa-artifacts"), { recursive: true });
     await fs.writeFile(path.join(repoRoot, "qa-artifacts", "timeline.html"), "<h1>Mantis</h1>");
@@ -121,6 +147,594 @@ describe("mantis desktop browser smoke runtime", () => {
     expect(summary.crabbox.vncCommand).toBe(
       "/tmp/crabbox vnc --provider hetzner --id cbx_abc123 --open",
     );
+  });
+
+  it("does not authenticate a reused output directory with an earlier screenshot or video", async () => {
+    let copyCount = 0;
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      if (copyCount++ === 0) {
+        await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "prior screenshot");
+        await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "prior video");
+      }
+    });
+    const options = {
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-reused",
+      repoRoot,
+    };
+
+    const initial = await runMantisDesktopBrowserSmoke(options);
+    expect(initial.status).toBe("pass");
+    expect(initial.videoPath).toBeDefined();
+
+    const rerun = await runMantisDesktopBrowserSmoke(options);
+    expect(rerun.status).toBe("fail");
+    expect(rerun.screenshotPath).toBeUndefined();
+    expect(rerun.videoPath).toBeUndefined();
+    await expect(
+      fs.access(path.join(rerun.outputDir, "desktop-browser-smoke.png")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs.access(path.join(rerun.outputDir, "desktop-browser-smoke.mp4")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("invalidates earlier visual evidence before lease inspection can fail", async () => {
+    const outputDir = path.join(repoRoot, ".artifacts/qa-e2e/mantis/desktop-browser-inspect-fail");
+    await fs.mkdir(outputDir, { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "earlier screenshot"),
+      fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "earlier video"),
+      fs.writeFile(path.join(outputDir, "remote-metadata.json"), "keep unrelated evidence"),
+    ]);
+    const runner = vi.fn(async (command: string, args: readonly string[]) => {
+      if (command === "/tmp/crabbox" && args[0] === "inspect") {
+        throw new Error("lease inspection failed");
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await runMantisDesktopBrowserSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: path.relative(repoRoot, outputDir),
+      repoRoot,
+    });
+
+    expect(result.status).toBe("fail");
+    await Promise.all(
+      ["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"].map(async (fileName) => {
+        await expect(fs.lstat(path.join(outputDir, fileName))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }),
+    );
+    await expect(fs.readFile(path.join(outputDir, "remote-metadata.json"), "utf8")).resolves.toBe(
+      "keep unrelated evidence",
+    );
+  });
+
+  it.each(["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"])(
+    "reports a preexisting %s directory without recursively deleting its contents",
+    async (artifactName) => {
+      const outputDir = path.join(repoRoot, ".artifacts/qa-e2e/mantis/desktop-browser-stale-dir");
+      const artifactDir = path.join(outputDir, artifactName);
+      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.writeFile(path.join(artifactDir, "unrelated.txt"), "preserve stale directory data");
+      const siblingName =
+        artifactName === "desktop-browser-smoke.png"
+          ? "desktop-browser-smoke.mp4"
+          : "desktop-browser-smoke.png";
+      await fs.writeFile(path.join(outputDir, siblingName), "remove earlier sibling evidence");
+      const runner = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: path.relative(repoRoot, outputDir),
+        repoRoot,
+      });
+
+      expect(result.status).toBe("fail");
+      expect(runner).not.toHaveBeenCalled();
+      await expect(fs.readFile(result.summaryPath, "utf8")).resolves.toContain('"status": "fail"');
+      await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("Status: fail");
+      await expect(fs.readFile(path.join(artifactDir, "unrelated.txt"), "utf8")).resolves.toBe(
+        "preserve stale directory data",
+      );
+      await expect(fs.lstat(path.join(outputDir, siblingName))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it.each([
+    {
+      expectedError: "Mantis browser profile archive env must be an environment variable name",
+      name: "unsafe-profile-env",
+      options: { browserProfileArchiveEnv: "BAD-NAME" },
+    },
+    {
+      expectedError: "Mantis browser profile dir must be an absolute path",
+      name: "unsafe-profile-dir",
+      options: { browserProfileDir: "relative-profile" },
+    },
+    {
+      expectedError: "ENOENT",
+      name: "missing-html",
+      options: { htmlFile: "missing-browser-proof.html" },
+    },
+  ])("clears previous captures before the $name option preflight rejects", async (testCase) => {
+    const outputDir = path.join(repoRoot, `.artifacts/qa-e2e/mantis/${testCase.name}`);
+    await fs.mkdir(outputDir, { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "earlier screenshot"),
+      fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "earlier video"),
+      fs.writeFile(path.join(outputDir, "remote-metadata.json"), "keep unrelated evidence"),
+    ]);
+    const runner = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+    await expect(
+      runMantisDesktopBrowserSmoke({
+        ...testCase.options,
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: path.relative(repoRoot, outputDir),
+        repoRoot,
+      }),
+    ).rejects.toThrow(testCase.expectedError);
+
+    expect(runner).not.toHaveBeenCalled();
+    await Promise.all(
+      ["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"].map(async (fileName) => {
+        await expect(fs.lstat(path.join(outputDir, fileName))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }),
+    );
+    await expect(fs.readFile(path.join(outputDir, "remote-metadata.json"), "utf8")).resolves.toBe(
+      "keep unrelated evidence",
+    );
+  });
+
+  it("rejects an empty copied desktop screenshot", async () => {
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "");
+    });
+
+    const result = await runMantisDesktopBrowserSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-empty-screenshot",
+      repoRoot,
+    });
+
+    expect(result.status).toBe("fail");
+    const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+      error?: string;
+    };
+    expect(summary.error).toMatch(/screenshot.*(?:missing|empty)/iu);
+  });
+
+  it.each([
+    ["screenshot", "EACCES", "screenshot permission denied"],
+    ["screenshot", "EIO", "screenshot filesystem I/O failed"],
+    ["video", "EACCES", "video permission denied"],
+    ["video", "EIO", "video filesystem I/O failed"],
+  ])("reports unexpected %s inspection error %s", async (artifactKind, errorCode, errorMessage) => {
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "current screenshot");
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "unvalidated video");
+    });
+    const failure = Object.assign(new Error(errorMessage), { code: errorCode });
+    const originalLstat = fs.lstat.bind(fs);
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const artifactName =
+        artifactKind === "screenshot" ? "desktop-browser-smoke.png" : "desktop-browser-smoke.mp4";
+      if (args[0].toString().endsWith(`/${artifactName}`)) {
+        throw failure;
+      }
+      return await originalLstat(...args);
+    });
+
+    try {
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: `.artifacts/qa-e2e/mantis/desktop-browser-${artifactKind}-error-${errorCode}`,
+        repoRoot,
+      });
+
+      expect(result.status).toBe("fail");
+      const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+        error?: string;
+      };
+      expect(summary.error).toContain(errorMessage);
+    } finally {
+      lstatSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ["screenshot", "EACCES"],
+    ["screenshot", "EIO"],
+    ["video", "EACCES"],
+    ["video", "EIO"],
+  ])(
+    "sanitizes both captures when %s inspection fails with %s",
+    async (failedArtifact, errorCode) => {
+      const runner = createReusedLeaseRunner(async (outputDir) => {
+        await Promise.all([
+          fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), ""),
+          fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), ""),
+        ]);
+      });
+      const failure = Object.assign(new Error(`${failedArtifact} artifact ${errorCode}`), {
+        code: errorCode,
+      });
+      const originalLstat = fs.lstat.bind(fs);
+      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        const artifactName =
+          failedArtifact === "screenshot"
+            ? "desktop-browser-smoke.png"
+            : "desktop-browser-smoke.mp4";
+        if (args[0].toString().endsWith(`/${artifactName}`)) {
+          throw failure;
+        }
+        return await originalLstat(...args);
+      });
+
+      try {
+        const result = await runMantisDesktopBrowserSmoke({
+          commandRunner: runner,
+          crabboxBin: "/tmp/crabbox",
+          leaseId: "cbx_existing",
+          outputDir: `.artifacts/qa-e2e/mantis/combined-inspection-${failedArtifact}-${errorCode}`,
+          repoRoot,
+        });
+
+        expect(result.status).toBe("fail");
+        const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+          error?: string;
+        };
+        expect(summary.error).toContain(`${failedArtifact} artifact ${errorCode}`);
+        await Promise.all(
+          ["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"].map(async (fileName) => {
+            await expect(fs.access(path.join(result.outputDir, fileName))).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+          }),
+        );
+      } finally {
+        lstatSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    ["screenshot", "regular"],
+    ["video", "regular"],
+    ["both", "regular"],
+    ["both", "empty"],
+    ["both", "symlink"],
+    ["directory", "regular"],
+  ])(
+    "sanitizes %s %s captures copied before rsync rejects",
+    async (captureSelection, captureType) => {
+      const runner = createReusedLeaseRunner(async (outputDir) => {
+        const screenshotPath = path.join(outputDir, "desktop-browser-smoke.png");
+        const videoPath = path.join(outputDir, "desktop-browser-smoke.mp4");
+        if (captureSelection === "directory") {
+          await fs.mkdir(screenshotPath);
+          await fs.writeFile(
+            path.join(screenshotPath, "unrelated.txt"),
+            "preserve nested evidence",
+          );
+          await fs.writeFile(videoPath, "partial video");
+        } else if (captureType === "symlink") {
+          await fs.writeFile(path.join(outputDir, "other-capture.png"), "preserve earlier image");
+          await fs.writeFile(path.join(outputDir, "other-recording.mp4"), "preserve earlier video");
+          await fs.symlink("other-capture.png", screenshotPath);
+          await fs.symlink("other-recording.mp4", videoPath);
+        } else {
+          const content = captureType === "empty" ? "" : "partial capture";
+          if (captureSelection === "screenshot" || captureSelection === "both") {
+            await fs.writeFile(screenshotPath, content);
+          }
+          if (captureSelection === "video" || captureSelection === "both") {
+            await fs.writeFile(videoPath, content);
+          }
+        }
+        await fs.writeFile(path.join(outputDir, "remote-metadata.json"), "preserve unrelated copy");
+        throw new Error("rsync transfer failed after writing partial captures");
+      });
+
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: `.artifacts/qa-e2e/mantis/rsync-failure-${captureSelection}-${captureType}`,
+        repoRoot,
+      });
+
+      expect(result.status).toBe("fail");
+      const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+        error?: string;
+      };
+      expect(summary.error).toContain("rsync transfer failed after writing partial captures");
+      await expect(
+        fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.mp4")),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      if (captureSelection === "directory") {
+        await expect(
+          fs.readFile(
+            path.join(result.outputDir, "desktop-browser-smoke.png", "unrelated.txt"),
+            "utf8",
+          ),
+        ).resolves.toBe("preserve nested evidence");
+      } else {
+        await expect(
+          fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.png")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }
+      await expect(
+        fs.readFile(path.join(result.outputDir, "remote-metadata.json"), "utf8"),
+      ).resolves.toBe("preserve unrelated copy");
+      if (captureType === "symlink") {
+        await expect(
+          fs.readFile(path.join(result.outputDir, "other-capture.png"), "utf8"),
+        ).resolves.toBe("preserve earlier image");
+        await expect(
+          fs.readFile(path.join(result.outputDir, "other-recording.mp4"), "utf8"),
+        ).resolves.toBe("preserve earlier video");
+      }
+    },
+  );
+
+  it("rejects a copied screenshot symlink even when its target is a valid file", async () => {
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "other-capture.png"), "earlier screenshot");
+      await fs.symlink("other-capture.png", path.join(outputDir, "desktop-browser-smoke.png"));
+    });
+
+    const result = await runMantisDesktopBrowserSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-screenshot-symlink",
+      repoRoot,
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.screenshotPath).toBeUndefined();
+    await expect(
+      fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.png")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs.readFile(path.join(result.outputDir, "other-capture.png"), "utf8"),
+    ).resolves.toBe("earlier screenshot");
+  });
+
+  it.each([
+    ["missing", "empty"],
+    ["missing", "existing symlink"],
+    ["missing", "dangling symlink"],
+    ["empty", "empty"],
+    ["empty", "existing symlink"],
+    ["empty", "dangling symlink"],
+    ["symlink", "empty"],
+    ["symlink", "existing symlink"],
+    ["symlink", "dangling symlink"],
+    ["directory", "empty"],
+    ["directory", "existing symlink"],
+    ["directory", "dangling symlink"],
+  ])(
+    "sanitizes a %s screenshot and %s video before reporting screenshot failure",
+    async (screenshotState, videoState) => {
+      const runner = createReusedLeaseRunner(async (outputDir) => {
+        const screenshotPath = path.join(outputDir, "desktop-browser-smoke.png");
+        if (screenshotState === "empty") {
+          await fs.writeFile(screenshotPath, "");
+        } else if (screenshotState === "symlink") {
+          await fs.writeFile(path.join(outputDir, "other-capture.png"), "preserve earlier image");
+          await fs.symlink("other-capture.png", screenshotPath);
+        } else if (screenshotState === "directory") {
+          await fs.mkdir(screenshotPath);
+          await fs.writeFile(
+            path.join(screenshotPath, "unrelated.txt"),
+            "preserve nested evidence",
+          );
+        }
+
+        const videoPath = path.join(outputDir, "desktop-browser-smoke.mp4");
+        if (videoState === "empty") {
+          await fs.writeFile(videoPath, "");
+        } else {
+          if (videoState === "existing symlink") {
+            await fs.writeFile(
+              path.join(outputDir, "other-recording.mp4"),
+              "preserve earlier video",
+            );
+          }
+          await fs.symlink("other-recording.mp4", videoPath);
+        }
+      });
+
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: `.artifacts/qa-e2e/mantis/combined-${screenshotState}-${videoState.replace(/ /gu, "-")}`,
+        repoRoot,
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.screenshotPath).toBeUndefined();
+      expect(result.videoPath).toBeUndefined();
+      await expect(
+        fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.mp4")),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      if (screenshotState === "directory") {
+        await expect(
+          fs.readFile(
+            path.join(result.outputDir, "desktop-browser-smoke.png", "unrelated.txt"),
+            "utf8",
+          ),
+        ).resolves.toBe("preserve nested evidence");
+      } else {
+        await expect(
+          fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.png")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }
+      if (screenshotState === "symlink") {
+        await expect(
+          fs.readFile(path.join(result.outputDir, "other-capture.png"), "utf8"),
+        ).resolves.toBe("preserve earlier image");
+      }
+      if (videoState === "existing symlink") {
+        await expect(
+          fs.readFile(path.join(result.outputDir, "other-recording.mp4"), "utf8"),
+        ).resolves.toBe("preserve earlier video");
+      }
+    },
+  );
+
+  it("does not attach an earlier video when a rerun captures only a fresh screenshot", async () => {
+    let copyCount = 0;
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(
+        path.join(outputDir, "desktop-browser-smoke.png"),
+        `screenshot ${copyCount}`,
+      );
+      if (copyCount++ === 0) {
+        await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "prior video");
+      }
+    });
+    const options = {
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-video-reused",
+      repoRoot,
+    };
+
+    expect((await runMantisDesktopBrowserSmoke(options)).videoPath).toBeDefined();
+    const rerun = await runMantisDesktopBrowserSmoke(options);
+    expect(rerun.status).toBe("pass");
+    expect(rerun.videoPath).toBeUndefined();
+    await expect(fs.readFile(rerun.screenshotPath ?? "", "utf8")).resolves.toBe("screenshot 1");
+    await expect(
+      fs.access(path.join(rerun.outputDir, "desktop-browser-smoke.mp4")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps video optional without advertising an empty recording", async () => {
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "current screenshot");
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.mp4"), "");
+    });
+
+    const result = await runMantisDesktopBrowserSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-empty-video",
+      repoRoot,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.videoPath).toBeUndefined();
+    const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+      artifacts?: { videoPath?: string };
+    };
+    expect(summary.artifacts?.videoPath).toBeUndefined();
+    await expect(
+      fs.access(path.join(result.outputDir, "desktop-browser-smoke.mp4")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each(["existing", "missing"])(
+    "removes an optional video symlink with an %s target",
+    async (targetState) => {
+      const runner = createReusedLeaseRunner(async (outputDir) => {
+        await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "current screenshot");
+        if (targetState === "existing") {
+          await fs.writeFile(path.join(outputDir, "other-recording.mp4"), "earlier recording");
+        }
+        await fs.symlink("other-recording.mp4", path.join(outputDir, "desktop-browser-smoke.mp4"));
+      });
+
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId: "cbx_existing",
+        outputDir: `.artifacts/qa-e2e/mantis/desktop-browser-video-symlink-${targetState}`,
+        repoRoot,
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.videoPath).toBeUndefined();
+      await expect(
+        fs.lstat(path.join(result.outputDir, "desktop-browser-smoke.mp4")),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      if (targetState === "existing") {
+        await expect(
+          fs.readFile(path.join(result.outputDir, "other-recording.mp4"), "utf8"),
+        ).resolves.toBe("earlier recording");
+      }
+    },
+  );
+
+  it("rejects an optional video directory without removing its unrelated contents", async () => {
+    const runner = createReusedLeaseRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "desktop-browser-smoke.png"), "current screenshot");
+      const videoDir = path.join(outputDir, "desktop-browser-smoke.mp4");
+      await fs.mkdir(videoDir);
+      await fs.writeFile(path.join(videoDir, "unrelated.txt"), "do not recursively delete");
+    });
+
+    const result = await runMantisDesktopBrowserSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_existing",
+      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-video-directory",
+      repoRoot,
+    });
+
+    expect(result.status).toBe("fail");
+    await expect(
+      fs.readFile(
+        path.join(result.outputDir, "desktop-browser-smoke.mp4", "unrelated.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("do not recursively delete");
   });
 
   it("rejects html files outside the repository", async () => {

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runMantisDesktopBrowserSmoke } from "./desktop-browser-smoke.runtime.js";
+import {
+  runMantisDesktopBrowserSmoke,
+  type MantisDesktopBrowserSmokeOptions,
+} from "./desktop-browser-smoke.runtime.js";
 
 describe("mantis desktop browser smoke runtime", () => {
   let repoRoot: string;
@@ -13,6 +16,7 @@ describe("mantis desktop browser smoke runtime", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(repoRoot, { force: true, recursive: true });
   });
 
@@ -308,6 +312,248 @@ describe("mantis desktop browser smoke runtime", () => {
     ]);
     await expect(fs.readFile(path.join(result.outputDir, "error.txt"), "utf8")).resolves.toContain(
       "remote chrome failed",
+    );
+  });
+
+  describe("capture artifact ownership", () => {
+    const names = ["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"] as const;
+    const metadataNames = [
+      "mantis-desktop-browser-smoke-summary.json",
+      "mantis-desktop-browser-smoke-report.md",
+      "error.txt",
+    ] as const;
+    let outputDir: string;
+    let target: string;
+
+    beforeEach(async () => {
+      outputDir = path.join(repoRoot, "captures");
+      target = path.join(repoRoot, "unrelated-target");
+      await fs.mkdir(outputDir);
+      await fs.writeFile(target, "preserve target");
+      await fs.writeFile(path.join(outputDir, "unrelated.txt"), "preserve evidence");
+    });
+
+    async function capture(
+      copy: () => Promise<void> = async () => {},
+      options: Partial<MantisDesktopBrowserSmokeOptions> = {},
+    ) {
+      return runMantisDesktopBrowserSmoke({
+        crabboxBin: "/controlled-crabbox",
+        env: {},
+        leaseId: "cbx_existing",
+        outputDir: "captures",
+        repoRoot,
+        commandRunner: async (command, args) => {
+          if (command === "rsync") {
+            await copy();
+          }
+          return {
+            stdout:
+              args[0] === "inspect"
+                ? JSON.stringify({ host: "127.0.0.1", sshKey: "unused", sshUser: "fixture" })
+                : "",
+            stderr: "",
+          };
+        },
+        ...options,
+      });
+    }
+
+    async function writeCaptures(png = "current png", mp4?: string) {
+      await fs.writeFile(path.join(outputDir, names[0]), png);
+      if (mp4 !== undefined) {
+        await fs.writeFile(path.join(outputDir, names[1]), mp4);
+      }
+    }
+
+    async function expectMissing(name: string) {
+      await expect(fs.lstat(path.join(outputDir, name))).rejects.toMatchObject({ code: "ENOENT" });
+    }
+
+    it("reuses an output directory without attributing previous captures to the next run", async () => {
+      expect((await capture(() => writeCaptures("first png", "first video"))).status).toBe("pass");
+      const second = await capture(() => writeCaptures("second png"));
+      expect(second.status).toBe("pass");
+      expect(second.videoPath).toBeUndefined();
+      await expectMissing(names[1]);
+      await expect(fs.readFile(second.screenshotPath!, "utf8")).resolves.toBe("second png");
+      const third = await capture();
+      expect(third.status).toBe("fail");
+      expect(third.screenshotPath).toBeUndefined();
+      await expectMissing(names[0]);
+      await expect(fs.readFile(third.reportPath, "utf8")).resolves.toContain("Screenshot: missing");
+      await expect(fs.readFile(path.join(outputDir, "unrelated.txt"), "utf8")).resolves.toBe(
+        "preserve evidence",
+      );
+    });
+
+    it.each([
+      { screenshot: "empty", video: "empty", expected: "fail" },
+      { screenshot: "symlink", video: "symlink", expected: "fail" },
+      { screenshot: "valid", video: "empty", expected: "pass" },
+      { screenshot: "valid", video: "symlink", expected: "pass" },
+      { screenshot: "empty", video: "valid", expected: "fail" },
+      { screenshot: "symlink", video: "valid", expected: "fail" },
+    ])(
+      "handles $screenshot screenshot and $video video without leaking invalid artifacts",
+      async ({ screenshot, video, expected }) => {
+        const kinds = [screenshot, video];
+        const result = await capture(async () => {
+          for (const [index, name] of names.entries()) {
+            const file = path.join(outputDir, name);
+            if (kinds[index] === "symlink") {
+              await fs.symlink(target, file);
+            } else {
+              await fs.writeFile(file, kinds[index] === "valid" ? `valid ${name}` : "");
+            }
+          }
+        });
+        expect(result.status).toBe(expected);
+        for (const [index, name] of names.entries()) {
+          if (kinds[index] === "valid") {
+            await expect(fs.readFile(path.join(outputDir, name), "utf8")).resolves.toBe(
+              `valid ${name}`,
+            );
+          } else {
+            await expectMissing(name);
+          }
+        }
+        expect(result.videoPath).toBeUndefined();
+        await expect(fs.readFile(target, "utf8")).resolves.toBe("preserve target");
+      },
+    );
+
+    it.each(names)(
+      "preserves a directory occupying %s while cleaning the other stale capture",
+      async (directoryName) => {
+        await writeCaptures("stale png", "stale video");
+        await fs.unlink(path.join(outputDir, directoryName));
+        await fs.mkdir(path.join(outputDir, directoryName));
+        await fs.writeFile(path.join(outputDir, directoryName, "keep"), "directory contents");
+        const commandRunner = vi.fn(async () => ({ stdout: "", stderr: "" }));
+        const result = await capture(undefined, { commandRunner });
+        expect(result.status).toBe("fail");
+        expect(commandRunner).not.toHaveBeenCalled();
+        await expectMissing(names.find((name) => name !== directoryName)!);
+        await expect(
+          fs.readFile(path.join(outputDir, directoryName, "keep"), "utf8"),
+        ).resolves.toBe("directory contents");
+        await expect(fs.readFile(result.summaryPath, "utf8")).resolves.toContain(directoryName);
+      },
+    );
+
+    it.each([
+      { htmlFile: "missing.html" },
+      { browserProfileArchiveEnv: "BAD-NAME" },
+      { browserProfileDir: "relative-profile" },
+    ])("invalidates stale artifacts before rejecting preflight options %j", async (options) => {
+      expect((await capture(() => writeCaptures("stale png", "stale video"))).status).toBe("pass");
+      await expect(capture(undefined, options)).rejects.toThrow();
+      for (const name of [...names, ...metadataNames]) await expectMissing(name);
+      await expect(fs.readFile(path.join(outputDir, "unrelated.txt"), "utf8")).resolves.toBe(
+        "preserve evidence",
+      );
+    });
+
+    it("retires a previous error when a later capture succeeds", async () => {
+      expect((await capture()).status).toBe("fail");
+      await expect(fs.readFile(path.join(outputDir, "error.txt"), "utf8")).resolves.toContain(
+        "screenshot",
+      );
+      expect((await capture(() => writeCaptures())).status).toBe("pass");
+      await expectMissing("error.txt");
+    });
+
+    it.each(metadataNames)("preserves a directory occupying metadata %s", async (name) => {
+      await writeCaptures("stale png", "stale video");
+      await fs.mkdir(path.join(outputDir, name));
+      await fs.writeFile(path.join(outputDir, name, "keep"), "directory contents");
+      const commandRunner = vi.fn(async () => ({ stdout: "", stderr: "" }));
+      await expect(capture(undefined, { commandRunner })).rejects.toThrow();
+      expect(commandRunner).not.toHaveBeenCalled();
+      for (const visual of names) await expectMissing(visual);
+      await expect(fs.readFile(path.join(outputDir, name, "keep"), "utf8")).resolves.toBe(
+        "directory contents",
+      );
+    });
+
+    it("retires metadata symlinks without following their targets", async () => {
+      for (const name of metadataNames) await fs.symlink(target, path.join(outputDir, name));
+      expect((await capture(() => writeCaptures())).status).toBe("pass");
+      await expectMissing("error.txt");
+      await expect(fs.readFile(target, "utf8")).resolves.toBe("preserve target");
+      for (const name of metadataNames.slice(0, 2)) {
+        expect((await fs.lstat(path.join(outputDir, name))).isSymbolicLink()).toBe(false);
+      }
+    });
+
+    it("removes partially copied captures and records the original transfer failure", async () => {
+      const result = await capture(async () => {
+        await writeCaptures("partial png", "partial video");
+        throw new Error("transfer interrupted");
+      });
+      expect(result.status).toBe("fail");
+      for (const name of names) await expectMissing(name);
+      await expect(fs.readFile(result.summaryPath, "utf8")).resolves.toContain(
+        "transfer interrupted",
+      );
+    });
+
+    it("reports cleanup failure alongside the transfer failure and still cleans the other capture", async () => {
+      const remove = fs.rm.bind(fs);
+      const result = await capture(async () => {
+        await writeCaptures("partial png", "partial video");
+        vi.spyOn(fs, "rm").mockImplementation(async (file, options) => {
+          if (file === path.join(outputDir, names[0])) {
+            throw Object.assign(new Error("capture removal denied"), { code: "EACCES" });
+          }
+          return remove(file, options);
+        });
+        throw new Error("transfer interrupted");
+      });
+      expect(result.status).toBe("fail");
+      await expectMissing(names[1]);
+      const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8"));
+      expect(summary.error).toContain("transfer interrupted");
+      expect(summary.error).toContain("capture removal denied");
+    });
+
+    it.each([false, true])(
+      "preserves inspection errors when removal fails: %s",
+      async (removalFails) => {
+        const inspect = fs.lstat.bind(fs);
+        const remove = fs.rm.bind(fs);
+        const result = await capture(async () => {
+          await writeCaptures("unreadable png", "");
+          if (removalFails) {
+            vi.spyOn(fs, "rm").mockImplementation(async (file, options) => {
+              if (file === path.join(outputDir, names[0])) {
+                throw Object.assign(new Error("capture removal denied"), { code: "EACCES" });
+              }
+              return remove(file, options);
+            });
+          }
+          vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+            if (args[0] === path.join(outputDir, names[0])) {
+              throw Object.assign(new Error("capture inspection failed"), { code: "EIO" });
+            }
+            return inspect(...args);
+          });
+        });
+        vi.restoreAllMocks();
+        expect(result.status).toBe("fail");
+        await expectMissing(names[1]);
+        const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8"));
+        expect(summary.error).toContain("capture inspection failed");
+        if (removalFails) {
+          expect(summary.error).toContain("capture removal denied");
+          await expect(fs.readFile(path.join(outputDir, names[0]), "utf8")).resolves.toBe(
+            "unreadable png",
+          );
+        } else {
+          await expectMissing(names[0]);
+        }
+      },
     );
   });
 });

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "../cli-paths.js";
 import { isTruthyOptIn, trimToValue } from "../mantis-options.runtime.js";
 import {
@@ -322,6 +321,12 @@ export async function runMantisDesktopBrowserSmoke(
   );
   const summaryPath = path.join(outputDir, "mantis-desktop-browser-smoke-summary.json");
   const reportPath = path.join(outputDir, "mantis-desktop-browser-smoke-report.md");
+  const screenshotPath = path.join(outputDir, "desktop-browser-smoke.png");
+  const videoPath = path.join(outputDir, "desktop-browser-smoke.mp4");
+  const clearVisualArtifacts = () =>
+    Promise.allSettled([fs.rm(screenshotPath, { force: true }), fs.rm(videoPath, { force: true })]);
+  // Capture cleanup failures without skipping option validation or leaking prior evidence.
+  const initialArtifactCleanup = await clearVisualArtifacts();
   const crabboxBin = await resolveCrabboxBin({
     env,
     envName: CRABBOX_BIN_ENV,
@@ -372,6 +377,12 @@ export async function runMantisDesktopBrowserSmoke(
   let summary: MantisDesktopBrowserSmokeSummary | undefined;
 
   try {
+    // Report cleanup failures only after both workflow-visible paths have settled.
+    for (const cleanup of initialArtifactCleanup) {
+      if (cleanup.status === "rejected") {
+        throw cleanup.reason;
+      }
+    }
     leaseId =
       leaseId ??
       (await warmupCrabbox({
@@ -419,20 +430,71 @@ export async function runMantisDesktopBrowserSmoke(
       runner,
       stdio: "inherit",
     });
-    await copyRemoteArtifacts({
-      cwd: repoRoot,
-      env,
-      inspect: inspected,
-      outputDir,
-      remoteOutputDir,
-      runner,
-    });
-    const screenshotPath = path.join(outputDir, "desktop-browser-smoke.png");
-    const videoPath = path.join(outputDir, "desktop-browser-smoke.mp4");
-    if (!(await pathExists(screenshotPath))) {
-      throw new Error("Desktop browser screenshot was not copied back from Crabbox.");
+    try {
+      await copyRemoteArtifacts({
+        cwd: repoRoot,
+        env,
+        inspect: inspected,
+        outputDir,
+        remoteOutputDir,
+        runner,
+      });
+    } catch (error) {
+      // rsync can leave partial captures behind even when its transfer ultimately fails.
+      await clearVisualArtifacts();
+      throw error;
     }
-    const copiedVideoPath = (await pathExists(videoPath)) ? videoPath : undefined;
+    const inspectArtifact = async (artifactPath: string) => {
+      try {
+        return await fs.lstat(artifactPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      }
+    };
+    const [screenshotInspection, videoInspection] = await Promise.allSettled([
+      inspectArtifact(screenshotPath),
+      inspectArtifact(videoPath),
+    ]);
+    const screenshot =
+      screenshotInspection.status === "fulfilled" ? screenshotInspection.value : undefined;
+    const video = videoInspection.status === "fulfilled" ? videoInspection.value : undefined;
+    const screenshotIsValid = Boolean(screenshot?.isFile() && screenshot.size > 0);
+    const videoIsValid = Boolean(video?.isFile() && video.size > 0);
+    const invalidArtifacts: string[] = [];
+    if (
+      screenshotInspection.status === "rejected" ||
+      (screenshot && !screenshotIsValid && !screenshot.isDirectory())
+    ) {
+      invalidArtifacts.push(screenshotPath);
+    }
+    if (videoInspection.status === "rejected" || (video && !videoIsValid && !video.isDirectory())) {
+      invalidArtifacts.push(videoPath);
+    }
+    // Failure workflows publish both raw paths; sanitize both before rejecting either capture.
+    for (const cleanup of await Promise.allSettled(
+      invalidArtifacts.map((artifactPath) => fs.rm(artifactPath, { force: true })),
+    )) {
+      if (cleanup.status === "rejected") {
+        throw cleanup.reason;
+      }
+    }
+    for (const inspection of [screenshotInspection, videoInspection]) {
+      if (inspection.status === "rejected") {
+        throw inspection.reason;
+      }
+    }
+    if (!screenshotIsValid) {
+      throw new Error(
+        "Desktop browser screenshot copied from Crabbox is missing, empty, or not a regular file.",
+      );
+    }
+    if (video?.isDirectory()) {
+      throw new Error("Desktop browser video copied from Crabbox must be a regular file.");
+    }
+    const copiedVideoPath = videoIsValid ? videoPath : undefined;
     summary = {
       artifacts: {
         reportPath,

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -3,12 +3,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "../cli-paths.js";
 import { isTruthyOptIn, trimToValue } from "../mantis-options.runtime.js";
 import {
   copyCrabboxArtifacts,
   type CommandRunner,
+  type CrabboxInspect,
   defaultCommandRunner,
   inspectCrabbox,
   resolveCrabboxBin,
@@ -48,12 +48,7 @@ type MantisDesktopBrowserSmokeResult = {
 };
 
 type MantisDesktopBrowserSmokeSummary = {
-  artifacts: {
-    reportPath: string;
-    screenshotPath?: string;
-    summaryPath: string;
-    videoPath?: string;
-  };
+  artifacts: Omit<MantisDesktopBrowserSmokeResult, "outputDir" | "status">;
   browserUrl: string;
   htmlFile?: string;
   crabbox: {
@@ -281,6 +276,33 @@ function renderReport(summary: MantisDesktopBrowserSmokeSummary) {
   return `${lines.join("\n")}\n`;
 }
 
+function artifactFailure(results: PromiseSettledResult<unknown>[]): AggregateError | undefined {
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  return errors.length
+    ? new AggregateError(errors, errors.map(formatErrorMessage).join("; "))
+    : undefined;
+}
+
+async function inspectVisualArtifact(filePath: string): Promise<string | undefined> {
+  const [inspection] = await Promise.allSettled([fs.lstat(filePath)]);
+  if (inspection.status === "fulfilled" && inspection.value.isFile() && inspection.value.size > 0) {
+    return filePath;
+  }
+  // Failure workflows upload raw paths: remove invalid entries, never symlink targets or directories.
+  // Settle cleanup separately so a removal failure cannot replace the original inspection error.
+  const results = await Promise.allSettled([fs.rm(filePath, { force: true })]);
+  if (
+    inspection.status === "rejected" &&
+    (inspection.reason as NodeJS.ErrnoException).code !== "ENOENT"
+  ) {
+    results.unshift(inspection);
+  }
+  const error = artifactFailure(results);
+  if (error) {
+    throw error;
+  }
+}
+
 export async function runMantisDesktopBrowserSmoke(
   opts: MantisDesktopBrowserSmokeOptions = {},
 ): Promise<MantisDesktopBrowserSmokeResult> {
@@ -295,6 +317,16 @@ export async function runMantisDesktopBrowserSmoke(
   );
   const summaryPath = path.join(outputDir, "mantis-desktop-browser-smoke-summary.json");
   const reportPath = path.join(outputDir, "mantis-desktop-browser-smoke-report.md");
+  const errorPath = path.join(outputDir, "error.txt");
+  const visualPaths = ["desktop-browser-smoke.png", "desktop-browser-smoke.mp4"].map((name) =>
+    path.join(outputDir, name),
+  );
+  const clearArtifacts = (paths: string[]) =>
+    Promise.allSettled(paths.map((filePath) => fs.rm(filePath, { force: true })));
+  // Retire old captures and reports before preflight can reject without publishing a new result.
+  const initialCleanupError = artifactFailure(
+    await clearArtifacts([...visualPaths, summaryPath, reportPath, errorPath]),
+  );
   const crabboxBin = await resolveCrabboxBin({
     env,
     envName: CRABBOX_BIN_ENV,
@@ -342,9 +374,19 @@ export async function runMantisDesktopBrowserSmoke(
     .toISOString()
     .replace(/[^0-9A-Za-z]/gu, "-")}`;
   let leaseId = explicitLeaseId;
-  let summary: MantisDesktopBrowserSmokeSummary | undefined;
+  let inspected: CrabboxInspect | undefined;
+  let errorMessage: string | undefined;
+  const result: MantisDesktopBrowserSmokeResult = {
+    outputDir,
+    reportPath,
+    status: "fail",
+    summaryPath,
+  };
 
   try {
+    if (initialCleanupError) {
+      throw initialCleanupError;
+    }
     leaseId =
       leaseId ??
       (await warmupCrabbox({
@@ -357,7 +399,7 @@ export async function runMantisDesktopBrowserSmoke(
         runner,
         ttl,
       }));
-    const inspected = await inspectCrabbox({
+    inspected = await inspectCrabbox({
       crabboxBin,
       cwd: repoRoot,
       env,
@@ -392,58 +434,50 @@ export async function runMantisDesktopBrowserSmoke(
       runner,
       stdio: "inherit",
     });
-    await copyCrabboxArtifacts({
-      cwd: repoRoot,
-      env,
-      exclude: ["chrome-profile/**"],
-      inspect: inspected,
-      outputDir,
-      remoteOutputDir,
-      runner,
-    });
-    const screenshotPath = path.join(outputDir, "desktop-browser-smoke.png");
-    const videoPath = path.join(outputDir, "desktop-browser-smoke.mp4");
-    if (!(await pathExists(screenshotPath))) {
-      throw new Error("Desktop browser screenshot was not copied back from Crabbox.");
+    try {
+      await copyCrabboxArtifacts({
+        cwd: repoRoot,
+        env,
+        exclude: ["chrome-profile/**"],
+        inspect: inspected,
+        outputDir,
+        remoteOutputDir,
+        runner,
+      });
+    } catch (error) {
+      const cleanupError = artifactFailure(await clearArtifacts(visualPaths));
+      throw cleanupError
+        ? new Error(
+            `${formatErrorMessage(error)}; artifact cleanup failed: ${cleanupError.message}`,
+            { cause: error },
+          )
+        : error;
     }
-    const copiedVideoPath = (await pathExists(videoPath)) ? videoPath : undefined;
-    summary = {
-      artifacts: {
-        reportPath,
-        screenshotPath,
-        summaryPath,
-        videoPath: copiedVideoPath,
-      },
-      browserUrl,
-      htmlFile,
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId,
-        provider,
-        slug: inspected.slug,
-        state: inspected.state,
-        vncCommand: `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`,
-      },
-      finishedAt: new Date().toISOString(),
-      outputDir,
-      remoteOutputDir,
-      startedAt: startedAt.toISOString(),
-      status: "pass",
-    };
-    return {
-      outputDir,
-      reportPath,
-      screenshotPath,
-      status: "pass",
-      summaryPath,
-      videoPath: copiedVideoPath,
-    };
+    // Settle both inspections/cleanups before rejecting either capture; video is optional.
+    const inspections = await Promise.allSettled(visualPaths.map(inspectVisualArtifact));
+    const inspectionError = artifactFailure(inspections);
+    if (inspectionError) {
+      throw inspectionError;
+    }
+    const [screenshotPath, videoPath] = inspections.map((entry) =>
+      entry.status === "fulfilled" ? entry.value : undefined,
+    );
+    if (!screenshotPath) {
+      throw new Error(
+        "Desktop browser screenshot copied from Crabbox is missing, empty, or not a regular file.",
+      );
+    }
+    Object.assign(result, { screenshotPath, status: "pass", videoPath });
   } catch (error) {
-    summary = {
+    errorMessage = formatErrorMessage(error);
+    await fs.writeFile(errorPath, `${errorMessage}\n`, "utf8");
+  } finally {
+    const summary: MantisDesktopBrowserSmokeSummary = {
       artifacts: {
         reportPath,
         summaryPath,
+        screenshotPath: result.screenshotPath,
+        videoPath: result.videoPath,
       },
       browserUrl,
       htmlFile,
@@ -452,32 +486,23 @@ export async function runMantisDesktopBrowserSmoke(
         createdLease,
         id: leaseId ?? "unallocated",
         provider,
+        ...(result.status === "pass" ? { slug: inspected?.slug, state: inspected?.state } : {}),
         vncCommand: leaseId
           ? `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`
           : "unallocated",
       },
-      error: formatErrorMessage(error),
+      error: errorMessage,
       finishedAt: new Date().toISOString(),
       outputDir,
       remoteOutputDir,
       startedAt: startedAt.toISOString(),
-      status: "fail",
+      status: result.status,
     };
-    await fs.writeFile(path.join(outputDir, "error.txt"), `${summary.error}\n`, "utf8");
-    return {
-      outputDir,
-      reportPath,
-      status: "fail",
-      summaryPath,
-    };
-  } finally {
-    if (summary) {
-      summary.finishedAt = new Date().toISOString();
-      await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
-      await fs.writeFile(reportPath, renderReport(summary), "utf8");
-    }
-    if (summary?.status === "pass" && createdLease && leaseId && !keepLease) {
+    await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+    await fs.writeFile(reportPath, renderReport(summary), "utf8");
+    if (result.status === "pass" && createdLease && leaseId && !keepLease) {
       await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
     }
   }
+  return result;
 }

--- a/test/scripts/mantis-status-reactions-artifacts.test.ts
+++ b/test/scripts/mantis-status-reactions-artifacts.test.ts
@@ -1,0 +1,164 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { loadEvidenceManifest } from "../../scripts/mantis/publish-pr-evidence.mjs";
+
+const scenario = "discord-status-reactions-tool-only";
+const rootRelative = ".artifacts/qa-e2e/mantis/discord-status-reactions";
+const tempDirs: string[] = [];
+const workflow = parse(
+  readFileSync(".github/workflows/mantis-discord-status-reactions.yml", "utf8"),
+) as {
+  jobs: Record<string, { steps: { id?: string; run?: string }[] }>;
+};
+const runScript = Object.values(workflow.jobs)
+  .flatMap((job) => job.steps ?? [])
+  .find((step) => step.id === "run_mantis")?.run;
+if (!runScript) throw new Error("Missing Mantis run step");
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// Replace only external capture/provider/preview commands; run the actual workflow's
+// copy, cleanup, status, report, and jq manifest production against real local files.
+const controlledCommands = String.raw`
+pnpm() { return 0; }
+ffmpeg() { return 0; }
+ffprobe() { return 0; }
+sudo() { echo "unexpected package installation" >&2; return 97; }
+crabbox() {
+  if [[ "$1" == warmup ]]; then echo cbx_117239; return 0; fi
+  if [[ "$1" == stop ]]; then return 0; fi
+  [[ "$1" == media && "$2" == preview ]] || return 98
+  shift 2
+  local input="" output="" clip=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --input) input="$2"; shift 2 ;;
+      --output) output="$2"; shift 2 ;;
+      --trimmed-video-output) clip="$2"; shift 2 ;;
+      --json) shift ;;
+      *) return 99 ;;
+    esac
+  done
+  printf '%s\n' "$input" >> preview-calls.txt
+  printf 'preview' > "$output"
+  printf 'clip' > "$clip"
+  printf '{}\n'
+  if [[ -n "$FAIL_PREVIEW_LANE" && "$input" == */"$FAIL_PREVIEW_LANE"/* ]]; then return 1; fi
+}
+`;
+
+function runWorkflow(videos: readonly string[], failedPreview = "", missingScreenshot = "") {
+  const dir = mkdtempSync(path.join(tmpdir(), "mantis-status-artifacts-"));
+  tempDirs.push(dir);
+  for (const lane of ["baseline", "candidate"]) {
+    const seed = path.join(dir, `${rootRelative}-worktrees`, lane, rootRelative, lane);
+    mkdirSync(path.join(seed, "desktop-browser"), { recursive: true });
+    writeFileSync(path.join(seed, `${scenario}-timeline.html`), "<h1>Synthetic timeline</h1>");
+    writeFileSync(path.join(seed, `${scenario}-timeline.png`), "timeline fixture");
+    writeFileSync(
+      path.join(seed, "qa-evidence.json"),
+      JSON.stringify({ entries: [{ result: { status: lane === "baseline" ? "fail" : "pass" } }] }),
+    );
+    if (missingScreenshot !== lane) {
+      writeFileSync(
+        path.join(seed, "desktop-browser", "desktop-browser-smoke.png"),
+        "capture fixture",
+      );
+    }
+    if (videos.includes(lane)) {
+      writeFileSync(
+        path.join(seed, "desktop-browser", "desktop-browser-smoke.mp4"),
+        "video fixture",
+      );
+    }
+  }
+  const result = spawnSync(
+    "bash",
+    ["-c", controlledCommands + runScript.replace(/\$\{\{[^}]+\}\}/gu, "fixture-revision")],
+    {
+      cwd: dir,
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        PATH: process.env.PATH,
+        OPENAI_API_KEY: "unused-fixture",
+        OPENCLAW_QA_CONVEX_SITE_URL: "unused-fixture",
+        OPENCLAW_QA_CONVEX_SECRET_CI: "unused-fixture",
+        CRABBOX_COORDINATOR_TOKEN: "unused-fixture",
+        FAIL_PREVIEW_LANE: failedPreview,
+        GITHUB_OUTPUT: path.join(dir, "outputs.txt"),
+        GITHUB_STEP_SUMMARY: path.join(dir, "summary.md"),
+      },
+    },
+  );
+  return { dir, result, root: path.join(dir, rootRelative) };
+}
+
+// The production workflow runs on Linux/Bash; this lane requires Bash and jq.
+describe.skipIf(process.platform === "win32")("Mantis status-reactions artifact consumers", () => {
+  it.each([
+    { videos: [], failedPreview: "" },
+    { videos: ["baseline"], failedPreview: "" },
+    { videos: ["candidate"], failedPreview: "" },
+    { videos: ["baseline", "candidate"], failedPreview: "" },
+    { videos: ["baseline", "candidate"], failedPreview: "baseline" },
+    { videos: ["baseline", "candidate"], failedPreview: "candidate" },
+  ])(
+    "publishes available videos $videos independently of failed preview $failedPreview",
+    ({ videos, failedPreview }) => {
+      const { dir, root, result } = runWorkflow(videos, failedPreview);
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      const manifest = loadEvidenceManifest(path.join(root, "mantis-evidence.json"));
+      expect(manifest.comparison.pass).toBe(true);
+      expect(manifest.artifacts.filter((entry) => entry.kind === "desktopScreenshot")).toHaveLength(
+        2,
+      );
+      expect(
+        manifest.artifacts.filter((entry) => entry.kind === "fullVideo").map((entry) => entry.lane),
+      ).toEqual(videos);
+      const previewLanes = videos.filter((lane) => lane !== failedPreview);
+      for (const kind of ["motionPreview", "motionClip"]) {
+        expect(
+          manifest.artifacts.filter((entry) => entry.kind === kind).map((entry) => entry.lane),
+        ).toEqual(previewLanes);
+      }
+      if (videos.length) {
+        const calls = readFileSync(path.join(dir, "preview-calls.txt"), "utf8").trim().split("\n");
+        expect(calls).toHaveLength(videos.length);
+      } else {
+        expect(() => readFileSync(path.join(dir, "preview-calls.txt"))).toThrow();
+      }
+      const report = readFileSync(path.join(root, "mantis-report.md"), "utf8");
+      for (const lane of ["baseline", "candidate"]) {
+        expect(report.includes(`${lane}/${scenario}-desktop.mp4`)).toBe(videos.includes(lane));
+      }
+      // Optional video must not weaken the publisher's required screenshot contract.
+      rmSync(path.join(root, `baseline/${scenario}-desktop.png`));
+      expect(() => loadEvidenceManifest(path.join(root, "mantis-evidence.json"))).toThrow(
+        "Missing required artifact",
+      );
+    },
+  );
+
+  it("does not turn a missing screenshot into a successful screenshot-only capture", () => {
+    const { result } = runWorkflow([], "", "baseline");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("desktop-browser-smoke.png");
+  });
+
+  it("keeps optional videos subject to the publisher's regular-file check", () => {
+    const { root, result } = runWorkflow([]);
+    expect(result.status, result.stderr).toBe(0);
+    mkdirSync(path.join(root, `baseline/${scenario}-desktop.mp4`));
+    expect(() => loadEvidenceManifest(path.join(root, "mantis-evidence.json"))).toThrow(
+      "Artifact is not a file",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Mantis desktop-browser QA could report screenshots or recordings left by an earlier run as current evidence when an output directory was reused. Empty or symlinked captures could also be accepted, and a screenshot-only success could subsequently fail the Discord status-reactions evidence workflow.

**Draft: the improved implementation is preserved for review, but mandatory real desktop proof is still outstanding. Do not merge or enable automerge yet.** This body replaces the previous head's proof claims; those older claims are not being carried forward as evidence for this rewrite.

## Why This Change Was Made

The capture owner now retires exactly its screenshot, recording, summary, report, and error file before preflight. It settles every cleanup without following symlink targets or recursively removing directories. Failed transfers clean only the two possibly partial visual files. Both captures are inspected as regular nonempty files; the screenshot is required, while the recording remains optional. Inspection and cleanup failures retain both causes, and one result drives summary/report publication.

The status-reactions workflow preserves optional-video behavior through copy, independent preview generation, report links, and the evidence manifest. Required screenshots remain required. Existing SSH selection, non-deleting rsync behavior, lease retention, unrelated output files, and remote diagnostic logs are unchanged. A valid video accompanying an invalid required screenshot remains on disk for diagnosis but is not claimed by the failed result.

This is a source-trusted rewrite on main baseline `8c7de197cd6d535943d10a04312547b134cf00e2`, preserving the original author's credit. The contributor branch was not executed locally.

## User Impact

Internal Mantis QA operators get accurate capture evidence and usable screenshot-only status-reactions runs. This does not change the general browser automation runtime. No configuration, dependency, persistent-store, provider, or security-policy surface is added. The root changelog is intentionally omitted under the internal-only exception.

Runtime: **+97/-72 (net +25)**. Workflow: **+22/-19 (net +3)**. Tests: **+411/-1 (net +410)**. Consolidating the duplicate summaries absorbs most of the owner repair; remaining production growth enforces artifact lifecycle, regular-file validation, error preservation, and independent optional-video handling.

## Evidence

- The trusted baseline reproduced six failures through the actual producer with real local filesystem operations and rsync: stale video reuse, false screenshot success, empty captures, symlinks, partial-copy remnants, and preflight remnants. The fresh-capture control passed.
- Regression tests failed before their respective repairs. Final focused suites pass: **28 owner tests + 8 workflow tests = 36**. These cover sequential directory reuse, invalid capture combinations, copy/inspection/cleanup failures, stale reports and errors, directory/symlink safety, absent optional videos, either lane's preview failure, and required screenshot enforcement.
- The same actual-producer/local-rsync harness passes on the final tree with no findings. It uses synthetic PNG/video fixtures and substitutes cloud transport; it is **not live Chrome, X11, remote Crabbox, or Discord proof**. Its preflight check covers visual names; metadata retirement is exercised by the separate owner filesystem tests.
- Workflow tests execute the actual workflow shell step with controlled external commands and validate artifacts through the actual evidence-manifest loader. They do not publish to GitHub or Discord.
- Targeted formatting, `git diff --check`, and actionlint pass. Two independent code/proof reviewers approved the final tree. Native Codex autoreview and a distinct full-source Codex review are clean after addressing both the double-fault error-loss and stale preflight-report findings.
- Native extension typechecking hit its 90-second watchdog without diagnostics under host load; this was not a pass. Full types, type-aware lint, complete workflow gates, and exact-head hosted CI remain pending. No build/SDK preparation or weaker lint configuration was substituted.

Reproducible focused commands:

```sh
node scripts/run-vitest.mjs extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
node scripts/run-vitest.mjs test/scripts/mantis-status-reactions-artifacts.test.ts
actionlint .github/workflows/mantis-discord-status-reactions.yml
git diff --check
```

### Remaining desktop proof

The real Mantis CLI must still run against an approved Linux desktop lease with a visible Chrome/X11 capture and actual SSH/rsync transfer, repeating the same output directory from PNG+MP4 to screenshot-only to failure. Standard Testbox cannot exercise this flow: its provider lacks desktop/browser capabilities and inspect does not supply the SSH endpoint/key/user required by the existing Mantis copy owner. Installing Chrome alone would not resolve that transport mismatch. No paid desktop lease has been acquired, and this PR does not add a provider adapter or alternate transport to work around the gap.

### Latest ClawSweeper findings and rank-up moves

The latest substantive review is August 19 on the original head; the August 26 comment is a review-start placeholder, not a new verdict.

- Optional status-reactions MP4 copy, preview/report paths, and full-video manifest entries: addressed, with both independent lanes covered.
- Refresh the old branch against main and rerun producer/consumer proof: addressed by the trusted-main rewrite and final 36-test plus filesystem/rsync run. Main advancing alone is not claimed as a reason for another rebase.
- Real desktop/workflow publication proof and exact-head CI: still pending; the PR remains draft. Earlier proof-sufficient labels and CLI-help output do not establish this rewritten head's real desktop behavior.
- The previous serialized-state warning concerned QA artifact fixtures, not an OpenClaw runtime store or schema migration; no persistent-store design change is included.

Named follow-up: **Mantis Slack/Telegram desktop artifact freshness**. Their separate producer lifecycles still warrant a dedicated sequential-reuse and cleanup audit with their own real-flow proof; this draft does not claim those owners are repaired or execute their authenticated flows.
