### PR TITLE
fix(gateway): stop post-ready sidecar timers on close

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -537,7 +537,6 @@ describe("startGatewayPostAttachRuntime", () => {
     await startGatewayPostAttachRuntime({
       ...createPostAttachParams(),
       log,
-      agentRuntimePluginPrewarm: { enabled: false },
       onPostReadySidecars: () => {
         events.push("post-ready-registered");
       },
@@ -622,7 +621,7 @@ describe("startGatewayPostAttachRuntime", () => {
     });
     hoisted.scheduleRestartSentinelWake.mockReturnValueOnce(wake);
 
-    testing.scheduleRestartSentinelWakeAfterReady({
+    const sidecar = testing.scheduleRestartSentinelWakeAfterReady({
       deps: {} as never,
       log: { warn: vi.fn() },
     });
@@ -635,6 +634,20 @@ describe("startGatewayPostAttachRuntime", () => {
     await waitForGatewayTestState(() => {
       expect(getActiveGatewayRootWorkCount()).toBe(0);
     });
+    await sidecar.stop();
+  });
+
+  it("cancels delayed restart sentinel recovery when the gateway closes", async () => {
+    vi.useFakeTimers();
+    const sidecar = testing.scheduleRestartSentinelWakeAfterReady({
+      deps: {} as never,
+      log: { warn: vi.fn() },
+    });
+
+    await sidecar.stop();
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(hoisted.scheduleRestartSentinelWake).not.toHaveBeenCalled();
   });
 
   it("starts sidecars while startup logging is still pending", async () => {
@@ -1172,7 +1185,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
-      expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
+      expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(2);
       expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(4);
       await vi.dynamicImportSettled();
       await waitForGatewayTestState(() => {
@@ -1236,10 +1249,8 @@ describe("startGatewayPostAttachRuntime", () => {
         gatewayPluginConfigAtStart: startupConfig,
       }),
       waitForPostReadyWork: () => gatewayReady,
-      providerAuthPrewarm: { enabled: false },
-      agentRuntimePluginPrewarm: {
-        enabled: true,
-        delayMs: 0,
+      providerAuthPrewarm: {
+        enabled: false,
         getConfig: () => currentConfig,
       },
     });
@@ -1344,7 +1355,7 @@ describe("startGatewayPostAttachRuntime", () => {
       const lifetimeSidecars = onGatewayLifetimeSidecars.mock.calls[0]?.[0] as
         | { stop: () => void }[]
         | undefined;
-      expect(gmailSidecars).toHaveLength(1);
+      expect(gmailSidecars).toHaveLength(3);
       expect(lifetimeSidecars).toHaveLength(4);
 
       for (const sidecar of gmailSidecars ?? []) {
@@ -1406,7 +1417,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const lifetimeSidecars = onGatewayLifetimeSidecars.mock.calls[0]?.[0] as
       | Array<{ stop: () => Promise<void> | void }>
       | undefined;
-    expect(gmailSidecars).toHaveLength(1);
+    expect(gmailSidecars).toHaveLength(3);
     expect(lifetimeSidecars).toHaveLength(4);
 
     await waitForGatewayTestState(() => {
@@ -2003,7 +2014,7 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 3],
+        ["postReadySidecarCount", 5],
       ],
     });
   });
@@ -2064,7 +2075,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    expect(result.postReadySidecars).toHaveLength(1);
+    expect(result.postReadySidecars).toHaveLength(3);
     expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
     onPostReadySidecars(result.postReadySidecars);
     expect(onPostReadySidecars).toHaveBeenCalledWith(result.postReadySidecars);
@@ -2078,7 +2089,9 @@ describe("startGatewayPostAttachRuntime", () => {
     if (!resolveWatcher) {
       throw new Error("Expected gmail watcher resolver to be initialized");
     }
-    await result.postReadySidecars[0]?.stop();
+    for (const sidecar of result.postReadySidecars) {
+      await sidecar.stop();
+    }
     expect(watcherSignal?.aborted).toBe(true);
     resolveWatcher();
   });
@@ -2107,7 +2120,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    expect(result.postReadySidecars).toHaveLength(1);
+    expect(result.postReadySidecars).toHaveLength(3);
     await waitForGatewayTestState(() => {
       expect(log.warn).toHaveBeenCalledWith(
         "sidecars.gmail-watch failed after gateway ready: Error: boom",
@@ -2136,8 +2149,10 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    expect(result.postReadySidecars).toHaveLength(1);
-    await result.postReadySidecars[0]?.stop();
+    expect(result.postReadySidecars).toHaveLength(3);
+    for (const sidecar of result.postReadySidecars) {
+      await sidecar.stop();
+    }
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
@@ -2183,7 +2198,9 @@ describe("startGatewayPostAttachRuntime", () => {
       await waitForGatewayTestState(() => {
         expect(releaseImport).toBeDefined();
       });
-      await result.postReadySidecars[0]?.stop();
+      for (const sidecar of result.postReadySidecars) {
+        await sidecar.stop();
+      }
       releaseImport?.();
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
@@ -2263,7 +2280,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    expect(result.postReadySidecars).toHaveLength(1);
+    expect(result.postReadySidecars).toHaveLength(3);
     expect(hoisted.loadModelCatalog).not.toHaveBeenCalled();
 
     await waitForGatewayTestState(() => {
@@ -2523,6 +2540,49 @@ describe("startGatewayPostAttachRuntime", () => {
       releaseHook();
       vi.useRealTimers();
     }
+  });
+
+  it("cancels registered gateway startup hooks when close starts", async () => {
+    vi.useFakeTimers();
+    hoisted.hasInternalHookListeners.mockReturnValue(true);
+    const trace = createStartupTraceRecorder();
+    let releasePostReadyWork!: () => void;
+    const postReadyWork = new Promise<void>((resolve) => {
+      releasePostReadyWork = resolve;
+    });
+
+    const result = await startGatewaySidecars({
+      cfg: {} as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+      startupTrace: trace.startupTrace,
+      waitForPostReadyWork: () => postReadyWork,
+    });
+
+    expect(result.postReadySidecars).toHaveLength(3);
+    testing.stopPostReadySidecarsAfterCloseStarted({
+      postReadySidecars: result.postReadySidecars,
+      closeStarted: true,
+    });
+    releasePostReadyWork();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(hoisted.createInternalHookEvent).not.toHaveBeenCalled();
+    expect(hoisted.triggerInternalHook).not.toHaveBeenCalled();
+    expect(trace.measures).not.toContain("sidecars.session-locks");
+    expect(trace.measures).not.toContain("sidecars.restart-sentinel");
   });
 
   it("waits for a healthy ACP runtime backend before startup identity reconcile", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -401,18 +401,54 @@ function schedulePostReadySidecarTask(params: {
   };
 }
 
+function scheduleGatewayGenerationTimer(params: {
+  delayMs: number;
+  run: (isStopped: () => boolean) => Awaitable<void>;
+  onError: (err: unknown) => void;
+}): GatewayPostReadySidecarHandle {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const isStopped = () => stopped;
+  timer = setTimeout(() => {
+    timer = undefined;
+    if (isStopped()) {
+      return;
+    }
+    void runWithGatewayIndependentRootWorkAdmission(() => params.run(isStopped)).catch(
+      (err: unknown) => {
+        if (!isStopped()) {
+          params.onError(err);
+        }
+      },
+    );
+  }, params.delayMs);
+  timer.unref?.();
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
 function scheduleRestartSentinelWakeAfterReady(params: {
   deps: CliDeps;
   log: { warn: (msg: string) => void };
-}): void {
-  setTimeout(() => {
-    void runWithGatewayIndependentRootWorkAdmission(async () => {
+}): GatewayPostReadySidecarHandle {
+  return scheduleGatewayGenerationTimer({
+    delayMs: 750,
+    run: async (isStopped) => {
       const { scheduleRestartSentinelWake } = await loadGatewayRestartSentinelModule();
+      if (isStopped()) {
+        return;
+      }
       await scheduleRestartSentinelWake({ deps: params.deps });
-    }).catch((err: unknown) => {
-      params.log.warn(`restart sentinel wake failed to schedule: ${String(err)}`);
-    });
-  }, 750);
+    },
+    onError: (err) => params.log.warn(`restart sentinel wake failed to schedule: ${String(err)}`),
+  });
 }
 
 type CleanStaleLockFiles = typeof import("../agents/session-write-lock.js").cleanStaleLockFiles;
@@ -754,19 +790,26 @@ export async function startGatewaySidecars(params: {
     });
     // Run startup hooks after sidecar startup has yielded once so gateway bind
     // and channel startup are not delayed by hook handlers.
-    setTimeout(() => {
-      void runWithGatewayIndependentRootWorkAdmission(async () => {
-        const { createInternalHookEvent, triggerInternalHook } = await loadInternalHooksModule();
-        const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
-          cfg: params.cfg,
-          deps: params.deps,
-          workspaceDir: params.defaultWorkspaceDir,
-        });
-        await triggerInternalHook(hookEvent);
-      }).catch((err: unknown) => {
-        params.logHooks.warn(`gateway startup hook failed: ${String(err)}`);
-      });
-    }, 250);
+    // This timer belongs to the current gateway generation; registration lets
+    // close cancel it before a replacement generation starts in the same process.
+    postReadySidecars.push(
+      scheduleGatewayGenerationTimer({
+        delayMs: 250,
+        run: async (isStopped) => {
+          const { createInternalHookEvent, triggerInternalHook } = await loadInternalHooksModule();
+          if (isStopped()) {
+            return;
+          }
+          const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+            cfg: params.cfg,
+            deps: params.deps,
+            workspaceDir: params.defaultWorkspaceDir,
+          });
+          await triggerInternalHook(hookEvent);
+        },
+        onError: (err) => params.logHooks.warn(`gateway startup hook failed: ${String(err)}`),
+      }),
+    );
   }
 
   if (params.cfg.acp?.enabled) {
@@ -807,47 +850,60 @@ export async function startGatewaySidecars(params: {
     scheduleGatewayMemoryBackend({ cfg: params.cfg, log: params.log, policy });
   });
 
-  schedulePostReadySidecarTask({
-    startupTrace: params.startupTrace,
-    name: "sidecars.session-locks",
-    log: params.log,
-    waitForPostReadyWork: params.waitForPostReadyWork,
-    run: async (isStopped) => {
-      try {
-        const [{ resolveAgentSessionDirs }, { cleanStaleLockFiles }] = await Promise.all([
-          import("../agents/session-dirs.js"),
-          import("../agents/session-write-lock.js"),
-        ]);
-        const stateDir = resolveStateDir(process.env);
-        const sessionDirs = await resolveAgentSessionDirs(stateDir);
-        await cleanupStaleSessionLocks({
-          sessionDirs,
-          cfg: params.cfg,
-          log: params.log,
-          isStopped,
-          cleanStaleLockFiles,
-        });
-      } catch (err) {
-        params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
-      }
-    },
-  });
+  // These tasks may still be waiting when close begins. Keep their handles in
+  // the generation-owned registry so they cannot run into a replacement gateway.
+  postReadySidecars.push(
+    schedulePostReadySidecarTask({
+      startupTrace: params.startupTrace,
+      name: "sidecars.session-locks",
+      log: params.log,
+      waitForPostReadyWork: params.waitForPostReadyWork,
+      run: async (isStopped) => {
+        try {
+          const [{ resolveAgentSessionDirs }, { cleanStaleLockFiles }] = await Promise.all([
+            import("../agents/session-dirs.js"),
+            import("../agents/session-write-lock.js"),
+          ]);
+          const stateDir = resolveStateDir(process.env);
+          const sessionDirs = await resolveAgentSessionDirs(stateDir);
+          await cleanupStaleSessionLocks({
+            sessionDirs,
+            cfg: params.cfg,
+            log: params.log,
+            isStopped,
+            cleanStaleLockFiles,
+          });
+        } catch (err) {
+          params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
+        }
+      },
+    }),
+  );
 
-  schedulePostReadySidecarTask({
-    startupTrace: params.startupTrace,
-    name: "sidecars.restart-sentinel",
-    log: params.log,
-    waitForPostReadyWork: params.waitForPostReadyWork,
-    run: async () => {
-      if (!shouldCheckRestartSentinel()) {
-        return;
-      }
-      if (!(await hasRestartSentinelFast())) {
-        return;
-      }
-      scheduleRestartSentinelWakeAfterReady({ deps: params.deps, log: params.log });
-    },
-  });
+  let restartSentinelWake: GatewayPostReadySidecarHandle | undefined;
+  postReadySidecars.push(
+    schedulePostReadySidecarTask({
+      startupTrace: params.startupTrace,
+      name: "sidecars.restart-sentinel",
+      log: params.log,
+      waitForPostReadyWork: params.waitForPostReadyWork,
+      run: async (isStopped) => {
+        if (!shouldCheckRestartSentinel() || isStopped()) {
+          return;
+        }
+        if (!(await hasRestartSentinelFast()) || isStopped()) {
+          return;
+        }
+        restartSentinelWake = scheduleRestartSentinelWakeAfterReady({
+          deps: params.deps,
+          log: params.log,
+        });
+      },
+      stop: async () => {
+        await restartSentinelWake?.stop();
+      },
+    }),
+  );
 
   if (params.cfg.hooks?.enabled && params.cfg.hooks.gmail?.account) {
     postReadySidecars.push(
@@ -1104,11 +1160,6 @@ export async function startGatewayPostAttachRuntime(
       delayMs?: number;
       getConfig?: () => OpenClawConfig;
     };
-    agentRuntimePluginPrewarm?: {
-      enabled?: boolean;
-      delayMs?: number;
-      getConfig?: () => OpenClawConfig;
-    };
     waitForPostReadyWork?: () => Promise<void>;
   },
   runtimeDeps: GatewayPostAttachRuntimeDeps = defaultGatewayPostAttachRuntimeDeps,
@@ -1321,21 +1372,16 @@ export async function startGatewayPostAttachRuntime(
         if (workerEnvironmentSidecar) {
           gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
         }
-        if (params.agentRuntimePluginPrewarm?.enabled !== false) {
-          gatewayLifetimeSidecars.push(
-            scheduleAgentRuntimePluginPrewarm({
-              getConfig:
-                params.agentRuntimePluginPrewarm?.getConfig ??
-                params.providerAuthPrewarm?.getConfig ??
-                (() => params.gatewayPluginConfigAtStart),
-              workspaceDir: params.defaultWorkspaceDir,
-              startupTrace: params.startupTrace,
-              log: params.log,
-              delayMs: params.agentRuntimePluginPrewarm?.delayMs,
-              waitForPostReadyWork: params.waitForPostReadyWork,
-            }),
-          );
-        }
+        gatewayLifetimeSidecars.push(
+          scheduleAgentRuntimePluginPrewarm({
+            getConfig:
+              params.providerAuthPrewarm?.getConfig ?? (() => params.gatewayPluginConfigAtStart),
+            workspaceDir: params.defaultWorkspaceDir,
+            startupTrace: params.startupTrace,
+            log: params.log,
+            waitForPostReadyWork: params.waitForPostReadyWork,
+          }),
+        );
         if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
           gatewayLifetimeSidecars.push(
             scheduleProviderAuthStatePrewarm({

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -414,13 +414,13 @@ function scheduleGatewayGenerationTimer(params: {
     if (isStopped()) {
       return;
     }
-    void runWithGatewayIndependentRootWorkAdmission(() => params.run(isStopped)).catch(
-      (err: unknown) => {
-        if (!isStopped()) {
-          params.onError(err);
-        }
-      },
-    );
+    void runWithGatewayIndependentRootWorkAdmission(async () => {
+      await params.run(isStopped);
+    }).catch((err: unknown) => {
+      if (!isStopped()) {
+        params.onError(err);
+      }
+    });
   }, params.delayMs);
   timer.unref?.();
   return {


### PR DESCRIPTION
## What Problem This Solves

Gateway post-ready background work could outlive the gateway that scheduled it. In `src/gateway/server-startup-post-attach.ts`:

- Two `schedulePostReadySidecarTask` call sites (`sidecars.session-locks`, `sidecars.restart-sentinel`) discarded their returned `{stop}` handles, making them unreachable from `stopRegisteredPostReadySidecars` — the tasks kept running after gateway close.
- `scheduleRestartSentinelWakeAfterReady` fired a bare 750 ms `setTimeout` with no retained handle, no `unref()`, and no closing check — launched from one of the discarded sidecars, it is concrete "background work that begins after shutdown".
- The `gateway:startup` internal hook fired via an unretained 250 ms `setTimeout` with no closing guard.

This matters because SIGUSR1 restarts a fresh gateway **in the same process** (`src/cli/gateway-cli/run-loop.ts`): old-generation timers must not fire into the replacement instance.

Additionally, the `agentRuntimePluginPrewarm` option was dead config: `finishGatewayStartup` (the sole production caller) never passed it, so the guard `?.enabled !== false` was always true.

## Why This Change Was Made

All post-ready work now belongs to the gateway generation that scheduled it: the two discarded handles are registered in `postReadySidecars`, and both raw timers go through a small shared `scheduleGatewayGenerationTimer` helper (retained handle, `unref`, stopped-check, cancel-on-close). The dead `agentRuntimePluginPrewarm` option is deleted rather than kept: prewarm behavior is unchanged (still enabled, same config fallback chain) — the option provably had no production caller on `origin/main`, and `startGatewayPostAttachRuntime` is gateway-internal, not shipped SDK.

Structured review raised preserving the option's opt-out; rejected after verification: zero production callers exist, the repo's policy is to remove stale internal args cleanly, and hypothetical callers do not warrant compat.

## User Impact

No behavior change during normal operation. On shutdown and in-process restart (SIGUSR1), stale session-lock cleanup, restart-sentinel work, and the startup hook can no longer execute into a closing or replacement gateway — eliminating a class of post-shutdown races.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts` — 63/63 pass (also run as autoreview parallel tests), including new close-before-fire coverage for all three handles.
- Close/reload lifecycle tests: 155/155 pass.
- Structured autoreview (Codex, gpt-5.6-sol, high): one P2 finding, rejected with the caller-verification above; no other findings.
- Prod diff +125/−79; the shared timer helper replaces two duplicated raw `setTimeout` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Runtime proof (added post-review)

Close-race transcript on an integration build containing this PR: SIGTERM 40 ms after ready (inside both deferred-timer windows, with `gateway-start-hooks=scheduled` recorded), no callback output after "shutting down", and process exit in 111 ms — impossible pre-fix, when the 750 ms sentinel wake held the event loop with no handle or unref. Full transcript: https://github.com/openclaw/openclaw/pull/117242#issuecomment-5150095013
