### PR TITLE
fix(agents): serialize subagent orphan recovery

### DIFF
--- a/src/agents/subagent-orphan-recovery.coordination.test.ts
+++ b/src/agents/subagent-orphan-recovery.coordination.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
+import {
+  resetOrphanRecoveryCoordinationForTest,
+  scheduleOrphanRecovery,
+} from "./subagent-orphan-recovery.js";
+import * as subagentRegistrySteerRuntime from "./subagent-registry-steer-runtime.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { createSubagentRunRecord } from "./subagent-test-fixtures.test-helpers.js";
+
+const sessionMocks = vi.hoisted(() => {
+  type MockSessionEntry = Record<string, unknown>;
+  type MockSessionStore = Record<string, MockSessionEntry>;
+  const loadSessionStore = vi.fn((): MockSessionStore => ({}));
+  const patchSessionEntry = vi.fn(
+    async (
+      scope: { sessionKey: string },
+      update: (
+        entry: MockSessionEntry,
+      ) => MockSessionEntry | Partial<MockSessionEntry> | null | Promise<MockSessionEntry | null>,
+    ) => {
+      const store = loadSessionStore();
+      const current = store[scope.sessionKey];
+      if (!current) {
+        return null;
+      }
+      const next = await update({ ...current });
+      if (!next) {
+        return current;
+      }
+      store[scope.sessionKey] = next;
+      return next;
+    },
+  );
+  return { loadSessionStore, patchSessionEntry };
+});
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: vi.fn(() => ({ session: { store: undefined } })),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/test-sessions.json"),
+}));
+
+vi.mock("../config/sessions/session-accessor.js", () => ({
+  loadSessionEntry: vi.fn(
+    (scope: { sessionKey: string }) => sessionMocks.loadSessionStore()[scope.sessionKey],
+  ),
+  patchSessionEntry: sessionMocks.patchSessionEntry,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ info: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock("./subagent-registry-steer-runtime.js", () => ({
+  finalizeInterruptedSubagentRun: vi.fn(async () => 1),
+  replaceSubagentRunAfterSteer: vi.fn(() => true),
+  reserveSwarmCollectorLaunch: vi.fn(() => true),
+}));
+
+const childSessionKey = "agent:main:subagent:recovery-coordination";
+const dispatchAgent = vi.fn(async () => ({ runId: "recovery-run" }));
+const readSessionMessages = vi.fn(async () => [] as unknown[]);
+const gatewayRuntime: GatewayRecoveryRuntime = {
+  dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
+  waitForAgent: vi.fn(),
+  sendRecoveryNotice: vi.fn(),
+};
+
+function createRun(): SubagentRunRecord {
+  return createSubagentRunRecord({
+    runId: "interrupted-run",
+    childSessionKey,
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "continue the interrupted task",
+    cleanup: "keep",
+    createdAt: Date.now() - 60_000,
+    startedAt: Date.now() - 55_000,
+  });
+}
+
+function createActiveRuns(): Map<string, SubagentRunRecord> {
+  const run = createRun();
+  return new Map([[run.runId, run]]);
+}
+
+function mockAbortedSession() {
+  const store = {
+    [childSessionKey]: {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      abortedLastRun: true,
+    },
+  };
+  sessionMocks.loadSessionStore.mockReturnValue(store);
+  return store;
+}
+
+function schedule(
+  getActiveRuns: () => Map<string, SubagentRunRecord>,
+  options: {
+    delayMs?: number;
+    getGatewayRuntime?: () => GatewayRecoveryRuntime | undefined;
+    maxRetries?: number;
+  } = {},
+) {
+  scheduleOrphanRecovery({
+    getGatewayRuntime: options.getGatewayRuntime ?? (() => gatewayRuntime),
+    getActiveRuns,
+    readSessionMessages,
+    delayMs: options.delayMs ?? 1,
+    maxRetries: options.maxRetries ?? 0,
+  });
+}
+
+describe("subagent orphan recovery coordination", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    resetOrphanRecoveryCoordinationForTest();
+    dispatchAgent.mockResolvedValue({ runId: "recovery-run" });
+    readSessionMessages.mockResolvedValue([]);
+    vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    resetOrphanRecoveryCoordinationForTest();
+    vi.useRealTimers();
+  });
+
+  it("coalesces duplicate schedules before the recovery scan starts", async () => {
+    mockAbortedSession();
+    const activeRuns = createActiveRuns();
+    const getActiveRuns = vi.fn(() => activeRuns);
+
+    schedule(getActiveRuns);
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getActiveRuns).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
+    expect(sessionMocks.patchSessionEntry).toHaveBeenCalledOnce();
+  });
+
+  it("queues one follow-up scan when recovery is requested during an active scan", async () => {
+    mockAbortedSession();
+    const activeRuns = createActiveRuns();
+    const getActiveRuns = vi.fn(() => activeRuns);
+    let releaseDispatch: () => void = () => {};
+    let markDispatchStarted: () => void = () => {};
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const dispatchRelease = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    dispatchAgent.mockImplementationOnce(async () => {
+      markDispatchStarted();
+      await dispatchRelease;
+      return { runId: "recovery-run" };
+    });
+
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(1);
+    await dispatchStarted;
+
+    schedule(getActiveRuns);
+    releaseDispatch();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getActiveRuns).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getActiveRuns).toHaveBeenCalledTimes(2);
+    expect(dispatchAgent).toHaveBeenCalledOnce();
+  });
+
+  it("queues one follow-up scan when recovery is requested during retry backoff", async () => {
+    mockAbortedSession();
+    const activeRuns = createActiveRuns();
+    const getActiveRuns = vi.fn(() => activeRuns);
+    dispatchAgent
+      .mockRejectedValueOnce(new Error("gateway unavailable"))
+      .mockResolvedValueOnce({ runId: "recovery-run" });
+
+    schedule(getActiveRuns, { maxRetries: 1 });
+    await vi.advanceTimersByTimeAsync(1);
+
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(2);
+
+    expect(getActiveRuns).toHaveBeenCalledTimes(2);
+    expect(dispatchAgent).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getActiveRuns).toHaveBeenCalledTimes(3);
+    expect(dispatchAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["missing runtime", () => undefined],
+    [
+      "thrown runtime lookup",
+      () => {
+        throw new Error("runtime unavailable");
+      },
+    ],
+  ])("releases coordination after terminal %s", async (_label, getGatewayRuntime) => {
+    mockAbortedSession();
+    const activeRuns = createActiveRuns();
+    const getActiveRuns = vi.fn(() => activeRuns);
+
+    schedule(getActiveRuns, { getGatewayRuntime });
+    await vi.advanceTimersByTimeAsync(1);
+
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getActiveRuns).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
+  });
+
+  it("releases coordination after terminal finalization is exhausted", async () => {
+    mockAbortedSession();
+    const activeRuns = createActiveRuns();
+    const getActiveRuns = vi.fn(() => activeRuns);
+    dispatchAgent.mockRejectedValueOnce(new Error("gateway unavailable"));
+    vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).mockResolvedValue(0);
+
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(4);
+
+    expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenCalledTimes(3);
+
+    schedule(getActiveRuns);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getActiveRuns).toHaveBeenCalledTimes(2);
+    expect(dispatchAgent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -13,6 +13,7 @@ import { resolveInternalSessionEffectsTarget } from "./internal-session-effects.
 import * as announceDelivery from "./subagent-announce-delivery.js";
 import {
   recoverOrphanedSubagentSessions as recoverOrphanedSubagentSessionsWithRuntime,
+  resetOrphanRecoveryCoordinationForTest,
   scheduleOrphanRecovery as scheduleOrphanRecoveryWithRuntime,
 } from "./subagent-orphan-recovery.js";
 import * as subagentRegistrySteerRuntime from "./subagent-registry-steer-runtime.js";
@@ -224,6 +225,7 @@ describe("subagent-orphan-recovery", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     resetGatewayWorkAdmission();
+    resetOrphanRecoveryCoordinationForTest();
     dispatchAgent.mockReset();
     dispatchAgent.mockResolvedValue({ runId: "test-run-id" });
     readSessionMessages.mockReset();
@@ -235,6 +237,7 @@ describe("subagent-orphan-recovery", () => {
 
   afterEach(() => {
     resetGatewayWorkAdmission();
+    resetOrphanRecoveryCoordinationForTest();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -44,6 +44,24 @@ const log = createSubsystemLogger("subagent-interrupted-resume");
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 
+type OrphanRecoveryScheduleParams = {
+  getGatewayRuntime: () => GatewayRecoveryRuntime | undefined;
+  getActiveRuns: () => Map<string, SubagentRunRecord>;
+  readSessionMessages?: typeof readSessionMessagesAsync;
+  delayMs?: number;
+  maxRetries?: number;
+};
+
+let scheduledRecoveryPhase: "scheduled" | "running" | undefined;
+let scheduledRecoveryHasStarted = false;
+let pendingRecoverySchedule: OrphanRecoveryScheduleParams | undefined;
+
+export function resetOrphanRecoveryCoordinationForTest(): void {
+  scheduledRecoveryPhase = undefined;
+  scheduledRecoveryHasStarted = false;
+  pendingRecoverySchedule = undefined;
+}
+
 function isLegacyRestartInterruptedTimeout(
   runRecord: SubagentRunRecord,
   entry: SessionEntry | undefined,
@@ -603,21 +621,34 @@ async function finalizeInterruptedRunWithRetry(params: {
  * The delay gives the gateway time to fully bootstrap after restart.
  * If recovery fails (e.g. gateway not yet ready), retries with exponential backoff.
  */
-export function scheduleOrphanRecovery(params: {
-  getGatewayRuntime: () => GatewayRecoveryRuntime | undefined;
-  getActiveRuns: () => Map<string, SubagentRunRecord>;
-  /** Test seam for transcript reads; production uses the canonical reader. */
-  readSessionMessages?: typeof readSessionMessagesAsync;
-  delayMs?: number;
-  maxRetries?: number;
-}): void {
+export function scheduleOrphanRecovery(params: OrphanRecoveryScheduleParams): void {
+  if (scheduledRecoveryPhase) {
+    if (scheduledRecoveryHasStarted) {
+      pendingRecoverySchedule = params;
+    }
+    return;
+  }
+
+  scheduledRecoveryPhase = "scheduled";
   const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
   const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
 
   const resumedSessionKeys = new Set<string>();
   const pendingStaleFinalizations = new Map<string, string>();
+  const finishSchedule = () => {
+    const pending = pendingRecoverySchedule;
+    pendingRecoverySchedule = undefined;
+    scheduledRecoveryPhase = undefined;
+    scheduledRecoveryHasStarted = false;
+    if (pending) {
+      scheduleOrphanRecovery(pending);
+    }
+  };
   const attemptRecovery = (attempt: number, delay: number) => {
+    scheduledRecoveryPhase = "scheduled";
     setTimeout(() => {
+      scheduledRecoveryPhase = "running";
+      scheduledRecoveryHasStarted = true;
       // Every delayed/retry scan owns a fresh root lease. Keep terminal
       // mutation in the same lease so suspension cannot become ready mid-attempt.
       void runWithGatewayIndependentRootWorkAdmission(async () => {
@@ -627,6 +658,8 @@ export function scheduleOrphanRecovery(params: {
         if (!gatewayRuntime) {
           if (attempt < maxRetries) {
             attemptRecovery(attempt + 1, delay * RETRY_BACKOFF_MULTIPLIER);
+          } else {
+            finishSchedule();
           }
           return;
         }
@@ -646,6 +679,7 @@ export function scheduleOrphanRecovery(params: {
           return;
         }
         if (result.failedRuns.length === 0) {
+          finishSchedule();
           return;
         }
         const attempts = attempt + 1;
@@ -668,6 +702,7 @@ export function scheduleOrphanRecovery(params: {
             { runIds: incomplete },
           );
         }
+        finishSchedule();
       }).catch((err: unknown) => {
         if (attempt < maxRetries) {
           const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
@@ -677,6 +712,7 @@ export function scheduleOrphanRecovery(params: {
           attemptRecovery(attempt + 1, nextDelay);
         } else {
           log.warn(`scheduled orphan recovery failed after ${maxRetries} retries: ${String(err)}`);
+          finishSchedule();
         }
       });
     }, delay).unref?.();


### PR DESCRIPTION
Fixes #103724

## What Problem This Solves

Two independent orphan-recovery scheduler families could overlap after a Gateway restart. Each family owned private de-duplication state, so both could observe the same `abortedLastRun` child and dispatch duplicate resume turns.

## Why This Change Was Made

This replaces the old 118-file draft with a current-`main`, scheduler-only fix.

`scheduleOrphanRecovery` now owns one process-wide recovery family. Calls before the first scan coalesce because that scan reads the live registry. Calls arriving after an attempt starts queue one follow-up scan, including during retry backoff, so new recovery work is not lost while the family is active.

The scanner, dispatch, remap, session-marker, protocol, config, and persistence behavior are otherwise unchanged.

## User Impact

One Gateway process cannot run overlapping orphan-recovery scans. This prevents the reported duplicate resume turns and avoids repeated full-registry scans during startup recovery bursts.

## Evidence

- Exact signed head: `f00bf01d1f1f9f5532f493b4fe26c0a3f332ca37`
- Focused proof: 177/177 tests passed
  - scheduler coordination: 6/6
  - orphan recovery: 29/29
  - restart integration: 3/3
  - subagent registry: 139/139
- Targeted `oxfmt`, `oxlint`, and `git diff --check`: passed
- Canonical P1 autoreview: no accepted/actionable findings
- Six independent exact-SHA reviews: approved with no P0/P1
- Hosted changed gate: passed on Testbox `tbx_01kyye5erdthnmyh9k35b61neh` ([run 30695937637](https://github.com/openclaw/openclaw/actions/runs/30695937637))
