### PR TITLE
fix: keep CLI compaction on rotated context-engine sessions

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -89,6 +89,84 @@ async function persistSessionEntry(params: {
   );
 }
 
+async function prepareContextSuccessorScenario(params: {
+  result: (target: {
+    sessionKey: string;
+    sessionId: string;
+    storePath: string;
+  }) =>
+    | Awaited<ReturnType<ContextEngine["compact"]>>
+    | Promise<Awaited<ReturnType<ContextEngine["compact"]>>>;
+  suffix: string;
+  tmpDir: string;
+}) {
+  const sessionKey = `agent:main:cli-successor-${params.suffix}`;
+  const sessionId = `session-cli-successor-${params.suffix}`;
+  const sessionFile = path.join(params.tmpDir, `${params.suffix}.jsonl`);
+  const storePath = path.join(params.tmpDir, `${params.suffix}.sqlite`);
+  const sessionEntry: SessionEntry = {
+    sessionId,
+    updatedAt: Date.now(),
+    sessionFile,
+    contextTokens: 1_000,
+    totalTokens: 950,
+    totalTokensFresh: true,
+  };
+  const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+  await writeSessionFile({ sessionFile, sessionId });
+  await persistSessionEntry({ sessionKey, storePath, entry: sessionEntry });
+
+  const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+  const recordCliCompactionInStore = vi.fn(async () => sessionEntry);
+  setCliCompactionTestDeps({
+    resolveContextEngine: async () => ({
+      ...buildContextEngine({ compactCalls: [] }),
+      async compact() {
+        return params.result({ sessionId, sessionKey, storePath });
+      },
+    }),
+    createPreparedEmbeddedAgentSettingsManager: async () => ({
+      getCompactionReserveTokens: () => 200,
+      getCompactionKeepRecentTokens: () => 0,
+      applyOverrides: () => {},
+    }),
+    shouldPreemptivelyCompactBeforePrompt: () => ({
+      route: "fits",
+      shouldCompact: false,
+      estimatedPromptTokens: 600,
+      promptBudgetBeforeReserve: 800,
+      overflowTokens: 0,
+      toolResultReducibleChars: 0,
+      effectiveReserveTokens: 200,
+    }),
+    resolveLiveToolResultMaxChars: () => 20_000,
+    runContextEngineMaintenance: maintenance,
+    recordCliCompactionInStore,
+  });
+
+  return {
+    maintenance,
+    recordCliCompactionInStore,
+    run: () =>
+      runCliTurnCompactionLifecycle({
+        cfg: {} as OpenClawConfig,
+        sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        storePath,
+        sessionAgentId: "main",
+        workspaceDir: params.tmpDir,
+        agentDir: params.tmpDir,
+        provider: "claude-cli",
+        model: "opus",
+      }),
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+}
+
 describe("runCliTurnCompactionLifecycle", () => {
   let tmpDir: string;
 
@@ -373,6 +451,131 @@ describe("runCliTurnCompactionLifecycle", () => {
         newSessionId: successorSessionId,
         tokensAfter: 100,
       }),
+    );
+  });
+
+  it("preserves deprecated SQLite-marker successors during CLI maintenance", async () => {
+    const successorId = "session-cli-marker-successor";
+    const scenario = await prepareContextSuccessorScenario({
+      suffix: "marker",
+      tmpDir,
+      result: ({ storePath }) => ({
+        ok: true,
+        compacted: true,
+        result: {
+          tokensBefore: 950,
+          tokensAfter: 100,
+          sessionId: successorId,
+          sessionFile: `sqlite:main:${successorId}:${storePath}`,
+        },
+      }),
+    });
+
+    await scenario.run();
+
+    expect(scenario.maintenance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: `sqlite:main:${successorId}:${scenario.storePath}`,
+        sessionId: successorId,
+        sessionTarget: {
+          agentId: "main",
+          sessionId: successorId,
+          sessionKey: scenario.sessionKey,
+          storePath: scenario.storePath,
+        },
+      }),
+    );
+    expect(scenario.recordCliCompactionInStore).toHaveBeenCalledWith(
+      expect.objectContaining({ newSessionId: successorId }),
+    );
+  });
+
+  it("adopts a deprecated session-key successor after the engine rotates its stored id", async () => {
+    const successorId = "session-cli-key-successor";
+    const scenario = await prepareContextSuccessorScenario({
+      suffix: "session-key",
+      tmpDir,
+      result: async ({ sessionKey, storePath }) => {
+        await persistSessionEntry({
+          sessionKey,
+          storePath,
+          entry: { sessionId: successorId, updatedAt: Date.now() },
+        });
+        return {
+          ok: true,
+          compacted: true,
+          result: {
+            tokensBefore: 950,
+            sessionId: successorId,
+            sessionFile: sessionKey,
+          },
+        };
+      },
+    });
+
+    await scenario.run();
+
+    expect(scenario.maintenance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: scenario.sessionKey,
+        sessionId: successorId,
+        sessionTarget: expect.objectContaining({
+          sessionId: successorId,
+          sessionKey: scenario.sessionKey,
+        }),
+      }),
+    );
+  });
+
+  it("rejects conflicting CLI successor ids", async () => {
+    const scenario = await prepareContextSuccessorScenario({
+      suffix: "conflicting-ids",
+      tmpDir,
+      result: ({ sessionKey, storePath }) => ({
+        ok: true,
+        compacted: true,
+        result: {
+          tokensBefore: 950,
+          sessionId: "reported-successor",
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "target-successor",
+            sessionKey,
+            storePath,
+          },
+        },
+      }),
+    });
+
+    await expect(scenario.run()).rejects.toThrow("successor identity is inconsistent");
+  });
+
+  it.each([
+    ["agent", { agentId: "other" }],
+    ["session key", { sessionKey: "agent:main:other" }],
+    ["store", { storePath: "/tmp/other-openclaw-sessions.sqlite" }],
+  ])("rejects a CLI successor outside the active %s binding", async (_label, override) => {
+    const scenario = await prepareContextSuccessorScenario({
+      suffix: `outside-${_label.replace(" ", "-")}`,
+      tmpDir,
+      result: ({ sessionKey, storePath }) => ({
+        ok: true,
+        compacted: true,
+        result: {
+          tokensBefore: 950,
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "outside-successor",
+            sessionKey,
+            storePath,
+            ...override,
+          },
+        },
+      }),
+    });
+
+    await expect(scenario.run()).rejects.toThrow(
+      "successor target changed the active session binding",
     );
   });
 

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
 /**
  * CLI turn compaction lifecycle.
@@ -34,6 +33,7 @@ import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "../embedded-agent-runner/compaction-safety-timeout.js";
+import { resolveContextEngineCompactionSuccessor } from "../embedded-agent-runner/compaction-successor.js";
 import { runContextEngineMaintenance as runContextEngineMaintenanceImpl } from "../embedded-agent-runner/context-engine-maintenance.js";
 import { shouldPreemptivelyCompactBeforePrompt as shouldPreemptivelyCompactBeforePromptImpl } from "../embedded-agent-runner/run/preemptive-compaction.js";
 import { resolveLiveToolResultMaxChars as resolveLiveToolResultMaxCharsImpl } from "../embedded-agent-runner/tool-result-truncation.js";
@@ -41,7 +41,6 @@ import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.
 import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImpl } from "../harness/runtime-plugin.js";
-import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
@@ -253,65 +252,6 @@ function buildCliCompactionRuntimeContext(params: CliCompactionRuntimeContextPar
   };
 }
 
-async function resolveCliContextCompactionSuccess(params: {
-  agentId: string;
-  cfg: OpenClawConfig;
-  compactResult: Awaited<ReturnType<ContextEngine["compact"]>>;
-  sessionFile: string;
-  sessionId: string;
-  sessionKey: string;
-  storePath?: string;
-}): Promise<{
-  maintenanceSessionFile: string;
-  maintenanceSessionId: string;
-  successorSessionFile?: string;
-  successorSessionId?: string;
-  tokensAfter?: number;
-}> {
-  const result = params.compactResult.result;
-  const resultTarget = result?.sessionTarget;
-  const explicitResultSessionId = result?.sessionId ?? resultTarget?.sessionId;
-  const resultSessionId = explicitResultSessionId ?? params.sessionId;
-  const resultSessionTarget =
-    resultTarget && resultSessionId
-      ? { ...resultTarget, sessionId: resultTarget.sessionId ?? resultSessionId }
-      : resultTarget;
-  if (!resultSessionTarget && !explicitResultSessionId) {
-    return {
-      maintenanceSessionFile: params.sessionFile,
-      maintenanceSessionId: params.sessionId,
-      ...(result?.tokensAfter !== undefined ? { tokensAfter: result.tokensAfter } : {}),
-    };
-  }
-  const resolvedTarget = await resolveAgentRunSessionTarget({
-    agentId: resultSessionTarget?.agentId ?? readAgentIdFromSessionKey(params.sessionKey),
-    config: params.cfg,
-    sessionId: resultSessionId,
-    sessionKey: resultSessionTarget?.sessionKey ?? params.sessionKey,
-    sessionTarget: Object.assign(
-      {},
-      resultSessionTarget,
-      params.storePath && !resultSessionTarget?.storePath ? { storePath: params.storePath } : {},
-    ),
-  });
-  if (
-    resolvedTarget.agentId !== params.agentId ||
-    resolvedTarget.sessionKey !== params.sessionKey ||
-    (params.storePath && path.resolve(resolvedTarget.storePath) !== path.resolve(params.storePath))
-  ) {
-    throw new Error(
-      "CLI context compaction cannot adopt a successor outside the active session binding",
-    );
-  }
-  return {
-    maintenanceSessionFile: resolvedTarget.sessionKey,
-    maintenanceSessionId: resolvedTarget.sessionId,
-    successorSessionFile: resolvedTarget.sessionKey,
-    successorSessionId: resolvedTarget.sessionId,
-    ...(result?.tokensAfter !== undefined ? { tokensAfter: result.tokensAfter } : {}),
-  };
-}
-
 async function compactCliTranscript(params: {
   agentId: string;
   contextEngine: ContextEngine;
@@ -319,7 +259,7 @@ async function compactCliTranscript(params: {
   sessionKey: string;
   sessionFile: string;
   sessionManager: SessionManagerLike;
-  storePath?: string;
+  storePath: string;
   cfg: OpenClawConfig;
   workspaceDir: string;
   cwd?: string;
@@ -426,21 +366,26 @@ async function compactCliTranscript(params: {
     };
   }
 
-  const successor = await resolveCliContextCompactionSuccess({
-    agentId: params.agentId,
-    cfg: params.cfg,
-    compactResult,
-    sessionFile: params.sessionFile,
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    storePath: params.storePath,
+  const result = compactResult.result;
+  const hasSuccessor = Boolean(result?.sessionTarget || result?.sessionId || result?.sessionFile);
+  const successor = await resolveContextEngineCompactionSuccessor({
+    config: params.cfg,
+    currentSessionFile: params.sessionFile,
+    currentTarget: {
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    },
+    result: compactResult,
   });
   try {
     await cliCompactionDeps.runContextEngineMaintenance({
       contextEngine: params.contextEngine,
-      sessionId: successor.maintenanceSessionId,
+      sessionId: successor.sessionId,
       sessionKey: params.sessionKey,
-      sessionFile: successor.maintenanceSessionFile,
+      sessionFile: successor.sessionFile,
+      sessionTarget: hasSuccessor ? successor.sessionTarget : undefined,
       reason: "compaction",
       sessionManager: params.sessionManager,
       runtimeContext,
@@ -455,7 +400,13 @@ async function compactCliTranscript(params: {
       `CLI transcript compaction maintenance failed after fallback for ${params.provider}/${params.model}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  return { compacted: true, ...successor };
+  return {
+    compacted: true,
+    ...(hasSuccessor
+      ? { successorSessionFile: successor.sessionFile, successorSessionId: successor.sessionId }
+      : {}),
+    ...(result?.tokensAfter !== undefined ? { tokensAfter: result.tokensAfter } : {}),
+  };
 }
 
 async function compactNativeHarnessCliTranscript(params: {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -1,12 +1,6 @@
 /**
  * Queues embedded-agent session compaction onto the correct command lane.
  */
-import path from "node:path";
-import {
-  formatSqliteSessionFileMarker,
-  parseSqliteSessionFileMarker,
-} from "../../config/sessions/legacy-sqlite-marker.js";
-import { listSessionEntries, loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import {
@@ -14,20 +8,17 @@ import {
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
 import { buildContextEngineRuntimeSettings } from "../../context-engine/runtime-settings.js";
-import {
-  resolveCompactionSuccessorTranscript,
-  type ContextEngine,
-  type ContextEngineRuntimeContext,
-  type ContextEngineRuntimeSettings,
-  type ContextEngineSessionTarget,
+import type {
+  ContextEngine,
+  ContextEngineRuntimeContext,
+  ContextEngineRuntimeSettings,
+  ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
@@ -55,6 +46,7 @@ import {
   compactContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
+import { resolveContextEngineCompactionSuccessor } from "./compaction-successor.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
@@ -670,153 +662,15 @@ async function compactResolvedContextEngine(
             reason: formatErrorMessage(compactErr),
           };
         }
-        const reportedSessionId = result.result?.sessionId;
-        const delegatedSuccessor = resolveCompactionSuccessorTranscript(result);
-        const delegatedSessionTarget = result.result?.sessionTarget;
-        const delegatedSessionId = delegatedSuccessor.sessionId;
-        const delegatedSessionFile = delegatedSuccessor.sessionFile;
-        let postCompactionSessionId = delegatedSessionId ?? params.sessionId;
-        // Shipped pre-sessionTarget engines report rotation via the deprecated
-        // sessionFile field; honor it when no typed target is present.
-        let postCompactionSessionFile = delegatedSessionFile ?? params.sessionFile;
-        let postCompactionSessionTarget = runtimeTarget;
-        if (delegatedSessionTarget) {
-          if (
-            reportedSessionId &&
-            delegatedSessionTarget.sessionId &&
-            delegatedSessionTarget.sessionId !== reportedSessionId
-          ) {
-            throw new Error("Context-engine successor identity is inconsistent");
-          }
-          const resolvedDelegatedTarget = await resolveAgentRunSessionTarget({
-            agentId: delegatedSessionTarget.agentId ?? sessionAgentId,
-            config: params.config,
-            sessionId: delegatedSessionTarget.sessionId ?? postCompactionSessionId,
-            sessionFile: delegatedSessionFile,
-            sessionKey: delegatedSessionTarget.sessionKey ?? params.sessionKey,
-            sessionTarget: {
-              ...delegatedSessionTarget,
-              storePath: delegatedSessionTarget.storePath ?? runtimeTarget.storePath,
-            },
-          });
-          if (
-            resolvedDelegatedTarget.agentId !== runtimeTarget.agentId ||
-            resolvedDelegatedTarget.sessionKey !== runtimeTarget.sessionKey ||
-            path.resolve(resolvedDelegatedTarget.storePath) !==
-              path.resolve(runtimeTarget.storePath)
-          ) {
-            throw new Error("Context-engine successor target changed the active session binding");
-          }
-          postCompactionSessionId = resolvedDelegatedTarget.sessionId;
-          postCompactionSessionFile = resolvedDelegatedTarget.sessionKey;
-          postCompactionSessionTarget = resolvedDelegatedTarget;
-        } else if (delegatedSessionFile) {
-          const marker = parseSqliteSessionFileMarker(delegatedSessionFile);
-          if (
-            marker &&
-            (marker.agentId !== runtimeTarget.agentId ||
-              (delegatedSessionId && marker.sessionId !== delegatedSessionId))
-          ) {
-            throw new Error("Legacy context-engine successor identity is inconsistent");
-          }
-          const keyedEntry = delegatedSessionFile.startsWith("agent:")
-            ? loadSessionEntry({
-                agentId: runtimeTarget.agentId,
-                sessionKey: delegatedSessionFile,
-                storePath: runtimeTarget.storePath,
-              })
-            : undefined;
-          if (
-            delegatedSessionFile.startsWith("agent:") &&
-            (resolveAgentIdFromSessionKey(delegatedSessionFile) !== runtimeTarget.agentId ||
-              !keyedEntry?.sessionId ||
-              (delegatedSessionId && keyedEntry.sessionId !== delegatedSessionId))
-          ) {
-            throw new Error("Legacy context-engine successor identity is inconsistent");
-          }
-          const keyedSessionId = delegatedSessionFile.startsWith("agent:")
-            ? (delegatedSessionId ?? keyedEntry?.sessionId)
-            : undefined;
-          const retainedMarkerEntry = marker
-            ? loadSessionEntry({
-                agentId: marker.agentId,
-                sessionKey: runtimeTarget.sessionKey,
-                storePath: marker.storePath,
-              })
-            : undefined;
-          const markerMatches = marker
-            ? listSessionEntries({
-                agentId: marker.agentId,
-                storePath: marker.storePath,
-              }).filter(({ entry }) => entry.sessionId === marker.sessionId)
-            : [];
-          const preferredMarkerSessionKey = marker
-            ? resolvePreferredSessionKeyForSessionIdMatches(
-                markerMatches.map(({ sessionKey, entry }) => [sessionKey, entry]),
-                marker.sessionId,
-              )
-            : undefined;
-          const markerMappedToRetainedKey = markerMatches.some(
-            ({ sessionKey }) => sessionKey === runtimeTarget.sessionKey,
-          );
-          const markerSessionKey = marker
-            ? retainedMarkerEntry?.sessionId === marker.sessionId ||
-              (retainedMarkerEntry?.sessionId === runtimeTarget.sessionId &&
-                (markerMatches.length === 0 || markerMappedToRetainedKey))
-              ? runtimeTarget.sessionKey
-              : (preferredMarkerSessionKey ??
-                (markerMatches.length === 0 && !retainedMarkerEntry
-                  ? runtimeTarget.sessionKey
-                  : undefined))
-            : undefined;
-          const legacyTarget = marker
-            ? markerSessionKey
-              ? {
-                  ...marker,
-                  sessionId: marker.sessionId,
-                  sessionKey: markerSessionKey,
-                }
-              : undefined
-            : keyedSessionId
-              ? {
-                  ...runtimeTarget,
-                  sessionId: keyedSessionId,
-                  sessionKey: delegatedSessionFile,
-                }
-              : undefined;
-          if (!legacyTarget) {
-            throw new Error(
-              "Legacy context-engine successor files are unsupported; return a structured sessionTarget",
-            );
-          }
-          const resolvedDelegatedTarget = await resolveAgentRunSessionTarget({
-            agentId: legacyTarget.agentId,
-            config: params.config,
-            sessionId: legacyTarget.sessionId,
-            sessionKey: legacyTarget.sessionKey,
-            sessionTarget: legacyTarget,
-          });
-          if (
-            resolvedDelegatedTarget.agentId !== runtimeTarget.agentId ||
-            resolvedDelegatedTarget.sessionKey !== runtimeTarget.sessionKey ||
-            path.resolve(resolvedDelegatedTarget.storePath) !==
-              path.resolve(runtimeTarget.storePath)
-          ) {
-            throw new Error(
-              "Legacy context-engine successor target changed the active session binding",
-            );
-          }
-          postCompactionSessionId = resolvedDelegatedTarget.sessionId;
-          postCompactionSessionFile = marker
-            ? formatSqliteSessionFileMarker(resolvedDelegatedTarget)
-            : resolvedDelegatedTarget.sessionKey;
-          postCompactionSessionTarget = resolvedDelegatedTarget;
-        } else if (delegatedSessionId && !delegatedSessionFile) {
-          postCompactionSessionTarget = {
-            ...runtimeTarget,
-            sessionId: delegatedSessionId,
-          };
-        }
+        const successor = await resolveContextEngineCompactionSuccessor({
+          config: params.config,
+          currentSessionFile: params.sessionFile,
+          currentTarget: runtimeTarget,
+          result,
+        });
+        const postCompactionSessionId = successor.sessionId;
+        const postCompactionSessionFile = successor.sessionFile;
+        const postCompactionSessionTarget = successor.sessionTarget;
         if (result.ok && result.compacted) {
           checkpointSnapshotRetained = await persistCompactionCheckpoint({
             config: params.config,

--- a/src/agents/embedded-agent-runner/compaction-successor.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor.ts
@@ -1,0 +1,154 @@
+import path from "node:path";
+import {
+  formatSqliteSessionFileMarker,
+  parseSqliteSessionFileMarker,
+} from "../../config/sessions/legacy-sqlite-marker.js";
+import { listSessionEntries, loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { CompactResult } from "../../context-engine/types.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
+import { resolveAgentRunSessionTarget } from "../run-session-target.js";
+
+/** Resolve a context engine's successor without letting it cross the active store binding. */
+export async function resolveContextEngineCompactionSuccessor(params: {
+  config?: OpenClawConfig;
+  currentSessionFile: string;
+  currentTarget: SessionTranscriptRuntimeTarget;
+  result: CompactResult;
+}) {
+  const current = params.currentTarget;
+  const result = params.result.result;
+  const target = result?.sessionTarget;
+  const successorId = target?.sessionId ?? result?.sessionId;
+  const successorFile = result?.sessionFile;
+  // Shipped pre-sessionTarget engines report rotation via the deprecated
+  // sessionFile field; honor it when no typed target is present.
+  if (target) {
+    if (result?.sessionId && target.sessionId && target.sessionId !== result.sessionId) {
+      throw new Error("Context-engine successor identity is inconsistent");
+    }
+    const resolvedTarget = await resolveAgentRunSessionTarget({
+      agentId: target.agentId ?? current.agentId,
+      config: params.config,
+      sessionId: target.sessionId ?? successorId ?? current.sessionId,
+      sessionFile: successorFile,
+      sessionKey: target.sessionKey ?? current.sessionKey,
+      sessionTarget: {
+        ...target,
+        storePath: target.storePath ?? current.storePath,
+      },
+    });
+    assertSameSessionBinding(current, resolvedTarget, "Context-engine");
+    return {
+      sessionId: resolvedTarget.sessionId,
+      sessionFile: resolvedTarget.sessionKey,
+      sessionTarget: resolvedTarget,
+    };
+  }
+
+  if (successorFile) {
+    const marker = parseSqliteSessionFileMarker(successorFile);
+    if (
+      marker &&
+      (marker.agentId !== current.agentId || (successorId && marker.sessionId !== successorId))
+    ) {
+      throw new Error("Legacy context-engine successor identity is inconsistent");
+    }
+    const isSessionKey = successorFile.startsWith("agent:");
+    const keyedEntry = isSessionKey
+      ? loadSessionEntry({
+          agentId: current.agentId,
+          sessionKey: successorFile,
+          storePath: current.storePath,
+        })
+      : undefined;
+    if (
+      isSessionKey &&
+      (resolveAgentIdFromSessionKey(successorFile) !== current.agentId ||
+        !keyedEntry?.sessionId ||
+        (successorId && keyedEntry.sessionId !== successorId))
+    ) {
+      throw new Error("Legacy context-engine successor identity is inconsistent");
+    }
+    const keyedSessionId = isSessionKey ? (successorId ?? keyedEntry?.sessionId) : undefined;
+    const retainedMarkerEntry = marker
+      ? loadSessionEntry({
+          agentId: marker.agentId,
+          sessionKey: current.sessionKey,
+          storePath: marker.storePath,
+        })
+      : undefined;
+    const markerMatches = marker
+      ? listSessionEntries({
+          agentId: marker.agentId,
+          storePath: marker.storePath,
+        }).filter(({ entry }) => entry.sessionId === marker.sessionId)
+      : [];
+    const preferredMarkerSessionKey = marker
+      ? resolvePreferredSessionKeyForSessionIdMatches(
+          markerMatches.map(({ sessionKey, entry }) => [sessionKey, entry]),
+          marker.sessionId,
+        )
+      : undefined;
+    const markerMappedToRetainedKey = markerMatches.some(
+      ({ sessionKey }) => sessionKey === current.sessionKey,
+    );
+    const markerSessionKey = marker
+      ? retainedMarkerEntry?.sessionId === marker.sessionId ||
+        (retainedMarkerEntry?.sessionId === current.sessionId &&
+          (markerMatches.length === 0 || markerMappedToRetainedKey))
+        ? current.sessionKey
+        : (preferredMarkerSessionKey ??
+          (markerMatches.length === 0 && !retainedMarkerEntry ? current.sessionKey : undefined))
+      : undefined;
+    const legacyTarget = marker
+      ? markerSessionKey
+        ? { ...marker, sessionId: marker.sessionId, sessionKey: markerSessionKey }
+        : undefined
+      : keyedSessionId
+        ? { ...current, sessionId: keyedSessionId, sessionKey: successorFile }
+        : undefined;
+    if (!legacyTarget) {
+      throw new Error(
+        "Legacy context-engine successor files are unsupported; return a structured sessionTarget",
+      );
+    }
+    const resolvedTarget = await resolveAgentRunSessionTarget({
+      agentId: legacyTarget.agentId,
+      config: params.config,
+      sessionId: legacyTarget.sessionId,
+      sessionKey: legacyTarget.sessionKey,
+      sessionTarget: legacyTarget,
+    });
+    assertSameSessionBinding(current, resolvedTarget, "Legacy context-engine");
+    return {
+      sessionId: resolvedTarget.sessionId,
+      sessionFile: marker
+        ? formatSqliteSessionFileMarker(resolvedTarget)
+        : resolvedTarget.sessionKey,
+      sessionTarget: resolvedTarget,
+    };
+  }
+
+  return {
+    sessionId: successorId ?? current.sessionId,
+    sessionFile: params.currentSessionFile,
+    sessionTarget: successorId ? { ...current, sessionId: successorId } : current,
+  };
+}
+
+function assertSameSessionBinding(
+  currentTarget: SessionTranscriptRuntimeTarget,
+  successorTarget: SessionTranscriptRuntimeTarget,
+  label: string,
+): void {
+  if (
+    successorTarget.agentId !== currentTarget.agentId ||
+    successorTarget.sessionKey !== currentTarget.sessionKey ||
+    path.resolve(successorTarget.storePath) !== path.resolve(currentTarget.storePath)
+  ) {
+    throw new Error(`${label} successor target changed the active session binding`);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI-backed sessions could ignore a rotated transcript when a shipped third-party context engine reported its successor through the deprecated `sessionFile` result. The queued compaction path validated and adopted that successor, but the CLI post-turn path only handled typed targets and session IDs, so maintenance and persisted resume state could remain attached to the old transcript.

## Why This Change Was Made

Compaction successor interpretation now has one canonical internal owner shared by queued and CLI compaction. It preserves typed-target precedence, partial-target inheritance, legacy SQLite-marker and `agent:` key compatibility, and the invariant that a successor cannot change the active agent, session key, or store path. Native harness routing, context-engine hooks/auth/timeouts, checkpointing, cancellation precedence, and store mutation remain in their existing dispatchers.

## User Impact

CLI sessions using context-engine plugins now continue on the correct compacted transcript, including plugins on the shipped deprecated successor contract. Invalid cross-agent, cross-key, cross-store, and conflicting-ID successors are rejected consistently in both compaction entrypoints.

Production delta: 193 additions / 234 deletions, net -41 lines. Tests are counted separately.

## Evidence

- Blacksmith Testbox `tbx_01kyxxt18fvcapc39rzmjs047e`: 169 focused tests passed (`cli-compaction`, `compact.hooks`, and compaction rotation).
- Exact rebased head `0fbb55a36ca4eb6344be6df44fb7cfcb94ab0c1f`: full `pnpm check:changed` passed, including formatting, oxlint, core/core-test tsgo, SDK API, deprecated API, plugin boundaries, dead exports, database-first, schema, and import-cycle guards.
- [Blacksmith focused and full-gate proof](https://github.com/openclaw/openclaw/actions/runs/30686506595)
- Isolated autoreview: `gpt-5.6-sol` at xhigh, clean with no accepted/actionable findings.
- Regression coverage adds CLI adoption for deprecated SQLite markers and session keys, plus conflicting-ID and cross-agent/key/store rejection.

### Inspectable after-fix runtime proof

A trusted Blacksmith Testbox ran the real exported CLI lifecycle against an ephemeral SQLite session store and a context-engine implementation returning each shipped deprecated successor shape. The only redaction below is the random temporary directory. [Run 30687019376](https://github.com/openclaw/openclaw/actions/runs/30687019376), lease `tbx_01kyxyqy2js4yynxcnzz0g4ct5`, exit 0.

```text
$ CI=1 node --import tsx compaction-successor-proof.ts
marker.reported = { sessionId: proof-marker-after, sessionFile: sqlite:main:proof-marker-after:<temp>/marker.sqlite }
marker.maintenance = { sessionId: proof-marker-after, sessionFile: sqlite:main:proof-marker-after:<temp>/marker.sqlite, sessionTarget: { agentId: main, sessionKey: agent:main:proof-marker, storePath: <temp>/marker.sqlite, sessionId: proof-marker-after } }
marker.returnedResume = { sessionId: proof-marker-after }
marker.persistedResume = { sessionId: proof-marker-after, compactionCount: 1, totalTokens: 100 }

sessionKey.reported = { sessionId: proof-session-key-after, sessionFile: agent:main:proof-session-key }
sessionKey.maintenance = { sessionId: proof-session-key-after, sessionFile: agent:main:proof-session-key, sessionTarget: { agentId: main, sessionKey: agent:main:proof-session-key, storePath: <temp>/session-key.sqlite, sessionId: proof-session-key-after } }
sessionKey.returnedResume = { sessionId: proof-session-key-after }
sessionKey.persistedResume = { sessionId: proof-session-key-after, totalTokens: 950 }

blacksmith run summary ... exit=0
```

This directly shows both deprecated result shapes reaching maintenance with the bound `agentId` / `sessionKey` / `storePath`, and the next persisted resume resolving to the successor session ID.

### Direct upstream Codex contract proof

Personally inspected sibling `openai/codex` at `07490c75234ed3c63291a8eb7629f04f647038fa`. Explicit app-server compaction remains native:

```rust
// codex-rs/app-server/src/request_processors/thread_processor.rs:1874-1877
let (_, thread) = self.load_thread(&thread_id).await?;
self.submit_core_op(request_id, thread.as_ref(), Op::Compact)
    .await
    .map_err(|err| internal_error(format!("failed to start compaction: {err}")))?;
```

Automatic compaction remains inline before sampling:

```rust
// codex-rs/core/src/session/turn.rs:992-1012
maybe_run_previous_model_inline_compact(sess, turn_context, client_session, cancellation_token).await?;
let token_status = context_window_token_status(...).await;
if token_status.token_limit_reached {
    run_auto_compact(..., CompactionReason::ContextLimit, CompactionPhase::PreTurn).await?;
}
```

Therefore this PR does not alter `thread/compact/start` to `Op::Compact`, pre-sampling automatic compaction, or introduce a generic OAuth fallback.

AI-assisted: yes. I reviewed the implementation, contracts, and validation results.