### PR TITLE
fix(providers): enforce canonical binary response ownership

### DIFF
--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -21,6 +21,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
   const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
   return {
     // REAL byte-bounded JSON reader under test — not stubbed.
+    assertProviderBinaryResponseContent: actual.assertProviderBinaryResponseContent,
     readProviderJsonResponse: actual.readProviderJsonResponse,
     postJsonRequest: postJsonRequestMock,
     pollProviderOperationJson: async (params: {
@@ -267,6 +268,73 @@ describe("byteplus video generation provider", () => {
     expect(video.fileName).toBe("video-1.webm");
     const metadata = result.metadata as Record<string, unknown>;
     expect(metadata.taskId).toBe("task_123");
+  });
+
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty video", contentType: "video/mp4", body: "" },
+  ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-invalid-download" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-invalid-download",
+          status: "succeeded",
+          content: { video_url: "https://example.com/invalid.mp4" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(body, { headers: { "content-type": contentType } }));
+
+    await expect(
+      buildBytePlusVideoGenerationProvider().generateVideo({
+        provider: "byteplus",
+        model: "seedance-1-0-pro-250528",
+        prompt: "invalid download",
+        cfg: {},
+      }),
+    ).rejects.toThrow("BytePlus generated video download: malformed video response");
+  });
+
+  it("cancels the unread response body when a generated-video MIME type is rejected", async () => {
+    const canceled = vi.fn();
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-open-response" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-open-response",
+          status: "succeeded",
+          content: { video_url: "https://example.com/invalid.mp4" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"error":"still streaming"}'));
+            },
+            cancel: canceled,
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    await expect(
+      buildBytePlusVideoGenerationProvider().generateVideo({
+        provider: "byteplus",
+        model: "seedance-1-0-pro-250528",
+        prompt: "open invalid response",
+        cfg: {},
+      }),
+    ).rejects.toThrow("BytePlus generated video download: malformed video response");
+    expect(canceled).toHaveBeenCalledOnce();
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -8,6 +8,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   fetchProviderDownloadResponse,
@@ -196,6 +197,13 @@ async function downloadBytePlusVideo(params: {
     provider: "byteplus",
     requestFailedMessage: "BytePlus generated video download failed",
   });
+  try {
+    assertProviderBinaryResponseContent(response, "BytePlus generated video download", "video");
+  } catch (error) {
+    // A rejected binary response still owns a live socket until its unread body is canceled.
+    await response.body?.cancel().catch(() => undefined);
+    throw error;
+  }
   const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
   const buffer = await readResponseWithLimit(response, params.maxBytes, {
     timeoutMs,
@@ -206,6 +214,9 @@ async function downloadBytePlusVideo(params: {
     onOverflow: ({ maxBytes }) =>
       new Error(`BytePlus generated video download exceeds ${maxBytes} bytes`),
   });
+  if (buffer.byteLength === 0) {
+    throw new Error("BytePlus generated video download: malformed video response");
+  }
   return {
     buffer,
     mimeType,

--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -159,6 +159,100 @@ describe("minimax music generation provider", () => {
   });
 
   it.each([
+    { provider: "minimax", contentType: "application/json", body: '{"error":"denied"}' },
+    {
+      provider: "minimax",
+      contentType: "application/problem+json",
+      body: '{"title":"denied"}',
+    },
+    { provider: "minimax", contentType: "text/html", body: "<html>sign in</html>" },
+    { provider: "minimax", contentType: "audio/mpeg", body: "" },
+    { provider: "minimax-portal", contentType: "application/json", body: '{"error":"denied"}' },
+    {
+      provider: "minimax-portal",
+      contentType: "application/problem+json",
+      body: '{"title":"denied"}',
+    },
+    { provider: "minimax-portal", contentType: "text/html", body: "<html>sign in</html>" },
+    { provider: "minimax-portal", contentType: "audio/mpeg", body: "" },
+  ])(
+    "rejects a successful $contentType download through $provider",
+    async ({ provider: providerId, contentType, body }) => {
+      postJsonRequestMock.mockResolvedValue({
+        response: new Response(
+          JSON.stringify({
+            data: { audio_url: "https://example.com/invalid.mp3" },
+            base_resp: { status_code: 0 },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+        release: vi.fn(async () => {}),
+      });
+      fetchWithTimeoutMock.mockResolvedValueOnce(
+        new Response(body, { headers: { "content-type": contentType } }),
+      );
+      const provider =
+        providerId === "minimax-portal"
+          ? buildMinimaxPortalMusicGenerationProvider()
+          : buildMinimaxMusicGenerationProvider();
+
+      await expect(
+        provider.generateMusic({
+          provider: providerId,
+          model: "music-2.6",
+          prompt: "invalid download",
+          cfg: {},
+        }),
+      ).rejects.toThrow("MiniMax generated music download: malformed audio response");
+
+      const [guarded] = fetchWithTimeoutGuardedMock.mock.results;
+      const result = guarded ? await guarded.value : undefined;
+      expect(result?.release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("cancels invalid music responses before releasing their guarded dispatcher", async () => {
+    const cleanupOrder: string[] = [];
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          data: { audio_url: "https://example.com/invalid-open.mp3" },
+          base_resp: { status_code: 0 },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"error":"still streaming"}'));
+          },
+          cancel() {
+            cleanupOrder.push("body canceled");
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+      finalUrl: "https://example.com/invalid-open.mp3",
+      release: vi.fn(async () => {
+        cleanupOrder.push("dispatcher released");
+      }),
+    });
+
+    await expect(
+      buildMinimaxMusicGenerationProvider().generateMusic({
+        provider: "minimax",
+        model: "music-2.6",
+        prompt: "invalid download",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax generated music download: malformed audio response");
+    expect(cleanupOrder).toEqual(["body canceled", "dispatcher released"]);
+  });
+
+  it.each([
     {
       name: "streamed",
       contentType: "text/event-stream",

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -9,6 +9,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   executeProviderOperationWithRetry,
@@ -121,19 +122,34 @@ async function downloadTrackFromUrl(params: {
     },
   });
   try {
+    try {
+      assertProviderBinaryResponseContent(
+        result.response,
+        "MiniMax generated music download",
+        "audio",
+      );
+    } catch (error) {
+      // Release the unread response before its guarded dispatcher is closed.
+      await result.response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
     const mimeType =
       normalizeOptionalString(result.response.headers.get("content-type")) ?? "audio/mpeg";
     const ext = extensionForMime(mimeType)?.replace(/^\./u, "") || "mp3";
+    const buffer = await readResponseWithLimit(result.response, params.maxBytes, {
+      timeoutMs,
+      onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
+        new Error(
+          `MiniMax generated music download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
+        ),
+      onOverflow: ({ maxBytes }) =>
+        new Error(`MiniMax generated music download exceeds ${maxBytes} bytes`),
+    });
+    if (buffer.byteLength === 0) {
+      throw new Error("MiniMax generated music download: malformed audio response");
+    }
     return {
-      buffer: await readResponseWithLimit(result.response, params.maxBytes, {
-        timeoutMs,
-        onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
-          new Error(
-            `MiniMax generated music download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
-          ),
-        onOverflow: ({ maxBytes }) =>
-          new Error(`MiniMax generated music download exceeds ${maxBytes} bytes`),
-      }),
+      buffer,
       mimeType,
       fileName: `track-1.${ext}`,
     };

--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -160,6 +160,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
   const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
   return {
     assertOkOrThrowHttpError: minimaxProviderHttpMocks.assertOkOrThrowHttpErrorMock,
+    assertProviderBinaryResponseContent: actual.assertProviderBinaryResponseContent,
     createProviderOperationDeadline: ({
       label,
       timeoutMs,

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -143,6 +143,73 @@ describe("runway video generation provider", () => {
     expect(metadata.endpoint).toBe("/v1/text_to_video");
   });
 
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty video", contentType: "video/mp4", body: "" },
+  ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-invalid-download" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-invalid-download",
+          status: "SUCCEEDED",
+          output: ["https://example.com/invalid.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce(new Response(body, { headers: { "content-type": contentType } }));
+
+    await expect(
+      buildRunwayVideoGenerationProvider().generateVideo({
+        provider: "runway",
+        model: "gen4.5",
+        prompt: "invalid download",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Runway generated video download: malformed video response");
+  });
+
+  it("cancels the unread response body when a generated-video MIME type is rejected", async () => {
+    const canceled = vi.fn();
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-open-response" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-open-response",
+          status: "SUCCEEDED",
+          output: ["https://example.com/invalid.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"error":"still streaming"}'));
+            },
+            cancel: canceled,
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    await expect(
+      buildRunwayVideoGenerationProvider().generateVideo({
+        provider: "runway",
+        model: "gen4.5",
+        prompt: "open invalid response",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Runway generated video download: malformed video response");
+    expect(canceled).toHaveBeenCalledOnce();
+  });
+
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({ id: "task-too-large" }),

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -5,6 +5,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   fetchProviderDownloadResponse,
@@ -315,6 +316,13 @@ async function downloadRunwayVideos(params: {
       provider: "runway",
       requestFailedMessage: "Runway generated video download failed",
     });
+    try {
+      assertProviderBinaryResponseContent(response, "Runway generated video download", "video");
+    } catch (error) {
+      // A rejected binary response still owns a live socket until its unread body is canceled.
+      await response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
     const buffer = await readResponseWithLimit(response, params.maxBytes, {
       timeoutMs,
@@ -325,6 +333,9 @@ async function downloadRunwayVideos(params: {
       onOverflow: ({ maxBytes }) =>
         new Error(`Runway generated video download exceeds ${maxBytes} bytes`),
     });
+    if (buffer.byteLength === 0) {
+      throw new Error("Runway generated video download: malformed video response");
+    }
     videos.push({
       buffer,
       mimeType,

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -281,9 +281,12 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: providerHttpMocks.resolveApiKeyForProviderMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => ({
   assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
   assertOkOrThrowProviderError: providerHttpMocks.assertOkOrThrowProviderErrorMock,
+  assertProviderBinaryResponseContent: (
+    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
+  ).assertProviderBinaryResponseContent,
   createProviderOperationDeadline: ({
     label,
     timeoutMs,


### PR DESCRIPTION
## What Problem This Solves

BytePlus video, Runway video, and MiniMax music could report successful generated media when a provider-owned download actually returned HTTP-200 JSON, problem JSON, HTML, or zero bytes. MiniMax's `minimax` and `minimax-portal` aliases shared the same affected music owner.

## Why This Change Was Made

Validate the response at each existing provider-owned binary-download boundary with the canonical public provider HTTP validator, reject empty media after the existing bounded reader, and cancel unread invalid response bodies before their transport is released. Preserve provider-specific byte-limit and timeout errors, accepted audio/video/octet-stream/missing media types, request authentication, MiniMax retry behavior, and the recently landed MiniMax streaming-completion and strict-hex handling.

The only shared changes expose the existing real validator through existing test-only mocks; no production Plugin SDK surface, provider policy, configuration, or transport-security contract changes.

## User Impact

Generated BytePlus and Runway videos and MiniMax music now fail clearly when an upstream download is not valid nonempty media, instead of returning corrupt or empty successful output. Rejected unfinished response streams release their sockets promptly.

## Evidence

- Frozen baseline: `51c41c25c8c3fdb9340415b41c8faf1a44c18b45`; immutable candidate: `240421a0639abb0f641adb432cdd407abb0ef4f5`.
- Actual complete-provider, CA-verified HTTPS + real HTTP CONNECT proxy + unmodified native `fetch`: baseline reproduced 16 malformed-media successes while 24 valid/cap/strict-hex/stream-completion controls passed; immutable candidate passed all 44 cases across BytePlus, Runway, MiniMax, and MiniMax Portal, with 98 HTTPS requests and 68 real CONNECT tunnels.
- All four genuinely never-ending malformed response sockets closed, including both guarded MiniMax aliases.
- `OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/byteplus/video-generation-provider.test.ts extensions/runway/video-generation-provider.test.ts extensions/minimax/music-generation-provider.test.ts extensions/minimax/video-generation-provider.test.ts` — four files, 65 tests passed.
- Targeted `oxfmt --check` across all eight existing changed files and `git diff --check` both passed.
- Official vendor contracts: [BytePlus video output](https://docs.byteplus.com/api/docs/ModelArk/2298881), [Runway generated outputs](https://docs.dev.runwayml.com/assets/outputs/), and [MiniMax music output formats](https://platform.minimax.io/docs/api-reference/music-generation).
- Current main `ee320a6e411479a23faa89a75463ff1b15630afc` merges cleanly into synthetic tree `923e2e8fc8eb2b7adb73e448873d68d7054bbdc4`.
- Exact-head hosted checks and structured autoreview are tracked separately and must complete before landing.
