### PR TITLE
fix(agents): recover tagged Claude CLI reasoning

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2104,6 +2104,33 @@ describe("createCliJsonlStreamingParser", () => {
     expect(parser.getOutput()?.text).toBe("Visible answer.");
   });
 
+  it("streams rejected angle prefixes while valid split reasoning stays buffered", () => {
+    const visible = createClaudeTaggedReasoningHarness();
+    const tagged = createClaudeTaggedReasoningHarness();
+    const pushText = (parser: ReturnType<typeof createCliJsonlStreamingParser>, text: string) =>
+      parser.push(
+        `${JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text },
+          },
+        })}\n`,
+      );
+
+    pushText(visible.parser, "<div>Visible answer.</div>");
+    expect(visible.assistant.at(-1)?.text).toBe("<div>Visible answer.</div>");
+    expect(visible.parser.getOutput()?.text).toBe("<div>Visible answer.</div>");
+
+    pushText(tagged.parser, "<thi");
+    pushText(tagged.parser, "nking>Private analysis.");
+    expect(tagged.assistant).toEqual([]);
+    expect(tagged.thinking).toEqual([]);
+    pushText(tagged.parser, "</thinking>Visible answer.");
+    expect(tagged.thinking.at(-1)?.text).toBe("Private analysis.");
+    expect(tagged.assistant.at(-1)?.text).toBe("Visible answer.");
+  });
+
   it("promotes consecutive leading blocks but preserves later literal tags", () => {
     const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
 

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1331,6 +1331,23 @@ describe("parseCliOutput", () => {
 });
 
 describe("createCliJsonlStreamingParser", () => {
+  function createClaudeTaggedReasoningHarness() {
+    const assistant: Array<{ text: string; delta: string }> = [];
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: (delta) => assistant.push(delta),
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+    return { assistant, parser, thinking };
+  }
+
   it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
     "normalizes $name while incrementally streaming CLI JSONL",
     ({ raw, normalized }) => {
@@ -2009,6 +2026,210 @@ describe("createCliJsonlStreamingParser", () => {
       sessionId: "session-diverged",
       usage: undefined,
     });
+  });
+
+  it("promotes complete leading tagged Claude reasoning and keeps only the answer visible", () => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+
+    parser.push(
+      [
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "text_delta",
+              text: "<thinking>Private analysis.</thinking>Visible answer.",
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-tagged",
+          result: "<thinking>Private analysis.</thinking>Visible answer.",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      {
+        text: "Private analysis.",
+        delta: "Private analysis.",
+        isReasoningSnapshot: true,
+      },
+    ]);
+    expect(assistant).toEqual([
+      {
+        text: "Visible answer.",
+        delta: "Visible answer.",
+        sessionId: undefined,
+        usage: undefined,
+      },
+    ]);
+    expect(parser.getOutput()).toEqual({
+      text: "Visible answer.",
+      sessionId: "session-tagged",
+      usage: undefined,
+    });
+  });
+
+  it("holds chunk-split tagged reasoning until its close tag is complete", () => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+    const pushText = (text: string) =>
+      parser.push(
+        `${JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text },
+          },
+        })}\n`,
+      );
+
+    pushText("<thi");
+    pushText("nking>Private ");
+    expect(assistant).toEqual([]);
+    expect(thinking).toEqual([]);
+    pushText("analysis.</think");
+    expect(assistant).toEqual([]);
+    expect(thinking).toEqual([]);
+    pushText("ing>Visible answer.");
+    parser.finish();
+
+    expect(thinking.at(-1)?.text).toBe("Private analysis.");
+    expect(assistant.at(-1)?.text).toBe("Visible answer.");
+    expect(parser.getOutput()?.text).toBe("Visible answer.");
+  });
+
+  it("promotes consecutive leading blocks but preserves later literal tags", () => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+
+    parser.push(
+      `${JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: {
+            type: "text_delta",
+            text: [
+              "<think>First.</think>",
+              "<reasoning>Second.</reasoning>",
+              "Answer with <think>literal</think> markup.",
+            ].join("\n"),
+          },
+        },
+      })}\n`,
+    );
+    parser.finish();
+
+    expect(thinking.map((entry) => entry.text)).toEqual(["First.Second."]);
+    expect(assistant.at(-1)?.text).toBe("\nAnswer with <think>literal</think> markup.");
+    expect(parser.getOutput()?.text).toBe("Answer with <think>literal</think> markup.");
+  });
+
+  it("prefers native Claude thinking over a mirrored leading tagged block", () => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "Native analysis." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 1,
+            delta: {
+              type: "text_delta",
+              text: "<thinking>Native analysis.</thinking>Visible answer.",
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "<thinking>Native analysis.</thinking>Visible answer.",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "Native analysis.", delta: "Native analysis.", isReasoningSnapshot: true },
+    ]);
+    expect(assistant.at(-1)?.text).toBe("Visible answer.");
+    expect(parser.getOutput()?.text).toBe("Visible answer.");
+  });
+
+  it.each([
+    {
+      name: "fenced code example",
+      text: "```xml\n<thinking>literal example</thinking>\n```",
+    },
+    { name: "incomplete leading tag", text: "<thinking>unfinished visible text" },
+    { name: "malformed leading tag", text: "<thinking broken visible text" },
+  ])("preserves $name on the visible path", ({ text }) => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+
+    parser.push(
+      `${JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text },
+        },
+      })}\n`,
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([]);
+    expect(assistant.map((entry) => entry.delta).join("")).toBe(text);
+    expect(parser.getOutput()?.text).toBe(text);
+  });
+
+  it("resets tagged reasoning across Claude tool-round assistant messages", () => {
+    const { assistant, parser, thinking } = createClaudeTaggedReasoningHarness();
+    const textEvent = (text: string) =>
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text },
+        },
+      });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        textEvent("<think>First thought.</think>Before tool."),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "Read" },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        textEvent("<reasoning>Second thought.</reasoning>Final answer."),
+        JSON.stringify({ type: "result", result: "Final answer." }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking.map((entry) => entry.text)).toEqual(["First thought.", "Second thought."]);
+    expect(assistant.at(-1)?.text).toBe("Before tool.\n\nFinal answer.");
+    expect(parser.getOutput()?.text).toBe("Before tool.\n\nFinal answer.");
   });
 
   it("streams thinking deltas, skips signature deltas, and dedupes the snapshot", () => {

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2106,6 +2106,7 @@ describe("createCliJsonlStreamingParser", () => {
 
   it("streams rejected angle prefixes while valid split reasoning stays buffered", () => {
     const visible = createClaudeTaggedReasoningHarness();
+    const mixed = createClaudeTaggedReasoningHarness();
     const tagged = createClaudeTaggedReasoningHarness();
     const pushText = (parser: ReturnType<typeof createCliJsonlStreamingParser>, text: string) =>
       parser.push(
@@ -2118,9 +2119,14 @@ describe("createCliJsonlStreamingParser", () => {
         })}\n`,
       );
 
-    pushText(visible.parser, "<div>Visible answer.</div>");
-    expect(visible.assistant.at(-1)?.text).toBe("<div>Visible answer.</div>");
-    expect(visible.parser.getOutput()?.text).toBe("<div>Visible answer.</div>");
+    pushText(visible.parser, "<div>Visible prefix <thi");
+    expect(visible.assistant.at(-1)?.text).toBe("<div>Visible prefix <thi");
+    expect(visible.parser.getOutput()?.text).toBe("<div>Visible prefix <thi");
+
+    pushText(mixed.parser, "<div>Visible prefix ");
+    pushText(mixed.parser, "<thi");
+    expect(mixed.assistant.at(-1)?.text).toBe("<div>Visible prefix <thi");
+    expect(mixed.parser.getOutput()?.text).toBe("<div>Visible prefix <thi");
 
     pushText(tagged.parser, "<thi");
     pushText(tagged.parser, "nking>Private analysis.");

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1270,7 +1270,9 @@ function partitionLeadingTaggedReasoning(
   const pendingTagAfterBlock =
     end !== -1 && scan.pendingStart !== undefined && !text.slice(end, scan.pendingStart).trim();
   if (end === -1) {
-    return final ? { pending: false, reasoningText: "", visibleText: text } : { pending: true };
+    return !final && (depth > 0 || scan.pendingStart !== undefined)
+      ? { pending: true }
+      : { pending: false, reasoningText: "", visibleText: text };
   }
   if (!final && (depth > 0 || pendingTagAfterBlock || !text.slice(end).trim())) {
     return { pending: true };

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -6,6 +6,11 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  createReasoningTagTextPartitioner,
+  scanReasoningTags,
+  type ReasoningTagTextDelta,
+} from "../../packages/markdown-core/src/reasoning-tags.js";
 import type { AgentPlanStep } from "../channels/streaming.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type {
@@ -1232,6 +1237,83 @@ function readGeminiCliStreamJsonError(parsed: Record<string, unknown>): string |
   return undefined;
 }
 
+// A possible leading block stays buffered until visible prose or the message
+// boundary proves where private reasoning ends. Later tags remain literal.
+function partitionLeadingTaggedReasoning(
+  text: string,
+  final: boolean,
+): { pending: true } | { pending: false; reasoningText: string; visibleText: string } {
+  const first = text.search(/\S/u);
+  if (first === -1) {
+    return final ? { pending: false, reasoningText: "", visibleText: text } : { pending: true };
+  }
+  if (text.charAt(first) !== "<") {
+    return { pending: false, reasoningText: "", visibleText: text };
+  }
+
+  const scan = scanReasoningTags(text, final);
+  let depth = 0;
+  let end = -1;
+  for (const tag of scan.tags) {
+    if (depth === 0) {
+      const expectedStart = end === -1 ? first : end;
+      if (text.slice(expectedStart, tag.index).trim() || tag.isClose || tag.isSelfClosing) {
+        break;
+      }
+    }
+    depth += tag.isClose ? -1 : tag.isSelfClosing ? 0 : 1;
+    if (depth === 0 && tag.isClose) {
+      end = tag.index + tag.text.length;
+    }
+  }
+
+  const pendingTagAfterBlock =
+    end !== -1 && scan.pendingStart !== undefined && !text.slice(end, scan.pendingStart).trim();
+  if (end === -1) {
+    return final ? { pending: false, reasoningText: "", visibleText: text } : { pending: true };
+  }
+  if (!final && (depth > 0 || pendingTagAfterBlock || !text.slice(end).trim())) {
+    return { pending: true };
+  }
+
+  const partitioner = createReasoningTagTextPartitioner();
+  const deltas = [...partitioner.pushVisible(text.slice(0, end)), ...partitioner.flush()];
+  const reasoningText = deltas
+    .filter((delta) => delta.kind === "thinking")
+    .map((delta) => delta.text)
+    .join("");
+  return reasoningText
+    ? { pending: false, reasoningText, visibleText: text.slice(end) }
+    : { pending: false, reasoningText: "", visibleText: text };
+}
+
+function createLeadingTaggedReasoningRouter() {
+  let pending = "";
+  let settled = false;
+  const consume = (chunk: string, final: boolean): ReasoningTagTextDelta[] => {
+    if (settled) {
+      return chunk ? [{ kind: "text", text: chunk }] : [];
+    }
+    pending += chunk;
+    const result = partitionLeadingTaggedReasoning(pending, final);
+    if (result.pending) {
+      return [];
+    }
+    settled = true;
+    pending = "";
+    return [
+      ...(result.reasoningText
+        ? ([{ kind: "thinking", text: result.reasoningText }] as const)
+        : []),
+      ...(result.visibleText ? ([{ kind: "text", text: result.visibleText }] as const) : []),
+    ];
+  };
+  return {
+    push: (chunk: string) => consume(chunk, false),
+    finish: () => consume("", true),
+  };
+}
+
 /** Creates a stateful parser for streaming JSONL CLI backend output. */
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
@@ -1280,6 +1362,9 @@ export function createCliJsonlStreamingParser(params: {
   const classifyClaudeCommentary =
     Boolean(params.onCommentaryText) && supportsCliJsonlToolEvents(params);
   const thinkingTracker = createThinkingTracker();
+  const claudeStreamJson = isClaudeStreamJsonDialect(params);
+  let taggedReasoningRouter = createLeadingTaggedReasoningRouter();
+  let currentTaggedReasoningText = "";
 
   const flushPendingClaudeAssistantText = () => {
     if (!pendingClaudeText) {
@@ -1305,6 +1390,78 @@ export function createCliJsonlStreamingParser(params: {
     if (text) {
       params.onCommentaryText?.(text);
     }
+  };
+
+  const emitClaudeVisibleText = (delta: string) => {
+    if (!delta) {
+      return;
+    }
+    if (classifyClaudeCommentary) {
+      pendingClaudeText = `${pendingClaudeText}${delta}`;
+      return;
+    }
+    // A tool_use block starts a new post-tool segment even inside one assistant
+    // message; only tool-split boundaries may later outrank the result envelope.
+    // A message boundary is a tool split only when the PREVIOUS message used a
+    // tool: a tool-first fresh message must not connect an earlier draft, while
+    // a tool-using message keeps its text connected across its own boundary.
+    const boundaryPending = pendingMessageSeparator || sawToolUseSinceText;
+    const isToolSplitBoundary = pendingMessageSeparator
+      ? previousMessageHadToolUse
+      : sawToolUseSinceText;
+    const separator =
+      boundaryPending && assistantText ? missingMessageBoundarySeparator(assistantText, delta) : "";
+    if (boundaryPending && assistantText) {
+      currentMessageStart = assistantText.length + separator.length;
+      // Text before a non-tool boundary may be a superseded draft; only text
+      // connected to the result through tool splits stays a candidate.
+      if (!isToolSplitBoundary) {
+        preserveFrom = currentMessageStart;
+      }
+    }
+    pendingMessageSeparator = false;
+    sawToolUseSinceText = false;
+    const deltaText = `${separator}${delta}`;
+    assistantText = `${assistantText}${deltaText}`;
+    params.onAssistantDelta({ text: assistantText, delta: deltaText, sessionId, usage });
+  };
+
+  const emitTaggedReasoning = (delta: string) => {
+    if (!delta) {
+      return;
+    }
+    currentTaggedReasoningText = `${currentTaggedReasoningText}${delta}`;
+    // Native thinking is the provider-authored shape and remains authoritative
+    // when a text block mirrors it with tags.
+    if (!thinkingTracker.emittedText) {
+      params.onThinkingDelta?.({
+        text: currentTaggedReasoningText,
+        delta,
+        isReasoningSnapshot: true,
+      });
+    }
+  };
+
+  const routeTaggedReasoningDeltas = (deltas: readonly ReasoningTagTextDelta[]) => {
+    for (const delta of deltas) {
+      if (delta.kind === "thinking") {
+        emitTaggedReasoning(delta.text);
+      } else {
+        emitClaudeVisibleText(delta.text);
+      }
+    }
+  };
+
+  const finishTaggedReasoningMessage = () => {
+    if (claudeStreamJson) {
+      routeTaggedReasoningDeltas(taggedReasoningRouter.finish());
+    }
+  };
+
+  const beginTaggedReasoningMessage = () => {
+    finishTaggedReasoningMessage();
+    taggedReasoningRouter = createLeadingTaggedReasoningRouter();
+    currentTaggedReasoningText = "";
   };
 
   const updateSessionId = (nextSessionId: string | undefined) => {
@@ -1479,10 +1636,13 @@ export function createCliJsonlStreamingParser(params: {
     }
 
     if (classifyClaudeCommentary && parsed.type === "result") {
+      finishTaggedReasoningMessage();
       flushPendingClaudeAssistantText();
+    } else if (parsed.type === "result") {
+      finishTaggedReasoningMessage();
     }
 
-    const result = parseClaudeCliJsonlResult({
+    let result = parseClaudeCliJsonlResult({
       backend: params.backend,
       providerId: params.providerId,
       parsed,
@@ -1493,6 +1653,19 @@ export function createCliJsonlStreamingParser(params: {
       if (result.errorText) {
         output = result;
         return;
+      }
+      if (claudeStreamJson && result.text) {
+        const taggedResult = partitionLeadingTaggedReasoning(result.text, true);
+        if (!taggedResult.pending && taggedResult.reasoningText) {
+          if (
+            !thinkingTracker.emittedText &&
+            taggedResult.reasoningText !== currentTaggedReasoningText
+          ) {
+            currentTaggedReasoningText = "";
+            emitTaggedReasoning(taggedResult.reasoningText);
+          }
+          result = { ...result, text: taggedResult.visibleText.trim() };
+        }
       }
       // Empty terminal result can follow already-streamed text; keep that text.
       const streamedText = assistantText.slice(segmentStart).trim();
@@ -1569,9 +1742,12 @@ export function createCliJsonlStreamingParser(params: {
       // boundary so accumulated text joins with a paragraph break instead of
       // gluing the pre-tool text to the next message's first delta.
       if (evt.type === "message_start") {
+        beginTaggedReasoningMessage();
         pendingMessageSeparator = true;
         previousMessageHadToolUse = currentMessageHadToolUse;
         currentMessageHadToolUse = false;
+      } else if (evt.type === "message_stop") {
+        finishTaggedReasoningMessage();
       }
       const isToolUseBlockStart =
         evt.type === "content_block_start" &&
@@ -1658,36 +1834,11 @@ export function createCliJsonlStreamingParser(params: {
       }
       return;
     }
-    if (classifyClaudeCommentary) {
-      pendingClaudeText = `${pendingClaudeText}${delta.delta}`;
+    if (claudeStreamJson) {
+      routeTaggedReasoningDeltas(taggedReasoningRouter.push(delta.delta));
       return;
     }
-    // A tool_use block starts a new post-tool segment even inside one assistant
-    // message; only tool-split boundaries may later outrank the result envelope.
-    // A message boundary is a tool split only when the PREVIOUS message used a
-    // tool: a tool-first fresh message must not connect an earlier draft, while
-    // a tool-using message keeps its text connected across its own boundary.
-    const boundaryPending = pendingMessageSeparator || sawToolUseSinceText;
-    const isToolSplitBoundary = pendingMessageSeparator
-      ? previousMessageHadToolUse
-      : sawToolUseSinceText;
-    const separator =
-      boundaryPending && assistantText
-        ? missingMessageBoundarySeparator(assistantText, delta.delta)
-        : "";
-    if (boundaryPending && assistantText) {
-      currentMessageStart = assistantText.length + separator.length;
-      // Text before a non-tool boundary may be a superseded draft; only text
-      // connected to the result through tool splits stays a candidate.
-      if (!isToolSplitBoundary) {
-        preserveFrom = currentMessageStart;
-      }
-    }
-    pendingMessageSeparator = false;
-    sawToolUseSinceText = false;
-    const deltaText = `${separator}${delta.delta}`;
-    assistantText = `${assistantText}${deltaText}`;
-    params.onAssistantDelta({ ...delta, text: assistantText, delta: deltaText });
+    emitClaudeVisibleText(delta.delta);
   };
 
   const flushLines = (flushPartial: boolean) => {
@@ -1757,6 +1908,7 @@ export function createCliJsonlStreamingParser(params: {
         return;
       }
       flushLines(true);
+      finishTaggedReasoningMessage();
       if (classifyClaudeCommentary) {
         flushPendingClaudeAssistantText();
       }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1270,7 +1270,9 @@ function partitionLeadingTaggedReasoning(
   const pendingTagAfterBlock =
     end !== -1 && scan.pendingStart !== undefined && !text.slice(end, scan.pendingStart).trim();
   if (end === -1) {
-    return !final && (depth > 0 || scan.pendingStart !== undefined)
+    const pendingLeadingTag =
+      scan.pendingStart !== undefined && !text.slice(first, scan.pendingStart).trim();
+    return !final && (depth > 0 || pendingLeadingTag)
       ? { pending: true }
       : { pending: false, reasoningText: "", visibleText: text };
   }

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createCliJsonlStreamingParser } from "../../agents/cli-output.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -722,6 +723,98 @@ describe("executeAgentTurn: CLI progress bridging", () => {
         requiresReasoningProgressOptIn: true,
       },
     ]);
+  });
+
+  it("bridges tagged Claude CLI reasoning separately from its visible answer", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-7"),
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      const parser = createCliJsonlStreamingParser({
+        backend: {
+          command: "local-cli",
+          output: "jsonl",
+          jsonlDialect: "claude-stream-json",
+        },
+        providerId: "claude-cli",
+        onAssistantDelta: (delta) =>
+          realAgentEvents.emitAgentEvent({
+            runId: params.runId,
+            stream: "assistant",
+            data: delta,
+          }),
+        onThinkingDelta: (delta) =>
+          realAgentEvents.emitAgentEvent({
+            runId: params.runId,
+            stream: "thinking",
+            data: delta,
+          }),
+      });
+      parser.push(
+        [
+          JSON.stringify({
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              delta: {
+                type: "text_delta",
+                text: "<thinking>Private analysis.</thinking>Visible answer.",
+              },
+            },
+          }),
+          JSON.stringify({
+            type: "result",
+            result: "<thinking>Private analysis.</thinking>Visible answer.",
+          }),
+          "",
+        ].join("\n"),
+      );
+      parser.finish();
+      return { payloads: [{ text: parser.getOutput()?.text ?? "" }], meta: {} };
+    });
+
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async () => undefined,
+    );
+    const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
+      async () => undefined,
+    );
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-7";
+
+    await executeAgentTurn({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onPartialReply, onReasoningStream },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(onReasoningStream.mock.calls.map(([payload]) => payload.text)).toEqual([
+      "Private analysis.",
+    ]);
+    expect(onPartialReply.mock.calls.map(([payload]) => payload.text)).toEqual(["Visible answer."]);
   });
 
   it("does not bridge CLI thinking events to onReasoningStream when silentExpected is set", async () => {


### PR DESCRIPTION
Fixes #112052.

## What Problem This Solves

Fixes an issue where users running Claude through the CLI with thinking enabled could receive the final answer but lose the reasoning output when Claude emitted reasoning in a complete leading tag block. Ordinary angle-bracket-prefixed output could also be delayed while a later partial tag spelling was being disambiguated.

## Why This Change Was Made

Claude stream-json normalization now promotes complete leading reasoning-tag blocks through the existing thinking-event lane while keeping visible answer text separate. The incremental scanner buffers only a candidate at the true leading boundary, preserves native-thinking precedence and private-reasoning safety, and leaves provider, direct Anthropic, configuration, and channel policy unchanged.

## User Impact

Claude CLI reasoning is delivered through the expected reasoning surface instead of silently disappearing, and ordinary angle-bracket text continues streaming without waiting for the response to finish. No configuration change or operator action is required.

## Evidence

- Exact verified head after rebase: `0396e3f1d2dacb8440e88977a50194c741b6f7cc`
- [Redacted exact-head Claude stream-json runtime proof](https://github.com/openclaw/openclaw/pull/117264#issuecomment-5150266408): a deterministic real child process traversed the production JSONL parser, agent event bus, reply bridge, and final payload path; the verdict records `thinking` before `assistant`, separate durable payloads, and no tag or reasoning leakage into visible output. The evidence is explicitly labeled synthetic because a natural provider run was unavailable.
- 189 focused tests passed: CLI output normalization (104), CLI execution progress (15), CLI dispatch (24), and Telegram reasoning/progress suites (46)
- [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30687067399): candidate content hashes matched; core production/test typechecks and targeted lint passed
- Independent verification passed the original reasoning-loss reproduction, split-tag privacy controls, native-thinking precedence, terminal-result deduplication, and both angle-prefix streaming regressions
- Commit-mode autoreview passed with no findings (0.99 confidence)
- Production delta: +185/-29; tests: +347/-0
