### PR TITLE
fix(slack): recover bot identity after transient auth.test failure

### DIFF
--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import type { RetryOptions, WebClientOptions } from "@slack/web-api";
 import {
   addActiveManagedProxyTlsOptions,
+  resolveFetch,
   resolveEnvHttpProxyAgentOptions,
 } from "openclaw/plugin-sdk/fetch-runtime";
 import type { EnvHttpProxyAgent } from "undici";
@@ -53,9 +54,12 @@ export function resolveSlackProxyDispatcher(): SlackProxyDispatcher | undefined 
   }
 }
 
-function createSlackDispatcherFetch(
-  dispatcher: SlackProxyDispatcher,
-): NonNullable<WebClientOptions["fetch"]> {
+function buildSlackFetch(
+  dispatcher?: SlackProxyDispatcher,
+): NonNullable<WebClientOptions["fetch"]> | undefined {
+  if (!dispatcher) {
+    return resolveFetch() as NonNullable<WebClientOptions["fetch"]> | undefined;
+  }
   const { fetch: slackFetch } = loadSlackUndiciRuntime();
   return ((input: RequestInfo | URL, init?: RequestInit) => {
     // Slack Web API invokes this hook with URL/string inputs. The cast only bridges
@@ -76,7 +80,7 @@ function applySlackApiUrlAndProxyOptions(
 ): void {
   const slackApiUrl = options.slackApiUrl ?? resolveSlackApiUrlFromEnv();
   if (dispatcher && !options.fetch) {
-    options.fetch = createSlackDispatcherFetch(dispatcher);
+    options.fetch = buildSlackFetch(dispatcher);
   }
   if (slackApiUrl !== undefined) {
     options.slackApiUrl = slackApiUrl;
@@ -91,6 +95,7 @@ export function resolveSlackWebClientOptions(
 ): WebClientOptions {
   const resolved: WebClientOptions = Object.assign({}, options);
   applySlackApiUrlAndProxyOptions(resolved, dispatcher);
+  resolved.fetch ??= buildSlackFetch(dispatcher);
   resolved.retryConfig ??= SLACK_DEFAULT_RETRY_OPTIONS;
   return resolved;
 }

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -231,13 +231,18 @@ describe("slack web client config", () => {
       slackApiUrl: "https://slack.test/api/",
     });
 
-    expect(WebClient).toHaveBeenCalledWith("xoxb-startup", {
-      fetch: customFetch,
-      rejectRateLimitedCalls: true,
-      retryConfig: { retries: 2, minTimeout: 0 },
-      slackApiUrl: "https://slack.test/api/",
-      timeout: 10_000,
-    });
+    expect(WebClient).toHaveBeenCalledWith(
+      "xoxb-startup",
+      expect.objectContaining({
+        fetch: expect.any(Function),
+        retryConfig: { ...SLACK_DEFAULT_RETRY_OPTIONS, maxRetryTime: 35_000 },
+        slackApiUrl: "https://slack.test/api/",
+        timeout: 10_000,
+      }),
+    );
+    const options = WebClient.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(options.fetch).not.toBe(customFetch);
+    expect(options).not.toHaveProperty("rejectRateLimitedCalls");
   });
 
   it("applies the default retry config when constructing a client without proxy env", () => {

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -138,10 +138,14 @@ describe("slack web client config", () => {
     try {
       createSlackReadClient("xoxb-read");
 
-      expect(WebClient).toHaveBeenCalledWith("xoxb-read", {
-        retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
-        timeout: 30_000,
-      });
+      expect(WebClient).toHaveBeenCalledWith(
+        "xoxb-read",
+        expect.objectContaining({
+          fetch: expect.any(Function),
+          retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+          timeout: 30_000,
+        }),
+      );
     } finally {
       restoreProxyEnvForTest();
     }
@@ -152,10 +156,14 @@ describe("slack web client config", () => {
     try {
       createSlackReadClient("xoxb-read", { timeout: 60_000 });
 
-      expect(WebClient).toHaveBeenCalledWith("xoxb-read", {
-        retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
-        timeout: 60_000,
-      });
+      expect(WebClient).toHaveBeenCalledWith(
+        "xoxb-read",
+        expect.objectContaining({
+          fetch: expect.any(Function),
+          retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+          timeout: 60_000,
+        }),
+      );
     } finally {
       restoreProxyEnvForTest();
     }
@@ -250,10 +258,14 @@ describe("slack web client config", () => {
     try {
       createSlackWebClient("xoxb-test", { timeout: 1234 });
 
-      expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
-        retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
-        timeout: 1234,
-      });
+      expect(WebClient).toHaveBeenCalledWith(
+        "xoxb-test",
+        expect.objectContaining({
+          fetch: expect.any(Function),
+          retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+          timeout: 1234,
+        }),
+      );
     } finally {
       restoreProxyEnvForTest();
     }
@@ -413,9 +425,9 @@ describe("slack proxy dispatcher", () => {
     await dispatcher?.close();
   });
 
-  it("does not attach a fetch when no proxy env var is configured", () => {
+  it("attaches the shared fetch when no proxy env var is configured", () => {
     expect(resolveSlackProxyDispatcher()).toBeUndefined();
-    expect(resolveSlackWebClientOptions().fetch).toBeUndefined();
+    expect(requireFetch(resolveSlackWebClientOptions())).toBeTypeOf("function");
   });
 
   it("preserves an explicitly provided fetch", async () => {
@@ -464,6 +476,6 @@ describe("slack proxy dispatcher", () => {
     process.env.HTTPS_PROXY = "not-a-valid-url://:::bad";
 
     expect(resolveSlackProxyDispatcher()).toBeUndefined();
-    expect(resolveSlackWebClientOptions().fetch).toBeUndefined();
+    expect(requireFetch(resolveSlackWebClientOptions())).toBeTypeOf("function");
   });
 });

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -40,10 +40,10 @@ export function createSlackReadClient(token: string, options: WebClientOptions =
   return new WebClient(token, resolveSlackReadClientOptions(options));
 }
 
-function createSlackStartupAuthFetch(fetch: SlackFetch): SlackFetch {
+function createSlackStartupAuthFetch(baseFetch: SlackFetch): SlackFetch {
   const deadline = Date.now() + SLACK_STARTUP_AUTH_RETRY_BUDGET_MS;
   return async (input, init) => {
-    const response = await fetch(input, init);
+    const response = await baseFetch(input, init);
     if (response.status !== 429) {
       return response;
     }
@@ -62,12 +62,14 @@ function createSlackStartupAuthFetch(fetch: SlackFetch): SlackFetch {
 }
 
 export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {
-  const fetch = createSlackStartupAuthFetch(
-    options.fetch ?? (globalThis.fetch as NonNullable<WebClientOptions["fetch"]>),
-  );
-  return createSlackWebClient(token, {
-    ...options,
-    fetch,
+  const resolvedOptions = resolveSlackWebClientOptions(options);
+  const baseFetch = resolvedOptions.fetch;
+  if (!baseFetch) {
+    throw new Error("Slack startup auth fetch is unavailable");
+  }
+  return new WebClient(token, {
+    ...resolvedOptions,
+    fetch: createSlackStartupAuthFetch(baseFetch),
     retryConfig: {
       ...SLACK_DEFAULT_RETRY_OPTIONS,
       maxRetryTime: SLACK_STARTUP_AUTH_RETRY_BUDGET_MS,

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -7,10 +7,13 @@ import {
   resolveSlackReadClientOptions,
   resolveSlackWebClientOptions,
   resolveSlackWriteClientOptions,
+  SLACK_DEFAULT_RETRY_OPTIONS,
   SLACK_WRITE_RETRY_OPTIONS,
 } from "./client-options.js";
 
 const SLACK_WRITE_CLIENT_CACHE_MAX = 32;
+const SLACK_STARTUP_AUTH_TIMEOUT_MS = 10_000;
+const SLACK_STARTUP_AUTH_RETRY_BUDGET_MS = 35_000;
 const slackWriteClientCache = new Map<string, WebClient>();
 let slackListenerUploadCompletionClientCache = new WeakMap<
   WebClient,
@@ -18,6 +21,7 @@ let slackListenerUploadCompletionClientCache = new WeakMap<
 >();
 
 type SlackWriteClientCacheOptions = Pick<WebClientOptions, "slackApiUrl">;
+type SlackFetch = NonNullable<WebClientOptions["fetch"]>;
 
 export {
   resolveSlackWebClientOptions,
@@ -36,14 +40,39 @@ export function createSlackReadClient(token: string, options: WebClientOptions =
   return new WebClient(token, resolveSlackReadClientOptions(options));
 }
 
+function createSlackStartupAuthFetch(fetch: SlackFetch): SlackFetch {
+  const deadline = Date.now() + SLACK_STARTUP_AUTH_RETRY_BUDGET_MS;
+  return async (input, init) => {
+    const response = await fetch(input, init);
+    if (response.status !== 429) {
+      return response;
+    }
+    const retryAfter = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
+    const remainingMs = Math.max(0, deadline - Date.now());
+    if (!Number.isFinite(retryAfter) || retryAfter * 1000 <= remainingMs) {
+      return response;
+    }
+    // Slack sleeps through Retry-After outside its per-attempt timeout. Wait only
+    // within the startup budget, then let the retry policy terminate the call.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, remainingMs);
+    });
+    throw new Error("Slack startup auth retry budget exhausted after rate limit");
+  };
+}
+
 export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {
-  // Startup identity stays degraded until restart after auth.test fails. Retry two transient
-  // transport failures before committing that state, without delaying on Slack rate limits.
+  const fetch = createSlackStartupAuthFetch(
+    options.fetch ?? (globalThis.fetch as NonNullable<WebClientOptions["fetch"]>),
+  );
   return createSlackWebClient(token, {
     ...options,
-    rejectRateLimitedCalls: true,
-    retryConfig: { retries: 2, minTimeout: 0 },
-    timeout: 10_000,
+    fetch,
+    retryConfig: {
+      ...SLACK_DEFAULT_RETRY_OPTIONS,
+      maxRetryTime: SLACK_STARTUP_AUTH_RETRY_BUDGET_MS,
+    },
+    timeout: SLACK_STARTUP_AUTH_TIMEOUT_MS,
   });
 }
 

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -224,6 +224,32 @@ describe("Slack Web API routing", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retries startup auth after a rate limit", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
+          status: 429,
+          headers: { "retry-after": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, team_id: "TMOCK", user_id: "UMOCK" }), {
+          status: 200,
+        }),
+      );
+    const client = createSlackStartupAuthClient("rate-limited-fixture", {
+      fetch: fetchMock as never,
+    });
+
+    await expect(client.auth.test()).resolves.toMatchObject({
+      ok: true,
+      team_id: "TMOCK",
+      user_id: "UMOCK",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("aborts a stalled-header lookup after one request", async () => {
     for (const key of TEST_ENV_KEYS) {
       delete process.env[key];

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -25,6 +25,7 @@ function createTestContext(params?: {
     runtime: {} as RuntimeEnv,
     botUserId: "U_BOT",
     botId: "B_BOT",
+    identityHealth: { healthState: "healthy", lastError: null },
     teamId: "T_EXPECTED",
     apiAppId: params?.apiAppId ?? "A_EXPECTED",
     historyLimit: 0,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -29,7 +29,7 @@ import type { SlackChannelConfigEntries } from "./channel-config.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType } from "./channel-type.js";
 import { resolveSessionKey } from "./config.runtime.js";
-import type { SlackInstallationIdentity } from "./enterprise-install.js";
+import type { SlackIdentityHealth, SlackInstallationIdentity } from "./enterprise-install.js";
 import type { SlackEventScope } from "./event-scope.js";
 import { readLruMapEntry, writeLruMapEntry } from "./lru-map-cache.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
@@ -122,6 +122,7 @@ export type SlackMonitorContext = {
 
   botUserId: string;
   botId?: string;
+  identityHealth: SlackIdentityHealth;
   teamId: string;
   apiAppId: string;
   installationIdentity: SlackInstallationIdentity;
@@ -219,6 +220,7 @@ export function createSlackMonitorContext(params: {
 
   botUserId: string;
   botId?: string;
+  identityHealth: SlackIdentityHealth;
   teamId: string;
   apiAppId: string;
   installationIdentity?: SlackInstallationIdentity;
@@ -683,6 +685,7 @@ export function createSlackMonitorContext(params: {
     channelRuntime: params.channelRuntime,
     botUserId: params.botUserId,
     botId: params.botId,
+    identityHealth: params.identityHealth,
     teamId: params.teamId,
     apiAppId: params.apiAppId,
     installationIdentity: params.installationIdentity ?? {

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -32,6 +32,7 @@ export function createInboundSlackTestContext(params: {
     channelRuntime: params.channelRuntime ?? createPluginRuntimeMock().channel,
     botUserId: "B1",
     botId: "B1",
+    identityHealth: { healthState: "healthy", lastError: null },
     teamId: "T1",
     apiAppId: "A1",
     historyLimit: 0,

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -197,6 +197,7 @@ const baseParams = () => ({
   runtime: {} as RuntimeEnv,
   botUserId: "B1",
   botId: "B1",
+  identityHealth: { healthState: "healthy" as const, lastError: null },
   teamId: "T1",
   apiAppId: "A1",
   historyLimit: 0,

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -40,10 +40,12 @@ type SlackSelfFilterArgs = {
   context?: {
     botId?: string;
     botUserId?: string;
+    isEnterpriseInstall?: boolean;
   };
   event?: unknown;
   message?: unknown;
 };
+type SlackContextIdentity = NonNullable<SlackSelfFilterArgs["context"]>;
 
 function isConstructorFunction<
   // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Constructor guard preserves the requested concrete Slack constructor type.
@@ -312,6 +314,7 @@ export function createSlackBoltApp(params: {
   clientOptions: Record<string, unknown>;
   dispatcher?: SlackSocketModeReceiverOptions["dispatcher"];
   wrapReceiver?: (receiver: SlackReceiver) => SlackReceiver;
+  onContextIdentity?: (identity: SlackContextIdentity) => void;
 }) {
   const socketModeLogger = createSlackSocketModeLogger();
   const socketModeReceiverOptions: SlackSocketModeReceiverOptions = {
@@ -355,6 +358,7 @@ export function createSlackBoltApp(params: {
     ...(appReceiver ? { receiver: appReceiver } : {}),
   });
   app.use(async (args) => {
+    params.onContextIdentity?.(args.context ?? {});
     if (shouldSkipOpenClawSlackSelfEvent(args)) {
       return;
     }
@@ -388,7 +392,7 @@ function createSlackSocketDisconnectWaiter(app: unknown, abortSignal?: AbortSign
 export async function startSlackSocketAndWaitForDisconnect(params: {
   app: { start: () => unknown };
   abortSignal?: AbortSignal;
-  onStarted?: () => void;
+  onStarted?: () => void | Promise<void>;
 }) {
   const disconnectWaiter = createSlackSocketDisconnectWaiter(params.app, params.abortSignal);
   try {
@@ -397,7 +401,7 @@ export async function startSlackSocketAndWaitForDisconnect(params: {
       disconnectWaiter.cancel();
       return null;
     }
-    params.onStarted?.();
+    await params.onStarted?.();
     const disconnect = await disconnectWaiter.promise;
     disconnectWaiter.complete();
     return disconnect;

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -125,7 +125,7 @@ describe("auth.test boot call", () => {
   it("warns when auth.test returns a user id without bot_id", async () => {
     const runtimeLog = vi.fn();
     const client = getSlackClient();
-    client.auth.test.mockResolvedValueOnce({
+    client.auth.test.mockResolvedValue({
       app_id: "A1",
       user_id: "UUSER",
       user: "human-installer",
@@ -165,7 +165,7 @@ describe("auth.test boot call", () => {
       },
     });
     const client = getSlackClient();
-    client.auth.test.mockResolvedValueOnce({
+    client.auth.test.mockResolvedValue({
       app_id: "A1",
       user_id: "UUSER",
       user: "human-installer",
@@ -215,6 +215,10 @@ describe("auth.test boot call", () => {
         "required-mention channels will fail closed without another trusted activation signal",
       ),
     );
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("while the bot identity is unresolved"),
+    );
+    expect(runtimeLog).not.toHaveBeenCalledWith(expect.stringContaining("until restart"));
   });
 
   it("continues startup after the startup auth client times out", async () => {
@@ -243,7 +247,7 @@ describe("auth.test boot call", () => {
         slackApiUrl: "https://slack.test/api/",
       }),
     );
-    expect(getSlackClient().auth.test).toHaveBeenCalledTimes(1);
+    expect(getSlackClient().auth.test).toHaveBeenCalledTimes(2);
     expect(appStartMock).toHaveBeenCalledTimes(1);
     expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("timeout of 10000ms exceeded"));
   });
@@ -605,7 +609,7 @@ describe("connected identity health", () => {
     if (config) {
       resetSlackTestState(config);
     }
-    getSlackClient().auth.test.mockResolvedValueOnce(auth);
+    getSlackClient().auth.test.mockResolvedValue(auth);
     const setStatus = vi.fn();
 
     const monitor = startSlackMonitor(monitorSlackProvider, { setStatus });
@@ -618,7 +622,7 @@ describe("connected identity health", () => {
     });
   });
 
-  it("publishes auth.test failures as degraded", async () => {
+  it("recovers auth.test failures when socket startup re-resolves identity", async () => {
     getSlackClient().auth.test.mockRejectedValueOnce(new Error("request_timeout"));
     const setStatus = vi.fn();
 
@@ -628,8 +632,66 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      healthState: "healthy",
+      lastError: null,
+    });
+    expect(getSlackClient().auth.test).toHaveBeenCalledTimes(2);
+  });
+
+  it("adopts Bolt identity from the first HTTP event and restores mention detection", async () => {
+    resetSlackTestState({
+      channels: {
+        slack: {
+          mode: "http",
+          signingSecret: "test-signing-secret",
+          groupPolicy: "open",
+          requireMention: true,
+        },
+      },
+    });
+    const client = getSlackClient();
+    client.auth.test.mockRejectedValue(new Error("request_timeout"));
+    client.conversations.info.mockResolvedValueOnce({
+      channel: { name: "general", is_channel: true },
+    });
+    const { replyMock, sendMock } = getSlackTestState();
+    replyMock.mockResolvedValue({ text: "identity restored" });
+    const setStatus = vi.fn();
+    const monitor = startSlackMonitor(monitorSlackProvider, { setStatus });
+    const handler = await getSlackHandlerOrThrow("message");
+
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: true,
+      lastConnectedAt: expect.any(Number),
       healthState: "degraded",
       lastError: "request_timeout",
     });
+    expect(setStatus).not.toHaveBeenCalledWith(expect.objectContaining({ connected: false }));
+
+    await handler({
+      event: {
+        type: "message",
+        user: "U_OTHER",
+        text: "<@URECOVERED> status",
+        ts: "999999.123",
+        channel: "C12345678",
+        channel_type: "channel",
+      },
+      context: {
+        botUserId: "URECOVERED",
+        botId: "BRECOVERED",
+        isEnterpriseInstall: false,
+      },
+      body: {},
+    });
+
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: true,
+      lastConnectedAt: expect.any(Number),
+      healthState: "healthy",
+      lastError: null,
+    });
+    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await stopSlackMonitor(monitor);
   });
 });

--- a/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
@@ -109,7 +109,7 @@ describe("slack socket reconnect loop", () => {
     );
   });
 
-  it("keeps degraded identity health after a recoverable reconnect", async () => {
+  it("re-resolves degraded identity after a recoverable reconnect", async () => {
     getSlackClient().auth.test.mockResolvedValueOnce({
       app_id: "A1",
       user_id: "UUSER",
@@ -152,9 +152,10 @@ describe("slack socket reconnect loop", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
-      healthState: "degraded",
-      lastError: expect.stringContaining("without bot_id"),
+      healthState: "healthy",
+      lastError: null,
     });
+    expect(getSlackClient().auth.test).toHaveBeenCalledTimes(2);
     controller.abort();
     await expect(run).resolves.toBeUndefined();
   });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -53,7 +53,7 @@ import {
   resolveOpenProviderRuntimeGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "./config.runtime.js";
-import { createSlackMonitorContext } from "./context.js";
+import { createSlackMonitorContext, type SlackMonitorContext } from "./context.js";
 import {
   assertEnterpriseSlackDmPolicy,
   assertEnterpriseSlackPolicyConfig,
@@ -106,6 +106,51 @@ const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-sourc
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+type SlackRuntimeIdentity = {
+  botUserId: string;
+  botId?: string;
+};
+
+function resolveSlackRuntimeIdentity(params: {
+  identity: "bot" | "user";
+  botUserId?: unknown;
+  botId?: unknown;
+  isEnterpriseInstall?: unknown;
+}): SlackRuntimeIdentity | undefined {
+  if (params.isEnterpriseInstall === true) {
+    return undefined;
+  }
+  const botUserId = normalizeOptionalString(params.botUserId);
+  const botId = normalizeOptionalString(params.botId);
+  if (!botUserId || (params.identity === "bot" && !botId)) {
+    return undefined;
+  }
+  return {
+    botUserId,
+    ...(botId ? { botId } : {}),
+  };
+}
+
+function adoptSlackRuntimeIdentity(params: {
+  ctx: SlackMonitorContext;
+  identity: "bot" | "user";
+  botUserId?: unknown;
+  botId?: unknown;
+  isEnterpriseInstall?: unknown;
+}): boolean {
+  if (params.ctx.identityHealth.healthState !== "degraded") {
+    return false;
+  }
+  const resolved = resolveSlackRuntimeIdentity(params);
+  if (!resolved) {
+    return false;
+  }
+  params.ctx.botUserId = resolved.botUserId;
+  params.ctx.botId = resolved.botId;
+  params.ctx.identityHealth = { healthState: "healthy", lastError: null };
+  return true;
+}
 
 function resolveStableSlackUserIdEntry(raw: string): string | undefined {
   const trimmed = raw.trim();
@@ -348,6 +393,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     ...(runtime.log ? { onLog: runtime.log } : {}),
     ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
   });
+  const monitorContextRef: { current?: SlackMonitorContext } = {};
   const { app, receiver, socketModeLogger } = createSlackBoltApp({
     interop: await getSlackBoltInterop(),
     slackMode,
@@ -358,6 +404,21 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     clientOptions: clientOptions as Record<string, unknown>,
     dispatcher: slackDispatcher,
     wrapReceiver: durableIngress.wrapReceiver,
+    onContextIdentity: (identity) => {
+      const current = monitorContextRef.current;
+      if (
+        current &&
+        adoptSlackRuntimeIdentity({
+          ctx: current,
+          identity: account.identity,
+          botUserId: identity.botUserId,
+          botId: identity.botId,
+          isEnterpriseInstall: identity.isEnterpriseInstall,
+        })
+      ) {
+        publishSlackConnectedStatus(opts.setStatus, current.identityHealth);
+      }
+    },
   });
 
   // Pre-set shuttingDown on the SocketModeClient before app.stop() to prevent
@@ -414,10 +475,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   try {
     const auth = await createSlackStartupAuthClient(token, clientOptions).auth.test();
     const authUserId = normalizeOptionalString(auth.user_id) ?? "";
-    botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
-    // User identity has no bot_id; its authenticated human id is both the mention target and
-    // the self-send dedupe source. Bot identity keeps the bot_id-gated fail-closed behavior.
-    botUserId = account.identity === "user" ? authUserId : botId ? authUserId : "";
+    const resolvedIdentity = resolveSlackRuntimeIdentity({
+      identity: account.identity,
+      botUserId: authUserId,
+      botId: (auth as { bot_id?: string }).bot_id,
+      isEnterpriseInstall: auth.is_enterprise_install,
+    });
+    botUserId = resolvedIdentity?.botUserId ?? "";
+    botId = resolvedIdentity?.botId ?? "";
     authTestIdentity = auth;
     if (account.identity === "bot") {
       authIdentityWarning = formatSlackBotTokenIdentityWarning({
@@ -443,8 +508,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   if (authTestError !== undefined) {
     const identityFailureDetail =
       account.identity === "user"
-        ? "explicit self-mention detection will be disabled until restart with a valid user token"
-        : "explicit bot-mention detection will be disabled until restart with a valid bot token";
+        ? "explicit self-mention detection will be disabled while the user identity is unresolved"
+        : "explicit bot-mention detection will be disabled while the bot identity is unresolved";
     runtime.log?.(
       warn(
         `[${account.accountId}] slack auth.test failed at boot (${authTestError}); ` +
@@ -480,6 +545,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     channelRuntime: opts.channelRuntime,
     botUserId,
     botId,
+    identityHealth,
     teamId,
     apiAppId,
     installationIdentity,
@@ -508,6 +574,30 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     typingReaction,
     mediaMaxBytes,
   });
+  monitorContextRef.current = ctx;
+
+  const recoverSlackIdentity = async () => {
+    if (ctx.identityHealth.healthState !== "degraded") {
+      return;
+    }
+    try {
+      const auth = await createSlackStartupAuthClient(token, clientOptions).auth.test();
+      resolveSlackInstallationIdentity({
+        enterpriseOrgInstall,
+        auth,
+        transportApiAppId: expectedApiAppIdFromAppToken,
+      });
+      adoptSlackRuntimeIdentity({
+        ctx,
+        identity: account.identity,
+        botUserId: auth.user_id,
+        botId: (auth as { bot_id?: string }).bot_id,
+        isEnterpriseInstall: auth.is_enterprise_install,
+      });
+    } catch {
+      // The socket is usable while identity remains degraded; retry on its next start.
+    }
+  };
 
   // Slack's socket-mode client keeps ping/pong health private and closes on
   // missed pongs. App events are useful status activity, but not transport proof.
@@ -725,6 +815,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         log: runtime.log,
         accountId: account.accountId,
       });
+      publishSlackConnectedStatus(opts.setStatus, ctx.identityHealth);
     }
 
     if (slackMode === "socket") {
@@ -735,13 +826,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           const disconnect = await startSlackSocketAndWaitForDisconnect({
             app,
             abortSignal: opts.abortSignal,
-            onStarted: () => {
+            onStarted: async () => {
               reconnectAttempts = 0;
-              publishSlackConnectedStatus(opts.setStatus, identityHealth);
+              await recoverSlackIdentity();
+              publishSlackConnectedStatus(opts.setStatus, ctx.identityHealth);
               if (!hasLoggedSocketConnected) {
                 hasLoggedSocketConnected = true;
                 runtime.log?.(
-                  identityHealth.healthState === "degraded"
+                  ctx.identityHealth.healthState === "degraded"
                     ? "slack socket mode connected (degraded identity)"
                     : "slack socket mode connected",
                 );
@@ -832,6 +924,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         acceptRelayEvent: durableIngress.acceptRelayEvent,
         runtime,
         abortSignal: opts.abortSignal,
+        identityHealth: ctx.identityHealth,
         setStatus: opts.setStatus,
         setIdentity: (identity) => setSlackDefaultSendIdentity(account.accountId, identity),
       });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -121,6 +121,8 @@ function resolveSlackRuntimeIdentity(params: {
   if (params.isEnterpriseInstall === true) {
     return undefined;
   }
+  // User identity has no bot_id; its human id is both the mention target and self-send dedupe
+  // source. Bot identity stays bot_id-gated so token mismatches fail closed.
   const botUserId = normalizeOptionalString(params.botUserId);
   const botId = normalizeOptionalString(params.botId);
   if (!botUserId || (params.identity === "bot" && !botId)) {

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -153,6 +153,7 @@ describe("Slack relay source", () => {
       acceptRelayEvent,
       runtime: { error: runtimeError, log: vi.fn() } as unknown as RuntimeEnv,
       abortSignal: abortController.signal,
+      identityHealth: { healthState: "degraded", lastError: "request_timeout" },
       setIdentity: (identity) => identities.push(identity),
       setStatus: (status) => statuses.push(status),
     });
@@ -182,6 +183,12 @@ describe("Slack relay source", () => {
     });
     expect(statuses).toContainEqual({
       relayRoute: { kind: "channel_default", key: "T1:C1" },
+    });
+    expect(statuses).toContainEqual({
+      connected: true,
+      lastConnectedAt: expect.any(Number),
+      healthState: "degraded",
+      lastError: "request_timeout",
     });
 
     abortController.abort();

--- a/extensions/slack/src/monitor/relay-source.ts
+++ b/extensions/slack/src/monitor/relay-source.ts
@@ -11,6 +11,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import WebSocket, { type ClientOptions, type RawData } from "ws";
 import type { SlackSendIdentity } from "../send.js";
 import type { SlackMessageEvent } from "../types.js";
+import type { SlackIdentityHealth } from "./enterprise-install.js";
 import { formatUnknownError, SLACK_SOCKET_RECONNECT_POLICY } from "./reconnect-policy.js";
 
 export type SlackRelaySourceConfig = {
@@ -39,6 +40,7 @@ export async function monitorSlackRelaySource(params: {
   acceptRelayEvent: SlackRelayEventAcceptor;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
+  identityHealth: SlackIdentityHealth;
   setStatus?: (next: Record<string, unknown>) => void;
   setIdentity?: (identity: SlackRelayIdentity | undefined) => void;
 }): Promise<void> {
@@ -51,8 +53,7 @@ export async function monitorSlackRelaySource(params: {
       params.setStatus?.({
         connected: true,
         lastConnectedAt: Date.now(),
-        healthState: "healthy",
-        lastError: null,
+        ...params.identityHealth,
       });
       params.runtime.log?.(`slack relay mode connected gateway_id:${params.config.gatewayId}`);
       await runRelayWebSocket({


### PR DESCRIPTION
## What Problem This Solves

A single transient failure of Slack's boot-time `auth.test` (one 429, one >10s network blip) leaves the account **permanently connected but unable to recognize mentions**. The startup auth client used `retries: 0` + `rejectRateLimitedCalls: true`; the failure was swallowed; the empty `botUserId` was frozen into the monitor context for the process lifetime; the socket then connected and published `connected: true` with a `healthState: "degraded"` string no core consumer reads. With `requireMention` defaulting to true for channels, every non-`app_mention` room message was dropped as `mention-detection-unavailable`, forever. Nothing retried; nothing restarted; status looked healthy. This exact terminal state was asserted by the shipped test `provider.auth-test-token.test.ts`.

Two adjacent status lies: HTTP mode never published connected/health status at all, and relay mode hardcoded `healthState: "healthy"` over a degraded identity.

## Why This Change Was Made

Identity now recovers instead of freezing, fixed at the plugin's ownership boundary:

- **Boot retry**: the startup auth client uses the plugin's standard retry options within a bounded 35s budget (10s per attempt), with a fetch wrapper that refuses to sleep through a Retry-After longer than the remaining budget.
- **Late-bound identity**: `botUserId`/`botId`/`identityHealth` live as mutable state on the monitor context (the existing `channelsConfig` post-construction pattern). A single `resolveSlackRuntimeIdentity` helper encodes the identity rules once: user identity needs no `bot_id` (its human id is both mention target and self-send dedupe source); bot identity stays `bot_id`-gated fail-closed; enterprise installs never adopt from runtime context.
- **Two recovery paths**: Bolt already re-resolves `auth.test` per event (`tokenVerificationEnabled: false`) — a new `onContextIdentity` middleware seam adopts that identity when degraded; and socket `onStarted` re-runs `auth.test` when degraded, so recovery does not require inbound traffic. Adoption only ever fires while degraded — a healthy identity is never overwritten. Recovery republishes status, clearing the degraded state; mention gating reads the context per message, so detection resumes automatically.
- **Status honesty**: HTTP mode publishes connected status with identity health after webhook registration (never publishing `connected: false` — tri-state rules preserved); relay mode reports actual identity health instead of hardcoded healthy.
- Enterprise Grid boot validation (`enterpriseOrgInstall` throw) and bot/user identity selection are unchanged.

## User Impact

A Slack account that boots during a rate limit or network blip now heals itself — on the next inbound event or socket (re)connect — instead of silently ignoring mentions until an operator notices and restarts. Operators see truthful status in all three transport modes.

## Evidence

- `provider.auth-test-token.test.ts` — 21/21; assertion changes are deliberate and inverted on purpose: transient boot failure now expects recovery (previously asserted permanent degradation); invalid bot-token fixtures remain persistently degraded, proving missing `bot_id` is never adopted; boot warning asserts "while unresolved" wording.
- New HTTP-mode test: initial degraded readiness → first-event identity adoption → healthy status → successful required-mention dispatch. Relay test verifies degraded health is preserved.
- Full Slack monitor directory: **977/977 across 48 files**; Slack client tests 43/43; extension prod+test typechecks, targeted lint, formatting all green.
- Structured autoreview (Codex, gpt-5.6-sol, high): clean, twice — after implementation and again after rebasing onto latest `main`.
- Prod diff +150/−20 within `extensions/slack` only; no core, SDK, or config surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Dependency contract + live-proof status (added post-review)

Direct `@slack/web-api@8.0.0` source inspection confirming the retry semantics this PR relies on (429 sleeps the full Retry-After inside the attempt where `maxRetryTime` cannot interrupt it — the startup fetch wrapper is what enforces the 35s budget; old `rejectRateLimitedCalls: true` made one 429 immediately fatal at boot): https://github.com/openclaw/openclaw/pull/117253#issuecomment-5150171594

No Slack credentials exist on the implementing host, so an after-fix real-workspace transcript is not included; the end-to-end HTTP-mode adoption test plus 977/977 monitor tests are the standing behavioral evidence. Maintainer call on sufficiency is explicitly open.
