### PR TITLE
fix(gateway): keep managed media referenced by inactive transcript branches

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -5,7 +5,10 @@ import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
-import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
+import type {
+  SessionTranscriptEventRow,
+  TranscriptEvent,
+} from "./session-accessor.sqlite-contract.js";
 import {
   collectSessionEntryLookupKeys,
   readSessionEntryRow,
@@ -236,13 +239,13 @@ function forkSqliteCheckpointTranscriptInTransaction(
   let selected:
     | {
         source: SqliteCheckpointTranscriptForkSource;
-        rows: TranscriptEvent[];
+        rows: SessionTranscriptEventRow[];
       }
     | undefined;
   for (const source of sources) {
     const rows = readSqliteTranscriptRowsForFork(database, source);
     if (rows.status === "created") {
-      selected = { source, rows: rows.events };
+      selected = { source, rows: rows.rows };
       break;
     }
     lastFailure = rows;
@@ -261,7 +264,7 @@ function forkSqliteCheckpointTranscriptInTransaction(
     sessionKey: params.targetSessionKey,
   };
   const sessionFile = formatSqliteSessionReferenceForScope(targetScope);
-  const selectedEvents = selected?.rows ?? legacySource?.events ?? [];
+  const selectedEvents = selected?.rows.map((row) => row.event) ?? legacySource?.events ?? [];
   const totalTokens = selected?.source.totalTokens ?? legacySource?.totalTokens;
   appendTranscriptEventsInTransaction(database, targetScope, [
     createSessionTranscriptHeader({
@@ -293,7 +296,7 @@ function resolvePreparedLegacyCheckpointSource(
   return matches ? source : undefined;
 }
 
-function resolveSqliteCheckpointTranscriptForkSources(
+export function resolveSqliteCheckpointTranscriptForkSources(
   checkpoint: SessionCompactionCheckpoint,
 ): SqliteCheckpointTranscriptForkSource[] {
   const sources: SqliteCheckpointTranscriptForkSource[] = [];
@@ -323,10 +326,12 @@ function resolveSqliteCheckpointTranscriptForkSources(
   return sources;
 }
 
-function readSqliteTranscriptRowsForFork(
+export function readSqliteTranscriptRowsForFork(
   database: OpenClawAgentDatabase,
   source: { sessionId: string; leafId?: string },
-): { status: "created"; events: TranscriptEvent[] } | { status: "missing-boundary" | "failed" } {
+):
+  | { status: "created"; rows: SessionTranscriptEventRow[] }
+  | { status: "missing-boundary" | "failed" } {
   const boundarySeq = source.leafId
     ? readTranscriptIdentityByEventId(database, source.sessionId, source.leafId)?.seq
     : undefined;
@@ -350,7 +355,10 @@ function readSqliteTranscriptRowsForFork(
   try {
     return {
       status: "created",
-      events: rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent),
+      rows: rows.map((row) => ({
+        event: JSON.parse(row.event_json) as TranscriptEvent,
+        seq: row.seq,
+      })),
     };
   } catch {
     return { status: "failed" };

--- a/src/config/sessions/session-accessor.sqlite-restorable-messages.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-restorable-messages.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  loadTranscriptEventRowsAfterSeqSync,
+  readSessionTranscriptRestorableMessageSnapshot,
+  replaceTranscriptEvents,
+  rewriteTranscriptEventRowsExact,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("SQLite restorable transcript messages", () => {
+  let scope: {
+    agentId: string;
+    env: NodeJS.ProcessEnv;
+    sessionId: string;
+    sessionKey: string;
+  };
+
+  beforeEach(async () => {
+    const stateDir = tempDirs.make("openclaw-restorable-messages-");
+    scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      sessionId: "restorable-messages",
+      sessionKey: "agent:main:restorable-messages",
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: Date.now() });
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  function ids() {
+    return readSessionTranscriptRestorableMessageSnapshot(scope).events.map(
+      ({ event }) => (event as { id?: unknown }).id,
+    );
+  }
+
+  function retainedIds() {
+    return readSessionTranscriptRestorableMessageSnapshot(scope).retainedEvents.map(
+      ({ event }) => (event as { id?: unknown }).id,
+    );
+  }
+
+  it("returns active and inactive branch messages once in storage order", async () => {
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId, version: 3 },
+      { type: "message", id: "u1", parentId: null, message: { role: "user", content: "one" } },
+      {
+        type: "message",
+        id: "a1",
+        parentId: "u1",
+        message: { role: "assistant", content: "one" },
+      },
+      { type: "message", id: "u2", parentId: "a1", message: { role: "user", content: "two" } },
+      {
+        type: "message",
+        id: "a2",
+        parentId: "u2",
+        message: { role: "assistant", content: "two" },
+      },
+      { type: "message", id: "u3", parentId: "a2", message: { role: "user", content: "three" } },
+      {
+        type: "leaf",
+        id: "rewind-leaf",
+        parentId: "u3",
+        targetId: "a1",
+      },
+    ]);
+
+    expect(ids()).toEqual(["u1", "a1", "u2", "a2", "u3"]);
+    expect(retainedIds()).toEqual(["u1", "a1", "u2", "a2", "u3"]);
+  });
+
+  it("keeps reset ancestry retained until a newer compaction makes it restorable", async () => {
+    const baseEvents = [
+      { type: "session", id: scope.sessionId, version: 3 },
+      { type: "message", id: "old", parentId: null, message: { role: "user", content: "old" } },
+      {
+        type: "message",
+        id: "pre-reset-tip",
+        parentId: "old",
+        message: { role: "assistant", content: "retired branch" },
+      },
+      {
+        type: "message",
+        id: "kept-user",
+        parentId: "old",
+        message: { role: "user", content: "kept" },
+      },
+      {
+        type: "message",
+        id: "kept-tool",
+        parentId: "kept-user",
+        message: { role: "toolResult", content: "not replayed" },
+      },
+      {
+        type: "message",
+        id: "kept-assistant",
+        parentId: "kept-tool",
+        message: { role: "assistant", content: "kept answer" },
+      },
+      {
+        type: "reset",
+        id: "reset-boundary",
+        parentId: "kept-assistant",
+        firstKeptEntryId: "kept-user",
+      },
+      {
+        type: "message",
+        id: "post-reset",
+        parentId: "reset-boundary",
+        message: { role: "user", content: "new active branch" },
+      },
+      {
+        type: "message",
+        id: "post-reset-inactive",
+        parentId: "reset-boundary",
+        message: { role: "assistant", content: "new inactive branch" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "post-reset-inactive",
+        targetId: "post-reset",
+      },
+    ];
+    await replaceTranscriptEvents(scope, baseEvents);
+
+    expect(ids()).toEqual(["kept-user", "kept-assistant", "post-reset", "post-reset-inactive"]);
+    expect(retainedIds()).toEqual([
+      "old",
+      "kept-user",
+      "kept-tool",
+      "kept-assistant",
+      "post-reset",
+      "post-reset-inactive",
+    ]);
+
+    await replaceTranscriptEvents(scope, [
+      ...baseEvents,
+      {
+        type: "compaction",
+        id: "newer-compaction",
+        parentId: "post-reset",
+        firstKeptEntryId: "post-reset",
+      },
+    ]);
+
+    expect(ids()).toEqual([
+      "old",
+      "kept-user",
+      "kept-tool",
+      "kept-assistant",
+      "post-reset",
+      "post-reset-inactive",
+    ]);
+    expect(retainedIds()).toEqual([
+      "old",
+      "kept-user",
+      "kept-tool",
+      "kept-assistant",
+      "post-reset",
+      "post-reset-inactive",
+    ]);
+  });
+
+  it("retains live compaction checkpoint sources through their fork boundaries", async () => {
+    const preCompactionScope = { ...scope, sessionId: "pre-compaction-session" };
+    const postCompactionScope = { ...scope, sessionId: "post-compaction-session" };
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "current",
+        parentId: null,
+        message: { role: "user", content: "current" },
+      },
+    ]);
+    await replaceTranscriptEvents(preCompactionScope, [
+      { type: "session", id: preCompactionScope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "pre-one",
+        parentId: null,
+        message: { role: "user", content: "pre one" },
+      },
+      {
+        type: "message",
+        id: "pre-leaf",
+        parentId: "pre-one",
+        message: { role: "assistant", content: "pre leaf" },
+      },
+      {
+        type: "message",
+        id: "pre-after",
+        parentId: "pre-leaf",
+        message: { role: "user", content: "outside checkpoint" },
+      },
+    ]);
+    await replaceTranscriptEvents(postCompactionScope, [
+      { type: "session", id: postCompactionScope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "post-one",
+        parentId: null,
+        message: { role: "user", content: "post one" },
+      },
+      {
+        type: "message",
+        id: "post-leaf",
+        parentId: "post-one",
+        message: { role: "assistant", content: "post leaf" },
+      },
+      {
+        type: "message",
+        id: "post-after",
+        parentId: "post-leaf",
+        message: { role: "user", content: "outside checkpoint" },
+      },
+    ]);
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId: "checkpoint-retention",
+          sessionKey: scope.sessionKey,
+          sessionId: scope.sessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: {
+            sessionId: preCompactionScope.sessionId,
+            leafId: "pre-leaf",
+          },
+          postCompaction: {
+            sessionId: postCompactionScope.sessionId,
+            entryId: "post-leaf",
+          },
+        },
+      ],
+    });
+
+    expect(ids()).toEqual(["current"]);
+    expect(retainedIds()).toEqual(["current", "pre-one", "pre-leaf", "post-one", "post-leaf"]);
+    expect(readSessionTranscriptRestorableMessageSnapshot(scope).artifactRetentionComplete).toBe(
+      true,
+    );
+  });
+
+  it("marks file-backed checkpoint retention incomplete", async () => {
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "current",
+        parentId: null,
+        message: { role: "user", content: "current" },
+      },
+    ]);
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId: "legacy-checkpoint-retention",
+          sessionKey: scope.sessionKey,
+          sessionId: scope.sessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: {
+            sessionId: "legacy-pre-session",
+            sessionFile: "/tmp/pre-compaction.jsonl",
+          },
+          postCompaction: {
+            sessionId: "legacy-post-session",
+            sessionFile: "/tmp/post-compaction.jsonl",
+          },
+        },
+      ],
+    });
+
+    expect(readSessionTranscriptRestorableMessageSnapshot(scope)).toMatchObject({
+      artifactRetentionComplete: false,
+      events: [expect.objectContaining({ event: expect.objectContaining({ id: "current" }) })],
+    });
+  });
+
+  it("marks an unreadable checkpoint source incomplete while retaining a valid fallback", async () => {
+    const postCompactionScope = { ...scope, sessionId: "post-fallback-session" };
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "current",
+        parentId: null,
+        message: { role: "user", content: "current" },
+      },
+    ]);
+    await replaceTranscriptEvents(postCompactionScope, [
+      { type: "session", id: postCompactionScope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "post-fallback",
+        parentId: null,
+        message: { role: "assistant", content: "fallback" },
+      },
+    ]);
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId: "checkpoint-fallback-retention",
+          sessionKey: scope.sessionKey,
+          sessionId: scope.sessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: {
+            sessionId: "missing-pre-session",
+            leafId: "missing-pre-leaf",
+          },
+          postCompaction: {
+            sessionId: postCompactionScope.sessionId,
+            entryId: "post-fallback",
+          },
+        },
+      ],
+    });
+
+    const snapshot = readSessionTranscriptRestorableMessageSnapshot(scope);
+    expect(snapshot.artifactRetentionComplete).toBe(false);
+    expect(snapshot.retainedEvents.map(({ event }) => (event as { id?: unknown }).id)).toEqual([
+      "current",
+      "post-fallback",
+    ]);
+  });
+
+  it("rotates generation for exact-row rewrites without changing max sequence", async () => {
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId, version: 3 },
+      {
+        type: "message",
+        id: "assistant",
+        parentId: null,
+        message: { role: "assistant", content: "before" },
+      },
+    ]);
+    const before = readSessionTranscriptRestorableMessageSnapshot(scope);
+    const row = loadTranscriptEventRowsAfterSeqSync(scope, -1).find(
+      ({ event }) => (event as { id?: unknown }).id === "assistant",
+    );
+    if (!row) {
+      throw new Error("expected assistant transcript row");
+    }
+
+    await expect(
+      rewriteTranscriptEventRowsExact(scope, {
+        expectedGeneration: before.generation,
+        rows: [
+          {
+            event: {
+              ...(row.event as Record<string, unknown>),
+              message: { role: "assistant", content: "after" },
+            },
+            expectedEventJson: JSON.stringify(row.event),
+            seq: row.seq,
+          },
+        ],
+      }),
+    ).resolves.toEqual({ generation: expect.any(String) });
+
+    const after = readSessionTranscriptRestorableMessageSnapshot(scope);
+    expect(after.generation).not.toBe(before.generation);
+    expect(after.maxSeq).toBe(before.maxSeq);
+    expect(after.events).toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          id: "assistant",
+          message: { role: "assistant", content: "after" },
+        }),
+      }),
+    ]);
+    expect(after.retainedEvents).toEqual(after.events);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-restorable-messages.ts
+++ b/src/config/sessions/session-accessor.sqlite-restorable-messages.ts
@@ -1,0 +1,204 @@
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+} from "../../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  readSqliteTranscriptRowsForFork,
+  resolveSqliteCheckpointTranscriptForkSources,
+} from "./session-accessor.sqlite-checkpoint.js";
+import type {
+  SessionTranscriptEventRow,
+  SessionTranscriptReadScope,
+  TranscriptEvent,
+} from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import { coerceSqliteNumber } from "./session-accessor.sqlite-normalize.js";
+import {
+  getSessionKysely,
+  resolveSqliteTranscriptReadScope,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import {
+  scanSessionTranscriptTree,
+  selectSessionTranscriptRetainedMessageNodes,
+  selectSessionTranscriptRestorableMessageNodes,
+} from "./transcript-tree.js";
+import type { SessionCompactionCheckpoint } from "./types.js";
+
+export type SessionTranscriptRestorableMessageSnapshot = {
+  artifactRetentionComplete: boolean;
+  events: SessionTranscriptEventRow[];
+  retainedEvents: SessionTranscriptEventRow[];
+  generation: string | null;
+  maxSeq: number | null;
+  retentionFence: string;
+};
+
+/**
+ * Every session fact that can turn an unreferenced message back into a retained one.
+ *
+ * A transcript rewrite and a checkpoint publication commit through separate write
+ * paths, so a retention snapshot is only valid while both are unchanged. Destructive
+ * callers must revalidate this token at the point of deletion, not just when reading.
+ */
+function buildSessionTranscriptRetentionFence(params: {
+  generation: string | null;
+  maxSeq: number | null;
+  checkpoints: readonly SessionCompactionCheckpoint[];
+}): string {
+  const checkpoints = params.checkpoints
+    .map((checkpoint) =>
+      [
+        checkpoint.checkpointId,
+        checkpoint.preCompaction.sessionId,
+        checkpoint.preCompaction.entryId ?? checkpoint.preCompaction.leafId ?? "",
+        checkpoint.preCompaction.sessionFile ? "file" : "",
+        checkpoint.postCompaction.sessionId,
+        checkpoint.postCompaction.entryId ?? checkpoint.postCompaction.leafId ?? "",
+        checkpoint.postCompaction.sessionFile ? "file" : "",
+      ].join(":"),
+    )
+    .toSorted();
+  return JSON.stringify([params.generation, params.maxSeq, checkpoints]);
+}
+
+/**
+ * Reads restorable and artifact-retained branch messages from one SQLite snapshot.
+ *
+ * Branch/reset policy belongs to the session store; gateway retention callers must
+ * not infer it from raw transcript rows.
+ */
+export function readSessionTranscriptRestorableMessageSnapshot(
+  scope: SessionTranscriptReadScope,
+): SessionTranscriptRestorableMessageSnapshot {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return runSqliteDeferredTransactionSync(
+    database.db,
+    () => {
+      const db = getSessionKysely(database.db);
+      const generation =
+        executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("transcript_rewrite_watermarks")
+            .select("generation")
+            .where("session_id", "=", resolved.sessionId),
+        )?.generation ?? null;
+      const rows = executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("transcript_events")
+          .select(["event_json", "seq"])
+          .where("session_id", "=", resolved.sessionId)
+          .orderBy("seq", "asc"),
+      ).rows.map((row) => ({
+        event: JSON.parse(row.event_json) as TranscriptEvent,
+        seq: coerceSqliteNumber(row.seq),
+      }));
+      const tree = scanSessionTranscriptTree(rows.map((row) => row.event));
+      const retainedEvents = new Map<string, SessionTranscriptEventRow>();
+      for (const node of selectSessionTranscriptRetainedMessageNodes(tree)) {
+        const row = rows[node.index];
+        if (row) {
+          retainedEvents.set(`${resolved.sessionId}:${row.seq}`, row);
+        }
+      }
+      const entry = resolved.sessionKey
+        ? readSessionEntryRow(database, resolved.sessionKey)?.entry
+        : undefined;
+      const entryMatchesScope = entry?.sessionId === resolved.sessionId;
+      let artifactRetentionComplete = entryMatchesScope;
+      if (entryMatchesScope) {
+        for (const checkpoint of entry.compactionCheckpoints ?? []) {
+          artifactRetentionComplete &&= ![
+            checkpoint.preCompaction.sessionFile,
+            checkpoint.postCompaction.sessionFile,
+          ].some((sessionFile) => Boolean(sessionFile?.trim()));
+          for (const source of resolveSqliteCheckpointTranscriptForkSources(checkpoint)) {
+            const sourceRows = readSqliteTranscriptRowsForFork(database, source);
+            if (sourceRows.status !== "created") {
+              artifactRetentionComplete = false;
+              continue;
+            }
+            const sourceTree = scanSessionTranscriptTree(sourceRows.rows.map((row) => row.event));
+            for (const node of selectSessionTranscriptRetainedMessageNodes(sourceTree)) {
+              const row = sourceRows.rows[node.index];
+              if (row) {
+                retainedEvents.set(`${source.sessionId}:${row.seq}`, row);
+              }
+            }
+          }
+        }
+      }
+      const maxSeq = rows.at(-1)?.seq ?? null;
+      return {
+        artifactRetentionComplete,
+        events: selectSessionTranscriptRestorableMessageNodes(tree).flatMap(
+          (node) => rows[node.index] ?? [],
+        ),
+        retainedEvents: [...retainedEvents.values()],
+        generation,
+        maxSeq,
+        retentionFence: buildSessionTranscriptRetentionFence({
+          generation,
+          maxSeq,
+          checkpoints: entryMatchesScope ? (entry.compactionCheckpoints ?? []) : [],
+        }),
+      };
+    },
+    {
+      databaseLabel: database.path,
+      operationLabel: "sessions.transcript.restorable-messages.read",
+    },
+  );
+}
+
+/**
+ * Reads only the retention fence, for revalidation immediately before an irreversible delete.
+ *
+ * Deliberately cheaper than the full snapshot: a stale retention decision must be
+ * detectable without re-walking every branch and checkpoint source.
+ */
+export function readSessionTranscriptRetentionFence(scope: SessionTranscriptReadScope): string {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return runSqliteDeferredTransactionSync(
+    database.db,
+    () => {
+      const db = getSessionKysely(database.db);
+      const generation =
+        executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("transcript_rewrite_watermarks")
+            .select("generation")
+            .where("session_id", "=", resolved.sessionId),
+        )?.generation ?? null;
+      const maxSeqValue = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("transcript_events")
+          .select((eb) => eb.fn.max<number>("seq").as("seq"))
+          .where("session_id", "=", resolved.sessionId),
+      )?.seq;
+      const maxSeq =
+        maxSeqValue === undefined || maxSeqValue === null ? null : coerceSqliteNumber(maxSeqValue);
+      const entry = resolved.sessionKey
+        ? readSessionEntryRow(database, resolved.sessionKey)?.entry
+        : undefined;
+      return buildSessionTranscriptRetentionFence({
+        generation,
+        maxSeq,
+        checkpoints:
+          entry?.sessionId === resolved.sessionId ? (entry.compactionCheckpoints ?? []) : [],
+      });
+    },
+    {
+      databaseLabel: database.path,
+      operationLabel: "sessions.transcript.retention-fence.read",
+    },
+  );
+}

--- a/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -35,21 +36,30 @@ export function readSessionTranscriptWatermark(
   const result = withOpenClawAgentDatabaseReadOnly(
     (database) => {
       const db = getNodeSqliteKysely<WatermarkDatabase>(database.db);
-      const maxSeq = executeSqliteQueryTakeFirstSync(
+      return runSqliteDeferredTransactionSync(
         database.db,
-        db
-          .selectFrom("transcript_events")
-          .select((eb) => eb.fn.max<number>("seq").as("max_seq"))
-          .where("session_id", "=", resolved.sessionId),
-      )?.max_seq;
-      const generation = executeSqliteQueryTakeFirstSync(
-        database.db,
-        db
-          .selectFrom("transcript_rewrite_watermarks")
-          .select("generation")
-          .where("session_id", "=", resolved.sessionId),
-      )?.generation;
-      return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+        () => {
+          const maxSeq = executeSqliteQueryTakeFirstSync(
+            database.db,
+            db
+              .selectFrom("transcript_events")
+              .select((eb) => eb.fn.max<number>("seq").as("max_seq"))
+              .where("session_id", "=", resolved.sessionId),
+          )?.max_seq;
+          const generation = executeSqliteQueryTakeFirstSync(
+            database.db,
+            db
+              .selectFrom("transcript_rewrite_watermarks")
+              .select("generation")
+              .where("session_id", "=", resolved.sessionId),
+          )?.generation;
+          return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+        },
+        {
+          databaseLabel: database.path,
+          operationLabel: "sessions.transcript.watermark.read",
+        },
+      );
     },
     toDatabaseOptions(resolved),
     { throwOnMissingTable: true },

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -297,6 +297,11 @@ export type {
   SessionTranscriptMessageEventPage,
 } from "./session-accessor.sqlite-active-events.js";
 export {
+  readSessionTranscriptRestorableMessageSnapshot,
+  readSessionTranscriptRetentionFence,
+  type SessionTranscriptRestorableMessageSnapshot,
+} from "./session-accessor.sqlite-restorable-messages.js";
+export {
   readSessionTranscriptWatermark,
   readSessionTranscriptWatermarkBatch,
   type SessionTranscriptWatermark,

--- a/src/config/sessions/transcript-tree.test.ts
+++ b/src/config/sessions/transcript-tree.test.ts
@@ -4,6 +4,8 @@ import {
   mergeSessionTranscriptVisiblePathWithOpaqueAppendPath,
   parseSessionTranscriptTreeEntry,
   scanSessionTranscriptTree,
+  selectSessionTranscriptRestorableBranchTipNodes,
+  selectSessionTranscriptRestorableMessageNodes,
   selectSessionTranscriptLeafControlledPath,
   selectSessionTranscriptTreePathNodes,
 } from "./transcript-tree.js";
@@ -25,6 +27,72 @@ describe("session transcript tree helpers", () => {
         parentId: "old-tail",
       }),
     ).toBe(false);
+  });
+
+  it("keeps side and opaque suffixes out of restorable branch selection", () => {
+    const entries = [
+      { type: "message", id: "root", parentId: null, message: { role: "user" } },
+      {
+        type: "message",
+        id: "active-tip",
+        parentId: "root",
+        message: { role: "assistant" },
+      },
+      {
+        type: "message",
+        id: "side-message",
+        parentId: "active-tip",
+        appendMode: "side",
+        message: { role: "assistant" },
+      },
+      { type: "opaque", id: "opaque-suffix", parentId: "active-tip" },
+    ];
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(selectSessionTranscriptRestorableBranchTipNodes(tree).map((node) => node.id)).toEqual([
+      "active-tip",
+    ]);
+    expect(selectSessionTranscriptRestorableMessageNodes(tree).map((node) => node.id)).toEqual([
+      "root",
+      "active-tip",
+    ]);
+  });
+
+  it("retires pre-reset tips while keeping every descendant branch", () => {
+    const entries = [
+      { type: "message", id: "old", parentId: null, message: { role: "user" } },
+      {
+        type: "message",
+        id: "pre-reset-tip",
+        parentId: "old",
+        message: { role: "assistant" },
+      },
+      { type: "reset", id: "reset", parentId: "old", firstKeptEntryId: "old" },
+      {
+        type: "message",
+        id: "post-reset-active",
+        parentId: "reset",
+        message: { role: "assistant" },
+      },
+      {
+        type: "message",
+        id: "post-reset-inactive",
+        parentId: "reset",
+        message: { role: "assistant" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "post-reset-inactive",
+        targetId: "post-reset-active",
+      },
+    ];
+
+    expect(
+      selectSessionTranscriptRestorableBranchTipNodes(scanSessionTranscriptTree(entries))
+        .map((node) => node.id)
+        .toSorted(),
+    ).toEqual(["post-reset-active", "post-reset-inactive"]);
   });
 
   it("treats leaf controls as navigation to their target", () => {

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -392,6 +392,125 @@ export function selectSessionTranscriptTreePathNodes<T>(
   return path.toReversed();
 }
 
+/**
+ * Select canonical branch tips that remain reachable under current reset semantics.
+ *
+ * Side and opaque suffixes are not conversation branches, so they neither become
+ * tips nor hide the canonical tip they extend. A reset retires branches that do
+ * not descend from that boundary.
+ */
+export function selectSessionTranscriptRestorableBranchTipNodes<T>(
+  tree: SessionTranscriptTree<T>,
+): SessionTranscriptTreeNode<T>[] {
+  const canonicalNodes = tree.nodes.filter(
+    (node) =>
+      isCanonicalSessionTranscriptEntry(node.entry) &&
+      !isSessionTranscriptSideAppendEntry(node.entry),
+  );
+  const referencedParents = new Set(
+    canonicalNodes.flatMap((node) => (node.parentId === null ? [] : [node.parentId])),
+  );
+  const latestReset = canonicalNodes.findLast(
+    (node) => isRecord(node.entry) && node.entry.type === "reset",
+  );
+  // The scanner already rejects leaf controls that target a pre-reset node, so
+  // every active branch after a reset is necessarily one of its descendants.
+  return canonicalNodes.filter((node) => {
+    if (node.id !== tree.leafId && referencedParents.has(node.id)) {
+      return false;
+    }
+    if (!latestReset) {
+      return true;
+    }
+    return selectSessionTranscriptTreePathNodes(tree, node.id).some(
+      (pathNode) => pathNode.id === latestReset.id,
+    );
+  });
+}
+
+function isSessionTranscriptMessageNode<T>(
+  node: SessionTranscriptTreeNode<T>,
+): node is SessionTranscriptTreeNode<T> & {
+  entry: TranscriptRecord & { type: "message" };
+} {
+  return (
+    isRecord(node.entry) &&
+    node.entry.type === "message" &&
+    !isSessionTranscriptSideAppendEntry(node.entry)
+  );
+}
+
+function hasReplayableResetMessageRole(node: SessionTranscriptTreeNode<unknown>): boolean {
+  if (!isSessionTranscriptMessageNode(node) || !isRecord(node.entry.message)) {
+    return false;
+  }
+  return node.entry.message.role === "user" || node.entry.message.role === "assistant";
+}
+
+/** Select the message path restored when switching to one canonical branch tip. */
+export function selectSessionTranscriptRestorableMessagePathNodes<T>(
+  tree: SessionTranscriptTree<T>,
+  leafId: string,
+): SessionTranscriptTreeNode<T>[] {
+  const path = selectSessionTranscriptTreePathNodes(tree, leafId);
+  const boundaryIndex = path.findLastIndex(
+    (node) =>
+      isRecord(node.entry) && (node.entry.type === "reset" || node.entry.type === "compaction"),
+  );
+  const boundary = boundaryIndex >= 0 ? path[boundaryIndex] : undefined;
+  const boundaryRecord = boundary && isRecord(boundary.entry) ? boundary.entry : undefined;
+  // Compaction summarizes replay context without deleting branch history. Only a
+  // reset narrows what branch switching can restore; a newer compaction shadows it.
+  if (boundaryRecord?.type !== "reset") {
+    return path.filter(isSessionTranscriptMessageNode);
+  }
+
+  const selected: SessionTranscriptTreeNode<T>[] = [];
+  const firstKeptEntryId = readNonEmptyString(boundaryRecord.firstKeptEntryId);
+  const keptStart = firstKeptEntryId
+    ? path.findIndex((node, index) => index < boundaryIndex && node.id === firstKeptEntryId)
+    : -1;
+  if (keptStart >= 0) {
+    selected.push(...path.slice(keptStart, boundaryIndex).filter(hasReplayableResetMessageRole));
+  }
+  selected.push(...path.slice(boundaryIndex + 1).filter(isSessionTranscriptMessageNode));
+  return selected;
+}
+
+/** Select every message event that can be restored by switching conversation branches. */
+export function selectSessionTranscriptRestorableMessageNodes<T>(
+  tree: SessionTranscriptTree<T>,
+): SessionTranscriptTreeNode<T>[] {
+  const selected = new Map<number, SessionTranscriptTreeNode<T>>();
+  for (const tip of selectSessionTranscriptRestorableBranchTipNodes(tree)) {
+    for (const node of selectSessionTranscriptRestorableMessagePathNodes(tree, tip.id)) {
+      selected.set(node.index, node);
+    }
+  }
+  return [...selected.values()].toSorted((left, right) => left.index - right.index);
+}
+
+/**
+ * Select messages whose durable artifacts must survive branch evolution.
+ *
+ * A reset narrows immediate replay, but a later compaction on the same branch
+ * restores its full ancestry. Retention therefore follows full canonical paths
+ * to currently reachable tips instead of treating the reset window as a GC boundary.
+ */
+export function selectSessionTranscriptRetainedMessageNodes<T>(
+  tree: SessionTranscriptTree<T>,
+): SessionTranscriptTreeNode<T>[] {
+  const selected = new Map<number, SessionTranscriptTreeNode<T>>();
+  for (const tip of selectSessionTranscriptRestorableBranchTipNodes(tree)) {
+    for (const node of selectSessionTranscriptTreePathNodes(tree, tip.id)) {
+      if (isSessionTranscriptMessageNode(node)) {
+        selected.set(node.index, node);
+      }
+    }
+  }
+  return [...selected.values()].toSorted((left, right) => left.index - right.index);
+}
+
 /** Merge normalized paths in original file order and expose their retained parent links. */
 export function mergeSessionTranscriptTreePaths<T>(
   paths: Array<SessionTranscriptTreeNode<T>[]>,

--- a/src/gateway/managed-image-attachments.branch-retention.test.ts
+++ b/src/gateway/managed-image-attachments.branch-retention.test.ts
@@ -1,0 +1,592 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  listSessionBranches,
+  loadTranscriptEventRowsAfterSeqSync,
+  readSessionTranscriptRetentionFence,
+  readSessionTranscriptWatermark,
+  replaceTranscriptEvents,
+  rewindSessionToMessage,
+  rewriteTranscriptEventRowsExact,
+  switchSessionBranch,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { restoreCompactionCheckpointSession } from "../config/sessions/session-accessor.sqlite-checkpoint.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  attachManagedOutgoingMediaToMessage,
+  cleanupManagedOutgoingMediaRecords,
+  handleManagedOutgoingMediaHttpRequest,
+  resolveManagedOutgoingMediaArtifactDownload,
+} from "./managed-image-attachments.js";
+import {
+  insertManagedImageRecord,
+  listManagedImageRecordEntries,
+  MANAGED_OUTGOING_ORIGINALS_SUBDIR,
+} from "./managed-image-record-store.js";
+import { rewriteAssistantTranscriptMessageByTurnIndexAndMedia } from "./server-methods/chat-transcript-persistence.js";
+import { readSessionMessagesWithSourceAsync } from "./session-transcript-readers.js";
+import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
+
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const agentId = "main";
+const sessionKey = "agent:main:media-branch";
+const sessionId = "media-branch-session";
+const attachmentId = "3f5c9c0e-1f9a-4a2b-8b3d-5c7e9a1d2b4f";
+const mediaId = "managed-branch.png";
+
+let stateDir: string;
+let mediaRoot: string;
+let originalPath: string;
+
+function mediaUrl(): string {
+  return `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+}
+
+async function seedSessionWithManagedImage() {
+  const scope = { agentId, env: process.env, sessionId, sessionKey };
+  await upsertSessionEntryCore(scope, { sessionId, updatedAt: Date.now() });
+  await appendTranscriptEvent(scope, {
+    type: "session",
+    id: sessionId,
+    version: 3,
+    timestamp: "2026-08-01T00:00:00.000Z",
+  });
+  const turns = [
+    { id: "u1", parentId: null, message: { role: "user", content: "first prompt" } },
+    { id: "a1", parentId: "u1", message: { role: "assistant", content: "first answer" } },
+    { id: "u2", parentId: "a1", message: { role: "user", content: "draw me a chart" } },
+    {
+      id: "a2",
+      parentId: "u2",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "here is the chart" },
+          { type: "image", url: mediaUrl(), openUrl: mediaUrl(), mimeType: "image/png" },
+        ],
+      },
+    },
+    { id: "u3", parentId: "a2", message: { role: "user", content: "third prompt" } },
+    { id: "a3", parentId: "u3", message: { role: "assistant", content: "third answer" } },
+  ];
+  let offset = 1;
+  for (const turn of turns) {
+    await appendTranscriptMessage(scope, {
+      eventId: turn.id,
+      message: turn.message,
+      now: Date.parse("2026-08-01T00:00:00.000Z") + offset * 1000,
+      parentId: turn.parentId,
+    });
+    offset += 1;
+  }
+}
+
+async function commitManagedRecord(messageId: string | null) {
+  await fs.mkdir(path.dirname(originalPath), { recursive: true });
+  await fs.writeFile(originalPath, Buffer.from("89504e470d0a1a0a", "hex"));
+  insertManagedImageRecord(
+    {
+      attachmentId,
+      sessionKey,
+      agentId,
+      messageId,
+      createdAt: "2026-08-01T00:00:04.000Z",
+      updatedAt: "2026-08-01T00:00:04.000Z",
+      retentionClass: "history",
+      alt: "chart",
+      original: {
+        mediaRoot,
+        mediaSubdir: MANAGED_OUTGOING_ORIGINALS_SUBDIR,
+        mediaId,
+        contentType: "image/png",
+        width: 8,
+        height: 8,
+        sizeBytes: 8,
+        filename: mediaId,
+      },
+    },
+    stateDir,
+  );
+}
+
+async function readActiveMessages(): Promise<unknown[]> {
+  const loaded = loadGatewaySessionEntryReadOnly(sessionKey, { agentId });
+  const result = await readSessionMessagesWithSourceAsync(
+    {
+      agentId,
+      sessionEntry: loaded.entry,
+      sessionId: loaded.entry?.sessionId ?? sessionId,
+      sessionKey,
+      storePath: loaded.storePath,
+    },
+    { mode: "full", reason: "branch retention", allowResetArchiveFallback: true },
+  );
+  return result.messages;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  return await fs
+    .access(target)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function fetchManagedArtifact(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<{ body: Buffer; status: number }> {
+  const server = http.createServer((req, res) => {
+    void handleManagedOutgoingMediaHttpRequest(req, res, {
+      auth: { mode: "token", token: "test-token", allowTailscale: false },
+      stateDir,
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  try {
+    const response = await fetch(`http://127.0.0.1:${address.port}${url}`, { headers });
+    return {
+      body: Buffer.from(await response.arrayBuffer()),
+      status: response.status,
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function currentTranscriptScope() {
+  const loaded = loadGatewaySessionEntryReadOnly(sessionKey, { agentId });
+  return {
+    agentId,
+    env: process.env,
+    sessionId: loaded.entry?.sessionId ?? sessionId,
+    sessionKey,
+    storePath: loaded.storePath,
+  };
+}
+
+async function rewriteManagedMessageContent(content: unknown) {
+  const scope = currentTranscriptScope();
+  const watermark = readSessionTranscriptWatermark(scope);
+  const row = loadTranscriptEventRowsAfterSeqSync(scope, -1).find(
+    ({ event }) => (event as { id?: unknown }).id === "a2",
+  );
+  if (!row) {
+    throw new Error("expected managed assistant transcript row");
+  }
+  const rewritten = await rewriteTranscriptEventRowsExact(scope, {
+    expectedGeneration: watermark.generation,
+    rows: [
+      {
+        event: {
+          ...(row.event as Record<string, unknown>),
+          message: { role: "assistant", content },
+        },
+        expectedEventJson: JSON.stringify(row.event),
+        seq: row.seq,
+      },
+    ],
+  });
+  expect(rewritten).toEqual({ generation: expect.any(String) });
+  return {
+    after: readSessionTranscriptWatermark(scope),
+    before: watermark,
+  };
+}
+
+async function rewindPastManagedImage(): Promise<string> {
+  const rewind = await rewindSessionToMessage({
+    agentId,
+    env: process.env,
+    entryId: "u2",
+    sessionKey,
+  });
+  expect(rewind.status).toBe("created");
+  const branches = await listSessionBranches({ agentId, env: process.env, sessionKey });
+  if (branches.status !== "ok") {
+    throw new Error(`branch listing failed: ${branches.status}`);
+  }
+  const inactive = branches.branches.find((branch) => !branch.active);
+  expect(inactive?.messageCount).toBe(6);
+  return inactive?.leafEntryId ?? "a3";
+}
+
+describe("managed outgoing media retention across transcript branches", () => {
+  beforeEach(async () => {
+    stateDir = tempDirs.make("managed-media-branch-");
+    mediaRoot = path.join(stateDir, "media");
+    originalPath = path.join(mediaRoot, MANAGED_OUTGOING_ORIGINALS_SUBDIR, mediaId);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await seedSessionWithManagedImage();
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+  });
+
+  it("retains media referenced only by an inactive branch after a rewind", async () => {
+    await commitManagedRecord("a2");
+    const restorableLeaf = await rewindPastManagedImage();
+
+    const result = await cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId });
+
+    expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(listManagedImageRecordEntries({ stateDir })).toHaveLength(1);
+    expect(await pathExists(originalPath)).toBe(true);
+
+    const restored = await switchSessionBranch({
+      agentId,
+      env: process.env,
+      leafEntryId: restorableLeaf,
+      sessionKey,
+    });
+    expect(restored.status).toBe("created");
+    const messages = await readActiveMessages();
+    expect(messages).toHaveLength(6);
+    expect(JSON.stringify(messages)).toContain(`${attachmentId}/full`);
+    expect(await pathExists(originalPath)).toBe(true);
+  });
+
+  it("resolves an artifact download for media on an inactive branch", async () => {
+    await commitManagedRecord("a2");
+    await rewindPastManagedImage();
+
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.not.toBeNull();
+  });
+
+  it("streams ticket-authenticated media referenced only by an inactive branch", async () => {
+    await commitManagedRecord("a2");
+    await rewindPastManagedImage();
+    const download = await resolveManagedOutgoingMediaArtifactDownload({
+      sessionKey,
+      artifactId: `artifact_managed_image_${attachmentId}`,
+      stateDir,
+    });
+    if (!download) {
+      throw new Error("expected inactive-branch artifact download");
+    }
+
+    const response = await fetchManagedArtifact(download.url);
+
+    expect(response).toEqual({
+      body: Buffer.from("89504e470d0a1a0a", "hex"),
+      status: 200,
+    });
+  });
+
+  it("streams bearer-authenticated media referenced only by an inactive branch", async () => {
+    await commitManagedRecord("a2");
+    await rewindPastManagedImage();
+
+    const response = await fetchManagedArtifact(mediaUrl(), {
+      Authorization: "Bearer test-token",
+    });
+
+    expect(response).toEqual({
+      body: Buffer.from("89504e470d0a1a0a", "hex"),
+      status: 200,
+    });
+  });
+
+  it("invalidates a warmed index after the production media rewrite rotates generation", async () => {
+    await commitManagedRecord("a2");
+    const source = await rewriteManagedMessageContent([
+      { type: "text", text: "here is the chart\nMEDIA:/tmp/chart.png" },
+    ]);
+    expect(source.after.maxSeq).toBe(source.before.maxSeq);
+    expect(source.after.generation).not.toBe(source.before.generation);
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.toBeNull();
+
+    const managedContent = [
+      { type: "text", text: "here is the chart" },
+      { type: "image", url: mediaUrl(), openUrl: mediaUrl(), mimeType: "image/png" },
+    ];
+    const rewritten = await rewriteAssistantTranscriptMessageByTurnIndexAndMedia({
+      afterSeq: 0,
+      assistantMessageIndex: 2,
+      content: managedContent,
+      expectedGeneration: source.after.generation,
+      mediaUrls: ["/tmp/chart.png"],
+      scope: currentTranscriptScope(),
+    });
+    expect(rewritten).toEqual({
+      generation: expect.any(String),
+      messageId: "a2",
+    });
+    if (!rewritten) {
+      throw new Error("expected production transcript rewrite");
+    }
+    attachManagedOutgoingMediaToMessage({
+      messageId: rewritten.messageId,
+      blocks: managedContent,
+      stateDir,
+    });
+    const restored = readSessionTranscriptWatermark(currentTranscriptScope());
+    expect(restored.maxSeq).toBe(source.after.maxSeq);
+    expect(restored.generation).toBe(rewritten.generation);
+    expect(restored.generation).not.toBe(source.after.generation);
+
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.not.toBeNull();
+    await expect(
+      cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+  });
+
+  it("keeps reset-hidden media until a later compaction restores it", async () => {
+    await commitManagedRecord("a2");
+    const scope = currentTranscriptScope();
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "a3",
+      firstKeptEntryId: "u3",
+      timestamp: "2026-08-01T00:01:00.000Z",
+    });
+    await appendTranscriptMessage(scope, {
+      eventId: "post-reset",
+      message: { role: "user", content: "new context" },
+      now: Date.parse("2026-08-01T00:01:01.000Z"),
+      parentId: "reset-boundary",
+    });
+
+    await expect(
+      fetchManagedArtifact(mediaUrl(), {
+        Authorization: "Bearer test-token",
+      }),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(await pathExists(originalPath)).toBe(true);
+
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "newer-compaction",
+      parentId: "post-reset",
+      firstKeptEntryId: "post-reset",
+      timestamp: "2026-08-01T00:01:02.000Z",
+    });
+
+    await expect(
+      fetchManagedArtifact(mediaUrl(), {
+        Authorization: "Bearer test-token",
+      }),
+    ).resolves.toEqual({
+      body: Buffer.from("89504e470d0a1a0a", "hex"),
+      status: 200,
+    });
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.not.toBeNull();
+    await expect(
+      cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(await pathExists(originalPath)).toBe(true);
+  });
+
+  it("keeps checkpoint-only media through cleanup and restore", async () => {
+    await commitManagedRecord("a2");
+    const currentSessionId = "post-compaction-current";
+    const checkpointId = "managed-media-checkpoint";
+    const currentScope = {
+      agentId,
+      env: process.env,
+      sessionId: currentSessionId,
+      sessionKey,
+    };
+    await replaceTranscriptEvents(currentScope, [
+      { type: "session", id: currentSessionId, version: 3 },
+      {
+        type: "message",
+        id: "post-compaction-message",
+        parentId: null,
+        message: { role: "user", content: "current compacted context" },
+      },
+    ]);
+    await upsertSessionEntryCore(currentScope, {
+      sessionId: currentSessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId,
+          sessionKey,
+          sessionId: currentSessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: {
+            sessionId,
+            leafId: "a3",
+          },
+          postCompaction: {
+            sessionId: currentSessionId,
+            entryId: "post-compaction-message",
+          },
+        },
+      ],
+    });
+
+    await expect(
+      fetchManagedArtifact(mediaUrl(), {
+        Authorization: "Bearer test-token",
+      }),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(await pathExists(originalPath)).toBe(true);
+
+    const restored = await restoreCompactionCheckpointSession({
+      agentId,
+      env: process.env,
+      expectedState: { sessionId: currentSessionId, lifecycleRevision: undefined },
+      sessionKey,
+      checkpointId,
+    });
+    expect(restored.status).toBe("created");
+    await expect(
+      fetchManagedArtifact(mediaUrl(), {
+        Authorization: "Bearer test-token",
+      }),
+    ).resolves.toEqual({
+      body: Buffer.from("89504e470d0a1a0a", "hex"),
+      status: 200,
+    });
+    await expect(
+      resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey,
+        artifactId: `artifact_managed_image_${attachmentId}`,
+        stateDir,
+      }),
+    ).resolves.not.toBeNull();
+  });
+
+  it("moves the retention fence when a checkpoint is published after a retention read", async () => {
+    await commitManagedRecord("missing-message");
+    const scope = currentTranscriptScope();
+
+    const beforePublication = readSessionTranscriptRetentionFence(scope);
+    expect(readSessionTranscriptRetentionFence(scope)).toBe(beforePublication);
+
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId: "late-checkpoint",
+          sessionKey,
+          sessionId: scope.sessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: { sessionId, leafId: "a3" },
+          postCompaction: { sessionId: scope.sessionId, entryId: "a2" },
+        },
+      ],
+    });
+
+    expect(readSessionTranscriptRetentionFence(scope)).not.toBe(beforePublication);
+  });
+
+  it("keeps media whose message a checkpoint publication restores before deletion", async () => {
+    await commitManagedRecord("a2");
+    const scope = currentTranscriptScope();
+    const currentSessionId = "fenced-post-compaction";
+    const currentScope = { agentId, env: process.env, sessionId: currentSessionId, sessionKey };
+    await replaceTranscriptEvents(currentScope, [
+      { type: "session", id: currentSessionId, version: 3 },
+      {
+        type: "message",
+        id: "fenced-current-message",
+        parentId: null,
+        message: { role: "user", content: "current compacted context" },
+      },
+    ]);
+    await upsertSessionEntryCore(currentScope, {
+      sessionId: currentSessionId,
+      updatedAt: Date.now(),
+    });
+
+    const unfenced = readSessionTranscriptRetentionFence(currentScope);
+
+    await upsertSessionEntryCore(currentScope, {
+      sessionId: currentSessionId,
+      updatedAt: Date.now(),
+      compactionCheckpoints: [
+        {
+          checkpointId: "fenced-checkpoint",
+          sessionKey,
+          sessionId: currentSessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          preCompaction: { sessionId, leafId: "a3" },
+          postCompaction: { sessionId: currentSessionId, entryId: "fenced-current-message" },
+        },
+      ],
+    });
+
+    expect(readSessionTranscriptRetentionFence(currentScope)).not.toBe(unfenced);
+    expect(readSessionTranscriptRetentionFence(scope)).not.toBe(unfenced);
+
+    await expect(
+      cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(await pathExists(originalPath)).toBe(true);
+  });
+
+  it("still deletes media whose message is absent from every branch", async () => {
+    await commitManagedRecord("missing-message");
+
+    const result = await cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey, agentId });
+
+    expect(result).toEqual({ deletedRecordCount: 1, deletedFileCount: 1, retainedCount: 0 });
+    expect(listManagedImageRecordEntries({ stateDir })).toHaveLength(0);
+    expect(await pathExists(originalPath)).toBe(false);
+  });
+});

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -32,6 +32,7 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   attachManagedImageRecordToMessage,
+  claimManagedImageRecordCleanupIfCurrent,
   insertManagedImageRecord,
   listManagedImageRecordEntries,
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
@@ -53,6 +54,28 @@ const resolveOpenAiCompatibleHttpOperatorScopesMock = vi.fn();
 const resolveOpenAiCompatibleHttpSenderIsOwnerMock = vi.fn();
 const loadSessionEntryMock = vi.fn();
 const readSessionMessagesMock = vi.fn();
+type RestorableBranchSessionMessagesSnapshotScopeMock = {
+  sessionKey?: string;
+};
+type RestorableBranchSessionMessagesSnapshotMock = {
+  artifactRetentionComplete?: boolean;
+  generation: string | null;
+  maxSeq: number | null;
+  messages: unknown[];
+  retainedMessages?: unknown[];
+  retentionFence?: string;
+};
+const readRestorableBranchSessionMessagesSnapshotMock = vi.fn<
+  (
+    scope: RestorableBranchSessionMessagesSnapshotScopeMock,
+  ) => RestorableBranchSessionMessagesSnapshotMock
+>(() => ({
+  generation: "generation-1",
+  maxSeq: 0,
+  messages: [],
+}));
+const readSessionTranscriptRevisionMock = vi.fn<() => string | null>(() => "sess-1:generation-1:0");
+const readSessionRetentionFenceMock = vi.fn<() => string>(() => "retention-fence-1");
 const resolveSessionHistoryTranscriptPathMock = vi.fn();
 const getRuntimeConfigMock = vi.fn(() => ({}));
 const probePlaybackMediaFileDescriptorMock = vi.fn(async () => ({ durationMs: 1000 }));
@@ -86,6 +109,19 @@ vi.mock("./session-utils.js", () => ({
 }));
 
 vi.mock("./session-transcript-readers.js", () => ({
+  readRestorableBranchSessionMessagesSnapshot: (
+    scope: RestorableBranchSessionMessagesSnapshotScopeMock,
+  ) => {
+    const snapshot = readRestorableBranchSessionMessagesSnapshotMock(scope);
+    return {
+      ...snapshot,
+      artifactRetentionComplete: snapshot.artifactRetentionComplete ?? true,
+      retainedMessages: snapshot.retainedMessages ?? snapshot.messages,
+      retentionFence: snapshot.retentionFence ?? readSessionRetentionFenceMock(),
+    };
+  },
+  readSessionRetentionFence: readSessionRetentionFenceMock,
+  readSessionTranscriptRevision: readSessionTranscriptRevisionMock,
   readSessionMessagesAsync: readSessionMessagesMock,
   readSessionMessagesWithSourceAsync: async (...args: unknown[]) => ({
     messages: await readSessionMessagesMock(...args),
@@ -260,6 +296,19 @@ async function prepareManagedSessionStore(stateDir: string): Promise<void> {
   getRuntimeConfigMock.mockReturnValue({ session: { store: storePath } });
 }
 
+async function prepareManagedSessionKey(stateDir: string, sessionKey: string): Promise<void> {
+  await replaceTestSessionEntry(
+    {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      sessionKey,
+      storePath: path.join(stateDir, "sessions.sqlite"),
+    },
+    { sessionId: "sess-1", updatedAt: Date.now() },
+  );
+  closeOpenClawAgentDatabasesForTest();
+}
+
 async function createFixture(
   stateDir: string,
   options?: {
@@ -315,8 +364,16 @@ async function requestManagedImage(params: {
   transcriptMessages?: Record<string, unknown>[];
   sessionEntry?: { sessionId: string; sessionFile?: string };
   resolvedTranscriptPath?: string | null;
-  onReadTranscriptMessages?: () => Promise<void> | void;
+  transcriptGeneration?: string | null;
+  transcriptMaxSeq?: number | null;
+  transcriptRevision?: string | null;
+  transcriptReadError?: Error;
 }) {
+  const transcriptGeneration =
+    params.transcriptGeneration === undefined
+      ? `generation-${path.basename(params.stateDir)}`
+      : params.transcriptGeneration;
+  const transcriptMaxSeq = params.transcriptMaxSeq === undefined ? 0 : params.transcriptMaxSeq;
   authorizeGatewayHttpRequestOrReplyMock.mockImplementation(async ({ res }) => {
     if (params.denyAuth) {
       res.statusCode = 401;
@@ -342,8 +399,46 @@ async function requestManagedImage(params: {
   resolveSessionHistoryTranscriptPathMock.mockResolvedValue(
     params.resolvedTranscriptPath ?? params.sessionEntry?.sessionFile ?? "session.jsonl",
   );
+  const transcriptReadError = params.transcriptReadError;
+  if (transcriptReadError) {
+    readSessionTranscriptRevisionMock.mockImplementation(() => {
+      throw transcriptReadError;
+    });
+    readRestorableBranchSessionMessagesSnapshotMock.mockImplementation(() => {
+      throw transcriptReadError;
+    });
+  } else {
+    readSessionTranscriptRevisionMock.mockReturnValue(
+      params.transcriptRevision === undefined
+        ? transcriptGeneration
+          ? `sess-1:${transcriptGeneration}:${transcriptMaxSeq}`
+          : null
+        : params.transcriptRevision,
+    );
+    readRestorableBranchSessionMessagesSnapshotMock.mockImplementation(() => {
+      return {
+        generation: transcriptGeneration,
+        maxSeq: transcriptMaxSeq,
+        messages:
+          params.resolvedTranscriptPath?.includes(".reset.") === true
+            ? []
+            : (params.transcriptMessages ?? [
+                {
+                  role: "assistant",
+                  content: [
+                    {
+                      type: "image",
+                      url: params.pathName,
+                      openUrl: params.pathName,
+                    },
+                  ],
+                  __openclaw: { id: "msg-1" },
+                },
+              ]),
+      };
+    });
+  }
   readSessionMessagesMock.mockImplementation(async () => {
-    await params.onReadTranscriptMessages?.();
     return (
       params.transcriptMessages ?? [
         {
@@ -425,6 +520,15 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     stateDir = tempDirs.make("managed-images-");
     vi.clearAllMocks();
     await prepareManagedSessionStore(stateDir);
+    readSessionMessagesMock.mockResolvedValue([]);
+    resolveSessionHistoryTranscriptPathMock.mockResolvedValue(null);
+    const generation = `generation-${path.basename(stateDir)}`;
+    readSessionTranscriptRevisionMock.mockReturnValue(`sess-1:${generation}:0`);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation,
+      maxSeq: 0,
+      messages: [],
+    });
   });
 
   afterEach(async () => {
@@ -450,12 +554,16 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       authResponse: { authMethod: "token" },
     });
 
-    expect(resolveSessionHistoryTranscriptPathMock).toHaveBeenCalled();
-    expect(readSessionMessagesMock).toHaveBeenCalled();
     expect(result.statusCode).toBe(200);
     expect(result.headers["content-type"]).toBe("image/png");
     expect(result.headers["content-disposition"]).toContain("inline");
     expect(result.body.toString("utf-8")).toBe("original-image");
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-1",
+        sessionKey: "agent:main:main",
+      }),
+    );
   });
 
   it("serves Unicode media filenames with an encoded content disposition", async () => {
@@ -686,13 +794,17 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       entry: { sessionId: "sess-1", sessionFile: "session.jsonl" },
     });
     resolveSessionHistoryTranscriptPathMock.mockResolvedValue("session.jsonl");
-    readSessionMessagesMock.mockResolvedValue([
-      {
-        role: "assistant",
-        content: [{ type: "audio", url: canonicalPath, openUrl: canonicalPath }],
-        __openclaw: { id: "msg-1" },
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "audio", url: canonicalPath, openUrl: canonicalPath }],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
     const download = await resolveManagedOutgoingImageArtifactDownload({
       sessionKey,
       artifactId: `${MANAGED_OUTGOING_MEDIA_ARTIFACT_ID_PREFIX}${attachmentId}`,
@@ -773,18 +885,22 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       entry: { sessionId: "sess-1", sessionFile: "session.jsonl" },
     });
     resolveSessionHistoryTranscriptPathMock.mockResolvedValue("session.jsonl");
-    readSessionMessagesMock.mockResolvedValue([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "audio",
-            url: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
-          },
-        ],
-        __openclaw: { id: "msg-1" },
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "audio",
+              url: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+            },
+          ],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
     resolvePlaybackTranscodeMock.mockRejectedValueOnce(new Error("playback inspection failed"));
     const originalOpen = fs.open;
     let closeOpenedHandle: MockInstance<() => Promise<void>> | undefined;
@@ -906,13 +1022,17 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       entry: { sessionId: "sess-1", sessionFile: "session.jsonl" },
     });
     resolveSessionHistoryTranscriptPathMock.mockResolvedValue("session.jsonl");
-    readSessionMessagesMock.mockResolvedValue([
-      {
-        role: "assistant",
-        content: [{ type: "image", url: canonicalPath, openUrl: canonicalPath }],
-        __openclaw: { id: "msg-1" },
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "image", url: canonicalPath, openUrl: canonicalPath }],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
 
     const download = await resolveManagedOutgoingImageArtifactDownload({
       sessionKey,
@@ -960,6 +1080,17 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
         __openclaw: { id: "msg-1" },
       },
     ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: "generation-1",
+      maxSeq: 0,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "audio", url: canonicalPath, openUrl: canonicalPath }],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
 
     const download = await resolveManagedOutgoingImageArtifactDownload({
       sessionKey,
@@ -987,6 +1118,11 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     });
     resolveSessionHistoryTranscriptPathMock.mockResolvedValue("session.jsonl");
     readSessionMessagesMock.mockResolvedValue(transcriptMessages);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: "generation-1",
+      maxSeq: 0,
+      messages: transcriptMessages,
+    });
     const download = await resolveManagedOutgoingImageArtifactDownload({
       sessionKey,
       artifactId: `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${attachmentId}`,
@@ -1181,6 +1317,29 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.statusCode).toBe(404);
   });
 
+  it("fails closed instead of trusting an archive when the canonical read fails", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName,
+      authResponse: { authMethod: "token" },
+      resolvedTranscriptPath: "/tmp/sess-main.jsonl.reset.old",
+      transcriptMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "image", url: pathName, openUrl: pathName }],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+      transcriptReadError: new Error("synthetic canonical read failure"),
+    });
+
+    expect(result.statusCode).toBe(404);
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
+  });
+
   it("reuses the session attachment index across requests until the transcript changes", async () => {
     const { attachmentId, sessionKey } = await createFixture(stateDir);
     const sessionFile = path.join(stateDir, "sessions", "sess-main.jsonl");
@@ -1219,7 +1378,7 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
 
     expect(first.result.statusCode).toBe(200);
     expect(second.result.statusCode).toBe(200);
-    expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledTimes(1);
 
     await fs.writeFile(sessionFile, '{"message":{}}\n{"message":{"content":"updated"}}\n', "utf-8");
 
@@ -1229,10 +1388,13 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       authResponse: { authMethod: "token" },
       sessionEntry: { sessionId: "sess-main", sessionFile },
       transcriptMessages,
+      transcriptGeneration: "generation-2",
+      transcriptMaxSeq: 1,
+      transcriptRevision: "sess-1:generation-2:1",
     });
 
     expect(third.result.statusCode).toBe(200);
-    expect(readSessionMessagesMock).toHaveBeenCalledTimes(2);
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledTimes(2);
   });
 
   it("reuses the session attachment index for archive-backed requests", async () => {
@@ -1266,6 +1428,9 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       sessionEntry: { sessionId: "sess-main" },
       resolvedTranscriptPath: archiveFile,
       transcriptMessages,
+      transcriptGeneration: null,
+      transcriptMaxSeq: null,
+      transcriptRevision: null,
     });
     const second = await requestManagedImage({
       stateDir,
@@ -1274,6 +1439,9 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       sessionEntry: { sessionId: "sess-main" },
       resolvedTranscriptPath: archiveFile,
       transcriptMessages,
+      transcriptGeneration: null,
+      transcriptMaxSeq: null,
+      transcriptRevision: null,
     });
 
     expect(first.result.statusCode).toBe(200);
@@ -1281,7 +1449,7 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not cache a session attachment index when the transcript changes during the read", async () => {
+  it("keys the attachment index to the generation returned by the owner snapshot", async () => {
     const { attachmentId, sessionKey } = await createFixture(stateDir);
     const sessionFile = path.join(stateDir, "sessions", "sess-main.jsonl");
     await fs.mkdir(path.dirname(sessionFile), { recursive: true });
@@ -1300,7 +1468,6 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       },
     ];
 
-    let mutatedTranscript = false;
     const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
     const first = await requestManagedImage({
       stateDir,
@@ -1308,12 +1475,9 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       authResponse: { authMethod: "token" },
       sessionEntry: { sessionId: "sess-main", sessionFile },
       transcriptMessages,
-      onReadTranscriptMessages: async () => {
-        if (!mutatedTranscript) {
-          mutatedTranscript = true;
-          await fs.appendFile(sessionFile, '{"message":{"content":"updated"}}\n', "utf-8");
-        }
-      },
+      transcriptGeneration: "generation-2",
+      transcriptMaxSeq: 0,
+      transcriptRevision: "sess-1:generation-1:0",
     });
     const second = await requestManagedImage({
       stateDir,
@@ -1321,11 +1485,14 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       authResponse: { authMethod: "token" },
       sessionEntry: { sessionId: "sess-main", sessionFile },
       transcriptMessages,
+      transcriptGeneration: "generation-2",
+      transcriptMaxSeq: 0,
+      transcriptRevision: "sess-1:generation-2:0",
     });
 
     expect(first.result.statusCode).toBe(200);
     expect(second.result.statusCode).toBe(200);
-    expect(readSessionMessagesMock).toHaveBeenCalledTimes(2);
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -2478,6 +2645,15 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     stateDir = tempDirs.make("managed-image-cleanup-");
     vi.clearAllMocks();
     await prepareManagedSessionStore(stateDir);
+    readSessionMessagesMock.mockResolvedValue([]);
+    resolveSessionHistoryTranscriptPathMock.mockResolvedValue(null);
+    const generation = `generation-${path.basename(stateDir)}`;
+    readSessionTranscriptRevisionMock.mockReturnValue(`sess-1:${generation}:0`);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation,
+      maxSeq: 0,
+      messages: [],
+    });
   });
 
   afterEach(async () => {
@@ -2492,13 +2668,65 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({ stateDir });
 
     expect(result.deletedRecordCount).toBe(1);
     expect(result.deletedFileCount).toBe(1);
     expect(result.retainedCount).toBe(0);
+    await expectPathMissing(fixture.originalPath);
+  });
+
+  it("keeps media when a checkpoint publication moves the retention fence before deletion", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+      retentionFence: "retention-fence-before-publication",
+    });
+    readSessionRetentionFenceMock.mockReturnValue("retention-fence-after-publication");
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("deletes media when the retention fence is unchanged at deletion", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+      retentionFence: "retention-fence-stable",
+    });
+    readSessionRetentionFenceMock.mockReturnValue("retention-fence-stable");
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toEqual({
+      deletedRecordCount: 1,
+      deletedFileCount: 1,
+      retainedCount: 0,
+    });
     await expectPathMissing(fixture.originalPath);
   });
 
@@ -2586,13 +2814,126 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     await expectPathMissing(fixture.originalPath);
   });
 
+  it("does not resurrect retired refs from an archive after an empty canonical snapshot", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    resolveSessionHistoryTranscriptPathMock.mockResolvedValue("/tmp/sess-main.jsonl.reset.old");
+    readSessionMessagesMock.mockResolvedValue([
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+          },
+        ],
+      },
+    ]);
+
+    await expect(cleanupManagedOutgoingImageRecords({ stateDir })).resolves.toEqual({
+      deletedRecordCount: 1,
+      deletedFileCount: 1,
+      retainedCount: 0,
+    });
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
+    await expectPathMissing(fixture.originalPath);
+  });
+
+  it("retains all history records when only a reset archive is available", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readSessionTranscriptRevisionMock.mockReturnValue(null);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: null,
+      maxSeq: null,
+      messages: [],
+      retainedMessages: [],
+    });
+    resolveSessionHistoryTranscriptPathMock.mockResolvedValue("/tmp/sess-main.jsonl.reset.old");
+    readSessionMessagesMock.mockResolvedValue([]);
+
+    await expect(cleanupManagedOutgoingImageRecords({ stateDir })).resolves.toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+    expect(resolveSessionHistoryTranscriptPathMock).not.toHaveBeenCalled();
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("retains all history records when checkpoint file fallback is still possible", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      artifactRetentionComplete: false,
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+      retainedMessages: [],
+    });
+
+    await expect(cleanupManagedOutgoingImageRecords({ stateDir })).resolves.toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("aborts cleanup without trusting an archive when the canonical read fails", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    resolveSessionHistoryTranscriptPathMock.mockResolvedValue("/tmp/sess-main.jsonl.reset.old");
+    readSessionTranscriptRevisionMock.mockImplementation(() => {
+      throw new Error("synthetic canonical read failure");
+    });
+    readSessionMessagesMock.mockResolvedValue([
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+          },
+        ],
+      },
+    ]);
+
+    await expect(cleanupManagedOutgoingImageRecords({ stateDir })).rejects.toThrow(
+      "synthetic canonical read failure",
+    );
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
   it("retries a durably claimed file deletion after a filesystem failure", async () => {
     const fixture = await createFixture(stateDir);
     loadSessionEntryMock.mockReturnValue({
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
     const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("synthetic rm failure"));
 
     let failed: Awaited<ReturnType<typeof cleanupManagedOutgoingImageRecords>>;
@@ -2610,6 +2951,196 @@ describe("cleanupManagedOutgoingImageRecords", () => {
 
     expect(retried).toEqual({ deletedRecordCount: 1, deletedFileCount: 1, retainedCount: 0 });
     await expectPathMissing(fixture.originalPath);
+  });
+
+  it("releases a stale cleanup claim when upgraded retention still owns the media", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+      retainedMessages: [
+        {
+          __openclaw: { id: "msg-1" },
+          content: [
+            {
+              type: "image",
+              url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+            },
+          ],
+        },
+      ],
+    });
+    const record = readManagedImageRecord(fixture.attachmentId, stateDir);
+    if (!record) {
+      throw new Error("expected managed image record");
+    }
+    expect(claimManagedImageRecordCleanupIfCurrent(record, stateDir)).toBe(true);
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).toBeNull();
+
+    await expect(cleanupManagedOutgoingImageRecords({ stateDir })).resolves.toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("serializes stale-claim rescue behind active cleanup in the same state directory", async () => {
+    const deleting = await createFixture(stateDir, {
+      attachmentId: "11111111-1111-4111-8111-111111111111",
+      sessionKey: "agent:main:deleting",
+    });
+    const retained = await createFixture(stateDir, {
+      attachmentId: "22222222-2222-4222-8222-222222222222",
+      sessionKey: "agent:main:retained",
+    });
+    await prepareManagedSessionKey(stateDir, deleting.sessionKey);
+    await prepareManagedSessionKey(stateDir, retained.sessionKey);
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: sessionKey, sessionFile: `/tmp/${sessionKey}.jsonl` },
+    }));
+    readRestorableBranchSessionMessagesSnapshotMock.mockImplementation((scope) => ({
+      generation: `generation-${scope.sessionKey}`,
+      maxSeq: 0,
+      messages: [],
+      retainedMessages:
+        scope.sessionKey === retained.sessionKey
+          ? [
+              {
+                __openclaw: { id: "msg-1" },
+                content: [
+                  {
+                    type: "image",
+                    url: `/api/chat/media/outgoing/${encodeURIComponent(retained.sessionKey)}/${retained.attachmentId}/full`,
+                  },
+                ],
+              },
+            ]
+          : [],
+    }));
+    const retainedRecord = readManagedImageRecord(retained.attachmentId, stateDir);
+    if (!retainedRecord) {
+      throw new Error("expected retained managed image record");
+    }
+    expect(claimManagedImageRecordCleanupIfCurrent(retainedRecord, stateDir)).toBe(true);
+
+    const remove = fs.rm.bind(fs);
+    let releaseDeletion!: () => void;
+    let markDeletionStarted!: () => void;
+    const deletionBlocked = new Promise<void>((resolve) => {
+      releaseDeletion = resolve;
+    });
+    const deletionStarted = new Promise<void>((resolve) => {
+      markDeletionStarted = resolve;
+    });
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementationOnce(async (...args) => {
+      markDeletionStarted();
+      await deletionBlocked;
+      return await remove(...args);
+    });
+
+    try {
+      const activeCleanup = cleanupManagedOutgoingImageRecords({
+        stateDir,
+        sessionKey: deleting.sessionKey,
+      });
+      await deletionStarted;
+      const rescueCleanup = cleanupManagedOutgoingImageRecords({
+        stateDir,
+        sessionKey: retained.sessionKey,
+      });
+      await Promise.resolve();
+
+      expect(readManagedImageRecord(retained.attachmentId, stateDir)).toBeNull();
+
+      releaseDeletion();
+      await expect(activeCleanup).resolves.toEqual({
+        deletedRecordCount: 1,
+        deletedFileCount: 1,
+        retainedCount: 1,
+      });
+      await expect(rescueCleanup).resolves.toEqual({
+        deletedRecordCount: 0,
+        deletedFileCount: 0,
+        retainedCount: 1,
+      });
+    } finally {
+      releaseDeletion();
+      rmSpy.mockRestore();
+    }
+
+    expect(readManagedImageRecord(retained.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(retained.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("does not reuse a retained index after checkpoint metadata changes", async () => {
+    const first = await createFixture(stateDir, {
+      attachmentId: "11111111-1111-4111-8111-111111111111",
+      sessionKey: "agent:main:checkpoint-cache",
+    });
+    await prepareManagedSessionKey(stateDir, first.sessionKey);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    const retainedMessages: unknown[] = [
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(first.sessionKey)}/${first.attachmentId}/full`,
+          },
+        ],
+      },
+    ];
+    readRestorableBranchSessionMessagesSnapshotMock.mockImplementation(() => ({
+      artifactRetentionComplete: true,
+      generation: "unchanged-current-generation",
+      maxSeq: 0,
+      messages: [],
+      retainedMessages,
+    }));
+
+    await expect(
+      cleanupManagedOutgoingImageRecords({ stateDir, sessionKey: first.sessionKey }),
+    ).resolves.toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+
+    const second = await createFixture(stateDir, {
+      attachmentId: "22222222-2222-4222-8222-222222222222",
+      sessionKey: first.sessionKey,
+    });
+    retainedMessages.push({
+      __openclaw: { id: "msg-1" },
+      content: [
+        {
+          type: "image",
+          url: `/api/chat/media/outgoing/${encodeURIComponent(second.sessionKey)}/${second.attachmentId}/full`,
+        },
+      ],
+    });
+
+    await expect(
+      cleanupManagedOutgoingImageRecords({ stateDir, sessionKey: first.sessionKey }),
+    ).resolves.toEqual({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 2,
+    });
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(readManagedImageRecord(second.attachmentId, stateDir)).not.toBeNull();
+    await expect(fs.access(second.originalPath)).resolves.toBeUndefined();
   });
 
   it("reaps aged files left before a SQLite record was committed", async () => {
@@ -2969,18 +3500,22 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([
-      {
-        __openclaw: { id: "msg-1" },
-        content: [
-          {
-            type: "image",
-            url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
-            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
-          },
-        ],
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [
+        {
+          __openclaw: { id: "msg-1" },
+          content: [
+            {
+              type: "image",
+              url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+              openUrl: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+            },
+          ],
+        },
+      ],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({ stateDir });
 
@@ -2988,7 +3523,12 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     expect(result.deletedFileCount).toBe(0);
     expect(result.retainedCount).toBe(1);
     await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
-    expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-1",
+        sessionKey: "agent:main:main",
+      }),
+    );
   });
 
   it("reads each session transcript once while evaluating committed records", async () => {
@@ -3004,30 +3544,34 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([
-      {
-        __openclaw: { id: "msg-1" },
-        content: [
-          {
-            type: "image",
-            url: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
-            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
-          },
-          {
-            type: "image",
-            url: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
-            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
-          },
-        ],
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [
+        {
+          __openclaw: { id: "msg-1" },
+          content: [
+            {
+              type: "image",
+              url: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
+              openUrl: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
+            },
+            {
+              type: "image",
+              url: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
+              openUrl: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
+            },
+          ],
+        },
+      ],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({ stateDir });
 
     expect(result.deletedRecordCount).toBe(0);
     expect(result.deletedFileCount).toBe(0);
     expect(result.retainedCount).toBe(2);
-    expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not delete files still referenced by other sessions during session-scoped cleanup", async () => {
@@ -3047,7 +3591,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
         sessionFile: "/tmp/session.jsonl",
       },
     }));
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({
       stateDir,
@@ -3089,7 +3637,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-main-global", sessionFile: "/tmp/global-main.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({
       stateDir,
@@ -3137,21 +3689,26 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "agents", "work", "sessions", "sessions.json"),
       entry: { sessionId: "sess-work", sessionFile: "/tmp/work.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([
-      {
-        __openclaw: { id: "msg-1" },
-        content: [
-          {
-            type: "image",
-            url: `/api/chat/media/outgoing/${fixture.sessionKey}/${fixture.attachmentId}/full`,
-          },
-        ],
-      },
-    ]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+      retainedMessages: [
+        {
+          __openclaw: { id: "msg-1" },
+          content: [
+            {
+              type: "image",
+              url: `/api/chat/media/outgoing/${fixture.sessionKey}/${fixture.attachmentId}/full`,
+            },
+          ],
+        },
+      ],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({ stateDir });
 
-    expect(readSessionMessagesMock).toHaveBeenCalled();
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalled();
     expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
     await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
   });
@@ -3198,7 +3755,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-work-global", sessionFile: "/tmp/global-work.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({
       stateDir,
@@ -3206,7 +3767,7 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       agentId: "work",
     });
 
-    expect(readSessionMessagesMock).toHaveBeenCalled();
+    expect(readRestorableBranchSessionMessagesSnapshotMock).toHaveBeenCalled();
     expect(result.deletedRecordCount).toBe(1);
     expect(result.retainedCount).toBe(1);
     await expectPathMissing(deletedFixture.originalPath);
@@ -3254,7 +3815,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       storePath: path.join(stateDir, "gateway-sessions.json"),
       entry: { sessionId: "sess-work-global", sessionFile: "/tmp/global-work.jsonl" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
+    readRestorableBranchSessionMessagesSnapshotMock.mockReturnValue({
+      generation: `generation-${path.basename(stateDir)}`,
+      maxSeq: 0,
+      messages: [],
+    });
 
     const result = await cleanupManagedOutgoingImageRecords({ stateDir });
 

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -45,6 +45,7 @@ import {
   resolvePlaybackTranscode,
 } from "../media/playback-transcode.js";
 import { getMediaDir, MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../media/store.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { readAssistantDisplayContent } from "../shared/assistant-display-content.js";
@@ -65,6 +66,7 @@ import {
 import {
   attachManagedImageRecordToMessage,
   claimManagedImageRecordCleanupIfCurrent,
+  clearClaimedManagedImageRecordCleanupIfCurrent,
   deleteClaimedManagedImageRecord,
   insertManagedImageRecord,
   listManagedImageRecordEntries,
@@ -74,7 +76,13 @@ import {
 } from "./managed-image-record-store.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
-import { readSessionMessagesWithSourceAsync } from "./session-transcript-readers.js";
+import {
+  readRestorableBranchSessionMessagesSnapshot,
+  readSessionMessagesWithSourceAsync,
+  readSessionRetentionFence,
+  readSessionTranscriptRevision,
+  type SessionTranscriptReadScope,
+} from "./session-transcript-readers.js";
 import {
   loadGatewaySessionEntryReadOnly,
   resolveSessionHistoryTranscriptPathAsync,
@@ -177,8 +185,19 @@ type CleanupManagedOutgoingMediaRecordsResult = {
 };
 
 type SessionManagedOutgoingAttachmentIndex = Set<string>;
+type SessionManagedOutgoingAttachmentIndexMode = "restorable" | "retained";
+const RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS = Symbol("retain-all-session-attachments");
+type SessionManagedOutgoingAttachmentIndexResult =
+  | SessionManagedOutgoingAttachmentIndex
+  | typeof RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS
+  | null;
+type ManagedOutgoingRetentionHandle = { fence: string; revalidate: () => string };
 type SessionManagedOutgoingAttachmentIndexRead =
-  | { kind: "available"; index: SessionManagedOutgoingAttachmentIndex | null }
+  | {
+      kind: "available";
+      index: SessionManagedOutgoingAttachmentIndexResult;
+      retention?: ManagedOutgoingRetentionHandle;
+    }
   | {
       kind: "unavailable";
       reason:
@@ -194,9 +213,7 @@ type SessionStoreAvailabilityRead = ReturnType<
 >;
 
 type SessionManagedOutgoingAttachmentIndexCacheEntry = {
-  transcriptPath: string;
-  mtimeMs: number;
-  size: number;
+  transcriptRevision: string;
   index: SessionManagedOutgoingAttachmentIndex;
 };
 
@@ -276,22 +293,21 @@ async function resolveManagedImageThumbnail(
   managedImageThumbnailJobs.set(cacheKey, pending);
   return await pending;
 }
-type SessionManagedOutgoingAttachmentTranscriptStat = Omit<
-  SessionManagedOutgoingAttachmentIndexCacheEntry,
-  "index"
->;
 
 const sessionManagedOutgoingAttachmentIndexCache = new Map<
   string,
   SessionManagedOutgoingAttachmentIndexCacheEntry
 >();
+const managedOutgoingMediaCleanupQueue = new KeyedAsyncQueue();
 const MAX_SESSION_MANAGED_OUTGOING_ATTACHMENT_INDEX_CACHE_ENTRIES = 500;
 
 function buildSessionManagedOutgoingAttachmentIndexCacheKey(
   sessionKey: string,
   agentId?: string,
+  mode: SessionManagedOutgoingAttachmentIndexMode = "restorable",
 ): string {
-  return sessionKey === "global" && agentId ? `agent:${agentId}:global` : sessionKey;
+  const ownerKey = sessionKey === "global" && agentId ? `agent:${agentId}:global` : sessionKey;
+  return `${ownerKey}:${mode}`;
 }
 
 export function resolveManagedImageAttachmentLimits(
@@ -720,6 +736,22 @@ async function getVariantStats(params: { filePath: string; buffer?: Buffer; size
   };
 }
 
+/**
+ * Confirms the retention snapshot still describes the session at the point of deletion.
+ *
+ * A transcript rewrite and a checkpoint publication commit outside the cleanup queue,
+ * so a snapshot that reported the media unreferenced can be obsolete by the time the
+ * file is removed. An unreadable fence is treated as moved, because deletion is
+ * irreversible and a restore would surface a dead URL.
+ */
+function retentionFenceStillValid(retention: ManagedOutgoingRetentionHandle): boolean {
+  try {
+    return retention.revalidate() === retention.fence;
+  } catch {
+    return false;
+  }
+}
+
 async function deleteManagedImageRecordArtifacts(
   record: ManagedImageRecord,
   stateDir = resolveStateDir(),
@@ -740,7 +772,7 @@ async function deleteManagedImageRecordArtifacts(
   };
 }
 
-export async function cleanupManagedOutgoingMediaRecords(params?: {
+type CleanupManagedOutgoingMediaRecordsParams = {
   stateDir?: string;
   nowMs?: number;
   transientMaxAgeMs?: number;
@@ -748,8 +780,23 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
   agentId?: string;
   forceDeleteSessionRecords?: boolean;
   hasActiveSessionRun?: (sessionKey: string, agentId: string | undefined) => boolean;
-}): Promise<CleanupManagedOutgoingMediaRecordsResult> {
+};
+
+export async function cleanupManagedOutgoingMediaRecords(
+  params?: CleanupManagedOutgoingMediaRecordsParams,
+): Promise<CleanupManagedOutgoingMediaRecordsResult> {
   const stateDir = params?.stateDir ?? resolveStateDir();
+  // The gateway state lock excludes another live process for this state directory.
+  // Serialize local sweeps too, so a persisted boolean claim is either active here or stale.
+  return await managedOutgoingMediaCleanupQueue.enqueue(path.resolve(stateDir), async () =>
+    cleanupManagedOutgoingMediaRecordsSerialized({ ...params, stateDir }),
+  );
+}
+
+async function cleanupManagedOutgoingMediaRecordsSerialized(
+  params: CleanupManagedOutgoingMediaRecordsParams & { stateDir: string },
+): Promise<CleanupManagedOutgoingMediaRecordsResult> {
+  const { stateDir } = params;
   const nowMs = params?.nowMs ?? Date.now();
   const transientMaxAgeMs = params?.transientMaxAgeMs ?? DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS;
   const sessionKeyFilter = params?.sessionKey ?? null;
@@ -767,10 +814,11 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
   let retainedCount = 0;
   const transcriptAttachmentIndexCache = new Map<
     string,
-    SessionManagedOutgoingAttachmentIndex | null
+    SessionManagedOutgoingAttachmentIndexResult
   >();
   const sessionStoreAvailabilityCache = new Map<string, SessionStoreAvailabilityRead>();
   const sessionStoreTargetsReadCache: SessionStoreTargetsReadCache = new Map();
+  const retentionHandles = new Map<string, ManagedOutgoingRetentionHandle>();
   for (const entry of entries) {
     const { record } = entry;
     if (sessionKeyFilter && record.sessionKey !== sessionKeyFilter) {
@@ -791,24 +839,37 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
       continue;
     }
 
-    let shouldDelete = entry.cleanupPending;
+    let shouldDelete = false;
+    let retention: ManagedOutgoingRetentionHandle | undefined;
     if (
-      !entry.cleanupPending &&
       forceDeleteSessionRecords &&
       (!sessionKeyFilter || record.sessionKey === sessionKeyFilter)
     ) {
       shouldDelete = true;
-    } else if (!entry.cleanupPending && record.messageId) {
-      const transcriptMatch = await recordMatchesTranscriptMessage(
+    } else if (record.messageId) {
+      const retained = await resolveManagedOutgoingTranscriptMatch(
         record,
         transcriptAttachmentIndexCache,
         sessionStoreAvailabilityCache,
         sessionStoreTargetsReadCache,
         stateDir,
+        "retained",
+        retentionHandles,
       );
       // Session-store unavailability is not proof that durable chat history no longer owns media.
-      shouldDelete = transcriptMatch === "missing";
-    } else if (!entry.cleanupPending) {
+      if (retained.match !== "missing") {
+        // Only a positive retained match retires a claim written by the active-path-only decision.
+        if (entry.cleanupPending && retained.match === "match") {
+          clearClaimedManagedImageRecordCleanupIfCurrent(record, stateDir);
+        }
+        retainedCount += 1;
+        continue;
+      }
+      retention = retained.retention;
+      shouldDelete = true;
+    } else if (entry.cleanupPending) {
+      shouldDelete = true;
+    } else {
       const createdAtMs = Date.parse(record.createdAt);
       const otherwiseDeletable =
         Number.isFinite(createdAtMs) &&
@@ -823,6 +884,11 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
           pendingPreparedAttachmentIds !== null &&
           !pendingPreparedAttachmentIds.has(record.attachmentId);
       }
+    }
+
+    if (shouldDelete && retention && !retentionFenceStillValid(retention)) {
+      retainedCount += 1;
+      continue;
     }
 
     if (shouldDelete) {
@@ -1106,19 +1172,12 @@ async function loadPendingPreparedAttachmentIds(stateDir: string): Promise<Set<s
 function getCachedSessionManagedOutgoingAttachmentIndex(
   sessionKey: string,
   agentId: string | undefined,
-  stat: { transcriptPath: string; mtimeMs: number; size: number },
+  transcriptRevision: string,
+  mode: SessionManagedOutgoingAttachmentIndexMode,
 ) {
-  const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId);
+  const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId, mode);
   const cached = sessionManagedOutgoingAttachmentIndexCache.get(cacheKey);
-  if (!cached) {
-    return null;
-  }
-  if (
-    cached.transcriptPath !== stat.transcriptPath ||
-    cached.mtimeMs !== stat.mtimeMs ||
-    cached.size !== stat.size
-  ) {
-    sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
+  if (!cached || cached.transcriptRevision !== transcriptRevision) {
     return null;
   }
   sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
@@ -1129,17 +1188,13 @@ function getCachedSessionManagedOutgoingAttachmentIndex(
 function setCachedSessionManagedOutgoingAttachmentIndex(
   sessionKey: string,
   agentId: string | undefined,
-  stat: SessionManagedOutgoingAttachmentTranscriptStat,
+  transcriptRevision: string,
   index: SessionManagedOutgoingAttachmentIndex,
+  mode: SessionManagedOutgoingAttachmentIndexMode,
 ) {
   sessionManagedOutgoingAttachmentIndexCache.set(
-    buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId),
-    {
-      transcriptPath: stat.transcriptPath,
-      mtimeMs: stat.mtimeMs,
-      size: stat.size,
-      index,
-    },
+    buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId, mode),
+    { transcriptRevision, index },
   );
   pruneMapToMaxSize(
     sessionManagedOutgoingAttachmentIndexCache,
@@ -1147,28 +1202,59 @@ function setCachedSessionManagedOutgoingAttachmentIndex(
   );
 }
 
-function sameManagedOutgoingAttachmentTranscriptStat(
-  left: SessionManagedOutgoingAttachmentTranscriptStat | null,
-  right: SessionManagedOutgoingAttachmentTranscriptStat | null,
-): boolean {
-  return (
-    left?.transcriptPath === right?.transcriptPath &&
-    left?.mtimeMs === right?.mtimeMs &&
-    left?.size === right?.size
-  );
+function buildManagedOutgoingAttachmentIndex(
+  messages: readonly unknown[],
+  sessionKey: string,
+): SessionManagedOutgoingAttachmentIndex {
+  const index: SessionManagedOutgoingAttachmentIndex = new Set();
+  for (const message of messages) {
+    const meta = (message as { __openclaw?: { id?: string } } | null)?.["__openclaw"];
+    const messageId = meta?.id;
+    if (typeof messageId !== "string" || !messageId) {
+      continue;
+    }
+    for (const ref of collectManagedOutgoingAttachmentRefs(
+      readAssistantDisplayContent(message),
+      sessionKey,
+    )) {
+      index.add(buildManagedOutgoingAttachmentRefKey(messageId, ref.attachmentId));
+    }
+  }
+  return index;
+}
+
+function readManagedOutgoingTranscriptRevision(scope: SessionTranscriptReadScope): string | null {
+  const revision = readSessionTranscriptRevision(scope);
+  return revision ? `transcript:${revision}` : null;
+}
+
+async function readManagedOutgoingArchiveRevision(transcriptPath: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(transcriptPath);
+    return `archive:${transcriptPath}:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return null;
+  }
 }
 
 async function getSessionManagedOutgoingAttachmentIndex(
   sessionKey: string,
-  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndexResult>,
   agentId?: string,
   storeAvailabilityCache?: Map<string, SessionStoreAvailabilityRead>,
   storeTargetsReadCache?: SessionStoreTargetsReadCache,
   stateDir?: string,
+  mode: SessionManagedOutgoingAttachmentIndexMode = "restorable",
+  retentionHandles?: Map<string, ManagedOutgoingRetentionHandle>,
 ): Promise<SessionManagedOutgoingAttachmentIndexRead> {
-  const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId);
+  const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId, mode);
   if (cache?.has(cacheKey)) {
-    return { kind: "available", index: cache.get(cacheKey) ?? null };
+    const retention = retentionHandles?.get(cacheKey);
+    return {
+      kind: "available",
+      index: cache.get(cacheKey) ?? null,
+      ...(retention ? { retention } : {}),
+    };
   }
   const cfg = getRuntimeConfig();
   const ownerAgentId =
@@ -1247,93 +1333,106 @@ async function getSessionManagedOutgoingAttachmentIndex(
     cache?.set(cacheKey, null);
     return { kind: "available", index: null };
   }
+  const scope = { agentId, sessionEntry: entry, sessionId, sessionKey, storePath };
 
-  let transcriptStat: SessionManagedOutgoingAttachmentTranscriptStat | null = null;
-  // This path is only a cache/reset-archive hint. Canonical active messages are
-  // read from the structured SQLite identity below even when no artifact exists.
+  const transcriptRevision = readManagedOutgoingTranscriptRevision(scope);
+  if (transcriptRevision && mode === "restorable") {
+    const cachedIndex = getCachedSessionManagedOutgoingAttachmentIndex(
+      sessionKey,
+      agentId,
+      transcriptRevision,
+      mode,
+    );
+    if (cachedIndex) {
+      cache?.set(cacheKey, cachedIndex);
+      return { kind: "available", index: cachedIndex };
+    }
+  }
+  const snapshot = readRestorableBranchSessionMessagesSnapshot(scope);
+  if (mode === "retained" && !snapshot.artifactRetentionComplete) {
+    cache?.set(cacheKey, RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS);
+    return { kind: "available", index: RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS };
+  }
+  if (snapshot.generation !== null || snapshot.maxSeq !== null) {
+    const index = buildManagedOutgoingAttachmentIndex(
+      mode === "retained" ? snapshot.retainedMessages : snapshot.messages,
+      sessionKey,
+    );
+    const snapshotRevision = snapshot.generation
+      ? `transcript:${sessionId}:${snapshot.generation}:${snapshot.maxSeq ?? -1}`
+      : null;
+    if (snapshotRevision && mode === "restorable") {
+      setCachedSessionManagedOutgoingAttachmentIndex(
+        sessionKey,
+        agentId,
+        snapshotRevision,
+        index,
+        mode,
+      );
+    } else {
+      sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
+    }
+    cache?.set(cacheKey, index);
+    if (mode === "retained") {
+      const retention: ManagedOutgoingRetentionHandle = {
+        fence: snapshot.retentionFence,
+        revalidate: () => readSessionRetentionFence(scope),
+      };
+      retentionHandles?.set(cacheKey, retention);
+      return { kind: "available", index, retention };
+    }
+    return { kind: "available", index };
+  }
+  if (mode === "retained") {
+    // Reset archives expose one visible path, not the full branch set needed for GC.
+    // Without a canonical SQLite snapshot, retaining every session record is the safe answer.
+    cache?.set(cacheKey, RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS);
+    return { kind: "available", index: RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS };
+  }
+
   const resolvedTranscriptPath = await resolveSessionHistoryTranscriptPathAsync(
     sessionId,
     storePath,
     undefined,
     { allowResetArchiveFallback: true },
   );
-  if (resolvedTranscriptPath) {
-    try {
-      const stat = await fs.stat(resolvedTranscriptPath);
-      transcriptStat = {
-        transcriptPath: resolvedTranscriptPath,
-        mtimeMs: stat.mtimeMs,
-        size: stat.size,
-      };
-      const cachedIndex = getCachedSessionManagedOutgoingAttachmentIndex(
-        sessionKey,
-        agentId,
-        transcriptStat,
-      );
-      if (cachedIndex) {
-        cache?.set(cacheKey, cachedIndex);
-        return { kind: "available", index: cachedIndex };
-      }
-    } catch {
-      sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
+  const archiveRevision = resolvedTranscriptPath
+    ? await readManagedOutgoingArchiveRevision(resolvedTranscriptPath)
+    : null;
+  if (archiveRevision) {
+    const cachedIndex = getCachedSessionManagedOutgoingAttachmentIndex(
+      sessionKey,
+      agentId,
+      archiveRevision,
+      mode,
+    );
+    if (cachedIndex) {
+      cache?.set(cacheKey, cachedIndex);
+      return { kind: "available", index: cachedIndex };
     }
   } else {
     sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
   }
 
-  const readResult = await readSessionMessagesWithSourceAsync(
-    {
+  const readResult = await readSessionMessagesWithSourceAsync(scope, {
+    mode: "full",
+    reason: "managed outgoing attachment index",
+    allowResetArchiveFallback: true,
+  });
+  const index = buildManagedOutgoingAttachmentIndex(readResult.messages, sessionKey);
+  const postReadRevision = readResult.transcriptPath
+    ? await readManagedOutgoingArchiveRevision(readResult.transcriptPath)
+    : null;
+  if (archiveRevision && postReadRevision === archiveRevision) {
+    setCachedSessionManagedOutgoingAttachmentIndex(
+      sessionKey,
       agentId,
-      sessionEntry: entry,
-      sessionId,
-      sessionKey,
-      storePath,
-    },
-    {
-      mode: "full",
-      reason: "managed outgoing attachment index",
-      allowResetArchiveFallback: true,
-    },
-  );
-  const messages = readResult.messages;
-  const preReadTranscriptStat = transcriptStat;
-  if (readResult.transcriptPath) {
-    try {
-      const stat = await fs.stat(readResult.transcriptPath);
-      const postReadTranscriptStat = {
-        transcriptPath: readResult.transcriptPath,
-        mtimeMs: stat.mtimeMs,
-        size: stat.size,
-      };
-      transcriptStat = sameManagedOutgoingAttachmentTranscriptStat(
-        preReadTranscriptStat,
-        postReadTranscriptStat,
-      )
-        ? postReadTranscriptStat
-        : null;
-    } catch {
-      transcriptStat = null;
-    }
+      archiveRevision,
+      index,
+      mode,
+    );
   } else {
-    transcriptStat = null;
-  }
-  const index: SessionManagedOutgoingAttachmentIndex = new Set();
-  for (const message of messages) {
-    const meta = (message as { __openclaw?: { id?: string } } | null)?.["__openclaw"];
-    const messageId = meta?.id;
-    if (typeof messageId !== "string" || !messageId) {
-      continue;
-    }
-    for (const ref of collectManagedOutgoingAttachmentRefs(
-      readAssistantDisplayContent(message),
-      sessionKey,
-    )) {
-      index.add(buildManagedOutgoingAttachmentRefKey(messageId, ref.attachmentId));
-    }
-  }
-
-  if (transcriptStat) {
-    setCachedSessionManagedOutgoingAttachmentIndex(sessionKey, agentId, transcriptStat, index);
+    sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
   }
   cache?.set(cacheKey, index);
   return { kind: "available", index };
@@ -1341,13 +1440,37 @@ async function getSessionManagedOutgoingAttachmentIndex(
 
 async function recordMatchesTranscriptMessage(
   record: ManagedImageRecord,
-  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndexResult>,
   storeAvailabilityCache?: Map<string, SessionStoreAvailabilityRead>,
   storeTargetsReadCache?: SessionStoreTargetsReadCache,
   stateDir?: string,
+  mode: SessionManagedOutgoingAttachmentIndexMode = "restorable",
+  retentionHandles?: Map<string, ManagedOutgoingRetentionHandle>,
 ): Promise<ManagedOutgoingTranscriptMatch> {
+  return (
+    await resolveManagedOutgoingTranscriptMatch(
+      record,
+      cache,
+      storeAvailabilityCache,
+      storeTargetsReadCache,
+      stateDir,
+      mode,
+      retentionHandles,
+    )
+  ).match;
+}
+
+async function resolveManagedOutgoingTranscriptMatch(
+  record: ManagedImageRecord,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndexResult>,
+  storeAvailabilityCache?: Map<string, SessionStoreAvailabilityRead>,
+  storeTargetsReadCache?: SessionStoreTargetsReadCache,
+  stateDir?: string,
+  mode: SessionManagedOutgoingAttachmentIndexMode = "restorable",
+  retentionHandles?: Map<string, ManagedOutgoingRetentionHandle>,
+): Promise<{ match: ManagedOutgoingTranscriptMatch; retention?: ManagedOutgoingRetentionHandle }> {
   if (!record.messageId) {
-    return "missing";
+    return { match: "missing" };
   }
   const read = await getSessionManagedOutgoingAttachmentIndex(
     record.sessionKey,
@@ -1356,25 +1479,38 @@ async function recordMatchesTranscriptMessage(
     storeAvailabilityCache,
     storeTargetsReadCache,
     stateDir,
+    mode,
+    retentionHandles,
   );
   if (read.kind === "unavailable") {
-    return "unavailable";
+    return { match: "unavailable" };
   }
-  return read.index?.has(
-    buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId),
-  )
-    ? "match"
-    : "missing";
+  const retention = read.retention ? { retention: read.retention } : {};
+  if (read.index === RETAIN_ALL_SESSION_MANAGED_OUTGOING_ATTACHMENTS) {
+    return { match: "match", ...retention };
+  }
+  return {
+    match: read.index?.has(
+      buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId),
+    )
+      ? "match"
+      : "missing",
+    ...retention,
+  };
 }
 
 async function resolveManagedOutgoingMediaArtifactDownloadForRecord(
   record: ManagedImageRecord,
   stateDir?: string,
 ): Promise<ManagedOutgoingMediaArtifactDownload | null> {
-  if (
-    (await recordMatchesTranscriptMessage(record, undefined, undefined, undefined, stateDir)) !==
-    "match"
-  ) {
+  const artifactMatch = await recordMatchesTranscriptMessage(
+    record,
+    undefined,
+    undefined,
+    undefined,
+    stateDir,
+  ).catch(() => "unavailable" as const);
+  if (artifactMatch !== "match") {
     return null;
   }
   const kind = resolveManagedRecordKind(record);
@@ -1877,10 +2013,14 @@ export async function handleManagedOutgoingMediaHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  if (
-    (await recordMatchesTranscriptMessage(record, undefined, undefined, undefined, stateDir)) !==
-    "match"
-  ) {
+  const servedMatch = await recordMatchesTranscriptMessage(
+    record,
+    undefined,
+    undefined,
+    undefined,
+    stateDir,
+  ).catch(() => "unavailable" as const);
+  if (servedMatch !== "match") {
     sendStatus(res, 404, "not found");
     return true;
   }

--- a/src/gateway/managed-image-record-store.ts
+++ b/src/gateway/managed-image-record-store.ts
@@ -243,6 +243,38 @@ export function claimManagedImageRecordCleanupIfCurrent(
   }, stateDatabaseOptions(stateDir));
 }
 
+/** Release an exact durable claim when authoritative history still retains the record. */
+export function clearClaimedManagedImageRecordCleanupIfCurrent(
+  planned: ManagedImageRecord,
+  stateDir?: string,
+): boolean {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const stateDb = getNodeSqliteKysely<ManagedImageRecordDatabase>(db);
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      stateDb
+        .selectFrom("managed_outgoing_image_records")
+        .selectAll()
+        .where("attachment_id", "=", planned.attachmentId),
+    );
+    if (
+      !row ||
+      row.cleanup_pending !== 1 ||
+      !managedImageRecordsEqual(managedImageRecordFromRow(row), planned)
+    ) {
+      return false;
+    }
+    executeSqliteQuerySync(
+      db,
+      stateDb
+        .updateTable("managed_outgoing_image_records")
+        .set({ cleanup_pending: 0 })
+        .where("attachment_id", "=", planned.attachmentId),
+    );
+    return true;
+  }, stateDatabaseOptions(stateDir));
+}
+
 /** Delete a durably claimed row only after its attachment file is gone. */
 export function deleteClaimedManagedImageRecord(
   planned: ManagedImageRecord,

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -4,11 +4,15 @@ import {
   isSessionTranscriptProjectionUnavailableError,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptMessageEvents,
+  readSessionTranscriptRestorableMessageSnapshot,
+  readSessionTranscriptRetentionFence,
+  readSessionTranscriptWatermark,
   resolveConcreteSessionStorePath,
   resolveSessionTranscriptReadTarget,
   waitForSessionTranscriptProjection,
   type SessionTranscriptMessageEvent,
   type SessionTranscriptReadScope,
+  type SessionTranscriptRestorableMessageSnapshot,
   type TranscriptEvent,
 } from "../config/sessions/session-accessor.js";
 import { visitSessionTranscriptMessageEvents } from "../config/sessions/session-accessor.sqlite-active-events.js";
@@ -217,6 +221,45 @@ export async function readSessionMessagesWithSourceAsync(
     messages,
     transcriptPath: target.sessionFile,
   };
+}
+
+type RestorableBranchSessionMessagesSnapshot = Omit<
+  SessionTranscriptRestorableMessageSnapshot,
+  "events" | "retainedEvents"
+> & {
+  messages: unknown[];
+  retainedMessages: unknown[];
+};
+
+/** Reads immediately restorable messages plus the conservative artifact-retention set. */
+export function readRestorableBranchSessionMessagesSnapshot(
+  scope: SessionTranscriptReadScope,
+): RestorableBranchSessionMessagesSnapshot {
+  const target = resolveTranscriptReadTarget(scope);
+  const snapshot = readSessionTranscriptRestorableMessageSnapshot(toTranscriptReadScope(target));
+  return {
+    artifactRetentionComplete: snapshot.artifactRetentionComplete,
+    generation: snapshot.generation,
+    maxSeq: snapshot.maxSeq,
+    retentionFence: snapshot.retentionFence,
+    messages: projectSqliteHistoryEvents(snapshot.events),
+    retainedMessages: projectSqliteHistoryEvents(snapshot.retainedEvents),
+  };
+}
+
+/** Re-reads the retention fence that validates a retention snapshot at its point of use. */
+export function readSessionRetentionFence(scope: SessionTranscriptReadScope): string {
+  const target = resolveTranscriptReadTarget(scope);
+  return readSessionTranscriptRetentionFence(toTranscriptReadScope(target));
+}
+
+/** Reads the canonical transcript watermark used to validate derived transcript caches. */
+export function readSessionTranscriptRevision(scope: SessionTranscriptReadScope): string | null {
+  const target = resolveTranscriptReadTarget(scope);
+  const watermark = readSessionTranscriptWatermark(toTranscriptReadScope(target));
+  return watermark.generation
+    ? `${target.sessionId}:${watermark.generation}:${watermark.maxSeq ?? -1}`
+    : null;
 }
 
 /** Finds one display message by transcript id through the reader seam. */


### PR DESCRIPTION
## What Problem This Solves

Rewinding or resetting a conversation could permanently delete generated media that was no longer on the active transcript path but was still reachable through an inactive branch or a live compaction checkpoint.

Cleanup treated absence from the active projection as proof that the media was orphaned. It deleted the SQLite record and the backing file. Restoring the branch or the checkpoint brought the message and its URL back, but the bytes were already gone.

## Root Cause

Managed-media cleanup, HTTP serving, and artifact download shared one attachment index built from the active/restorable message projection. That projection is correct for what the operator can open immediately, but it is not the lifecycle owner for destructive retention.

The session owner already records the facts retention needs: the full SQLite transcript event tree, reset and compaction boundaries, live compaction checkpoint source sessions and fork boundaries, and the transcript rewrite generation and maximum sequence. The bug was using a consumer projection as a garbage-collection authority instead of asking the session owner which messages can become reachable again.

## Canonical Fix

- Split managed-media lookup into `restorable` and `retained` modes. HTTP serving and artifact download stay on the immediate restorable projection.
- Destructive cleanup asks the session owner for the retained event set, walking complete canonical paths for every live transcript tip including reset-hidden ancestry that remains checkpoint-reachable.
- Read current transcript rows, the authoritative session entry, and every live compaction checkpoint source in one deferred SQLite transaction.
- Fail closed for destructive cleanup when checkpoint retention is incomplete, legacy file-backed, or unreadable.
- Bypass the process-global attachment cache for retained-mode reads, because checkpoint metadata and source sessions can change without advancing the current transcript watermark.

No schema, config, migration, protocol, or changelog change is required.

## Fencing Deletion Against Checkpoint Publication

The previous review found a real P1 on top of the retention change: the retention snapshot and the irreversible delete were separated by an unfenced window. Checkpoint publication commits through `updateSessionEntry`, which the cleanup queue does not serialize, so a snapshot that reported media unreferenced could be obsolete by the time the record and file were removed.

The session owner now derives a retention fence inside the same deferred transaction that produces the retention snapshot, from the transcript generation, the maximum sequence, and the published checkpoint set. Destructive cleanup carries that fence to the point of deletion and revalidates it there, retaining the record when the fence moved or cannot be read. This reuses the optimistic-concurrency shape already used by the checkpoint and message-cut expected-state fences rather than introducing a second independent guard.

Scope note for the maintainer: this fences the snapshot-to-delete window, which is where the reported loss occurs. It does not make deletion atomic with respect to checkpoint publication; a checkpoint committing between the fence revalidation and the `unlink` remains theoretically possible. Closing that last gap requires the session owner to own media deletion inside its own write transaction, which is a lifecycle redesign beyond this fix.

## Safety Guards Preserved From Current Main

Every newer safeguard on the surfaces this touches is carried into the resolved integration rather than replaced.

- Compatibility-owner resolution (#123257): `resolveManagedSessionOwnerAgentId` plus `tryResolveSessionCompatibilityOwnerAgentId` remain the owner resolver for cleanup, the attachment index, and artifact download.
- Publish-after-preparation ordering (#124048): `insertManagedImageRecord` still runs after the fallible playback and mode preparation.
- Checkpoint expected-state mutation fence (#122597): `restoreCompactionCheckpointSession` and `branchCompactionCheckpointSession` keep the required `expectedState` parameter and the `conflict` result.
- Tri-state session-store availability (#119090, #119260): `recordMatchesTranscriptMessage` still returns `match` / `missing` / `unavailable`, retained mode included, and cleanup deletes only on `missing`.
- Live-run retention for uncommitted transient media (#119764): the `hasActiveSessionRun` predicate still guards the aged-transient branch.
- Read-only database reads (#128631): `readSessionTranscriptWatermark` keeps main's `withOpenClawAgentDatabaseReadOnly` shape; this branch's atomic generation-and-sequence pair is applied inside it rather than replacing it.
- Canonical transcript projection (#135392): the retention snapshot reader uses main's `projectSqliteHistoryEvents` instead of the helpers that refactor removed.
- Memoized branch summaries (#123541): left untouched. An earlier revision of this branch also routed `listSessionBranches` through the new shared branch-tip selector; that changed which rows count as branches and broke the large-shared-graph assertion added by that commit, so it is dropped. Retention no longer depends on it.

## Verification

Run from the rebased worktree at head `ff07bd20f864bdfc8a85d77cdb69bd6c751e4e4d`, base `1623683f478b1e4a2e3d5632585f006ea142e08c`:

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-restorable-messages.test.ts src/config/sessions/transcript-tree.test.ts src/config/sessions/session-accessor.sqlite-message-cut.test.ts` - 3 files, 50 tests passed.
- `node scripts/run-vitest.mjs src/gateway/managed-image-attachments.branch-retention.test.ts src/gateway/managed-image-attachments.test.ts` - 2 files, 132 tests passed.
- `oxfmt` on the 12 changed files - clean.
- `oxlint --tsconfig config/tsconfig/oxlint.core.json` on the 12 changed files - clean.
- The two new fence cases fail on pristine base and pass on this head.

## Real behavior proof
Behavior addressed: after `sessions.rewind`, managed media still referenced by the inactive transcript branch is permanently deleted by managed-media cleanup, so switching back to that branch restores a message whose bytes no longer exist.
Real environment tested: the real production entry points driven end to end against one temporary state directory with a real SQLite session store, on pristine `main` `1623683f478b1e4a2e3d5632585f006ea142e08c` and on the rebased head `ff07bd20f864bdfc8a85d77cdb69bd6c751e4e4d`. Real `upsertSessionEntryCore` and `appendTranscriptMessage` build the transcript, real `rewindSessionToMessage`, `listSessionBranches` and `switchSessionBranch` drive the branch lifecycle, real `cleanupManagedOutgoingMediaRecords` performs the sweep, real `resolveManagedOutgoingMediaArtifactDownload` mints the scoped URL, and the bytes are fetched over a real loopback HTTP server running the real `handleManagedOutgoingMediaHttpRequest`. Nothing is stubbed; the only synthetic input is the seeded conversation.
Exact steps or command run after this patch: seed a six-turn session whose assistant turn carries a managed image, commit the managed record and its file, rewind to the user turn before it, sweep, switch back to the inactive branch leaf, mint an artifact URL and fetch it over authenticated loopback HTTP, publish a compaction checkpoint and re-read the session retention fence, then sweep a second record referenced by no branch at all.
Evidence after fix:
```
# BEFORE (pristine main 1623683f478b1e4a2e3d5632585f006ea142e08c)
[1] seeded real SQLite session store at oc-media-branch-ITSICe
    media file on disk: true
[2] rewind to turn u2 -> status=created
    branches: 2 (inactive leaf=a3 messages=6)
    the image on turn a2 is now reachable only from the inactive branch
[3] cleanup sweep -> {"deletedRecordCount":1,"deletedFileCount":1,"retainedCount":0}
    media file still on disk: false
    durable records remaining: 0
[4] switch back to the inactive branch -> status=created
    artifact download minted: false
[5] loopback HTTP GET of the managed media -> status=404 bytes=9
[6] retention fence exposed by the session owner: absent on this build
[7] deletion control: media referenced by no branch -> {"deletedRecordCount":1,"deletedFileCount":1,"retainedCount":0}
    orphan file removed: true
    branch-referenced file kept: false

# AFTER (this patch, identical inputs, head ff07bd20f864bdfc8a85d77cdb69bd6c751e4e4d)
[1] seeded real SQLite session store at oc-media-branch-dsKy2H
    media file on disk: true
[2] rewind to turn u2 -> status=created
    branches: 2 (inactive leaf=a3 messages=6)
    the image on turn a2 is now reachable only from the inactive branch
[3] cleanup sweep -> {"deletedRecordCount":0,"deletedFileCount":0,"retainedCount":1}
    media file still on disk: true
    durable records remaining: 1
[4] switch back to the inactive branch -> status=created
    artifact download minted: true
[5] loopback HTTP GET of the managed media -> status=200 bytes=8
[6] retention fence moved when a checkpoint was published: true
[7] deletion control: media referenced by no branch -> {"deletedRecordCount":1,"deletedFileCount":1,"retainedCount":1}
    orphan file removed: true
    branch-referenced file kept: true
```
Observed result after fix: on pristine main the rewind sweep destroys the inactive-branch record and its bytes, and the later branch switch restores a message whose artifact URL can no longer be minted and whose bytes answer 404; with this patch the same sweep keeps the record and the file, the restored branch mints a scoped URL and serves the bytes over authenticated loopback HTTP with status 200, the session retention fence visibly moves when a compaction checkpoint is published so a stale retention verdict is detectable at the point of deletion, and media referenced by no branch at all is still removed, so the change does not over-retain.
What was not tested: no live model provider or network media generation; the full production build and the complete repository suite were not run, only the affected suites; the residual window between fence revalidation and file removal is argued from the code path rather than observed, because forcing that interleaving deterministically would require a test-only hook in the cleanup loop.
