### PR TITLE
fix(agents): fingerprint structured exec failures

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -72,9 +72,13 @@ You can also enable the global rolling-history detectors in **Settings -> Labs**
 | --------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `enabled` | `false` | Master switch for the rolling-history detectors. `false` also disables the post-compaction guard. |
 
-For `exec`, no-progress hashing compares stable command outcomes (status,
-exit code, timed-out flag, output) and ignores volatile runtime metadata such
-as duration, PID, session ID, and working directory. Outbound message-send
+For `exec`, no-progress hashing compares stable command outcomes. Completed
+commands include their output. Failed process outcomes with a specific
+structured failure kind use exit facts such as status, exit code, signal,
+failure kind, and timeout state without volatile diagnostic text. Broad
+runtime errors and unclassified failures keep their output in the hash so
+distinct failures do not collapse together. Runtime metadata such as duration,
+PID, session ID, and working directory is ignored. Outbound message-send
 results are hashed with volatile per-call ids (message id, file id, timestamp)
 stripped, so a "sent" result does not look identical to a different "sent"
 result. When a run id is available, history is evaluated only within that run,

--- a/src/agents/tool-loop-detection.exec-integration.test.ts
+++ b/src/agents/tool-loop-detection.exec-integration.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { SessionState } from "../logging/diagnostic-session-state.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import {
+  detectToolCallLoop,
+  recordToolCall,
+  recordToolCallOutcome,
+} from "./tool-loop-detection.js";
+
+const CRITICAL_THRESHOLD = 20;
+
+describe("exec loop detection integration", () => {
+  it.runIf(process.platform !== "win32")(
+    "blocks repeated real shell failures despite changing diagnostics",
+    async () => {
+      const state: SessionState = {
+        lastActivity: Date.now(),
+        state: "processing",
+        queueDepth: 0,
+      };
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        allowBackground: false,
+      });
+      const params = {
+        command: `printf 'failed-pid=%s\n' "$$" >&2; command openclaw_command_that_does_not_exist`,
+      };
+      const outputs = new Set<string>();
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        const toolCallId = `exec-${index}`;
+        recordToolCall(state, "exec", params, toolCallId);
+        const result = await tool.execute(toolCallId, params);
+        expect(result.details).toMatchObject({
+          status: "failed",
+          exitCode: 127,
+          failureKind: "shell-command-not-found",
+        });
+        if (result.details.status === "failed") {
+          outputs.add(result.details.aggregated);
+        }
+        recordToolCallOutcome(state, {
+          toolName: "exec",
+          toolParams: params,
+          toolCallId,
+          result,
+        });
+      }
+
+      expect(outputs.size).toBeGreaterThan(1);
+      expect(detectToolCallLoop(state, "exec", params, { enabled: true })).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "generic_repeat",
+        count: CRITICAL_THRESHOLD,
+      });
+    },
+  );
+});

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1055,7 +1055,37 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps changing empty-output exec failures below the global no-progress breaker", () => {
+    it("blocks changing exec failures at the critical no-progress threshold", () => {
+      const state = createState();
+      const params = { command: "openclaw flaky-helper" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `Runtime failed before spawn: attempt ${index}` }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              durationMs: 100 + index,
+              aggregated: "",
+            },
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("blocks changing exec failures at the global no-progress threshold", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -1078,11 +1108,12 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
-      expect(loopResult.stuck).toBe(true);
-      if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
-      }
+      expect(loopResult).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "global_circuit_breaker",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
     });
 
     it("does not block repeated unknown-tool failures before the unknown-tool threshold", () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1055,7 +1055,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("blocks changing exec failures at the critical no-progress threshold", () => {
+    it("blocks changing normal non-zero exec exits at the critical no-progress threshold", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -1065,12 +1065,12 @@ describe("tool-loop-detection", () => {
           "exec",
           params,
           {
-            content: [{ type: "text", text: `Runtime failed before spawn: attempt ${index}` }],
+            content: [{ type: "text", text: `Command failed: attempt ${index}` }],
             details: {
-              status: "failed",
-              exitCode: null,
+              status: "completed",
+              exitCode: 1,
               durationMs: 100 + index,
-              aggregated: "",
+              aggregated: `Command failed: attempt ${index}`,
             },
           },
           index,
@@ -1085,7 +1085,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("blocks changing exec failures at the global no-progress threshold", () => {
+    it("blocks changing normal non-zero exec exits at the global no-progress threshold", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -1095,12 +1095,12 @@ describe("tool-loop-detection", () => {
           "exec",
           params,
           {
-            content: [{ type: "text", text: `Runtime failed before spawn: attempt ${index}` }],
+            content: [{ type: "text", text: `Command failed: attempt ${index}` }],
             details: {
-              status: "failed",
-              exitCode: null,
+              status: "completed",
+              exitCode: 1,
               durationMs: 100 + index,
-              aggregated: "",
+              aggregated: `Command failed: attempt ${index}`,
             },
           },
           index,

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1055,37 +1055,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("blocks changing normal non-zero exec exits at the critical no-progress threshold", () => {
-      const state = createState();
-      const params = { command: "openclaw flaky-helper" };
-
-      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
-        recordSuccessfulCall(
-          state,
-          "exec",
-          params,
-          {
-            content: [{ type: "text", text: `Command failed: attempt ${index}` }],
-            details: {
-              status: "completed",
-              exitCode: 1,
-              durationMs: 100 + index,
-              aggregated: `Command failed: attempt ${index}`,
-            },
-          },
-          index,
-        );
-      }
-
-      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
-      expect(loopResult.stuck).toBe(true);
-      if (loopResult.stuck) {
-        expect(loopResult.level).toBe("critical");
-        expect(loopResult.detector).toBe("generic_repeat");
-      }
-    });
-
-    it("blocks changing normal non-zero exec exits at the global no-progress threshold", () => {
+    it("keeps changing completed non-zero exec output below the global no-progress breaker", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -1108,10 +1078,115 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
-      expect(loopResult).toMatchObject({
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("blocks changing structured exec failures at the global no-progress threshold", () => {
+      const state = createState();
+      const params = { command: "openclaw missing-helper" };
+
+      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `Command not found: attempt ${index}` }],
+            details: {
+              status: "failed",
+              exitCode: 127,
+              exitSignal: null,
+              exitReason: "exit",
+              failureKind: "shell-command-not-found",
+              timedOut: false,
+              durationMs: 100 + index,
+              aggregated: "",
+            },
+          },
+          index,
+        );
+      }
+
+      expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject({
         stuck: true,
         level: "critical",
         detector: "global_circuit_breaker",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+    });
+
+    it.each([
+      { label: "runtime errors", failureKind: "runtime-error" },
+      { label: "approval failures", failureKind: "approval_required" },
+      { label: "failures without a structured kind", failureKind: undefined },
+    ])("keeps changing $label below the global no-progress breaker", ({ failureKind }) => {
+      const state = createState();
+      const params = { command: "openclaw flaky-helper" };
+
+      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `Failure ${index}` }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              ...(failureKind ? { failureKind } : {}),
+              timedOut: false,
+              durationMs: 100 + index,
+              aggregated: "",
+            },
+          },
+          index,
+        );
+      }
+
+      expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject({
+        stuck: true,
+        level: "warning",
+        detector: "generic_repeat",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+    });
+
+    it("keeps materially different structured exec failures distinct", () => {
+      const state = createState();
+      const params = { command: "openclaw flaky-helper" };
+
+      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        const timedOut = index % 2 === 0;
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `Failure ${index}` }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              exitSignal: timedOut ? null : "SIGTERM",
+              exitReason: timedOut ? "overall-timeout" : "signal",
+              failureKind: timedOut ? "overall-timeout" : "signal",
+              timedOut,
+              noOutputTimedOut: false,
+              durationMs: 100 + index,
+              aggregated: "",
+            },
+          },
+          index,
+        );
+      }
+
+      expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject({
+        stuck: true,
+        level: "warning",
+        detector: "generic_repeat",
         count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
       });
     });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -171,11 +171,21 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
     });
   }
 
+  const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
+  const stableOutcome = {
+    status,
+    exitCode,
+    timedOut: details.timedOut === true,
+  };
+
   if (status === "completed") {
+    // Normal non-zero exits are completed outcomes, but their diagnostics are
+    // failure noise and must not reset the no-progress streak.
+    if (exitCode !== null && exitCode !== 0) {
+      return digestStable(stableOutcome);
+    }
     return digestStable({
-      status,
-      exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
-      timedOut: details.timedOut === true,
+      ...stableOutcome,
       output: nonEmptyStringField(details.aggregated) ?? text,
     });
   }
@@ -183,11 +193,7 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
   // Failed exec diagnostics vary between attempts without proving progress; hash only stable
   // execution facts so repeated failures can reach the loop guards.
   if (status === "failed") {
-    return digestStable({
-      status,
-      exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
-      timedOut: details.timedOut === true,
-    });
+    return digestStable(stableOutcome);
   }
 
   if (status === "approval-pending" || status === "approval-unavailable") {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -158,6 +158,15 @@ function stringField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+const STRUCTURED_EXEC_FAILURE_KINDS = new Set([
+  "shell-command-not-found",
+  "shell-not-executable",
+  "overall-timeout",
+  "no-output-timeout",
+  "signal",
+  "aborted",
+]);
+
 function hashExecToolOutcome(details: Record<string, unknown>, text: string): string | undefined {
   const status = stringField(details.status);
   if (!status) {
@@ -172,28 +181,33 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
   }
 
   const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
+  const failureKind = stringField(details.failureKind);
   const stableOutcome = {
     status,
     exitCode,
+    exitSignal:
+      typeof details.exitSignal === "string" || typeof details.exitSignal === "number"
+        ? details.exitSignal
+        : null,
+    exitReason: stringField(details.exitReason),
+    failureKind,
     timedOut: details.timedOut === true,
+    noOutputTimedOut: details.noOutputTimedOut === true,
   };
 
-  if (status === "completed") {
-    // Normal non-zero exits are completed outcomes, but their diagnostics are
-    // failure noise and must not reset the no-progress streak.
-    if (exitCode !== null && exitCode !== 0) {
-      return digestStable(stableOutcome);
-    }
-    return digestStable({
-      ...stableOutcome,
-      output: nonEmptyStringField(details.aggregated) ?? text,
-    });
+  // Failed outcomes carry producer-owned facts that distinguish failure modes.
+  // Diagnostic text may contain volatile runtime details that are not progress.
+  if (status === "failed" && failureKind && STRUCTURED_EXEC_FAILURE_KINDS.has(failureKind)) {
+    return digestStable(stableOutcome);
   }
 
-  // Failed exec diagnostics vary between attempts without proving progress; hash only stable
-  // execution facts so repeated failures can reach the loop guards.
-  if (status === "failed") {
-    return digestStable(stableOutcome);
+  if (status === "completed" || status === "failed") {
+    return digestStable({
+      status,
+      exitCode,
+      timedOut: details.timedOut === true,
+      output: nonEmptyStringField(details.aggregated) ?? text,
+    });
   }
 
   if (status === "approval-pending" || status === "approval-unavailable") {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -171,12 +171,22 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
     });
   }
 
-  if (status === "completed" || status === "failed") {
+  if (status === "completed") {
     return digestStable({
       status,
       exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
       timedOut: details.timedOut === true,
       output: nonEmptyStringField(details.aggregated) ?? text,
+    });
+  }
+
+  // Failed exec diagnostics vary between attempts without proving progress; hash only stable
+  // execution facts so repeated failures can reach the loop guards.
+  if (status === "failed") {
+    return digestStable({
+      status,
+      exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
+      timedOut: details.timedOut === true,
     });
   }
 


### PR DESCRIPTION
Related to #93917

## What Problem This Solves

Repeated producer-classified `exec` process failures can carry changing diagnostic text such as shell PIDs or timeout details. Hashing that text as progress prevents the existing critical and global no-progress guards from stopping a real hard-failure loop.

## Why This Change Was Made

The loop fingerprint now ignores diagnostic text only for the six structured process failure kinds owned by the gateway exec producer:

- `shell-command-not-found`
- `shell-not-executable`
- `overall-timeout`
- `no-output-timeout`
- `signal`
- `aborted`

Those outcomes retain status, exit code, signal, termination reason, failure kind, and timeout state in the fingerprint. Every `status: "completed"` result remains output-sensitive, including ordinary non-zero exits. Broad runtime errors, approval failures, and unclassified failures also remain output-sensitive because their text may be the only semantic distinction.

This is intentionally a partial hard-failure fix. It does not close #93917: ordinary exit-1 SSH, Docker, or grep retries need an explicit producer-owned progress/failure contract before their arbitrary shell output can be normalized safely.

## User Impact

Repeated shell lookup, permission, timeout, signal, and abort failures can now reach the existing loop breakers despite volatile diagnostics, without blocking completed commands or collapsing broad failures that are making observable progress.

## Evidence

Exact head: `cc4edcb640d8036966c146e7ed73b655483a6a5d`

- Real gateway exec integration: the same shell command emits a different PID, exits 127, and returns `failureKind: "shell-command-not-found"`; the detector blocks at the critical threshold.
- Focused tests: `74` detector tests and `1` real-shell integration test passed.
- Controls cover completed non-zero output, runtime errors, approval failures, missing failure kinds, and alternating structured failure identities.
- Exact-head changed gate passed: format, typecheck, core-test types, changed-file lint, dependency/boundary guards, dead-export scans, import cycles, and database-first guards.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30692885445
- Exact-head autoreview: clean, no P0/P1 findings, confidence `0.93`.
