### PR TITLE
fix(sessions): preserve target rows during legacy migration

### DIFF
--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -185,7 +185,7 @@ export async function migrateLegacySessions(
   ) {
     const normalized = Object.create(null) as Record<string, SessionEntry>;
     for (const [key, entry] of Object.entries(merged)) {
-      const normalizedEntry = normalizeSessionEntry(entry);
+      const normalizedEntry = normalizeSessionEntry(entry, key);
       if (!normalizedEntry) {
         continue;
       }
@@ -259,7 +259,7 @@ export async function migrateLegacySessions(
     if (rewroteSessionFiles) {
       const normalized = Object.create(null) as Record<string, SessionEntry>;
       for (const [key, entry] of Object.entries(merged)) {
-        const normalizedEntry = normalizeSessionEntry(entry);
+        const normalizedEntry = normalizeSessionEntry(entry, key);
         if (normalizedEntry) {
           normalized[key] = normalizedEntry;
         }

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -26,6 +26,28 @@ import {
 } from "./state-migrations.session-store.js";
 import type { LegacyStateDetection } from "./state-migrations.types.js";
 
+function normalizeMergedSessionStore(
+  merged: Record<string, SessionEntryLike>,
+  protectedKeys: ReadonlySet<string>,
+): {
+  store: Record<string, SessionEntry>;
+  rejectedProtectedKeyCount: number;
+} {
+  const store = Object.create(null) as Record<string, SessionEntry>;
+  let rejectedProtectedKeyCount = 0;
+  for (const [key, entry] of Object.entries(merged)) {
+    const normalizedEntry = normalizeSessionEntry(entry, key);
+    if (!normalizedEntry) {
+      if (protectedKeys.has(key)) {
+        rejectedProtectedKeyCount++;
+      }
+      continue;
+    }
+    store[key] = normalizedEntry;
+  }
+  return { store, rejectedProtectedKeyCount };
+}
+
 export async function migrateLegacySessions(
   detected: LegacyStateDetection,
   now: () => number,
@@ -107,6 +129,7 @@ export async function migrateLegacySessions(
     preserveCanonicalAgentOwner: true,
     preserveForeignMainAliases: detected.sessions.preserveForeignMainAliases,
   });
+  const targetKeys = new Set(Object.keys(canonicalizedTarget.store));
   const preservedLegacyForeignMainAliasCount = detected.sessions.preserveForeignMainAliases
     ? Object.keys(legacyStore).filter((key) =>
         isLegacyDefaultMainAliasKey(key, detected.targetMainKey),
@@ -183,15 +206,14 @@ export async function migrateLegacySessions(
     (legacyParsed.ok || targetParsed.ok) &&
     (Object.keys(legacyStore).length > 0 || Object.keys(targetStore).length > 0)
   ) {
-    const normalized = Object.create(null) as Record<string, SessionEntry>;
-    for (const [key, entry] of Object.entries(merged)) {
-      const normalizedEntry = normalizeSessionEntry(entry, key);
-      if (!normalizedEntry) {
-        continue;
-      }
-      normalized[key] = normalizedEntry;
+    const normalized = normalizeMergedSessionStore(merged, targetKeys);
+    if (normalized.rejectedProtectedKeyCount > 0) {
+      warnings.push(
+        `Refused legacy session migration because normalization rejected ${normalized.rejectedProtectedKeyCount} existing target session ${normalized.rejectedProtectedKeyCount === 1 ? "key" : "keys"}; left ${detected.sessions.targetStorePath} and ${detected.sessions.legacyStorePath} in place. Repair the conflicting rows, then rerun openclaw doctor --fix.`,
+      );
+      return { changes, warnings };
     }
-    await saveSessionStoreStrict(detected.sessions.targetStorePath, normalized);
+    await saveSessionStoreStrict(detected.sessions.targetStorePath, normalized.store);
     if (migratedDirectChatKey) {
       changes.push(`Migrated latest direct-chat session → ${migratedDirectChatKey}`);
     }
@@ -257,14 +279,10 @@ export async function migrateLegacySessions(
       rewroteSessionFiles = true;
     }
     if (rewroteSessionFiles) {
-      const normalized = Object.create(null) as Record<string, SessionEntry>;
-      for (const [key, entry] of Object.entries(merged)) {
-        const normalizedEntry = normalizeSessionEntry(entry, key);
-        if (normalizedEntry) {
-          normalized[key] = normalizedEntry;
-        }
-      }
-      await saveSessionStoreStrict(detected.sessions.targetStorePath, normalized);
+      // The first pass already validated protected rows. Adding retired
+      // sessionFile metadata cannot change their normalization outcome.
+      const normalized = normalizeMergedSessionStore(merged, targetKeys);
+      await saveSessionStoreStrict(detected.sessions.targetStorePath, normalized.store);
       changes.push("Rewrote migrated session transcript paths");
     }
   }

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -235,7 +235,6 @@ export async function migrateLegacySessions(
     return { changes, warnings };
   }
 
-  const movedSessionFiles = new Map<string, string>();
   const entries = safeReadDir(detected.sessions.legacyDir);
   for (const entry of entries) {
     if (!entry.isFile()) {
@@ -252,38 +251,9 @@ export async function migrateLegacySessions(
     }
     try {
       fs.renameSync(from, to);
-      movedSessionFiles.set(path.resolve(from), to);
       changes.push(`Moved ${entry.name} → agents/${detected.targetAgentId}/sessions`);
     } catch (err) {
       warnings.push(`Failed moving ${from}: ${String(err)}`);
-    }
-  }
-
-  if (movedSessionFiles.size > 0) {
-    let rewroteSessionFiles = false;
-    for (const entry of Object.values(merged)) {
-      const rawSessionFile = entry.sessionFile;
-      const legacySessionFile =
-        typeof rawSessionFile === "string"
-          ? path.resolve(detected.sessions.legacyDir, rawSessionFile)
-          : typeof entry.sessionId === "string"
-            ? path.join(detected.sessions.legacyDir, `${entry.sessionId}.jsonl`)
-            : undefined;
-      const movedSessionFile = legacySessionFile
-        ? movedSessionFiles.get(path.resolve(legacySessionFile))
-        : undefined;
-      if (!movedSessionFile) {
-        continue;
-      }
-      entry.sessionFile = movedSessionFile;
-      rewroteSessionFiles = true;
-    }
-    if (rewroteSessionFiles) {
-      // The first pass already validated protected rows. Adding retired
-      // sessionFile metadata cannot change their normalization outcome.
-      const normalized = normalizeMergedSessionStore(merged, targetKeys);
-      await saveSessionStoreStrict(detected.sessions.targetStorePath, normalized.store);
-      changes.push("Rewrote migrated session transcript paths");
     }
   }
 

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -885,8 +885,8 @@ export async function migrateLegacyAcpSessionMetadata(params: {
         isAmbiguousSharedStoreKey(key, mainKey, scope) ||
         (pluginForeignMainAliasRisk && isLegacyDefaultMainAliasKey(key, mainKey)),
     ).length;
-    const hasLegacyAcpMetadata = Object.values(parsed.store).some(
-      (entry) => normalizeSessionEntry(entry)?.acp !== undefined,
+    const hasLegacyAcpMetadata = Object.entries(parsed.store).some(
+      ([sessionKey, entry]) => normalizeSessionEntry(entry, sessionKey)?.acp !== undefined,
     );
     if (hasLegacyAcpMetadata && storeAliases.hasUnresolvedIdentity) {
       warnings.push(unresolvedSessionStoreIdentityWarning("ACP metadata migration", storePath));

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -4261,5 +4261,38 @@ describe("state migrations", () => {
     expect(result.warnings).toStrictEqual([]);
     await expectMissingPath(path.join(stateDir, "sessions", "sessions.json"));
   });
+
+  it("preserves key-shaped pending rows during automatic legacy session migration", async () => {
+    const { root, stateDir, env, cfg } = await createLegacyStateFixture();
+
+    const targetStorePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
+    const pendingKey = "agent:worker-1:desk";
+    const targetStore = {
+      [pendingKey]: { sessionId: pendingKey, updatedAt: 50 },
+      "agent:worker-1:desk:other": { sessionId: "other-session", updatedAt: 60 },
+    };
+    await fs.writeFile(targetStorePath, `${JSON.stringify(targetStore, null, 2)}\n`, "utf8");
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({
+      detected,
+      now: () => 1234,
+    });
+
+    expect(result.changes.some((c) => c.startsWith("Merged sessions store"))).toBe(true);
+
+    const afterStore = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
+      string,
+      { sessionId?: string; initializationPending?: boolean; updatedAt?: number }
+    >;
+    expect(afterStore[pendingKey]).toBeDefined();
+    expect(afterStore[pendingKey]?.initializationPending).toBe(true);
+    expect(afterStore[pendingKey]?.sessionId).toBeUndefined();
+    expect(afterStore["agent:worker-1:desk:other"]?.sessionId).toBe("other-session");
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1042,7 +1042,6 @@ describe("state migrations", () => {
       `Merged sessions store → ${path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json")}`,
       "Canonicalized 3 legacy session key(s)",
       "Moved trace.jsonl → agents/worker-1/sessions",
-      "Rewrote migrated session transcript paths",
       "Migrated 2 ACP session metadata rows → shared SQLite state",
       "Moved agent file settings.json → agents/worker-1/agent",
       `Moved MobileAuth auth creds.json → ${path.join(stateDir, "credentials", "mobileauth", "default", "creds.json")}`,
@@ -4429,12 +4428,9 @@ describe("state migrations", () => {
     );
   });
 
-  it.each([
-    { phase: "initial merge", transcriptSessionId: "other-session", rewrites: false },
-    { phase: "post-move rewrite", transcriptSessionId: "trace", rewrites: true },
-  ])(
-    "preserves key-shaped pending rows through the $phase",
-    async ({ transcriptSessionId, rewrites }) => {
+  it.runIf(process.platform !== "win32")(
+    "preserves a key-shaped pending row while moving its matching legacy transcript",
+    async () => {
       const { root, stateDir, env, cfg } = await createLegacyStateFixture();
 
       const targetStorePath = path.join(
@@ -4460,10 +4456,15 @@ describe("state migrations", () => {
           groupActivation: "always",
           delivery: { kind: "none" },
         },
-        [transcriptKey]: { sessionId: transcriptSessionId, updatedAt: 60 },
+        [transcriptKey]: { sessionId: "trace", updatedAt: 60 },
         [ordinaryKey]: { sessionId: "ordinary-session", updatedAt: 70 },
       };
       await fs.writeFile(targetStorePath, `${JSON.stringify(targetStore, null, 2)}\n`, "utf8");
+      await fs.writeFile(
+        path.join(stateDir, "sessions", `${pendingKey}.jsonl`),
+        '{"type":"session"}\n',
+        "utf8",
+      );
 
       const result = await autoMigrateLegacyState({
         cfg,
@@ -4474,10 +4475,17 @@ describe("state migrations", () => {
 
       expect(result.changes).toContain(`Merged sessions store → ${targetStorePath}`);
       expect(result.changes).toContain("Moved trace.jsonl → agents/worker-1/sessions");
-      expect(result.changes.includes("Rewrote migrated session transcript paths")).toBe(rewrites);
+      expect(result.changes).toContain(`Moved ${pendingKey}.jsonl → agents/worker-1/sessions`);
+      expect(result.changes).not.toContain("Rewrote migrated session transcript paths");
       await expect(
         fs.readFile(path.join(stateDir, "agents", "worker-1", "sessions", "trace.jsonl"), "utf8"),
       ).resolves.toBe("{}\n");
+      await expect(
+        fs.readFile(
+          path.join(stateDir, "agents", "worker-1", "sessions", `${pendingKey}.jsonl`),
+          "utf8",
+        ),
+      ).resolves.toBe('{"type":"session"}\n');
 
       const afterStore = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
         string,
@@ -4509,7 +4517,7 @@ describe("state migrations", () => {
         delivery: { kind: "none" },
       });
       expect(afterStore[pendingKey]?.sessionId).toBeUndefined();
-      expect(afterStore[transcriptKey]?.sessionId).toBe(transcriptSessionId);
+      expect(afterStore[transcriptKey]?.sessionId).toBe("trace");
       expect(afterStore[transcriptKey]?.sessionFile).toBeUndefined();
       expect(afterStore[ordinaryKey]?.sessionId).toBe("ordinary-session");
 
@@ -4526,7 +4534,7 @@ describe("state migrations", () => {
       expect(rerun.changes.some((change) => change.startsWith("Merged sessions store"))).toBe(
         false,
       );
-      expect(rerun.changes).not.toContain("Rewrote migrated session transcript paths");
+      expect(rerun.changes.some((change) => change.startsWith("Moved "))).toBe(false);
     },
   );
 });

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1451,11 +1451,12 @@ describe("state migrations", () => {
     const stateDir = path.join(root, ".openclaw");
     const env = createEnv(stateDir);
     const outsideStorePath = path.join(root, "outside-sessions.json");
+    const pendingKey = "agent:main:task";
     await fs.writeFile(
       outsideStorePath,
       JSON.stringify({
-        "agent:main:task": {
-          sessionId: "canonical-acp",
+        [pendingKey]: {
+          sessionId: pendingKey,
           updatedAt: 10,
           acp: {
             backend: "test",
@@ -1481,9 +1482,17 @@ describe("state migrations", () => {
     expect((await fs.lstat(configuredStorePath)).isSymbolicLink()).toBe(true);
     const outsideStore = JSON.parse(await fs.readFile(outsideStorePath, "utf8")) as Record<
       string,
-      { sessionId: string; acp?: unknown }
+      { sessionId?: string; acp?: unknown }
     >;
-    expect(outsideStore["agent:main:task"]?.acp).toBeDefined();
+    expect(outsideStore[pendingKey]?.sessionId).toBe(pendingKey);
+    expect(outsideStore[pendingKey]?.acp).toBeDefined();
+    expect(
+      readAcpSessionMetaForEntry({
+        sessionKey: pendingKey,
+        entry: { sessionId: pendingKey, lifecycleRevision: undefined },
+        env,
+      }),
+    ).toBeUndefined();
     expect(result.warnings).toContain(
       `Deferred ACP metadata migration in final-component symlink store ${configuredStorePath}; configure one canonical session.store path, then rerun openclaw doctor --fix`,
     );
@@ -1874,13 +1883,18 @@ describe("state migrations", () => {
     const stateDir = path.join(root, ".openclaw");
     const env = createEnv(stateDir);
     const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const pendingKey = "agent:main:existing";
     await fs.mkdir(path.dirname(storePath), { recursive: true });
     await fs.writeFile(
       storePath,
       JSON.stringify({
-        "agent:main:existing": {
-          sessionId: "existing-main",
+        [pendingKey]: {
+          sessionId: pendingKey,
           updatedAt: 20,
+          displayName: "Pending ACP session",
+          providerOverride: "test-provider",
+          modelOverride: "test-model",
+          modelOverrideSource: "user",
           acp: {
             backend: "test",
             agent: "main",
@@ -1901,13 +1915,47 @@ describe("state migrations", () => {
     });
 
     expect(result.changes).toContain("Migrated 1 ACP session metadata row → shared SQLite state");
+    const afterStore = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+      string,
+      {
+        sessionId?: string;
+        initializationPending?: boolean;
+        acp?: unknown;
+        displayName?: string;
+        providerOverride?: string;
+        modelOverride?: string;
+        modelOverrideSource?: string;
+      }
+    >;
+    expect(afterStore[pendingKey]).toMatchObject({
+      initializationPending: true,
+      displayName: "Pending ACP session",
+      providerOverride: "test-provider",
+      modelOverride: "test-model",
+      modelOverrideSource: "user",
+    });
+    expect(afterStore[pendingKey]?.sessionId).toBeUndefined();
+    expect(afterStore[pendingKey]?.acp).toBeUndefined();
     expect(
       readAcpSessionMetaForEntry({
-        sessionKey: "agent:main:existing",
-        entry: { sessionId: "existing-main", lifecycleRevision: undefined },
+        sessionKey: pendingKey,
+        entry: { lifecycleRevision: undefined },
         env,
       })?.runtimeSessionName,
     ).toBe("existing-runtime");
+
+    const firstBytes = await fs.readFile(storePath, "utf8");
+    closeOpenClawStateDatabaseForTest();
+    resetAutoMigrateLegacyStateForTest();
+    const rerun = await autoMigrateLegacyState({
+      cfg: { agents: { list: [{ id: "main", default: true }] } },
+      env,
+      homedir: () => root,
+    });
+    await expect(fs.readFile(storePath, "utf8")).resolves.toBe(firstBytes);
+    expect(rerun.changes).not.toContain(
+      "Migrated 1 ACP session metadata row → shared SQLite state",
+    );
   });
 
   it("migrates existing and imported ACP metadata in one canonical session phase", async () => {
@@ -4262,16 +4310,21 @@ describe("state migrations", () => {
     await expectMissingPath(path.join(stateDir, "sessions", "sessions.json"));
   });
 
-  it("preserves key-shaped pending rows during automatic legacy session migration", async () => {
+  it("preserves a readable target store when normalization rejects an existing key", async () => {
     const { root, stateDir, env, cfg } = await createLegacyStateFixture();
 
     const targetStorePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
-    const pendingKey = "agent:worker-1:desk";
-    const targetStore = {
-      [pendingKey]: { sessionId: pendingKey, updatedAt: 50 },
-      "agent:worker-1:desk:other": { sessionId: "other-session", updatedAt: 60 },
-    };
-    await fs.writeFile(targetStorePath, `${JSON.stringify(targetStore, null, 2)}\n`, "utf8");
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    const targetBytes = `${JSON.stringify(
+      {
+        "agent:worker-1:desk": { sessionId: "valid-session", updatedAt: 50 },
+        "agent:worker-1:desk:invalid": { sessionId: "../invalid", updatedAt: 60 },
+      },
+      null,
+      2,
+    )}\n`;
+    const legacyBytes = await fs.readFile(legacyStorePath, "utf8");
+    await fs.writeFile(targetStorePath, targetBytes, "utf8");
 
     const detected = await detectLegacyStateMigrations({
       cfg,
@@ -4283,16 +4336,198 @@ describe("state migrations", () => {
       now: () => 1234,
     });
 
-    expect(result.changes.some((c) => c.startsWith("Merged sessions store"))).toBe(true);
+    await expect(fs.readFile(targetStorePath, "utf8")).resolves.toBe(targetBytes);
+    await expect(fs.readFile(legacyStorePath, "utf8")).resolves.toBe(legacyBytes);
+    await expect(fs.readFile(path.join(stateDir, "sessions", "trace.jsonl"), "utf8")).resolves.toBe(
+      "{}\n",
+    );
+    expect(result.changes.some((change) => change.startsWith("Merged sessions store"))).toBe(false);
+    expect(result.changes.some((change) => change.startsWith("Moved trace.jsonl"))).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("normalization rejected 1 existing target session key"),
+    );
+  });
+
+  it("still filters invalid legacy-only rows", async () => {
+    const { root, stateDir, env, cfg } = await createLegacyStateFixture();
+
+    const targetStorePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    await fs.writeFile(
+      legacyStorePath,
+      `${JSON.stringify(
+        {
+          invalidLegacy: { sessionId: "../invalid", updatedAt: 100 },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({
+      detected,
+      now: () => 1234,
+    });
 
     const afterStore = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
       string,
-      { sessionId?: string; initializationPending?: boolean; updatedAt?: number }
+      { sessionId?: string }
     >;
-    expect(afterStore[pendingKey]).toBeDefined();
-    expect(afterStore[pendingKey]?.initializationPending).toBe(true);
-    expect(afterStore[pendingKey]?.sessionId).toBeUndefined();
-    expect(afterStore["agent:worker-1:desk:other"]?.sessionId).toBe("other-session");
+    expect(afterStore["agent:worker-1:invalidLegacy"]).toBeUndefined();
+    expect(Object.values(afterStore).some((entry) => entry.sessionId === "group-session")).toBe(
+      true,
+    );
+    expect(result.changes).toContain(`Merged sessions store → ${targetStorePath}`);
+    expect(result.warnings).toStrictEqual([]);
+    await expectMissingPath(legacyStorePath);
   });
+
+  it("defers when an invalid legacy winner would replace an existing target key", async () => {
+    const { root, stateDir, env, cfg } = await createLegacyStateFixture();
+
+    const targetStorePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    const conflictKey = "agent:worker-1:desk:conflict";
+    const targetBytes = `${JSON.stringify(
+      {
+        [conflictKey]: { sessionId: "target-session", updatedAt: 50 },
+      },
+      null,
+      2,
+    )}\n`;
+    const legacyBytes = `${JSON.stringify(
+      {
+        [conflictKey]: { sessionId: "../invalid", updatedAt: 100 },
+      },
+      null,
+      2,
+    )}\n`;
+    await fs.writeFile(targetStorePath, targetBytes, "utf8");
+    await fs.writeFile(legacyStorePath, legacyBytes, "utf8");
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({
+      detected,
+      now: () => 1234,
+    });
+
+    await expect(fs.readFile(targetStorePath, "utf8")).resolves.toBe(targetBytes);
+    await expect(fs.readFile(legacyStorePath, "utf8")).resolves.toBe(legacyBytes);
+    expect(result.changes.some((change) => change.startsWith("Merged sessions store"))).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("normalization rejected 1 existing target session key"),
+    );
+  });
+
+  it.each([
+    { phase: "initial merge", transcriptSessionId: "other-session", rewrites: false },
+    { phase: "post-move rewrite", transcriptSessionId: "trace", rewrites: true },
+  ])(
+    "preserves key-shaped pending rows through the $phase",
+    async ({ transcriptSessionId, rewrites }) => {
+      const { root, stateDir, env, cfg } = await createLegacyStateFixture();
+
+      const targetStorePath = path.join(
+        stateDir,
+        "agents",
+        "worker-1",
+        "sessions",
+        "sessions.json",
+      );
+      const pendingKey = "agent:worker-1:desk";
+      const transcriptKey = "agent:worker-1:desk:transcript";
+      const ordinaryKey = "agent:worker-1:desk:ordinary";
+      const targetStore = {
+        [pendingKey]: {
+          sessionId: pendingKey,
+          updatedAt: 50,
+          displayName: "Pending desk",
+          label: "pending-label",
+          category: "triage",
+          providerOverride: "test-provider",
+          modelOverride: "test-model",
+          modelOverrideSource: "user",
+          groupActivation: "always",
+          delivery: { kind: "none" },
+        },
+        [transcriptKey]: { sessionId: transcriptSessionId, updatedAt: 60 },
+        [ordinaryKey]: { sessionId: "ordinary-session", updatedAt: 70 },
+      };
+      await fs.writeFile(targetStorePath, `${JSON.stringify(targetStore, null, 2)}\n`, "utf8");
+
+      const result = await autoMigrateLegacyState({
+        cfg,
+        env,
+        homedir: () => root,
+        now: () => 1234,
+      });
+
+      expect(result.changes).toContain(`Merged sessions store → ${targetStorePath}`);
+      expect(result.changes).toContain("Moved trace.jsonl → agents/worker-1/sessions");
+      expect(result.changes.includes("Rewrote migrated session transcript paths")).toBe(rewrites);
+      await expect(
+        fs.readFile(path.join(stateDir, "agents", "worker-1", "sessions", "trace.jsonl"), "utf8"),
+      ).resolves.toBe("{}\n");
+
+      const afterStore = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
+        string,
+        {
+          sessionId?: string;
+          sessionFile?: string;
+          initializationPending?: boolean;
+          updatedAt?: number;
+          displayName?: string;
+          label?: string;
+          category?: string;
+          providerOverride?: string;
+          modelOverride?: string;
+          modelOverrideSource?: string;
+          groupActivation?: string;
+          delivery?: { kind?: string };
+        }
+      >;
+      expect(afterStore[pendingKey]).toMatchObject({
+        initializationPending: true,
+        updatedAt: 50,
+        displayName: "Pending desk",
+        label: "pending-label",
+        category: "triage",
+        providerOverride: "test-provider",
+        modelOverride: "test-model",
+        modelOverrideSource: "user",
+        groupActivation: "always",
+        delivery: { kind: "none" },
+      });
+      expect(afterStore[pendingKey]?.sessionId).toBeUndefined();
+      expect(afterStore[transcriptKey]?.sessionId).toBe(transcriptSessionId);
+      expect(afterStore[transcriptKey]?.sessionFile).toBeUndefined();
+      expect(afterStore[ordinaryKey]?.sessionId).toBe("ordinary-session");
+
+      const firstBytes = await fs.readFile(targetStorePath, "utf8");
+      closeOpenClawStateDatabaseForTest();
+      resetAutoMigrateLegacyStateForTest();
+      const rerun = await autoMigrateLegacyState({
+        cfg,
+        env,
+        homedir: () => root,
+        now: () => 1234,
+      });
+      await expect(fs.readFile(targetStorePath, "utf8")).resolves.toBe(firstBytes);
+      expect(rerun.changes.some((change) => change.startsWith("Merged sessions store"))).toBe(
+        false,
+      );
+      expect(rerun.changes).not.toContain("Rewrote migrated session transcript paths");
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Fixes #117263

## What Problem This Solves

Automatic startup migration could silently delete readable target-session rows whose `sessionId` equals their canonical agent session key. The normalizer needs the store key to recognize that legacy shape as `initializationPending`; without it, the row is rejected and omitted from the replacement store.

The original repair exposed a second destructive path: after moving legacy transcripts, migration re-normalized mutable raw rows and replaced the store again. A matching `<pendingKey>.jsonl` added retired `sessionFile` metadata to the pending row, made normalization reject it, and deleted it in the second write.

## Root Cause

- Legacy-session and ACP metadata normalization omitted the in-scope store key.
- Store replacement did not protect rows already present in the readable target store from normalization rejection.
- The post-move rewrite persisted `sessionFile`, a file-era field retired by #113233 and removed from the canonical session-entry shape. That obsolete second replacement write violated the same target-row preservation invariant.

## Canonical Repair

- Pass the session key through every affected normalization path.
- Track canonical target keys and refuse the migration before replacement if normalization rejects any protected target row.
- Keep filtering invalid legacy-only rows, which are not authoritative target state.
- Remove the obsolete post-move `sessionFile` rewrite entirely. Transcript files still move to the canonical agent directory; the canonical store is written once.
- Cover initial preservation, fail-closed target rejection, legacy-only filtering, ACP extraction, matching `<pendingKey>.jsonl`, metadata preservation, and rerun idempotence.

Best-fix judgment: deleting the obsolete second write is better than carrying first-pass entries into it or adding another guard. Canonical entries no longer persist file paths, so preserving the rewrite would keep dead policy and another state-replacement boundary without a supported contract.

## User Impact

Startup migration now preserves live pending-session metadata, including display name, category, provider/model overrides, delivery state, and group activation. A matching legacy transcript is moved without mutating or deleting the canonical row. A second startup is byte-stable.

## Evidence

Validated head: `f4aa51d96b2b5df7c8a6198fb1c0f63741419ac3`

Sanitized direct AWS Crabbox: public networking, no Tailscale, no instance role, no hydration, only `CI` forwarded, trusted bootstrap, exact SHA verification.

- [Static and focused proof](https://crabbox.openclaw.ai/portal/runs/run_998218051ce1)
  - `pnpm format:check`
  - full oxlint: 0 warnings, 0 errors
  - `src/infra/state-migrations.test.ts`: 79/79
  - `src/config/sessions/sessions.test.ts`: 21/21
  - `src/acp/runtime/session-meta.test.ts`: 12/12
  - SQLite sessions/transcripts flip E2E: 1/1
- [Built CLI startup proof](https://crabbox.openclaw.ai/portal/runs/run_a9084c30f1c9)
  - built the packaged CLI
  - ran real `openclaw status --json` startup migration twice against isolated state
  - preserved the key-shaped pending row and all checked metadata
  - moved the literal matching `<pendingKey>.jsonl`
  - migrated ACP metadata with a null runtime session id
  - proved byte-stable rerun state
  - output: `ACP_PROOF_OK`, `LEGACY_PROOF_OK`, `RUNTIME_PROOF_OK`
- Exact-head autoreview: clean, no accepted/actionable findings, confidence 0.95.
- GitHub `openclaw/ci-gate`: passed on the exact head.

## Diff Shape

- Production: +32/-44, net -12 lines.
- Tests: +285/-9.
- No config, protocol, schema-version, or public API change.

## AI Assistance

- **AI-assisted**: Yes
- **Original model**: glm-5.1
