### PR TITLE
fix(feishu): preserve custom HTTPS domain ports

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -148,7 +148,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 type HttpInstanceLike = {
   request: (options?: Record<string, unknown>) => Promise<unknown>;
   get: (url: string, options?: Record<string, unknown>) => Promise<unknown>;
+  delete: (url: string, options?: Record<string, unknown>) => Promise<unknown>;
+  head: (url: string, options?: Record<string, unknown>) => Promise<unknown>;
+  options: (url: string, options?: Record<string, unknown>) => Promise<unknown>;
   post: (url: string, body?: unknown, options?: Record<string, unknown>) => Promise<unknown>;
+  put: (url: string, body?: unknown, options?: Record<string, unknown>) => Promise<unknown>;
+  patch: (url: string, body?: unknown, options?: Record<string, unknown>) => Promise<unknown>;
 };
 
 function requireHttpInstance(value: unknown): HttpInstanceLike {
@@ -158,11 +163,7 @@ function requireHttpInstance(value: unknown): HttpInstanceLike {
     typeof value.get === "function" &&
     typeof value.post === "function"
   ) {
-    return {
-      request: value.request as HttpInstanceLike["request"],
-      get: value.get as HttpInstanceLike["get"],
-      post: value.post as HttpInstanceLike["post"],
-    };
+    return value as HttpInstanceLike;
   }
   throw new Error("expected Feishu HTTP instance");
 }
@@ -199,7 +200,7 @@ function firstWsClientOptions(): {
 beforeAll(async () => {
   vi.doMock("@larksuiteoapi/node-sdk", () => ({
     AppType: { SelfBuild: "self" },
-    Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
+    Domain: { Feishu: 0, Lark: 1 },
     LoggerLevel: { info: "info" },
     Client: clientCtorMock,
     WSClient: wsClientCtorMock,
@@ -275,6 +276,148 @@ describe("Feishu default User-Agent interceptor", () => {
 
     expect(headers.set).toHaveBeenCalledWith("User-Agent", getFeishuUserAgent());
   });
+});
+
+describe("Feishu custom HTTPS API domains", () => {
+  const sdkOrigin = "https://open.feishu.cn";
+  const customDomain = "https://private.feishu.test:8443/reverse-proxy/";
+
+  function createCustomDomainHttpInstance(accountId: string): HttpInstanceLike {
+    createFeishuClient({
+      appId: `app_${accountId}`,
+      appSecret: "local-test-placeholder", // pragma: allowlist secret
+      accountId,
+      domain: customDomain,
+    });
+    expect(readCallOptions(clientCtorMock).domain).toBe(0);
+    return requireHttpInstance(readCallOptions(clientCtorMock).httpInstance);
+  }
+
+  it.each(["get", "delete", "head", "options"] as const)(
+    "routes SDK %s requests through the configured HTTPS origin, port, and path",
+    async (method) => {
+      const httpInstance = createCustomDomainHttpInstance(`custom-domain-${method}`);
+      const requestUrl = `${sdkOrigin}/open-apis/im/v1/messages/om_proof?locale=en`;
+
+      await httpInstance[method](requestUrl, { headers: { "X-Proof": "true" } });
+
+      expect(mockBaseHttpInstance[method]).toHaveBeenCalledWith(
+        "https://private.feishu.test:8443/reverse-proxy/open-apis/im/v1/messages/om_proof?locale=en",
+        { timeout: FEISHU_HTTP_TIMEOUT_MS, headers: { "X-Proof": "true" } },
+      );
+    },
+  );
+
+  it.each(["post", "put", "patch"] as const)(
+    "routes SDK %s requests without changing their body or request options",
+    async (method) => {
+      const httpInstance = createCustomDomainHttpInstance(`custom-domain-${method}`);
+      const body = { content: "preserve this body" };
+
+      await httpInstance[method](`${sdkOrigin}/open-apis/im/v1/messages`, body, {
+        headers: { "X-Proof": "true" },
+      });
+
+      expect(mockBaseHttpInstance[method]).toHaveBeenCalledWith(
+        "https://private.feishu.test:8443/reverse-proxy/open-apis/im/v1/messages",
+        body,
+        { timeout: FEISHU_HTTP_TIMEOUT_MS, headers: { "X-Proof": "true" } },
+      );
+    },
+  );
+
+  it("routes request options after preserving Feishu SDK multipart normalization", async () => {
+    const httpInstance = createCustomDomainHttpInstance("custom-domain-upload");
+
+    await httpInstance.request({
+      url: `${sdkOrigin}/open-apis/im/v1/files?folder=root`,
+      method: "POST",
+      headers: { "Content-Type": "multipart/form-data" },
+      data: { file_type: "stream", file_name: "proof.txt", file: Buffer.from("proof") },
+    });
+
+    const delegated = readCallOptions(mockBaseHttpInstance.request);
+    expect(delegated.url).toBe(
+      "https://private.feishu.test:8443/reverse-proxy/open-apis/im/v1/files?folder=root",
+    );
+    expect(delegated.timeout).toBe(FEISHU_HTTP_TIMEOUT_MS);
+    expect(delegated.data).toBeInstanceOf(FormData);
+    expect((delegated.data as FormData).get("file_type")).toBe("stream");
+  });
+
+  it.each([
+    "https://open.feishu.cn.evil.test/open-apis/im/v1/messages",
+    "https://open.feishu.cn:444/open-apis/im/v1/messages",
+    "https://unrelated.example/open-apis/im/v1/messages",
+  ])("does not rewrite an unrelated request origin: %s", async (url) => {
+    const httpInstance = createCustomDomainHttpInstance(`custom-domain-external-${url.length}`);
+
+    await httpInstance.get(url);
+
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(url, {
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+    });
+  });
+
+  it("keeps independent account transport origins isolated", async () => {
+    const first = createCustomDomainHttpInstance("custom-domain-first-account");
+    createFeishuClient({
+      appId: "app_second_account",
+      appSecret: "local-test-placeholder", // pragma: allowlist secret
+      accountId: "custom-domain-second-account",
+      domain: "https://another.feishu.test:9443/tenant",
+    });
+    const second = requireHttpInstance(readCallOptions(clientCtorMock).httpInstance);
+
+    await first.get(`${sdkOrigin}/open-apis/im/v1/chats/oc_first`);
+    await second.get(`${sdkOrigin}/open-apis/im/v1/chats/oc_second`);
+
+    expect(mockBaseHttpInstance.get.mock.calls.map((call) => call[0])).toEqual([
+      "https://private.feishu.test:8443/reverse-proxy/open-apis/im/v1/chats/oc_first",
+      "https://another.feishu.test:9443/tenant/open-apis/im/v1/chats/oc_second",
+    ]);
+  });
+
+  it("routes WebSocket endpoint discovery through the same configured origin", async () => {
+    await createFeishuWSClient({
+      ...baseAccount,
+      accountId: "custom-domain-websocket",
+      domain: customDomain,
+    });
+
+    const options = readCallOptions(wsClientCtorMock);
+    expect(options.domain).toBe(0);
+    const httpInstance = requireHttpInstance(options.httpInstance);
+    await httpInstance.request({ url: `${sdkOrigin}/callback/ws/endpoint`, method: "post" });
+
+    expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
+      url: "https://private.feishu.test:8443/reverse-proxy/callback/ws/endpoint",
+      method: "post",
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+    });
+  });
+
+  it.each([
+    ["feishu", 0, "https://open.feishu.cn"],
+    ["lark", 1, "https://open.larksuite.com"],
+  ] as const)(
+    "preserves the existing %s SDK domain and direct requests",
+    async (domain, sdkDomain, url) => {
+      createFeishuClient({
+        appId: `app_${domain}`,
+        appSecret: "local-test-placeholder", // pragma: allowlist secret
+        accountId: `official-domain-${domain}`,
+        domain,
+      });
+
+      const options = readCallOptions(clientCtorMock);
+      expect(options.domain).toBe(sdkDomain);
+      await requireHttpInstance(options.httpInstance).get(`${url}/open-apis/im/v1/messages`);
+      expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(`${url}/open-apis/im/v1/messages`, {
+        timeout: FEISHU_HTTP_TIMEOUT_MS,
+      });
+    },
+  );
 });
 
 describe("createFeishuClient HTTP timeout", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -14,6 +14,7 @@ const require = createRequire(import.meta.url);
 const pluginVersion = readPluginPackageVersion({ require });
 
 const FEISHU_USER_AGENT = `openclaw-feishu-builtin/${pluginVersion}/${process.platform}`;
+const FEISHU_SDK_ORIGIN = "https://open.feishu.cn";
 
 const FEISHU_WS_CONFIG = {
   pingTimeout: 3,
@@ -260,14 +261,10 @@ const clientCache = new Map<
   }
 >();
 
-function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
-  if (domain === "lark") {
-    return feishuClientSdk.Domain.Lark;
-  }
-  if (domain === "feishu" || !domain) {
-    return feishuClientSdk.Domain.Feishu;
-  }
-  return domain.replace(/\/+$/, ""); // Custom URL for private deployment
+function resolveSdkDomain(domain: FeishuDomain | undefined): Lark.Domain {
+  // The SDK parses :port in its domain as an API route parameter; custom origins
+  // must stay in their account-owned HTTP transport until path expansion ends.
+  return domain === "lark" ? feishuClientSdk.Domain.Lark : feishuClientSdk.Domain.Feishu;
 }
 
 /**
@@ -276,13 +273,38 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
  * indefinite hangs, set a standardized User-Agent per OAPI best practices, and
  * keep axios from taking a separate ambient proxy path for HTTPS requests.
  */
-function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
+function createFeishuHttpInstance(
+  defaultTimeoutMs: number,
+  configuredDomain?: FeishuDomain,
+): Lark.HttpInstance {
   const base: FeishuHttpInstanceLike = feishuClientSdk.defaultHttpInstance;
+  const customDomain =
+    configuredDomain && configuredDomain !== "feishu" && configuredDomain !== "lark"
+      ? new URL(configuredDomain)
+      : undefined;
+
+  function resolveRequestUrl(url: string): string {
+    if (!customDomain) {
+      return url;
+    }
+    const requestUrl = new URL(url);
+    if (requestUrl.origin !== FEISHU_SDK_ORIGIN) {
+      return url;
+    }
+    const destination = new URL(customDomain);
+    destination.pathname = `${destination.pathname.replace(/\/+$/, "")}${requestUrl.pathname}`;
+    destination.search = requestUrl.search;
+    destination.hash = requestUrl.hash;
+    return destination.toString();
+  }
 
   async function injectRequestOptions<D>(
     opts?: Lark.HttpRequestOptions<D>,
   ): Promise<FeishuProxyAwareHttpRequestOptions<D>> {
     const next: FeishuProxyAwareHttpRequestOptions<D> = { timeout: defaultTimeoutMs, ...opts };
+    if (typeof next.url === "string") {
+      next.url = resolveRequestUrl(next.url);
+    }
     const agent = await getFeishuProxyAgent();
     if (agent) {
       if (isManagedProxyActive()) {
@@ -300,13 +322,18 @@ function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   return {
     request: async (opts) =>
       base.request(await injectRequestOptions(normalizeMultipartUploadData(opts))),
-    get: async (url, opts) => base.get(url, await injectRequestOptions(opts)),
-    post: async (url, data, opts) => base.post(url, data, await injectRequestOptions(opts)),
-    put: async (url, data, opts) => base.put(url, data, await injectRequestOptions(opts)),
-    patch: async (url, data, opts) => base.patch(url, data, await injectRequestOptions(opts)),
-    delete: async (url, opts) => base.delete(url, await injectRequestOptions(opts)),
-    head: async (url, opts) => base.head(url, await injectRequestOptions(opts)),
-    options: async (url, opts) => base.options(url, await injectRequestOptions(opts)),
+    get: async (url, opts) => base.get(resolveRequestUrl(url), await injectRequestOptions(opts)),
+    post: async (url, data, opts) =>
+      base.post(resolveRequestUrl(url), data, await injectRequestOptions(opts)),
+    put: async (url, data, opts) =>
+      base.put(resolveRequestUrl(url), data, await injectRequestOptions(opts)),
+    patch: async (url, data, opts) =>
+      base.patch(resolveRequestUrl(url), data, await injectRequestOptions(opts)),
+    delete: async (url, opts) =>
+      base.delete(resolveRequestUrl(url), await injectRequestOptions(opts)),
+    head: async (url, opts) => base.head(resolveRequestUrl(url), await injectRequestOptions(opts)),
+    options: async (url, opts) =>
+      base.options(resolveRequestUrl(url), await injectRequestOptions(opts)),
   };
 }
 
@@ -352,8 +379,8 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     appId,
     appSecret,
     appType: feishuClientSdk.AppType.SelfBuild,
-    domain: resolveDomain(domain),
-    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs),
+    domain: resolveSdkDomain(domain),
+    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs, domain),
   });
 
   // Cache it
@@ -389,8 +416,8 @@ export async function createFeishuWSClient(
   return new feishuClientSdk.WSClient({
     appId,
     appSecret,
-    domain: resolveDomain(domain),
-    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs),
+    domain: resolveSdkDomain(domain),
+    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs, domain),
     ...callbacks,
     loggerLevel: feishuClientSdk.LoggerLevel.info,
     wsConfig: FEISHU_WS_CONFIG,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu operators using a documented custom HTTPS API domain with an explicit port could not send messages, read messages, or inspect chats because the upstream SDK interpreted the domain port as a missing API route argument.

## Why This Change Was Made

The Feishu client owner now gives the SDK its canonical port-free domain during route expansion while its existing account-owned HTTP transport restores the operator's exact HTTPS origin, explicit port, and optional reverse-proxy path for every request. The same canonical transport serves REST authentication, all HTTP methods, Drive calls, media uploads, and WebSocket endpoint discovery; no configuration, dependency, plugin SDK, authentication policy, or other plugin changes.

## User Impact

Private Feishu deployments using HTTPS domains such as `https://feishu.example:8443/company` can send messages, read message/chat context, upload media, access Drive, and initialize WebSockets without losing their configured port or path. Official Feishu/Lark domains, per-account isolation, existing proxies, timeout behavior, and unrelated request origins remain unchanged.

## Evidence

- Immutable reviewed head: `d2e4c6509f4e059465664a79383a30c65c65a17a`; tree: `199de5d07fff2296a93e03115b567cbab7042f20`; base: `ad3e36ef33148ea5b341ebbbc8f5b0fcd84b0596`; current main: `8ed6c98b08f47b0c1a35335b8faa8bb2601de9bb`; clean synthetic merge tree: `e61c2dc2145b4927fbc11e893429620df42b8232`.
- Before the refactor, **13 focused custom-domain regression cases failed** and the actual installed `@larksuiteoapi/node-sdk@1.71.1` reported `request miss <port> path argument` for real message send, message read, and chat read.
- After the refactor, **five focused owner/sibling test files and all 96 tests passed**, covering the client, Drive, streaming cards, actual direct-message loopback, and actual message-content loopback.
- A genuine local HTTPS server, custom explicit port, reverse-proxy prefix, actual installed SDK, and authenticated requests independently passed tenant-token acquisition, message send, message read, chat read, direct Drive access, and WebSocket endpoint discovery; every request remained scoped to the configured HTTPS origin and path.
- Focused cases additionally verify every SDK HTTP verb, multipart normalization before URL rewriting, per-account origin isolation, official Feishu/Lark numeric SDK domains, exact-origin spoof rejection, proxy behavior, and unchanged timeouts.
- Formatting, focused lint, and `git diff --check` passed on the immutable head; independent hostile owner reviews and the fresh complete-branch P0–P3 autoreview are recorded in the landing manifest.
