### PR TITLE
fix(agents): reject invalid UTF-8 LSP responses

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -367,6 +367,41 @@ describe("bundle LSP runtime", () => {
     await runtime.dispose();
   });
 
+  it("rejects invalid UTF-8 in LSP JSON bodies", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess("", new Set(["initialize"]));
+    spawnMock.mockReturnValue(child);
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
+    if (!hoverTool) {
+      throw new Error("expected hover tool");
+    }
+    const request = hoverTool.execute("call-1", {
+      uri: "file:///tmp/workspace/index.ts",
+      line: 0,
+      character: 0,
+    });
+    const hoverRequest = child.receivedMessages.find(
+      (message) => message.method === "textDocument/hover",
+    );
+    if (typeof hoverRequest?.id !== "number") {
+      throw new Error("expected numeric hover request id");
+    }
+    const body = Buffer.concat([
+      Buffer.from(`{"jsonrpc":"2.0","id":${hoverRequest.id},"result":{"contents":"`),
+      Buffer.from([0xff]),
+      Buffer.from('"}}'),
+    ]);
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, "ascii");
+    child.stdout.write(Buffer.concat([header, body]));
+
+    await expect(request).rejects.toThrow(/LSP framing error: body is not valid UTF-8/i);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+
+    await runtime.dispose();
+  });
+
   it.each([
     {
       name: "a suffixed Content-Length value",

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -166,6 +166,7 @@ function encodeLspMessage(body: unknown): string {
 const LSP_HEADER_SEPARATOR = Buffer.from("\r\n\r\n", "ascii");
 const MAX_LSP_HEADER_BYTES = 8 * 1024;
 const MAX_LSP_BODY_BYTES = 64 * 1024 * 1024;
+const LSP_BODY_DECODER = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
 
 class LspFramingError extends Error {
   override readonly name = "LspFramingError";
@@ -241,7 +242,12 @@ function parseLspMessages(buffer: Buffer): LspParseResult {
       return { ok: true, messages, remaining };
     }
 
-    const body = remaining.subarray(bodyStart, bodyEnd).toString("utf8");
+    let body: string;
+    try {
+      body = LSP_BODY_DECODER.decode(remaining.subarray(bodyStart, bodyEnd));
+    } catch {
+      return framingError(messages, "body is not valid UTF-8");
+    }
     try {
       messages.push(JSON.parse(body));
     } catch (error) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where agent bundle LSP requests could accept a response containing malformed UTF-8 when the replacement character still left the body as valid JSON. The corrupted payload could then be returned to the caller with `�` instead of failing the transport.

## Why This Change Was Made

LSP response bodies are now decoded with a fatal UTF-8 `TextDecoder` before JSON parsing. Decode failures enter the existing framing-error path, which rejects pending requests, terminates the language-server process, and latches the error for later requests; `ignoreBOM: true` preserves the previous JSON BOM rejection behavior.

## User Impact

Malformed language-server responses can no longer be silently altered and treated as valid results. Callers receive a clear framing error, and the compromised LSP process is shut down instead of continuing with corrupted data.

## Evidence

Fresh red on the pinned `main` baseline:

```text
$ node scripts/run-vitest.mjs src/agents/agent-bundle-lsp-runtime.test.ts -t 'rejects invalid UTF-8 in LSP JSON bodies'
AssertionError: promise resolved instead of rejecting
"contents": "�"
Test Files  2 failed (2)
```

Focused regression suite after the fix:

```text
$ node scripts/run-vitest.mjs src/agents/agent-bundle-lsp-runtime.test.ts
Test Files  1 passed (1)
Tests  20 passed (20)
```

Strong live E2E used the production `createBundleLspToolRuntime`, a real spawned Node child process, and real stdio `Content-Length` frames. Gateway is not applicable because this runtime talks directly to its language-server child.

```text
entrypoint=createBundleLspToolRuntime
transport=real_spawned_child_process_stdio
scenario=valid
trigger=hover response body is valid UTF-8 JSON
outcome=resolved
tool_text="{\n  \"contents\": \"live-ok-✓\"\n}"
child_close=observed_after_dispose
scenario=invalid
trigger=hover response body contains raw byte 0xff inside a JSON string
outcome=rejected
error=LSP framing error: body is not valid UTF-8
child_close=observed_after_framing_error
future_request=rejected_with_latched_framing_error
verdict=PASS
```

Formatting and whitespace checks also passed (`oxfmt --check` and `git diff --check`).
