### PR TITLE
fix(memory): reuse targeted session corpus snapshot

### DIFF
--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -50,6 +50,10 @@ type MemorySessionTranscriptUpdate = {
 };
 
 export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps {
+  protected listSessionCorpusEntries(): Promise<SessionTranscriptCorpusEntry[]> {
+    return listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+  }
+
   protected sessionPathForCorpusEntry(entry: SessionTranscriptCorpusEntry): string {
     return entry.transcriptSource === "sqlite"
       ? sessionPathForSessionIdentity(entry.agentId, entry.sessionId)
@@ -114,7 +118,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
 
   private async scheduleCorpusSessionFileDirty(sessionFile: string): Promise<void> {
     const resolvedSessionFile = path.resolve(sessionFile);
-    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    const corpusEntries = await this.listSessionCorpusEntries();
     if (corpusEntries.some((entry) => path.resolve(entry.sessionFile) === resolvedSessionFile)) {
       this.scheduleSessionDirty(resolvedSessionFile);
     }
@@ -133,7 +137,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     if (!this.sources.has("sessions") || this.closed) {
       return [];
     }
-    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    const corpusEntries = await this.listSessionCorpusEntries();
     if (corpusEntries.length === 0 || this.closed) {
       return [];
     }
@@ -487,30 +491,6 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     return normalized.size > 0 ? normalized : null;
   }
 
-  private normalizeTargetSessions(
-    sessions?: MemorySessionSyncTarget[],
-  ): Map<string, MemorySessionSyncTarget> | null {
-    if (!sessions || sessions.length === 0) {
-      return null;
-    }
-    const normalized = new Map<string, MemorySessionSyncTarget>();
-    for (const session of sessions) {
-      const sessionId = session.sessionId.trim();
-      const agentId = session.agentId?.trim() || this.agentId;
-      if (!sessionId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
-        continue;
-      }
-      const sessionKey = session.sessionKey?.trim();
-      const target = {
-        agentId,
-        sessionId,
-        ...(sessionKey ? { sessionKey } : {}),
-      };
-      normalized.set(this.memorySessionSyncTargetKey(target), target);
-    }
-    return normalized.size > 0 ? normalized : null;
-  }
-
   private async resolveArchiveFilesForSyncTargets(
     sessions?: Iterable<MemorySessionSyncTarget> | null,
     knownCorpusEntries?: readonly SessionTranscriptCorpusEntry[],
@@ -520,27 +500,27 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     if (targets.length === 0) {
       return files;
     }
-    const corpusEntries =
-      knownCorpusEntries ?? (await listSessionTranscriptCorpusEntriesForAgent(this.agentId));
-    for (const session of targets) {
-      const sessionKey = session.sessionKey?.trim();
-      let matchedCorpusEntry = false;
-      for (const entry of corpusEntries) {
-        if (normalizeAgentId(entry.agentId) !== normalizeAgentId(this.agentId)) {
-          continue;
-        }
-        if (entry.sessionId !== session.sessionId) {
-          continue;
-        }
-        if (sessionKey && entry.sessionKey !== sessionKey) {
-          continue;
-        }
+    const corpusEntries = knownCorpusEntries ?? (await this.listSessionCorpusEntries());
+    for (const rawSession of targets) {
+      const sessionId = rawSession.sessionId.trim();
+      const agentId = rawSession.agentId?.trim() || this.agentId;
+      if (!sessionId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+        continue;
+      }
+      const sessionKey = rawSession.sessionKey?.trim();
+      const session = { agentId, sessionId, ...(sessionKey ? { sessionKey } : {}) };
+      const matchingEntries = corpusEntries.filter(
+        (entry) =>
+          normalizeAgentId(entry.agentId) === normalizeAgentId(this.agentId) &&
+          entry.sessionId === sessionId &&
+          (!sessionKey || entry.sessionKey === sessionKey),
+      );
+      for (const entry of matchingEntries) {
         files.add(
           entry.transcriptSource === "sqlite" ? entry.sessionFile : path.resolve(entry.sessionFile),
         );
-        matchedCorpusEntry = true;
       }
-      if (matchedCorpusEntry) {
+      if (matchingEntries.length > 0) {
         continue;
       }
       const resolved = resolveSessionFileForSyncTarget(session, this.agentId);
@@ -558,22 +538,22 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     return files;
   }
 
-  protected async combineTargetArchiveFiles(params: {
+  protected async resolveTargetSessionSyncPlan(params: {
     sessions?: MemorySessionSyncTarget[];
     archiveFiles?: string[];
-  }): Promise<Set<string> | null> {
+  }) {
     const files = new Set<string>();
-    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    const corpusEntries = await this.listSessionCorpusEntries();
     for (const file of this.normalizeTargetArchiveFiles(params.archiveFiles, corpusEntries) ?? []) {
       files.add(file);
     }
     for (const file of await this.resolveArchiveFilesForSyncTargets(
-      this.normalizeTargetSessions(params.sessions)?.values(),
+      params.sessions,
       corpusEntries,
     )) {
       files.add(file);
     }
-    return files.size > 0 ? files : null;
+    return files.size > 0 ? { corpusEntries, targetArchiveFiles: files } : null;
   }
 
   private memorySessionSyncTargetKey(target: MemorySessionSyncTarget): string {

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   buildSessionEntry,
-  listSessionTranscriptCorpusEntriesForAgent,
   parseSqliteSessionFileMarker,
   parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
@@ -168,6 +167,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
   protected override async syncArchiveFiles(params: {
     needsFullReindex: boolean;
     targetArchiveFiles?: string[];
+    corpusEntries?: readonly SessionTranscriptCorpusEntry[];
     progress?: MemorySyncProgressState;
     deferIndex?: boolean;
     prefixIndexItems?: MemoryIndexWorkItem[];
@@ -183,7 +183,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
         : null;
 
-    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    const corpusEntries = params.corpusEntries ?? (await this.listSessionCorpusEntries());
     const targetArchiveFiles = params.needsFullReindex
       ? null
       : this.normalizeTargetArchiveFiles(params.targetArchiveFiles, corpusEntries);

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -9,10 +9,11 @@ import {
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { statSessionEntrySync } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
-import type {
-  MemorySource,
-  MemorySyncParams,
-  MemorySyncProgressUpdate,
+import {
+  MEMORY_CHUNKING_VERSION,
+  type MemorySource,
+  type MemorySyncParams,
+  type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   clearConfigCache,
@@ -25,6 +26,11 @@ import {
   formatSqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MEMORY_INDEX_PROVENANCE_VERSION,
+  resolveConfiguredScopeHash,
+  type MemoryIndexMeta,
+} from "./manager-reindex-state.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -142,6 +148,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   readonly syncCalls: SyncParams[] = [];
   readonly indexedPaths: string[] = [];
   readonly indexedContents: string[] = [];
+  corpusListCalls = 0;
+  private afterNextCorpusList: (() => Promise<void>) | null = null;
   private pendingSyncWork: Promise<void> = Promise.resolve();
 
   constructor(
@@ -202,18 +210,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     await this.pendingSyncWork;
   }
 
-  async combineTargetArchiveFilesForTest(params: {
-    sessions?: MemorySyncParams["sessions"];
-    archiveFiles?: string[];
-  }): Promise<Set<string> | null> {
-    return await (
-      this as unknown as {
-        combineTargetArchiveFiles: (params: {
-          sessions?: MemorySyncParams["sessions"];
-          archiveFiles?: string[];
-        }) => Promise<Set<string> | null>;
-      }
-    ).combineTargetArchiveFiles(params);
+  afterNextCorpusListForTest(callback: () => Promise<void>): void {
+    this.afterNextCorpusList = callback;
   }
 
   isSessionsDirty(): boolean {
@@ -253,6 +251,24 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return [];
   }
 
+  protected override readMeta(): MemoryIndexMeta {
+    return {
+      model: "fts-only",
+      provider: "none",
+      sources: ["sessions"],
+      scopeHash: resolveConfiguredScopeHash({
+        workspaceDir: this.workspaceDir,
+        extraPaths: this.settings.extraPaths,
+        multimodal: this.settings.multimodal,
+      }),
+      chunkTokens: this.settings.chunking.tokens,
+      chunkOverlap: this.settings.chunking.overlap,
+      chunkingVersion: MEMORY_CHUNKING_VERSION,
+      ftsTokenizer: this.settings.store.fts.tokenizer,
+      provenanceVersion: MEMORY_INDEX_PROVENANCE_VERSION,
+    };
+  }
+
   protected async sync(params?: MemorySyncParams): Promise<void> {
     this.syncCalls.push(params ?? {});
     this.pendingSyncWork = this.indexSessionUpdates
@@ -271,6 +287,15 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   protected getIndexConcurrency(): number {
     return 1;
+  }
+
+  protected override async listSessionCorpusEntries() {
+    const entries = await super.listSessionCorpusEntries();
+    this.corpusListCalls += 1;
+    const callback = this.afterNextCorpusList;
+    this.afterNextCorpusList = null;
+    await callback?.();
+    return entries;
   }
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
@@ -599,6 +624,14 @@ describe("session startup catch-up", () => {
     expect(harness.indexedPaths).toEqual([]);
   });
 
+  it("skips corpus preflight when an ordinary sync has no session work", async () => {
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await harness.runSyncForTest({ reason: "session-delta" });
+
+    expect(harness.corpusListCalls).toBe(0);
+  });
+
   it("resolves identity-targeted delta sync through a custom session store", async () => {
     const storePath = path.join(stateDir, "custom-sessions", "sessions.json");
     const session = await writeSqliteSession({
@@ -624,6 +657,42 @@ describe("session startup catch-up", () => {
 
     expect(harness.getDirtyArchiveFiles()).toEqual([session.sessionKey]);
     expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("keeps targeted indexing on the SQLite store resolved by its corpus snapshot", async () => {
+    const session = await writeSqliteSession({
+      storePath: path.join(stateDir, "custom-sessions", "sessions.json"),
+      sessionId: "snapshot-thread",
+      sessionKey: "agent:main:chat:snapshot",
+      content: "original snapshot target",
+    });
+    const replacement = await writeSqliteSession({
+      storePath: path.join(stateDir, "replacement-sessions", "sessions.json"),
+      sessionId: session.sessionId,
+      sessionKey: session.sessionKey,
+      content: "replacement store target",
+    });
+    await configureTestSessionStore(session.storePath);
+    const harness = new SessionStartupCatchupHarness([]);
+    harness.afterNextCorpusListForTest(async () => {
+      await configureTestSessionStore(replacement.storePath);
+    });
+
+    await harness.runSyncForTest({
+      reason: "queued-sessions",
+      sessions: [
+        {
+          agentId: "main",
+          sessionId: session.sessionId,
+          sessionKey: session.sessionKey,
+        },
+      ],
+    });
+
+    expect(harness.corpusListCalls).toBe(1);
+    expect(harness.indexedPaths).toEqual([session.corpusPath]);
+    expect(harness.indexedContents[0]).toContain("original snapshot target");
+    expect(harness.indexedContents[0]).not.toContain("replacement store target");
   });
 
   it("preserves generated-session classification during targeted custom-store indexing", async () => {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -174,10 +174,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     // the vector extension before text and FTS indexing can proceed.
     const vectorReady = syncProvider ? await this.ensureVectorReady() : false;
     const meta = this.readMeta();
-    const targetArchiveFiles = await this.combineTargetArchiveFiles({
-      sessions: params?.sessions,
-      archiveFiles: params?.archiveFiles,
-    });
+    // Resolve and index a targeted session against one corpus snapshot. A reset
+    // between separate enumerations could otherwise replace the chosen identity.
+    const targetSessionSync = this.hasRequestedTargetSessionSync(params)
+      ? await this.resolveTargetSessionSyncPlan({
+          sessions: params?.sessions,
+          archiveFiles: params?.archiveFiles,
+        })
+      : null;
+    const targetArchiveFiles = targetSessionSync?.targetArchiveFiles ?? null;
     const hasTargetArchiveFiles = targetArchiveFiles !== null;
     if (this.hasRequestedTargetSessionSync(params) && !hasTargetArchiveFiles) {
       return;
@@ -272,7 +277,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         sessionsFullRetryDirty: this.sessionsFullRetryDirty,
         sessionsDirtyFiles: this.sessionsDirtyFiles,
         syncArchiveFiles: async (targetedParams) => {
-          await this.syncArchiveFiles(targetedParams);
+          await this.syncArchiveFiles({
+            ...targetedParams,
+            corpusEntries: targetSessionSync?.corpusEntries,
+          });
         },
         shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
         activateFallbackProvider: async (reason) => {

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -7,6 +7,7 @@ import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runti
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
+import { isolateMemoryManagerTestConfig } from "./test-manager-helpers.js";
 import "./test-runtime-mocks.js";
 
 const createEmbeddingProviderMock = vi.hoisted(() =>
@@ -93,7 +94,7 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
       params.vectorEnabled === undefined
         ? undefined
         : { vector: { enabled: params.vectorEnabled } };
-    const cfg = {
+    const cfg = isolateMemoryManagerTestConfig({
       memory: {
         backend: "builtin",
         search: {
@@ -110,7 +111,7 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
         },
         list: [{ id: "main", default: true }],
       },
-    } as OpenClawConfig;
+    } as OpenClawConfig);
     const result = await getMemorySearchManager({
       cfg,
       agentId: "main",

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -175,6 +175,7 @@ import {
   getMemorySearchManager,
   type MemoryIndexManager,
 } from "./index.js";
+import { isolateMemoryManagerTestConfig } from "./test-manager-helpers.js";
 
 describe("memory watcher config", () => {
   let manager: MemoryIndexManager | null = null;
@@ -230,7 +231,7 @@ describe("memory watcher config", () => {
     const defaults: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> = {
       workspace: workspaceDir,
     };
-    return {
+    return isolateMemoryManagerTestConfig({
       memory: {
         backend: "builtin",
         search: {
@@ -247,7 +248,7 @@ describe("memory watcher config", () => {
         defaults,
         list: [{ id: "main", default: true }],
       },
-    } as OpenClawConfig;
+    } as OpenClawConfig);
   }
 
   async function expectWatcherManager(cfg: OpenClawConfig) {

--- a/extensions/memory-core/src/memory/test-manager-helpers.ts
+++ b/extensions/memory-core/src/memory/test-manager-helpers.ts
@@ -11,6 +11,16 @@ const loadGetMemorySearchManager = createLazyRuntimeModule(() =>
   import("./index.js").then((mod) => mod.getMemorySearchManager),
 );
 
+export function isolateMemoryManagerTestConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      enabled: cfg.plugins?.enabled ?? false,
+    },
+  };
+}
+
 export async function getRequiredMemoryIndexManager(params: {
   cfg: OpenClawConfig;
   agentId?: string;

--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -8,6 +8,7 @@ import {
   setMemorySearchImpl,
 } from "./memory-tool-manager.test-mocks.js";
 import { createMemorySearchTool } from "./tools.js";
+import { asOpenClawConfig } from "./tools.test-helpers.js";
 
 type RecordShortTermRecallsFn = (params: {
   workspaceDir?: string;
@@ -24,10 +25,6 @@ const recallTrackingMock = vi.hoisted(() => ({
 vi.mock("./short-term-promotion.js", () => ({
   recordShortTermRecalls: recallTrackingMock.recordShortTermRecalls,
 }));
-
-function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
-  return config;
-}
 
 function createSearchTool(config: OpenClawConfig) {
   const tool = createMemorySearchTool({ config });

--- a/extensions/memory-core/src/tools.test-helpers.ts
+++ b/extensions/memory-core/src/tools.test-helpers.ts
@@ -2,10 +2,11 @@ import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry
 // Memory Core helper module supports tools helpers behavior.
 import { expect } from "vitest";
 import type { OpenClawConfig } from "../api.js";
+import { isolateMemoryManagerTestConfig } from "./memory/test-manager-helpers.js";
 import { createMemoryGetTool, createMemorySearchTool } from "./tools.js";
 
 export function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
-  return config;
+  return isolateMemoryManagerTestConfig(config as OpenClawConfig);
 }
 
 export function createDefaultMemoryToolConfig(): OpenClawConfig {
@@ -21,7 +22,7 @@ export function createMemorySearchToolOrThrow(params?: {
   activeProjectKeys?: readonly string[];
 }) {
   const tool = createMemorySearchTool({
-    config: params?.config ?? createDefaultMemoryToolConfig(),
+    config: params?.config ? asOpenClawConfig(params.config) : createDefaultMemoryToolConfig(),
     ...(params?.agentId ? { agentId: params.agentId } : {}),
     ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
     ...(params?.oneShotCliRun ? { oneShotCliRun: params.oneShotCliRun } : {}),


### PR DESCRIPTION
## What Problem This Solves

Targeted memory session sync resolved a requested session against one transcript-corpus enumeration, then enumerated the corpus again during indexing. A session-store reset or configuration rotation between those reads could make the chosen identity disappear or be materialized from a different store. Ordinary syncs also paid for corpus discovery during preflight even when there was no session work.

## Why This Change Was Made

- Carry one immutable corpus snapshot from targeted identity resolution into targeted indexing.
- Remove the duplicate target-normalization map; the resolved file set is already the canonical dedupe boundary.
- Skip corpus discovery entirely for non-target sync preflight.
- Keep full/session-retry reindexes on a fresh full corpus enumeration, because those paths intentionally ignore targeted files and rebuild the complete session source.
- Preserve `.dreams/session-corpus`, Doctor repair, SQLite schema, config/provider contracts, and persistent user data. The dreaming corpus has shipped citation and repair semantics and is not safe to remove without a dedicated migration.

Architectural owner: memory-core's manager session/source sync boundary. The canonical repair resolves and indexes a targeted session from one prepared corpus snapshot; no fallback or parallel storage path was added.

Production delta: 43 additions, 55 deletions (net -12). Tests/helpers: 105 additions, 26 deletions (net +79).

## User Impact

Targeted session indexing remains consistent if the configured SQLite session store rotates while a sync is starting. Ordinary memory syncs avoid an unnecessary session-corpus scan when no target or session indexing work exists. Full reindex, restart/catch-up, archived/reset session, dreaming, backfill, repair, redaction, and provenance behavior remain unchanged.

## Evidence

- Local focused proof: 9 files, 127 tests passed.
- Blacksmith Testbox `tbx_01kyxykp86qbdw81fgsv51eszb`: the same 9 files / 127 tests passed, including a real SQLite store A→B rotation during actual `runSync`; indexing retained store A's resolved snapshot and rejected store B's replacement content.
- Hosted CI exposed a pre-existing mocked-fixture cold-start problem: self-heal, watcher, and memory-tool fixtures cold-loaded the full plugin capability runtime while resolving static config. Unmodified current `main` timed out in 339.9s locally and 170.9s on Testbox in the first affected fixture. The shared test-config owner now defaults only an omitted `plugins.enabled` to `false`; it preserves every explicit `plugins` field, including `enabled`, entries, allowlists, slots, and load settings. The tools fixture uses that owner centrally, and recall tracking no longer carries a duplicate config cast. Provider-auto behavior, explicit dreaming config, real SQLite/self-heal and recall-persistence assertions, timeouts, mocks, and production behavior remain unchanged.
- Exact hosted changed-2 shard: 12 files / 223 tests passed sequentially on Blacksmith Testbox `tbx_01kyy2mby6xkk1cprx6rj42mhe` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/30689252163)).
- The actual ordinary `runSync({ reason: "session-delta" })` path records zero corpus enumerations when index identity is valid and no session work is dirty.
- Remote `node scripts/check-changed.mjs -- <nine changed files>` passed on Blacksmith Testbox `tbx_01kyy302zc2ycqbdw65140mxxh`: formatting, API/boundary/dead-export guards, extension and extension-test tsgo, lint, database-first guards, and runtime import cycles ([Actions run](https://github.com/openclaw/openclaw/actions/runs/30689473692)).
- `git diff --check` passed.
- Fresh structured Codex autoreview at xhigh: clean, no actionable findings, patch correct at 0.99 confidence.
- No SQLite schema, config/default, provider, localization, or user-data migration changes.
