### PR TITLE
fix(plugins): preserve workspace discovery and management ownership

### DIFF
--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -178,6 +178,31 @@ function emptyMetadataSnapshot() {
   };
 }
 
+function mockHostedOfficialCatalog(entries: unknown[]) {
+  mocks.officialCatalog.mockResolvedValue({
+    source: "hosted",
+    entries,
+    feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
+    metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
+  });
+}
+
+function mockClawHubInstall(pluginId: string, packageName: string, targetDir?: string) {
+  mocks.clawhubInstall.mockResolvedValue({
+    ok: true,
+    pluginId,
+    targetDir: targetDir ?? `/tmp/extensions/${pluginId}`,
+    extensions: ["index.js"],
+    packageName,
+    clawhub: {
+      source: "clawhub",
+      clawhubUrl: "https://clawhub.ai",
+      clawhubPackage: packageName,
+      clawhubFamily: "code-plugin",
+    },
+  });
+}
+
 const hostedDiffsEntry = {
   name: "@openclaw/diffs",
   version: "2.0.0",
@@ -227,12 +252,7 @@ describe("plugin management service", () => {
     mocks.providerAuthChoices.mockReturnValue([]);
     mocks.recommendedInstalls.mockReturnValue([]);
     mocks.clawReferenceWarnings.mockReturnValue([]);
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      entries: [],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
+    mockHostedOfficialCatalog([]);
   });
 
   it("keeps bundled curation when the hosted catalog falls back offline", async () => {
@@ -260,12 +280,7 @@ describe("plugin management service", () => {
 
   it("normalizes package-shaped hosted rows and deduplicates their runtime id", async () => {
     mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      entries: [hostedFeedDiffsEntry],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
+    mockHostedOfficialCatalog([hostedFeedDiffsEntry]);
 
     const available = await listManagedPlugins({ config: {}, env: {} });
     expect(available.plugins).toEqual([
@@ -289,21 +304,16 @@ describe("plugin management service", () => {
 
   it("does not transfer bundled endorsement to a package identity impostor", async () => {
     mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      entries: [
-        {
-          ...hostedDiffsEntry,
-          name: "community/impostor",
-          openclaw: {
-            ...hostedDiffsEntry.openclaw,
-            install: { clawhubSpec: "clawhub:community/impostor", defaultChoice: "clawhub" },
-          },
+    mockHostedOfficialCatalog([
+      {
+        ...hostedDiffsEntry,
+        name: "community/impostor",
+        openclaw: {
+          ...hostedDiffsEntry.openclaw,
+          install: { clawhubSpec: "clawhub:community/impostor", defaultChoice: "clawhub" },
         },
-      ],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
+      },
+    ]);
 
     const catalog = await listManagedPlugins({ config: {}, env: {} });
 
@@ -370,22 +380,42 @@ describe("plugin management service", () => {
 
   it("projects and resolves installed manifest icons by plugin identity", async () => {
     const icon = "https://cdn.example.test/workboard.svg";
+    const config = {
+      agents: {
+        defaults: { workspace: "~/fallback-workspace" },
+        list: [
+          { id: "main" },
+          { id: "research", default: true, workspace: "~/research-workspace" },
+        ],
+      },
+    };
+    const env = { HOME: "/tmp/openclaw-managed-plugin-home" };
     mocks.metadata.mockReturnValue(metadataSnapshot({ enabled: false, icon }));
 
     const catalog = await listManagedPlugins({
-      config: {},
-      env: {},
+      config,
+      env,
       officialCatalog: { entries: [] },
     });
     const resolved = await resolveManagedPluginIconUrl({
-      config: {},
-      env: {},
+      config,
+      env,
       pluginId: "workboard",
       officialCatalog: { entries: [] },
     });
 
     expect(catalog.plugins[0]).toMatchObject({ id: "workboard", hasIcon: true });
     expect(resolved).toBe(icon);
+    expect(mocks.metadata).toHaveBeenNthCalledWith(1, {
+      config,
+      env,
+      workspaceDir: "/tmp/openclaw-managed-plugin-home/research-workspace",
+    });
+    expect(mocks.metadata).toHaveBeenNthCalledWith(2, {
+      config,
+      env,
+      workspaceDir: "/tmp/openclaw-managed-plugin-home/research-workspace",
+    });
   });
 
   it("projects and resolves official catalog icons without exposing their URL", async () => {
@@ -483,7 +513,10 @@ describe("plugin management service", () => {
   });
 
   it("preserves config hash and include ownership when enabling Workboard", async () => {
-    const prepared = configSnapshot();
+    const env = { HOME: "/tmp/openclaw-managed-toggle-home" };
+    const prepared = configSnapshot({
+      agents: { defaults: { workspace: "~/managed-toggle-workspace" } },
+    });
     mocks.readConfig.mockResolvedValue(prepared);
     mocks.metadata
       .mockReturnValueOnce(metadataSnapshot({ enabled: false }))
@@ -494,9 +527,24 @@ describe("plugin management service", () => {
     const result = await setManagedPluginEnabled({
       pluginId: "workboard",
       enabled: true,
-      env: {},
+      env,
     });
 
+    expect(mocks.metadata).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        config: prepared.snapshot.sourceConfig,
+        env,
+        workspaceDir: "/tmp/openclaw-managed-toggle-home/managed-toggle-workspace",
+      }),
+    );
+    expect(mocks.metadata).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        env,
+        workspaceDir: "/tmp/openclaw-managed-toggle-home/managed-toggle-workspace",
+      }),
+    );
     expect(mocks.replaceConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         baseHash: "base-hash",
@@ -505,6 +553,7 @@ describe("plugin management service", () => {
     );
     expect(mocks.refreshRegistry).toHaveBeenCalledWith(
       expect.objectContaining({
+        env,
         reason: "policy-changed",
         policyPluginIds: ["workboard"],
       }),
@@ -632,25 +681,8 @@ describe("plugin management service", () => {
 
   it("pins curated ClawHub installs to the expected runtime id", async () => {
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      entries: [hostedFeedDiffsEntry],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "impostor",
-      targetDir: "/tmp/extensions/impostor",
-      extensions: ["index.js"],
-      packageName: "@openclaw/diffs",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "@openclaw/diffs",
-        clawhubFamily: "code-plugin",
-      },
-    });
+    mockHostedOfficialCatalog([hostedFeedDiffsEntry]);
+    mockClawHubInstall("impostor", "@openclaw/diffs");
 
     await expect(
       installManagedPlugin({
@@ -680,37 +712,19 @@ describe("plugin management service", () => {
       installPath: "/tmp/extensions/bluebubbles",
     };
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      // Hosted feed row without a declared runtime id: the id falls back to
-      // the package name, which must not become an expectedPluginId pin.
-      entries: [
-        {
-          id: "@openclaw/bluebubbles",
-          title: "BlueBubbles",
-          state: "available",
-          publisher: { id: "openclaw", trust: "official" },
-          install: {
-            candidates: [{ sourceRef: "public-clawhub", package: "@openclaw/bluebubbles" }],
-          },
+    // Package identity without a declared runtime id must not become an expectedPluginId pin.
+    mockHostedOfficialCatalog([
+      {
+        id: "@openclaw/bluebubbles",
+        title: "BlueBubbles",
+        state: "available",
+        publisher: { id: "openclaw", trust: "official" },
+        install: {
+          candidates: [{ sourceRef: "public-clawhub", package: "@openclaw/bluebubbles" }],
         },
-      ],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "bluebubbles",
-      targetDir: "/tmp/extensions/bluebubbles",
-      extensions: ["index.js"],
-      packageName: "@openclaw/bluebubbles",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "@openclaw/bluebubbles",
-        clawhubFamily: "code-plugin",
       },
-    });
+    ]);
+    mockClawHubInstall("bluebubbles", "@openclaw/bluebubbles");
     mocks.persistInstall.mockResolvedValue({});
     mocks.refreshRegistry.mockResolvedValue(undefined);
     mocks.metadata.mockReturnValue(
@@ -736,35 +750,18 @@ describe("plugin management service", () => {
 
   it("keeps the runtime-id pin when a declared id equals the package name", async () => {
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      // Unscoped package whose declared plugin id legitimately equals its name.
-      entries: [
-        {
-          id: "sonos",
-          title: "Sonos",
-          state: "available",
-          publisher: { id: "openclaw", trust: "official" },
-          openclaw: { plugin: { id: "sonos" } },
-          install: { candidates: [{ sourceRef: "public-clawhub", package: "sonos" }] },
-        },
-      ],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "impostor",
-      targetDir: "/tmp/extensions/impostor",
-      extensions: ["index.js"],
-      packageName: "sonos",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "sonos",
-        clawhubFamily: "code-plugin",
+    // An unscoped package can legitimately declare its package name as the runtime id.
+    mockHostedOfficialCatalog([
+      {
+        id: "sonos",
+        title: "Sonos",
+        state: "available",
+        publisher: { id: "openclaw", trust: "official" },
+        openclaw: { plugin: { id: "sonos" } },
+        install: { candidates: [{ sourceRef: "public-clawhub", package: "sonos" }] },
       },
-    });
+    ]);
+    mockClawHubInstall("impostor", "sonos");
 
     await expect(
       installManagedPlugin({
@@ -779,25 +776,8 @@ describe("plugin management service", () => {
 
   it("threads hosted ClawHub candidate integrity into official installs", async () => {
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.officialCatalog.mockResolvedValue({
-      source: "hosted",
-      entries: [hostedFeedDiffsEntry],
-      feed: { schemaVersion: 1, id: "test", generatedAt: "now", sequence: 1, entries: [] },
-      metadata: { url: "https://clawhub.ai/feed", status: 200, checksum: "hash" },
-    });
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "diffs",
-      targetDir: "/tmp/extensions/diffs",
-      extensions: ["index.js"],
-      packageName: "@openclaw/diffs",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "@openclaw/diffs",
-        clawhubFamily: "code-plugin",
-      },
-    });
+    mockHostedOfficialCatalog([hostedFeedDiffsEntry]);
+    mockClawHubInstall("diffs", "@openclaw/diffs");
     mocks.persistInstall.mockResolvedValue({});
     mocks.metadata.mockReturnValue(
       metadataSnapshot({ enabled: true, id: "diffs", name: "Diffs", origin: "global" }),
@@ -818,22 +798,11 @@ describe("plugin management service", () => {
   });
 
   it("removes only the newly installed managed target after persistence conflicts", async () => {
+    const env = { HOME: "/tmp/openclaw-managed-install-conflict-home" };
     const conflict = new Error("config changed during plugin install");
     const targetDir = "/tmp/extensions/demo";
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "demo",
-      targetDir,
-      extensions: ["index.js"],
-      packageName: "community/demo",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "community/demo",
-        clawhubFamily: "code-plugin",
-      },
-    });
+    mockClawHubInstall("demo", "community/demo", targetDir);
     mocks.persistInstall.mockRejectedValue(conflict);
     mocks.planUninstall.mockReturnValue({
       ok: true,
@@ -846,9 +815,10 @@ describe("plugin management service", () => {
     await expect(
       installManagedPlugin({
         request: { source: "clawhub", packageName: "community/demo" },
-        env: {},
+        env,
       }),
     ).rejects.toBe(conflict);
+    expect(mocks.installRecords).toHaveBeenCalledWith({ env });
     expect(mocks.planUninstall).toHaveBeenCalledWith({
       config: {
         plugins: {
@@ -869,37 +839,65 @@ describe("plugin management service", () => {
   });
 
   it("retains a failed install target when the durable record already owns it", async () => {
+    const env = { HOME: "/tmp/openclaw-managed-install-committed-home" };
     const persistenceError = new Error("post-commit refresh failed");
-    const targetDir = "/tmp/extensions/demo";
+    const targetDir = "/tmp/openclaw-managed-install-committed-home/extensions/demo";
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "demo",
-      targetDir,
-      extensions: ["index.js"],
-      packageName: "community/demo",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "community/demo",
-        clawhubFamily: "code-plugin",
-      },
+    mockClawHubInstall("demo", "community/demo", targetDir);
+    let committedInstallRecords: Record<string, { source: string; installPath: string }> = {};
+    mocks.persistInstall.mockImplementation(async () => {
+      committedInstallRecords = { demo: { source: "clawhub", installPath: targetDir } };
+      throw persistenceError;
     });
-    mocks.persistInstall.mockRejectedValue(persistenceError);
-    mocks.installRecords.mockResolvedValue({
-      demo: { source: "clawhub", installPath: targetDir },
+    mocks.installRecords.mockImplementation(async (options?: { env?: NodeJS.ProcessEnv }) =>
+      options?.env === env ? committedInstallRecords : {},
+    );
+    mocks.planUninstall.mockReturnValue({
+      ok: true,
+      config: {},
+      pluginId: "demo",
+      actions: {},
+      directoryRemoval: { target: targetDir },
     });
 
     await expect(
       installManagedPlugin({
         request: { source: "clawhub", packageName: "community/demo" },
-        env: {},
+        env,
       }),
     ).rejects.toMatchObject({
       message: "post-commit refresh failed",
       warning: expect.stringContaining("retained the managed target"),
       cause: persistenceError,
     });
+    expect(mocks.installRecords).toHaveBeenCalledWith({ env });
+    expect(committedInstallRecords.demo?.installPath).toBe(targetDir);
+    expect(mocks.planUninstall).not.toHaveBeenCalled();
+    expect(mocks.applyUninstall).not.toHaveBeenCalled();
+  });
+
+  it("retains a failed install target when its durable records cannot be verified", async () => {
+    const env = { HOME: "/tmp/openclaw-managed-install-unavailable-home" };
+    const persistenceError = new Error("post-commit refresh failed");
+    const targetDir = "/tmp/openclaw-managed-install-unavailable-home/extensions/demo";
+    mocks.readConfig.mockResolvedValue(configSnapshot());
+    mockClawHubInstall("demo", "community/demo", targetDir);
+    mocks.persistInstall.mockRejectedValue(persistenceError);
+    mocks.installRecords.mockRejectedValue(new Error("durable index unavailable"));
+
+    await expect(
+      installManagedPlugin({
+        request: { source: "clawhub", packageName: "community/demo" },
+        env,
+      }),
+    ).rejects.toMatchObject({
+      message: "post-commit refresh failed",
+      warning: expect.stringContaining(
+        "Could not verify whether the failed plugin install was committed",
+      ),
+      cause: persistenceError,
+    });
+    expect(mocks.installRecords).toHaveBeenCalledWith({ env });
     expect(mocks.planUninstall).not.toHaveBeenCalled();
     expect(mocks.applyUninstall).not.toHaveBeenCalled();
   });
@@ -910,19 +908,7 @@ describe("plugin management service", () => {
       releasePersist = resolve;
     });
     mocks.readConfig.mockResolvedValue(configSnapshot());
-    mocks.clawhubInstall.mockResolvedValue({
-      ok: true,
-      pluginId: "demo",
-      targetDir: "/tmp/extensions/demo",
-      extensions: ["index.js"],
-      packageName: "community/demo",
-      clawhub: {
-        source: "clawhub",
-        clawhubUrl: "https://clawhub.ai",
-        clawhubPackage: "community/demo",
-        clawhubFamily: "code-plugin",
-      },
-    });
+    mockClawHubInstall("demo", "community/demo");
     mocks.persistInstall.mockReturnValueOnce(heldPersist);
     mocks.replaceConfig.mockResolvedValue({});
     mocks.refreshRegistry.mockResolvedValue(undefined);
@@ -947,15 +933,9 @@ describe("plugin management service", () => {
   });
 
   it.each([
-    {
-      code: "clawhub_risk_acknowledgement_required",
-      expectedKind: "invalid-request",
-    },
-    {
-      code: "clawhub_security_unavailable",
-      expectedKind: "unavailable",
-    },
-  ] as const)("classifies ClawHub failure $code", async ({ code, expectedKind }) => {
+    ["clawhub_risk_acknowledgement_required", "invalid-request"],
+    ["clawhub_security_unavailable", "unavailable"],
+  ] as const)("classifies ClawHub failure %s", async (code, expectedKind) => {
     mocks.readConfig.mockResolvedValue(configSnapshot());
     mocks.clawhubInstall.mockResolvedValue({
       ok: false,
@@ -1005,12 +985,16 @@ describe("plugin management service", () => {
   });
 
   it("uninstalls an external plugin through commit, file removal, and registry refresh", async () => {
+    const env = { HOME: "/tmp/openclaw-managed-uninstall-home" };
     const installRecord = {
       source: "clawhub",
       spec: "clawhub:@openclaw/diffs",
       installPath: "/tmp/extensions/diffs",
     };
-    const prepared = configSnapshot({ plugins: { entries: { diffs: { enabled: true } } } });
+    const prepared = configSnapshot({
+      agents: { defaults: { workspace: "~/managed-uninstall-workspace" } },
+      plugins: { entries: { diffs: { enabled: true } } },
+    });
     mocks.readConfig.mockResolvedValue(prepared);
     mocks.installRecords.mockResolvedValue({ diffs: installRecord });
     mocks.metadata.mockReturnValue(
@@ -1046,8 +1030,15 @@ describe("plugin management service", () => {
     ]);
     mocks.refreshRegistry.mockResolvedValue(undefined);
 
-    const result = await uninstallManagedPlugin({ pluginId: "diffs", env: {} });
+    const result = await uninstallManagedPlugin({ pluginId: "diffs", env });
 
+    expect(mocks.installRecords).toHaveBeenCalledWith({ env });
+    expect(mocks.metadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env,
+        workspaceDir: "/tmp/openclaw-managed-uninstall-home/managed-uninstall-workspace",
+      }),
+    );
     expect(mocks.planUninstall).toHaveBeenCalledWith(
       expect.objectContaining({ pluginId: "diffs", deleteFiles: true }),
     );
@@ -1067,6 +1058,13 @@ describe("plugin management service", () => {
       )[0].nextConfig.plugins?.installs,
     ).toBeUndefined();
     expect(mocks.applyUninstall).toHaveBeenCalledWith({ target: "/tmp/extensions/diffs" });
+    expect(mocks.refreshRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env,
+        reason: "source-changed",
+        installRecords: {},
+      }),
+    );
     expect(result).toMatchObject({
       pluginId: "diffs",
       removed: ["config entry", "install record", "directory"],

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { collectChangedPaths } from "../config/config-change-paths.js";
 import {
@@ -638,6 +639,14 @@ function resolvePluginIconUrlFromCatalogFacts(params: {
   return resolveCatalogEntryIcon(officialEntry) ?? localIcon;
 }
 
+function resolveManagedPluginMetadataParams(config: OpenClawConfig, env: NodeJS.ProcessEnv) {
+  return {
+    config,
+    env,
+    workspaceDir: resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config), env),
+  };
+}
+
 /** Resolve the current manifest/catalog icon URL without accepting a caller-provided URL. */
 export async function resolveManagedPluginIconUrl(params: {
   config: OpenClawConfig;
@@ -646,7 +655,9 @@ export async function resolveManagedPluginIconUrl(params: {
   officialCatalog?: OfficialCatalogResult;
 }): Promise<string | undefined> {
   const env = params.env ?? process.env;
-  const metadata = resolvePluginMetadataSnapshot({ config: params.config, env });
+  const metadata = resolvePluginMetadataSnapshot(
+    resolveManagedPluginMetadataParams(params.config, env),
+  );
   const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
   return resolvePluginIconUrlFromCatalogFacts({
     metadata,
@@ -703,7 +714,9 @@ export async function listManagedPlugins(params: {
   officialCatalog?: OfficialCatalogResult;
 }): Promise<ManagedPluginCatalog> {
   const env = params.env ?? process.env;
-  const metadata = resolvePluginMetadataSnapshot({ config: params.config, env });
+  const metadata = resolvePluginMetadataSnapshot(
+    resolveManagedPluginMetadataParams(params.config, env),
+  );
   const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
   const bundledOfficialEntries = listOfficialExternalPluginCatalogEntries();
   const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {
@@ -983,6 +996,7 @@ function installRecordOwnsTarget(
 }
 
 async function cleanupFailedManagedPluginInstall(params: {
+  env: NodeJS.ProcessEnv;
   pluginId: string;
   install: PluginInstallRecord;
   targetDir: string;
@@ -990,7 +1004,7 @@ async function cleanupFailedManagedPluginInstall(params: {
 }): Promise<string[]> {
   let installRecords: Record<string, PluginInstallRecord>;
   try {
-    installRecords = await loadInstalledPluginIndexInstallRecords();
+    installRecords = await loadInstalledPluginIndexInstallRecords({ env: params.env });
   } catch (error) {
     return [
       `Could not verify whether the failed plugin install was committed; retained ${params.targetDir}: ${formatErrorMessage(error)}`,
@@ -1055,6 +1069,7 @@ function throwPersistenceFailureWithCleanupWarnings(error: unknown, warnings: st
 }
 
 async function persistManagedSourceInstall(params: {
+  env: NodeJS.ProcessEnv;
   snapshot: ConfigSnapshotForInstallPersist;
   pluginId: string;
   install: PluginInstallRecord;
@@ -1099,7 +1114,8 @@ export async function installManagedPluginSource(params: {
   cleanupOnPersistenceFailure?: boolean;
 }): Promise<ManagedPluginSourceInstallResult> {
   const { request } = params;
-  const extensionsDir = resolveDefaultPluginExtensionsDir(params.env ?? process.env);
+  const env = params.env ?? process.env;
+  const extensionsDir = resolveDefaultPluginExtensionsDir(env);
   if (request.source === "bundled") {
     const result = await installBundledPluginSource({
       snapshot: params.snapshot,
@@ -1149,6 +1165,7 @@ export async function installManagedPluginSource(params: {
     const targetDir = completed.targetDir ?? installed.targetDir;
     const config = await persistManagedSourceInstall({
       ...params,
+      env,
       snapshot: completed.snapshot ?? params.snapshot,
       pluginId: installed.pluginId,
       install: completed.install(installed),
@@ -1431,7 +1448,9 @@ export async function setManagedPluginEnabled(params: {
   const env = params.env ?? process.env;
   return await withPluginLifecycleLease({ env }, async () => {
     const snapshot = await readPluginMutationSnapshot(env);
-    const metadata = loadPluginMetadataSnapshot({ config: snapshot.config, env });
+    const metadata = loadPluginMetadataSnapshot(
+      resolveManagedPluginMetadataParams(snapshot.config, env),
+    );
     const pluginId = metadata.normalizePluginId(params.pluginId.trim());
     if (!metadata.index.plugins.some((plugin) => plugin.pluginId === pluginId)) {
       throw new ManagedPluginLifecycleError(`plugin not installed: ${params.pluginId}`);
@@ -1470,6 +1489,7 @@ export async function setManagedPluginEnabled(params: {
     });
     await refreshPluginRegistryAfterConfigMutation({
       config: next,
+      env,
       reason: "policy-changed",
       invalidateRuntimeCache: false,
       policyPluginIds: [policyPluginId],
@@ -1498,11 +1518,13 @@ export async function uninstallManagedPlugin(params: {
   const env = params.env ?? process.env;
   return await withPluginLifecycleLease({ env }, async () => {
     const snapshot = await readPluginMutationSnapshot(env);
-    const installRecords = await loadInstalledPluginIndexInstallRecords();
+    const installRecords = await loadInstalledPluginIndexInstallRecords({ env });
     // Mirror the CLI uninstall flow: plan against config carrying install records
     // so managed npm/git directories resolve, then persist the stripped config.
     const configWithRecords = withPluginInstallRecords(snapshot.config, installRecords);
-    const metadata = loadPluginMetadataSnapshot({ config: configWithRecords, env });
+    const metadata = loadPluginMetadataSnapshot(
+      resolveManagedPluginMetadataParams(configWithRecords, env),
+    );
     const pluginId = metadata.normalizePluginId(params.pluginId.trim());
     const record = metadata.index.plugins.find((plugin) => plugin.pluginId === pluginId);
     if (record?.origin === "bundled") {
@@ -1584,6 +1606,7 @@ export async function uninstallManagedPlugin(params: {
     ];
     await refreshPluginRegistryAfterConfigMutation({
       config: nextConfig,
+      env,
       reason: "source-changed",
       installRecords: nextInstallRecords,
       invalidateRuntimeCache: false,

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
@@ -611,5 +612,12 @@ export function inspectPluginRegistry(
 export function refreshPluginRegistry(
   params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
 ): Promise<PluginRegistrySnapshot> {
-  return refreshPersistedInstalledPluginIndex(params);
+  const workspaceDir =
+    params.workspaceDir ??
+    (params.config
+      ? resolveAgentWorkspaceDir(params.config, resolveDefaultAgentId(params.config), params.env)
+      : undefined);
+  return refreshPersistedInstalledPluginIndex(
+    workspaceDir === undefined ? params : { ...params, workspaceDir },
+  );
 }

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -1,4 +1,5 @@
 /** Builds plugin status reports from persisted metadata without importing full plugin runtimes. */
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
@@ -120,7 +121,7 @@ function buildPluginRecordFromInstalledIndex(
     commands: [...(manifest?.commandAliases?.map((alias) => alias.name) ?? [])],
     httpRoutes: 0,
     hookCount: 0,
-    configSchema: false,
+    configSchema: Boolean(manifest?.configSchema),
     contracts: manifest?.contracts,
     dependencyStatus: buildPluginDependencyStatus({
       rootDir: plugin.rootDir,
@@ -135,26 +136,28 @@ export function buildPluginRegistrySnapshotReport(
   params?: PluginRegistrySnapshotReportParams,
 ): PluginRegistryStatusReport {
   const config = params?.config ?? getRuntimeConfig();
+  const env = params?.env ?? process.env;
+  const workspaceDir =
+    params?.workspaceDir ?? resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config), env);
   const result = tracePluginLifecyclePhase(
     "plugin registry snapshot",
     () =>
       loadPluginRegistrySnapshotWithMetadata({
         config,
         env: params?.env,
-        workspaceDir: params?.workspaceDir,
+        workspaceDir,
       }),
     { surface: "status" },
   );
-  const env = params?.env ?? process.env;
   const metadataSnapshot = loadPluginMetadataSnapshot({
     index: result.snapshot,
     config,
     env,
-    workspaceDir: params?.workspaceDir,
+    workspaceDir,
   });
   const manifestByPluginId = metadataSnapshot.byPluginId;
   return projectPluginDependencyHealth({
-    workspaceDir: params?.workspaceDir,
+    workspaceDir,
     ...createEmptyPluginRegistry(),
     plugins: result.snapshot.plugins.map((plugin) =>
       buildPluginRecordFromInstalledIndex(plugin, manifestByPluginId.get(plugin.pluginId)),

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import {
+  readPersistedInstalledPluginIndex,
+  writePersistedInstalledPluginIndexSync,
+} from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
 import { refreshPluginRegistry } from "./plugin-registry.js";
 import {
@@ -23,6 +26,16 @@ const tempDirs: string[] = [];
 
 function makeTempDir() {
   return makeTrackedTempDir("openclaw-plugin-status", tempDirs);
+}
+
+function createWorkspacePluginFixture(workspaceDir: string, pluginId: string) {
+  const rootDir = path.join(workspaceDir, ".openclaw", "extensions", pluginId);
+  fs.mkdirSync(rootDir, { recursive: true });
+  return createColdPluginFixture({
+    rootDir,
+    pluginId,
+    manifest: { id: pluginId, name: `Workspace ${pluginId}` },
+  });
 }
 
 afterEach(() => {
@@ -167,6 +180,7 @@ describe("buildPluginRegistrySnapshotReport", () => {
       speechProviderIds: ["indexed-speech-provider"],
       realtimeTranscriptionProviderIds: ["indexed-transcription-provider"],
       realtimeVoiceProviderIds: ["indexed-voice-provider"],
+      configSchema: true,
       contracts: {
         agentToolResultMiddleware: ["openclaw", "codex"],
         speechProviders: ["indexed-speech-provider"],
@@ -179,6 +193,181 @@ describe("buildPluginRegistrySnapshotReport", () => {
       status: "loaded",
     });
     expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  });
+
+  it("discovers the configured default-agent workspace without importing plugin runtime", () => {
+    const tempRoot = makeTempDir();
+    const workspaceDir = path.join(tempRoot, "configured-workspace");
+    const fixture = createWorkspacePluginFixture(workspaceDir, "configured-workspace-plugin");
+    const env = {
+      ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+    };
+    const config = {
+      agents: { defaults: { workspace: workspaceDir } },
+      plugins: {
+        allow: [fixture.pluginId],
+        entries: { [fixture.pluginId]: { enabled: true } },
+      },
+    };
+
+    const report = buildPluginRegistrySnapshotReport({ config, env });
+
+    expect(report.workspaceDir).toBe(workspaceDir);
+    expectFields(requirePlugin(report.plugins, fixture.pluginId), {
+      id: fixture.pluginId,
+      origin: "workspace",
+      configSchema: true,
+    });
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  });
+
+  it("uses the selected default agent's workspace for cold plugin inventory", () => {
+    const tempRoot = makeTempDir();
+    const workspaceDir = path.join(tempRoot, "selected-agent-workspace");
+    const fallbackWorkspace = path.join(tempRoot, "fallback-workspace");
+    const fixture = createWorkspacePluginFixture(workspaceDir, "selected-agent-plugin");
+    const env = {
+      ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+    };
+    const config = {
+      agents: {
+        defaults: { workspace: fallbackWorkspace },
+        list: [{ id: "main" }, { id: "research", default: true, workspace: workspaceDir }],
+      },
+      plugins: {
+        allow: [fixture.pluginId],
+        entries: { [fixture.pluginId]: { enabled: true } },
+      },
+    };
+
+    const report = buildPluginRegistrySnapshotReport({ config, env });
+
+    expect(report.workspaceDir).toBe(workspaceDir);
+    expectFields(requirePlugin(report.plugins, fixture.pluginId), {
+      id: fixture.pluginId,
+      origin: "workspace",
+    });
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  });
+
+  it("preserves an explicit workspace over the configured default agent", () => {
+    const tempRoot = makeTempDir();
+    const configuredWorkspace = path.join(tempRoot, "configured-workspace");
+    const explicitWorkspace = path.join(tempRoot, "explicit-workspace");
+    const configured = createWorkspacePluginFixture(configuredWorkspace, "configured-plugin");
+    const explicit = createWorkspacePluginFixture(explicitWorkspace, "explicit-plugin");
+    const env = {
+      ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+    };
+    const config = {
+      agents: { defaults: { workspace: configuredWorkspace } },
+      plugins: {
+        allow: [configured.pluginId, explicit.pluginId],
+        entries: {
+          [configured.pluginId]: { enabled: true },
+          [explicit.pluginId]: { enabled: true },
+        },
+      },
+    };
+
+    const report = buildPluginRegistrySnapshotReport({
+      config,
+      env,
+      workspaceDir: explicitWorkspace,
+    });
+
+    expect(report.workspaceDir).toBe(explicitWorkspace);
+    expect(report.plugins.map((plugin) => plugin.id)).toEqual([explicit.pluginId]);
+    expect(isColdPluginRuntimeLoaded(configured)).toBe(false);
+    expect(isColdPluginRuntimeLoaded(explicit)).toBe(false);
+  });
+
+  it("keeps configured workspace plugins across manual and policy registry refreshes", async () => {
+    const rootDir = makeTempDir();
+    const stateDir = path.join(rootDir, "state");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const fixture = createWorkspacePluginFixture(workspaceDir, "workspace-demo");
+    const env = {
+      ...createColdPluginHermeticEnv(rootDir, { bundledPluginsDir: makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const config = {
+      agents: { defaults: { workspace: workspaceDir } },
+      plugins: {
+        allow: [fixture.pluginId],
+        entries: { [fixture.pluginId]: { enabled: true } },
+      },
+    };
+
+    const initial = await refreshPluginRegistry({ config, env, reason: "manual", stateDir });
+    expect(initial.plugins.map((plugin) => plugin.pluginId)).toEqual([fixture.pluginId]);
+
+    const disabledConfig = {
+      ...config,
+      plugins: { ...config.plugins, entries: { [fixture.pluginId]: { enabled: false } } },
+    };
+    const disabled = await refreshPluginRegistry({
+      config: disabledConfig,
+      env,
+      policyPluginIds: [fixture.pluginId],
+      reason: "policy-changed",
+      stateDir,
+    });
+    expect(disabled.plugins).toEqual([
+      expect.objectContaining({ pluginId: fixture.pluginId, origin: "workspace", enabled: false }),
+    ]);
+
+    const reenabled = await refreshPluginRegistry({
+      config,
+      env,
+      policyPluginIds: [fixture.pluginId],
+      reason: "policy-changed",
+      stateDir,
+    });
+    expect(reenabled.plugins).toEqual([
+      expect.objectContaining({ pluginId: fixture.pluginId, origin: "workspace", enabled: true }),
+    ]);
+    const persisted = await readPersistedInstalledPluginIndex({ stateDir });
+    expect(persisted?.plugins.map((plugin) => plugin.pluginId)).toEqual([fixture.pluginId]);
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  });
+
+  it("preserves an explicit workspace when refreshing the configured plugin registry", async () => {
+    const rootDir = makeTempDir();
+    const stateDir = path.join(rootDir, "state");
+    const configuredWorkspace = path.join(rootDir, "configured-workspace");
+    const explicitWorkspace = path.join(rootDir, "explicit-workspace");
+    const configured = createWorkspacePluginFixture(configuredWorkspace, "configured-plugin");
+    const explicit = createWorkspacePluginFixture(explicitWorkspace, "explicit-plugin");
+    const env = {
+      ...createColdPluginHermeticEnv(rootDir, { bundledPluginsDir: makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+
+    const refreshed = await refreshPluginRegistry({
+      config: {
+        agents: { defaults: { workspace: configuredWorkspace } },
+        plugins: { allow: [configured.pluginId, explicit.pluginId] },
+      },
+      env,
+      reason: "manual",
+      stateDir,
+      workspaceDir: explicitWorkspace,
+    });
+
+    expect(refreshed.plugins).toEqual([
+      expect.objectContaining({ pluginId: explicit.pluginId, origin: "workspace" }),
+    ]);
+    expect(isColdPluginRuntimeLoaded(configured)).toBe(false);
+    expect(isColdPluginRuntimeLoaded(explicit)).toBe(false);
   });
 
   it("reports package dependency install state without importing plugin runtime", () => {


### PR DESCRIPTION
## What Problem This Solves

Configured selected-agent workspace plugins disappeared from cold CLI and Control UI inventory, icons, Gateway enable/disable, linked uninstall, and persisted registry refresh. Valid plugin configuration schemas were also falsely reported absent. A post-commit install failure could delete an already-persisted plugin when management used a different home/state root.

## Why This Change Was Made

Move selected-agent workspace ownership into the existing cold control-plane readers and persisted registry writer, carry one effective management environment through metadata, mutation, install rollback and record lookup, and derive schema availability from the manifest. No configuration surface, plugin SDK, security policy, Gateway protocol, provider policy, runtime import, or SQLite schema changes.

## User Impact

Workspace plugins stay visible and manageable across Control UI, Gateway and CLI; icons resolve, enabled state survives refresh, sibling plugins survive linked uninstall, configuration support is accurately reported, and a physically installed plugin is retained after a durable post-commit failure.

## Evidence

- Test-first regressions reproduced dropped workspace inventory, false schema flags, destructive wrong-home refresh, and unsafe post-commit cleanup; ten focused existing suites pass **142 tests** across Gateway, CLI and plugin projects.
- Real Gateway handlers, Control UI inventory/icon/policy, actual CLI/manual registry refresh, distinct-home two-plugin toggles, linked uninstall, and actual persisted SQLite rows verify the complete authorized operator path with no plugin-runtime import or network request.
- An independent reviewer reran the hostile two-plugin distinct-home flow; isolated decoy-home runs emitted expected stale-config/config-migration warnings without affecting behavior or operator state.
- Real local-source installation physically copies a plugin, commits its SQLite record into an explicit state root, then injects a post-commit failure; the source and committed record survive while the separate process-owned SQLite store stays empty.
- Real existing oxlint passes all affected test suites after consolidating repeated ClawHub/catalog fixtures and relocating preserved workspace refresh regressions to their existing snapshot suite; no max-lines suppressions or new files.
- Four completed independent hostile P0–P3 audits; the sole genuine full official automated review exited 0 with no findings and 0.93 confidence.
- Production delta: **+47/-13 (net +34)** across three canonical control-plane owners; no new configuration, SDK, security, provider, protocol, or SQLite schema surface.
- Known residual intentionally held outside the five approved files: a **successful** managed install with an explicit alternate state root still needs separate shared persistence/commit-owner work; this change only guarantees its rollback safety and does not claim to fix that broader flow.
