### PR TITLE
test(infra): realpath sandbox migration temp root for macOS

### DIFF
--- a/src/infra/state-migrations.workspace-setup-sandbox.test.ts
+++ b/src/infra/state-migrations.workspace-setup-sandbox.test.ts
@@ -41,7 +41,9 @@ describe("sandbox workspace Doctor migration", () => {
   });
 
   function setup() {
-    const homeDir = tempDirs.make("openclaw-sandbox-workspace-migration-home-");
+    // macOS os.tmpdir() is a /var -> /private/var symlink; prod resolvers return
+    // canonical paths, so expectations must build from the realpathed root.
+    const homeDir = fs.realpathSync(tempDirs.make("openclaw-sandbox-workspace-migration-home-"));
     const stateDir = path.join(homeDir, ".openclaw");
     const workspaceDir = path.join(homeDir, "workspace");
     fs.mkdirSync(workspaceDir, { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

`src/infra/state-migrations.workspace-setup-sandbox.test.ts` fails 14 of 18 tests locally on macOS (passing on Linux CI) with `/var/folders` vs `/private/var/folders` mismatches. The suite builds all expectations from a raw `mkdtemp` root under `os.tmpdir()`, which on macOS is a `/var → /private/var` symlink, while the production resolvers under test return canonical paths.

## Why This Change Was Made

Root `AGENTS.md` prescribes the exact fix for this class: "Tests asserting resolver/root-containment paths: fs.realpath mkdtemp/tmp roots first." The suite has a single temp-root construction site (`setup()`), so the fix is one `fs.realpathSync(...)` around it plus the required invariant comment. The shared `test/helpers/temp-dir.ts` helper is deliberately untouched — canonicalizing it would change every consumer, beyond this fix's scope.

## User Impact

None at runtime — test-only. Maintainers and agents on macOS get a green local run for this suite instead of 14 false failures.

## Evidence

- Before (macOS, main-based checkouts, verified twice on 2026-07-31): 14 failed | 4 passed.
- After: `node scripts/run-vitest.mjs src/infra/state-migrations.workspace-setup-sandbox.test.ts` — 18/18 pass on macOS (Darwin 27).
- Linux CI behavior unchanged: `realpathSync` is an identity transform on a non-symlinked tmpdir.
- Three-line test-only diff; structured autoreview skipped as trivial under the repo's triviality provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
