### PR TITLE
fix(release): gate Docker publication on npm release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,25 +1,19 @@
 name: Docker Release
 
 on:
-  push:
-    tags:
-      - "v*"
-      - "!v*-alpha.*"
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.mdx"
-      - ".agents/**"
-      - "skills/**"
-  workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
-        description: Existing stable, extended-stable, or beta release tag
+        description: Immutable stable, extended-stable, or beta release tag
+        required: true
+        type: string
+      release_sha:
+        description: Full immutable commit SHA resolved from tag
         required: true
         type: string
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}
+  group: docker-release-publish-${{ inputs.tag }}
   cancel-in-progress: false
   queue: max
 
@@ -31,15 +25,15 @@ env:
   DOCKERHUB_IMAGE_NAME: openclaw/openclaw
 
 jobs:
-  validate_manual_backfill:
-    if: github.event_name == 'workflow_dispatch'
+  validate_release_identity:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
-      - name: Validate tag input format
+      - name: Validate immutable tag and SHA inputs
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
           if [[ "${RELEASE_TAG}" == *"-alpha."* ]]; then
@@ -50,16 +44,38 @@ jobs:
             echo "Invalid release tag: ${RELEASE_TAG}"
             exit 1
           fi
+          if [[ ! "${RELEASE_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "Release SHA must be a full lowercase commit SHA."
+            exit 1
+          fi
 
-      - name: Checkout selected tag
+      - name: Checkout immutable release tag
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag, SHA, and package identity agree
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          tag_sha="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          checkout_sha="$(git rev-parse HEAD)"
+          package_version="$(node -p "require('./package.json').version")"
+          if [[ "${tag_sha}" != "${RELEASE_SHA}" || "${checkout_sha}" != "${RELEASE_SHA}" ]]; then
+            echo "Release tag ${RELEASE_TAG} must resolve to supplied SHA ${RELEASE_SHA}; got ${tag_sha}." >&2
+            exit 1
+          fi
+          if [[ "v${package_version}" != "${RELEASE_TAG}" && ! "${RELEASE_TAG}" =~ ^v${package_version}-[1-9][0-9]*$ ]]; then
+            echo "Release tag ${RELEASE_TAG} does not match package.json version ${package_version} or its correction-tag form." >&2
+            exit 1
+          fi
 
   resolve_release_policy:
-    needs: validate_manual_backfill
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.validate_manual_backfill.result == 'success') }}
+    needs: validate_release_identity
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -78,7 +94,7 @@ jobs:
         id: policy
         shell: bash
         env:
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           if [[ "${SOURCE_REF}" != refs/tags/v* ]]; then
@@ -98,20 +114,19 @@ jobs:
             echo "- Channel: ${channel}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  approve_manual_backfill:
-    name: Approve Docker backfill ${{ inputs.tag }}
-    if: github.event_name == 'workflow_dispatch'
-    needs: [validate_manual_backfill, resolve_release_policy]
-    # WARNING: KEEP MANUAL BACKFILLS GATED BY THE docker-release ENVIRONMENT.
+  approve_docker_publish:
+    name: Approve Docker publication ${{ inputs.tag }}
+    needs: [validate_release_identity, resolve_release_policy]
+    # Docker publication remains protected even though only release orchestration can call it.
     runs-on: ubuntu-24.04
     environment: docker-release
     permissions: {}
     steps:
-      - name: Approve Docker backfill
+      - name: Approve Docker publication
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          echo "Approved immutable Docker image backfill for ${RELEASE_TAG}"
+          echo "Approved immutable Docker image publication for ${RELEASE_TAG}"
 
   validate_publish_config:
     runs-on: ubuntu-24.04
@@ -132,8 +147,8 @@ jobs:
           echo "Docker Hub publishing configured for ${DOCKERHUB_IMAGE}."
 
   resolve_build_provenance:
-    needs: [approve_manual_backfill, resolve_release_policy, validate_publish_config]
-    if: ${{ always() && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_docker_publish, resolve_release_policy, validate_publish_config]
+    if: ${{ always() && needs.approve_docker_publish.result == 'success' && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -144,7 +159,7 @@ jobs:
       - name: Checkout selected source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+          ref: ${{ inputs.release_sha }}
           fetch-depth: 0
 
       - name: Resolve shared build provenance
@@ -159,8 +174,8 @@ jobs:
   # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
   # Build amd64 image. Default and slim tags point to the same slim runtime.
   build-amd64:
-    needs: [approve_manual_backfill, validate_publish_config, resolve_build_provenance]
-    if: ${{ always() && needs.validate_publish_config.result == 'success' && needs.resolve_build_provenance.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_docker_publish, validate_publish_config, resolve_build_provenance]
+    if: ${{ always() && needs.approve_docker_publish.result == 'success' && needs.validate_publish_config.result == 'success' && needs.resolve_build_provenance.result == 'success' }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
@@ -219,7 +234,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           tags=()
@@ -259,7 +274,7 @@ jobs:
         env:
           BUILD_TIMESTAMP: ${{ needs.resolve_build_provenance.outputs.built_at }}
           SOURCE_SHA: ${{ needs.resolve_build_provenance.outputs.source_sha }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           source_sha="${SOURCE_SHA}"
@@ -386,8 +401,8 @@ jobs:
 
   # Build arm64 image. Default and slim tags point to the same slim runtime.
   build-arm64:
-    needs: [approve_manual_backfill, validate_publish_config, resolve_build_provenance]
-    if: ${{ always() && needs.validate_publish_config.result == 'success' && needs.resolve_build_provenance.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_docker_publish, validate_publish_config, resolve_build_provenance]
+    if: ${{ always() && needs.approve_docker_publish.result == 'success' && needs.validate_publish_config.result == 'success' && needs.resolve_build_provenance.result == 'success' }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -427,7 +442,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           tags=()
@@ -467,7 +482,7 @@ jobs:
         env:
           BUILD_TIMESTAMP: ${{ needs.resolve_build_provenance.outputs.built_at }}
           SOURCE_SHA: ${{ needs.resolve_build_provenance.outputs.source_sha }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           source_sha="${SOURCE_SHA}"
@@ -596,14 +611,14 @@ jobs:
   create-manifest:
     needs:
       [
-        approve_manual_backfill,
+        approve_docker_publish,
         resolve_release_policy,
         validate_publish_config,
         resolve_build_provenance,
         build-amd64,
         build-arm64,
       ]
-    if: ${{ always() && needs.validate_publish_config.result == 'success' && needs.build-amd64.result == 'success' && needs.build-arm64.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    if: ${{ always() && needs.approve_docker_publish.result == 'success' && needs.validate_publish_config.result == 'success' && needs.build-amd64.result == 'success' && needs.build-arm64.result == 'success' }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
@@ -636,7 +651,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           tags=()
@@ -683,7 +698,7 @@ jobs:
         shell: bash
         env:
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
           TAGS: ${{ steps.tags.outputs.value }}
           BROWSER_TAGS: ${{ steps.tags.outputs.browser }}
           DOCKERHUB_TAGS: ${{ steps.tags.outputs.dockerhub }}
@@ -765,7 +780,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
           multi_refs=()
@@ -880,7 +895,7 @@ jobs:
             "${dockerhub_arm64_refs[@]}"
 
       - name: Promote and verify channel aliases
-        if: ${{ github.event_name != 'workflow_dispatch' && needs.resolve_release_policy.outputs.channel != 'beta' }}
+        if: ${{ needs.resolve_release_policy.outputs.channel != 'beta' }}
         env:
           VERSION: ${{ needs.resolve_release_policy.outputs.version }}
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -44,6 +44,7 @@ on:
           - alpha
           - beta
           - latest
+          - extended-stable
       plugin_publish_scope:
         description: Plugin publish scope to run before OpenClaw publish
         required: true
@@ -60,6 +61,11 @@ on:
         description: Publish the OpenClaw npm package after plugin npm succeeds; ClawHub may still run
         required: true
         default: true
+        type: boolean
+      publish_docker_only:
+        description: Publish Docker only after independently verifying an already-published extended-stable npm package
+        required: true
+        default: false
         type: boolean
       release_profile:
         description: Release coverage profile used for release evidence summaries; default reads it from the validation manifest
@@ -98,6 +104,7 @@ jobs:
     outputs:
       sha: ${{ steps.manifest.outputs.sha || steps.ref.outputs.sha }}
       preflight_artifact_name: ${{ steps.preflight_artifact.outputs.name }}
+      preflight_tarball_sha256: ${{ steps.manifest.outputs.tarball_sha256 }}
       full_release_validation_run_attempt: ${{ steps.full_run.outputs.attempt }}
       windows_node_installer_digests: ${{ steps.windows_source.outputs.installer_digests }}
     steps:
@@ -112,6 +119,7 @@ jobs:
           WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
           WINDOWS_NODE_INSTALLER_DIGESTS: ${{ inputs.windows_node_installer_digests }}
           PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
+          PUBLISH_DOCKER_ONLY: ${{ inputs.publish_docker_only && 'true' || 'false' }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
@@ -133,7 +141,7 @@ jobs:
             exit 1
           fi
           release_evidence_required=false
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" || "${PLUGIN_PUBLISH_SCOPE}" == "all-publishable" ]]; then
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" || "${PUBLISH_DOCKER_ONLY}" == "true" || "${PLUGIN_PUBLISH_SCOPE}" == "all-publishable" ]]; then
             release_evidence_required=true
           fi
           release_evidence_supplied=false
@@ -164,6 +172,20 @@ jobs:
           fi
           if [[ -n "${OPENCLAW_NPM_RESUME_RUN_ID}" && "${PUBLISH_OPENCLAW_NPM}" != "true" ]]; then
             echo "openclaw_npm_resume_run_id requires publish_openclaw_npm=true." >&2
+            exit 1
+          fi
+          if [[ "${PUBLISH_DOCKER_ONLY}" == "true" ]]; then
+            if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
+              echo "publish_docker_only requires publish_openclaw_npm=false." >&2
+              exit 1
+            fi
+            if [[ "${RELEASE_NPM_DIST_TAG}" != "extended-stable" ]]; then
+              echo "publish_docker_only is reserved for an already-published extended-stable release." >&2
+              exit 1
+            fi
+          fi
+          if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" && "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
+            echo "Extended-stable core npm publication stays on the canonical extended-stable release flow; use publish_docker_only=true only after its registry readback." >&2
             exit 1
           fi
           stable_release=true
@@ -453,6 +475,7 @@ jobs:
             exit 1
           fi
           echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "tarball_sha256=$tarball_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Validate full release validation manifest
         id: full_manifest
@@ -520,7 +543,8 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            '+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*'
           if git merge-base --is-ancestor HEAD origin/main; then
             exit 0
           fi
@@ -529,6 +553,11 @@ jobs:
               exit 0
             fi
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          while IFS= read -r release_ref; do
+            if git merge-base --is-ancestor HEAD "${release_ref}"; then
+              exit 0
+            fi
+          done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/extended-stable)
           if [[ "${RELEASE_TAG}" == *"-alpha."* ]]; then
             if [[ ! "${WORKFLOW_REF_NAME}" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
               echo "Alpha publish tags must be dispatched from tideclaw/alpha/YYYY-MM-DD-HHMMZ." >&2
@@ -539,7 +568,7 @@ jobs:
               exit 0
             fi
           fi
-          echo "Release tag must point to a commit reachable from main, release/*, or the matching Tideclaw alpha branch for alpha prereleases." >&2
+          echo "Release tag must point to a commit reachable from main, release/*, extended-stable/*, or the matching Tideclaw alpha branch for alpha prereleases." >&2
           exit 1
 
       - name: Summarize release target
@@ -567,6 +596,7 @@ jobs:
   publish:
     name: Publish plugins, then OpenClaw
     needs: [resolve_release_target]
+    if: ${{ !inputs.publish_docker_only }}
     permissions:
       actions: write
       attestations: write
@@ -2331,7 +2361,7 @@ jobs:
             upload_release_evidence_assets
             append_release_proof_to_github_release
             if [[ "${failed}" == "0" ]]; then
-              publish_github_release
+              echo "- GitHub release: kept draft until Docker publication succeeds" >> "$GITHUB_STEP_SUMMARY"
             else
               echo "- GitHub release: left as draft because a required publish child failed" >> "$GITHUB_STEP_SUMMARY"
             fi
@@ -2347,3 +2377,74 @@ jobs:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
           path: ${{ runner.temp }}/openclaw-release-postpublish-evidence
           if-no-files-found: error
+
+  verify_core_npm_registry:
+    name: Verify already-published core npm package
+    needs: [resolve_release_target]
+    if: ${{ inputs.publish_docker_only }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify exact npm and selector readback matches preflight bytes
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_TARBALL_SHA256: ${{ needs.resolve_release_target.outputs.preflight_tarball_sha256 }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          exact_version="$(npm view "openclaw@${version}" version)"
+          selector_version="$(npm view openclaw@extended-stable version)"
+          if [[ "${exact_version}" != "${version}" || "${selector_version}" != "${version}" ]]; then
+            echo "npm exact-version or extended-stable selector readback does not match ${version}." >&2
+            exit 1
+          fi
+          tarball_url="$(npm view "openclaw@${version}" dist.tarball)"
+          tarball_path="${RUNNER_TEMP}/openclaw-${version}.tgz"
+          curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 180 \
+            -o "${tarball_path}" "${tarball_url}"
+          actual_tarball_sha256="$(sha256sum "${tarball_path}" | awk '{print $1}')"
+          if [[ -z "${EXPECTED_TARBALL_SHA256}" || "${actual_tarball_sha256}" != "${EXPECTED_TARBALL_SHA256}" ]]; then
+            echo "Published npm tarball does not match the release preflight artifact." >&2
+            exit 1
+          fi
+
+  publish_docker:
+    name: Publish Docker images
+    needs: [resolve_release_target, publish, verify_core_npm_registry]
+    if: ${{ always() && ((inputs.publish_openclaw_npm && needs.publish.result == 'success') || (inputs.publish_docker_only && needs.verify_core_npm_registry.result == 'success')) }}
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      tag: ${{ inputs.tag }}
+      release_sha: ${{ needs.resolve_release_target.outputs.sha }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+
+  finalize_github_release:
+    name: Finalize GitHub release
+    needs: [publish, publish_docker]
+    if: ${{ always() && inputs.publish_openclaw_npm && needs.publish.result == 'success' && needs.publish_docker.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: write
+    steps:
+      - name: Publish the verified draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          expected_prerelease=false
+          if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
+            expected_prerelease=true
+          fi
+          gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+          release_json="$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease)"
+          if [[ "$(printf '%s' "${release_json}" | jq -r '.isDraft')" != "false" ]] || \
+            [[ "$(printf '%s' "${release_json}" | jq -r '.isPrerelease')" != "${expected_prerelease}" ]]; then
+            echo "Published GitHub release state does not match the requested draft/prerelease classification." >&2
+            exit 1
+          fi

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -103,7 +103,8 @@ Classify failures before editing:
 
 Any branch change invalidates both gates. Once they pass, require the tip still
 equals `RELEASE_SHA`, then push signed `vYYYY.M.P`. Later changes need the next
-patch; never move or delete the tag. Its push starts `Docker Release`.
+patch; never move or delete the tag. Tagging fixes the immutable release
+identity; it does not publish Docker images.
 
 ### Publish the npm packages
 
@@ -168,6 +169,25 @@ must advance only
 `extended-stable`, `extended-stable-slim`, and `extended-stable-browser` by
 digest; regular aliases remain unchanged and automatic rollback is rejected.
 
+After that core registry readback succeeds, start Docker publication only through
+`OpenClaw Release Publish`. Its Docker-only extended-stable path rechecks the
+saved npm preflight artifact, exact `Full Release Validation` evidence, exact npm
+version and `extended-stable` selector, and published tarball digest before it
+calls the reusable `Docker Release` workflow. A tag push never publishes Docker
+images by itself:
+
+```bash
+gh workflow run openclaw-release-publish.yml \
+  --ref main \
+  -f tag=vYYYY.M.P \
+  -f preflight_run_id=<npm-preflight-run-id> \
+  -f full_release_validation_run_id=<full-validation-run-id> \
+  -f full_release_validation_run_attempt=<full-validation-run-attempt> \
+  -f npm_dist_tag=extended-stable \
+  -f publish_openclaw_npm=false \
+  -f publish_docker_only=true
+```
+
 For alias repair, run approval-gated `Docker Channel Promotion` from current
 `main` with the tag. It repeats digest, attestation, and platform checks, allows
 an explicit rollback, and never rebuilds images.
@@ -201,7 +221,7 @@ This checklist is the public shape of the release flow. Private credentials, sig
 
    For stable, also pass `--windows-node-tag vX.Y.Z`. The helper verifies release-note provenance, npm preflight bytes, Parallels install/update proof, Telegram package proof, and plugin publish plans, then prints the publish command.
 
-   `OpenClaw Release Publish` dispatches the selected or all-publishable plugin packages to npm and the same set to ClawHub in parallel, then promotes the prepared OpenClaw npm preflight artifact with the matching dist-tag once plugin npm publish succeeds. The release checkout remains the product/data root, while planning and final verification execute from the exact trusted workflow-source checkout so an older release commit cannot silently use obsolete release tooling. Before any publish child starts, it renders and caches the exact GitHub release body. When the complete matching `CHANGELOG.md` section fits GitHub's 125,000-character limit and the renderer's matching 125,000-byte safety ceiling, the page contains that exact `## YYYY.M.PATCH` section including its heading. When the source section does not fit, the page keeps the exact grouped editorial notes and replaces the oversized contribution record with a stable link to the full record in the tag-pinned `CHANGELOG.md`; partial records and truncated bullets are never published. The workflow chooses that full or compact body before adding `### Release verification`; if the proof tail would exceed the limit, it keeps the canonical body and relies on the immutable attached evidence instead. Stable releases published to npm `latest` become the GitHub latest release, while stable maintenance releases kept on npm `beta` are created with GitHub `latest=false`. The workflow also uploads the preflight dependency evidence, the full-validation manifest, and postpublish registry verification evidence to the GitHub release for post-release incident response. It prints child run IDs immediately, auto-approves release environment gates the workflow token is allowed to approve, summarizes failed child jobs with log tails, creates the draft GitHub release page up front and promotes Windows and Android assets concurrently with the OpenClaw npm publish, closes out the release page and dependency evidence once those stages succeed, waits for ClawHub whenever OpenClaw npm is being published, then runs the trusted-main beta verifier and uploads postpublish evidence for the GitHub release, npm package, selected plugin npm packages, selected ClawHub packages, child workflow run IDs, and optional NPM Telegram run ID. The ClawHub bootstrap verifier requires the exact trusted-main workflow path and SHA, producer and terminal run attempts, release SHA, requested package set, immutable package artifact tuple, and terminal registry readback artifact; a successful legacy release-ref run is not accepted.
+   `OpenClaw Release Publish` dispatches the selected or all-publishable plugin packages to npm and the same set to ClawHub in parallel, then promotes the prepared OpenClaw npm preflight artifact with the matching dist-tag once plugin npm publish succeeds. It keeps the GitHub release as a draft while it verifies registry readback, calls `Docker Release` with the immutable tag and Release SHA, and only then finalizes the GitHub release. The release checkout remains the product/data root, while planning and final verification execute from the exact trusted workflow-source checkout so an older release commit cannot silently use obsolete release tooling. Before any publish child starts, it renders and caches the exact GitHub release body. When the complete matching `CHANGELOG.md` section fits GitHub's 125,000-character limit and the renderer's matching 125,000-byte safety ceiling, the page contains that exact `## YYYY.M.PATCH` section including its heading. When the source section does not fit, the page keeps the exact grouped editorial notes and replaces the oversized contribution record with a stable link to the full record in the tag-pinned `CHANGELOG.md`; partial records and truncated bullets are never published. The workflow chooses that full or compact body before adding `### Release verification`; if the proof tail would exceed the limit, it keeps the canonical body and relies on the immutable attached evidence instead. Stable releases published to npm `latest` become the GitHub latest release, while stable maintenance releases kept on npm `beta` are created with GitHub `latest=false`. The workflow also uploads the preflight dependency evidence, the full-validation manifest, and postpublish registry verification evidence to the GitHub release for post-release incident response. It prints child run IDs immediately, auto-approves release environment gates the workflow token is allowed to approve, summarizes failed child jobs with log tails, creates the draft GitHub release page up front and promotes Windows and Android assets concurrently with the OpenClaw npm publish, waits for ClawHub whenever OpenClaw npm is being published, then runs the trusted-main beta verifier and uploads postpublish evidence for the GitHub release, npm package, selected plugin npm packages, selected ClawHub packages, child workflow run IDs, and optional NPM Telegram run ID. The ClawHub bootstrap verifier requires the exact trusted-main workflow path and SHA, producer and terminal run attempts, release SHA, requested package set, immutable package artifact tuple, and terminal registry readback artifact; a successful legacy release-ref run is not accepted.
 
    Then run the post-publish package acceptance against the published `openclaw@YYYY.M.PATCH-beta.N` or `openclaw@beta` package. If a pushed or published prerelease needs a fix, cut the next matching prerelease number; never delete or rewrite the old one.
 
@@ -495,7 +515,7 @@ release needs:
 4. Dispatch `Plugin NPM Release` with `publish_scope=all-publishable` and `ref=<release-sha>`.
 5. Dispatch `Plugin ClawHub Release` with the same scope and SHA.
 6. Dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and saved `preflight_run_id` after verifying the saved `full_release_validation_run_id` and exact run attempt.
-7. For stable releases, create or update the GitHub release as a draft, dispatch `Windows Node Release` with the explicit `windows_node_tag` and candidate-approved `windows_node_installer_digests`, and verify the canonical Windows installer/checksum assets. Also dispatch `Android Release` to build the exact-tag signed APK plus checksum and provenance. Verify both native asset contracts before publishing the draft.
+7. Verify the published npm package and selector readback, then call reusable `Docker Release` with the immutable tag and SHA. For stable releases, create or update the GitHub release as a draft, dispatch `Windows Node Release` with the explicit `windows_node_tag` and candidate-approved `windows_node_installer_digests`, and verify the canonical Windows installer/checksum assets. Also dispatch `Android Release` to build the exact-tag signed APK plus checksum and provenance. Finalize the GitHub release only after Docker and both native asset contracts succeed.
 
 Beta publish example:
 
@@ -622,7 +642,8 @@ readback confirms that every exact package and `extended-stable` tag converged.
 - `windows_node_tag`: exact non-prerelease `openclaw/openclaw-windows-node` release tag; required for stable OpenClaw publish
 - `windows_node_installer_digests`: candidate-approved compact JSON map of the current Windows installer names to their pinned `sha256:` digests; required for stable OpenClaw publish
 - `npm_telegram_run_id`: optional successful `NPM Telegram Beta E2E` run id to include in final release evidence
-- `npm_dist_tag`: npm target tag for the OpenClaw package, one of `alpha`, `beta`, or `latest`
+- `npm_dist_tag`: npm target tag for the OpenClaw package, one of `alpha`, `beta`, `latest`, or `extended-stable`
+- `publish_docker_only`: extended-stable-only recovery/closeout path. It requires `publish_openclaw_npm=false`, complete preflight and Full Release Validation evidence, then verifies the exact npm package, selector, and tarball digest before invoking Docker publication.
 - `plugin_publish_scope`: defaults to `all-publishable`; use `selected` only for focused plugin-only repair work with `publish_openclaw_npm=false`
 - `plugins`: comma-separated `@openclaw/*` package names when `plugin_publish_scope=selected`
 - `publish_openclaw_npm`: defaults to `true`; set `false` only when using the workflow as a plugin-only repair orchestrator

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -554,11 +554,20 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
-  it("validates release tags before immutable Docker publication", async () => {
+  it("validates immutable release identity before Docker publication", async () => {
     const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
 
-    expect(workflow).toContain("Existing stable, extended-stable, or beta release tag");
+    expect(workflow).toContain("workflow_call:");
+    expect(workflow).toContain("Immutable stable, extended-stable, or beta release tag");
+    expect(workflow).toContain("Full immutable commit SHA resolved from tag");
     expect(workflow).toContain('! "${RELEASE_TAG}" =~ ^v[0-9]{4}');
+    expect(workflow).toContain('! "${RELEASE_SHA}" =~ ^[a-f0-9]{40}$');
+    expect(workflow).toContain('git rev-parse "refs/tags/${RELEASE_TAG}^{commit}"');
+    expect(workflow).toContain('"${tag_sha}" != "${RELEASE_SHA}"');
+    expect(workflow).toContain('"v${package_version}" != "${RELEASE_TAG}"');
+    expect(workflow).toContain("^v${package_version}-[1-9][0-9]*$");
+    expect(workflow).not.toContain("workflow_dispatch:");
+    expect(workflow).not.toContain("push:\n");
     expect(workflow).toContain("(-(beta\\.)?[1-9][0-9]*)?");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -375,8 +375,7 @@ describe("Docker channel promotion", () => {
     const promote = requireJob(workflow, "promote");
 
     expect(releaseWorkflow.concurrency).toEqual({
-      group:
-        "${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}",
+      group: "docker-release-publish-${{ inputs.tag }}",
       "cancel-in-progress": false,
       queue: "max",
     });
@@ -401,7 +400,7 @@ describe("Docker channel promotion", () => {
     expect(releaseAttestationIndex).toBeGreaterThan(-1);
     expect(releasePromotionIndex).toBeGreaterThan(releaseAttestationIndex);
     expect(releaseSteps[releasePromotionIndex]?.if).toBe(
-      "${{ github.event_name != 'workflow_dispatch' && needs.resolve_release_policy.outputs.channel != 'beta' }}",
+      "${{ needs.resolve_release_policy.outputs.channel != 'beta' }}",
     );
     expect(releaseSteps[releasePromotionIndex]?.run).toContain(
       "node scripts/docker-channel-promote.mjs",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -31,6 +31,7 @@ const DOCKER_E2E_IMAGE_HELPER = "scripts/lib/docker-e2e-image.sh";
 type WorkflowInput = {
   default?: boolean | number | string;
   options?: string[];
+  required?: boolean;
   type?: string;
 };
 
@@ -975,6 +976,70 @@ describe("release validation no-push transport", () => {
       expect(text).not.toContain("create-github-app-token");
       expect(text).not.toContain("git push");
     }
+  });
+
+  it("routes Docker publication through release publish after immutable npm evidence", () => {
+    const dockerRelease = readWorkflow(DOCKER_RELEASE);
+    const releasePublishPath = ".github/workflows/openclaw-release-publish.yml";
+    const releasePublish = readWorkflow(releasePublishPath);
+    const dockerCall = job(releasePublish, "publish_docker");
+
+    expect(dockerRelease.on?.push).toBeUndefined();
+    expect(dockerRelease.on?.workflow_dispatch).toBeUndefined();
+    expect(dockerRelease.on?.workflow_call?.inputs).toMatchObject({
+      tag: { required: true, type: "string" },
+      release_sha: { required: true, type: "string" },
+    });
+
+    const callers = readdirSync(".github/workflows")
+      .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+      .filter((name) =>
+        readFileSync(join(".github/workflows", name), "utf8").includes(
+          "uses: ./.github/workflows/docker-release.yml",
+        ),
+      )
+      .toSorted();
+    expect(callers).toEqual(["openclaw-release-publish.yml"]);
+
+    expect(dockerCall.needs).toEqual([
+      "resolve_release_target",
+      "publish",
+      "verify_core_npm_registry",
+    ]);
+    expect(dockerCall.if).toContain("needs.publish.result == 'success'");
+    expect(dockerCall.if).toContain("needs.verify_core_npm_registry.result == 'success'");
+    expect(dockerCall.with).toEqual({
+      tag: "${{ inputs.tag }}",
+      release_sha: "${{ needs.resolve_release_target.outputs.sha }}",
+    });
+    expect(
+      step(
+        job(releasePublish, "resolve_release_target"),
+        "Validate OpenClaw npm preflight manifest",
+      ).run,
+    ).toContain("Preflight manifest SHA mismatch");
+    expect(
+      step(
+        job(releasePublish, "resolve_release_target"),
+        "Validate full release validation manifest",
+      ).run,
+    ).toContain("Full release validation target SHA mismatch");
+    expect(readFileSync(releasePublishPath, "utf8")).toContain(
+      "kept draft until Docker publication succeeds",
+    );
+    expect(job(releasePublish, "finalize_github_release").needs).toEqual([
+      "publish",
+      "publish_docker",
+    ]);
+
+    const identity = step(
+      job(dockerRelease, "validate_release_identity"),
+      "Verify tag, SHA, and package identity agree",
+    );
+    expect(identity.run).toContain('git rev-parse "refs/tags/${RELEASE_TAG}^{commit}"');
+    expect(identity.run).toContain('"${tag_sha}" != "${RELEASE_SHA}"');
+    expect(identity.run).toContain('"v${package_version}" != "${RELEASE_TAG}"');
+    expect(identity.run).toContain("^v${package_version}-[1-9][0-9]*$");
   });
 
   it("fails a missing required local live image before any registry pull", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could publish public Docker images merely by pushing a `v*` tag, even when the release npm preflight later failed. On 2026-07-22 at 05:16 UTC, `v2026.6.34` triggered `Docker Release` and published GHCR and Docker Hub; the NPM preflight dispatched two seconds later failed because `CHANGELOG.md` had no `2026.6.34` section, leaving Docker public without npm or a GitHub Release.

## Why This Change Was Made

`Docker Release` is now reusable-only and accepts a required immutable tag/SHA tuple. It verifies the tag resolves to that SHA and that the package/tag identity matches (including the established correction-tag form) before publishing. `OpenClaw Release Publish` is its sole caller: normal releases invoke Docker only after the exact-SHA preflight, Full Release Validation evidence, core npm publication, and postpublish readback have succeeded; the GitHub Release remains a draft until Docker succeeds. The extended-stable Docker-only path independently rechecks the preflight tarball digest plus npm exact-version and selector readback before the same reusable call.

## User Impact

Tag pushes no longer create partial public releases. Operators get one ordered, evidence-bound path for all Docker variants and channel promotion: default, slim, and browser images for amd64/arm64 on GHCR and Docker Hub. Existing attestation, channel-promotion, `npm-release`, and Docker-environment approvals remain in force.

## Evidence

- `actionlint .github/workflows/docker-release.yml .github/workflows/openclaw-release-publish.yml`
- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts test/scripts/docker-channel-promote.test.ts src/dockerfile.test.ts test/scripts/test-projects.test.ts`
  - 4 files passed, 326 tests passed.
- Added static workflow-contract coverage proving no Docker tag-push/manual trigger, `OpenClaw Release Publish` as the sole caller, publish-job evidence gates before Docker, and fail-closed tag/SHA/package checks.
- `TMPDIR=/tmp .agents/skills/autoreview/scripts/autoreview --mode uncommitted`
  - clean: no accepted/actionable findings.

AI-assisted; reviewed and validated locally.