### PR TITLE
fix(anthropic): honor configured model pricing

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -1,4 +1,5 @@
 // Anthropic tests cover index plugin behavior.
+import { calculateCost, type Usage } from "openclaw/plugin-sdk/llm";
 import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
@@ -858,6 +859,70 @@ describe("anthropic provider replay hooks", () => {
     // promotional -> standard pricing cutover.
     expect(normalized?.cost).toEqual((resolved as ProviderRuntimeModel).cost);
   });
+
+  it.each(["claude-sonnet-5", "claude-opus-5"])(
+    "uses operator-configured %s pricing for assistant usage",
+    async (modelId) => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const configuredCost = { input: 777, output: 888, cacheRead: 999, cacheWrite: 666 };
+      const config: NonNullable<ProviderResolveDynamicModelContext["config"]> = {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  id: modelId,
+                  name: modelId,
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: configuredCost,
+                  contextWindow: 1_000_000,
+                  maxTokens: 128_000,
+                },
+              ],
+            },
+          },
+        },
+      };
+      const discoveredModel = provider.resolveDynamicModel?.({
+        config,
+        provider: "anthropic",
+        modelId,
+        modelRegistry: createModelRegistry([]),
+      } as ProviderResolveDynamicModelContext);
+      expect(discoveredModel).toBeDefined();
+
+      const configuredModel = {
+        ...(discoveredModel as ProviderRuntimeModel),
+        cost: configuredCost,
+      };
+      const resolvedModel =
+        provider.normalizeResolvedModel?.({
+          config,
+          provider: "anthropic",
+          modelId,
+          model: configuredModel,
+        } as never) ?? configuredModel;
+      const usage: Usage = {
+        input: 1_000,
+        output: 1_000,
+        cacheRead: 1_000,
+        cacheWrite: 1_000,
+        totalTokens: 4_000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      };
+
+      calculateCost(resolvedModel as Parameters<typeof calculateCost>[0], usage);
+
+      expect(resolvedModel.cost).toEqual(configuredCost);
+      expect(usage.cost.input).toBeCloseTo(0.777);
+      expect(usage.cost.output).toBeCloseTo(0.888);
+      expect(usage.cost.cacheRead).toBeCloseTo(0.999);
+      expect(usage.cost.cacheWrite).toBeCloseTo(0.666);
+      expect(usage.cost.total).toBeCloseTo(3.33);
+    },
+  );
 
   it("resolves Claude Mythos 5 with its direct-only mandatory-adaptive contract", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -631,10 +631,11 @@ function supportsAnthropicNativeMaxEffort(modelId: string): boolean {
   return supportsClaudeNativeMaxEffort({ id: modelId }) || isAnthropicMythosPreviewModel(modelId);
 }
 
-function hasConfiguredModelContextOverride(
+function hasConfiguredModelOverride(
   config: ProviderNormalizeResolvedModelContext["config"],
   provider: string,
   modelId: string,
+  override: "context" | "cost",
 ): boolean {
   const providers = config?.models?.providers;
   if (!providers || typeof providers !== "object") {
@@ -657,8 +658,10 @@ function hasConfiguredModelContextOverride(
         continue;
       }
       if (
-        (typeof model?.contextTokens === "number" && model.contextTokens > 0) ||
-        (typeof model?.contextWindow === "number" && model.contextWindow > 0)
+        override === "cost"
+          ? model?.cost !== undefined
+          : (typeof model?.contextTokens === "number" && model.contextTokens > 0) ||
+            (typeof model?.contextWindow === "number" && model.contextWindow > 0)
       ) {
         return true;
       }
@@ -681,7 +684,7 @@ function applyAnthropicFixedContextWindow(params: {
   if (fixedContextWindow === undefined) {
     return undefined;
   }
-  if (hasConfiguredModelContextOverride(params.config, params.provider, params.modelId)) {
+  if (hasConfiguredModelOverride(params.config, params.provider, params.modelId, "context")) {
     return undefined;
   }
   const exactContextWindow = isAnthropicExact1MClaude5Model(params.contractModelId);
@@ -878,8 +881,10 @@ function normalizeAnthropicResolvedModel(
       contractModelId,
       model: thinkingLevelModel,
     }) ?? thinkingLevelModel;
+  // Provider catalog defaults must not replace explicit operator pricing.
   const pricingModel =
-    normalizeLowercaseStringOrEmpty(ctx.provider) === PROVIDER_ID
+    normalizeLowercaseStringOrEmpty(ctx.provider) === PROVIDER_ID &&
+    !hasConfiguredModelOverride(ctx.config, ctx.provider, ctx.modelId, "cost")
       ? (applyAnthropicOpus5Cost({
           modelId: contractModelId,
           model: contextWindowModel,


### PR DESCRIPTION
Fixes #116714

Original contributor: @synthalorian. Original issue reporter: @1Vision365-PeterTijsma.

## What Problem This Solves

Explicit operator pricing under `models.providers.anthropic.models[].cost` was silently overwritten by the Anthropic provider normalizer for both Claude Sonnet 5 and Claude Opus 5. The documented configured rates therefore never reached real assistant-usage cost calculation.

## Why This Change Was Made

The actual producer is `extensions/anthropic/register.runtime.ts`: `normalizeAnthropicResolvedModel` reapplied Sonnet/Opus catalog pricing after an explicitly configured model rate was already present. Generalize its existing configured-model override detector from context alone to context or cost, and skip provider-default repricing only for an explicitly configured cost on that same provider/model.

This maintainer takeover deliberately removes the original broad `src/plugins/runtime/runtime-llm.runtime.ts` and `src/utils/usage-format*` changes. Provider-reported billed totals remain authoritative; this PR does not replace, hide, or reinterpret them. The fix stays entirely inside the Anthropic pricing owner, adds only five net production lines, and introduces no config options, dependencies, or migrations.

## User Impact

Configured per-million input, output, cache-read, and cache-write rates now determine estimated usage for both affected Anthropic model families. Unconfigured catalog defaults, the Sonnet promotional-price cutoff, explicit context overrides, Claude CLI pricing, and authoritative provider-billed totals keep their existing behavior.

## Evidence

Actual production `buildAnthropicProvider().normalizeResolvedModel` and `calculateCost`, with 1,000 tokens in each category:

Before, current main:

```json
{"results":[{"modelId":"claude-sonnet-5","configuredRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"normalizedRate":{"input":2,"output":10,"cacheRead":0.2,"cacheWrite":2.5},"calculated":{"input":0.002,"output":0.01,"cacheRead":0.0002,"cacheWrite":0.0025,"total":0.014700000000000001},"configuredContext":321000,"defaultInputRate":2,"claudeCliInputRate":0,"providerBilled":{"total":42,"totalOrigin":"provider-billed"}},{"modelId":"claude-opus-5","configuredRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"normalizedRate":{"input":5,"output":25,"cacheRead":0.5,"cacheWrite":6.25},"calculated":{"input":0.005,"output":0.025,"cacheRead":0.0005,"cacheWrite":0.00625,"total":0.036750000000000005},"configuredContext":321000,"defaultInputRate":5,"claudeCliInputRate":0,"providerBilled":{"total":42,"totalOrigin":"provider-billed"}}]}
```

After, exact contributor PR head `e0d28b5f115486555aea56623bd2562d988bee5d`:

```json
{"results":[{"modelId":"claude-sonnet-5","configuredRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"normalizedRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"calculated":{"input":0.777,"output":0.888,"cacheRead":0.9990000000000001,"cacheWrite":0.666,"total":3.33},"configuredContext":321000,"defaultInputRate":2,"claudeCliInputRate":0,"providerBilled":{"total":42,"totalOrigin":"provider-billed"}},{"modelId":"claude-opus-5","configuredRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"normalizedRate":{"input":777,"output":888,"cacheRead":999,"cacheWrite":666},"calculated":{"input":0.777,"output":0.888,"cacheRead":0.9990000000000001,"cacheWrite":0.666,"total":3.33},"configuredContext":321000,"defaultInputRate":5,"claudeCliInputRate":0,"providerBilled":{"total":42,"totalOrigin":"provider-billed"}}]}
```

Both Sonnet and Opus preserve the configured `777/888/999/666` rates and calculate `0.777 + 0.888 + 0.999 + 0.666 = 3.33`. The same production run also proves configured context remains `321000`, catalog defaults remain `2/5`, Claude CLI remains `0`, and a real provider-reported billed total remains `42` with origin `provider-billed`.

Native focused owner test:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-117275-70b4ad6d node scripts/run-vitest.mjs extensions/anthropic/index.test.ts
```

Result: **1 file passed; 51 tests passed**, including both new real-plugin-plus-cost-calculator regressions.

The exact identical two-path patch was also validated on trusted Blacksmith Testbox lease `tbx_01kyyqv92jdej6v1e11hpy4rkc`:

```bash
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01kyyqv92jdej6v1e11hpy4rkc --timing-json -- bash -lc 'pnpm format:check extensions/anthropic/index.test.ts extensions/anthropic/register.runtime.ts && pnpm tsgo:extensions && pnpm tsgo:extensions:test && pnpm test extensions/anthropic/index.test.ts'
```

Formatting, production extension typecheck, test extension typecheck, and all 51 tests passed; remote timing JSON reports `exitCode=0`. The newly added two model regressions were also observed failing before the production fix. Fresh Codex Sol xhigh autoreview reports no accepted or actionable findings.

The earlier ClawSweeper wrong-owner finding is resolved by deleting the plugin-runtime and usage-format patch entirely; the missing changed-surface proof is resolved by actual provider registration, normalization, cost calculation, both model-family regressions, and the before/after runtime transcripts above. No provider-billed compatibility change remains.