### PR TITLE
fix(plugin-state): treat missing plugin-state table as empty on read-only fresh stores

### DIFF
--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -8,12 +8,14 @@ import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadNodeHostConfig } from "../node-host/config.js";
 import { readChannelPairingStateSnapshot } from "../pairing/pairing-store-sqlite.test-helpers.js";
+import type { PluginDoctorStateMigrationContext } from "../plugins/doctor-contract-registry.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
 import {
@@ -29,6 +31,7 @@ import {
   readPersistedVapidKeyPair,
 } from "./push-web-store.js";
 import { readRestartSentinel } from "./restart-sentinel.js";
+import { acquireStartupMigrationLease } from "./startup-migration-checkpoint.js";
 import {
   autoMigrateLegacyState,
   autoMigrateLegacyPluginDoctorState,
@@ -746,6 +749,53 @@ describe("state migrations", () => {
     } finally {
       writer.exec("ROLLBACK;");
       writer.close();
+    }
+  });
+
+  it("detects no plugin-state migration warnings after the startup lease creates fresh state", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const detectLegacyState = vi.fn(async ({ context }: { context: unknown }) => {
+      const pluginState = (context as PluginDoctorStateMigrationContext).openPluginStateKeyedStore({
+        namespace: "fresh-start-detection",
+        maxEntries: 10,
+      });
+      await expect(pluginState.lookup("legacy")).resolves.toBeUndefined();
+      await expect(pluginState.entries()).resolves.toEqual([]);
+      return null;
+    });
+    pluginDoctorStateMigrationEntries.entries = [
+      {
+        pluginId: "fixture",
+        migration: {
+          id: "fixture-fresh-start-plugin-state",
+          label: "Fixture fresh-start plugin state",
+          detectLegacyState,
+          migrateLegacyState: vi.fn(() => ({ changes: [], warnings: [] })),
+        },
+      },
+    ];
+
+    const lease = acquireStartupMigrationLease({ env, owner: "fresh-start-test" });
+    try {
+      const databasePath = resolveOpenClawStateSqlitePath(env);
+      const database = new DatabaseSync(databasePath, { readOnly: true });
+      expect(
+        database.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(),
+      ).toEqual([{ name: "schema_meta" }, { name: "state_leases" }]);
+      database.close();
+
+      const detected = await detectLegacyStateMigrations({
+        cfg: createConfig(),
+        env,
+        homedir: () => root,
+      });
+
+      expect(detectLegacyState).toHaveBeenCalledOnce();
+      expect(detected.warnings).toEqual([]);
+    } finally {
+      lease.release();
     }
   });
 

--- a/src/plugin-state/plugin-state-store.fresh-store.test.ts
+++ b/src/plugin-state/plugin-state-store.fresh-store.test.ts
@@ -1,9 +1,8 @@
-// Fresh-store reads: a state DB created before the first plugin-state write has no
+// Fresh-store reads: a startup-checkpoint DB created before the first plugin-state write has no
 // plugin_state_entries table; read-only paths must report empty, not error (#117249).
-import { mkdirSync } from "node:fs";
-import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
+import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
@@ -12,10 +11,29 @@ import {
   pluginStateEntriesInKeyRange,
   resetPluginStateStoreForTests,
 } from "./plugin-state-store.js";
+import { PluginStateStoreError } from "./plugin-state-store.types.js";
 
 afterEach(() => {
   resetPluginStateStoreForTests({ closeDatabase: false });
 });
+
+async function expectPluginStateReadFailure(
+  promise: Promise<unknown>,
+  expected: { operation: "entries" | "lookup"; path: string },
+): Promise<void> {
+  let storeError: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    storeError = error;
+  }
+  expect(storeError).toBeInstanceOf(PluginStateStoreError);
+  expect(storeError).toMatchObject({
+    code: "PLUGIN_STATE_READ_FAILED",
+    operation: expected.operation,
+    path: expected.path,
+  });
+}
 
 describe("plugin state fresh-store reads", () => {
   it("treats an existing state database without the lazy plugin-state table as empty", async () => {
@@ -23,10 +41,7 @@ describe("plugin state fresh-store reads", () => {
       { label: "plugin-state-read-only-table-missing", applyEnv: false },
       async (state) => {
         const databasePath = resolveOpenClawStateSqlitePath(state.env);
-        mkdirSync(path.dirname(databasePath), { recursive: true });
-        const database = new DatabaseSync(databasePath);
-        database.exec("CREATE TABLE unrelated_state (id INTEGER PRIMARY KEY)");
-        database.close();
+        withOpenClawStateStartupMigrationCheckpointDatabase(() => undefined, { env: state.env });
 
         const store = createPluginStateKeyedStore("discord", {
           namespace: "read-only-table-missing",
@@ -49,14 +64,45 @@ describe("plugin state fresh-store reads", () => {
         expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
 
         const verify = new DatabaseSync(databasePath, { readOnly: true });
-        expect(
-          verify
-            .prepare(
-              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_state_entries'",
-            )
-            .get(),
-        ).toBeUndefined();
+        const tables = verify
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name")
+          .all();
         verify.close();
+        expect(tables).toEqual([{ name: "schema_meta" }, { name: "state_leases" }]);
+      },
+    );
+  });
+
+  it("rejects a missing plugin-state table after another state table has been initialized", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-state-read-only-table-damaged", applyEnv: false },
+      async (state) => {
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        withOpenClawStateStartupMigrationCheckpointDatabase(() => undefined, { env: state.env });
+        const database = new DatabaseSync(databasePath);
+        database.exec(`
+          CREATE TABLE config_machine_state (
+            state_key TEXT NOT NULL PRIMARY KEY,
+            value_json TEXT NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+          ) STRICT
+        `);
+        database.close();
+
+        const store = createPluginStateKeyedStore("discord", {
+          namespace: "read-only-table-damaged",
+          maxEntries: 10,
+          env: state.env,
+        });
+
+        await expectPluginStateReadFailure(store.lookup("k"), {
+          operation: "lookup",
+          path: databasePath,
+        });
+        await expectPluginStateReadFailure(store.entries(), {
+          operation: "entries",
+          path: databasePath,
+        });
       },
     );
   });

--- a/src/plugin-state/plugin-state-store.fresh-store.test.ts
+++ b/src/plugin-state/plugin-state-store.fresh-store.test.ts
@@ -1,0 +1,63 @@
+// Fresh-store reads: a state DB created before the first plugin-state write has no
+// plugin_state_entries table; read-only paths must report empty, not error (#117249).
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  countPluginStateLiveEntries,
+  createPluginStateKeyedStore,
+  pluginStateEntriesInKeyRange,
+  resetPluginStateStoreForTests,
+} from "./plugin-state-store.js";
+
+afterEach(() => {
+  resetPluginStateStoreForTests({ closeDatabase: false });
+});
+
+describe("plugin state fresh-store reads", () => {
+  it("treats an existing state database without the lazy plugin-state table as empty", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-state-read-only-table-missing", applyEnv: false },
+      async (state) => {
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        mkdirSync(path.dirname(databasePath), { recursive: true });
+        const database = new DatabaseSync(databasePath);
+        database.exec("CREATE TABLE unrelated_state (id INTEGER PRIMARY KEY)");
+        database.close();
+
+        const store = createPluginStateKeyedStore("discord", {
+          namespace: "read-only-table-missing",
+          maxEntries: 10,
+          env: state.env,
+        });
+
+        await expect(store.lookup("k")).resolves.toBeUndefined();
+        await expect(store.entries()).resolves.toEqual([]);
+        expect(
+          pluginStateEntriesInKeyRange({
+            pluginId: "discord",
+            namespace: "read-only-table-missing",
+            keyStartInclusive: "a",
+            keyEndExclusive: "z",
+            limit: 1,
+            env: state.env,
+          }),
+        ).toEqual([]);
+        expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
+
+        const verify = new DatabaseSync(databasePath, { readOnly: true });
+        expect(
+          verify
+            .prepare(
+              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_state_entries'",
+            )
+            .get(),
+        ).toBeUndefined();
+        verify.close();
+      },
+    );
+  });
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -399,6 +399,14 @@ function openPluginStateDatabase(
   }
 }
 
+function isMissingPluginStateTableError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === "ERR_SQLITE_ERROR" &&
+    error.message === "no such table: plugin_state_entries"
+  );
+}
+
 /** Read plugin state without joining the shared writable database lifecycle. */
 function withPluginStateDatabaseReadOnly<T>(
   operationName: PluginStateStoreOperation,
@@ -421,6 +429,11 @@ function withPluginStateDatabaseReadOnly<T>(
         "Failed to open the plugin state database.",
         pathname,
       );
+    }
+    if (isMissingPluginStateTableError(error)) {
+      // Startup leases create the shared file before the first plugin-state write.
+      // Read-only callers cannot ensure the lazy table, so its absence means no data yet.
+      return undefined;
     }
     throw error;
   }

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -407,6 +407,16 @@ function isMissingPluginStateTableError(error: unknown): boolean {
   );
 }
 
+function hasStateTablesBeyondStartupCheckpoint(db: DatabaseSync): boolean {
+  return (
+    /* sqlite-allow-raw -- Read-only startup-checkpoint schema discriminator. */ db
+      .prepare(
+        "SELECT 1 FROM main.sqlite_schema WHERE type = 'table' AND name NOT IN ('schema_meta', 'state_leases') LIMIT 1",
+      )
+      .get() !== undefined
+  );
+}
+
 /** Read plugin state without joining the shared writable database lifecycle. */
 function withPluginStateDatabaseReadOnly<T>(
   operationName: PluginStateStoreOperation,
@@ -418,7 +428,18 @@ function withPluginStateDatabaseReadOnly<T>(
   try {
     return withExistingOpenClawStateDatabaseReadOnly(({ db, path }) => {
       operationStarted = true;
-      return operation({ db, path });
+      try {
+        return operation({ db, path });
+      } catch (error) {
+        if (isMissingPluginStateTableError(error)) {
+          // The lease bootstrap creates exactly schema_meta + state_leases before the first write;
+          // any other table means the missing plugin-state table is damage, not fresh state.
+          if (!hasStateTablesBeyondStartupCheckpoint(db)) {
+            return undefined;
+          }
+        }
+        throw error;
+      }
     }, options);
   } catch (error) {
     if (!operationStarted) {
@@ -429,11 +450,6 @@ function withPluginStateDatabaseReadOnly<T>(
         "Failed to open the plugin state database.",
         pathname,
       );
-    }
-    if (isMissingPluginStateTableError(error)) {
-      // Startup leases create the shared file before the first plugin-state write.
-      // Read-only callers cannot ensure the lazy table, so its absence means no data yet.
-      return undefined;
     }
     throw error;
   }

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -1,5 +1,5 @@
 // Plugin state store tests cover per-plugin persisted state reads and writes.
-import { chmodSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
@@ -922,49 +922,6 @@ describe("plugin state keyed store", () => {
         await expect(store.entries()).resolves.toEqual([]);
         expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
         expect(existsSync(databasePath)).toBe(false);
-      },
-    );
-  });
-
-  it("treats an existing state database without the lazy plugin-state table as empty", async () => {
-    await withOpenClawTestState(
-      { label: "plugin-state-read-only-table-missing", applyEnv: false },
-      async (state) => {
-        const databasePath = resolveOpenClawStateSqlitePath(state.env);
-        mkdirSync(path.dirname(databasePath), { recursive: true });
-        const database = new DatabaseSync(databasePath);
-        database.exec("CREATE TABLE unrelated_state (id INTEGER PRIMARY KEY)");
-        database.close();
-
-        const store = createPluginStateKeyedStore("discord", {
-          namespace: "read-only-table-missing",
-          maxEntries: 10,
-          env: state.env,
-        });
-
-        await expect(store.lookup("k")).resolves.toBeUndefined();
-        await expect(store.entries()).resolves.toEqual([]);
-        expect(
-          pluginStateEntriesInKeyRange({
-            pluginId: "discord",
-            namespace: "read-only-table-missing",
-            keyStartInclusive: "a",
-            keyEndExclusive: "z",
-            limit: 1,
-            env: state.env,
-          }),
-        ).toEqual([]);
-        expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
-
-        const verify = new DatabaseSync(databasePath, { readOnly: true });
-        expect(
-          verify
-            .prepare(
-              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_state_entries'",
-            )
-            .get(),
-        ).toBeUndefined();
-        verify.close();
       },
     );
   });

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -1,5 +1,5 @@
 // Plugin state store tests cover per-plugin persisted state reads and writes.
-import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
@@ -922,6 +922,49 @@ describe("plugin state keyed store", () => {
         await expect(store.entries()).resolves.toEqual([]);
         expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
         expect(existsSync(databasePath)).toBe(false);
+      },
+    );
+  });
+
+  it("treats an existing state database without the lazy plugin-state table as empty", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-state-read-only-table-missing", applyEnv: false },
+      async (state) => {
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        mkdirSync(path.dirname(databasePath), { recursive: true });
+        const database = new DatabaseSync(databasePath);
+        database.exec("CREATE TABLE unrelated_state (id INTEGER PRIMARY KEY)");
+        database.close();
+
+        const store = createPluginStateKeyedStore("discord", {
+          namespace: "read-only-table-missing",
+          maxEntries: 10,
+          env: state.env,
+        });
+
+        await expect(store.lookup("k")).resolves.toBeUndefined();
+        await expect(store.entries()).resolves.toEqual([]);
+        expect(
+          pluginStateEntriesInKeyRange({
+            pluginId: "discord",
+            namespace: "read-only-table-missing",
+            keyStartInclusive: "a",
+            keyEndExclusive: "z",
+            limit: 1,
+            env: state.env,
+          }),
+        ).toEqual([]);
+        expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
+
+        const verify = new DatabaseSync(databasePath, { readOnly: true });
+        expect(
+          verify
+            .prepare(
+              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_state_entries'",
+            )
+            .get(),
+        ).toBeUndefined();
+        verify.close();
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes #117249. Booting the gateway against a fresh, empty `OPENCLAW_STATE_DIR` exits code 7 — "startup migrations did not complete cleanly; refusing to report the gateway ready" — because legacy-state migration detection errors on a store that simply has no data yet. The startup lease system creates `state/openclaw.sqlite` first (only `schema_meta` + `state_leases`), then detection reads plugin state through a read-only connection that cannot run the lazy table ensure: `SELECT` fails with `no such table: plugin_state_entries`, wrapped as `PluginStateStoreError`, surfacing as "Failed detecting …" warnings for the Matrix/Reef/Workboard detectors, which block ready. First-run out-of-box path broken; the workaround was a manual `openclaw doctor --fix`.

## Why This Change Was Made

The read-only helper already returns `undefined` when the DB **file** is missing — the benign "no legacy state" answer. This fix extends the same semantics to the missing-**table** case at one narrow point (`withPluginStateDatabaseReadOnly`): a matcher requiring `ERR_SQLITE_ERROR` **and** the exact message `no such table: plugin_state_entries` returns `undefined`; every other SQLite failure still throws wrapped. No table creation from read paths, no schema-version change, no startup reordering — this is the additive lazy-ensure storage model working as designed: reads before the first write mean an empty store.

## User Impact

A brand-new install reaches gateway-ready without a doctor step. No behavior change for populated stores; genuine corruption still fails loudly.

## Evidence

- **Live before/after on real builds**: before (main-based integration build, 2026-07-31): exit 7 with seven "Failed detecting … PluginStateStoreError" warnings on a fresh state dir. After (same build + this fix): fresh state dir, no doctor → `readyz=200` in 7s, `{"ready":true,"failing":[]}`, **zero** detection warnings, detectors complete ("Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 0 JSON roots scanned)"), 13 plugins loaded in 1.1s.
- New regression tests: (a) plugin-state lookup/list/key-range/count against a DB file containing only unrelated tables return empty instead of throwing; (b) boundary-level: real startup-lease bootstrap followed by migration detection yields zero warnings (`src/infra/state-migrations.test.ts`).
- Focused suites: plugin-state 76/76 (4 files); state-migrations detection tests 75/75.
- Pre-existing, unrelated on `main`: 14 macOS-local failures in `state-migrations.workspace-setup-sandbox.test.ts` (`/var` vs `/private/var` canonicalization) — reproduced identically on a checkout **without** this change; Linux CI is authoritative there. Follow-up filed separately.
- Structured autoreview (Codex, gpt-5.6-sol, high): clean, no actionable findings.
- Matched error shape verified against the real driver: `code: ERR_SQLITE_ERROR`, `message: no such table: plugin_state_entries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review refinement (accepted finding)

The empty-state fallback is now gated on the genuine lease-bootstrap shape: a read-only schema discriminator (`SELECT 1 FROM sqlite_schema WHERE type='table' AND name NOT IN ('schema_meta','state_leases') LIMIT 1`, run on the already-open handle) returns empty only for true fresh checkpoints; any store initialized beyond the checkpoint keeps failing loudly (`PLUGIN_STATE_READ_FAILED`) so a damaged canonical schema can never masquerade as empty. New corruption-case test covers exactly that; fresh-case fixture now uses the real startup-checkpoint bootstrap. Suites: fresh-store 2/2, plugin-state 77/77, migration regression 75/75; autoreview clean.
