### PR TITLE
fix(gateway): prevent mixed content when resuming changed media

### DIFF
--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -1,4 +1,5 @@
 // Control UI assistant media e2e tests verify scoped media-ticket access through gateway HTTP routes.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -59,13 +60,19 @@ describe("Control UI assistant media e2e", () => {
         expect(ranged.headers.get("accept-ranges")).toBe("bytes");
         expect(ranged.headers.get("content-range")).toBe("bytes 9-15/26");
         expect(ranged.headers.get("content-length")).toBe("7");
-        expect(ranged.headers.get("etag")).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
+        expect(ranged.headers.get("etag")).toBeNull();
+        expect(ranged.headers.get("last-modified")).toBeNull();
         expect(await ranged.text()).toBe("control");
 
         const mutableFilePath = path.join(mediaDir, "mutable-preview.txt");
         const preservedTime = new Date("2026-07-01T00:00:00.000Z");
         await fs.writeFile(mutableFilePath, "AAAA", "utf8");
         await fs.utimes(mutableFilePath, preservedTime, preservedTime);
+        const originalStat = await fs.stat(mutableFilePath);
+        const legacyEtag = `"${createHash("sha256")
+          .update(`${originalStat.size}:${originalStat.mtimeMs}`)
+          .digest("base64url")}"`;
+        const legacyLastModified = originalStat.mtime.toUTCString();
         const mutableUrl = `${route}?source=${encodeURIComponent(mutableFilePath)}`;
         const initialRange = await fetch(mutableUrl, {
           headers: {
@@ -75,23 +82,43 @@ describe("Control UI assistant media e2e", () => {
         });
         expect(initialRange.status).toBe(206);
         expect(await initialRange.text()).toBe("AA");
-        const initialEtag = initialRange.headers.get("etag");
-        expect(initialEtag).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
-        const initialLastModified = initialRange.headers.get("last-modified");
-        expect(initialLastModified).toBe(preservedTime.toUTCString());
+        expect(initialRange.headers.get("etag")).toBeNull();
+        expect(initialRange.headers.get("last-modified")).toBeNull();
 
         await fs.writeFile(mutableFilePath, "BBBB", "utf8");
         await fs.utimes(mutableFilePath, preservedTime, preservedTime);
+        const revalidatedByEtag = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            "If-None-Match": legacyEtag,
+          },
+        });
+        expect(revalidatedByEtag.status).toBe(200);
+        expect(revalidatedByEtag.headers.get("etag")).toBeNull();
+        expect(revalidatedByEtag.headers.get("last-modified")).toBeNull();
+        expect(await revalidatedByEtag.text()).toBe("BBBB");
+
+        const revalidatedByDate = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            "If-Modified-Since": legacyLastModified,
+          },
+        });
+        expect(revalidatedByDate.status).toBe(200);
+        expect(revalidatedByDate.headers.get("etag")).toBeNull();
+        expect(revalidatedByDate.headers.get("last-modified")).toBeNull();
+        expect(await revalidatedByDate.text()).toBe("BBBB");
+
         const resumed = await fetch(mutableUrl, {
           headers: {
             Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
             Range: "bytes=2-3",
-            "If-Range": initialEtag ?? "",
+            "If-Range": legacyEtag,
           },
         });
         expect(resumed.status).toBe(200);
-        expect(resumed.headers.get("etag")).toBe(initialEtag);
-        expect(resumed.headers.get("last-modified")).toBe(initialLastModified);
+        expect(resumed.headers.get("etag")).toBeNull();
+        expect(resumed.headers.get("last-modified")).toBeNull();
         expect(resumed.headers.get("content-range")).toBeNull();
         expect(await resumed.text()).toBe("BBBB");
 
@@ -99,14 +126,24 @@ describe("Control UI assistant media e2e", () => {
           headers: {
             Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
             Range: "bytes=2-3",
-            "If-Range": initialLastModified ?? "",
+            "If-Range": legacyLastModified,
           },
         });
         expect(resumedByDate.status).toBe(200);
-        expect(resumedByDate.headers.get("etag")).toBe(initialEtag);
-        expect(resumedByDate.headers.get("last-modified")).toBe(initialLastModified);
+        expect(resumedByDate.headers.get("etag")).toBeNull();
+        expect(resumedByDate.headers.get("last-modified")).toBeNull();
         expect(resumedByDate.headers.get("content-range")).toBeNull();
         expect(await resumedByDate.text()).toBe("BBBB");
+
+        const currentRange = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            Range: "bytes=2-3",
+          },
+        });
+        expect(currentRange.status).toBe(206);
+        expect(currentRange.headers.get("content-range")).toBe("bytes 2-3/4");
+        expect(await currentRange.text()).toBe("BB");
 
         const head = await fetch(
           `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
@@ -115,7 +152,8 @@ describe("Control UI assistant media e2e", () => {
         expect(head.status).toBe(200);
         expect(head.headers.get("accept-ranges")).toBe("bytes");
         expect(head.headers.get("content-length")).toBe("26");
-        expect(head.headers.get("etag")).toBe(ranged.headers.get("etag"));
+        expect(head.headers.get("etag")).toBeNull();
+        expect(head.headers.get("last-modified")).toBeNull();
         expect(await head.text()).toBe("");
 
         for (const method of ["GET", "HEAD"]) {
@@ -124,14 +162,15 @@ describe("Control UI assistant media e2e", () => {
             {
               method,
               headers: {
-                "If-None-Match": ranged.headers.get("etag") ?? "",
+                "If-None-Match": "*",
                 Range: "bytes=9-15",
                 "If-Range": '"stale"',
               },
             },
           );
           expect(notModified.status).toBe(304);
-          expect(notModified.headers.get("etag")).toBe(ranged.headers.get("etag"));
+          expect(notModified.headers.get("etag")).toBeNull();
+          expect(notModified.headers.get("last-modified")).toBeNull();
           expect(notModified.headers.get("content-length")).toBeNull();
           expect(await notModified.text()).toBe("");
         }

--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -59,8 +59,54 @@ describe("Control UI assistant media e2e", () => {
         expect(ranged.headers.get("accept-ranges")).toBe("bytes");
         expect(ranged.headers.get("content-range")).toBe("bytes 9-15/26");
         expect(ranged.headers.get("content-length")).toBe("7");
-        expect(ranged.headers.get("etag")).toMatch(/^"[A-Za-z0-9_-]+"$/);
+        expect(ranged.headers.get("etag")).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
         expect(await ranged.text()).toBe("control");
+
+        const mutableFilePath = path.join(mediaDir, "mutable-preview.txt");
+        const preservedTime = new Date("2026-07-01T00:00:00.000Z");
+        await fs.writeFile(mutableFilePath, "AAAA", "utf8");
+        await fs.utimes(mutableFilePath, preservedTime, preservedTime);
+        const mutableUrl = `${route}?source=${encodeURIComponent(mutableFilePath)}`;
+        const initialRange = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            Range: "bytes=0-1",
+          },
+        });
+        expect(initialRange.status).toBe(206);
+        expect(await initialRange.text()).toBe("AA");
+        const initialEtag = initialRange.headers.get("etag");
+        expect(initialEtag).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
+        const initialLastModified = initialRange.headers.get("last-modified");
+        expect(initialLastModified).toBe(preservedTime.toUTCString());
+
+        await fs.writeFile(mutableFilePath, "BBBB", "utf8");
+        await fs.utimes(mutableFilePath, preservedTime, preservedTime);
+        const resumed = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            Range: "bytes=2-3",
+            "If-Range": initialEtag ?? "",
+          },
+        });
+        expect(resumed.status).toBe(200);
+        expect(resumed.headers.get("etag")).toBe(initialEtag);
+        expect(resumed.headers.get("last-modified")).toBe(initialLastModified);
+        expect(resumed.headers.get("content-range")).toBeNull();
+        expect(await resumed.text()).toBe("BBBB");
+
+        const resumedByDate = await fetch(mutableUrl, {
+          headers: {
+            Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}`,
+            Range: "bytes=2-3",
+            "If-Range": initialLastModified ?? "",
+          },
+        });
+        expect(resumedByDate.status).toBe(200);
+        expect(resumedByDate.headers.get("etag")).toBe(initialEtag);
+        expect(resumedByDate.headers.get("last-modified")).toBe(initialLastModified);
+        expect(resumedByDate.headers.get("content-range")).toBeNull();
+        expect(await resumedByDate.text()).toBe("BBBB");
 
         const head = await fetch(
           `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
@@ -78,7 +124,7 @@ describe("Control UI assistant media e2e", () => {
             {
               method,
               headers: {
-                "If-None-Match": `W/${ranged.headers.get("etag")}`,
+                "If-None-Match": ranged.headers.get("etag") ?? "",
                 Range: "bytes=9-15",
                 "If-Range": '"stale"',
               },

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -576,220 +576,130 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it.each(["GET", "HEAD"] as const)(
-    "revalidates assistant media ETags before ranges for %s",
-    async (method) => {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-conditional-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
-          expect(etag).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
-
-          const conditional = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: {
-              "if-none-match": String(etag),
-              range: "bytes=0-3",
-              "if-range": '"stale"',
-            },
-          });
-
-          expect(conditional.handled).toBe(true);
-          expect(conditional.res.statusCode).toBe(304);
-          expect(conditional.setHeader).toHaveBeenCalledWith("ETag", etag);
-          expect(conditional.setHeader).not.toHaveBeenCalledWith(
-            "Content-Length",
-            expect.anything(),
-          );
-          expect(conditional.end).toHaveBeenCalledWith();
-        },
-      });
-    },
-  );
-
-  it.each(["GET", "HEAD"] as const)(
-    "revalidates assistant media with If-Modified-Since before ranges for %s",
-    async (method) => {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-modified-since-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const lastModified = initial.setHeader.mock.calls.find(
-            ([name]) => name === "Last-Modified",
-          )?.[1];
-          expect(lastModified).toEqual(expect.any(String));
-
-          const unchanged = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: {
-              "if-modified-since": String(lastModified),
-              range: "bytes=0-3",
-              "if-range": '"stale"',
-            },
-          });
-
-          expect(unchanged.res.statusCode).toBe(304);
-          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-          expect(unchanged.setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
-          expect(unchanged.end).toHaveBeenCalledWith();
-        },
-      });
-    },
-  );
-
-  it.each(["GET", "HEAD"] as const)(
-    "ignores duplicate assistant-media dates discarded by normalized Node headers for %s",
-    async (method) => {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-duplicate-modified-since-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const lastModified = String(
-            initial.setHeader.mock.calls.find(([name]) => name === "Last-Modified")?.[1],
-          );
-
-          const duplicate = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: { "if-modified-since": lastModified },
-            distinctHeaders: {
-              "if-modified-since": [lastModified, "not-an-http-date"],
-            },
-          });
-
-          expect(duplicate.res.statusCode).toBe(200);
-          expect(duplicate.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-        },
-      });
-    },
-  );
-
-  it("does not resume mutable assistant media for an If-Range HTTP-date", async () => {
+  it("omits unreliable validators for mutable assistant media", async () => {
     await withAllowedAssistantMediaRoot({
-      prefix: "ui-media-if-range-date-",
+      prefix: "ui-media-no-validators-",
       fn: async (tmpRoot) => {
         const filePath = path.join(tmpRoot, "photo.png");
         const body = Buffer.from("assistant-media-bytes");
-        const modified = new Date("2025-07-08T18:40:00.789Z");
         await fs.writeFile(filePath, body);
-        await fs.utimes(filePath, modified, modified);
-        const lastModified = (await fs.stat(filePath)).mtime.toUTCString();
         const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
         const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
 
-        const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-        expect(initial.res.statusCode).toBe(200);
-        expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+        const response = await runAssistantMediaRequest({ url, method: "HEAD", auth });
 
-        const ranged = await runAssistantMediaRequest({
-          url,
-          method: "GET",
-          auth,
-          headers: { range: "bytes=0-8", "if-range": lastModified },
-        });
-        expect(ranged.res.statusCode).toBe(200);
-        expect(ranged.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-        expect(ranged.setHeader).toHaveBeenCalledWith("Content-Length", String(body.byteLength));
-        expect(ranged.setHeader).not.toHaveBeenCalledWith("Content-Range", expect.anything());
-
-        const future = await runAssistantMediaRequest({
-          url,
-          method: "GET",
-          auth,
-          headers: {
-            range: "bytes=0-8",
-            "if-range": new Date(Date.parse(lastModified) + 1000).toUTCString(),
-          },
-        });
-        expect(future.res.statusCode).toBe(200);
-        expect(future.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+        expect(response.res.statusCode).toBe(200);
+        expect(response.setHeader).toHaveBeenCalledWith("Content-Length", String(body.byteLength));
+        expect(response.setHeader).not.toHaveBeenCalledWith("ETag", expect.anything());
+        expect(response.setHeader).not.toHaveBeenCalledWith("Last-Modified", expect.anything());
       },
     });
   });
 
-  it("bounds future-dated assistant media validators across conditional response plans", async () => {
-    const nowMs = Math.floor(Date.now() / 1000) * 1000;
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    try {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-future-mtime-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          const body = Buffer.from("future-assistant-media");
-          const future = new Date(nowMs + 60_000);
-          await fs.writeFile(filePath, body);
-          await fs.utimes(filePath, future, future);
-          const futureLastModified = (await fs.stat(filePath)).mtime.toUTCString();
-          const expectedLastModified = new Date(nowMs).toUTCString();
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+  it("does not return stale 304 responses after same-size same-mtime media changes", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-stale-revalidation-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.png");
+        const preservedTime = new Date("2025-07-08T18:40:00.000Z");
+        await fs.writeFile(filePath, "AAAA", "utf8");
+        await fs.utimes(filePath, preservedTime, preservedTime);
+        const originalStat = await fs.stat(filePath);
+        const legacyEtag = `"${createHash("sha256")
+          .update(`${originalStat.size}:${originalStat.mtimeMs}`)
+          .digest("base64url")}"`;
+        const legacyLastModified = originalStat.mtime.toUTCString();
+        await fs.writeFile(filePath, "BBBB", "utf8");
+        await fs.utimes(filePath, preservedTime, preservedTime);
+        const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+        const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
 
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          expect(initial.res.statusCode).toBe(200);
-          expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
+        const byEtag = await runAssistantMediaRequest({
+          url,
+          method: "GET",
+          auth,
+          headers: { "if-none-match": legacyEtag },
+        });
+        const byDate = await runAssistantMediaRequest({
+          url,
+          method: "GET",
+          auth,
+          headers: { "if-modified-since": legacyLastModified },
+        });
 
-          const ranged = await runAssistantMediaRequest({
+        for (const response of [byEtag, byDate]) {
+          expect(response.res.statusCode).toBe(200);
+          expect(response.setHeader).toHaveBeenCalledWith("Content-Length", "4");
+          expect(response.setHeader).not.toHaveBeenCalledWith("ETag", expect.anything());
+          expect(response.setHeader).not.toHaveBeenCalledWith("Last-Modified", expect.anything());
+        }
+      },
+    });
+  });
+
+  it("rejects mutable If-Range validators while retaining unconditional ranges", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-if-range-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.png");
+        const body = Buffer.from("assistant-media-bytes");
+        const modified = new Date("2025-07-08T18:40:00.000Z");
+        await fs.writeFile(filePath, body);
+        await fs.utimes(filePath, modified, modified);
+        const fileStat = await fs.stat(filePath);
+        const legacyEtag = `"${createHash("sha256")
+          .update(`${fileStat.size}:${fileStat.mtimeMs}`)
+          .digest("base64url")}"`;
+        const legacyLastModified = fileStat.mtime.toUTCString();
+        const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+        const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
+
+        for (const validator of [legacyEtag, legacyLastModified]) {
+          const response = await runAssistantMediaRequest({
             url,
             method: "GET",
             auth,
-            headers: { range: "bytes=0-5", "if-range": expectedLastModified },
+            headers: { range: "bytes=0-8", "if-range": validator },
           });
-          expect(ranged.res.statusCode).toBe(200);
-          expect(ranged.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-          expect(ranged.setHeader).not.toHaveBeenCalledWith("Content-Range", expect.anything());
-
-          const futureRange = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { range: "bytes=0-5", "if-range": futureLastModified },
-          });
-          expect(futureRange.res.statusCode).toBe(200);
-
-          const unchanged = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { "if-none-match": String(etag) },
-          });
-          expect(unchanged.res.statusCode).toBe(304);
-          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-
-          const unsatisfiable = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { range: `bytes=${body.byteLength}-` },
-          });
-          expect(unsatisfiable.res.statusCode).toBe(416);
-          expect(unsatisfiable.setHeader).toHaveBeenCalledWith(
-            "Last-Modified",
-            expectedLastModified,
+          expect(response.res.statusCode).toBe(200);
+          expect(response.setHeader).toHaveBeenCalledWith(
+            "Content-Length",
+            String(body.byteLength),
           );
-        },
-      });
-    } finally {
-      dateNow.mockRestore();
-    }
+          expect(response.setHeader).not.toHaveBeenCalledWith("Content-Range", expect.anything());
+        }
+
+        const unconditional = await runAssistantMediaRequest({
+          url,
+          method: "GET",
+          auth,
+          headers: { range: "bytes=0-8" },
+        });
+        expect(unconditional.res.statusCode).toBe(206);
+        expect(unconditional.setHeader).toHaveBeenCalledWith("Content-Range", "bytes 0-8/21");
+      },
+    });
+  });
+
+  it("honors If-None-Match wildcard without emitting a mutable validator", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-if-none-match-wildcard-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.png");
+        await fs.writeFile(filePath, "assistant-media-bytes", "utf8");
+        const response = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+          headers: { "if-none-match": "*" },
+        });
+
+        expect(response.res.statusCode).toBe(304);
+        expect(response.setHeader).not.toHaveBeenCalledWith("ETag", expect.anything());
+        expect(response.setHeader).not.toHaveBeenCalledWith("Last-Modified", expect.anything());
+        expect(response.setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
+      },
+    });
   });
 
   it("returns 202 while assistant playback media is preparing", async () => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -588,14 +588,14 @@ describe("handleControlUiHttpRequest", () => {
           const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
           const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
           const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
-          expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+          expect(etag).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
 
           const conditional = await runAssistantMediaRequest({
             url,
             method,
             auth,
             headers: {
-              "if-none-match": `W/${String(etag)}`,
+              "if-none-match": String(etag),
               range: "bytes=0-3",
               "if-range": '"stale"',
             },
@@ -682,7 +682,7 @@ describe("handleControlUiHttpRequest", () => {
     },
   );
 
-  it("resumes assistant media only for an exact If-Range HTTP-date", async () => {
+  it("does not resume mutable assistant media for an If-Range HTTP-date", async () => {
     await withAllowedAssistantMediaRoot({
       prefix: "ui-media-if-range-date-",
       fn: async (tmpRoot) => {
@@ -699,18 +699,16 @@ describe("handleControlUiHttpRequest", () => {
         expect(initial.res.statusCode).toBe(200);
         expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
 
-        const partial = await runAssistantMediaRequest({
+        const ranged = await runAssistantMediaRequest({
           url,
           method: "GET",
           auth,
           headers: { range: "bytes=0-8", "if-range": lastModified },
         });
-        expect(partial.res.statusCode).toBe(206);
-        expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-        expect(partial.setHeader).toHaveBeenCalledWith(
-          "Content-Range",
-          `bytes 0-8/${body.byteLength}`,
-        );
+        expect(ranged.res.statusCode).toBe(200);
+        expect(ranged.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
+        expect(ranged.setHeader).toHaveBeenCalledWith("Content-Length", String(body.byteLength));
+        expect(ranged.setHeader).not.toHaveBeenCalledWith("Content-Range", expect.anything());
 
         const future = await runAssistantMediaRequest({
           url,
@@ -749,14 +747,15 @@ describe("handleControlUiHttpRequest", () => {
           expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
           const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
 
-          const partial = await runAssistantMediaRequest({
+          const ranged = await runAssistantMediaRequest({
             url,
             method: "GET",
             auth,
             headers: { range: "bytes=0-5", "if-range": expectedLastModified },
           });
-          expect(partial.res.statusCode).toBe(206);
-          expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
+          expect(ranged.res.statusCode).toBe(200);
+          expect(ranged.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
+          expect(ranged.setHeader).not.toHaveBeenCalledWith("Content-Range", expect.anything());
 
           const futureRange = await runAssistantMediaRequest({
             url,

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -730,6 +730,7 @@ export async function handleControlUiAssistantMediaRequest(
     res.setHeader("Cache-Control", "no-cache");
     const byteResponse = resolveByteResponse({
       file: opened.stat,
+      validatorStrength: "weak",
       method: req.method,
       request: req,
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -730,7 +730,7 @@ export async function handleControlUiAssistantMediaRequest(
     res.setHeader("Cache-Control", "no-cache");
     const byteResponse = resolveByteResponse({
       file: opened.stat,
-      validatorStrength: "weak",
+      validatorPolicy: "none",
       method: req.method,
       request: req,
     });

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -33,15 +33,22 @@ function createByteRequest(
   };
 }
 
-const STRONG_FILE = { file: FILE, validatorStrength: "strong" } as const;
-const WEAK_FILE = { file: FILE, validatorStrength: "weak" } as const;
+const IMMUTABLE_FILE = { file: FILE, validatorPolicy: "immutable-metadata" } as const;
+const MUTABLE_FILE = { file: FILE, validatorPolicy: "none" } as const;
 
 function resolveByteResponse(
-  params: Omit<Parameters<typeof resolveByteResponseImpl>[0], "validatorStrength"> & {
-    validatorStrength?: "strong" | "weak";
+  params: Omit<Parameters<typeof resolveByteResponseImpl>[0], "validatorPolicy"> & {
+    validatorPolicy?: "immutable-metadata" | "none";
   },
 ) {
-  return resolveByteResponseImpl({ validatorStrength: "strong", ...params });
+  return resolveByteResponseImpl({ validatorPolicy: "immutable-metadata", ...params });
+}
+
+function requireEtag(plan: ReturnType<typeof resolveByteResponse>): string {
+  if (!plan.etag) {
+    throw new Error("expected an ETag");
+  }
+  return plan.etag;
 }
 
 describe("resolveByteResponse", () => {
@@ -128,10 +135,10 @@ describe("resolveByteResponse", () => {
   );
 
   it("honors a matching strong If-Range ETag", () => {
-    const etag = resolveByteResponse(STRONG_FILE).etag;
+    const etag = requireEtag(resolveByteResponse(IMMUTABLE_FILE));
     expect(
       resolveByteResponse({
-        ...STRONG_FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
       }),
@@ -212,7 +219,7 @@ describe("resolveByteResponse", () => {
     "bounds the future Last-Modified validator on %s not-modified responses",
     (method) => {
       const nowMs = FILE.mtimeMs - 60_000;
-      const etag = resolveByteResponse({ file: FILE, nowMs }).etag;
+      const etag = requireEtag(resolveByteResponse({ file: FILE, nowMs }));
 
       expect(
         resolveByteResponse({
@@ -415,43 +422,30 @@ describe("resolveByteResponse", () => {
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
 
-  it("does not use a weak metadata ETag as an If-Range validator", () => {
-    const etag = resolveByteResponse(WEAK_FILE).etag;
+  it("does not use an ETag as an If-Range validator for mutable content", () => {
     expect(
       resolveByteResponse({
-        ...WEAK_FILE,
+        ...MUTABLE_FILE,
         method: "GET",
-        request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
+        request: createByteRequest({ range: "bytes=1-2", "if-range": '"stale"' }),
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
 
-  it("does not use the strong form of a weak metadata ETag as an If-Range validator", () => {
-    const etag = resolveByteResponse(WEAK_FILE).etag;
+  it("does not use a Last-Modified date as an If-Range validator for mutable content", () => {
     expect(
       resolveByteResponse({
-        ...WEAK_FILE,
+        ...MUTABLE_FILE,
         method: "GET",
-        request: createByteRequest({ range: "bytes=1-2", "if-range": etag.slice(2) }),
+        request: createByteRequest({ range: "bytes=1-2", "if-range": LAST_MODIFIED }),
       }),
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
 
-  it("does not use a weak metadata Last-Modified date as an If-Range validator", () => {
-    const lastModified = resolveByteResponse(WEAK_FILE).lastModified;
+  it("still serves an unconditional range for mutable content", () => {
     expect(
       resolveByteResponse({
-        ...WEAK_FILE,
-        method: "GET",
-        request: createByteRequest({ range: "bytes=1-2", "if-range": lastModified }),
-      }),
-    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
-  });
-
-  it("still serves an unconditional range for a weakly validated file", () => {
-    expect(
-      resolveByteResponse({
-        ...WEAK_FILE,
+        ...MUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2" }),
       }),
@@ -461,7 +455,7 @@ describe("resolveByteResponse", () => {
   it("falls back to a full response for a mismatched If-Range ETag", () => {
     expect(
       resolveByteResponse({
-        ...STRONG_FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": '"different"' }),
       }),
@@ -475,7 +469,7 @@ describe("resolveByteResponse", () => {
     { label: "list", header: (etag: string) => `"other", ${etag}` },
     { label: "multiple headers", header: (etag: string) => ['"other"', `W/${etag}`] },
   ])("returns 304 for a matching $label If-None-Match validator", ({ header }) => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+    const etag = requireEtag(resolveByteResponse({ file: FILE }));
     const plan = resolveByteResponse({
       file: FILE,
       method: "GET",
@@ -497,21 +491,40 @@ describe("resolveByteResponse", () => {
     expect(setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
   });
 
-  it("weakly compares the strong form of a current weak ETag for If-None-Match", () => {
-    const etag = resolveByteResponse(WEAK_FILE).etag;
+  it("does not match a specific If-None-Match tag without a current validator", () => {
     expect(
       resolveByteResponse({
-        ...WEAK_FILE,
+        ...MUTABLE_FILE,
         method: "GET",
-        request: createByteRequest({ "if-none-match": etag.slice(2) }),
+        request: createByteRequest({ "if-none-match": '"stale"' }),
       }),
-    ).toMatchObject({ kind: "not-modified", statusCode: 304, etag });
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
+  });
+
+  it("still honors If-None-Match wildcard for an existing mutable representation", () => {
+    expect(
+      resolveByteResponse({
+        ...MUTABLE_FILE,
+        method: "GET",
+        request: createByteRequest({ "if-none-match": "*" }),
+      }),
+    ).toEqual({ kind: "not-modified", statusCode: 304 });
+  });
+
+  it("ignores If-Modified-Since without a reliable modification validator", () => {
+    expect(
+      resolveByteResponse({
+        ...MUTABLE_FILE,
+        method: "GET",
+        request: createByteRequest({ "if-modified-since": LAST_MODIFIED }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
 
   it.each(["GET", "HEAD"])(
     "evaluates matching If-None-Match before Range and If-Range for %s",
     (method) => {
-      const etag = resolveByteResponse({ file: FILE }).etag;
+      const etag = requireEtag(resolveByteResponse({ file: FILE }));
 
       expect(
         resolveByteResponse({
@@ -528,7 +541,7 @@ describe("resolveByteResponse", () => {
   );
 
   it("keeps the requested range when If-None-Match does not match", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+    const etag = requireEtag(resolveByteResponse({ file: FILE }));
 
     expect(
       resolveByteResponse({
@@ -567,19 +580,30 @@ describe("resolveByteResponse", () => {
 });
 
 describe("byte ETag generation", () => {
-  it("is stable for the same file identity and reflects the requested strength", () => {
-    const strongEtag = resolveByteResponse(STRONG_FILE).etag;
-    expect(resolveByteResponse({ ...STRONG_FILE, file: { ...FILE } }).etag).toBe(strongEtag);
+  it("is stable for the same immutable file identity", () => {
+    const strongEtag = requireEtag(resolveByteResponse(IMMUTABLE_FILE));
+    expect(resolveByteResponse({ ...IMMUTABLE_FILE, file: { ...FILE } }).etag).toBe(strongEtag);
     expect(
-      resolveByteResponse({ ...STRONG_FILE, file: { ...FILE, size: FILE.size + 1 } }).etag,
+      resolveByteResponse({ ...IMMUTABLE_FILE, file: { ...FILE, size: FILE.size + 1 } }).etag,
     ).not.toBe(strongEtag);
     expect(
-      resolveByteResponse({ ...STRONG_FILE, file: { ...FILE, mtimeMs: FILE.mtimeMs + 1 } }).etag,
+      resolveByteResponse({
+        ...IMMUTABLE_FILE,
+        file: { ...FILE, mtimeMs: FILE.mtimeMs + 1 },
+      }).etag,
     ).not.toBe(strongEtag);
     expect(strongEtag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+  });
 
-    const weakEtag = resolveByteResponse(WEAK_FILE).etag;
-    expect(weakEtag).toBe(`W/${strongEtag}`);
+  it("omits representation validators for mutable content", () => {
+    const plan = resolveByteResponse(MUTABLE_FILE);
+    const setHeader = vi.fn();
+    const res = { statusCode: 0, setHeader } as unknown as ServerResponse;
+
+    expect(plan).toEqual({ kind: "full", statusCode: 200, contentLength: FILE.size });
+    writeByteHeaders(res, plan);
+    expect(setHeader).not.toHaveBeenCalledWith("ETag", expect.anything());
+    expect(setHeader).not.toHaveBeenCalledWith("Last-Modified", expect.anything());
   });
 });
 

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createGatewayByteStream,
-  resolveByteResponse,
+  resolveByteResponse as resolveByteResponseImpl,
   writeByteHeaders,
 } from "./http-byte-range.js";
 
@@ -31,6 +31,17 @@ function createByteRequest(
       entries.map(([name, value]) => [name, Array.isArray(value) ? value : [value]]),
     ),
   };
+}
+
+const STRONG_FILE = { file: FILE, validatorStrength: "strong" } as const;
+const WEAK_FILE = { file: FILE, validatorStrength: "weak" } as const;
+
+function resolveByteResponse(
+  params: Omit<Parameters<typeof resolveByteResponseImpl>[0], "validatorStrength"> & {
+    validatorStrength?: "strong" | "weak";
+  },
+) {
+  return resolveByteResponseImpl({ validatorStrength: "strong", ...params });
 }
 
 describe("resolveByteResponse", () => {
@@ -116,11 +127,11 @@ describe("resolveByteResponse", () => {
     },
   );
 
-  it("honors a matching If-Range ETag", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+  it("honors a matching strong If-Range ETag", () => {
+    const etag = resolveByteResponse(STRONG_FILE).etag;
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...STRONG_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
       }),
@@ -404,10 +415,53 @@ describe("resolveByteResponse", () => {
     ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
   });
 
+  it("does not use a weak metadata ETag as an If-Range validator", () => {
+    const etag = resolveByteResponse(WEAK_FILE).etag;
+    expect(
+      resolveByteResponse({
+        ...WEAK_FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
+  });
+
+  it("does not use the strong form of a weak metadata ETag as an If-Range validator", () => {
+    const etag = resolveByteResponse(WEAK_FILE).etag;
+    expect(
+      resolveByteResponse({
+        ...WEAK_FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=1-2", "if-range": etag.slice(2) }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
+  });
+
+  it("does not use a weak metadata Last-Modified date as an If-Range validator", () => {
+    const lastModified = resolveByteResponse(WEAK_FILE).lastModified;
+    expect(
+      resolveByteResponse({
+        ...WEAK_FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=1-2", "if-range": lastModified }),
+      }),
+    ).toMatchObject({ kind: "full", statusCode: 200, contentLength: 10 });
+  });
+
+  it("still serves an unconditional range for a weakly validated file", () => {
+    expect(
+      resolveByteResponse({
+        ...WEAK_FILE,
+        method: "GET",
+        request: createByteRequest({ range: "bytes=1-2" }),
+      }),
+    ).toMatchObject({ kind: "partial", statusCode: 206, range: { start: 1, end: 2 } });
+  });
+
   it("falls back to a full response for a mismatched If-Range ETag", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...STRONG_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": '"different"' }),
       }),
@@ -441,6 +495,17 @@ describe("resolveByteResponse", () => {
     expect(setHeader).toHaveBeenCalledWith("ETag", etag);
     expect(setHeader).toHaveBeenCalledWith("Last-Modified", LAST_MODIFIED);
     expect(setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
+  });
+
+  it("weakly compares the strong form of a current weak ETag for If-None-Match", () => {
+    const etag = resolveByteResponse(WEAK_FILE).etag;
+    expect(
+      resolveByteResponse({
+        ...WEAK_FILE,
+        method: "GET",
+        request: createByteRequest({ "if-none-match": etag.slice(2) }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304, etag });
   });
 
   it.each(["GET", "HEAD"])(
@@ -502,14 +567,19 @@ describe("resolveByteResponse", () => {
 });
 
 describe("byte ETag generation", () => {
-  it("is stable for the same file identity and changes with size or mtime", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
-    expect(resolveByteResponse({ file: { ...FILE } }).etag).toBe(etag);
-    expect(resolveByteResponse({ file: { ...FILE, size: FILE.size + 1 } }).etag).not.toBe(etag);
-    expect(resolveByteResponse({ file: { ...FILE, mtimeMs: FILE.mtimeMs + 1 } }).etag).not.toBe(
-      etag,
-    );
-    expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+  it("is stable for the same file identity and reflects the requested strength", () => {
+    const strongEtag = resolveByteResponse(STRONG_FILE).etag;
+    expect(resolveByteResponse({ ...STRONG_FILE, file: { ...FILE } }).etag).toBe(strongEtag);
+    expect(
+      resolveByteResponse({ ...STRONG_FILE, file: { ...FILE, size: FILE.size + 1 } }).etag,
+    ).not.toBe(strongEtag);
+    expect(
+      resolveByteResponse({ ...STRONG_FILE, file: { ...FILE, mtimeMs: FILE.mtimeMs + 1 } }).etag,
+    ).not.toBe(strongEtag);
+    expect(strongEtag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+
+    const weakEtag = resolveByteResponse(WEAK_FILE).etag;
+    expect(weakEtag).toBe(`W/${strongEtag}`);
   });
 });
 

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -19,7 +19,7 @@ type FileIdentity = {
   mtimeMs: number;
 };
 
-type ValidatorStrength = "strong" | "weak";
+type ValidatorPolicy = "immutable-metadata" | "none";
 
 type ByteSlice = {
   start: number;
@@ -27,8 +27,8 @@ type ByteSlice = {
 };
 
 type ByteResponsePlan = {
-  etag: string;
-  lastModified: string;
+  etag?: string;
+  lastModified?: string;
 } & (
   | {
       kind: "full";
@@ -117,10 +117,9 @@ function parseConditionalHttpDate(value: string, nowMs: number): number | undefi
   return seconds === 60 ? timestamp + 1_000 : timestamp;
 }
 
-function createByteEtag(file: FileIdentity, strength: ValidatorStrength): string {
+function createByteEtag(file: FileIdentity): string {
   const digest = createHash("sha256").update(`${file.size}:${file.mtimeMs}`).digest("base64url");
-  const opaqueTag = `"${digest}"`;
-  return strength === "weak" ? `W/${opaqueTag}` : opaqueTag;
+  return `"${digest}"`;
 }
 
 function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "unsatisfiable" {
@@ -160,15 +159,24 @@ function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "u
 export function resolveByteResponse(params: {
   file: FileIdentity;
   nowMs?: number;
-  validatorStrength: ValidatorStrength;
+  validatorPolicy: ValidatorPolicy;
   method?: string;
   request?: Pick<IncomingMessage, "headers" | "headersDistinct">;
 }): ByteResponsePlan {
-  const etag = createByteEtag(params.file, params.validatorStrength);
-  const originatedAtMs = params.nowMs ?? Date.now();
+  const usesMetadataValidators = params.validatorPolicy === "immutable-metadata";
+  const etag = usesMetadataValidators ? createByteEtag(params.file) : undefined;
+  const originatedAtMs = usesMetadataValidators ? (params.nowMs ?? Date.now()) : undefined;
   // Filesystem clocks may lead this host; validators cannot postdate message origination.
-  const lastModifiedMs = Math.floor(Math.min(params.file.mtimeMs, originatedAtMs) / 1_000) * 1_000;
-  const lastModified = new Date(lastModifiedMs).toUTCString();
+  const lastModifiedMs =
+    originatedAtMs === undefined
+      ? undefined
+      : Math.floor(Math.min(params.file.mtimeMs, originatedAtMs) / 1_000) * 1_000;
+  const lastModified =
+    lastModifiedMs === undefined ? undefined : new Date(lastModifiedMs).toUTCString();
+  const validators = {
+    ...(etag ? { etag } : {}),
+    ...(lastModified ? { lastModified } : {}),
+  };
   const headers = params.request?.headers;
   const ifNoneMatch = headers?.["if-none-match"];
   const ifModifiedSinceValues = params.request?.headersDistinct["if-modified-since"];
@@ -180,19 +188,20 @@ export function resolveByteResponse(params: {
     (params.method === "GET" || params.method === "HEAD") &&
     (matchesHttpIfNoneMatch(ifNoneMatch, etag) ||
       (ifNoneMatch === undefined &&
+        originatedAtMs !== undefined &&
+        lastModifiedMs !== undefined &&
         typeof ifModifiedSince === "string" &&
         (parseConditionalHttpDate(ifModifiedSince, originatedAtMs) ?? Number.NEGATIVE_INFINITY) >=
           lastModifiedMs))
   ) {
     // RFC 9110 evaluates representation validators before Range or If-Range.
-    return { kind: "not-modified", statusCode: 304, etag, lastModified };
+    return { kind: "not-modified", statusCode: 304, ...validators };
   }
   const full = {
     kind: "full",
     statusCode: 200,
     contentLength: params.file.size,
-    etag,
-    lastModified,
+    ...validators,
   } as const;
   const rangeHeader = headers?.range;
   if (params.method !== "GET" || typeof rangeHeader !== "string") {
@@ -201,13 +210,13 @@ export function resolveByteResponse(params: {
   const ifRangeHeader = headers?.["if-range"];
   if (
     ifRangeHeader !== undefined &&
-    (params.validatorStrength === "weak" ||
+    (params.validatorPolicy === "none" ||
       (ifRangeHeader !== etag &&
         // If-Range must exactly match the emitted HTTP-date; parsing accepts invalid lookalikes.
         ifRangeHeader !== lastModified))
   ) {
-    // Mutable files only have weak metadata validators, so neither their ETag nor
-    // Last-Modified date can safely authorize reusing bytes from an earlier response.
+    // Mutable files have no stable representation validator, so no prior response
+    // can safely authorize reusing bytes from the current file.
     return full;
   }
 
@@ -220,8 +229,7 @@ export function resolveByteResponse(params: {
       kind: "unsatisfiable",
       statusCode: 416,
       contentLength: 0,
-      etag,
-      lastModified,
+      ...validators,
       size: params.file.size,
     };
   }
@@ -229,8 +237,7 @@ export function resolveByteResponse(params: {
     kind: "partial",
     statusCode: 206,
     contentLength: range.end - range.start + 1,
-    etag,
-    lastModified,
+    ...validators,
     range,
     size: params.file.size,
   };
@@ -239,8 +246,12 @@ export function resolveByteResponse(params: {
 export function writeByteHeaders(res: ServerResponse, plan: ByteResponsePlan): void {
   res.statusCode = plan.statusCode;
   res.setHeader("Accept-Ranges", "bytes");
-  res.setHeader("ETag", plan.etag);
-  res.setHeader("Last-Modified", plan.lastModified);
+  if (plan.etag) {
+    res.setHeader("ETag", plan.etag);
+  }
+  if (plan.lastModified) {
+    res.setHeader("Last-Modified", plan.lastModified);
+  }
   if (plan.kind === "not-modified") {
     return;
   }

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -19,6 +19,8 @@ type FileIdentity = {
   mtimeMs: number;
 };
 
+type ValidatorStrength = "strong" | "weak";
+
 type ByteSlice = {
   start: number;
   end: number;
@@ -115,11 +117,10 @@ function parseConditionalHttpDate(value: string, nowMs: number): number | undefi
   return seconds === 60 ? timestamp + 1_000 : timestamp;
 }
 
-function createByteEtag(file: FileIdentity): string {
-  // Gateway media files are write-once, so size + mtimeMs uniquely version their bytes here.
-  // Serving mutable files with a strong validator would instead require a content hash.
+function createByteEtag(file: FileIdentity, strength: ValidatorStrength): string {
   const digest = createHash("sha256").update(`${file.size}:${file.mtimeMs}`).digest("base64url");
-  return `"${digest}"`;
+  const opaqueTag = `"${digest}"`;
+  return strength === "weak" ? `W/${opaqueTag}` : opaqueTag;
 }
 
 function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "unsatisfiable" {
@@ -159,10 +160,11 @@ function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "u
 export function resolveByteResponse(params: {
   file: FileIdentity;
   nowMs?: number;
+  validatorStrength: ValidatorStrength;
   method?: string;
   request?: Pick<IncomingMessage, "headers" | "headersDistinct">;
 }): ByteResponsePlan {
-  const etag = createByteEtag(params.file);
+  const etag = createByteEtag(params.file, params.validatorStrength);
   const originatedAtMs = params.nowMs ?? Date.now();
   // Filesystem clocks may lead this host; validators cannot postdate message origination.
   const lastModifiedMs = Math.floor(Math.min(params.file.mtimeMs, originatedAtMs) / 1_000) * 1_000;
@@ -199,10 +201,13 @@ export function resolveByteResponse(params: {
   const ifRangeHeader = headers?.["if-range"];
   if (
     ifRangeHeader !== undefined &&
-    ifRangeHeader !== etag &&
-    // If-Range must exactly match the emitted HTTP-date; parsing accepts invalid lookalikes.
-    ifRangeHeader !== lastModified
+    (params.validatorStrength === "weak" ||
+      (ifRangeHeader !== etag &&
+        // If-Range must exactly match the emitted HTTP-date; parsing accepts invalid lookalikes.
+        ifRangeHeader !== lastModified))
   ) {
+    // Mutable files only have weak metadata validators, so neither their ETag nor
+    // Last-Modified date can safely authorize reusing bytes from an earlier response.
     return full;
   }
 

--- a/src/gateway/http-conditional.ts
+++ b/src/gateway/http-conditional.ts
@@ -7,8 +7,10 @@ export function matchesHttpIfNoneMatch(
   if (!value) {
     return false;
   }
+  const currentTag = etag.startsWith("W/") ? etag.slice(2) : etag;
   return value.split(",").some((candidate) => {
     const tag = candidate.trim();
-    return tag === "*" || tag === etag || (tag.startsWith("W/") && tag.slice(2) === etag);
+    const candidateTag = tag.startsWith("W/") ? tag.slice(2) : tag;
+    return tag === "*" || candidateTag === currentTag;
   });
 }

--- a/src/gateway/http-conditional.ts
+++ b/src/gateway/http-conditional.ts
@@ -1,16 +1,14 @@
 // HTTP conditional requests use weak entity-tag comparison for representation reuse.
 export function matchesHttpIfNoneMatch(
   header: string | string[] | undefined,
-  etag: string,
+  etag: string | undefined,
 ): boolean {
   const value = Array.isArray(header) ? header.join(",") : header;
   if (!value) {
     return false;
   }
-  const currentTag = etag.startsWith("W/") ? etag.slice(2) : etag;
   return value.split(",").some((candidate) => {
     const tag = candidate.trim();
-    const candidateTag = tag.startsWith("W/") ? tag.slice(2) : tag;
-    return tag === "*" || candidateTag === currentTag;
+    return tag === "*" || tag === etag || (tag.startsWith("W/") && tag.slice(2) === etag);
   });
 }

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1517,6 +1517,7 @@ export async function handleManagedOutgoingMediaHttpRequest(
   );
   const byteResponse = resolveByteResponse({
     file: opened.stat,
+    validatorStrength: "strong",
     method: req.method,
     request: req,
   });

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1517,7 +1517,7 @@ export async function handleManagedOutgoingMediaHttpRequest(
   );
   const byteResponse = resolveByteResponse({
     file: opened.stat,
-    validatorStrength: "strong",
+    validatorPolicy: "immutable-metadata",
     method: req.method,
     request: req,
   });


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Control UI clients could reuse or combine bytes from different assistant-media versions when a mutable local file changed without changing its size or modification time. The previous strong ETag and Last-Modified value were derived only from those two metadata fields, so stale conditional and `If-Range` requests could be accepted for different content.

## Why This Change Was Made

The shared byte-range helper previously emitted size-and-mtime validators for every caller, even though that metadata cannot identify a mutable representation. It now requires callers to choose a validator policy. Control UI assistant media chooses `none`, so the route emits neither ETag nor Last-Modified and cannot incorrectly return `304` or authorize a stale `If-Range` resume. Managed outgoing attachments use the `immutable-metadata` policy and retain their existing strong validators and resumable range behavior.

Hashing the live file before streaming would not by itself make a strong validator reliable because the file can still be modified between hashing and later reads. Omitting validators on this mutable route avoids that time-of-check/time-of-use gap without buffering or snapshotting unbounded media files.

## User Impact

Conditional requests for a changed Control UI media file now return the complete current file instead of reusing stale metadata. A range request carrying any `If-Range` validator also returns the complete current file, preventing old and new bytes from being spliced together. Unconditional range requests still return `206`, `If-None-Match: *` retains its representation-exists semantics, and managed immutable attachments continue to support strong `If-Range` resumes.

## Evidence

The pre-fix baseline returned `206` for matching metadata-based `If-Range` values after replacing `AAAA` with `BBBB` while restoring the original size and mtime.

A real Gateway exercised the Control UI assistant-media HTTP route after the fix:

```text
$ curl <assistant-media-route> -H "Range: bytes=0-1"
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Length: 2
Content-Range: bytes 0-1/4
body: AA

$ record the legacy size+mtime validators and replace AAAA with BBBB at the same size/mtime
legacy ETag: "9e5XKgcxFASwXYPORjr8hBetMJAMZgbyYCQ2_uCqXDA"
legacy Last-Modified: Wed, 01 Jul 2026 00:00:00 GMT
before: size=4 mtimeMs=1782864000000
after:  size=4 mtimeMs=1782864000000

$ curl <assistant-media-route> -H "If-None-Match: <legacy-etag>"
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 4
body: BBBB

$ curl <assistant-media-route> -H "If-Modified-Since: <legacy-last-modified>"
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 4
body: BBBB

$ curl <assistant-media-route> -H "Range: bytes=2-3" -H "If-Range: <legacy-etag>"
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 4
body: BBBB

$ curl <assistant-media-route> -H "Range: bytes=2-3" -H "If-Range: <legacy-last-modified>"
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 4
body: BBBB

$ curl <assistant-media-route> -H "Range: bytes=2-3"
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Length: 2
Content-Range: bytes 2-3/4
body: BB

PASS: stale ETag/date revalidation and If-Range requests all returned the complete current BBBB representation; the mutable route emitted no unreliable validators, while an unconditional range still returned 206 with BB.
```

Focused verification:

- `node scripts/run-vitest.mjs src/gateway/http-byte-range.test.ts src/gateway/control-ui.http.test.ts src/gateway/managed-image-attachments.test.ts` — 282 tests passed.
- `node scripts/run-vitest.mjs src/gateway/control-ui-assistant-media.e2e.test.ts` — 1 Gateway E2E test passed.
- Targeted `oxfmt --check` passed for all seven changed files.
- The repository max-lines ratchet passed on an exact synthetic merge preview against the fresh pre-submit main SHA.
