### PR TITLE
fix(plugins): normalize required plugin dependency identity

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -587,37 +587,103 @@ describe("discoverOpenClawPlugins", () => {
     });
   });
 
-  it("recognizes the validated manifest id of an explicitly configured plugin file", async () => {
-    const stateDir = makeTempDir();
-    const coreDir = path.join(stateDir, "configured-plugins", "acme-core");
-    const coreEntry = path.join(coreDir, "index.ts");
-    mkdirSafe(coreDir);
-    writePluginManifest({ pluginDir: coreDir, id: "acme-core" });
-    writePluginEntry(coreEntry);
+  it.each([
+    { installedPluginId: "Core-Mixed", requiredPluginId: "core-mixed" },
+    { installedPluginId: "core-mixed", requiredPluginId: "CORE-MIXED" },
+  ])(
+    "matches installed plugin dependency ids case-insensitively ($installedPluginId -> $requiredPluginId)",
+    async ({ installedPluginId, requiredPluginId }) => {
+      const stateDir = makeTempDir();
+      const extensionsDir = path.join(stateDir, "extensions");
+      createPackagePluginWithEntry({
+        packageDir: path.join(extensionsDir, "core"),
+        packageName: "@openclaw/core",
+        pluginId: installedPluginId,
+      });
+      const addonDir = path.join(extensionsDir, "addon");
+      createPackagePluginWithEntry({
+        packageDir: addonDir,
+        packageName: "@openclaw/addon",
+        pluginId: "addon",
+      });
+      writePluginManifest({
+        pluginDir: addonDir,
+        id: "addon",
+        requiresPlugins: [requiredPluginId],
+      });
 
-    const dependentDir = path.join(stateDir, "extensions", "acme-addon");
+      const result = await discoverWithStateDir(stateDir, {});
+
+      expectCandidatePresence(result, { present: [installedPluginId, "addon"] });
+      expectNoDiagnostic({
+        diagnostics: result.diagnostics,
+        pluginId: "addon",
+        messageIncludes: "requires plugin",
+      });
+    },
+  );
+
+  it.each([
+    { manifestId: "acme-core", requiredPluginId: "acme-core" },
+    { manifestId: "Acme-Core", requiredPluginId: "acme-core" },
+    { manifestId: "acme-core", requiredPluginId: "ACME-CORE" },
+  ])(
+    "recognizes the validated manifest id of an explicitly configured plugin file ($manifestId -> $requiredPluginId)",
+    async ({ manifestId, requiredPluginId }) => {
+      const stateDir = makeTempDir();
+      const coreDir = path.join(stateDir, "configured-plugins", "acme-core");
+      const coreEntry = path.join(coreDir, "index.ts");
+      mkdirSafe(coreDir);
+      writePluginManifest({ pluginDir: coreDir, id: manifestId });
+      writePluginEntry(coreEntry);
+
+      const dependentDir = path.join(stateDir, "extensions", "acme-addon");
+      createPackagePluginWithEntry({
+        packageDir: dependentDir,
+        packageName: "@acme/acme-addon",
+        pluginId: "acme-addon",
+      });
+      writePluginManifest({
+        pluginDir: dependentDir,
+        id: "acme-addon",
+        requiresPlugins: [requiredPluginId],
+      });
+
+      const result = await discoverWithStateDir(stateDir, { extraPaths: [coreEntry] });
+
+      expectCandidatePresence(result, {
+        present: ["index", "acme-addon"],
+        absent: ["acme-core"],
+      });
+      expectNoDiagnostic({
+        diagnostics: result.diagnostics,
+        pluginId: "acme-addon",
+        messageIncludes: "requires plugin",
+      });
+    },
+  );
+
+  it("reports one actionable warning for repeated missing dependency casing", async () => {
+    const stateDir = makeTempDir();
+    const addonDir = path.join(stateDir, "extensions", "addon");
     createPackagePluginWithEntry({
-      packageDir: dependentDir,
-      packageName: "@acme/acme-addon",
-      pluginId: "acme-addon",
+      packageDir: addonDir,
+      packageName: "@openclaw/addon",
+      pluginId: "addon",
     });
     writePluginManifest({
-      pluginDir: dependentDir,
-      id: "acme-addon",
-      requiresPlugins: ["acme-core"],
+      pluginDir: addonDir,
+      id: "addon",
+      requiresPlugins: ["Missing-Core", "missing-core"],
     });
 
-    const result = await discoverWithStateDir(stateDir, { extraPaths: [coreEntry] });
+    const result = await discoverWithStateDir(stateDir, {});
+    const missingWarnings = result.diagnostics.filter(
+      (entry) => entry.pluginId === "addon" && entry.message.includes("requires plugin"),
+    );
 
-    expectCandidatePresence(result, {
-      present: ["index", "acme-addon"],
-      absent: ["acme-core"],
-    });
-    expectNoDiagnostic({
-      diagnostics: result.diagnostics,
-      pluginId: "acme-addon",
-      messageIncludes: 'requires plugin "acme-core"',
-    });
+    expect(missingWarnings).toHaveLength(1);
+    expect(missingWarnings[0]?.message).toContain('requires plugin "Missing-Core"');
   });
 
   it.skipIf(!canCreateDirectorySymlinks)(

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -39,6 +39,7 @@ import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
+import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { withPluginScanExistenceCache } from "./plugin-scan-existence-cache.js";
 import { resolvePluginSourceRoots } from "./roots.js";
 import {
@@ -414,16 +415,19 @@ function addMissingRequiredPluginDiagnostics(
   result: PluginDiscoveryResult,
   params: { env: NodeJS.ProcessEnv; realpathCache: Map<string, string> },
 ): void {
-  const candidateIds = new Set(result.candidates.map((candidate) => candidate.idHint));
+  const candidatePolicyIds = new Set(
+    result.candidates.map((candidate) => normalizePluginPolicyId(candidate.idHint)),
+  );
   const seen = new Set<string>();
-  let configuredFileManifestIds: Set<string> | undefined;
+  let configuredFileManifestPolicyIds: Set<string> | undefined;
   for (const candidate of result.candidates) {
     for (const requiredPluginId of candidate.requiredPluginIds ?? []) {
-      if (candidateIds.has(requiredPluginId) || requiredPluginId === candidate.idHint) {
+      const requiredPolicyId = normalizePluginPolicyId(requiredPluginId);
+      if (candidatePolicyIds.has(requiredPolicyId)) {
         continue;
       }
-      if (!configuredFileManifestIds) {
-        configuredFileManifestIds = new Set();
+      if (!configuredFileManifestPolicyIds) {
+        configuredFileManifestPolicyIds = new Set();
         // Explicit files keep filename hints; only a validated root manifest
         // can establish their canonical identity for a missing dependency.
         for (const configuredCandidate of result.candidates) {
@@ -438,14 +442,14 @@ function addMissingRequiredPluginDiagnostics(
           });
           const manifest = resolveCandidateManifest(configuredCandidate.rootDir, rejectHardlinks);
           if (manifest) {
-            configuredFileManifestIds.add(manifest.manifest.id);
+            configuredFileManifestPolicyIds.add(normalizePluginPolicyId(manifest.manifest.id));
           }
         }
       }
-      if (configuredFileManifestIds.has(requiredPluginId)) {
+      if (configuredFileManifestPolicyIds.has(requiredPolicyId)) {
         continue;
       }
-      const key = `${candidate.idHint}\0${requiredPluginId}`;
+      const key = `${normalizePluginPolicyId(candidate.idHint)}\0${requiredPolicyId}`;
       if (seen.has(key)) {
         continue;
       }


### PR DESCRIPTION
## What Problem This Solves

An installed, enabled plugin whose declared ID uses different casing from another plugin's `requiresPlugins` reference is falsely reported missing. The same false install warning propagates through discovery, manifest status, and the live runtime even though both plugins load successfully.

## Why This Change Was Made

The existing discovery owner now reuses OpenClaw's canonical case-insensitive plugin policy identity for discovered IDs, explicit validated-file manifest IDs, dependency references, and duplicate-warning keys. Declared plugin IDs and actionable user-facing diagnostic spelling remain unchanged.

## User Impact

Operators stop receiving false reinstall warnings for already-installed mixed-case plugin dependencies. Genuine missing dependencies still produce one actionable warning with the original requested spelling. Existing plugin policy, case-fold collision rejection, and TypeScript declaration-file filtering remain intact.

## Evidence

- Real generated packages on current main load both plugins successfully while all three discovery, manifest, and live-loader surfaces incorrectly report the dependency missing; the frozen candidate loads both and removes all three false warnings.
- Actual no-mock before/after artifacts: `/private/tmp/openclaw-qa400-plugin-casefold-dependency-main-red.json` and `/private/tmp/openclaw-qa400-plugin-casefold-dependency-fixed-green.json`.
- Five regressions were demonstrated red before the owner refactor: both global-case directions, both explicit-file manifest-case directions, and duplicate missing-dependency aliases.
- Five focused existing suites, two Vitest projects: **227 tests passed**, including real case-fold collision rejection, true missing diagnostics, deterministic discovery, config policy, dependency health, and `.d.ts`/`.d.mts`/`.d.cts` exclusion.
- Fresh genuine full-branch Codex autoreview (`gpt-5.6-sol`, high, P0–P3): TruffleHog clean, process exit 0, findings empty, confidence 0.98.
- Current-main clean synthetic merge: `947886e7649ca0172f7e0f643c35f9e6283ebe5b` -> `6b1f9584ece0532d199ddcd4937cfdaad7cc04ef`.
