### PR TITLE
fix(buzz): messages sent during Gateway downtime are dropped after restart

### DIFF
--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { finalizeEvent, getPublicKey, Relay, type Event, type Filter } from "nostr-tools";
+import { finalizeEvent, getPublicKey, type Event, type Filter } from "nostr-tools";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const relayMocks = vi.hoisted(() => ({
@@ -124,7 +124,6 @@ vi.mock("nostr-tools", async (importOriginal) => {
 });
 
 import { startBuzzBus } from "./buzz-bus.js";
-import { createBuzzRoomMembershipTracker } from "./room-membership-tracker.js";
 
 const BUZZ_NORMAL_MESSAGE_KIND = 9;
 const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
@@ -444,22 +443,5 @@ describe("Buzz reconnect history catch-up", () => {
     expect(received.length).toBeLessThan(250);
     expect(fatalErrors).toEqual([]);
     expect(historyErrors).toEqual([]);
-  });
-
-  it("reports history catch-up incomplete when a page cannot be dispatched", async () => {
-    seedOfflineBacklog(HISTORY_LIMIT + 1, (index) => BASE_TIMESTAMP + index);
-    const tracker = await createBuzzRoomMembershipTracker({
-      relay: new Relay("wss://buzz.example.com"),
-      relayPublicKey: RELAY_PUBLIC_KEY,
-      channelIds: [CHANNEL_ID],
-      botPublicKey: BOT_PUBLIC_KEY,
-      since: BASE_TIMESTAMP - 60,
-      messageSince: () => BASE_TIMESTAMP - 60,
-      messageLimit: HISTORY_LIMIT,
-      reserveDispatchCapacity: async () => undefined,
-      onMessageEvent: () => {},
-    });
-
-    expect(await tracker.catchUpHistory()).toBe("incomplete");
   });
 });

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { finalizeEvent, getPublicKey, type Event, type Filter } from "nostr-tools";
+import { finalizeEvent, getPublicKey, Relay, type Event, type Filter } from "nostr-tools";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const relayMocks = vi.hoisted(() => ({
@@ -123,7 +123,6 @@ vi.mock("nostr-tools", async (importOriginal) => {
   };
 });
 
-import { Relay } from "nostr-tools";
 import { startBuzzBus } from "./buzz-bus.js";
 import { createBuzzRoomMembershipTracker } from "./room-membership-tracker.js";
 

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -236,7 +236,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },
@@ -260,7 +260,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },
@@ -283,7 +283,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },
@@ -311,7 +311,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },
@@ -340,7 +340,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },
@@ -370,7 +370,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async () => {},
       onFatalError: (error) => {
         fatalErrors.push(error.message);
@@ -394,7 +394,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async () => {},
       onFatalError: (error) => {
         fatalErrors.push(error.message);
@@ -421,7 +421,7 @@ describe("Buzz reconnect history catch-up", () => {
       relayUrl: "wss://buzz.example.com",
       privateKey: PRIVATE_KEY,
       channelIds: [CHANNEL_ID],
-      since: BASE_TIMESTAMP - 60,
+      since: () => BASE_TIMESTAMP - 60,
       onMessage: async (message) => {
         received.push(message.text);
       },

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -123,7 +123,9 @@ vi.mock("nostr-tools", async (importOriginal) => {
   };
 });
 
+import { Relay } from "nostr-tools";
 import { startBuzzBus } from "./buzz-bus.js";
+import { createBuzzRoomMembershipTracker } from "./room-membership-tracker.js";
 
 const BUZZ_NORMAL_MESSAGE_KIND = 9;
 const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
@@ -443,5 +445,22 @@ describe("Buzz reconnect history catch-up", () => {
     expect(received.length).toBeLessThan(250);
     expect(fatalErrors).toEqual([]);
     expect(historyErrors).toEqual([]);
+  });
+
+  it("reports history catch-up incomplete when a page cannot be dispatched", async () => {
+    seedOfflineBacklog(HISTORY_LIMIT + 1, (index) => BASE_TIMESTAMP + index);
+    const tracker = await createBuzzRoomMembershipTracker({
+      relay: new Relay("wss://buzz.example.com"),
+      relayPublicKey: RELAY_PUBLIC_KEY,
+      channelIds: [CHANNEL_ID],
+      botPublicKey: BOT_PUBLIC_KEY,
+      since: BASE_TIMESTAMP - 60,
+      messageSince: () => BASE_TIMESTAMP - 60,
+      messageLimit: HISTORY_LIMIT,
+      reserveDispatchCapacity: async () => undefined,
+      onMessageEvent: () => {},
+    });
+
+    expect(await tracker.catchUpHistory()).toBe("incomplete");
   });
 });

--- a/extensions/buzz/src/buzz-bus.ts
+++ b/extensions/buzz/src/buzz-bus.ts
@@ -15,7 +15,6 @@ import {
   type BuzzInboundMessage,
 } from "./message-event.js";
 import { syncBuzzProfile } from "./profile.js";
-import type { BuzzRecoveryFrontier } from "./recovery-watermark.js";
 import {
   connectAuthenticatedBuzzRelay,
   connectAuthenticatedBuzzRelaySession,
@@ -223,7 +222,6 @@ export async function startBuzzBus(options: {
   authTag?: string;
   channelIds: string[];
   since?: (channelId: string) => number;
-  recoveryFrontier?: BuzzRecoveryFrontier;
   onMessage: (message: BuzzInboundMessage, bus: BuzzBus, signal: AbortSignal) => Promise<void>;
   onMessageError?: (error: Error) => void;
   onFatalError?: (error: Error) => void;
@@ -386,31 +384,13 @@ export async function startBuzzBus(options: {
               }
               // Admit only room members to bounded workers; claim replay dedupe inside
               // each worker so queued history cannot create unbounded in-flight state.
-              const token = options.recoveryFrontier?.admit({
-                channelId: message.channelId,
-                createdAt: event.created_at,
-                observedSeconds: Math.floor(Date.now() / 1000),
-              });
               const admission = (reservation ?? dispatchQueue).enqueue(async () => {
-                try {
-                  await replayGuard.processGuarded(event, async () => {
-                    await options.onMessage(message, bus, signal);
-                  });
-                } catch (error) {
-                  if (token) {
-                    options.recoveryFrontier?.abandon(token);
-                  }
-                  throw error;
-                }
-                if (token) {
-                  options.recoveryFrontier?.settle(token);
-                }
+                await replayGuard.processGuarded(event, async () => {
+                  await options.onMessage(message, bus, signal);
+                });
               });
               if (admission !== "overflow") {
                 return;
-              }
-              if (token) {
-                options.recoveryFrontier?.abandon(token);
               }
               if (reservation) {
                 options.onHistoryError?.(
@@ -449,11 +429,7 @@ export async function startBuzzBus(options: {
         : undefined;
     directory.replaceMemberships(membershipTracker?.memberships() ?? new Map());
     directoryRelay.replaceProfilePublicKeys(directory.profilePublicKeys());
-    void Promise.resolve(membershipTracker?.catchUpHistory()).then((outcome) => {
-      if (!membershipTracker || outcome === "drained") {
-        options.recoveryFrontier?.markBacklogDrained();
-      }
-    });
+    void membershipTracker?.catchUpHistory();
     stopPresenceHeartbeat = startBuzzPresenceHeartbeat({
       relay,
       secretKey,

--- a/extensions/buzz/src/buzz-bus.ts
+++ b/extensions/buzz/src/buzz-bus.ts
@@ -227,6 +227,7 @@ export async function startBuzzBus(options: {
   onFatalError?: (error: Error) => void;
   onDedupeError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
+  onHistoryDrained?: () => void;
   onPresenceError?: (error: Error) => void;
   profileName?: string;
   onProfilePublished?: (eventId: string) => void;
@@ -429,7 +430,11 @@ export async function startBuzzBus(options: {
         : undefined;
     directory.replaceMemberships(membershipTracker?.memberships() ?? new Map());
     directoryRelay.replaceProfilePublicKeys(directory.profilePublicKeys());
-    void membershipTracker?.catchUpHistory();
+    void Promise.resolve(membershipTracker?.catchUpHistory()).then((outcome) => {
+      if (!membershipTracker || outcome === "drained") {
+        options.onHistoryDrained?.();
+      }
+    });
     stopPresenceHeartbeat = startBuzzPresenceHeartbeat({
       relay,
       secretKey,

--- a/extensions/buzz/src/buzz-bus.ts
+++ b/extensions/buzz/src/buzz-bus.ts
@@ -15,6 +15,7 @@ import {
   type BuzzInboundMessage,
 } from "./message-event.js";
 import { syncBuzzProfile } from "./profile.js";
+import type { BuzzRecoveryFrontier } from "./recovery-watermark.js";
 import {
   connectAuthenticatedBuzzRelay,
   connectAuthenticatedBuzzRelaySession,
@@ -221,13 +222,13 @@ export async function startBuzzBus(options: {
   privateKey: string;
   authTag?: string;
   channelIds: string[];
-  since?: number;
+  since?: (channelId: string) => number;
+  recoveryFrontier?: BuzzRecoveryFrontier;
   onMessage: (message: BuzzInboundMessage, bus: BuzzBus, signal: AbortSignal) => Promise<void>;
   onMessageError?: (error: Error) => void;
   onFatalError?: (error: Error) => void;
   onDedupeError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
-  onHistoryDrained?: () => void;
   onPresenceError?: (error: Error) => void;
   profileName?: string;
   onProfilePublished?: (eventId: string) => void;
@@ -371,7 +372,7 @@ export async function startBuzzBus(options: {
             channelIds: activeChannelIds,
             botPublicKey: publicKey,
             since: sessionStartedAt,
-            messageSince: options.since ?? sessionStartedAt,
+            messageSince: (channelId) => options.since?.(channelId) ?? sessionStartedAt,
             messageLimit: resolveBuzzRoomHistoryLimit(activeChannelIds.length),
             reserveDispatchCapacity: (slots) => dispatchQueue.reserveCapacity(slots),
             onHistoryError: options.onHistoryError,
@@ -385,13 +386,31 @@ export async function startBuzzBus(options: {
               }
               // Admit only room members to bounded workers; claim replay dedupe inside
               // each worker so queued history cannot create unbounded in-flight state.
+              const token = options.recoveryFrontier?.admit({
+                channelId: message.channelId,
+                createdAt: event.created_at,
+                observedSeconds: Math.floor(Date.now() / 1000),
+              });
               const admission = (reservation ?? dispatchQueue).enqueue(async () => {
-                await replayGuard.processGuarded(event, async () => {
-                  await options.onMessage(message, bus, signal);
-                });
+                try {
+                  await replayGuard.processGuarded(event, async () => {
+                    await options.onMessage(message, bus, signal);
+                  });
+                } catch (error) {
+                  if (token) {
+                    options.recoveryFrontier?.abandon(token);
+                  }
+                  throw error;
+                }
+                if (token) {
+                  options.recoveryFrontier?.settle(token);
+                }
               });
               if (admission !== "overflow") {
                 return;
+              }
+              if (token) {
+                options.recoveryFrontier?.abandon(token);
               }
               if (reservation) {
                 options.onHistoryError?.(
@@ -432,7 +451,7 @@ export async function startBuzzBus(options: {
     directoryRelay.replaceProfilePublicKeys(directory.profilePublicKeys());
     void Promise.resolve(membershipTracker?.catchUpHistory()).then((outcome) => {
       if (!membershipTracker || outcome === "drained") {
-        options.onHistoryDrained?.();
+        options.recoveryFrontier?.markBacklogDrained();
       }
     });
     stopPresenceHeartbeat = startBuzzPresenceHeartbeat({

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -120,11 +120,7 @@ vi.mock("./inbound.js", () => ({
 }));
 
 import { startBuzzGatewayAccount } from "./gateway.js";
-import {
-  advanceBuzzRecoveryWatermark,
-  openBuzzRecoveryWatermarkStore,
-  resolveBuzzColdStartSince,
-} from "./recovery-watermark.js";
+import { openBuzzRecoveryWatermarkStore, resolveBuzzColdStartSince } from "./recovery-watermark.js";
 import { setBuzzRuntime } from "./runtime.js";
 import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 import { resolveBuzzAccount } from "./types.js";
@@ -250,12 +246,15 @@ async function runGatewayProcess(
 ): Promise<void> {
   const channelIds = params.channelIds ?? [CHANNEL_ID];
   const gatewayProcess = startGatewayProcess(channelIds);
-  await waitForSettled(() => relayMocks.messageFilters.length >= channelIds.length);
-  if (params.until) {
-    await waitForSettled(params.until);
+  try {
+    await waitForSettled(() => relayMocks.messageFilters.length >= channelIds.length);
+    if (params.until) {
+      await waitForSettled(params.until);
+    }
+  } finally {
+    gatewayProcess.abort.abort();
+    await gatewayProcess.lifecycle;
   }
-  gatewayProcess.abort.abort();
-  await gatewayProcess.lifecycle;
 }
 
 function roomSubscriptionSince(channelId = CHANNEL_ID): number {
@@ -268,7 +267,7 @@ function roomSubscriptionSince(channelId = CHANNEL_ID): number {
 
 async function readWatermark(channelId = CHANNEL_ID): Promise<number | undefined> {
   const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
-  return (await store?.lookup(`room:${channelId}`))?.seconds;
+  return (await store.lookup(`room:${channelId}`))?.seconds;
 }
 
 function openProcessBoundary(): void {
@@ -342,23 +341,22 @@ afterEach(() => {
 });
 
 describe("Buzz gateway cold-start recovery", () => {
-  it("resumes from the persisted watermark after a process restart", async () => {
+  it("recovers downtime messages from the persisted room activation floor", async () => {
     await runGatewayProcess();
     expect(roomSubscriptionSince()).toBe(START_SECONDS);
 
     openProcessBoundary();
     postRoomMessage("live-msg", START_SECONDS + 10);
     advanceSeconds(600);
-    await runGatewayProcess({
-      until: async () => (await readWatermark()) === START_SECONDS + 10,
-    });
+    await runGatewayProcess({ until: () => handled.includes("live-msg") });
 
     openProcessBoundary();
     postRoomMessage("outage-msg", START_SECONDS + 3_610);
     advanceSeconds(7_200);
     await runGatewayProcess({ until: () => handled.includes("outage-msg") });
-    expect(roomSubscriptionSince()).toBe(START_SECONDS + 10);
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
     expect(handled).toContain("outage-msg");
+    expect(handled).not.toContain("live-msg");
   });
 
   it("keeps an account with no cursor at the current time on its first start", async () => {
@@ -369,31 +367,89 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(await readWatermark()).toBe(START_SECONDS);
   });
 
-  it("registers a cursor for every supported room", async () => {
+  it("keeps recovery capacity available when configured rooms change", async () => {
     const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
     const channelIds = Array.from(
       { length: BUZZ_MAX_CONFIGURED_ROOMS },
       (_value, index) => `room-${index}`,
     );
-    const errors: Error[] = [];
     const sinceByRoom = await resolveBuzzColdStartSince({
       store,
       channelIds,
       nowSeconds: START_SECONDS,
       lookbackSeconds: LOOKBACK_SECONDS,
-      onError: (error) => errors.push(error),
     });
 
-    expect(errors).toEqual([]);
     expect(sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
     const lastChannelId = channelIds.at(-1) as string;
-    expect(await store?.lookup(`room:${lastChannelId}`)).toEqual({
+    expect(await store.lookup(`room:${lastChannelId}`)).toEqual({
       seconds: START_SECONDS,
+    });
+
+    const removedChannelId = channelIds[0] as string;
+    const retainedChannelId = channelIds[1] as string;
+    const replacementChannelId = "replacement-room";
+    const rotatedRooms = [...channelIds.slice(1), replacementChannelId];
+    const rotatedSinceByRoom = await resolveBuzzColdStartSince({
+      store,
+      channelIds: rotatedRooms,
+      nowSeconds: START_SECONDS + 60,
+      lookbackSeconds: LOOKBACK_SECONDS,
+    });
+
+    expect(await store.lookup(`room:${removedChannelId}`)).toBeUndefined();
+    expect(rotatedSinceByRoom.get(retainedChannelId)).toBe(START_SECONDS);
+    expect(await store.lookup(`room:${replacementChannelId}`)).toEqual({
+      seconds: START_SECONDS + 60,
     });
   });
 
+  it("rejects recovery when an existing room cursor cannot be read", async () => {
+    const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
+    await store.register(`room:${SECOND_CHANNEL_ID}`, { seconds: START_SECONDS - 60 });
+    vi.spyOn(store, "lookup").mockRejectedValueOnce(new Error("first room cursor unavailable"));
+    await expect(
+      resolveBuzzColdStartSince({
+        store,
+        channelIds: [CHANNEL_ID, SECOND_CHANNEL_ID],
+        nowSeconds: START_SECONDS,
+        lookbackSeconds: LOOKBACK_SECONDS,
+      }),
+    ).rejects.toThrow("first room cursor unavailable");
+  });
+
+  it("rejects recovery when a persisted room activation floor is invalid", async () => {
+    const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
+    await store.register(`room:${CHANNEL_ID}`, { seconds: "corrupt" } as never);
+
+    await expect(
+      resolveBuzzColdStartSince({
+        store,
+        channelIds: [CHANNEL_ID],
+        nowSeconds: START_SECONDS,
+        lookbackSeconds: LOOKBACK_SECONDS,
+      }),
+    ).rejects.toThrow(`Invalid Buzz recovery watermark for room ${CHANNEL_ID}`);
+  });
+
+  it("recovers a later-arriving room message with an older sender timestamp", async () => {
+    await runGatewayProcess();
+
+    openProcessBoundary();
+    postRoomMessage("newer-msg", START_SECONDS + 200);
+    advanceSeconds(600);
+    await runGatewayProcess({ until: () => handled.includes("newer-msg") });
+
+    openProcessBoundary();
+    postRoomMessage("older-late-msg", START_SECONDS + 100);
+    advanceSeconds(600);
+    await runGatewayProcess({ until: () => handled.includes("older-late-msg") });
+
+    expect(handled).toContain("older-late-msg");
+    expect(roomSubscriptionSince()).toBeLessThanOrEqual(START_SECONDS + 100);
+  });
+
   it("keeps every supported room for a second account after the first one saturates", async () => {
-    const errors: Error[] = [];
     const saturate = async (accountId: string) => {
       const channelIds = Array.from(
         { length: BUZZ_MAX_CONFIGURED_ROOMS },
@@ -405,7 +461,6 @@ describe("Buzz gateway cold-start recovery", () => {
         channelIds,
         nowSeconds: START_SECONDS,
         lookbackSeconds: LOOKBACK_SECONDS,
-        onError: (error) => errors.push(error),
       });
       return { store, sinceByRoom, lastChannelId: channelIds.at(-1) as string };
     };
@@ -413,33 +468,34 @@ describe("Buzz gateway cold-start recovery", () => {
     const first = await saturate(ACCOUNT_ID);
     const second = await saturate(SECOND_ACCOUNT_ID);
 
-    expect(errors).toEqual([]);
     expect(first.sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
     expect(second.sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
-    expect(await first.store?.lookup(`room:${first.lastChannelId}`)).toEqual({
+    expect(await first.store.lookup(`room:${first.lastChannelId}`)).toEqual({
       seconds: START_SECONDS,
     });
-    expect(await second.store?.lookup(`room:${second.lastChannelId}`)).toEqual({
+    expect(await second.store.lookup(`room:${second.lastChannelId}`)).toEqual({
       seconds: START_SECONDS,
     });
   });
 
-  it("keeps a second account cursor advance out of the first account rooms", async () => {
+  it("keeps room activation floors scoped to their account", async () => {
     const firstStore = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
     const secondStore = openBuzzRecoveryWatermarkStore({ accountId: SECOND_ACCOUNT_ID });
-    await advanceBuzzRecoveryWatermark({
+    await resolveBuzzColdStartSince({
       store: firstStore,
-      channelId: CHANNEL_ID,
-      seconds: START_SECONDS,
+      channelIds: [CHANNEL_ID],
+      nowSeconds: START_SECONDS,
+      lookbackSeconds: LOOKBACK_SECONDS,
     });
-    await advanceBuzzRecoveryWatermark({
+    await resolveBuzzColdStartSince({
       store: secondStore,
-      channelId: CHANNEL_ID,
-      seconds: START_SECONDS + 500,
+      channelIds: [CHANNEL_ID],
+      nowSeconds: START_SECONDS + 500,
+      lookbackSeconds: LOOKBACK_SECONDS,
     });
 
-    expect(await firstStore?.lookup(`room:${CHANNEL_ID}`)).toEqual({ seconds: START_SECONDS });
-    expect(await secondStore?.lookup(`room:${CHANNEL_ID}`)).toEqual({
+    expect(await firstStore.lookup(`room:${CHANNEL_ID}`)).toEqual({ seconds: START_SECONDS });
+    expect(await secondStore.lookup(`room:${CHANNEL_ID}`)).toEqual({
       seconds: START_SECONDS + 500,
     });
   });
@@ -476,10 +532,9 @@ describe("Buzz gateway cold-start recovery", () => {
     for (const settler of settlers) {
       settler.settle();
     }
-    await waitForSettled(async () => (await readWatermark()) !== undefined);
-    expect(await readWatermark()).toBeLessThanOrEqual(START_SECONDS + 100);
     gatewayProcess.abort.abort();
     await gatewayProcess.lifecycle;
+    expect(await readWatermark()).toBe(START_SECONDS);
 
     openProcessBoundary();
     advanceSeconds(600);
@@ -487,15 +542,13 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(handled).toContain(queuedText);
   });
 
-  it("clamps a stale watermark to the retention floor", async () => {
+  it("clamps a stale room activation floor to the existing recovery lookback", async () => {
     await runGatewayProcess();
 
     openProcessBoundary();
     postRoomMessage("live-msg", START_SECONDS + 10);
     advanceSeconds(600);
-    await runGatewayProcess({
-      until: async () => (await readWatermark()) === START_SECONDS + 10,
-    });
+    await runGatewayProcess({ until: () => handled.includes("live-msg") });
 
     openProcessBoundary();
     advanceSeconds(72 * 60 * 60);
@@ -512,30 +565,7 @@ describe("Buzz gateway cold-start recovery", () => {
     await process.lifecycle;
   });
 
-  it("holds the watermark behind an unfinished older message", async () => {
-    await runGatewayProcess();
-
-    openProcessBoundary();
-    postRoomMessage("older-msg", START_SECONDS + 100);
-    postRoomMessage("newer-msg", START_SECONDS + 200);
-    const older = gateHandler("older-msg");
-    advanceSeconds(600);
-    const gatewayProcess = startGatewayProcess();
-    await waitForSettled(() => handled.includes("older-msg") && handled.includes("newer-msg"));
-    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 100);
-
-    older.settle();
-    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 200);
-    gatewayProcess.abort.abort();
-    await gatewayProcess.lifecycle;
-
-    openProcessBoundary();
-    advanceSeconds(600);
-    await runGatewayProcess();
-    expect(roomSubscriptionSince()).toBe(START_SECONDS + 200);
-  });
-
-  it("never advances the watermark past locally observed time", async () => {
+  it("recovers downtime messages after a sender supplies a future timestamp", async () => {
     await runGatewayProcess();
 
     openProcessBoundary();
@@ -543,10 +573,10 @@ describe("Buzz gateway cold-start recovery", () => {
     postRoomMessage("future-msg", START_SECONDS + 3_600);
     advanceSeconds(600);
     await runGatewayProcess({
-      until: async () => (await readWatermark()) === START_SECONDS + 600,
+      until: () => handled.includes("backlog-msg") && handled.includes("future-msg"),
     });
     expect(handled).toEqual(expect.arrayContaining(["backlog-msg", "future-msg"]));
-    expect(await readWatermark()).toBeLessThanOrEqual(nowSeconds());
+    expect(await readWatermark()).toBe(START_SECONDS);
 
     openProcessBoundary();
     postRoomMessage("outage-msg", START_SECONDS + 900);
@@ -555,7 +585,7 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(handled).toContain("outage-msg");
   });
 
-  it("holds the watermark behind a message whose handling failed", async () => {
+  it("retries a previously failed room message after a process restart", async () => {
     await runGatewayProcess();
 
     openProcessBoundary();
@@ -568,14 +598,13 @@ describe("Buzz gateway cold-start recovery", () => {
     await waitForSettled(() => handled.includes("fail-msg") && handled.includes("ok-msg"));
     failing.fail(new Error("agent dispatch failed"));
     succeeding.settle();
-    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 100);
     gatewayProcess.abort.abort();
     await gatewayProcess.lifecycle;
 
     openProcessBoundary();
     advanceSeconds(600);
     await runGatewayProcess({ until: () => handled.includes("fail-msg") });
-    expect(roomSubscriptionSince()).toBe(START_SECONDS + 100);
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
     expect(handled).toContain("fail-msg");
   });
 });

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -318,10 +318,9 @@ beforeEach(() => {
   } as never);
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ self: RELAY_PUBLIC_KEY, software: "https://github.com/block/buzz" }),
-    })),
+    vi.fn(async () =>
+      Response.json({ self: RELAY_PUBLIC_KEY, software: "https://github.com/block/buzz" }),
+    ),
   );
 });
 

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -1,6 +1,7 @@
-import fs from "node:fs";
-import os from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { finalizeEvent, getPublicKey, type Event, type Filter } from "nostr-tools";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createPluginStateKeyedStoreForTests,
@@ -8,43 +9,173 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelGatewayContext } from "../runtime-api.js";
-import type { BuzzBus } from "./buzz-bus.js";
 import type { BuzzInboundMessage } from "./message-event.js";
 import type { ResolvedBuzzAccount } from "./types.js";
 
-const coldStartMocks = vi.hoisted(() => ({
-  close: vi.fn(async () => {}),
-  busSendText: vi.fn(async () => "event-id"),
-  sendBuzzTextOneShot: vi.fn(async () => "standalone-event-id"),
-  startBuzzBus: vi.fn(),
-  onMessage: undefined as
-    | ((message: BuzzInboundMessage, bus: BuzzBus, signal?: AbortSignal) => Promise<void>)
-    | undefined,
+const relayMocks = vi.hoisted(() => ({
+  connect: vi.fn<() => Promise<void>>(),
+  auth: vi.fn<() => Promise<string>>(),
+  publish: vi.fn<(event: Event) => Promise<string>>(),
+  send: vi.fn<(message: string) => Promise<void>>(),
+  close: vi.fn(),
+  connected: true,
+  storedEvents: [] as Event[],
+  messageFilters: [] as Filter[],
+  dropSubscriptionReason: undefined as string | undefined,
 }));
 
-vi.mock("./buzz-bus.js", () => ({
-  sendBuzzTextOneShot: coldStartMocks.sendBuzzTextOneShot,
-  startBuzzBus: coldStartMocks.startBuzzBus,
+function matchesRelayFilter(event: Event, filter: Filter): boolean {
+  if (filter.kinds && !filter.kinds.includes(event.kind)) {
+    return false;
+  }
+  if (filter.authors && !filter.authors.includes(event.pubkey)) {
+    return false;
+  }
+  for (const [key, values] of Object.entries(filter)) {
+    if (!key.startsWith("#") || !Array.isArray(values)) {
+      continue;
+    }
+    const tagName = key.slice(1);
+    const tagValues = event.tags.filter((tag) => tag[0] === tagName).map((tag) => tag[1] ?? "");
+    if (!tagValues.some((value) => (values as string[]).includes(value))) {
+      return false;
+    }
+  }
+  if (filter.since !== undefined && event.created_at < filter.since) {
+    return false;
+  }
+  if (filter.until !== undefined && event.created_at > filter.until) {
+    return false;
+  }
+  return true;
+}
+
+function selectRelayEvents(filter: Filter): Event[] {
+  const matched = relayMocks.storedEvents
+    .filter((event) => matchesRelayFilter(event, filter))
+    .toSorted((left, right) => right.created_at - left.created_at);
+  return filter.limit === undefined ? matched : matched.slice(0, filter.limit);
+}
+
+vi.mock("nostr-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("nostr-tools")>();
+  return {
+    ...actual,
+    Relay: class {
+      onauth?: (template: unknown) => Promise<unknown>;
+      idleSince: number | undefined;
+      ongoingOperations = 0;
+      get connected() {
+        return relayMocks.connected;
+      }
+      connect = relayMocks.connect;
+      auth = relayMocks.auth;
+      publish = relayMocks.publish;
+      send = relayMocks.send;
+      close = relayMocks.close;
+      scheduleIdleClose = vi.fn();
+
+      prepareSubscription(
+        filters: Filter[],
+        handlers: {
+          onevent: (event: Event) => void;
+          oneose?: () => void;
+          onclose: (reason: string) => void;
+        },
+      ) {
+        let carriesMessages = false;
+        for (const filter of filters) {
+          if (filter.kinds?.includes(9)) {
+            relayMocks.messageFilters.push(filter);
+            carriesMessages = true;
+          }
+          for (const event of selectRelayEvents(filter)) {
+            handlers.onevent(event);
+          }
+        }
+        handlers.oneose?.();
+        if (carriesMessages && relayMocks.dropSubscriptionReason) {
+          const reason = relayMocks.dropSubscriptionReason;
+          relayMocks.dropSubscriptionReason = undefined;
+          queueMicrotask(() => {
+            handlers.onclose(reason);
+          });
+        }
+        return {
+          id: `sub:${relayMocks.messageFilters.length}`,
+          close: vi.fn(),
+          closed: false,
+        };
+      }
+    },
+  };
+});
+
+const inboundMocks = vi.hoisted(() => ({
+  handleBuzzInbound: vi.fn(),
 }));
 
 vi.mock("./inbound.js", () => ({
-  handleBuzzInbound: vi.fn(async () => {}),
+  handleBuzzInbound: inboundMocks.handleBuzzInbound,
 }));
 
 import { startBuzzGatewayAccount } from "./gateway.js";
+import { openBuzzRecoveryWatermarkStore } from "./recovery-watermark.js";
 import { setBuzzRuntime } from "./runtime.js";
 import { resolveBuzzAccount } from "./types.js";
 
+const BUZZ_MESSAGE_KIND = 9;
+const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
+const ACCOUNT_ID = "default";
 const CHANNEL_ID = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
 const PRIVATE_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const SENDER_PRIVATE_KEY = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+const SENDER_SECRET = Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex"));
+const BOT_PUBLIC_KEY = getPublicKey(Uint8Array.from(Buffer.from(PRIVATE_KEY, "hex")));
+const SENDER_PUBLIC_KEY = getPublicKey(SENDER_SECRET);
+const RELAY_PUBLIC_KEY = "f".repeat(64);
 const LOOKBACK_SECONDS = 24 * 60 * 60;
+const START_SECONDS = 1_800_000_000;
 
 let tempDir: string | undefined;
 let previousStateDir: string | undefined;
-let currentNowMs = 0;
+let currentNowMs = START_SECONDS * 1_000;
+let handled: string[] = [];
+let gates = new Map<string, Promise<void>>();
 
 function nowSeconds(): number {
   return Math.floor(currentNowMs / 1000);
+}
+
+function advanceSeconds(seconds: number): void {
+  currentNowMs += seconds * 1_000;
+}
+
+function gateHandler(text: string): { settle: () => void; fail: (error: Error) => void } {
+  let settle = () => {};
+  let fail = (_error: Error) => {};
+  gates.set(
+    text,
+    new Promise<void>((resolve, reject) => {
+      settle = resolve;
+      fail = reject;
+    }),
+  );
+  return { settle, fail };
+}
+
+function postRoomMessage(text: string, createdAt: number): void {
+  relayMocks.storedEvents.push(
+    finalizeEvent(
+      {
+        kind: BUZZ_MESSAGE_KIND,
+        content: text,
+        created_at: createdAt,
+        tags: [["h", CHANNEL_ID]],
+      },
+      SENDER_SECRET,
+    ),
+  );
 }
 
 function buildConfig(): OpenClawConfig {
@@ -59,7 +190,102 @@ function buildConfig(): OpenClawConfig {
   } as OpenClawConfig;
 }
 
-function installRuntime() {
+function startGatewayProcess(): { abort: AbortController; lifecycle: Promise<void> } {
+  const cfg = buildConfig();
+  const account = resolveBuzzAccount({ cfg });
+  const abort = new AbortController();
+  const ctx = {
+    cfg,
+    accountId: account.accountId,
+    account,
+    runtime: {},
+    abortSignal: abort.signal,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getStatus: vi.fn(),
+    setStatus: vi.fn(),
+  } as unknown as ChannelGatewayContext<ResolvedBuzzAccount>;
+  return { abort, lifecycle: startBuzzGatewayAccount(ctx) };
+}
+
+async function waitForSettled(predicate: () => boolean | Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+  throw new Error("timed out waiting for the Buzz gateway to settle");
+}
+
+async function runGatewayProcess(
+  params: { until?: () => boolean | Promise<boolean> } = {},
+): Promise<void> {
+  const gatewayProcess = startGatewayProcess();
+  await waitForSettled(() => relayMocks.messageFilters.length > 0);
+  if (params.until) {
+    await waitForSettled(params.until);
+  }
+  gatewayProcess.abort.abort();
+  await gatewayProcess.lifecycle;
+}
+
+function roomSubscriptionSince(): number {
+  const filter = relayMocks.messageFilters.at(0);
+  expect(filter?.since).toBeTypeOf("number");
+  return filter?.since as number;
+}
+
+async function readWatermark(): Promise<number | undefined> {
+  const store = openBuzzRecoveryWatermarkStore();
+  return (await store?.lookup(ACCOUNT_ID))?.seconds;
+}
+
+function openProcessBoundary(): void {
+  relayMocks.messageFilters.length = 0;
+  handled = [];
+  gates = new Map();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentNowMs = START_SECONDS * 1_000;
+  vi.spyOn(Date, "now").mockImplementation(() => currentNowMs);
+  previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  // openclaw-temp-dir: allow extension tests cannot import root test helpers.
+  tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-buzz-coldstart-"));
+  process.env.OPENCLAW_STATE_DIR = tempDir;
+  handled = [];
+  gates = new Map();
+  relayMocks.messageFilters.length = 0;
+  relayMocks.dropSubscriptionReason = undefined;
+  relayMocks.connected = true;
+  relayMocks.connect.mockResolvedValue();
+  relayMocks.auth.mockResolvedValue("ok");
+  relayMocks.publish.mockResolvedValue("");
+  relayMocks.send.mockResolvedValue();
+  relayMocks.storedEvents = [
+    {
+      id: "membership-1",
+      kind: BUZZ_ROOM_MEMBERSHIP_KIND,
+      pubkey: RELAY_PUBLIC_KEY,
+      created_at: START_SECONDS - 3_600,
+      content: "",
+      sig: "e".repeat(128),
+      tags: [
+        ["d", CHANNEL_ID],
+        ["p", BOT_PUBLIC_KEY, "", "bot"],
+        ["p", SENDER_PUBLIC_KEY, "", "member"],
+      ],
+    },
+  ];
+  inboundMocks.handleBuzzInbound.mockImplementation(
+    async ({ message }: { message: BuzzInboundMessage }) => {
+      handled.push(message.text);
+      await gates.get(message.text);
+    },
+  );
   setBuzzRuntime({
     agent: { resolveAgentIdentity: vi.fn().mockReturnValue(undefined) },
     channel: {
@@ -74,80 +300,18 @@ function installRuntime() {
         createPluginStateKeyedStoreForTests<T>("buzz", options),
     },
   } as never);
-}
-
-async function runGatewayProcess(params: {
-  deliver?: BuzzInboundMessage;
-}): Promise<{ since: number }> {
-  const cfg = buildConfig();
-  const account = resolveBuzzAccount({ cfg });
-  const abortController = new AbortController();
-  const ctx = {
-    cfg,
-    accountId: account.accountId,
-    account,
-    runtime: {},
-    abortSignal: abortController.signal,
-    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    getStatus: vi.fn(),
-    setStatus: vi.fn(),
-  } as unknown as ChannelGatewayContext<ResolvedBuzzAccount>;
-
-  const lifecycle = startBuzzGatewayAccount(ctx);
-  await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledOnce());
-  const since = coldStartMocks.startBuzzBus.mock.calls[0]?.[0].since as number;
-  if (params.deliver) {
-    await coldStartMocks.onMessage?.(
-      params.deliver,
-      {
-        publicKey: "a".repeat(64),
-        sendText: coldStartMocks.busSendText,
-        close: coldStartMocks.close,
-      },
-      abortController.signal,
-    );
-  }
-  abortController.abort();
-  await lifecycle;
-  return { since };
-}
-
-function buildMessage(createdAt: number): BuzzInboundMessage {
-  return {
-    id: `event-${createdAt}`,
-    senderPubkey: "b".repeat(64),
-    text: "outage message",
-    channelId: CHANNEL_ID,
-    createdAt,
-    mentionedPubkeys: [],
-  };
-}
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  currentNowMs = 1_800_000_000_000;
-  vi.spyOn(Date, "now").mockImplementation(() => currentNowMs);
-  previousStateDir = process.env.OPENCLAW_STATE_DIR;
-  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-buzz-coldstart-"));
-  process.env.OPENCLAW_STATE_DIR = tempDir;
-  coldStartMocks.onMessage = undefined;
-  installRuntime();
-  coldStartMocks.startBuzzBus.mockImplementation(
-    async (options: {
-      onMessage: (message: BuzzInboundMessage, bus: BuzzBus, signal?: AbortSignal) => Promise<void>;
-    }): Promise<BuzzBus> => {
-      coldStartMocks.onMessage = options.onMessage;
-      return {
-        publicKey: "a".repeat(64),
-        sendText: coldStartMocks.busSendText,
-        close: coldStartMocks.close,
-      };
-    },
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ self: RELAY_PUBLIC_KEY, software: "https://github.com/block/buzz" }),
+    })),
   );
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   resetPluginStateStoreForTests();
   if (previousStateDir === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
@@ -155,87 +319,127 @@ afterEach(() => {
     process.env.OPENCLAW_STATE_DIR = previousStateDir;
   }
   if (tempDir) {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    rmSync(tempDir, { recursive: true, force: true });
   }
   tempDir = undefined;
 });
 
 describe("Buzz gateway cold-start recovery", () => {
-  it("replays downtime messages after a process restart", async () => {
-    const startedAt = nowSeconds();
-    const first = await runGatewayProcess({});
-    expect(first.since).toBe(startedAt);
+  it("resumes from the persisted watermark after a process restart", async () => {
+    await runGatewayProcess();
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
 
-    const admittedAt = startedAt + 10;
-    coldStartMocks.startBuzzBus.mockClear();
-    await runGatewayProcess({ deliver: buildMessage(admittedAt) });
+    openProcessBoundary();
+    postRoomMessage("live-msg", START_SECONDS + 10);
+    advanceSeconds(600);
+    await runGatewayProcess({
+      until: async () => (await readWatermark()) === START_SECONDS + 10,
+    });
 
-    const outageAt = admittedAt + 60 * 60;
-    currentNowMs += 2 * 60 * 60 * 1_000;
-    coldStartMocks.startBuzzBus.mockClear();
-    const restarted = await runGatewayProcess({});
-    expect(restarted.since).toBe(admittedAt);
-    expect(restarted.since).toBeLessThanOrEqual(outageAt);
+    openProcessBoundary();
+    postRoomMessage("outage-msg", START_SECONDS + 3_610);
+    advanceSeconds(7_200);
+    await runGatewayProcess({ until: () => handled.includes("outage-msg") });
+    expect(roomSubscriptionSince()).toBe(START_SECONDS + 10);
+    expect(handled).toContain("outage-msg");
   });
 
   it("keeps the first-ever start at the current time", async () => {
-    const startedAt = nowSeconds();
-    const first = await runGatewayProcess({});
-    expect(first.since).toBe(startedAt);
+    postRoomMessage("older-than-setup", START_SECONDS - 60);
+    await runGatewayProcess();
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
+    expect(handled).toEqual([]);
   });
 
   it("clamps a stale watermark to the retention floor", async () => {
-    const startedAt = nowSeconds();
-    await runGatewayProcess({});
-    coldStartMocks.startBuzzBus.mockClear();
-    await runGatewayProcess({ deliver: buildMessage(startedAt + 10) });
+    await runGatewayProcess();
 
-    currentNowMs += 72 * 60 * 60 * 1_000;
-    coldStartMocks.startBuzzBus.mockClear();
-    const restarted = await runGatewayProcess({});
-    expect(restarted.since).toBe(nowSeconds() - LOOKBACK_SECONDS);
+    openProcessBoundary();
+    postRoomMessage("live-msg", START_SECONDS + 10);
+    advanceSeconds(600);
+    await runGatewayProcess({
+      until: async () => (await readWatermark()) === START_SECONDS + 10,
+    });
+
+    openProcessBoundary();
+    advanceSeconds(72 * 60 * 60);
+    await runGatewayProcess();
+    expect(roomSubscriptionSince()).toBe(nowSeconds() - LOOKBACK_SECONDS);
   });
 
   it("keeps the full backlog lookback on an in-process reconnect", async () => {
-    const cfg = buildConfig();
-    const account = resolveBuzzAccount({ cfg });
-    const abortController = new AbortController();
-    let reportFatal: ((error: Error) => void) | undefined;
-    coldStartMocks.startBuzzBus.mockImplementation(
-      async (options: {
-        onMessage: (message: BuzzInboundMessage, bus: BuzzBus) => Promise<void>;
-        onFatalError?: (error: Error) => void;
-      }): Promise<BuzzBus> => {
-        coldStartMocks.onMessage = options.onMessage;
-        reportFatal = options.onFatalError;
-        return {
-          publicKey: "a".repeat(64),
-          sendText: coldStartMocks.busSendText,
-          close: coldStartMocks.close,
-        };
-      },
-    );
-    const ctx = {
-      cfg,
-      accountId: account.accountId,
-      account,
-      runtime: {},
-      abortSignal: abortController.signal,
-      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getStatus: vi.fn(),
-      setStatus: vi.fn(),
-    } as unknown as ChannelGatewayContext<ResolvedBuzzAccount>;
+    relayMocks.dropSubscriptionReason = "relay dropped the subscription";
+    const process = startGatewayProcess();
+    await waitForSettled(() => relayMocks.messageFilters.length >= 2);
+    expect(relayMocks.messageFilters.at(1)?.since).toBe(nowSeconds() - LOOKBACK_SECONDS);
+    process.abort.abort();
+    await process.lifecycle;
+  });
 
-    const lifecycle = startBuzzGatewayAccount(ctx);
-    await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledOnce());
-    reportFatal?.(new Error("relay failed"));
-    await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
-      timeout: 5_000,
+  it("holds the watermark behind an unfinished older message", async () => {
+    await runGatewayProcess();
+
+    openProcessBoundary();
+    postRoomMessage("older-msg", START_SECONDS + 100);
+    postRoomMessage("newer-msg", START_SECONDS + 200);
+    const older = gateHandler("older-msg");
+    advanceSeconds(600);
+    const gatewayProcess = startGatewayProcess();
+    await waitForSettled(() => handled.includes("older-msg") && handled.includes("newer-msg"));
+    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 100);
+
+    older.settle();
+    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 200);
+    gatewayProcess.abort.abort();
+    await gatewayProcess.lifecycle;
+
+    openProcessBoundary();
+    advanceSeconds(600);
+    await runGatewayProcess();
+    expect(roomSubscriptionSince()).toBe(START_SECONDS + 200);
+  });
+
+  it("never advances the watermark past locally observed time", async () => {
+    await runGatewayProcess();
+
+    openProcessBoundary();
+    postRoomMessage("backlog-msg", START_SECONDS + 300);
+    postRoomMessage("future-msg", START_SECONDS + 3_600);
+    advanceSeconds(600);
+    await runGatewayProcess({
+      until: async () => (await readWatermark()) === START_SECONDS + 600,
     });
-    const reconnectSince = coldStartMocks.startBuzzBus.mock.calls[1]?.[0].since as number;
-    expect(reconnectSince).toBe(nowSeconds() - LOOKBACK_SECONDS);
+    expect(handled).toEqual(expect.arrayContaining(["backlog-msg", "future-msg"]));
+    expect(await readWatermark()).toBeLessThanOrEqual(nowSeconds());
 
-    abortController.abort();
-    await lifecycle;
+    openProcessBoundary();
+    postRoomMessage("outage-msg", START_SECONDS + 900);
+    advanceSeconds(6_600);
+    await runGatewayProcess({ until: () => handled.includes("outage-msg") });
+    expect(handled).toContain("outage-msg");
+  });
+
+  it("holds the watermark behind a message whose handling failed", async () => {
+    await runGatewayProcess();
+
+    openProcessBoundary();
+    postRoomMessage("fail-msg", START_SECONDS + 100);
+    postRoomMessage("ok-msg", START_SECONDS + 200);
+    const failing = gateHandler("fail-msg");
+    const succeeding = gateHandler("ok-msg");
+    advanceSeconds(600);
+    const gatewayProcess = startGatewayProcess();
+    await waitForSettled(() => handled.includes("fail-msg") && handled.includes("ok-msg"));
+    failing.fail(new Error("agent dispatch failed"));
+    succeeding.settle();
+    await waitForSettled(async () => (await readWatermark()) === START_SECONDS + 100);
+    gatewayProcess.abort.abort();
+    await gatewayProcess.lifecycle;
+
+    openProcessBoundary();
+    advanceSeconds(600);
+    await runGatewayProcess({ until: () => handled.includes("fail-msg") });
+    expect(roomSubscriptionSince()).toBe(START_SECONDS + 100);
+    expect(handled).toContain("fail-msg");
   });
 });

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelGatewayContext } from "../runtime-api.js";
+import type { BuzzBus } from "./buzz-bus.js";
+import type { BuzzInboundMessage } from "./message-event.js";
+import type { ResolvedBuzzAccount } from "./types.js";
+
+const coldStartMocks = vi.hoisted(() => ({
+  close: vi.fn(async () => {}),
+  busSendText: vi.fn(async () => "event-id"),
+  sendBuzzTextOneShot: vi.fn(async () => "standalone-event-id"),
+  startBuzzBus: vi.fn(),
+  onMessage: undefined as
+    | ((message: BuzzInboundMessage, bus: BuzzBus, signal?: AbortSignal) => Promise<void>)
+    | undefined,
+}));
+
+vi.mock("./buzz-bus.js", () => ({
+  sendBuzzTextOneShot: coldStartMocks.sendBuzzTextOneShot,
+  startBuzzBus: coldStartMocks.startBuzzBus,
+}));
+
+vi.mock("./inbound.js", () => ({
+  handleBuzzInbound: vi.fn(async () => {}),
+}));
+
+import { startBuzzGatewayAccount } from "./gateway.js";
+import { setBuzzRuntime } from "./runtime.js";
+import { resolveBuzzAccount } from "./types.js";
+
+const CHANNEL_ID = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
+const PRIVATE_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const LOOKBACK_SECONDS = 24 * 60 * 60;
+
+let tempDir: string | undefined;
+let previousStateDir: string | undefined;
+let currentNowMs = 0;
+
+function nowSeconds(): number {
+  return Math.floor(currentNowMs / 1000);
+}
+
+function buildConfig(): OpenClawConfig {
+  return {
+    channels: {
+      buzz: {
+        relayUrl: "wss://buzz.example.com",
+        privateKey: PRIVATE_KEY,
+        groups: { [CHANNEL_ID]: {} },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function installRuntime() {
+  setBuzzRuntime({
+    agent: { resolveAgentIdentity: vi.fn().mockReturnValue(undefined) },
+    channel: {
+      routing: { resolveAgentRoute: vi.fn().mockReturnValue({ agentId: "main" }) },
+      text: {
+        resolveMarkdownTableMode: () => "preserve",
+        convertMarkdownTables: (text: string) => text,
+      },
+    },
+    state: {
+      openKeyedStore: <T>(options: Parameters<typeof createPluginStateKeyedStoreForTests>[1]) =>
+        createPluginStateKeyedStoreForTests<T>("buzz", options),
+    },
+  } as never);
+}
+
+async function runGatewayProcess(params: {
+  deliver?: BuzzInboundMessage;
+}): Promise<{ since: number }> {
+  const cfg = buildConfig();
+  const account = resolveBuzzAccount({ cfg });
+  const abortController = new AbortController();
+  const ctx = {
+    cfg,
+    accountId: account.accountId,
+    account,
+    runtime: {},
+    abortSignal: abortController.signal,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getStatus: vi.fn(),
+    setStatus: vi.fn(),
+  } as unknown as ChannelGatewayContext<ResolvedBuzzAccount>;
+
+  const lifecycle = startBuzzGatewayAccount(ctx);
+  await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledOnce());
+  const since = coldStartMocks.startBuzzBus.mock.calls[0]?.[0].since as number;
+  if (params.deliver) {
+    await coldStartMocks.onMessage?.(
+      params.deliver,
+      {
+        publicKey: "a".repeat(64),
+        sendText: coldStartMocks.busSendText,
+        close: coldStartMocks.close,
+      },
+      abortController.signal,
+    );
+  }
+  abortController.abort();
+  await lifecycle;
+  return { since };
+}
+
+function buildMessage(createdAt: number): BuzzInboundMessage {
+  return {
+    id: `event-${createdAt}`,
+    senderPubkey: "b".repeat(64),
+    text: "outage message",
+    channelId: CHANNEL_ID,
+    createdAt,
+    mentionedPubkeys: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentNowMs = 1_800_000_000_000;
+  vi.spyOn(Date, "now").mockImplementation(() => currentNowMs);
+  previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-buzz-coldstart-"));
+  process.env.OPENCLAW_STATE_DIR = tempDir;
+  coldStartMocks.onMessage = undefined;
+  installRuntime();
+  coldStartMocks.startBuzzBus.mockImplementation(
+    async (options: {
+      onMessage: (message: BuzzInboundMessage, bus: BuzzBus, signal?: AbortSignal) => Promise<void>;
+    }): Promise<BuzzBus> => {
+      coldStartMocks.onMessage = options.onMessage;
+      return {
+        publicKey: "a".repeat(64),
+        sendText: coldStartMocks.busSendText,
+        close: coldStartMocks.close,
+      };
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetPluginStateStoreForTests();
+  if (previousStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = previousStateDir;
+  }
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  tempDir = undefined;
+});
+
+describe("Buzz gateway cold-start recovery", () => {
+  it("replays downtime messages after a process restart", async () => {
+    const startedAt = nowSeconds();
+    const first = await runGatewayProcess({});
+    expect(first.since).toBe(startedAt);
+
+    const admittedAt = startedAt + 10;
+    coldStartMocks.startBuzzBus.mockClear();
+    await runGatewayProcess({ deliver: buildMessage(admittedAt) });
+
+    const outageAt = admittedAt + 60 * 60;
+    currentNowMs += 2 * 60 * 60 * 1_000;
+    coldStartMocks.startBuzzBus.mockClear();
+    const restarted = await runGatewayProcess({});
+    expect(restarted.since).toBe(admittedAt);
+    expect(restarted.since).toBeLessThanOrEqual(outageAt);
+  });
+
+  it("keeps the first-ever start at the current time", async () => {
+    const startedAt = nowSeconds();
+    const first = await runGatewayProcess({});
+    expect(first.since).toBe(startedAt);
+  });
+
+  it("clamps a stale watermark to the retention floor", async () => {
+    const startedAt = nowSeconds();
+    await runGatewayProcess({});
+    coldStartMocks.startBuzzBus.mockClear();
+    await runGatewayProcess({ deliver: buildMessage(startedAt + 10) });
+
+    currentNowMs += 72 * 60 * 60 * 1_000;
+    coldStartMocks.startBuzzBus.mockClear();
+    const restarted = await runGatewayProcess({});
+    expect(restarted.since).toBe(nowSeconds() - LOOKBACK_SECONDS);
+  });
+
+  it("keeps the full backlog lookback on an in-process reconnect", async () => {
+    const cfg = buildConfig();
+    const account = resolveBuzzAccount({ cfg });
+    const abortController = new AbortController();
+    let reportFatal: ((error: Error) => void) | undefined;
+    coldStartMocks.startBuzzBus.mockImplementation(
+      async (options: {
+        onMessage: (message: BuzzInboundMessage, bus: BuzzBus) => Promise<void>;
+        onFatalError?: (error: Error) => void;
+      }): Promise<BuzzBus> => {
+        coldStartMocks.onMessage = options.onMessage;
+        reportFatal = options.onFatalError;
+        return {
+          publicKey: "a".repeat(64),
+          sendText: coldStartMocks.busSendText,
+          close: coldStartMocks.close,
+        };
+      },
+    );
+    const ctx = {
+      cfg,
+      accountId: account.accountId,
+      account,
+      runtime: {},
+      abortSignal: abortController.signal,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getStatus: vi.fn(),
+      setStatus: vi.fn(),
+    } as unknown as ChannelGatewayContext<ResolvedBuzzAccount>;
+
+    const lifecycle = startBuzzGatewayAccount(ctx);
+    await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledOnce());
+    reportFatal?.(new Error("relay failed"));
+    await vi.waitFor(() => expect(coldStartMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
+      timeout: 5_000,
+    });
+    const reconnectSince = coldStartMocks.startBuzzBus.mock.calls[1]?.[0].since as number;
+    expect(reconnectSince).toBe(nowSeconds() - LOOKBACK_SECONDS);
+
+    abortController.abort();
+    await lifecycle;
+  });
+});

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -120,8 +120,9 @@ vi.mock("./inbound.js", () => ({
 }));
 
 import { startBuzzGatewayAccount } from "./gateway.js";
-import { openBuzzRecoveryWatermarkStore } from "./recovery-watermark.js";
+import { openBuzzRecoveryWatermarkStore, resolveBuzzColdStartSince } from "./recovery-watermark.js";
 import { setBuzzRuntime } from "./runtime.js";
+import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 import { resolveBuzzAccount } from "./types.js";
 
 const BUZZ_MESSAGE_KIND = 9;
@@ -338,7 +339,7 @@ afterEach(() => {
 describe("Buzz gateway cold-start recovery", () => {
   it("resumes from the persisted watermark after a process restart", async () => {
     await runGatewayProcess();
-    expect(roomSubscriptionSince()).toBe(START_SECONDS - LOOKBACK_SECONDS);
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
 
     openProcessBoundary();
     postRoomMessage("live-msg", START_SECONDS + 10);
@@ -355,13 +356,36 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(handled).toContain("outage-msg");
   });
 
-  it("recovers the retention window on the first start after an upgrade", async () => {
-    postRoomMessage("downtime-msg", START_SECONDS - 60);
-    postRoomMessage("beyond-retention-msg", START_SECONDS - LOOKBACK_SECONDS - 60);
-    await runGatewayProcess({ until: () => handled.includes("downtime-msg") });
-    expect(roomSubscriptionSince()).toBe(START_SECONDS - LOOKBACK_SECONDS);
-    expect(handled).toContain("downtime-msg");
-    expect(handled).not.toContain("beyond-retention-msg");
+  it("keeps an account with no cursor at the current time on its first start", async () => {
+    postRoomMessage("existing-room-history", START_SECONDS - 60);
+    await runGatewayProcess();
+    expect(roomSubscriptionSince()).toBe(START_SECONDS);
+    expect(handled).not.toContain("existing-room-history");
+    expect(await readWatermark()).toBe(START_SECONDS);
+  });
+
+  it("registers a cursor for every supported room", async () => {
+    const store = openBuzzRecoveryWatermarkStore();
+    const channelIds = Array.from(
+      { length: BUZZ_MAX_CONFIGURED_ROOMS },
+      (_value, index) => `room-${index}`,
+    );
+    const errors: Error[] = [];
+    const sinceByRoom = await resolveBuzzColdStartSince({
+      store,
+      accountId: ACCOUNT_ID,
+      channelIds,
+      nowSeconds: START_SECONDS,
+      lookbackSeconds: LOOKBACK_SECONDS,
+      onError: (error) => errors.push(error),
+    });
+
+    expect(errors).toEqual([]);
+    expect(sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
+    const lastChannelId = channelIds.at(-1) as string;
+    expect(await store?.lookup(`room:${ACCOUNT_ID}:${lastChannelId}`)).toEqual({
+      seconds: START_SECONDS,
+    });
   });
 
   it("keeps a room configured after the first start at the current time", async () => {
@@ -373,7 +397,7 @@ describe("Buzz gateway cold-start recovery", () => {
     await runGatewayProcess({ channelIds: [CHANNEL_ID, SECOND_CHANNEL_ID] });
     expect(roomSubscriptionSince(SECOND_CHANNEL_ID)).toBe(nowSeconds());
     expect(handled).not.toContain("before-second-room-setup");
-    expect(roomSubscriptionSince(CHANNEL_ID)).toBe(nowSeconds() - LOOKBACK_SECONDS);
+    expect(roomSubscriptionSince(CHANNEL_ID)).toBe(START_SECONDS);
   });
 
   it("recovers a replay message still queued when the process stops", async () => {

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -120,7 +120,11 @@ vi.mock("./inbound.js", () => ({
 }));
 
 import { startBuzzGatewayAccount } from "./gateway.js";
-import { openBuzzRecoveryWatermarkStore, resolveBuzzColdStartSince } from "./recovery-watermark.js";
+import {
+  advanceBuzzRecoveryWatermark,
+  openBuzzRecoveryWatermarkStore,
+  resolveBuzzColdStartSince,
+} from "./recovery-watermark.js";
 import { setBuzzRuntime } from "./runtime.js";
 import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 import { resolveBuzzAccount } from "./types.js";
@@ -128,6 +132,7 @@ import { resolveBuzzAccount } from "./types.js";
 const BUZZ_MESSAGE_KIND = 9;
 const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
 const ACCOUNT_ID = "default";
+const SECOND_ACCOUNT_ID = "second";
 const CHANNEL_ID = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
 const SECOND_CHANNEL_ID = "1b8f5c33-9a21-4d0e-8f77-2b6c1d4e5a90";
 const PRIVATE_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -262,8 +267,8 @@ function roomSubscriptionSince(channelId = CHANNEL_ID): number {
 }
 
 async function readWatermark(channelId = CHANNEL_ID): Promise<number | undefined> {
-  const store = openBuzzRecoveryWatermarkStore();
-  return (await store?.lookup(`room:${ACCOUNT_ID}:${channelId}`))?.seconds;
+  const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
+  return (await store?.lookup(`room:${channelId}`))?.seconds;
 }
 
 function openProcessBoundary(): void {
@@ -365,7 +370,7 @@ describe("Buzz gateway cold-start recovery", () => {
   });
 
   it("registers a cursor for every supported room", async () => {
-    const store = openBuzzRecoveryWatermarkStore();
+    const store = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
     const channelIds = Array.from(
       { length: BUZZ_MAX_CONFIGURED_ROOMS },
       (_value, index) => `room-${index}`,
@@ -373,7 +378,6 @@ describe("Buzz gateway cold-start recovery", () => {
     const errors: Error[] = [];
     const sinceByRoom = await resolveBuzzColdStartSince({
       store,
-      accountId: ACCOUNT_ID,
       channelIds,
       nowSeconds: START_SECONDS,
       lookbackSeconds: LOOKBACK_SECONDS,
@@ -383,8 +387,60 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(errors).toEqual([]);
     expect(sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
     const lastChannelId = channelIds.at(-1) as string;
-    expect(await store?.lookup(`room:${ACCOUNT_ID}:${lastChannelId}`)).toEqual({
+    expect(await store?.lookup(`room:${lastChannelId}`)).toEqual({
       seconds: START_SECONDS,
+    });
+  });
+
+  it("keeps every supported room for a second account after the first one saturates", async () => {
+    const errors: Error[] = [];
+    const saturate = async (accountId: string) => {
+      const channelIds = Array.from(
+        { length: BUZZ_MAX_CONFIGURED_ROOMS },
+        (_value, index) => `${accountId}-room-${index}`,
+      );
+      const store = openBuzzRecoveryWatermarkStore({ accountId });
+      const sinceByRoom = await resolveBuzzColdStartSince({
+        store,
+        channelIds,
+        nowSeconds: START_SECONDS,
+        lookbackSeconds: LOOKBACK_SECONDS,
+        onError: (error) => errors.push(error),
+      });
+      return { store, sinceByRoom, lastChannelId: channelIds.at(-1) as string };
+    };
+
+    const first = await saturate(ACCOUNT_ID);
+    const second = await saturate(SECOND_ACCOUNT_ID);
+
+    expect(errors).toEqual([]);
+    expect(first.sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
+    expect(second.sinceByRoom.size).toBe(BUZZ_MAX_CONFIGURED_ROOMS);
+    expect(await first.store?.lookup(`room:${first.lastChannelId}`)).toEqual({
+      seconds: START_SECONDS,
+    });
+    expect(await second.store?.lookup(`room:${second.lastChannelId}`)).toEqual({
+      seconds: START_SECONDS,
+    });
+  });
+
+  it("keeps a second account cursor advance out of the first account rooms", async () => {
+    const firstStore = openBuzzRecoveryWatermarkStore({ accountId: ACCOUNT_ID });
+    const secondStore = openBuzzRecoveryWatermarkStore({ accountId: SECOND_ACCOUNT_ID });
+    await advanceBuzzRecoveryWatermark({
+      store: firstStore,
+      channelId: CHANNEL_ID,
+      seconds: START_SECONDS,
+    });
+    await advanceBuzzRecoveryWatermark({
+      store: secondStore,
+      channelId: CHANNEL_ID,
+      seconds: START_SECONDS + 500,
+    });
+
+    expect(await firstStore?.lookup(`room:${CHANNEL_ID}`)).toEqual({ seconds: START_SECONDS });
+    expect(await secondStore?.lookup(`room:${CHANNEL_ID}`)).toEqual({
+      seconds: START_SECONDS + 500,
     });
   });
 

--- a/extensions/buzz/src/gateway.cold-start-recovery.test.ts
+++ b/extensions/buzz/src/gateway.cold-start-recovery.test.ts
@@ -128,6 +128,7 @@ const BUZZ_MESSAGE_KIND = 9;
 const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
 const ACCOUNT_ID = "default";
 const CHANNEL_ID = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
+const SECOND_CHANNEL_ID = "1b8f5c33-9a21-4d0e-8f77-2b6c1d4e5a90";
 const PRIVATE_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 const SENDER_PRIVATE_KEY = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
 const SENDER_SECRET = Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex"));
@@ -164,34 +165,53 @@ function gateHandler(text: string): { settle: () => void; fail: (error: Error) =
   return { settle, fail };
 }
 
-function postRoomMessage(text: string, createdAt: number): void {
+function postRoomMessage(text: string, createdAt: number, channelId = CHANNEL_ID): void {
   relayMocks.storedEvents.push(
     finalizeEvent(
       {
         kind: BUZZ_MESSAGE_KIND,
         content: text,
         created_at: createdAt,
-        tags: [["h", CHANNEL_ID]],
+        tags: [["h", channelId]],
       },
       SENDER_SECRET,
     ),
   );
 }
 
-function buildConfig(): OpenClawConfig {
+function publishRoomMembership(channelId: string): void {
+  relayMocks.storedEvents.push({
+    id: `membership-${channelId}`,
+    kind: BUZZ_ROOM_MEMBERSHIP_KIND,
+    pubkey: RELAY_PUBLIC_KEY,
+    created_at: START_SECONDS - 3_600,
+    content: "",
+    sig: "e".repeat(128),
+    tags: [
+      ["d", channelId],
+      ["p", BOT_PUBLIC_KEY, "", "bot"],
+      ["p", SENDER_PUBLIC_KEY, "", "member"],
+    ],
+  });
+}
+
+function buildConfig(channelIds: string[]): OpenClawConfig {
   return {
     channels: {
       buzz: {
         relayUrl: "wss://buzz.example.com",
         privateKey: PRIVATE_KEY,
-        groups: { [CHANNEL_ID]: {} },
+        groups: Object.fromEntries(channelIds.map((channelId) => [channelId, {}])),
       },
     },
   } as OpenClawConfig;
 }
 
-function startGatewayProcess(): { abort: AbortController; lifecycle: Promise<void> } {
-  const cfg = buildConfig();
+function startGatewayProcess(channelIds: string[] = [CHANNEL_ID]): {
+  abort: AbortController;
+  lifecycle: Promise<void>;
+} {
+  const cfg = buildConfig(channelIds);
   const account = resolveBuzzAccount({ cfg });
   const abort = new AbortController();
   const ctx = {
@@ -220,10 +240,11 @@ async function waitForSettled(predicate: () => boolean | Promise<boolean>): Prom
 }
 
 async function runGatewayProcess(
-  params: { until?: () => boolean | Promise<boolean> } = {},
+  params: { until?: () => boolean | Promise<boolean>; channelIds?: string[] } = {},
 ): Promise<void> {
-  const gatewayProcess = startGatewayProcess();
-  await waitForSettled(() => relayMocks.messageFilters.length > 0);
+  const channelIds = params.channelIds ?? [CHANNEL_ID];
+  const gatewayProcess = startGatewayProcess(channelIds);
+  await waitForSettled(() => relayMocks.messageFilters.length >= channelIds.length);
   if (params.until) {
     await waitForSettled(params.until);
   }
@@ -231,15 +252,17 @@ async function runGatewayProcess(
   await gatewayProcess.lifecycle;
 }
 
-function roomSubscriptionSince(): number {
-  const filter = relayMocks.messageFilters.at(0);
+function roomSubscriptionSince(channelId = CHANNEL_ID): number {
+  const filter = relayMocks.messageFilters.find((entry) =>
+    (entry["#h"] as string[] | undefined)?.includes(channelId),
+  );
   expect(filter?.since).toBeTypeOf("number");
   return filter?.since as number;
 }
 
-async function readWatermark(): Promise<number | undefined> {
+async function readWatermark(channelId = CHANNEL_ID): Promise<number | undefined> {
   const store = openBuzzRecoveryWatermarkStore();
-  return (await store?.lookup(ACCOUNT_ID))?.seconds;
+  return (await store?.lookup(`room:${ACCOUNT_ID}:${channelId}`))?.seconds;
 }
 
 function openProcessBoundary(): void {
@@ -265,21 +288,9 @@ beforeEach(() => {
   relayMocks.auth.mockResolvedValue("ok");
   relayMocks.publish.mockResolvedValue("");
   relayMocks.send.mockResolvedValue();
-  relayMocks.storedEvents = [
-    {
-      id: "membership-1",
-      kind: BUZZ_ROOM_MEMBERSHIP_KIND,
-      pubkey: RELAY_PUBLIC_KEY,
-      created_at: START_SECONDS - 3_600,
-      content: "",
-      sig: "e".repeat(128),
-      tags: [
-        ["d", CHANNEL_ID],
-        ["p", BOT_PUBLIC_KEY, "", "bot"],
-        ["p", SENDER_PUBLIC_KEY, "", "member"],
-      ],
-    },
-  ];
+  relayMocks.storedEvents = [];
+  publishRoomMembership(CHANNEL_ID);
+  publishRoomMembership(SECOND_CHANNEL_ID);
   inboundMocks.handleBuzzInbound.mockImplementation(
     async ({ message }: { message: BuzzInboundMessage }) => {
       handled.push(message.text);
@@ -327,7 +338,7 @@ afterEach(() => {
 describe("Buzz gateway cold-start recovery", () => {
   it("resumes from the persisted watermark after a process restart", async () => {
     await runGatewayProcess();
-    expect(roomSubscriptionSince()).toBe(START_SECONDS);
+    expect(roomSubscriptionSince()).toBe(START_SECONDS - LOOKBACK_SECONDS);
 
     openProcessBoundary();
     postRoomMessage("live-msg", START_SECONDS + 10);
@@ -344,11 +355,56 @@ describe("Buzz gateway cold-start recovery", () => {
     expect(handled).toContain("outage-msg");
   });
 
-  it("keeps the first-ever start at the current time", async () => {
-    postRoomMessage("older-than-setup", START_SECONDS - 60);
+  it("recovers the retention window on the first start after an upgrade", async () => {
+    postRoomMessage("downtime-msg", START_SECONDS - 60);
+    postRoomMessage("beyond-retention-msg", START_SECONDS - LOOKBACK_SECONDS - 60);
+    await runGatewayProcess({ until: () => handled.includes("downtime-msg") });
+    expect(roomSubscriptionSince()).toBe(START_SECONDS - LOOKBACK_SECONDS);
+    expect(handled).toContain("downtime-msg");
+    expect(handled).not.toContain("beyond-retention-msg");
+  });
+
+  it("keeps a room configured after the first start at the current time", async () => {
     await runGatewayProcess();
-    expect(roomSubscriptionSince()).toBe(START_SECONDS);
-    expect(handled).toEqual([]);
+
+    openProcessBoundary();
+    postRoomMessage("before-second-room-setup", START_SECONDS + 60, SECOND_CHANNEL_ID);
+    advanceSeconds(600);
+    await runGatewayProcess({ channelIds: [CHANNEL_ID, SECOND_CHANNEL_ID] });
+    expect(roomSubscriptionSince(SECOND_CHANNEL_ID)).toBe(nowSeconds());
+    expect(handled).not.toContain("before-second-room-setup");
+    expect(roomSubscriptionSince(CHANNEL_ID)).toBe(nowSeconds() - LOOKBACK_SECONDS);
+  });
+
+  it("recovers a replay message still queued when the process stops", async () => {
+    await runGatewayProcess();
+
+    openProcessBoundary();
+    const queuedText = "queued-msg";
+    postRoomMessage(queuedText, START_SECONDS + 100);
+    gateHandler(queuedText);
+    const settlers = [];
+    for (let index = 0; index < 8; index += 1) {
+      const text = `running-msg-${index}`;
+      postRoomMessage(text, START_SECONDS + 200 + index);
+      settlers.push(gateHandler(text));
+    }
+    advanceSeconds(600);
+    const gatewayProcess = startGatewayProcess();
+    await waitForSettled(() => handled.length === 8);
+    expect(handled).not.toContain(queuedText);
+    for (const settler of settlers) {
+      settler.settle();
+    }
+    await waitForSettled(async () => (await readWatermark()) !== undefined);
+    expect(await readWatermark()).toBeLessThanOrEqual(START_SECONDS + 100);
+    gatewayProcess.abort.abort();
+    await gatewayProcess.lifecycle;
+
+    openProcessBoundary();
+    advanceSeconds(600);
+    await runGatewayProcess({ until: () => handled.includes(queuedText) });
+    expect(handled).toContain(queuedText);
   });
 
   it("clamps a stale watermark to the retention floor", async () => {

--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -20,6 +20,7 @@ const gatewayMocks = vi.hoisted(() => ({
   onRoomDirectoryChanged: undefined as (() => void) | undefined,
   resolveAgentIdentity: vi.fn(),
   resolveAgentRoute: vi.fn(),
+  recoveryLookup: vi.fn(),
   startBuzzBus: vi.fn(),
 }));
 
@@ -140,6 +141,8 @@ describe("Buzz gateway lifecycle", () => {
     gatewayMocks.sendBuzzTextOneShot.mockResolvedValue("standalone-event-id");
     gatewayMocks.resolveAgentIdentity.mockReset().mockReturnValue(undefined);
     gatewayMocks.resolveAgentRoute.mockReset().mockReturnValue({ agentId: "main" });
+    const recoveryRooms = new Map<string, { seconds: number }>();
+    gatewayMocks.recoveryLookup.mockImplementation(async (key: string) => recoveryRooms.get(key));
     setBuzzRuntime({
       agent: {
         resolveAgentIdentity: gatewayMocks.resolveAgentIdentity,
@@ -152,6 +155,16 @@ describe("Buzz gateway lifecycle", () => {
           resolveMarkdownTableMode: () => "preserve",
           convertMarkdownTables: (text: string) => text,
         },
+      },
+      state: {
+        openKeyedStore: () => ({
+          lookup: gatewayMocks.recoveryLookup,
+          register: async (key: string, value: { seconds: number }) => {
+            recoveryRooms.set(key, value);
+          },
+          entries: async () => Array.from(recoveryRooms, ([key, value]) => ({ key, value })),
+          delete: async (key: string) => recoveryRooms.delete(key),
+        }),
       },
     } as never);
     gatewayMocks.startBuzzBus.mockImplementation(
@@ -190,6 +203,25 @@ describe("Buzz gateway lifecycle", () => {
     expect(invalidateDirectoryCache).toHaveBeenCalledOnce();
     gatewayMocks.onRoomDirectoryChanged?.();
     expect(invalidateDirectoryCache).toHaveBeenCalledTimes(2);
+
+    abortController.abort();
+    await expect(lifecycle).resolves.toBeUndefined();
+  });
+
+  it("reports unreadable recovery state without connecting or skipping room history", async () => {
+    gatewayMocks.recoveryLookup.mockRejectedValueOnce(new Error("room activation unreadable"));
+    const setStatus = vi.fn();
+    const { abortController, lifecycle } = startTestGateway({ setStatus });
+
+    await vi.waitFor(() =>
+      expect(setStatus).toHaveBeenCalledWith({
+        accountId: "default",
+        running: false,
+        lifecycle: "recovering",
+        lastError: "room activation unreadable",
+      }),
+    );
+    expect(gatewayMocks.startBuzzBus).not.toHaveBeenCalled();
 
     abortController.abort();
     await expect(lifecycle).resolves.toBeUndefined();

--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -121,6 +121,13 @@ function createMockBus(): BuzzBus {
   };
 }
 
+function resolveBusSince(callIndex: number): number {
+  const since = gatewayMocks.startBuzzBus.mock.calls[callIndex]?.[0].since as (
+    channelId: string,
+  ) => number;
+  return since(CHANNEL_ID);
+}
+
 describe("Buzz gateway lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -471,8 +478,8 @@ describe("Buzz gateway lifecycle", () => {
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
       timeout: 3_000,
     });
-    const firstSince = gatewayMocks.startBuzzBus.mock.calls[0]?.[0].since as number;
-    const secondSince = gatewayMocks.startBuzzBus.mock.calls[1]?.[0].since as number;
+    const firstSince = resolveBusSince(0);
+    const secondSince = resolveBusSince(1);
     expect(secondSince).toBeLessThanOrEqual(firstSince - 24 * 60 * 60 + 2);
 
     abortController.abort();
@@ -526,7 +533,7 @@ describe("Buzz gateway lifecycle", () => {
       timeout: 3_000,
     });
     expect(invalidateDirectoryCache).toHaveBeenCalledTimes(2);
-    const secondSince = gatewayMocks.startBuzzBus.mock.calls[1]?.[0].since as number;
+    const secondSince = resolveBusSince(1);
     expect(secondSince).toBeGreaterThanOrEqual(reconnectStartedAt - 24 * 60 * 60);
     expect(secondSince).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) - 24 * 60 * 60);
     expect(secondSince).toBeLessThan(createdAt);

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -7,12 +7,7 @@ import { computeBackoff, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env"
 import type { ChannelGatewayContext } from "../runtime-api.js";
 import { sendBuzzTextOneShot, startBuzzBus, type BuzzBus } from "./buzz-bus.js";
 import { handleBuzzInbound } from "./inbound.js";
-import {
-  advanceBuzzRecoveryWatermark,
-  createBuzzRecoveryFrontier,
-  openBuzzRecoveryWatermarkStore,
-  resolveBuzzColdStartSince,
-} from "./recovery-watermark.js";
+import { openBuzzRecoveryWatermarkStore, resolveBuzzColdStartSince } from "./recovery-watermark.js";
 import { getBuzzRuntime } from "./runtime.js";
 import { buildBuzzTarget, isConfiguredBuzzChannel, parseBuzzTarget } from "./target.js";
 import {
@@ -83,25 +78,7 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const configuredChannelIds = new Set(channelIds);
   const profileName = resolveBuzzProfileName({ cfg: ctx.cfg, account, channelIds });
 
-  const watermarkStore = openBuzzRecoveryWatermarkStore({
-    accountId: account.accountId,
-    onError: (error) => {
-      ctx.log?.warn?.(
-        `[${account.accountId}] Buzz recovery watermark unavailable: ${error.message}`,
-      );
-    },
-  });
-  const reportWatermarkError = (error: Error) => {
-    ctx.log?.warn?.(`[${account.accountId}] Buzz recovery watermark failed: ${error.message}`);
-  };
-  const commitRecoveryCheckpoint = (channelId: string, seconds: number) => {
-    void advanceBuzzRecoveryWatermark({
-      store: watermarkStore,
-      channelId,
-      seconds,
-      onError: reportWatermarkError,
-    });
-  };
+  const watermarkStore = openBuzzRecoveryWatermarkStore({ accountId: account.accountId });
 
   let hasAttemptedSession = false;
   let reconnectAttempt = 0;
@@ -123,15 +100,10 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
             channelIds,
             nowSeconds,
             lookbackSeconds: RECONNECT_LOOKBACK_SECONDS,
-            onError: reportWatermarkError,
           });
       hasAttemptedSession = true;
       const sinceFor = (channelId: string) =>
         coldStartSince ? (coldStartSince.get(channelId) ?? nowSeconds) : reconnectSince;
-      const recoveryFrontier = createBuzzRecoveryFrontier({
-        sinceFor,
-        onCheckpoint: commitRecoveryCheckpoint,
-      });
       bus = await startBuzzBus({
         accountId: account.accountId,
         relayUrl: account.relayUrl,
@@ -140,7 +112,6 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
         profileName,
         channelIds,
         since: sinceFor,
-        recoveryFrontier,
         signal: ctx.abortSignal,
         onMessage: async (message, sessionBus, signal) => {
           // Subscription filters reduce traffic, but relay events remain untrusted.

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -9,6 +9,7 @@ import { sendBuzzTextOneShot, startBuzzBus, type BuzzBus } from "./buzz-bus.js";
 import { handleBuzzInbound } from "./inbound.js";
 import {
   advanceBuzzRecoveryWatermark,
+  createBuzzRecoveryFrontier,
   openBuzzRecoveryWatermarkStore,
   resolveBuzzColdStartSince,
 } from "./recovery-watermark.js";
@@ -92,6 +93,17 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const reportWatermarkError = (error: Error) => {
     ctx.log?.warn?.(`[${account.accountId}] Buzz recovery watermark failed: ${error.message}`);
   };
+  const commitRecoveryCheckpoint = async (seconds: number | undefined) => {
+    if (seconds === undefined) {
+      return;
+    }
+    await advanceBuzzRecoveryWatermark({
+      store: watermarkStore,
+      accountId: account.accountId,
+      seconds,
+      onError: reportWatermarkError,
+    });
+  };
 
   let hasAttemptedSession = false;
   let reconnectAttempt = 0;
@@ -115,6 +127,7 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
             onError: reportWatermarkError,
           });
       hasAttemptedSession = true;
+      const recoveryFrontier = createBuzzRecoveryFrontier({ sinceSeconds: sessionSince });
       bus = await startBuzzBus({
         accountId: account.accountId,
         relayUrl: account.relayUrl,
@@ -129,20 +142,27 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
           if (!isConfiguredBuzzChannel(configuredChannelIds, message.channelId)) {
             return;
           }
-          await handleBuzzInbound({
-            account,
-            cfg: ctx.cfg,
-            bus: sessionBus,
-            message,
-            signal,
-            buildContext,
+          const token = recoveryFrontier.admit({
+            createdAt: message.createdAt,
+            observedSeconds: Math.floor(Date.now() / 1000),
           });
-          await advanceBuzzRecoveryWatermark({
-            store: watermarkStore,
-            accountId: account.accountId,
-            seconds: message.createdAt,
-            onError: reportWatermarkError,
-          });
+          try {
+            await handleBuzzInbound({
+              account,
+              cfg: ctx.cfg,
+              bus: sessionBus,
+              message,
+              signal,
+              buildContext,
+            });
+          } catch (error) {
+            recoveryFrontier.abandon(token);
+            throw error;
+          }
+          await commitRecoveryCheckpoint(recoveryFrontier.settle(token));
+        },
+        onHistoryDrained: () => {
+          void commitRecoveryCheckpoint(recoveryFrontier.markBacklogDrained());
         },
         onMessageError: (error) => {
           ctx.log?.error?.(`[${account.accountId}] Buzz message failed: ${error.message}`);

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -93,13 +93,11 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const reportWatermarkError = (error: Error) => {
     ctx.log?.warn?.(`[${account.accountId}] Buzz recovery watermark failed: ${error.message}`);
   };
-  const commitRecoveryCheckpoint = async (seconds: number | undefined) => {
-    if (seconds === undefined) {
-      return;
-    }
-    await advanceBuzzRecoveryWatermark({
+  const commitRecoveryCheckpoint = (channelId: string, seconds: number) => {
+    void advanceBuzzRecoveryWatermark({
       store: watermarkStore,
       accountId: account.accountId,
+      channelId,
       seconds,
       onError: reportWatermarkError,
     });
@@ -117,17 +115,24 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
     });
     try {
       const nowSeconds = Math.floor(Date.now() / 1000);
-      const sessionSince = hasAttemptedSession
-        ? nowSeconds - RECONNECT_LOOKBACK_SECONDS
+      const reconnectSince = nowSeconds - RECONNECT_LOOKBACK_SECONDS;
+      const coldStartSince = hasAttemptedSession
+        ? undefined
         : await resolveBuzzColdStartSince({
             store: watermarkStore,
             accountId: account.accountId,
+            channelIds,
             nowSeconds,
             lookbackSeconds: RECONNECT_LOOKBACK_SECONDS,
             onError: reportWatermarkError,
           });
       hasAttemptedSession = true;
-      const recoveryFrontier = createBuzzRecoveryFrontier({ sinceSeconds: sessionSince });
+      const sinceFor = (channelId: string) =>
+        coldStartSince ? (coldStartSince.get(channelId) ?? nowSeconds) : reconnectSince;
+      const recoveryFrontier = createBuzzRecoveryFrontier({
+        sinceFor,
+        onCheckpoint: commitRecoveryCheckpoint,
+      });
       bus = await startBuzzBus({
         accountId: account.accountId,
         relayUrl: account.relayUrl,
@@ -135,34 +140,22 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
         authTag: account.authTag,
         profileName,
         channelIds,
-        since: sessionSince,
+        since: sinceFor,
+        recoveryFrontier,
         signal: ctx.abortSignal,
         onMessage: async (message, sessionBus, signal) => {
           // Subscription filters reduce traffic, but relay events remain untrusted.
           if (!isConfiguredBuzzChannel(configuredChannelIds, message.channelId)) {
             return;
           }
-          const token = recoveryFrontier.admit({
-            createdAt: message.createdAt,
-            observedSeconds: Math.floor(Date.now() / 1000),
+          await handleBuzzInbound({
+            account,
+            cfg: ctx.cfg,
+            bus: sessionBus,
+            message,
+            signal,
+            buildContext,
           });
-          try {
-            await handleBuzzInbound({
-              account,
-              cfg: ctx.cfg,
-              bus: sessionBus,
-              message,
-              signal,
-              buildContext,
-            });
-          } catch (error) {
-            recoveryFrontier.abandon(token);
-            throw error;
-          }
-          await commitRecoveryCheckpoint(recoveryFrontier.settle(token));
-        },
-        onHistoryDrained: () => {
-          void commitRecoveryCheckpoint(recoveryFrontier.markBacklogDrained());
         },
         onMessageError: (error) => {
           ctx.log?.error?.(`[${account.accountId}] Buzz message failed: ${error.message}`);

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -84,6 +84,7 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const profileName = resolveBuzzProfileName({ cfg: ctx.cfg, account, channelIds });
 
   const watermarkStore = openBuzzRecoveryWatermarkStore({
+    accountId: account.accountId,
     onError: (error) => {
       ctx.log?.warn?.(
         `[${account.accountId}] Buzz recovery watermark unavailable: ${error.message}`,
@@ -96,7 +97,6 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const commitRecoveryCheckpoint = (channelId: string, seconds: number) => {
     void advanceBuzzRecoveryWatermark({
       store: watermarkStore,
-      accountId: account.accountId,
       channelId,
       seconds,
       onError: reportWatermarkError,
@@ -120,7 +120,6 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
         ? undefined
         : await resolveBuzzColdStartSince({
             store: watermarkStore,
-            accountId: account.accountId,
             channelIds,
             nowSeconds,
             lookbackSeconds: RECONNECT_LOOKBACK_SECONDS,

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -7,6 +7,11 @@ import { computeBackoff, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env"
 import type { ChannelGatewayContext } from "../runtime-api.js";
 import { sendBuzzTextOneShot, startBuzzBus, type BuzzBus } from "./buzz-bus.js";
 import { handleBuzzInbound } from "./inbound.js";
+import {
+  advanceBuzzRecoveryWatermark,
+  openBuzzRecoveryWatermarkStore,
+  resolveBuzzColdStartSince,
+} from "./recovery-watermark.js";
 import { getBuzzRuntime } from "./runtime.js";
 import { buildBuzzTarget, isConfiguredBuzzChannel, parseBuzzTarget } from "./target.js";
 import {
@@ -77,6 +82,17 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
   const configuredChannelIds = new Set(channelIds);
   const profileName = resolveBuzzProfileName({ cfg: ctx.cfg, account, channelIds });
 
+  const watermarkStore = openBuzzRecoveryWatermarkStore({
+    onError: (error) => {
+      ctx.log?.warn?.(
+        `[${account.accountId}] Buzz recovery watermark unavailable: ${error.message}`,
+      );
+    },
+  });
+  const reportWatermarkError = (error: Error) => {
+    ctx.log?.warn?.(`[${account.accountId}] Buzz recovery watermark failed: ${error.message}`);
+  };
+
   let hasAttemptedSession = false;
   let reconnectAttempt = 0;
   while (!ctx.abortSignal.aborted) {
@@ -88,8 +104,16 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
       reportBusFailure = resolve;
     });
     try {
-      const sessionSince =
-        Math.floor(Date.now() / 1000) - (hasAttemptedSession ? RECONNECT_LOOKBACK_SECONDS : 0);
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const sessionSince = hasAttemptedSession
+        ? nowSeconds - RECONNECT_LOOKBACK_SECONDS
+        : await resolveBuzzColdStartSince({
+            store: watermarkStore,
+            accountId: account.accountId,
+            nowSeconds,
+            lookbackSeconds: RECONNECT_LOOKBACK_SECONDS,
+            onError: reportWatermarkError,
+          });
       hasAttemptedSession = true;
       bus = await startBuzzBus({
         accountId: account.accountId,
@@ -112,6 +136,12 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
             message,
             signal,
             buildContext,
+          });
+          await advanceBuzzRecoveryWatermark({
+            store: watermarkStore,
+            accountId: account.accountId,
+            seconds: message.createdAt,
+            onError: reportWatermarkError,
           });
         },
         onMessageError: (error) => {

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -3,195 +3,55 @@ import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-run
 import { getBuzzRuntime } from "./runtime.js";
 import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 
-const WATERMARK_NAMESPACE_PREFIX = "buzz.recovery-watermark";
-const WATERMARK_MAX_ENTRIES = BUZZ_MAX_CONFIGURED_ROOMS;
-
-export type BuzzRecoveryWatermark = { seconds: number };
-
-export type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
+type BuzzRecoveryWatermark = { seconds: number };
+type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
 
 function roomCursorKey(channelId: string): string {
   return `room:${channelId}`;
 }
 
-function watermarkNamespace(accountId: string): string {
-  const scope = createHash("sha256").update(accountId).digest("hex").slice(0, 16);
-  return `${WATERMARK_NAMESPACE_PREFIX}-${scope}`;
-}
-
 export function openBuzzRecoveryWatermarkStore(params: {
   accountId: string;
-  onError?: (error: Error) => void;
-}): BuzzRecoveryWatermarkStore | undefined {
-  try {
-    return getBuzzRuntime().state.openKeyedStore<BuzzRecoveryWatermark>({
-      namespace: watermarkNamespace(params.accountId),
-      maxEntries: WATERMARK_MAX_ENTRIES,
-      overflowPolicy: "reject-new",
-    });
-  } catch (error) {
-    params.onError?.(error instanceof Error ? error : new Error(String(error)));
-    return undefined;
-  }
-}
-
-function isUsableWatermark(
-  value: BuzzRecoveryWatermark | undefined,
-): value is BuzzRecoveryWatermark {
-  return typeof value?.seconds === "number" && Number.isFinite(value.seconds);
+}): BuzzRecoveryWatermarkStore {
+  const accountScope = createHash("sha256").update(params.accountId).digest("hex").slice(0, 16);
+  return getBuzzRuntime().state.openKeyedStore<BuzzRecoveryWatermark>({
+    namespace: `buzz.recovery-watermark-${accountScope}`,
+    maxEntries: BUZZ_MAX_CONFIGURED_ROOMS,
+    overflowPolicy: "reject-new",
+  });
 }
 
 export async function resolveBuzzColdStartSince(params: {
-  store: BuzzRecoveryWatermarkStore | undefined;
+  store: BuzzRecoveryWatermarkStore;
   channelIds: readonly string[];
   nowSeconds: number;
   lookbackSeconds: number;
-  onError?: (error: Error) => void;
 }): Promise<Map<string, number>> {
   const { store, channelIds, nowSeconds, lookbackSeconds } = params;
-  const sinceByRoom = new Map(channelIds.map((channelId) => [channelId, nowSeconds]));
-  if (!store) {
-    return sinceByRoom;
-  }
-  try {
-    const floor = nowSeconds - lookbackSeconds;
-    for (const channelId of channelIds) {
-      const key = roomCursorKey(channelId);
-      const persisted = await store.lookup(key);
-      if (isUsableWatermark(persisted)) {
-        sinceByRoom.set(channelId, Math.min(Math.max(persisted.seconds, floor), nowSeconds));
-        continue;
-      }
-      await store.register(key, { seconds: nowSeconds });
+  const configuredKeys = new Set(channelIds.map(roomCursorKey));
+
+  // Reclaim removed rooms before reject-new capacity can strand their replacements.
+  for (const { key } of await store.entries()) {
+    if (key.startsWith("room:") && !configuredKeys.has(key)) {
+      await store.delete(key);
     }
-  } catch (error) {
-    params.onError?.(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  const sinceByRoom = new Map<string, number>();
+  const retentionFloor = nowSeconds - lookbackSeconds;
+  for (const channelId of channelIds) {
+    const key = roomCursorKey(channelId);
+    const activation = await store.lookup(key);
+    if (activation === undefined) {
+      await store.register(key, { seconds: nowSeconds });
+      sinceByRoom.set(channelId, nowSeconds);
+      continue;
+    }
+    if (typeof activation.seconds !== "number" || !Number.isFinite(activation.seconds)) {
+      throw new Error(`Invalid Buzz recovery watermark for room ${channelId}`);
+    }
+    // Keep the activation floor immutable: sender timestamps can arrive out of order.
+    sinceByRoom.set(channelId, Math.min(Math.max(activation.seconds, retentionFloor), nowSeconds));
   }
   return sinceByRoom;
-}
-
-export type BuzzRecoveryToken = { channelId: string; id: number };
-
-export type BuzzRecoveryFrontier = {
-  admit: (params: {
-    channelId: string;
-    createdAt: number;
-    observedSeconds: number;
-  }) => BuzzRecoveryToken;
-  settle: (token: BuzzRecoveryToken) => void;
-  abandon: (token: BuzzRecoveryToken) => void;
-  markBacklogDrained: () => void;
-};
-
-type RoomFrontier = {
-  committed: number;
-  outstanding: Map<number, number>;
-  settledCeiling: number | undefined;
-  failedFloor: number;
-};
-
-export function createBuzzRecoveryFrontier(params: {
-  sinceFor: (channelId: string) => number;
-  onCheckpoint: (channelId: string, seconds: number) => void;
-}): BuzzRecoveryFrontier {
-  const rooms = new Map<string, RoomFrontier>();
-  let backlogDrained = false;
-  let nextToken = 0;
-
-  const roomFrontier = (channelId: string): RoomFrontier => {
-    const existing = rooms.get(channelId);
-    if (existing) {
-      return existing;
-    }
-    const created = {
-      committed: params.sinceFor(channelId),
-      outstanding: new Map<number, number>(),
-      settledCeiling: undefined,
-      failedFloor: Number.POSITIVE_INFINITY,
-    } satisfies RoomFrontier;
-    rooms.set(channelId, created);
-    return created;
-  };
-
-  const publishCheckpoint = (channelId: string, room: RoomFrontier): void => {
-    if (!backlogDrained || room.settledCeiling === undefined) {
-      return;
-    }
-    let checkpoint = Math.min(room.settledCeiling, room.failedFloor);
-    for (const seconds of room.outstanding.values()) {
-      checkpoint = Math.min(checkpoint, seconds);
-    }
-    if (checkpoint <= room.committed) {
-      return;
-    }
-    room.committed = checkpoint;
-    params.onCheckpoint(channelId, checkpoint);
-  };
-
-  return {
-    admit({ channelId, createdAt, observedSeconds }) {
-      const id = nextToken;
-      nextToken += 1;
-      roomFrontier(channelId).outstanding.set(
-        id,
-        Number.isFinite(createdAt) ? Math.min(createdAt, observedSeconds) : observedSeconds,
-      );
-      return { channelId, id };
-    },
-    settle({ channelId, id }) {
-      const room = roomFrontier(channelId);
-      const seconds = room.outstanding.get(id);
-      if (seconds === undefined) {
-        return;
-      }
-      room.outstanding.delete(id);
-      room.settledCeiling =
-        room.settledCeiling === undefined ? seconds : Math.max(room.settledCeiling, seconds);
-      publishCheckpoint(channelId, room);
-    },
-    abandon({ channelId, id }) {
-      const room = roomFrontier(channelId);
-      const seconds = room.outstanding.get(id);
-      if (seconds === undefined) {
-        return;
-      }
-      room.outstanding.delete(id);
-      room.failedFloor = Math.min(room.failedFloor, seconds);
-    },
-    markBacklogDrained() {
-      backlogDrained = true;
-      for (const [channelId, room] of rooms) {
-        publishCheckpoint(channelId, room);
-      }
-    },
-  };
-}
-
-export async function advanceBuzzRecoveryWatermark(params: {
-  store: BuzzRecoveryWatermarkStore | undefined;
-  channelId: string;
-  seconds: number;
-  onError?: (error: Error) => void;
-}): Promise<void> {
-  const { store, channelId, seconds } = params;
-  if (!store || !Number.isFinite(seconds)) {
-    return;
-  }
-  const key = roomCursorKey(channelId);
-  const next = { seconds } satisfies BuzzRecoveryWatermark;
-  try {
-    if (store.update) {
-      await store.update(key, (current) =>
-        isUsableWatermark(current) && current.seconds >= seconds ? current : next,
-      );
-      return;
-    }
-    const current = await store.lookup(key);
-    if (isUsableWatermark(current) && current.seconds >= seconds) {
-      return;
-    }
-    await store.register(key, next);
-  } catch (error) {
-    params.onError?.(error instanceof Error ? error : new Error(String(error)));
-  }
 }

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -53,6 +53,70 @@ export async function resolveBuzzColdStartSince(params: {
   return nowSeconds;
 }
 
+export type BuzzRecoveryFrontier = {
+  admit: (params: { createdAt: number; observedSeconds: number }) => number;
+  settle: (token: number) => number | undefined;
+  abandon: (token: number) => void;
+  markBacklogDrained: () => number | undefined;
+};
+
+export function createBuzzRecoveryFrontier(params: { sinceSeconds: number }): BuzzRecoveryFrontier {
+  const outstanding = new Map<number, number>();
+  let committed = params.sinceSeconds;
+  let settledCeiling: number | undefined;
+  let failedFloor = Number.POSITIVE_INFINITY;
+  let backlogDrained = false;
+  let nextToken = 0;
+
+  const nextCheckpoint = (): number | undefined => {
+    if (!backlogDrained || settledCeiling === undefined) {
+      return undefined;
+    }
+    let checkpoint = Math.min(settledCeiling, failedFloor);
+    for (const seconds of outstanding.values()) {
+      checkpoint = Math.min(checkpoint, seconds);
+    }
+    if (checkpoint <= committed) {
+      return undefined;
+    }
+    committed = checkpoint;
+    return committed;
+  };
+
+  return {
+    admit({ createdAt, observedSeconds }) {
+      const token = nextToken;
+      nextToken += 1;
+      outstanding.set(
+        token,
+        Number.isFinite(createdAt) ? Math.min(createdAt, observedSeconds) : observedSeconds,
+      );
+      return token;
+    },
+    settle(token) {
+      const seconds = outstanding.get(token);
+      if (seconds === undefined) {
+        return undefined;
+      }
+      outstanding.delete(token);
+      settledCeiling = settledCeiling === undefined ? seconds : Math.max(settledCeiling, seconds);
+      return nextCheckpoint();
+    },
+    abandon(token) {
+      const seconds = outstanding.get(token);
+      if (seconds === undefined) {
+        return;
+      }
+      outstanding.delete(token);
+      failedFloor = Math.min(failedFloor, seconds);
+    },
+    markBacklogDrained() {
+      backlogDrained = true;
+      return nextCheckpoint();
+    },
+  };
+}
+
 export async function advanceBuzzRecoveryWatermark(params: {
   store: BuzzRecoveryWatermarkStore | undefined;
   accountId: string;

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -1,0 +1,82 @@
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { getBuzzRuntime } from "./runtime.js";
+
+const WATERMARK_NAMESPACE = "buzz.recovery-watermark";
+const WATERMARK_MAX_ENTRIES = 1_000;
+
+export type BuzzRecoveryWatermark = { seconds: number };
+
+export type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
+
+export function openBuzzRecoveryWatermarkStore(params?: {
+  onError?: (error: Error) => void;
+}): BuzzRecoveryWatermarkStore | undefined {
+  try {
+    return getBuzzRuntime().state.openKeyedStore<BuzzRecoveryWatermark>({
+      namespace: WATERMARK_NAMESPACE,
+      maxEntries: WATERMARK_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+    });
+  } catch (error) {
+    params?.onError?.(error instanceof Error ? error : new Error(String(error)));
+    return undefined;
+  }
+}
+
+function isUsableWatermark(
+  value: BuzzRecoveryWatermark | undefined,
+): value is BuzzRecoveryWatermark {
+  return typeof value?.seconds === "number" && Number.isFinite(value.seconds);
+}
+
+export async function resolveBuzzColdStartSince(params: {
+  store: BuzzRecoveryWatermarkStore | undefined;
+  accountId: string;
+  nowSeconds: number;
+  lookbackSeconds: number;
+  onError?: (error: Error) => void;
+}): Promise<number> {
+  const { store, accountId, nowSeconds, lookbackSeconds } = params;
+  if (!store) {
+    return nowSeconds;
+  }
+  try {
+    const persisted = await store.lookup(accountId);
+    if (isUsableWatermark(persisted)) {
+      const floor = nowSeconds - lookbackSeconds;
+      return Math.min(Math.max(persisted.seconds, floor), nowSeconds);
+    }
+    await store.register(accountId, { seconds: nowSeconds });
+  } catch (error) {
+    params.onError?.(error instanceof Error ? error : new Error(String(error)));
+  }
+  return nowSeconds;
+}
+
+export async function advanceBuzzRecoveryWatermark(params: {
+  store: BuzzRecoveryWatermarkStore | undefined;
+  accountId: string;
+  seconds: number;
+  onError?: (error: Error) => void;
+}): Promise<void> {
+  const { store, accountId, seconds } = params;
+  if (!store || !Number.isFinite(seconds)) {
+    return;
+  }
+  const next = { seconds } satisfies BuzzRecoveryWatermark;
+  try {
+    if (store.update) {
+      await store.update(accountId, (current) =>
+        isUsableWatermark(current) && current.seconds >= seconds ? current : next,
+      );
+      return;
+    }
+    const current = await store.lookup(accountId);
+    if (isUsableWatermark(current) && current.seconds >= seconds) {
+      return;
+    }
+    await store.register(accountId, next);
+  } catch (error) {
+    params.onError?.(error instanceof Error ? error : new Error(String(error)));
+  }
+}

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -1,16 +1,13 @@
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getBuzzRuntime } from "./runtime.js";
+import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 
 const WATERMARK_NAMESPACE = "buzz.recovery-watermark";
-const WATERMARK_MAX_ENTRIES = 1_000;
+const WATERMARK_MAX_ENTRIES = BUZZ_MAX_CONFIGURED_ROOMS;
 
 export type BuzzRecoveryWatermark = { seconds: number };
 
 export type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
-
-function accountStartKey(accountId: string): string {
-  return `account:${accountId}`;
-}
 
 function roomCursorKey(accountId: string, channelId: string): string {
   return `room:${accountId}:${channelId}`;
@@ -51,20 +48,15 @@ export async function resolveBuzzColdStartSince(params: {
     return sinceByRoom;
   }
   try {
-    const startedBefore = isUsableWatermark(await store.lookup(accountStartKey(accountId)));
-    if (!startedBefore) {
-      await store.register(accountStartKey(accountId), { seconds: nowSeconds });
-    }
     const floor = nowSeconds - lookbackSeconds;
     for (const channelId of channelIds) {
-      const persisted = await store.lookup(roomCursorKey(accountId, channelId));
+      const key = roomCursorKey(accountId, channelId);
+      const persisted = await store.lookup(key);
       if (isUsableWatermark(persisted)) {
         sinceByRoom.set(channelId, Math.min(Math.max(persisted.seconds, floor), nowSeconds));
         continue;
       }
-      const since = startedBefore ? nowSeconds : floor;
-      sinceByRoom.set(channelId, since);
-      await store.register(roomCursorKey(accountId, channelId), { seconds: since });
+      await store.register(key, { seconds: nowSeconds });
     }
   } catch (error) {
     params.onError?.(error instanceof Error ? error : new Error(String(error)));

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -8,6 +8,14 @@ export type BuzzRecoveryWatermark = { seconds: number };
 
 export type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
 
+function accountStartKey(accountId: string): string {
+  return `account:${accountId}`;
+}
+
+function roomCursorKey(accountId: string, channelId: string): string {
+  return `room:${accountId}:${channelId}`;
+}
+
 export function openBuzzRecoveryWatermarkStore(params?: {
   onError?: (error: Error) => void;
 }): BuzzRecoveryWatermarkStore | undefined {
@@ -32,87 +40,131 @@ function isUsableWatermark(
 export async function resolveBuzzColdStartSince(params: {
   store: BuzzRecoveryWatermarkStore | undefined;
   accountId: string;
+  channelIds: readonly string[];
   nowSeconds: number;
   lookbackSeconds: number;
   onError?: (error: Error) => void;
-}): Promise<number> {
-  const { store, accountId, nowSeconds, lookbackSeconds } = params;
+}): Promise<Map<string, number>> {
+  const { store, accountId, channelIds, nowSeconds, lookbackSeconds } = params;
+  const sinceByRoom = new Map(channelIds.map((channelId) => [channelId, nowSeconds]));
   if (!store) {
-    return nowSeconds;
+    return sinceByRoom;
   }
   try {
-    const persisted = await store.lookup(accountId);
-    if (isUsableWatermark(persisted)) {
-      const floor = nowSeconds - lookbackSeconds;
-      return Math.min(Math.max(persisted.seconds, floor), nowSeconds);
+    const startedBefore = isUsableWatermark(await store.lookup(accountStartKey(accountId)));
+    if (!startedBefore) {
+      await store.register(accountStartKey(accountId), { seconds: nowSeconds });
     }
-    await store.register(accountId, { seconds: nowSeconds });
+    const floor = nowSeconds - lookbackSeconds;
+    for (const channelId of channelIds) {
+      const persisted = await store.lookup(roomCursorKey(accountId, channelId));
+      if (isUsableWatermark(persisted)) {
+        sinceByRoom.set(channelId, Math.min(Math.max(persisted.seconds, floor), nowSeconds));
+        continue;
+      }
+      const since = startedBefore ? nowSeconds : floor;
+      sinceByRoom.set(channelId, since);
+      await store.register(roomCursorKey(accountId, channelId), { seconds: since });
+    }
   } catch (error) {
     params.onError?.(error instanceof Error ? error : new Error(String(error)));
   }
-  return nowSeconds;
+  return sinceByRoom;
 }
 
+export type BuzzRecoveryToken = { channelId: string; id: number };
+
 export type BuzzRecoveryFrontier = {
-  admit: (params: { createdAt: number; observedSeconds: number }) => number;
-  settle: (token: number) => number | undefined;
-  abandon: (token: number) => void;
-  markBacklogDrained: () => number | undefined;
+  admit: (params: {
+    channelId: string;
+    createdAt: number;
+    observedSeconds: number;
+  }) => BuzzRecoveryToken;
+  settle: (token: BuzzRecoveryToken) => void;
+  abandon: (token: BuzzRecoveryToken) => void;
+  markBacklogDrained: () => void;
 };
 
-export function createBuzzRecoveryFrontier(params: { sinceSeconds: number }): BuzzRecoveryFrontier {
-  const outstanding = new Map<number, number>();
-  let committed = params.sinceSeconds;
-  let settledCeiling: number | undefined;
-  let failedFloor = Number.POSITIVE_INFINITY;
+type RoomFrontier = {
+  committed: number;
+  outstanding: Map<number, number>;
+  settledCeiling: number | undefined;
+  failedFloor: number;
+};
+
+export function createBuzzRecoveryFrontier(params: {
+  sinceFor: (channelId: string) => number;
+  onCheckpoint: (channelId: string, seconds: number) => void;
+}): BuzzRecoveryFrontier {
+  const rooms = new Map<string, RoomFrontier>();
   let backlogDrained = false;
   let nextToken = 0;
 
-  const nextCheckpoint = (): number | undefined => {
-    if (!backlogDrained || settledCeiling === undefined) {
-      return undefined;
+  const roomFrontier = (channelId: string): RoomFrontier => {
+    const existing = rooms.get(channelId);
+    if (existing) {
+      return existing;
     }
-    let checkpoint = Math.min(settledCeiling, failedFloor);
-    for (const seconds of outstanding.values()) {
+    const created = {
+      committed: params.sinceFor(channelId),
+      outstanding: new Map<number, number>(),
+      settledCeiling: undefined,
+      failedFloor: Number.POSITIVE_INFINITY,
+    } satisfies RoomFrontier;
+    rooms.set(channelId, created);
+    return created;
+  };
+
+  const publishCheckpoint = (channelId: string, room: RoomFrontier): void => {
+    if (!backlogDrained || room.settledCeiling === undefined) {
+      return;
+    }
+    let checkpoint = Math.min(room.settledCeiling, room.failedFloor);
+    for (const seconds of room.outstanding.values()) {
       checkpoint = Math.min(checkpoint, seconds);
     }
-    if (checkpoint <= committed) {
-      return undefined;
+    if (checkpoint <= room.committed) {
+      return;
     }
-    committed = checkpoint;
-    return committed;
+    room.committed = checkpoint;
+    params.onCheckpoint(channelId, checkpoint);
   };
 
   return {
-    admit({ createdAt, observedSeconds }) {
-      const token = nextToken;
+    admit({ channelId, createdAt, observedSeconds }) {
+      const id = nextToken;
       nextToken += 1;
-      outstanding.set(
-        token,
+      roomFrontier(channelId).outstanding.set(
+        id,
         Number.isFinite(createdAt) ? Math.min(createdAt, observedSeconds) : observedSeconds,
       );
-      return token;
+      return { channelId, id };
     },
-    settle(token) {
-      const seconds = outstanding.get(token);
-      if (seconds === undefined) {
-        return undefined;
-      }
-      outstanding.delete(token);
-      settledCeiling = settledCeiling === undefined ? seconds : Math.max(settledCeiling, seconds);
-      return nextCheckpoint();
-    },
-    abandon(token) {
-      const seconds = outstanding.get(token);
+    settle({ channelId, id }) {
+      const room = roomFrontier(channelId);
+      const seconds = room.outstanding.get(id);
       if (seconds === undefined) {
         return;
       }
-      outstanding.delete(token);
-      failedFloor = Math.min(failedFloor, seconds);
+      room.outstanding.delete(id);
+      room.settledCeiling =
+        room.settledCeiling === undefined ? seconds : Math.max(room.settledCeiling, seconds);
+      publishCheckpoint(channelId, room);
+    },
+    abandon({ channelId, id }) {
+      const room = roomFrontier(channelId);
+      const seconds = room.outstanding.get(id);
+      if (seconds === undefined) {
+        return;
+      }
+      room.outstanding.delete(id);
+      room.failedFloor = Math.min(room.failedFloor, seconds);
     },
     markBacklogDrained() {
       backlogDrained = true;
-      return nextCheckpoint();
+      for (const [channelId, room] of rooms) {
+        publishCheckpoint(channelId, room);
+      }
     },
   };
 }
@@ -120,26 +172,28 @@ export function createBuzzRecoveryFrontier(params: { sinceSeconds: number }): Bu
 export async function advanceBuzzRecoveryWatermark(params: {
   store: BuzzRecoveryWatermarkStore | undefined;
   accountId: string;
+  channelId: string;
   seconds: number;
   onError?: (error: Error) => void;
 }): Promise<void> {
-  const { store, accountId, seconds } = params;
+  const { store, accountId, channelId, seconds } = params;
   if (!store || !Number.isFinite(seconds)) {
     return;
   }
+  const key = roomCursorKey(accountId, channelId);
   const next = { seconds } satisfies BuzzRecoveryWatermark;
   try {
     if (store.update) {
-      await store.update(accountId, (current) =>
+      await store.update(key, (current) =>
         isUsableWatermark(current) && current.seconds >= seconds ? current : next,
       );
       return;
     }
-    const current = await store.lookup(accountId);
+    const current = await store.lookup(key);
     if (isUsableWatermark(current) && current.seconds >= seconds) {
       return;
     }
-    await store.register(accountId, next);
+    await store.register(key, next);
   } catch (error) {
     params.onError?.(error instanceof Error ? error : new Error(String(error)));
   }

--- a/extensions/buzz/src/recovery-watermark.ts
+++ b/extensions/buzz/src/recovery-watermark.ts
@@ -1,29 +1,36 @@
+import { createHash } from "node:crypto";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getBuzzRuntime } from "./runtime.js";
 import { BUZZ_MAX_CONFIGURED_ROOMS } from "./subscription-budget.js";
 
-const WATERMARK_NAMESPACE = "buzz.recovery-watermark";
+const WATERMARK_NAMESPACE_PREFIX = "buzz.recovery-watermark";
 const WATERMARK_MAX_ENTRIES = BUZZ_MAX_CONFIGURED_ROOMS;
 
 export type BuzzRecoveryWatermark = { seconds: number };
 
 export type BuzzRecoveryWatermarkStore = PluginStateKeyedStore<BuzzRecoveryWatermark>;
 
-function roomCursorKey(accountId: string, channelId: string): string {
-  return `room:${accountId}:${channelId}`;
+function roomCursorKey(channelId: string): string {
+  return `room:${channelId}`;
 }
 
-export function openBuzzRecoveryWatermarkStore(params?: {
+function watermarkNamespace(accountId: string): string {
+  const scope = createHash("sha256").update(accountId).digest("hex").slice(0, 16);
+  return `${WATERMARK_NAMESPACE_PREFIX}-${scope}`;
+}
+
+export function openBuzzRecoveryWatermarkStore(params: {
+  accountId: string;
   onError?: (error: Error) => void;
 }): BuzzRecoveryWatermarkStore | undefined {
   try {
     return getBuzzRuntime().state.openKeyedStore<BuzzRecoveryWatermark>({
-      namespace: WATERMARK_NAMESPACE,
+      namespace: watermarkNamespace(params.accountId),
       maxEntries: WATERMARK_MAX_ENTRIES,
       overflowPolicy: "reject-new",
     });
   } catch (error) {
-    params?.onError?.(error instanceof Error ? error : new Error(String(error)));
+    params.onError?.(error instanceof Error ? error : new Error(String(error)));
     return undefined;
   }
 }
@@ -36,13 +43,12 @@ function isUsableWatermark(
 
 export async function resolveBuzzColdStartSince(params: {
   store: BuzzRecoveryWatermarkStore | undefined;
-  accountId: string;
   channelIds: readonly string[];
   nowSeconds: number;
   lookbackSeconds: number;
   onError?: (error: Error) => void;
 }): Promise<Map<string, number>> {
-  const { store, accountId, channelIds, nowSeconds, lookbackSeconds } = params;
+  const { store, channelIds, nowSeconds, lookbackSeconds } = params;
   const sinceByRoom = new Map(channelIds.map((channelId) => [channelId, nowSeconds]));
   if (!store) {
     return sinceByRoom;
@@ -50,7 +56,7 @@ export async function resolveBuzzColdStartSince(params: {
   try {
     const floor = nowSeconds - lookbackSeconds;
     for (const channelId of channelIds) {
-      const key = roomCursorKey(accountId, channelId);
+      const key = roomCursorKey(channelId);
       const persisted = await store.lookup(key);
       if (isUsableWatermark(persisted)) {
         sinceByRoom.set(channelId, Math.min(Math.max(persisted.seconds, floor), nowSeconds));
@@ -163,16 +169,15 @@ export function createBuzzRecoveryFrontier(params: {
 
 export async function advanceBuzzRecoveryWatermark(params: {
   store: BuzzRecoveryWatermarkStore | undefined;
-  accountId: string;
   channelId: string;
   seconds: number;
   onError?: (error: Error) => void;
 }): Promise<void> {
-  const { store, accountId, channelId, seconds } = params;
+  const { store, channelId, seconds } = params;
   if (!store || !Number.isFinite(seconds)) {
     return;
   }
-  const key = roomCursorKey(accountId, channelId);
+  const key = roomCursorKey(channelId);
   const next = { seconds } satisfies BuzzRecoveryWatermark;
   try {
     if (store.update) {

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -51,8 +51,6 @@ async function sleepWithSignal(delayMs: number, signal?: AbortSignal): Promise<v
   });
 }
 
-export type BuzzRoomHistoryCatchUpOutcome = "drained" | "incomplete";
-
 export async function createBuzzRoomMembershipTracker(params: {
   relay: Relay;
   relayPublicKey: string;
@@ -74,7 +72,7 @@ export async function createBuzzRoomMembershipTracker(params: {
   signal?: AbortSignal;
 }): Promise<{
   memberships: () => ReadonlyMap<string, BuzzRoomMembership>;
-  catchUpHistory: () => Promise<BuzzRoomHistoryCatchUpOutcome>;
+  catchUpHistory: () => Promise<void>;
 }> {
   type ExpectedMembership = "present" | "absent";
   type RefreshState = {
@@ -385,17 +383,16 @@ export async function createBuzzRoomMembershipTracker(params: {
   return {
     memberships: effectiveMemberships,
     catchUpHistory: async () => {
-      let outcome: BuzzRoomHistoryCatchUpOutcome = "drained";
       for (const channelId of params.channelIds) {
         const page = historyPages.get(channelId);
         if (params.signal?.aborted) {
-          return "incomplete";
+          return;
         }
         if (!page || page.count < params.messageLimit) {
           continue;
         }
         try {
-          const roomOutcome = await catchUpBuzzRoomHistory({
+          const outcome = await catchUpBuzzRoomHistory({
             relay: params.relay,
             channelId,
             since: params.messageSince(channelId),
@@ -405,10 +402,7 @@ export async function createBuzzRoomMembershipTracker(params: {
             onEvent: handleRoomEvent,
             signal: params.signal,
           });
-          if (roomOutcome !== "complete") {
-            outcome = "incomplete";
-          }
-          if (roomOutcome === "timestamp-over-limit") {
+          if (outcome === "timestamp-over-limit") {
             params.onHistoryError?.(
               new Error(
                 `Buzz room ${channelId} kept more than ${BUZZ_REPLAY_DISPATCH_MAX_PENDING} additional messages at one timestamp; older history was not recovered`,
@@ -417,17 +411,16 @@ export async function createBuzzRoomMembershipTracker(params: {
           }
         } catch (error) {
           if (params.signal?.aborted) {
-            return "incomplete";
+            return;
           }
           reportSystemEventError(
             error instanceof Error
               ? error
               : new Error(`Buzz room history recovery failed for ${channelId}`, { cause: error }),
           );
-          return "incomplete";
+          return;
         }
       }
-      return outcome;
     },
   };
 }

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -51,6 +51,8 @@ async function sleepWithSignal(delayMs: number, signal?: AbortSignal): Promise<v
   });
 }
 
+export type BuzzRoomHistoryCatchUpOutcome = "drained" | "incomplete";
+
 export async function createBuzzRoomMembershipTracker(params: {
   relay: Relay;
   relayPublicKey: string;
@@ -72,7 +74,7 @@ export async function createBuzzRoomMembershipTracker(params: {
   signal?: AbortSignal;
 }): Promise<{
   memberships: () => ReadonlyMap<string, BuzzRoomMembership>;
-  catchUpHistory: () => Promise<void>;
+  catchUpHistory: () => Promise<BuzzRoomHistoryCatchUpOutcome>;
 }> {
   type ExpectedMembership = "present" | "absent";
   type RefreshState = {
@@ -383,16 +385,17 @@ export async function createBuzzRoomMembershipTracker(params: {
   return {
     memberships: effectiveMemberships,
     catchUpHistory: async () => {
+      let outcome: BuzzRoomHistoryCatchUpOutcome = "drained";
       for (const channelId of params.channelIds) {
         const page = historyPages.get(channelId);
         if (params.signal?.aborted) {
-          return;
+          return "incomplete";
         }
         if (!page || page.count < params.messageLimit) {
           continue;
         }
         try {
-          const outcome = await catchUpBuzzRoomHistory({
+          const roomOutcome = await catchUpBuzzRoomHistory({
             relay: params.relay,
             channelId,
             since: params.messageSince,
@@ -402,7 +405,8 @@ export async function createBuzzRoomMembershipTracker(params: {
             onEvent: handleRoomEvent,
             signal: params.signal,
           });
-          if (outcome === "timestamp-over-limit") {
+          if (roomOutcome === "timestamp-over-limit") {
+            outcome = "incomplete";
             params.onHistoryError?.(
               new Error(
                 `Buzz room ${channelId} kept more than ${BUZZ_REPLAY_DISPATCH_MAX_PENDING} additional messages at one timestamp; older history was not recovered`,
@@ -411,16 +415,17 @@ export async function createBuzzRoomMembershipTracker(params: {
           }
         } catch (error) {
           if (params.signal?.aborted) {
-            return;
+            return "incomplete";
           }
           reportSystemEventError(
             error instanceof Error
               ? error
               : new Error(`Buzz room history recovery failed for ${channelId}`, { cause: error }),
           );
-          return;
+          return "incomplete";
         }
       }
+      return outcome;
     },
   };
 }

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -405,8 +405,10 @@ export async function createBuzzRoomMembershipTracker(params: {
             onEvent: handleRoomEvent,
             signal: params.signal,
           });
-          if (roomOutcome === "timestamp-over-limit") {
+          if (roomOutcome !== "complete") {
             outcome = "incomplete";
+          }
+          if (roomOutcome === "timestamp-over-limit") {
             params.onHistoryError?.(
               new Error(
                 `Buzz room ${channelId} kept more than ${BUZZ_REPLAY_DISPATCH_MAX_PENDING} additional messages at one timestamp; older history was not recovered`,

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -59,7 +59,7 @@ export async function createBuzzRoomMembershipTracker(params: {
   channelIds: string[];
   botPublicKey: string;
   since: number;
-  messageSince: number;
+  messageSince: (channelId: string) => number;
   messageLimit: number;
   reserveDispatchCapacity: (slots: number) => Promise<BuzzReplayDispatchReservation | undefined>;
   onMessageEvent: (
@@ -325,7 +325,7 @@ export async function createBuzzRoomMembershipTracker(params: {
             {
               kinds: [...BUZZ_INBOUND_MESSAGE_KINDS],
               "#h": [channelId],
-              since: params.messageSince,
+              since: params.messageSince(channelId),
               limit: params.messageLimit,
             },
           ],
@@ -398,7 +398,7 @@ export async function createBuzzRoomMembershipTracker(params: {
           const roomOutcome = await catchUpBuzzRoomHistory({
             relay: params.relay,
             channelId,
-            since: params.messageSince,
+            since: params.messageSince(channelId),
             until: page.oldest,
             limit: params.messageLimit,
             reserveCapacity: params.reserveDispatchCapacity,

--- a/extensions/buzz/src/subscription-budget.ts
+++ b/extensions/buzz/src/subscription-budget.ts
@@ -7,6 +7,9 @@ const BUZZ_RELAY_NON_ROOM_PROFILE_SUBSCRIPTION_RESERVE =
   BUZZ_RELAY_MEMBERSHIP_NOTIFICATION_SUBSCRIPTIONS + BUZZ_RELAY_MAX_CONCURRENT_QUERY_SUBSCRIPTIONS;
 const BUZZ_DIRECTORY_MAX_PROFILE_SUBSCRIPTIONS = 10;
 
+export const BUZZ_MAX_CONFIGURED_ROOMS =
+  BUZZ_RELAY_MAX_SUBSCRIPTIONS - BUZZ_RELAY_NON_ROOM_PROFILE_SUBSCRIPTION_RESERVE;
+
 export function resolveBuzzSubscriptionBudget(roomCount: number): {
   profileLimit: number;
 } {
@@ -17,9 +20,7 @@ export function resolveBuzzSubscriptionBudget(roomCount: number): {
     BUZZ_RELAY_MAX_SUBSCRIPTIONS - BUZZ_RELAY_NON_ROOM_PROFILE_SUBSCRIPTION_RESERVE - roomCount;
   if (availableProfileSubscriptions < 0) {
     throw new Error(
-      `Buzz supports at most ${
-        BUZZ_RELAY_MAX_SUBSCRIPTIONS - BUZZ_RELAY_NON_ROOM_PROFILE_SUBSCRIPTION_RESERVE
-      } configured rooms per account`,
+      `Buzz supports at most ${BUZZ_MAX_CONFIGURED_ROOMS} configured rooms per account`,
     );
   }
   return {


### PR DESCRIPTION
## What Problem This Solves

Buzz silently loses room messages sent while the Gateway process is stopped. On every new process, the first relay subscription previously used the process start time, so retained outage messages never reached the existing replay queue, persistent event-ID deduplication, or agent.

## Root cause and repair

The Buzz account gateway owns the process lifecycle and existing 24-hour reconnect lookback. It now persists one immutable activation timestamp per configured room in its existing account-scoped SQLite plugin-state namespace, then subscribes after a restart from `max(roomActivation, now - 24 hours)`.

The activation floor deliberately never advances with sender-controlled timestamps or handler completion. Advancing a checkpoint can permanently skip an older message that arrives later, a failed or still-queued dispatch, an incompletely paged history range, or messages after a future-dated event. The existing durable event-ID replay guard already commits only after successful delivery and releases failed work for redelivery, so replaying the bounded room history through that canonical owner solves all of those cases without a parallel checkpoint frontier, queue tokens, outcome plumbing, or a new persistence design.

- A room with no stored activation starts at the current time, preserving existing first-use behavior and preventing pre-configuration history from being delivered.
- Activation is registered before any relay subscription; unreadable or corrupt state fails visibly and enters the existing recovering lifecycle instead of silently subscribing from the present.
- Removed-room keys are reclaimed before new rooms are registered, preserving the existing 1,020-room bounded `reject-new` capacity across configuration churn.
- Namespaces remain account-scoped, so each account retains its independent room capacity and activation floors.
- In-process reconnect behavior remains unchanged and continues to request the existing 24-hour lookback.
- No SQLite schema change, new database, configuration surface, or additional persistent store is introduced.

The original contributor implementation introduced a sender-timestamp checkpoint/frontier owner and approximately 271 net production lines. The reviewed maintainer fixup removes that machinery, closes its out-of-order-message loss and swallowed-state-failure defects, and reduces the complete PR to approximately 71 net production lines.

## Evidence

The signed relay / real SQLite regression suite reproduces the original bug and covers restart recovery, no duplicate delivery, first-start and newly configured room boundaries, room replacement at the 1,020-room limit, independent accounts, unreadable and corrupt activation state, older late-arriving messages, future sender timestamps, queued and failed dispatch recovery, the 24-hour clamp, and unchanged in-process reconnects.

```
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/buzz/src/gateway.cold-start-recovery.test.ts \
  extensions/buzz/src/gateway.lifecycle.test.ts \
  extensions/buzz/src/buzz-bus.history-catchup.test.ts \
  extensions/buzz/src/buzz-bus.lifecycle.test.ts \
  extensions/buzz/src/buzz-bus.test.ts \
  extensions/buzz/src/subscription-budget.test.ts

Test Files  6 passed (6)
     Tests  66 passed (66)

node --import tsx scripts/check-deadcode-exports.mts
# all three unused-export scans passed with 0 entries

node --import tsx scripts/check-import-cycles.ts
# Import cycle check: 0 runtime value cycle(s).
```

Production and extension-test typechecks, formatting, type-aware changed-file lint, plugin boundaries, database-first storage, and all other applicable changed-file guards passed. The unchanged whole-tree runtime-sidecar loader guard was verified from the clean canonical checkout because native PR-worktree Vitest caches do not include its unrelated `playwright-core` package; none of the changed Buzz files introduces a runtime-sidecar import.

## Real behavior proof

The original contributor reproduced the defect with two successive real Gateway operating-system processes against a real NIP-01 WebSocket relay, real NIP-42 authentication, signed room membership and message events, real history paging, and shared on-disk SQLite plugin state.

```
BEFORE: process 1 receives the live room message; process 2 subscribes from its
        own start time after an outage; downtime message delivered: no.

AFTER:  process 1 receives the live room message; process 2 subscribes from the
        persisted room activation floor; its previously delivered event is
        durably deduplicated and the outage message reaches the agent: yes.
```

The rewritten owner retains that operator-visible behavior and adds failing-before/passing-after coverage for older late-arriving signed messages, visible recovery-state read failures, corrupt stored values, and room replacement at maximum capacity.

Contributor credit and all original commits from @yetval are preserved.
