### PR TITLE
fix(sessions): keep restart prompts on the active transcript tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway restart user turns:** reconcile a keyed user committed after the agent session snapshot when it is still the active transcript tail, preventing accepted reconnect/restart prompts from failing before provider invocation while preserving duplicate-turn rejection.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway restart user turns:** reconcile a keyed user committed after the agent session snapshot when it is still the active transcript tail, preventing accepted reconnect/restart prompts from failing before provider invocation while preserving duplicate-turn rejection.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -39,10 +39,23 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       !this.pendingDeliberateAppend &&
       this.appendMode !== "side" &&
       !isSessionTranscriptSideAppendEntry(canonicalEntry);
-    const effectiveParentId = this.persist(canonicalEntry, {
+    const persistenceResult = this.persist(canonicalEntry, {
       ...options,
       ...(activeBranchAppend ? { appendIntent: "active-branch" } : {}),
     });
+    if (persistenceResult && typeof persistenceResult === "object") {
+      this.reloadPersistedTranscript();
+      const adoptedMessageId =
+        canonicalEntry.type === "message"
+          ? this.resolveCurrentKeyedUserId(canonicalEntry.message)
+          : undefined;
+      if (adoptedMessageId !== persistenceResult.adoptedMessageId) {
+        throw new Error(`Session transcript parent entry was not persisted: ${canonicalEntry.id}`);
+      }
+      this.pendingDeliberateAppend = false;
+      return;
+    }
+    const effectiveParentId = persistenceResult;
     if (effectiveParentId !== undefined && effectiveParentId !== canonicalEntry.parentId) {
       this.reloadPersistedTranscript();
       this.pendingDeliberateAppend = false;
@@ -69,31 +82,41 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     }
   }
 
+  private resolveCurrentKeyedUserId(message: SessionMessageEntry["message"]): string | undefined {
+    if (
+      message.role !== "user" ||
+      !("idempotencyKey" in message) ||
+      typeof message.idempotencyKey !== "string" ||
+      message.idempotencyKey.length === 0
+    ) {
+      return undefined;
+    }
+    let parent = this.appendParentId ? this.byId.get(this.appendParentId) : undefined;
+    let remainingAncestors = this.byId.size;
+    while (parent && remainingAncestors-- > 0 && isSessionContextMetadataEntry(parent)) {
+      parent = parent.parentId ? this.byId.get(parent.parentId) : undefined;
+    }
+    if (
+      parent?.type === "message" &&
+      parent.message.role === "user" &&
+      "idempotencyKey" in parent.message &&
+      parent.message.idempotencyKey === message.idempotencyKey
+    ) {
+      return parent.id;
+    }
+    return undefined;
+  }
+
   appendMessage(
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
   ): string {
-    if (
-      options?.idempotencyLookup !== "caller-checked" &&
-      message.role === "user" &&
-      "idempotencyKey" in message &&
-      typeof message.idempotencyKey === "string" &&
-      message.idempotencyKey.length > 0
-    ) {
-      let parent = this.appendParentId ? this.byId.get(this.appendParentId) : undefined;
-      let remainingAncestors = this.byId.size;
-      while (parent && remainingAncestors-- > 0 && isSessionContextMetadataEntry(parent)) {
-        parent = parent.parentId ? this.byId.get(parent.parentId) : undefined;
-      }
-      if (
-        parent?.type === "message" &&
-        parent.message.role === "user" &&
-        "idempotencyKey" in parent.message &&
-        parent.message.idempotencyKey === message.idempotencyKey
-      ) {
+    if (options?.idempotencyLookup !== "caller-checked") {
+      const currentUserId = this.resolveCurrentKeyedUserId(message);
+      if (currentUserId) {
         // Session setup may insert context-free metadata after the ingress-persisted user.
         // Keep that metadata as the append parent while adopting the canonical user once.
-        return parent.id;
+        return currentUserId;
       }
     }
     const entry: SessionMessageEntry = {
@@ -104,7 +127,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       message,
     };
     this.appendEntry(entry, options);
-    return entry.id;
+    return this.resolveCurrentKeyedUserId(message) ?? entry.id;
   }
 
   appendThinkingLevelChange(thinkingLevel: string): string {

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -167,7 +167,15 @@ export class SessionManagerPersistence extends SessionManagerCore {
       return undefined;
     }
     if (entry.type !== "message") {
-      if (!appendTranscriptEventSync(scope, entry)) {
+      if (
+        !appendTranscriptEventSync(
+          scope,
+          entry,
+          options?.appendIntent === "active-branch"
+            ? { appendIntent: options.appendIntent }
+            : undefined,
+        )
+      ) {
         throw new Error(`Session transcript entry was not persisted: ${entry.id}`);
       }
       return undefined;

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -17,6 +17,8 @@ import type {
   SessionEntry,
 } from "./session-manager-types.js";
 
+type PersistRecordResult = string | null | undefined | { adoptedMessageId: string };
+
 export class SessionManagerPersistence extends SessionManagerCore {
   removeTrailingEntries(
     predicate: (entry: SessionEntry) => boolean,
@@ -128,24 +130,21 @@ export class SessionManagerPersistence extends SessionManagerCore {
     return removedEntries.length;
   }
 
-  protected persistRecord(
-    entry: unknown,
-    options?: AppendPersistenceOptions,
-  ): string | null | undefined {
+  protected persistRecord(entry: unknown, options?: AppendPersistenceOptions): PersistRecordResult {
     if (this.persistenceTarget) {
       return this.persistSqliteRecord(entry, options);
     }
     return undefined;
   }
 
-  persist(entry: SessionEntry, options?: AppendPersistenceOptions): string | null | undefined {
+  persist(entry: SessionEntry, options?: AppendPersistenceOptions): PersistRecordResult {
     return this.persistRecord(entry, options);
   }
 
   private persistSqliteRecord(
     entry: unknown,
     options?: AppendPersistenceOptions,
-  ): string | null | undefined {
+  ): PersistRecordResult {
     if (!this.persistenceTarget) {
       return undefined;
     }
@@ -188,6 +187,18 @@ export class SessionManagerPersistence extends SessionManagerCore {
       throw new Error(`Session transcript message was not persisted: ${entry.id}`);
     }
     if (result.messageId !== entry.id) {
+      const idempotencyKey =
+        entry.message.role === "user" &&
+        "idempotencyKey" in entry.message &&
+        typeof entry.message.idempotencyKey === "string" &&
+        entry.message.idempotencyKey.length > 0
+          ? entry.message.idempotencyKey
+          : undefined;
+      if (idempotencyKey && options?.idempotencyLookup !== "caller-checked") {
+        // Ingress can commit the keyed user after this manager loaded. The
+        // caller reloads and adopts only when that canonical row is still active.
+        return { adoptedMessageId: result.messageId };
+      }
       throw new Error(`Session transcript parent entry was not persisted: ${entry.id}`);
     }
     if (

--- a/src/agents/sessions/session-manager.user-idempotency.test.ts
+++ b/src/agents/sessions/session-manager.user-idempotency.test.ts
@@ -111,6 +111,59 @@ describe("SessionManager user idempotency", () => {
     ).toHaveLength(1);
   });
 
+  it("adopts a keyed user persisted after the manager loaded", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-runtime-user-concurrent-ingress",
+      sessionKey: "agent:main:dashboard:sqlite-runtime-user-concurrent-ingress",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    const userMessage = {
+      role: "user" as const,
+      content: "question",
+      idempotencyKey: "runtime-user-concurrent-ingress:user",
+      timestamp: 1,
+    };
+    await upsertSessionEntry(scope, {
+      sessionFile: formatSqliteSessionFileMarker(scope),
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+    });
+    await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "existing-assistant",
+      message: buildAssistantMessage("previous answer"),
+      now: 1,
+    });
+    const sessionManager = SessionManager.open(scope, dir);
+    await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "ingress-persisted-user",
+      message: userMessage,
+      now: 2,
+      parentId: "existing-assistant",
+    });
+
+    expect(sessionManager.appendMessage(userMessage)).toBe("ingress-persisted-user");
+    expect(sessionManager.getLeafId()).toBe("ingress-persisted-user");
+
+    const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+    const events = await loadTranscriptEvents(scope);
+    expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
+      parentId: "ingress-persisted-user",
+    });
+    expect(
+      events.filter(
+        (event) =>
+          (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
+            "user" &&
+          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+            userMessage.idempotencyKey,
+      ),
+    ).toHaveLength(1);
+  });
+
   it("adopts a persisted user across context-free session setup metadata", async () => {
     const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
     const scope = {

--- a/src/agents/sessions/session-manager.user-idempotency.test.ts
+++ b/src/agents/sessions/session-manager.user-idempotency.test.ts
@@ -144,14 +144,30 @@ describe("SessionManager user idempotency", () => {
       now: 2,
       parentId: "existing-assistant",
     });
+    const modelChangeId = sessionManager.appendModelChange("openai", "gpt-5.5");
+    const thinkingId = sessionManager.appendThinkingLevelChange("off");
+    const metadataId = sessionManager.appendCustomEntry("model-snapshot", {
+      modelApi: "openai-responses",
+      modelId: "gpt-5.5",
+      provider: "openai",
+    });
 
     expect(sessionManager.appendMessage(userMessage)).toBe("ingress-persisted-user");
-    expect(sessionManager.getLeafId()).toBe("ingress-persisted-user");
+    expect(sessionManager.getAppendParentId()).toBe(metadataId);
 
     const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
     const events = await loadTranscriptEvents(scope);
-    expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
+    expect(events.find((event) => (event as { id?: string }).id === modelChangeId)).toMatchObject({
       parentId: "ingress-persisted-user",
+    });
+    expect(events.find((event) => (event as { id?: string }).id === thinkingId)).toMatchObject({
+      parentId: modelChangeId,
+    });
+    expect(events.find((event) => (event as { id?: string }).id === metadataId)).toMatchObject({
+      parentId: thinkingId,
+    });
+    expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
+      parentId: metadataId,
     });
     expect(
       events.filter(

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -76,6 +76,10 @@ export type SessionTranscriptInstance = SessionEntrySummary & {
 
 export type TranscriptEvent = unknown;
 
+export type TranscriptEventAppendOptions = {
+  appendIntent?: "active-branch";
+};
+
 export type SessionTranscriptStats = {
   eventCount: number;
   lastMutationAtMs?: number;

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -13,6 +13,7 @@ import type {
   SessionTranscriptTurnWriteContext,
   SessionTranscriptWriteScope,
   TranscriptEvent,
+  TranscriptEventAppendOptions,
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
 } from "./session-accessor.sqlite-contract.js";
@@ -249,12 +250,17 @@ export async function trimSqliteTranscriptForManualCompact(
 export async function appendSqliteTranscriptEvent(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
+  options: TranscriptEventAppendOptions = {},
 ): Promise<void> {
   assertNonMessageTranscriptEvent(event);
   const resolved = resolveSqliteTranscriptScope(scope);
   await runExclusiveSqliteSessionWrite(resolved, async () => {
     runOpenClawAgentWriteTransaction((database) => {
-      appendTranscriptEventInTransaction(database, resolved, event);
+      appendTranscriptEventInTransaction(
+        database,
+        resolved,
+        resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+      );
     }, toDatabaseOptions(resolved));
   });
 }
@@ -263,6 +269,7 @@ export async function appendSqliteTranscriptEvent(
 export function appendSqliteTranscriptEventSync(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
+  options: TranscriptEventAppendOptions = {},
 ): boolean {
   assertNonMessageTranscriptEvent(event);
   const resolved = resolveSqliteTranscriptScope(scope);
@@ -272,9 +279,39 @@ export function appendSqliteTranscriptEventSync(
     if (!fresh || fresh.entry.sessionId !== resolved.sessionId) {
       return;
     }
-    appended = appendTranscriptEventInTransaction(database, resolved, event);
+    appended = appendTranscriptEventInTransaction(
+      database,
+      resolved,
+      resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+    );
   }, toDatabaseOptions(resolved));
   return appended;
+}
+
+function resolveTranscriptEventAppendParent(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  event: TranscriptEvent,
+  options: TranscriptEventAppendOptions,
+): TranscriptEvent {
+  if (
+    options.appendIntent !== "active-branch" ||
+    !event ||
+    typeof event !== "object" ||
+    Array.isArray(event) ||
+    !("parentId" in event)
+  ) {
+    return event;
+  }
+  const parentId = event.parentId;
+  if (parentId !== null && typeof parentId !== "string") {
+    return event;
+  }
+  const effectiveParentId = resolveTranscriptMessageAppendParent(database, sessionId, {
+    appendIntent: "active-branch",
+    parentId,
+  });
+  return effectiveParentId === parentId ? event : { ...event, parentId: effectiveParentId };
 }
 
 /** Appends a guarded transcript turn and touches its session row in one queued write. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a prompt accepted during a Gateway restart or reconnect could fail before provider invocation with `Session transcript parent entry was not persisted` when ingress committed the keyed user turn after the agent's `SessionManager` loaded its SQLite snapshot.

## Why This Change Was Made

Active-branch setup metadata now rebases onto the durable SQLite tail before it is stored. When SQLite then returns a different canonical message ID for a keyed user, the manager reloads the durable transcript and adopts that ID only if the user remains the active append tail through that metadata. If an assistant or another turn already follows the user, the existing duplicate-turn rejection remains unchanged.

## User Impact

Accepted restart/reconnect prompts no longer disappear into a generic LLM failure before reaching the model, while stale duplicate user turns remain blocked.

## Evidence

- New production-shaped regression opens a manager, commits the next ingress user out of band, writes stale model/thinking/custom setup metadata, verifies that metadata rebases onto the durable user tail, adopts the canonical user, and verifies the assistant is parented to the metadata chain.
- Existing collision regression still rejects the same keyed user when a persisted assistant already follows it.
- Focused session-manager proof: 30/30 tests passed locally and on Blacksmith Testbox.
- Blacksmith Testbox `tbx_01kyxyxxht3v6meh2vkarnanmr`: full real Gateway/TUI PTY file passed three consecutive times, 48/48 tests total. Each pass covered the restart-preserved draft followed by the non-deliverable reply case that failed CI.
- Blacksmith Testbox `tbx_01kyxze2pmwrb83qavm4v5jqnx`: core and core-test typechecks, targeted lint, changelog attribution, and focused tests passed.
- Autoreview: clean, no accepted/actionable findings.

Before-fix runtime evidence: [main CI run 30683534337, failed TUI PTY job](https://github.com/openclaw/openclaw/actions/runs/30683534337/job/91325444231) recorded `rawError=Session transcript parent entry was not persisted` after `chat.send` succeeded and before the mock provider received the prompt.

<details>
<summary>Redacted after-fix Testbox terminal transcript</summary>

Provider: Blacksmith Testbox. Lease workflow: [run 30687125231](https://github.com/openclaw/openclaw/actions/runs/30687125231).

```text
Pass 1: src/tui/tui-pty-local.e2e.test.ts  16 passed  tests=90.83s
  preserves a disconnected draft across a real Gateway restart  13.99s
  renders a non-deliverable direct reply failure                   3.64s

Pass 2: src/tui/tui-pty-local.e2e.test.ts  16 passed  tests=74.71s
  preserves a disconnected draft across a real Gateway restart  14.08s
  renders a non-deliverable direct reply failure                   3.66s

Pass 3: src/tui/tui-pty-local.e2e.test.ts  16 passed  tests=74.30s
  preserves a disconnected draft across a real Gateway restart  13.92s
  renders a non-deliverable direct reply failure                   3.68s

Total: 48 passed, 0 failed. No retries or timeout changes.
```

The transcript contains test names and timings only; session content, credentials, and private host data are omitted.

</details>

Provenance: PR #115474 removed the duplicate append fallback and made canonical ID mismatch fatal to prevent duplicate turns. That correctly rejects an older keyed user behind a persisted assistant, but it also rejected this later valid ingress/manager ordering. Main CI run 30683534337 captured the runtime failure in the real TUI restart path; PR #115658's stale-parent rebase was present but does not reconcile a canonical keyed user ID.
