### PR TITLE
fix(ui): focus capability prompt

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -13,6 +13,7 @@ import {
   sessionMatchesArchivedFilter,
 } from "../lib/sessions/index.ts";
 import {
+  composerDraftSearch,
   resolveSessionPreferredFace,
   sessionNavigationTarget,
 } from "../lib/sessions/route-navigation.ts";
@@ -547,7 +548,6 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       return;
     }
     const key = this.agentResumeKey(agentId);
-    const draft = encodeURIComponent(t("chat.welcome.suggestions.whatCanYouDo"));
     const target = sessionNavigationTarget({
       face: "chat",
       sessionKey: key,
@@ -559,7 +559,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     this.setApplicationSession(key, this.selectedAgentIdForSessions());
     this.onNavigate?.("chat", {
       ...target.options,
-      search: `?draft=${draft}`,
+      search: composerDraftSearch(t("chat.welcome.suggestions.whatCanYouDo")),
     });
   }
 

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -9,6 +9,69 @@ import {
 const suite = createSidebarCustomizationSuite("Control UI sidebar interactions mocked Gateway E2E");
 
 suite.define(() => {
+  async function openCapabilitiesPrompt(reducedMotion: "no-preference" | "reduce") {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      reducedMotion,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page);
+    await page.goto(`${suite.server.baseUrl}chat`);
+
+    const sidebar = page.locator("openclaw-app-sidebar");
+    await sidebar.locator(".sidebar-agent-card__main").click();
+    await sidebar
+      .locator('wa-dropdown.sidebar-agent-menu wa-dropdown-item[value="command:capabilities"]')
+      .click();
+
+    const textarea = page.locator(".agent-chat__composer-combobox > textarea");
+    await expect.poll(() => textarea.inputValue()).toBe("What can you do?");
+    await expect
+      .poll(() => textarea.evaluate((element) => element === document.activeElement))
+      .toBe(true);
+    const input = textarea.locator("xpath=ancestor::*[contains(@class, 'agent-chat__input')][1]");
+    await expect
+      .poll(() => input.getAttribute("class"))
+      .toContain("agent-chat__input--prefill-attention");
+    return { context, input, page };
+  }
+
+  it("focuses and highlights the composer from the agent capabilities action", async () => {
+    const { context, input, page } = await openCapabilitiesPrompt("no-preference");
+
+    try {
+      await expect
+        .poll(() => input.evaluate((element) => getComputedStyle(element).animationName))
+        .toBe("chat-composer-prefill-attention");
+      await captureSidebarUiProof(page, "capabilities-composer-focus.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps a static composer cue when reduced motion is requested", async () => {
+    const { context, input, page } = await openCapabilitiesPrompt("reduce");
+
+    try {
+      await expect
+        .poll(() =>
+          input.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return { animationName: style.animationName, boxShadow: style.boxShadow };
+          }),
+        )
+        .toEqual(expect.objectContaining({ animationName: "none" }));
+      await expect
+        .poll(() => input.evaluate((element) => getComputedStyle(element).boxShadow))
+        .not.toBe("none");
+      await captureSidebarUiProof(page, "capabilities-composer-reduced-motion.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("restores focus to the Pages edit button after closing the pin editor with Escape", async () => {
     const { context, page } = await openSidebarCustomizationPage(suite);
 

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -45,7 +45,16 @@ suite.define(() => {
       await expect
         .poll(() => input.evaluate((element) => getComputedStyle(element).animationName))
         .toBe("chat-composer-prefill-attention");
+      const highlightedBackground = await input.evaluate(
+        (element) => getComputedStyle(element).backgroundColor,
+      );
       await captureSidebarUiProof(page, "capabilities-composer-focus.png");
+      await expect
+        .poll(() => input.getAttribute("class"))
+        .not.toContain("agent-chat__input--prefill-attention");
+      expect(await input.evaluate((element) => getComputedStyle(element).backgroundColor)).not.toBe(
+        highlightedBackground,
+      );
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -66,7 +75,16 @@ suite.define(() => {
       await expect
         .poll(() => input.evaluate((element) => getComputedStyle(element).boxShadow))
         .not.toBe("none");
+      const highlightedBackground = await input.evaluate(
+        (element) => getComputedStyle(element).backgroundColor,
+      );
       await captureSidebarUiProof(page, "capabilities-composer-reduced-motion.png");
+      await expect
+        .poll(() => input.getAttribute("class"))
+        .not.toContain("agent-chat__input--prefill-attention");
+      expect(await input.evaluate((element) => getComputedStyle(element).backgroundColor)).not.toBe(
+        highlightedBackground,
+      );
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -17,6 +17,11 @@ import {
 
 export const SESSION_FACE_PREFERENCE_PARAM = "__openclawSessionFacePreference";
 export const SESSION_NAVIGATION_KEY_PARAM = "__openclawSessionKey";
+export const SESSION_COMPOSER_FOCUS_PARAM = "__openclawComposerFocus";
+
+export function composerDraftSearch(draft: string): string {
+  return `?${new URLSearchParams({ draft, [SESSION_COMPOSER_FOCUS_PARAM]: "1" }).toString()}`;
+}
 const SESSION_KEY_UUID_SUFFIX_RE =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -32,7 +32,8 @@ import { SESSION_DRAG_MIME } from "../../lib/sessions/drag.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { ChatPage } from "./chat-page.ts";
-import { loadChatRoute } from "./route-loader.ts";
+import { routeDraft } from "./route-draft.ts";
+import { loadChatRoute, type SessionChatRouteData } from "./route-loader.ts";
 
 const WORK_SESSION_KEY = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
 const SESSION_VIEWERS_SET_METHOD = "sessions.viewers.set";
@@ -100,11 +101,11 @@ function setNarrow(page: ChatPage, narrow: boolean) {
 }
 
 function getRouteDraftForActivePane(page: ChatPage): string | undefined {
-  return (
-    page as unknown as {
-      routeDraftForActivePane: () => string | undefined;
-    }
-  ).routeDraftForActivePane();
+  const state = page as unknown as {
+    data: SessionChatRouteData;
+    consumedDraftData: SessionChatRouteData | null;
+  };
+  return routeDraft(state.data, state.consumedDraftData);
 }
 
 function applySessionDrop(page: ChatPage, sessionKey: string, paneId: string, zone: SplitDropZone) {

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -51,6 +51,7 @@ import { insertPane, type ChatSplitLayout } from "./split-layout.ts";
 
 type RenderedPane = HTMLElement & {
   paneId: string;
+  focusComposer: boolean;
   chatMessagesBySession: ChatMessageCache;
   sessionKey: string;
   active: boolean;
@@ -256,6 +257,62 @@ describe("chat page split layout host", () => {
     expect(page.querySelector("resizable-divider")).toBeNull();
     // The always-on pane header owns the classic split-view opener.
     expect(typeof itemAt(panes, 0, "rendered pane").onOpenSplitView).toBe("function");
+  });
+
+  it("hands route-owned focus to the final page across pane replacement", async () => {
+    const sourcePage = new ChatPage();
+    setNavigationContext(sourcePage);
+    sourcePage.data = {
+      sessionKey: "main",
+      draft: "What can you do?",
+      focusComposer: true,
+    };
+    const page = new ChatPage();
+    setNavigationContext(page);
+    page.data = { sessionKey: "main" };
+
+    vi.useFakeTimers();
+    try {
+      document.body.append(sourcePage);
+      await sourcePage.updateComplete;
+      await Promise.resolve();
+
+      document.body.append(page);
+      await page.updateComplete;
+      const pane = itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 0, "pane");
+      expect(pane.focusComposer).toBe(true);
+
+      const combobox = document.createElement("div");
+      combobox.className = "agent-chat__composer-combobox";
+      const textarea = document.createElement("textarea");
+      combobox.append(textarea);
+      pane.append(combobox);
+      vi.advanceTimersByTime(250);
+      expect(document.activeElement).toBe(textarea);
+
+      const replacementPane = document.createElement("openclaw-chat-pane") as RenderedPane;
+      replacementPane.active = true;
+      replacementPane.sessionKey = "main";
+      const replacementCombobox = document.createElement("div");
+      replacementCombobox.className = "agent-chat__composer-combobox";
+      const replacementTextarea = document.createElement("textarea");
+      replacementCombobox.append(replacementTextarea);
+      replacementPane.append(replacementCombobox);
+      pane.replaceWith(replacementPane);
+
+      vi.advanceTimersByTime(250);
+      expect(document.activeElement).toBe(replacementTextarea);
+
+      const userTarget = document.createElement("button");
+      document.body.append(userTarget);
+      userTarget.focus();
+      vi.advanceTimersByTime(250);
+      expect(document.activeElement).toBe(userTarget);
+    } finally {
+      sourcePage.remove();
+      page.remove();
+      vi.useRealTimers();
+    }
   });
 
   it("passes the chat-owned gateway capability only to the rightmost pane", async () => {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -23,6 +23,7 @@ import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
+import { routeDraft } from "./route-draft.ts";
 import { locationWithoutDraft, type SessionChatRouteData } from "./route-loader.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import {
@@ -540,15 +541,6 @@ export class ChatPage extends OpenClawLightDomElement {
     }
   };
 
-  private routeDraftForActivePane(sessionKey = this.data?.sessionKey): string | undefined {
-    const data = this.data;
-    // Never hand a new route's draft to the old pane while the split layout catches up.
-    if (!data || sessionKey !== data.sessionKey || this.consumedDraftData === data) {
-      return undefined;
-    }
-    return data.draft;
-  }
-
   private renderPaneCell(
     pane: ChatSplitPane,
     active: boolean,
@@ -559,6 +551,10 @@ export class ChatPage extends OpenClawLightDomElement {
   ) {
     const sessions = this.context?.sessions?.state.result?.sessions ?? [];
     const nativeGateways = nativeGatewaysCapability();
+    const draft = active
+      ? routeDraft(this.data, this.consumedDraftData, pane.sessionKey)
+      : undefined;
+    const focus = Boolean(draft && this.data?.focusComposer);
     // Resolve aliases like the pane does so renamed sessions keep their display title.
     const resolvedKey =
       resolveSessionKey(pane.sessionKey, this.context?.gateway?.snapshot?.hello) || pane.sessionKey;
@@ -580,7 +576,8 @@ export class ChatPage extends OpenClawLightDomElement {
           .chatMessagesBySession=${this.chatMessagesBySession}
           .sessionKey=${pane.sessionKey}
           .active=${active}
-          .draft=${active ? this.routeDraftForActivePane(pane.sessionKey) : undefined}
+          .draft=${draft}
+          .focusComposer=${focus}
           .routeFace=${this.data?.face ?? "chat"}
           .paneTitle=${title}
           .narrow=${this.narrow}

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -23,6 +23,7 @@ import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
+import { RouteDraftComposerFocus, type ChatPaneElement } from "./route-draft-focus-handoff.ts";
 import { routeDraft } from "./route-draft.ts";
 import { locationWithoutDraft, type SessionChatRouteData } from "./route-loader.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
@@ -51,8 +52,6 @@ import {
 } from "./split-layout.ts";
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
-type ChatPaneElement = HTMLElement & { paneId?: string; sessionKey?: string };
-
 export class ChatPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
@@ -78,6 +77,7 @@ export class ChatPage extends OpenClawLightDomElement {
   private dragFrame = 0;
   private pendingDragOver: { pane: ChatPaneElement; x: number; y: number } | null = null;
   private consumedDraftData: SessionChatRouteData | null = null;
+  private readonly draftFocus = new RouteDraftComposerFocus(this);
   private readonly chatMessagesBySession: ChatMessageCache = new Map();
   private classicColumnId = "c1";
   private classicPaneId = "p1";
@@ -129,10 +129,8 @@ export class ChatPage extends OpenClawLightDomElement {
     }
     const data = this.data;
     const activePane = this.layout ? findPane(this.layout, this.layout.activePaneId)?.pane : null;
-    const routeDraftWasRendered =
-      Boolean(data?.draft) &&
-      this.consumedDraftData !== data &&
-      (!this.layout || activePane?.sessionKey === data.sessionKey);
+    const activeSessionKey = this.layout ? (activePane?.sessionKey ?? null) : undefined;
+    const draftRendered = this.draftFocus.rendered(data, activeSessionKey, this.consumedDraftData);
     if (changedProperties.has("data")) {
       if (
         data?.canonicalLocation &&
@@ -161,10 +159,11 @@ export class ChatPage extends OpenClawLightDomElement {
       this.syncRouteAgent();
       this.syncRouteToActivePane();
     }
-    if (data && routeDraftWasRendered) {
+    if (data && draftRendered) {
       // Process the route draft once so later focus changes cannot hand it to another pane.
       queueMicrotask(() => {
         if (this.isConnected && this.data === data && this.consumedDraftData !== data) {
+          this.draftFocus.beforeDraftCleanup(data);
           this.consumedDraftData = data;
           // Remove the one-shot draft from history once the matching pane owns it.
           this.updateRoute(data.sessionKey, true, data.face ?? "chat");
@@ -554,7 +553,7 @@ export class ChatPage extends OpenClawLightDomElement {
     const draft = active
       ? routeDraft(this.data, this.consumedDraftData, pane.sessionKey)
       : undefined;
-    const focus = Boolean(draft && this.data?.focusComposer);
+    const focus = this.draftFocus.shouldFocusPane(active, draft, pane.sessionKey, this.data);
     // Resolve aliases like the pane does so renamed sessions keep their display title.
     const resolvedKey =
       resolveSessionKey(pane.sessionKey, this.context?.gateway?.snapshot?.hello) || pane.sessionKey;

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -255,6 +255,8 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected headerRenameInitialValue = "";
   protected headerRenameSessionKey = "";
   protected headerCopiedTimer: number | null = null;
+  protected composerPrefillAttentionTimer: number | null = null;
+  protected composerPrefillAttentionTarget: HTMLElement | null = null;
 
   /** Checkout paths keyed by worktree id — stable for a worktree's lifetime,
    * so reused session keys can never inherit another checkout's path. */

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -82,6 +82,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @property({ attribute: false }) sessionKey = "";
   @property({ attribute: false }) active = false;
   @property({ attribute: false }) draft?: string;
+  @property({ attribute: false }) focusComposer = false;
   @property({ attribute: false }) routeFace: BoardFace = "chat";
   @property({ attribute: false }) onFaceChange?: (face: BoardFace) => void;
   @property({ attribute: false }) onFocusPane?: (paneId: string) => void;

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -36,30 +36,50 @@ function createDeferred<T>() {
 }
 
 describe("chat pane composer prefill attention", () => {
-  it("focuses and flashes the composer for an explicit route hint", () => {
+  function createComposerAttentionFixture() {
     const { pane } = createTestChatPane({
       client: {} as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
     const input = document.createElement("div");
     input.className = "agent-chat__input";
-    const combobox = document.createElement("div");
-    combobox.className = "agent-chat__composer-combobox";
     const textarea = document.createElement("textarea");
-    combobox.append(textarea);
-    input.append(combobox);
+    input.append(textarea);
     document.body.append(input);
     vi.spyOn(pane, "querySelector").mockReturnValue(textarea);
-
     const lifecycle = pane as TestChatPane & {
       focusComposer: boolean;
       updated: (changedProperties?: Map<PropertyKey, unknown>) => void;
     };
     lifecycle.focusComposer = true;
+    return { input, lifecycle, textarea };
+  }
+
+  it("focuses and clears the one-shot composer cue for an explicit route hint", () => {
+    vi.useFakeTimers();
+    const { input, lifecycle, textarea } = createComposerAttentionFixture();
+
     lifecycle.updated(new Map([["focusComposer", false]]));
 
     expect(document.activeElement).toBe(textarea);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    vi.advanceTimersByTime(1_200);
+    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
+    input.remove();
+  });
+
+  it("restarts the cue without letting the prior timer clear it", () => {
+    vi.useFakeTimers();
+    const { input, lifecycle } = createComposerAttentionFixture();
+
+    lifecycle.updated(new Map([["focusComposer", false]]));
+    vi.advanceTimersByTime(600);
+    lifecycle.updated(new Map([["focusComposer", false]]));
+    vi.advanceTimersByTime(600);
+
+    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    vi.advanceTimersByTime(600);
+    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
     input.remove();
   });
 });
@@ -687,6 +707,7 @@ function createConfirmationOwner() {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   for (const owner of confirmationOwners) {
     dismissConfirmedActionPopovers(owner);

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -35,6 +35,35 @@ function createDeferred<T>() {
   return { promise, reject, resolve };
 }
 
+describe("chat pane composer prefill attention", () => {
+  it("focuses and flashes the composer for an explicit route hint", () => {
+    const { pane } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const input = document.createElement("div");
+    input.className = "agent-chat__input";
+    const combobox = document.createElement("div");
+    combobox.className = "agent-chat__composer-combobox";
+    const textarea = document.createElement("textarea");
+    combobox.append(textarea);
+    input.append(combobox);
+    document.body.append(input);
+    vi.spyOn(pane, "querySelector").mockReturnValue(textarea);
+
+    const lifecycle = pane as TestChatPane & {
+      focusComposer: boolean;
+      updated: (changedProperties?: Map<PropertyKey, unknown>) => void;
+    };
+    lifecycle.focusComposer = true;
+    lifecycle.updated(new Map([["focusComposer", false]]));
+
+    expect(document.activeElement).toBe(textarea);
+    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    input.remove();
+  });
+});
+
 describe("chat pane first-turn attachment lifecycle", () => {
   it("claims the connected client's first message before attaching the pane", () => {
     const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -609,7 +609,20 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
     }
   }
 
-  override updated() {
+  override updated(changedProperties: Map<PropertyKey, unknown> = new Map()) {
+    if (changedProperties.has("focusComposer") && this.focusComposer) {
+      const textarea = this.querySelector<HTMLTextAreaElement>(
+        ".agent-chat__composer-combobox > textarea",
+      );
+      const input = textarea?.closest<HTMLElement>(".agent-chat__input");
+      textarea?.focus({ preventScroll: true });
+      if (input) {
+        input.classList.remove("agent-chat__input--prefill-attention");
+        // Restart the cue when the same mounted composer receives another prefill.
+        void input.offsetWidth;
+        input.classList.add("agent-chat__input--prefill-attention");
+      }
+    }
     this.cancelResetConfirmationForSessionChange();
     this.syncHistoryObserver();
     const board = this.resolveBoardView();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -55,7 +55,33 @@ import { exportChatMarkdown } from "./export.ts";
 import { admitInitialTurnHandoff, admitInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import { readChatSessionSnapshot } from "./session-message-cache.ts";
 
+const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
+const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
+
 export abstract class ChatPaneLifecycle extends ChatPaneBoard {
+  private clearComposerPrefillAttention(): void {
+    if (this.composerPrefillAttentionTimer !== null) {
+      window.clearTimeout(this.composerPrefillAttentionTimer);
+      this.composerPrefillAttentionTimer = null;
+    }
+    this.composerPrefillAttentionTarget?.classList.remove(COMPOSER_PREFILL_ATTENTION_CLASS);
+    this.composerPrefillAttentionTarget = null;
+  }
+
+  private showComposerPrefillAttention(input: HTMLElement): void {
+    this.clearComposerPrefillAttention();
+    // Force a fresh animation frame when the same mounted composer is prompted again.
+    void input.offsetWidth;
+    input.classList.add(COMPOSER_PREFILL_ATTENTION_CLASS);
+    this.composerPrefillAttentionTarget = input;
+    // Reduced motion disables animation events, so timer cleanup owns both modes.
+    this.composerPrefillAttentionTimer = window.setTimeout(() => {
+      if (this.composerPrefillAttentionTarget === input) {
+        this.clearComposerPrefillAttention();
+      }
+    }, COMPOSER_PREFILL_ATTENTION_DURATION_MS);
+  }
+
   protected confirmConversationReset(): Promise<boolean> {
     const board = this.resolveBoardView();
     const sessionKey = this.resolveBoardSessionKey(board.snapshot.sessionKey);
@@ -615,10 +641,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
       const input = textarea?.closest<HTMLElement>(".agent-chat__input");
       textarea?.focus({ preventScroll: true });
       if (input) {
-        input.classList.remove("agent-chat__input--prefill-attention");
-        // Restart the cue when the same mounted composer receives another prefill.
-        void input.offsetWidth;
-        input.classList.add("agent-chat__input--prefill-attention");
+        this.showComposerPrefillAttention(input);
       }
     }
     this.cancelResetConfirmationForSessionChange();
@@ -652,6 +675,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
   }
 
   override disconnectedCallback() {
+    this.clearComposerPrefillAttention();
     this.boardProviderLifecycleConnected = false;
     this.releaseBoardProviderLease();
     this.settleResetConfirmation(false);

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -611,9 +611,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
 
   override updated(changedProperties: Map<PropertyKey, unknown> = new Map()) {
     if (changedProperties.has("focusComposer") && this.focusComposer) {
-      const textarea = this.querySelector<HTMLTextAreaElement>(
-        ".agent-chat__composer-combobox > textarea",
-      );
+      const textarea = this.querySelector<HTMLTextAreaElement>(CHAT_COMPOSER_TEXTAREA_SELECTOR);
       const input = textarea?.closest<HTMLElement>(".agent-chat__input");
       textarea?.focus({ preventScroll: true });
       if (input) {

--- a/ui/src/pages/chat/route-draft-focus-handoff.ts
+++ b/ui/src/pages/chat/route-draft-focus-handoff.ts
@@ -1,0 +1,132 @@
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import type { SessionChatRouteData } from "./route-loader.ts";
+
+const HANDOFF_TTL_MS = 30_000;
+const MAINTENANCE_MS = 15_000;
+const RETRY_MS = 250;
+const COMPOSER_SELECTOR = ".agent-chat__composer-combobox textarea";
+
+type PendingHandoff = {
+  expiresAt: number;
+  sessionKey: string;
+  sourceData: SessionChatRouteData;
+};
+
+export type ChatPaneElement = HTMLElement & {
+  active?: boolean;
+  paneId?: string;
+  sessionKey?: string;
+};
+
+let pendingHandoff: PendingHandoff | undefined;
+
+function pendingMatches(sessionKey: string, data: SessionChatRouteData): boolean {
+  if (!pendingHandoff) {
+    return false;
+  }
+  if (pendingHandoff.expiresAt <= Date.now()) {
+    pendingHandoff = undefined;
+    return false;
+  }
+  return (
+    pendingHandoff.sourceData !== data &&
+    areUiSessionKeysEquivalent(pendingHandoff.sessionKey, sessionKey)
+  );
+}
+
+export class RouteDraftComposerFocus {
+  private timer: number | undefined;
+  private readonly host: HTMLElement;
+
+  constructor(host: HTMLElement) {
+    this.host = host;
+  }
+
+  rendered(
+    data: SessionChatRouteData | undefined,
+    activeSessionKey: string | null | undefined,
+    consumedData: SessionChatRouteData | null,
+  ): boolean {
+    const matchesActivePane = Boolean(
+      data &&
+      (activeSessionKey === undefined ||
+        (activeSessionKey !== null &&
+          areUiSessionKeysEquivalent(activeSessionKey, data.sessionKey))),
+    );
+    if (data && !data.draft && matchesActivePane && pendingMatches(data.sessionKey, data)) {
+      pendingHandoff = undefined;
+      this.maintain(data.sessionKey);
+    }
+    return Boolean(data?.draft && consumedData !== data && matchesActivePane);
+  }
+
+  shouldFocusPane(
+    active: boolean,
+    hasDraft: unknown,
+    sessionKey: string,
+    data?: SessionChatRouteData,
+  ): boolean {
+    return Boolean(
+      active &&
+      data &&
+      ((hasDraft && data.focusComposer) || (!hasDraft && pendingMatches(sessionKey, data))),
+    );
+  }
+
+  beforeDraftCleanup(data: SessionChatRouteData): void {
+    if (!data.focusComposer) {
+      return;
+    }
+    // Draft cleanup remounts the route page; carry the one-shot focus fact
+    // to that final owner so focus does not die with this page instance.
+    pendingHandoff = {
+      expiresAt: Date.now() + HANDOFF_TTL_MS,
+      sessionKey: data.sessionKey,
+      sourceData: data,
+    };
+  }
+
+  private maintain(sessionKey: string): void {
+    if (this.timer !== undefined) {
+      window.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    const deadline = Date.now() + MAINTENANCE_MS;
+    let ownedComposer: HTMLTextAreaElement | undefined;
+
+    const focusCurrentComposer = () => {
+      if (!this.host.isConnected) {
+        this.timer = undefined;
+        return;
+      }
+      const pane = [...this.host.querySelectorAll<ChatPaneElement>("openclaw-chat-pane")].find(
+        (candidate) =>
+          candidate.active &&
+          candidate.sessionKey !== undefined &&
+          areUiSessionKeysEquivalent(candidate.sessionKey, sessionKey),
+      );
+      const composer = pane?.querySelector<HTMLTextAreaElement>(COMPOSER_SELECTOR);
+      const activeElement = document.activeElement;
+      const focusStillOwned =
+        activeElement === ownedComposer ||
+        activeElement === document.body ||
+        (activeElement instanceof HTMLElement && !activeElement.isConnected);
+
+      if (composer && (!ownedComposer || focusStillOwned)) {
+        composer.focus({ preventScroll: true });
+        ownedComposer = composer;
+      } else if (ownedComposer && !focusStillOwned) {
+        this.timer = undefined;
+        return;
+      }
+
+      if (Date.now() < deadline) {
+        this.timer = window.setTimeout(focusCurrentComposer, RETRY_MS);
+      } else {
+        this.timer = undefined;
+      }
+    };
+
+    focusCurrentComposer();
+  }
+}

--- a/ui/src/pages/chat/route-draft.ts
+++ b/ui/src/pages/chat/route-draft.ts
@@ -1,4 +1,36 @@
+import type { RouteLocation } from "@openclaw/uirouter";
+import { SESSION_COMPOSER_FOCUS_PARAM } from "../../lib/sessions/route-navigation.ts";
+
+type RouteDraftHint = { draft?: string; focusComposer?: boolean };
 type RouteDraftData = { sessionKey: string; draft?: string };
+
+function draftFromLocation(location: RouteLocation): string | undefined {
+  return new URLSearchParams(location.search).get("draft") || undefined;
+}
+
+function focusComposerFromLocation(location: RouteLocation): boolean {
+  return new URLSearchParams(location.search).get(SESSION_COMPOSER_FOCUS_PARAM) === "1";
+}
+
+export function draftRouteDataFromLocation(location: RouteLocation): RouteDraftHint {
+  const draft = draftFromLocation(location);
+  return {
+    draft,
+    ...(draft && focusComposerFromLocation(location) ? { focusComposer: true } : {}),
+  };
+}
+
+export function draftSearchFromLocation(location: RouteLocation): string {
+  const search = new URLSearchParams();
+  const draft = draftFromLocation(location);
+  if (draft) {
+    search.set("draft", draft);
+  }
+  if (draft && focusComposerFromLocation(location)) {
+    search.set(SESSION_COMPOSER_FOCUS_PARAM, "1");
+  }
+  return search.size > 0 ? "?" + search.toString() : "";
+}
 
 // A one-shot route draft belongs only to its matching pane until the page consumes it.
 export function routeDraft(

--- a/ui/src/pages/chat/route-draft.ts
+++ b/ui/src/pages/chat/route-draft.ts
@@ -1,0 +1,10 @@
+type RouteDraftData = { sessionKey: string; draft?: string };
+
+// A one-shot route draft belongs only to its matching pane until the page consumes it.
+export function routeDraft(
+  data: RouteDraftData | null | undefined,
+  consumed: RouteDraftData | null,
+  sessionKey = data?.sessionKey,
+): string | undefined {
+  return !data || sessionKey !== data.sessionKey || consumed === data ? undefined : data.draft;
+}

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -15,6 +15,7 @@ import {
 } from "../../lib/sessions/catalog-key.ts";
 import {
   findUiSessionRow,
+  SESSION_COMPOSER_FOCUS_PARAM,
   SESSION_FACE_PREFERENCE_PARAM,
   SESSION_NAVIGATION_KEY_PARAM,
 } from "../../lib/sessions/route-navigation.ts";
@@ -56,6 +57,7 @@ export type ChatRouteData =
       sessionKey: string;
       agentId?: string;
       draft?: string;
+      focusComposer?: boolean;
       face: BoardFace;
       shortId?: string;
       canonicalLocation?: RouteLocation;
@@ -81,6 +83,7 @@ export type SessionChatRouteData = Omit<
 export function locationWithoutDraft(location: RouteLocation): RouteLocation {
   const params = new URLSearchParams(location.search);
   params.delete("draft");
+  params.delete(SESSION_COMPOSER_FOCUS_PARAM);
   const search = params.toString();
   return { ...location, search: search ? `?${search}` : "" };
 }
@@ -304,6 +307,32 @@ function draftFromLocation(location: RouteLocation): string | undefined {
   return new URLSearchParams(location.search).get("draft") || undefined;
 }
 
+function focusComposerFromLocation(location: RouteLocation): boolean {
+  return new URLSearchParams(location.search).get(SESSION_COMPOSER_FOCUS_PARAM) === "1";
+}
+
+function draftRouteDataFromLocation(
+  location: RouteLocation,
+): Pick<Extract<ChatRouteData, { kind: "session" }>, "draft" | "focusComposer"> {
+  const draft = draftFromLocation(location);
+  return {
+    draft,
+    ...(draft && focusComposerFromLocation(location) ? { focusComposer: true } : {}),
+  };
+}
+
+function draftSearchFromLocation(location: RouteLocation): string {
+  const search = new URLSearchParams();
+  const draft = draftFromLocation(location);
+  if (draft) {
+    search.set("draft", draft);
+  }
+  if (draft && focusComposerFromLocation(location)) {
+    search.set(SESSION_COMPOSER_FOCUS_PARAM, "1");
+  }
+  return search.size > 0 ? `?${search.toString()}` : "";
+}
+
 function isPreferenceDerivedFace(location: RouteLocation): boolean {
   return new URLSearchParams(location.search).get(SESSION_FACE_PREFERENCE_PARAM) === "1";
 }
@@ -420,7 +449,7 @@ function candidatesForResolution(
   context: ApplicationContext,
   face: BoardFace,
   resolution: Extract<SessionReferenceResolution, { kind: "ambiguous" }>,
-  draft: string | undefined,
+  location: RouteLocation,
   preferenceDerived: boolean,
 ): SessionCandidate[] {
   const resolvedRows = resolution.sessions.flatMap((row) => {
@@ -445,7 +474,7 @@ function candidatesForResolution(
           {
             agentId,
             displayName: row.displayName?.trim() || row.key,
-            href: `${href}${draft ? `?${new URLSearchParams({ draft }).toString()}` : ""}`,
+            href: `${href}${draftSearchFromLocation(location)}`,
             idPrefix: prefix,
           },
         ]
@@ -478,7 +507,7 @@ function resolvedSessionRouteData(params: {
   return {
     kind: "session",
     sessionKey: params.row.key,
-    draft: draftFromLocation(params.location),
+    ...draftRouteDataFromLocation(params.location),
     face,
     ...(params.shortId && params.shortId.length > 8 ? { shortId: params.shortId } : {}),
     ...(canonicalLocation ? { canonicalLocation, canonicalLocationSource: params.location } : {}),
@@ -516,7 +545,7 @@ function resolvedMainSessionRouteData(params: {
     kind: "session",
     sessionKey: params.row.key,
     agentId: params.target.agentId,
-    draft: draftFromLocation(params.location),
+    ...draftRouteDataFromLocation(params.location),
     face,
     ...(canonicalLocation ? { canonicalLocation, canonicalLocationSource: params.location } : {}),
   };
@@ -566,7 +595,7 @@ export async function loadChatRoute(
       kind: "session",
       sessionKey,
       agentId: target.agentId,
-      draft: draftFromLocation(routeLocation),
+      ...draftRouteDataFromLocation(routeLocation),
       face: resolvedFace,
       // Non-null only on a preference-derived open, where it always at least drops the
       // marker from the URL.
@@ -600,7 +629,7 @@ export async function loadChatRoute(
     return {
       kind: "session",
       sessionKey,
-      draft: draftFromLocation(routeLocation),
+      ...draftRouteDataFromLocation(routeLocation),
       face,
       ...(canonicalLocation && canonicalLocation.search !== routeLocation.search
         ? { canonicalLocation, canonicalLocationSource: routeLocation }
@@ -659,7 +688,7 @@ export async function loadChatRoute(
               context,
               face,
               slugResolution,
-              draftFromLocation(routeLocation),
+              routeLocation,
               preferenceDerived,
             ),
             truncated: slugResolution.truncated,
@@ -698,7 +727,7 @@ export async function loadChatRoute(
     return {
       kind: "session",
       sessionKey: target.sessionKey,
-      draft: draftFromLocation(routeLocation),
+      ...draftRouteDataFromLocation(routeLocation),
       face,
       ...(canonicalLocation
         ? { canonicalLocation, canonicalLocationSource: routeLocation }
@@ -717,7 +746,7 @@ export async function loadChatRoute(
     return {
       kind: "session",
       sessionKey: cached.sessionKey,
-      draft: draftFromLocation(routeLocation),
+      ...draftRouteDataFromLocation(routeLocation),
       face,
       ...(target.shortId.length > 8 ? { shortId: target.shortId } : {}),
       ...(canonicalLocationChanged
@@ -748,7 +777,7 @@ export async function loadChatRoute(
         context,
         face,
         resolution,
-        draftFromLocation(routeLocation),
+        routeLocation,
         preferenceDerived,
       ),
       truncated: resolution.truncated,

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -30,6 +30,7 @@ import {
   resolveUiConfiguredMainKey,
   resolveUiGlobalAliasAgentId,
 } from "../../lib/sessions/session-key.ts";
+import { draftRouteDataFromLocation, draftSearchFromLocation } from "./route-draft.ts";
 import {
   findCachedShortSession,
   incompleteShortSessionResolution,
@@ -301,36 +302,6 @@ async function querySessionReferencePages(
     }
     offset = nextOffset;
   }
-}
-
-function draftFromLocation(location: RouteLocation): string | undefined {
-  return new URLSearchParams(location.search).get("draft") || undefined;
-}
-
-function focusComposerFromLocation(location: RouteLocation): boolean {
-  return new URLSearchParams(location.search).get(SESSION_COMPOSER_FOCUS_PARAM) === "1";
-}
-
-function draftRouteDataFromLocation(
-  location: RouteLocation,
-): Pick<Extract<ChatRouteData, { kind: "session" }>, "draft" | "focusComposer"> {
-  const draft = draftFromLocation(location);
-  return {
-    draft,
-    ...(draft && focusComposerFromLocation(location) ? { focusComposer: true } : {}),
-  };
-}
-
-function draftSearchFromLocation(location: RouteLocation): string {
-  const search = new URLSearchParams();
-  const draft = draftFromLocation(location);
-  if (draft) {
-    search.set("draft", draft);
-  }
-  if (draft && focusComposerFromLocation(location)) {
-    search.set(SESSION_COMPOSER_FOCUS_PARAM, "1");
-  }
-  return search.size > 0 ? `?${search.toString()}` : "";
 }
 
 function isPreferenceDerivedFace(location: RouteLocation): boolean {

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -293,7 +293,11 @@ describe("loadChatRoute", () => {
     const { context } = contextFor(result(rows));
     const ambiguous = await loadChatRoute(
       context,
-      { pathname: "/dashboard/ignored/deploy-12345678", search: "?draft=ship", hash: "" },
+      {
+        pathname: "/dashboard/ignored/deploy-12345678",
+        search: "?draft=ship&__openclawComposerFocus=1",
+        hash: "",
+      },
       "dashboard",
       new AbortController().signal,
     );
@@ -302,8 +306,8 @@ describe("loadChatRoute", () => {
       throw new Error("expected an ambiguous route");
     }
     expect(ambiguous.candidates.map((candidate) => candidate.href)).toEqual([
-      "/dashboard/main/deploy-monitor-123456780a?draft=ship",
-      "/dashboard/work/deploy-monitor-two-123456780b?draft=ship",
+      "/dashboard/main/deploy-monitor-123456780a?draft=ship&__openclawComposerFocus=1",
+      "/dashboard/work/deploy-monitor-two-123456780b?draft=ship&__openclawComposerFocus=1",
     ]);
 
     for (const [candidate, expectedRow] of ambiguous.candidates.map(
@@ -324,6 +328,7 @@ describe("loadChatRoute", () => {
         kind: "session",
         sessionKey: expectedRow?.key,
         draft: "ship",
+        focusComposer: true,
         face: "dashboard",
         shortId: candidate.idPrefix,
       });

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2283,6 +2283,24 @@ openclaw-chat-video-player {
   box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
+.agent-chat__input--prefill-attention {
+  animation: chat-composer-prefill-attention 700ms ease-out;
+}
+
+@keyframes chat-composer-prefill-attention {
+  0%,
+  100% {
+    border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+  45% {
+    border-color: color-mix(in srgb, var(--accent) 80%, var(--border));
+    box-shadow:
+      0 0 0 5px color-mix(in srgb, var(--accent) 22%, transparent),
+      0 0 22px color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+}
+
 .agent-chat__input--offline,
 .agent-chat__input--offline:focus-within {
   border-color: color-mix(in srgb, var(--warn) 38%, var(--border));

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2301,6 +2301,14 @@ openclaw-chat-video-player {
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .agent-chat__input--prefill-attention {
+    animation: none;
+    border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
+    box-shadow: var(--focus-ring);
+  }
+}
+
 .agent-chat__input--offline,
 .agent-chat__input--offline:focus-within {
   border-color: color-mix(in srgb, var(--warn) 38%, var(--border));

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2284,28 +2284,33 @@ openclaw-chat-video-player {
 }
 
 .agent-chat__input--prefill-attention {
-  animation: chat-composer-prefill-attention 700ms ease-out;
+  animation: chat-composer-prefill-attention 1200ms ease-out;
 }
 
 @keyframes chat-composer-prefill-attention {
   0%,
+  30% {
+    background: color-mix(in srgb, var(--accent) 14%, var(--card));
+    border-color: color-mix(in srgb, var(--accent) 88%, var(--border));
+    box-shadow:
+      0 0 0 5px color-mix(in srgb, var(--accent) 32%, transparent),
+      0 0 28px color-mix(in srgb, var(--accent) 42%, transparent);
+  }
   100% {
+    background: var(--card);
     border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
     box-shadow: 0 0 0 3px var(--accent-subtle);
-  }
-  45% {
-    border-color: color-mix(in srgb, var(--accent) 80%, var(--border));
-    box-shadow:
-      0 0 0 5px color-mix(in srgb, var(--accent) 22%, transparent),
-      0 0 22px color-mix(in srgb, var(--accent) 28%, transparent);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .agent-chat__input--prefill-attention {
     animation: none;
-    border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
-    box-shadow: var(--focus-ring);
+    background: color-mix(in srgb, var(--accent) 14%, var(--card));
+    border-color: color-mix(in srgb, var(--accent) 88%, var(--border));
+    box-shadow:
+      0 0 0 5px color-mix(in srgb, var(--accent) 32%, transparent),
+      0 0 28px color-mix(in srgb, var(--accent) 42%, transparent);
   }
 }
 

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { createAgentIdentityCapability } from "../../lib/agents/identity.ts";
-import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
+import {
+  SESSION_COMPOSER_FOCUS_PARAM,
+  SESSION_FACE_PREFERENCE_PARAM,
+} from "../../lib/sessions/route-navigation.ts";
 import {
   createGateway,
   createGatewayHarness,
@@ -161,6 +164,35 @@ describe("AppSidebar agent chip", () => {
       search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
     });
     expect(sidebar.querySelector(".sidebar-agent-menu")).toBeNull();
+  });
+
+  it("requests composer focus and highlighting from the capabilities action", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      TWO_AGENTS,
+    );
+    const onNavigate = vi.fn();
+    sidebar.connected = true;
+    sidebar.onNavigate = onNavigate;
+    await sidebar.updateComplete;
+
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+    await sidebar.updateComplete;
+    const item = sidebar.querySelector<HTMLElement>(
+      'wa-dropdown-item[value="command:capabilities"]',
+    );
+    sidebar
+      .querySelector(".sidebar-agent-menu")
+      ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item }, bubbles: true }));
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    const options = onNavigate.mock.calls[0]?.[1] as { search: string };
+    const search = new URLSearchParams(options.search);
+    expect(search.get("draft")).toBe("What can you do?");
+    expect(search.get(SESSION_COMPOSER_FOCUS_PARAM)).toBe("1");
   });
 
   it("drops the menu below the agent card instead of covering it", async () => {


### PR DESCRIPTION
## Summary

- focus the matching chat composer after the agent capabilities action prefills “What can you do?”
- flash the composer with a short accent animation so the prefill is visually discoverable
- carry the one-shot focus hint through canonical and ambiguous session routing without affecting other programmatic drafts

## Testing

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` (219 tests)
- `node scripts/run-vitest.mjs ui/src/pages/chat/route.test.ts` (17 tests)
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-page.test.ts` (30 tests)
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-lifecycle.test.ts` (21 tests)
- `pnpm tsgo:ui`
- `pnpm tsgo:test:ui`
- focused Oxlint and configured Stylelint
- `git diff --check`

## Notes

- `pnpm check:changed` could not delegate because the installed Crabbox binary failed its sanity check; repository-policy local fallback checks passed.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":7,"user":3,"assistant":3,"toolCalls":9,"toolOutputsDropped":9,"web":0,"redactions":0,"omittedUnsafe":0,"rawEntries":23}

[user]
In the webUI there is a "What can <agent name> do?" menu item. It populates the chat text box with the question "What can you do?". It would be good if it also shifted the active focus to the text box and also flashed the text box so that it was visually clear what the button did.

[assistant]
I’m using the frontend-design skill because this is a small but user-visible Control UI interaction change. I’ll trace the menu action and existing focus/attention patterns, then implement and run focused UI tests.

The first read hit a sandbox networking-namespace error before touching the repo. I’m retrying the same read with the approved unrestricted path so I can follow the UI’s scoped rules.

The clean boundary is a one-shot navigation hint: the sidebar marks this particular prefill as “focus the composer,” the chat route consumes that hint with the draft, and the pane owns the actual focus plus visual cue. This avoids making every programmatic draft flash.

The edit tool hit the same environment namespace failure. I’m applying the identical patch through the repository’s patch utility with elevated sandbox access; no scope or design change.

The patch helper itself is unavailable in this environment—it re-enters the broken sandbox even after approval. I’m falling back to the standard `patch` utility with the same unified diff so the work can continue; I’ll verify the resulting diff immediately.

The implementation is now wired end-to-end, including short-link ambiguity so the focus intent is not lost during route resolution. I’m adding three regression proofs: the menu emits the hint, the router preserves/consumes it with the draft, and the pane actually focuses and highlights the composer.

The UI behavior and tests are formatted. I’m running the three focused suites now; if they expose lifecycle timing or route canonicalization issues, I’ll adjust at the owning layer rather than loosening assertions.

Two route assertions failed; the pane and sidebar suites did not report failures. I’m rerunning the small route suite alone to get the exact mismatches—this likely means my broad test-string replacement touched a neighboring case, not that the runtime path is failing.

All focused behavior tests pass. The bare stylelint binary lacked the repo config, so I’m rerunning the same targeted stylesheet check with the configured rules, then I’ll do the repository’s changed-file classifier for type/lint coverage.

The changed-file classifier tried to delegate to Testbox, but the installed Crabbox binary failed its own sanity check before any remote work began. Per the repo’s fallback policy, I’m doing the relevant local UI type/lint proof instead and will note the unavailable backend.

The typechecks passed. Focused lint caught the UI’s strict 700-line ratchet in two files: the new code pushed each just over its cap. I’m compacting the navigation call and binding without changing behavior, then rerunning lint and tests.

Sidebar and route suites passed. The chained runner stopped reporting after the third suite started, so I’m running the remaining chat-page and isolated lifecycle suites separately to get unambiguous completion.

Final review caught one important split-view edge: the visual focus hint must use the same matching-pane guard as the draft itself, or a route transition could briefly focus the old pane. I’m aligning those two facts and adding the invariant comment, then doing one last focused verification.

Implemented.

- “What can … do?” now requests composer focus when prefilling the draft: `ui/src/components/app-sidebar-session-navigation.ts:561`
- Focus is applied only to the matching active pane: `ui/src/pages/chat/chat-page.ts:555`
- Composer flashes with a 700ms accent highlight: `ui/src/styles/chat/layout.css:2286`
- Added sidebar, routing, split-pane, focus, and animation regression coverage.

Validation passed:

- 287 focused tests
- UI production and test typechecks
- Focused Oxlint and Stylelint
- Formatting and `git diff --check`

The remote changed-file check was unavailable because the installed Crabbox binary failed its sanity check; required checks were run locally instead.

[user]
make a pr

[assistant]
I’m using the agent-transcript skill because this is an agent-created OpenClaw PR. I’ll verify the branch and diff, commit only this UI change, push it, then open the PR with the required redacted transcript section.

The transcript skill requires your explicit opt-in before any session excerpt is added to GitHub. Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize; I can also open a local HTML preview first. I’ll prepare the branch and commit meanwhile, but won’t create the PR body with a transcript unless you approve.

Branch committed and pushed as `fix/control-ui-capabilities-composer-focus`.

Before I open the PR: include a redacted agent transcript? It can help reviewers prioritize the PR. I can include it directly, show a local HTML preview first, or omit it.

[user]
yes

[assistant]
Approved—I’ll include the sanitized transcript directly, without opening a preview. The transcript skill is now causing me to scan only local agent logs, render the redacted section, and fail closed if it detects anything unsafe before the PR is created.

The first high-score candidate was an approval-review mirror and its rendered excerpt retained irrelevant tool-review chatter, so I rejected it under the skill’s scope rules. I’m checking the other equally scored local session and will only use it if the sanitized output cleanly reflects this PR’s work.

[tool summary]
9 other; raw tool outputs dropped: 9
````

</details>
<!-- agent-transcript:end -->


## Exact-head behavior proof

- Head: `fb1d8c96821a148c340d6cc7e30d27555e510e63`
- [CI UI E2E shard 2/4](https://github.com/openclaw/openclaw/actions/runs/30717573896/job/91415773561) passed on that head, including the sidebar interaction assertions for composer focus, the animated cue, and the reduced-motion static cue.
- One-CPU stress reproduction: `taskset -c 0 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts` — 6/6 tests passed in 47.56s.
- Maintainer direction is confirmed in this task: land the focused-prefill interaction once the formerly failing shard passes.
