### PR TITLE
fix(exec): surface ambiguous node outcomes without retrying

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -157,6 +157,69 @@ describe("exec approval followup", () => {
     expect(prompt).toContain("Continue the task if needed, then reply to the user");
   });
 
+  it("warns the agent not to rerun an outcome-unknown command", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-unknown",
+      sessionKey: "agent:main:main",
+      resultText: [
+        "Exec outcome unknown (node=node-1 id=req-unknown, outcome-unknown)",
+        "Node command outcome is unknown for node-1.",
+        "The command may have executed. Do not rerun it automatically.",
+        "",
+        "Command:",
+        "printf 'one\\ntwo'",
+      ].join("\n"),
+    });
+
+    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
+    expect(prompt).toBeTypeOf("string");
+    expect(prompt).toContain("The command may have executed.");
+    expect(prompt).toContain("Do not run the command again automatically.");
+    expect(prompt).toContain("Do not claim it was denied, not dispatched, or safe to retry.");
+    expect(prompt).toContain("Command:\nprintf 'one\\ntwo'");
+  });
+
+  it("tells the agent a proven not-dispatched command did not run", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-not-dispatched",
+      sessionKey: "agent:main:main",
+      resultText: [
+        "Exec not dispatched (node=node-1 id=req-not-dispatched, not-dispatched)",
+        "Node command was not dispatched to node-1.",
+        "It can be retried after the node reconnects.",
+      ].join("\n"),
+    });
+
+    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
+    expect(prompt).toBeTypeOf("string");
+    expect(prompt).toContain("was not dispatched and did not run");
+    expect(prompt).toContain("Retry only after resolving the connection failure");
+    expect(prompt).not.toContain("already approved has completed");
+    expect(prompt).not.toContain("Do not run the command again.");
+  });
+
+  it("preserves outcome-unknown details in direct delivery", async () => {
+    const resultText = [
+      "Exec outcome unknown (node=node-1 id=req-direct-unknown, outcome-unknown)",
+      "The command may have executed. Do not rerun it automatically.",
+      "",
+      "Command:",
+      "echo first",
+      "echo second",
+    ].join("\n");
+
+    await sendExecApprovalFollowup({
+      approvalId: "req-direct-unknown",
+      direct: true,
+      turnSourceChannel: "telegram",
+      turnSourceTo: "-100123",
+      resultText,
+    });
+
+    expectDirectSend({ content: resultText });
+    expect(callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("keeps followups internal when no external route is available", async () => {
     await sendExecApprovalFollowup({
       approvalId: "req-1",

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -28,6 +28,7 @@ import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-f
 import {
   formatExecDeniedUserMessage,
   isExecDeniedResultText,
+  isExecOutcomeUnknownResultText,
   parseExecApprovalResultText,
 } from "./exec-approval-result.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -69,6 +70,36 @@ function buildExecDeniedFollowupPrompt(resultText: string): string {
   ].join("\n");
 }
 
+function buildExecOutcomeUnknownFollowupPrompt(resultText: string): string {
+  return [
+    "An approved async command has an unknown execution outcome.",
+    "The command may have executed.",
+    "Do not run the command again automatically.",
+    "There is no authoritative command output.",
+    "",
+    "Exact completion details:",
+    resultText.trim(),
+    "",
+    "Reply to the user in a helpful way.",
+    "Clearly explain that the command may have executed and its outcome is unknown.",
+    "Do not claim it was denied, not dispatched, or safe to retry.",
+  ].join("\n");
+}
+
+function buildExecNotDispatchedFollowupPrompt(resultText: string): string {
+  return [
+    "An approved async command was not dispatched and did not run.",
+    "There is no new command output.",
+    "Retry only after resolving the connection failure described below.",
+    "",
+    "Exact completion details:",
+    resultText.trim(),
+    "",
+    "Continue the task if the connection can be restored safely, then reply to the user.",
+    "Do not claim the command completed, was denied, or may have executed.",
+  ].join("\n");
+}
+
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -88,6 +119,12 @@ function buildExecApprovalFollowupPrompt(resultText: string): string {
   const trimmed = resultText.trim();
   if (isExecDeniedResultText(trimmed)) {
     return buildExecDeniedFollowupPrompt(trimmed);
+  }
+  if (isExecOutcomeUnknownResultText(trimmed)) {
+    return buildExecOutcomeUnknownFollowupPrompt(trimmed);
+  }
+  if (parseExecApprovalResultText(trimmed).kind === "not-dispatched") {
+    return buildExecNotDispatchedFollowupPrompt(trimmed);
   }
   return [
     "An async command the user already approved has completed.",
@@ -180,6 +217,10 @@ function formatDirectExecApprovalFollowupText(
   if (parsed.kind === "completed") {
     const body = sanitizeUserFacingText(parsed.body, { errorContext: true }).trim();
     return body || "Background command finished.";
+  }
+
+  if (parsed.kind === "outcome-unknown" || parsed.kind === "not-dispatched") {
+    return sanitizeUserFacingText(parsed.raw, { errorContext: true }).trim() || null;
   }
 
   return sanitizeUserFacingText(parsed.raw, { errorContext: true }).trim() || null;

--- a/src/agents/bash-tools.exec-host-node-failure.ts
+++ b/src/agents/bash-tools.exec-host-node-failure.ts
@@ -1,0 +1,186 @@
+import type { OperatorScope } from "../gateway/operator-scopes.js";
+import { renderExecUpdateText } from "./bash-tools.exec-output.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "./runtime/index.js";
+import { callGatewayTool } from "./tools/gateway.js";
+
+type NodeInvokeFailure =
+  | {
+      reason: "not-dispatched";
+      retrySafe: true;
+      code: "NOT_CONNECTED";
+      message: string;
+      nodeCommandDispatched: false;
+      requestSent?: boolean;
+    }
+  | {
+      reason: "outcome-unknown";
+      retrySafe: false;
+      code?: string;
+      message: string;
+      nodeCommandDispatched?: boolean;
+      requestSent?: boolean;
+    };
+
+type NodeSystemRunInvokeResult =
+  | { ok: true; raw: unknown }
+  | { ok: false; failure: NodeInvokeFailure };
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Only NOT_CONNECTED plus explicit pre-dispatch provenance proves a retry cannot duplicate work. */
+function classifyNodeInvokeFailure(error: unknown): NodeInvokeFailure {
+  const errorRecord = readRecord(error);
+  const details = readRecord(errorRecord?.details);
+  const nodeError = readRecord(details?.nodeError);
+  const code = readString(nodeError?.code);
+  const message =
+    readString(nodeError?.message) ??
+    (error instanceof Error ? error.message : readString(error)) ??
+    "node invoke failed";
+  const nodeCommandDispatched =
+    typeof details?.nodeCommandDispatched === "boolean" ? details.nodeCommandDispatched : undefined;
+  const requestSent =
+    typeof errorRecord?.requestSent === "boolean" ? errorRecord.requestSent : undefined;
+
+  if (code === "NOT_CONNECTED" && nodeCommandDispatched === false) {
+    return {
+      reason: "not-dispatched",
+      retrySafe: true,
+      code,
+      message,
+      nodeCommandDispatched,
+      ...(requestSent !== undefined ? { requestSent } : {}),
+    };
+  }
+  return {
+    reason: "outcome-unknown",
+    retrySafe: false,
+    ...(code ? { code } : {}),
+    message,
+    ...(nodeCommandDispatched !== undefined ? { nodeCommandDispatched } : {}),
+    ...(requestSent !== undefined ? { requestSent } : {}),
+  };
+}
+
+function formatNodeInvokeFailureText(params: {
+  failure: NodeInvokeFailure;
+  nodeId: string;
+  command: string;
+}): string {
+  const summary =
+    params.failure.reason === "outcome-unknown"
+      ? [
+          `Node command outcome is unknown for ${params.nodeId}.`,
+          "The command may have executed. Do not rerun it automatically.",
+        ]
+      : [
+          `Node command was not dispatched to ${params.nodeId}.`,
+          "It can be retried after the node reconnects.",
+        ];
+  return [
+    ...summary,
+    "",
+    "Command:",
+    params.command,
+    "",
+    `Details: ${params.failure.message}`,
+  ].join("\n");
+}
+
+export function formatNodeInvokeFailureFollowup(params: {
+  failure: NodeInvokeFailure;
+  nodeId: string;
+  approvalId: string;
+  command: string;
+}): string {
+  const prefix =
+    params.failure.reason === "outcome-unknown"
+      ? `Exec outcome unknown (node=${params.nodeId} id=${params.approvalId}, outcome-unknown)`
+      : `Exec not dispatched (node=${params.nodeId} id=${params.approvalId}, not-dispatched)`;
+  return `${prefix}\n${formatNodeInvokeFailureText(params)}`;
+}
+
+export function formatNodeInvokeFailureToolResult(params: {
+  failure: NodeInvokeFailure;
+  nodeId: string;
+  command: string;
+  startedAt: number;
+  cwd: string | undefined;
+  warnings?: string[];
+}): AgentToolResult<ExecToolDetails> {
+  const text = formatNodeInvokeFailureText(params);
+  return {
+    content: [
+      {
+        type: "text",
+        text: renderExecUpdateText({ tailText: text, warnings: params.warnings ?? [] }),
+      },
+    ],
+    details: {
+      status: "failed",
+      exitCode: null,
+      failureKind: params.failure.reason,
+      reason: params.failure.reason,
+      nodeInvokeFailure: {
+        ...(params.failure.code ? { failureCode: params.failure.code } : {}),
+        message: params.failure.message,
+        ...(params.failure.nodeCommandDispatched !== undefined
+          ? { nodeCommandDispatched: params.failure.nodeCommandDispatched }
+          : {}),
+        ...(params.failure.requestSent !== undefined
+          ? { requestSent: params.failure.requestSent }
+          : {}),
+      },
+      durationMs: Date.now() - params.startedAt,
+      aggregated: text,
+      cwd: params.cwd,
+    },
+  };
+}
+
+/** Invokes node system.run and turns every non-cancellation failure into provenance-aware data. */
+export async function invokeNodeSystemRun(params: {
+  invokeWaitMs: number;
+  invoke: Record<string, unknown>;
+  signal?: AbortSignal;
+  scopes?: OperatorScope[];
+}): Promise<NodeSystemRunInvokeResult> {
+  try {
+    const raw = await callGatewayTool(
+      "node.invoke",
+      { timeoutMs: params.invokeWaitMs },
+      params.invoke,
+      params.scopes || params.signal
+        ? {
+            ...(params.scopes ? { scopes: params.scopes } : {}),
+            ...(params.signal ? { signal: params.signal } : {}),
+          }
+        : undefined,
+    );
+    if (typeof readRecord(readRecord(raw)?.payload)?.success !== "boolean") {
+      return {
+        ok: false,
+        failure: {
+          reason: "outcome-unknown",
+          retrySafe: false,
+          message: "malformed node invoke response",
+        },
+      };
+    }
+    return { ok: true, raw };
+  } catch (error) {
+    if (params.signal?.aborted) {
+      throw error;
+    }
+    return { ok: false, failure: classifyNodeInvokeFailure(error) };
+  }
+}

--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatNodeInvokeFailureFollowup,
+  invokeNodeSystemRun,
+} from "./bash-tools.exec-host-node-failure.js";
+
+const callGatewayToolMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: callGatewayToolMock,
+}));
+
+function gatewayNodeInvokeError(params: {
+  code?: string;
+  message?: string;
+  nodeCommandDispatched?: boolean;
+  requestSent?: boolean;
+}): Error {
+  return Object.assign(new Error(params.message ?? "node invoke failed"), {
+    name: "GatewayClientRequestError",
+    gatewayCode: "UNAVAILABLE",
+    details: {
+      nodeError: {
+        ...(params.code ? { code: params.code } : {}),
+        message: params.message ?? "node invoke failed",
+      },
+      ...(params.nodeCommandDispatched !== undefined
+        ? { nodeCommandDispatched: params.nodeCommandDispatched }
+        : {}),
+    },
+    ...(params.requestSent !== undefined ? { requestSent: params.requestSent } : {}),
+  });
+}
+
+async function invokeFailure(error: unknown) {
+  callGatewayToolMock.mockRejectedValueOnce(error);
+  const result = await invokeNodeSystemRun({
+    invokeWaitMs: 1_000,
+    invoke: { nodeId: "node-1", command: "system.run" },
+  });
+  if (result.ok) {
+    throw new Error("expected node invoke failure");
+  }
+  return result.failure;
+}
+
+describe("invokeNodeSystemRun failure classification", () => {
+  it("classifies only proven pre-dispatch NOT_CONNECTED as retry-safe", async () => {
+    await expect(
+      invokeFailure(
+        gatewayNodeInvokeError({
+          code: "NOT_CONNECTED",
+          message: "node not connected",
+          nodeCommandDispatched: false,
+          requestSent: true,
+        }),
+      ),
+    ).resolves.toEqual({
+      reason: "not-dispatched",
+      retrySafe: true,
+      code: "NOT_CONNECTED",
+      message: "node not connected",
+      nodeCommandDispatched: false,
+      requestSent: true,
+    });
+  });
+
+  it.each([
+    {
+      name: "deadline before dispatch",
+      error: gatewayNodeInvokeError({
+        code: "TIMEOUT",
+        nodeCommandDispatched: false,
+      }),
+    },
+    {
+      name: "disconnect after dispatch",
+      error: gatewayNodeInvokeError({
+        code: "DISCONNECTED",
+        nodeCommandDispatched: true,
+      }),
+    },
+    {
+      name: "missing dispatch provenance",
+      error: gatewayNodeInvokeError({ code: "NOT_CONNECTED" }),
+    },
+    {
+      name: "client timeout before request bytes crossed send",
+      error: Object.assign(new Error("gateway request timeout for node.invoke"), {
+        name: "GatewayClientRequestTimeoutError",
+        requestSent: false,
+      }),
+    },
+    {
+      name: "malformed failure",
+      error: { message: 42 },
+    },
+  ])("classifies $name as outcome-unknown", async ({ error }) => {
+    await expect(invokeFailure(error)).resolves.toMatchObject({
+      reason: "outcome-unknown",
+      retrySafe: false,
+    });
+  });
+
+  it("preserves multiline command metadata in an outcome-unknown followup", async () => {
+    const failure = await invokeFailure(
+      gatewayNodeInvokeError({
+        code: "TIMEOUT",
+        message: "node invoke timed out",
+        nodeCommandDispatched: true,
+      }),
+    );
+    const text = formatNodeInvokeFailureFollowup({
+      failure,
+      nodeId: "node-1",
+      approvalId: "approval-1",
+      command: "printf 'one\\ntwo'\necho done",
+    });
+
+    expect(text).toContain("Exec outcome unknown (node=node-1 id=approval-1, outcome-unknown)");
+    expect(text).toContain("The command may have executed. Do not rerun it automatically.");
+    expect(text).toContain("Command:\nprintf 'one\\ntwo'\necho done");
+  });
+});

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -37,6 +37,10 @@ import {
   resolveSystemRunCommandRequest,
 } from "../infra/system-run-command.js";
 import { addSafeTimeoutDelayGraceMs } from "../utils/timer-delay.js";
+import {
+  formatNodeInvokeFailureToolResult,
+  invokeNodeSystemRun,
+} from "./bash-tools.exec-host-node-failure.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import { renderExecUpdateText } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -424,13 +428,23 @@ export async function invokeNodeSystemRunDirect(params: {
     notifyOnExit: params.request.notifyOnExit,
   });
   params.request.signal?.throwIfAborted();
-  const raw = params.request.signal
-    ? await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeWaitMs }, invoke, {
-        signal: params.request.signal,
-      })
-    : await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeWaitMs }, invoke);
+  const result = await invokeNodeSystemRun({
+    invokeWaitMs: params.target.invokeWaitMs,
+    invoke,
+    signal: params.request.signal,
+  });
+  if (!result.ok) {
+    return formatNodeInvokeFailureToolResult({
+      failure: result.failure,
+      nodeId: params.target.nodeId,
+      command: params.request.command,
+      startedAt,
+      cwd: params.request.workdir,
+      warnings: [...params.request.warnings, ...(params.request.foregroundWarnings ?? [])],
+    });
+  }
   return formatNodeRunToolResult({
-    raw,
+    raw: result.raw,
     startedAt,
     cwd: params.request.workdir,
     warnings: [...params.request.warnings, ...(params.request.foregroundWarnings ?? [])],

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -406,7 +406,28 @@ function requireRunParams(call: GatewayToolCall): Record<string, unknown> {
   if (!params) {
     throw new Error("expected system.run params");
   }
+
   return params;
+}
+
+function createNodeInvokeFailure(params: {
+  code: string;
+  nodeCommandDispatched?: boolean;
+  message?: string;
+}): Error {
+  return Object.assign(new Error(params.message ?? "node invoke failed"), {
+    name: "GatewayClientRequestError",
+    gatewayCode: "UNAVAILABLE",
+    details: {
+      nodeError: {
+        code: params.code,
+        message: params.message ?? "node invoke failed",
+      },
+      ...(params.nodeCommandDispatched !== undefined
+        ? { nodeCommandDispatched: params.nodeCommandDispatched }
+        : {}),
+    },
+  });
 }
 
 function requireRegisteredApprovalRequest(): Record<string, unknown> {
@@ -565,6 +586,7 @@ describe("executeNodeHostCommand", () => {
       plan: preparedPlan,
       execPolicy: { security: "full", ask: "off" },
     });
+
     commandRequiresSecurityAuditSuppressionApprovalMock.mockReset();
     commandRequiresSecurityAuditSuppressionApprovalMock.mockReturnValue(false);
     evaluateShellAllowlistMock.mockReset();
@@ -652,6 +674,111 @@ describe("executeNodeHostCommand", () => {
     detectInterpreterInlineEvalArgvMock.mockReset();
     detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     registerExecApprovalRequestForHostOrThrowMock.mockReset();
+  });
+
+  it("returns outcome-unknown for an ambiguous direct node timeout", async () => {
+    callGatewayToolMock.mockRejectedValueOnce(
+      createNodeInvokeFailure({
+        code: "TIMEOUT",
+        nodeCommandDispatched: true,
+        message: "node invoke timed out",
+      }),
+    );
+
+    const result = await executeNodeHostCommand(createNodeHostRequest());
+
+    expect(result.details).toMatchObject({
+      status: "failed",
+      failureKind: "outcome-unknown",
+      reason: "outcome-unknown",
+      nodeInvokeFailure: {
+        failureCode: "TIMEOUT",
+        message: "node invoke timed out",
+        nodeCommandDispatched: true,
+      },
+    });
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining(
+          "The command may have executed. Do not rerun it automatically.",
+        ),
+      }),
+    ]);
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns outcome-unknown for a malformed direct node response", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({ payload: { stdout: "partial" } });
+
+    const result = await executeNodeHostCommand(createNodeHostRequest());
+
+    expect(result.details).toMatchObject({
+      status: "failed",
+      reason: "outcome-unknown",
+      nodeInvokeFailure: {
+        message: "malformed node invoke response",
+      },
+    });
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining("The command may have executed."),
+      }),
+    ]);
+  });
+
+  it("returns outcome-unknown after an inline auto-approved node disconnect", async () => {
+    const defaultImplementation = callGatewayToolMock.getMockImplementation();
+    callGatewayToolMock.mockImplementation(
+      async (method: string, options: unknown, callParams: MockNodeInvokeParams | undefined) => {
+        if (method === "node.invoke" && callParams?.command === "system.run") {
+          throw createNodeInvokeFailure({
+            code: "DISCONNECTED",
+            nodeCommandDispatched: true,
+            message: "node disconnected",
+          });
+        }
+        if (!defaultImplementation) {
+          throw new Error("missing default gateway mock");
+        }
+        return await defaultImplementation(method, options, callParams);
+      },
+    );
+    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe read",
+    }));
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+    requiresExecApprovalMock.mockImplementation(
+      (value?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
+        value?.allowlistSatisfied !== true && value?.durableApprovalSatisfied !== true,
+    );
+
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer,
+      }),
+    );
+
+    expect(result.details).toMatchObject({
+      status: "failed",
+      reason: "outcome-unknown",
+      nodeInvokeFailure: {
+        failureCode: "DISCONNECTED",
+        nodeCommandDispatched: true,
+      },
+    });
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(4);
   });
 
   it("denies non-interactive approval requests without creating operator events", async () => {
@@ -756,6 +883,46 @@ describe("executeNodeHostCommand", () => {
     } finally {
       unhandledRejections.restore();
     }
+  });
+
+  it("reports outcome-unknown after an approved detached node timeout", async () => {
+    const defaultImplementation = callGatewayToolMock.getMockImplementation();
+    callGatewayToolMock.mockImplementation(
+      async (method: string, options: unknown, callParams: MockNodeInvokeParams | undefined) => {
+        if (method === "node.invoke" && callParams?.command === "system.run") {
+          throw createNodeInvokeFailure({
+            code: "TIMEOUT",
+            nodeCommandDispatched: true,
+            message: "node invoke timed out",
+          });
+        }
+        if (!defaultImplementation) {
+          throw new Error("missing default gateway mock");
+        }
+        return await defaultImplementation(method, options, callParams);
+      },
+    );
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({ ask: "always" }));
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalId: "approval-1" }),
+        expect.stringContaining(
+          "Exec outcome unknown (node=node-1 id=approval-1, outcome-unknown)",
+        ),
+      );
+    });
+    const followup = sendExecApprovalFollowupResultMock.mock.calls[0]?.[1];
+    expect(followup).toContain("The command may have executed. Do not rerun it automatically.");
+    expect(followup).not.toContain("Exec denied");
   });
 
   it("does not report a failed detached approval after its owning run is aborted", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -26,6 +26,11 @@ import {
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
+  formatNodeInvokeFailureFollowup,
+  formatNodeInvokeFailureToolResult,
+  invokeNodeSystemRun,
+} from "./bash-tools.exec-host-node-failure.js";
+import {
   analyzeNodeApprovalRequirement,
   buildNodeSystemRunInvoke,
   formatNodeRunToolResult,
@@ -572,10 +577,9 @@ export async function executeNodeHostCommand(
             }
             // Approved follow-up invocations need approval scopes because they mutate remote node state.
             nodeInvocationStarted = true;
-            const raw = await callGatewayTool(
-              "node.invoke",
-              { timeoutMs: target.invokeWaitMs },
-              buildNodeSystemRunInvoke({
+            const invocation = await invokeNodeSystemRun({
+              invokeWaitMs: target.invokeWaitMs,
+              invoke: buildNodeSystemRunInvoke({
                 target,
                 command: prepared.argv,
                 rawCommand: prepared.transportRawCommand,
@@ -598,11 +602,22 @@ export async function executeNodeHostCommand(
                 notifyOnExit: params.notifyOnExit,
                 systemRunPlan: prepared.plan,
               }),
-              {
-                scopes: APPROVED_NODE_INVOKE_SCOPES,
-                ...(params.signal ? { signal: params.signal } : {}),
-              },
-            );
+              scopes: APPROVED_NODE_INVOKE_SCOPES,
+              signal: params.signal,
+            });
+            if (!invocation.ok) {
+              await execHostShared.sendExecApprovalFollowupResult(
+                followupTarget,
+                formatNodeInvokeFailureFollowup({
+                  failure: invocation.failure,
+                  nodeId: target.nodeId,
+                  approvalId,
+                  command: params.command,
+                }),
+              );
+              return;
+            }
+            const raw = invocation.raw as { payload?: unknown };
             nodeInvocationCompleted = true;
             const payload =
               raw?.payload && typeof raw.payload === "object"
@@ -694,19 +709,26 @@ export async function executeNodeHostCommand(
       !requiresSecurityAuditSuppressionApproval,
   });
   params.signal?.throwIfAborted();
-  const raw =
-    (inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
-      ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke, {
-          scopes: APPROVED_NODE_INVOKE_SCOPES,
-          ...(params.signal ? { signal: params.signal } : {}),
-        })
-      : params.signal
-        ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke, {
-            signal: params.signal,
-          })
-        : await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke);
+  const invocation = await invokeNodeSystemRun({
+    invokeWaitMs: target.invokeWaitMs,
+    invoke,
+    signal: params.signal,
+    ...((inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
+      ? { scopes: APPROVED_NODE_INVOKE_SCOPES }
+      : {}),
+  });
+  if (!invocation.ok) {
+    return formatNodeInvokeFailureToolResult({
+      failure: invocation.failure,
+      nodeId: target.nodeId,
+      command: params.command,
+      startedAt,
+      cwd: params.workdir,
+      warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
+    });
+  }
   return formatNodeRunToolResult({
-    raw,
+    raw: invocation.raw,
     startedAt,
     cwd: params.workdir,
     warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -136,6 +136,13 @@ export type ExecToolDetails =
       exitCode: number | null;
       exitSignal?: NodeJS.Signals | number | null;
       failureKind?: string;
+      reason?: "not-dispatched" | "outcome-unknown";
+      nodeInvokeFailure?: {
+        failureCode?: string;
+        message: string;
+        nodeCommandDispatched?: boolean;
+        requestSent?: boolean;
+      };
       exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1914,6 +1914,63 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     ]);
   });
 
+  it("projects outcome-unknown exec results as errors with typed details", async () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx } = createTestContext();
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "The command may have executed. Do not rerun it automatically.",
+        },
+      ],
+      details: {
+        status: "failed",
+        exitCode: null,
+        failureKind: "outcome-unknown",
+        reason: "outcome-unknown",
+        nodeInvokeFailure: {
+          failureCode: "TIMEOUT",
+          message: "node invoke timed out",
+          nodeCommandDispatched: true,
+        },
+        durationMs: 10,
+        aggregated: "The command may have executed. Do not rerun it automatically.",
+      },
+    };
+
+    await endTool(ctx, {
+      toolName: "exec",
+      toolCallId: "tool-exec-outcome-unknown",
+      isError: false,
+      result,
+    });
+
+    expect(ctx.state.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "exec", isError: true }),
+    ]);
+    const toolResult = events.find(
+      (event) => event.stream === "tool" && event.data?.phase === "result",
+    );
+    expect(toolResult?.data).toMatchObject({
+      isError: true,
+      result: {
+        details: {
+          reason: "outcome-unknown",
+          nodeInvokeFailure: {
+            failureCode: "TIMEOUT",
+            nodeCommandDispatched: true,
+          },
+        },
+      },
+    });
+    resetAgentEventsForTest();
+  });
+
   it.each([
     {
       name: "uses raw exec metadata for failed tool payload warnings",

--- a/src/agents/exec-approval-result.ts
+++ b/src/agents/exec-approval-result.ts
@@ -22,6 +22,18 @@ type ExecApprovalResult =
       body: string;
     }
   | {
+      kind: "outcome-unknown";
+      raw: string;
+      metadata: string;
+      body: string;
+    }
+  | {
+      kind: "not-dispatched";
+      raw: string;
+      metadata: string;
+      body: string;
+    }
+  | {
       kind: "other";
       raw: string;
     };
@@ -121,6 +133,34 @@ export function parseExecApprovalResultText(resultText: string): ExecApprovalRes
     };
   }
 
+  const outcomeUnknownResult = parseExecApprovalResultWithMetadata(
+    raw,
+    "Exec outcome unknown (",
+    "\n",
+  );
+  if (outcomeUnknownResult) {
+    return {
+      kind: "outcome-unknown",
+      raw,
+      metadata: outcomeUnknownResult.metadata,
+      body: outcomeUnknownResult.body,
+    };
+  }
+
+  const notDispatchedResult = parseExecApprovalResultWithMetadata(
+    raw,
+    "Exec not dispatched (",
+    "\n",
+  );
+  if (notDispatchedResult) {
+    return {
+      kind: "not-dispatched",
+      raw,
+      metadata: notDispatchedResult.metadata,
+      body: notDispatchedResult.body,
+    };
+  }
+
   const completedMatch = EXEC_COMPLETED_RE.exec(raw);
   if (completedMatch) {
     return {
@@ -135,6 +175,10 @@ export function parseExecApprovalResultText(resultText: string): ExecApprovalRes
 
 export function isExecDeniedResultText(resultText: string): boolean {
   return parseExecApprovalResultText(resultText).kind === "denied";
+}
+
+export function isExecOutcomeUnknownResultText(resultText: string): boolean {
+  return parseExecApprovalResultText(resultText).kind === "outcome-unknown";
 }
 
 export function formatExecDeniedUserMessage(resultText: string): string | null {

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -680,6 +680,7 @@ describe("gateway tool defaults", () => {
       {
         name: "GatewayClientRequestError",
         gatewayCode: "INVALID_REQUEST",
+        details: { nodeCommandDispatched: false },
       },
     );
     mocks.callGateway.mockRejectedValueOnce(schemaError).mockResolvedValueOnce({ ok: true });
@@ -747,6 +748,39 @@ describe("gateway tool defaults", () => {
           ),
       ),
     ).rejects.toBe(dispatchedError);
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a node invoke schema rejection without pre-dispatch provenance", async () => {
+    const ambiguousError = Object.assign(
+      new Error("invalid node.invoke params: at root: unexpected property 'turnSourceChannel'"),
+      {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+      },
+    );
+    mocks.callGateway.mockRejectedValueOnce(ambiguousError);
+
+    await expect(
+      withGatewayToolCallerIdentity(
+        {
+          agentId: "ops",
+          sessionKey: "agent:ops:main",
+          turnSourceChannel: "telegram",
+          turnSourceTo: "chat:123",
+        },
+        async () =>
+          await callGatewayTool(
+            "node.invoke",
+            {},
+            {
+              nodeId: "node-1",
+              command: "device.info",
+              idempotencyKey: "invoke-ambiguous",
+            },
+          ),
+      ),
+    ).rejects.toBe(ambiguousError);
     expect(mocks.callGateway).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -473,9 +473,9 @@ function isStaleGatewayNodeInvokeTurnSourceRejection(error: unknown): boolean {
     return false;
   }
   const details = asNullableRecord(requestError.details);
-  // A dispatched command may have acted before returning an error. Never turn
-  // version fallback into a duplicate invocation when the Gateway says so.
-  if (details?.nodeCommandDispatched === true) {
+  // Only explicit pre-dispatch provenance makes a second invoke safe. Older
+  // gateways without this fact must fail rather than risk duplicate execution.
+  if (details?.nodeCommandDispatched !== false) {
     return false;
   }
   const message = formatErrorMessage(error);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3084,6 +3084,44 @@ describe("agent event handler", () => {
     expect(payload.data?.partialResult).toEqual(partialResult);
   });
 
+  it("preserves sanitized outcome-unknown exec details for Control UI recipients", () => {
+    const { broadcastToConnIds, toolEventRecipients, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-1",
+    });
+    const result = {
+      content: [{ type: "text", text: "The command may have executed." }],
+      details: {
+        status: "failed",
+        reason: "outcome-unknown",
+        nodeInvokeFailure: {
+          failureCode: "DISCONNECTED",
+          message: "node disconnected",
+          nodeCommandDispatched: true,
+        },
+      },
+    };
+    registerAgentRunContext("run-outcome-unknown", {
+      sessionKey: "session-1",
+      verboseLevel: "full",
+    });
+    toolEventRecipients.add("run-outcome-unknown", "conn-1");
+
+    emitAgentEvent(handler, "run-outcome-unknown", "tool", {
+      phase: "result",
+      name: "exec",
+      toolCallId: "tool-outcome-unknown",
+      isError: true,
+      result,
+    });
+
+    const payload = requireMockPayload(broadcastToConnIds, 0, 1, "outcome unknown tool payload");
+    expect(requireRecord(payload.data, "outcome unknown tool data")).toMatchObject({
+      phase: "result",
+      isError: true,
+      result,
+    });
+  });
+
   it("broadcasts fallback events to agent subscribers and node session", () => {
     const { broadcast, broadcastToConnIds, nodeSendToSession, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-fallback",


### PR DESCRIPTION
## What Problem This Solves

Node-host exec could project timeout, disconnect, or malformed post-invoke failures as denial or non-dispatch even when the Gateway could not prove whether `system.run` executed. That could prompt an unsafe automatic retry and duplicate side effects.

This PR is Layer 3 of the native PR stack and is stacked on #117139 at base SHA `e5dac88272be84fa5de6bee4393c158264685a44`. It depends on #117139 landing first.

## Why This Change Was Made

Consume the Gateway dispatch provenance added by #117139 at a single node-invoke boundary. Only `NOT_CONNECTED` with `nodeCommandDispatched:false` is classified as retry-safe `not-dispatched`; every ambiguous deadline, disconnect, post-dispatch, missing-provenance, timeout, or malformed result is classified as `outcome-unknown`.

Isolated Codex autoreview identified one actionable issue: detached `not-dispatched` follow-ups incorrectly used the generic completion prompt. That was fixed and reproved. Two repeated findings were rejected because they conflict with the explicit duplicate-execution safety contract:

- Do not treat every `nodeCommandDispatched:false` failure as retry-safe. Only `NOT_CONNECTED` plus explicit false is retry-safe; deadline and other ambiguous failures remain `outcome-unknown`.
- Do not retry stale-Gateway turn-source schema failures when dispatch provenance is missing. Missing provenance must not authorize a second invocation.

## User Impact

Users and models now see that an ambiguous node command may have executed and must not be rerun automatically. Direct, inline-approved, detached-approved, embedded tool events, and Gateway agent-event projections retain typed failure details. Multiline command metadata is preserved safely. Existing success and denial behavior is unchanged.

## Evidence

- Focused node exec, approval follow-up, embedded event, and Gateway sanitization tests: 443 passed across 3 Vitest shards.
- `pnpm tsgo`: passed.
- `pnpm tsgo:core:test`: passed.
- Targeted Oxlint and Oxfmt: passed.
- `pnpm deadcode:exports`: passed with 0 entries.
- `pnpm deadcode:unused-files`: passed with 0 entries.
- `pnpm check:deprecated-api-usage`: passed.
- `git diff --check`: passed.
- SDK/API gates were not required because no SDK/API surface changed.
- Changed-gate remote delegation was unavailable because the local `blacksmith` executable was missing; trusted-source local fallback completed the applicable gates.
- Final isolated Codex autoreview had no accepted/actionable findings remaining. Its two repeated recommendations were consciously rejected for the duplicate-execution safety reasons above.