### PR TITLE
fix(tui): own picker roster request lifecycles canonically

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -340,6 +340,70 @@ describe("tui command handlers", () => {
     ]);
   });
 
+  it.each(["/models", "/agents", "/sessions", "/context", "/settings"])(
+    "lets the newer %s picker own the overlay after an older model request resolves",
+    async (newerCommand) => {
+      const olderModels = createDeferred<Array<{ provider: string; id: string }>>();
+      const listModels = vi
+        .fn()
+        .mockReturnValueOnce(olderModels.promise)
+        .mockResolvedValueOnce([{ provider: "openai", id: "current-model" }]);
+      const harness = createHarness({
+        listModels,
+        listSessions: vi
+          .fn()
+          .mockResolvedValue({ sessions: [{ key: "agent:main:current", updatedAt: 1 }] }),
+        agents: [{ id: "main", name: "Main Agent" }],
+      });
+
+      const olderPicker = harness.handleCommand("/models");
+      await harness.handleCommand(newerCommand);
+      olderModels.resolve([{ provider: "openai", id: "obsolete-model" }]);
+      await olderPicker;
+
+      expect(harness.openOverlay).toHaveBeenCalledOnce();
+      for (const [selection] of listModels.mock.calls) {
+        expect(selection).toEqual({ agentId: "main" });
+      }
+    },
+  );
+
+  it("retires an unfinished agent refresh before opening a newer session picker", async () => {
+    const pendingRefresh = createDeferred<Result<void, string>>();
+    const refreshAgents = vi.fn(() => pendingRefresh.promise) as RefreshAgentsMock;
+    const harness = createHarness({
+      refreshAgents,
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [{ key: "agent:main:current", updatedAt: 1 }] }),
+      agents: [{ id: "main", name: "Main Agent" }],
+    });
+
+    const olderPicker = harness.handleCommand("/agents");
+    const [ownsRefresh] = refreshAgents.mock.calls[0] as [(() => boolean) | undefined];
+    await harness.handleCommand("/sessions");
+    expect(ownsRefresh?.()).toBe(false);
+
+    pendingRefresh.resolve({ ok: true, value: undefined });
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledOnce();
+  });
+
+  it("closes the exact current picker before opening its replacement", async () => {
+    const harness = createHarness({
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [{ key: "agent:main:current", updatedAt: 1 }] }),
+    });
+
+    await harness.handleCommand("/context");
+    await harness.handleCommand("/sessions");
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(2);
+    expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
+  });
+
   it("bounds Ctrl+P hydration to recent non-global TUI sessions", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       sessions: [

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -32,6 +32,7 @@ type AbortActiveMock = ReturnType<typeof vi.fn> &
 type SelectableOverlay = {
   items?: Array<{ value: string; label?: string; description?: string }>;
   onSelect?: (item: { value: string; label?: string; description?: string }) => void;
+  getSelectedItem?: () => { value: string } | null;
 };
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
@@ -340,6 +341,239 @@ describe("tui command handlers", () => {
         description: "default",
       },
     ]);
+  });
+
+  it("keeps only the newest agent picker when roster refreshes finish out of order", async () => {
+    const olderRefresh = createDeferred<Result<void, string>>();
+    const newerRefresh = createDeferred<Result<void, string>>();
+    const refreshAgents = vi
+      .fn()
+      .mockReturnValueOnce(olderRefresh.promise)
+      .mockReturnValueOnce(newerRefresh.promise) as RefreshAgentsMock;
+    const harness = createHarness({
+      refreshAgents,
+      agents: [{ id: "current-agent", kind: "agent" }],
+    });
+
+    const olderPicker = harness.handleCommand("/agents");
+    const newerPicker = harness.handleCommand("/agents");
+    newerRefresh.resolve({ ok: true, value: undefined });
+    await newerPicker;
+    olderRefresh.resolve({ ok: true, value: undefined });
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("current-agent");
+  });
+
+  it("opens the refreshed agent picker after the selected agent is replaced", async () => {
+    const harness = createHarness({
+      currentAgentId: "retired",
+      currentSessionKey: "agent:retired:main",
+      agents: [{ id: "retired", name: "Retired Agent" }],
+    });
+    harness.refreshAgents.mockImplementation(async () => {
+      harness.state.currentAgentId = "main";
+      harness.state.agents = [{ id: "main", name: "Available Agent" }];
+      return { ok: true, value: undefined };
+    });
+
+    await harness.handleCommand("/agents");
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("main");
+  });
+
+  it("keeps only the newest model picker when catalog requests finish out of order", async () => {
+    const olderCatalog = createDeferred<Array<{ provider: string; id: string }>>();
+    const newerCatalog = createDeferred<Array<{ provider: string; id: string }>>();
+    const listModels = vi
+      .fn()
+      .mockReturnValueOnce(olderCatalog.promise)
+      .mockReturnValueOnce(newerCatalog.promise);
+    const harness = createHarness({ listModels });
+
+    const olderPicker = harness.handleCommand("/models");
+    const newerPicker = harness.handleCommand("/models");
+    newerCatalog.resolve([{ provider: "anthropic", id: "current-model" }]);
+    await newerPicker;
+    olderCatalog.resolve([{ provider: "anthropic", id: "obsolete-model" }]);
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("anthropic/current-model");
+  });
+
+  it("keeps only the newest session picker when session requests finish out of order", async () => {
+    const olderSessions = createDeferred<{
+      sessions: Array<{ key: string; updatedAt: number }>;
+    }>();
+    const newerSessions = createDeferred<{
+      sessions: Array<{ key: string; updatedAt: number }>;
+    }>();
+    const listSessions = vi
+      .fn()
+      .mockReturnValueOnce(olderSessions.promise)
+      .mockReturnValueOnce(newerSessions.promise);
+    const harness = createHarness({ listSessions });
+
+    const olderPicker = harness.openSessionSelector();
+    const newerPicker = harness.openSessionSelector();
+    newerSessions.resolve({ sessions: [{ key: "agent:main:current", updatedAt: 2 }] });
+    await newerPicker;
+    olderSessions.resolve({ sessions: [{ key: "agent:main:obsolete", updatedAt: 1 }] });
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("agent:main:current");
+  });
+
+  it("supersedes an older picker when a different picker surface opens", async () => {
+    const olderModels = createDeferred<Array<{ provider: string; id: string }>>();
+    const harness = createHarness({
+      listModels: vi.fn(() => olderModels.promise),
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [{ key: "agent:main:current", updatedAt: 1 }] }),
+    });
+
+    const olderPicker = harness.handleCommand("/models");
+    await harness.openSessionSelector();
+    olderModels.resolve([{ provider: "anthropic", id: "obsolete-model" }]);
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("agent:main:current");
+  });
+
+  it("lets the synchronous context picker supersede an unfinished asynchronous picker", async () => {
+    const olderModels = createDeferred<Array<{ provider: string; id: string }>>();
+    const harness = createHarness({ listModels: vi.fn(() => olderModels.promise) });
+
+    const olderPicker = harness.handleCommand("/models");
+    await harness.handleCommand("/context");
+    olderModels.resolve([{ provider: "anthropic", id: "obsolete-model" }]);
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay).getSelectedItem?.()
+        ?.value,
+    ).toBe("list");
+  });
+
+  it("lets the synchronous settings picker supersede an unfinished asynchronous picker", async () => {
+    const olderModels = createDeferred<Array<{ provider: string; id: string }>>();
+    const harness = createHarness({ listModels: vi.fn(() => olderModels.promise) });
+
+    const olderPicker = harness.handleCommand("/models");
+    await harness.handleCommand("/settings");
+    olderModels.resolve([{ provider: "anthropic", id: "obsolete-model" }]);
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the exact previously opened picker when another surface supersedes it", async () => {
+    const harness = createHarness({
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [{ key: "agent:main:current", updatedAt: 1 }] }),
+    });
+
+    await harness.handleCommand("/context");
+    const originalHandle = harness.overlayHandle;
+    await harness.openSessionSelector();
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(2);
+    expect(harness.closeOverlay).toHaveBeenCalledTimes(1);
+    expect(harness.closeOverlay).toHaveBeenCalledWith(originalHandle);
+  });
+
+  it("does not report an older model request failure after a newer picker opens", async () => {
+    const olderCatalog = createDeferred<Array<{ provider: string; id: string }>>();
+    const newerCatalog = createDeferred<Array<{ provider: string; id: string }>>();
+    const harness = createHarness({
+      listModels: vi
+        .fn()
+        .mockReturnValueOnce(olderCatalog.promise)
+        .mockReturnValueOnce(newerCatalog.promise),
+    });
+
+    const olderPicker = harness.handleCommand("/models");
+    const newerPicker = harness.handleCommand("/models");
+    newerCatalog.resolve([{ provider: "anthropic", id: "current-model" }]);
+    await newerPicker;
+    harness.addSystem.mockClear();
+    olderCatalog.reject(new Error("obsolete catalog request failed"));
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it("does not report an agent picker failure after another picker supersedes it", async () => {
+    const pendingRefresh = createDeferred<Result<void, string>>();
+    const harness = createHarness({
+      refreshAgents: vi.fn(() => pendingRefresh.promise) as RefreshAgentsMock,
+    });
+
+    const olderPicker = harness.handleCommand("/agents");
+    const [refreshOptions] = harness.refreshAgents.mock.calls[0] as [
+      { shouldReportError?: () => boolean } | undefined,
+    ];
+    await harness.handleCommand("/context");
+    if (refreshOptions?.shouldReportError?.() !== false) {
+      harness.addSystem("agents list failed: obsolete roster request failed");
+    }
+    pendingRefresh.resolve({ ok: false, error: "obsolete roster request failed" });
+    await olderPicker;
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    expect(harness.addSystem).not.toHaveBeenCalledWith(
+      "agents list failed: obsolete roster request failed",
+    );
+  });
+
+  it("still reports the newest model picker failure to the operator", async () => {
+    const harness = createHarness({
+      listModels: vi.fn().mockRejectedValue(new Error("current catalog request failed")),
+    });
+
+    await harness.handleCommand("/models");
+
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+    expect(harness.addSystem).toHaveBeenCalledWith(
+      "model list failed: current catalog request failed",
+    );
+  });
+
+  it("still reports the newest session picker failure to the operator", async () => {
+    const harness = createHarness({
+      listSessions: vi.fn().mockRejectedValue(new Error("current sessions request failed")),
+    });
+
+    await harness.openSessionSelector();
+
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+    expect(harness.addSystem).toHaveBeenCalledWith(
+      "sessions list failed: current sessions request failed",
+    );
   });
 
   it("bounds session picker hydration to recent TUI sessions", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -370,18 +370,19 @@ describe("tui command handlers", () => {
   });
 
   it("opens the refreshed agent picker after the selected agent is replaced", async () => {
+    const refresh = createDeferred<Result<void, string>>();
     const harness = createHarness({
       currentAgentId: "retired",
       currentSessionKey: "agent:retired:main",
       agents: [{ id: "retired", name: "Retired Agent" }],
-    });
-    harness.refreshAgents.mockImplementation(async () => {
-      harness.state.currentAgentId = "main";
-      harness.state.agents = [{ id: "main", name: "Available Agent" }];
-      return { ok: true, value: undefined };
+      refreshAgents: vi.fn(() => refresh.promise) as RefreshAgentsMock,
     });
 
-    await harness.handleCommand("/agents");
+    const openingPicker = harness.handleCommand("/agents");
+    harness.state.currentAgentId = "main";
+    harness.state.agents = [{ id: "main", name: "Available Agent" }];
+    refresh.resolve({ ok: true, value: undefined });
+    await openingPicker;
 
     expect(harness.openOverlay).toHaveBeenCalledTimes(1);
     expect(

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -536,10 +536,10 @@ describe("tui command handlers", () => {
 
     const olderPicker = harness.handleCommand("/agents");
     const [refreshOptions] = harness.refreshAgents.mock.calls[0] as [
-      { shouldReportError?: () => boolean } | undefined,
+      { ownsRefresh?: () => boolean } | undefined,
     ];
     await harness.handleCommand("/context");
-    if (refreshOptions?.shouldReportError?.() !== false) {
+    if (refreshOptions?.ownsRefresh?.() !== false) {
       harness.addSystem("agents list failed: obsolete roster request failed");
     }
     pendingRefresh.resolve({ ok: false, error: "obsolete roster request failed" });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -77,7 +77,7 @@ type CommandHandlerContext = {
   refreshSessionInfo: () => Promise<void>;
   loadHistory: () => Promise<unknown>;
   setSession: (key: string) => Promise<void>;
-  refreshAgents: () => Promise<Result<void, string>>;
+  refreshAgents: (ownsRefresh?: () => boolean) => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
@@ -152,6 +152,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     boundary: null as "new" | "reset" | null,
     epoch: 0,
   };
+  let pickerRequest: { overlay?: OverlayHandle } | null = null;
 
   // Hold one owner through the full identity transition so later input cannot
   // target the session being retired while create/reset awaits the backend.
@@ -223,7 +224,18 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     chatLog.addSystem(`agent set to ${state.currentAgentId}; use /openclaw to return`);
   };
 
+  const beginPickerRequest = (): { overlay?: OverlayHandle } => {
+    if (pickerRequest?.overlay) {
+      closeOverlayAndRender(pickerRequest.overlay);
+    }
+    return (pickerRequest = {});
+  };
+
   const closeOverlayAndRender = (handle: OverlayHandle) => {
+    if (pickerRequest?.overlay !== handle) {
+      return;
+    }
+    pickerRequest = null;
     closeOverlay(handle);
     tui.requestRender();
   };
@@ -301,6 +313,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       onCancel?: () => void;
     },
     onSelect: (value: string) => Promise<void>,
+    request: { overlay?: OverlayHandle },
   ) => {
     selector.onSelect = (item) => {
       void (async () => {
@@ -315,17 +328,18 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       })();
     };
     selector.onCancel = () => closeOverlayAndRender(overlayHandle);
-    const overlayHandle: OverlayHandle = openOverlay(selector as Component);
+    const overlayHandle = (request.overlay = openOverlay(selector as Component));
     tui.requestRender();
   };
 
   const openModelSelector = async () => {
+    const request = beginPickerRequest();
     const selection = captureSessionSelection();
     try {
       chatLog.addSystem("loading models...");
       tui.requestRender();
       const models = await client.listModels({ agentId: selection.agentId });
-      if (!isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
         return;
       }
       if (models.length === 0) {
@@ -341,12 +355,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           description: model.name && model.name !== model.id ? model.name : "",
         };
       });
-      const selector = createSearchableSelectList(items, 9);
-      openSelector(selector, async (value) => {
-        await applySessionSetting({ model: value }, `model set to ${value}`, "model set failed");
-      });
+      openSelector(
+        createSearchableSelectList(items, 9),
+        (value) =>
+          applySessionSetting({ model: value }, `model set to ${value}`, "model set failed"),
+        request,
+      );
     } catch (err) {
-      if (!isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
         return;
       }
       chatLog.addSystem(`model list failed: ${formatTuiErrorMessage(err)}`);
@@ -355,7 +371,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openAgentSelector = async () => {
-    const refreshResult = await refreshAgents();
+    const request = beginPickerRequest();
+    const refreshResult = await refreshAgents(() => request === pickerRequest);
+    if (request !== pickerRequest) {
+      return;
+    }
     if (!refreshResult.ok) {
       tui.requestRender();
       return;
@@ -371,50 +391,32 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       label: agent.name ? `${agent.id} (${agent.name})` : agent.id,
       description: agent.id === state.agentDefaultId ? "default" : "",
     }));
-    const selector = createSearchableSelectList(items, 9);
-    openSelector(selector, async (value) => {
-      await setAgent(value);
-    });
+    openSelector(createSearchableSelectList(items, 9), setAgent, request);
   };
 
   const openContextModeSelector = () => {
+    const request = beginPickerRequest();
     const items = [
-      {
-        value: "list",
-        label: "list",
-        description: "Short context breakdown",
-      },
-      {
-        value: "detail",
-        label: "detail",
-        description: "Per-file, per-tool, per-skill, and system prompt size",
-      },
-      {
-        value: "json",
-        label: "json",
-        description: "Machine-readable context report",
-      },
-    ];
+      ["list", "Short context breakdown"] as const,
+      ["detail", "Per-file, per-tool, per-skill, and system prompt size"] as const,
+      ["json", "Machine-readable context report"] as const,
+    ].map(([value, description]) => ({ value, label: value, description }));
     const selector = createSearchableSelectList(items, 9);
-    openSelector(selector, async (value) => {
-      await sendMessage(`/context ${value}`);
-    });
+    openSelector(selector, (value) => sendMessage(`/context ${value}`), request);
   };
 
   const openSessionSelector = async () => {
+    const request = beginPickerRequest();
     const selection = captureSessionSelection();
     try {
       const sessions = await loadRecentSessions(client, { agentId: selection.agentId });
-      if (!isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
         return;
       }
-      const items = buildSessionChoices(sessions);
-      const selector = createFilterableSelectList(items, 9);
-      openSelector(selector, async (value) => {
-        await setSession(value);
-      });
+      const selector = createFilterableSelectList(buildSessionChoices(sessions), 9);
+      openSelector(selector, setSession, request);
     } catch (err) {
-      if (!isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
         return;
       }
       chatLog.addSystem(`sessions list failed: ${formatTuiErrorMessage(err)}`);
@@ -423,6 +425,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openSettings = () => {
+    const request = beginPickerRequest();
     const items = [
       {
         id: "tools",
@@ -450,12 +453,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         tui.requestRender();
       },
-      () => {
-        closeOverlay(overlayHandle);
-        tui.requestRender();
-      },
+      () => closeOverlayAndRender(overlayHandle),
     );
-    const overlayHandle: OverlayHandle = openOverlay(settings);
+    const overlayHandle = (request.overlay = openOverlay(settings));
     tui.requestRender();
   };
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -79,7 +79,7 @@ type CommandHandlerContext = {
   refreshSessionInfo: () => Promise<void>;
   loadHistory: () => Promise<unknown>;
   setSession: (key: string) => Promise<void>;
-  refreshAgents: () => Promise<Result<void, string>>;
+  refreshAgents: (options?: { shouldReportError?: () => boolean }) => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
@@ -174,6 +174,21 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     boundary: null as "new" | "reset" | null,
     epoch: 0,
   };
+  let pickerRequestGeneration = 0;
+  let activePickerOverlay: OverlayHandle | null = null;
+
+  // Picker requests and their exact overlays share one lifetime so late
+  // responses cannot restore stale choices after another surface takes focus.
+  const beginPickerRequest = () => {
+    pickerRequestGeneration += 1;
+    if (activePickerOverlay) {
+      const supersededOverlay = activePickerOverlay;
+      activePickerOverlay = null;
+      closeOverlayAndRender(supersededOverlay);
+    }
+    return pickerRequestGeneration;
+  };
+  const isCurrentPickerRequest = (generation: number) => generation === pickerRequestGeneration;
 
   // Hold one owner through the full identity transition so later input cannot
   // target the session being retired while create/reset awaits the backend.
@@ -250,6 +265,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     tui.requestRender();
   };
 
+  const closePickerOverlay = (handle: OverlayHandle) => {
+    if (activePickerOverlay !== handle) {
+      return;
+    }
+    activePickerOverlay = null;
+    closeOverlayAndRender(handle);
+  };
+
   const hasTrackedAbortTarget = () => Boolean(state.activeChatRunId || hasPendingSubmit(state));
 
   const hasUnsafeSessionRollover = () =>
@@ -299,26 +322,35 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       onSelect?: (item: SelectItem) => void;
       onCancel?: () => void;
     },
+    requestGeneration: number,
     onSelect: (value: string) => Promise<void>,
   ) => {
+    if (!isCurrentPickerRequest(requestGeneration)) {
+      return;
+    }
     selector.onSelect = (item) => {
+      if (!isCurrentPickerRequest(requestGeneration) || activePickerOverlay !== overlayHandle) {
+        return;
+      }
       void (async () => {
         await onSelect(item.value);
-        closeOverlayAndRender(overlayHandle);
+        closePickerOverlay(overlayHandle);
       })();
     };
-    selector.onCancel = () => closeOverlayAndRender(overlayHandle);
+    selector.onCancel = () => closePickerOverlay(overlayHandle);
     const overlayHandle: OverlayHandle = openOverlay(selector as Component);
+    activePickerOverlay = overlayHandle;
     tui.requestRender();
   };
 
   const openModelSelector = async () => {
+    const requestGeneration = beginPickerRequest();
     const selection = captureSessionSelection();
     try {
       chatLog.addSystem("loading models...");
       tui.requestRender();
       const models = await client.listModels();
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentPickerRequest(requestGeneration) || !isCurrentSessionSelection(selection)) {
         return;
       }
       if (models.length === 0) {
@@ -335,7 +367,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         };
       });
       const selector = createSearchableSelectList(items, 9);
-      openSelector(selector, async (value) => {
+      openSelector(selector, requestGeneration, async (value) => {
         try {
           const result = await patchCurrentSession({ model: value });
           if (!result) {
@@ -349,7 +381,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
       });
     } catch (err) {
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentPickerRequest(requestGeneration) || !isCurrentSessionSelection(selection)) {
         return;
       }
       chatLog.addSystem(`model list failed: ${formatTuiErrorMessage(err)}`);
@@ -358,7 +390,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openAgentSelector = async () => {
-    const refreshResult = await refreshAgents();
+    const requestGeneration = beginPickerRequest();
+    const refreshResult = await refreshAgents({
+      shouldReportError: () => isCurrentPickerRequest(requestGeneration),
+    });
+    if (!isCurrentPickerRequest(requestGeneration)) {
+      return;
+    }
     if (!refreshResult.ok) {
       tui.requestRender();
       return;
@@ -375,12 +413,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       description: agent.id === state.agentDefaultId ? "default" : "",
     }));
     const selector = createSearchableSelectList(items, 9);
-    openSelector(selector, async (value) => {
+    openSelector(selector, requestGeneration, async (value) => {
       await setAgent(value);
     });
   };
 
   const openContextModeSelector = () => {
+    const requestGeneration = beginPickerRequest();
     const items = [
       {
         value: "list",
@@ -399,12 +438,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       },
     ];
     const selector = createSearchableSelectList(items, 9);
-    openSelector(selector, async (value) => {
+    openSelector(selector, requestGeneration, async (value) => {
       await sendMessage(`/context ${value}`);
     });
   };
 
   const openSessionSelector = async () => {
+    const requestGeneration = beginPickerRequest();
     const selection = captureSessionSelection();
     try {
       const result = await client.listSessions({
@@ -416,7 +456,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         includeLastMessage: true,
         agentId: selection.agentId,
       });
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentPickerRequest(requestGeneration) || !isCurrentSessionSelection(selection)) {
         return;
       }
       const items = result.sessions.map((session) => {
@@ -448,11 +488,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         };
       });
       const selector = createFilterableSelectList(items, 9);
-      openSelector(selector, async (value) => {
+      openSelector(selector, requestGeneration, async (value) => {
         await setSession(value);
       });
     } catch (err) {
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentPickerRequest(requestGeneration) || !isCurrentSessionSelection(selection)) {
         return;
       }
       chatLog.addSystem(`sessions list failed: ${formatTuiErrorMessage(err)}`);
@@ -461,6 +501,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openSettings = () => {
+    const requestGeneration = beginPickerRequest();
     const items = [
       {
         id: "tools",
@@ -489,11 +530,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         tui.requestRender();
       },
       () => {
-        closeOverlay(overlayHandle);
-        tui.requestRender();
+        if (isCurrentPickerRequest(requestGeneration)) {
+          closePickerOverlay(overlayHandle);
+        }
       },
     );
     const overlayHandle: OverlayHandle = openOverlay(settings);
+    activePickerOverlay = overlayHandle;
     tui.requestRender();
   };
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -79,7 +79,7 @@ type CommandHandlerContext = {
   refreshSessionInfo: () => Promise<void>;
   loadHistory: () => Promise<unknown>;
   setSession: (key: string) => Promise<void>;
-  refreshAgents: (options?: { shouldReportError?: () => boolean }) => Promise<Result<void, string>>;
+  refreshAgents: (options?: { ownsRefresh?: () => boolean }) => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
@@ -392,7 +392,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   const openAgentSelector = async () => {
     const requestGeneration = beginPickerRequest();
     const refreshResult = await refreshAgents({
-      shouldReportError: () => isCurrentPickerRequest(requestGeneration),
+      ownsRefresh: () => isCurrentPickerRequest(requestGeneration),
     });
     if (!isCurrentPickerRequest(requestGeneration)) {
       return;

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -240,6 +240,49 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["success", "failure"])(
+    "does not publish a superseded picker roster %s",
+    async (outcome) => {
+      const pendingRoster = createDeferred<Awaited<ReturnType<TuiBackend["listAgents"]>>>();
+      const cachedAgents = [{ id: "research", name: "Research" }];
+      const state = createBaseState({
+        agentDefaultId: "research",
+        agents: cachedAgents,
+        currentAgentId: "research",
+        currentSessionKey: "agent:research:incident",
+      });
+      const addSystem = vi.fn();
+      const agentNames = new Map([["research", "Research"]]);
+      const { refreshAgents } = createTestSessionActions({
+        client: makeTuiBackend({ listAgents: vi.fn(() => pendingRoster.promise) }),
+        chatLog: makeChatLog({ addSystem }),
+        state,
+        agentNames,
+      });
+      let ownsRefresh = true;
+
+      const refresh = refreshAgents(() => ownsRefresh);
+      ownsRefresh = false;
+      if (outcome === "success") {
+        pendingRoster.resolve({
+          defaultId: "ops",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [{ id: "ops", name: "Operations" }],
+        });
+      } else {
+        pendingRoster.reject(new Error("obsolete roster request failed"));
+      }
+      await refresh;
+
+      expect(state.currentAgentId).toBe("research");
+      expect(state.currentSessionKey).toBe("agent:research:incident");
+      expect(state.agents).toBe(cachedAgents);
+      expect([...agentNames]).toEqual([["research", "Research"]]);
+      expect(addSystem).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     {
       scope: "per-sender" as const,

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -222,14 +222,16 @@ describe("tui session actions", () => {
       currentAgentId: "cached",
     });
     const updateHeader = vi.fn();
+    let pickerIsCurrent = true;
     const { refreshAgents } = createTestSessionActions({
       client: { listAgents } as unknown as TuiBackend,
       state,
       updateHeader,
     });
 
+    const pickerRefresh = refreshAgents({ ownsRefresh: () => pickerIsCurrent });
     const reconnectRefresh = refreshAgents();
-    const pickerRefresh = refreshAgents();
+    pickerIsCurrent = false;
     pendingRoster.resolve({
       defaultId: "main",
       mainKey: "main",
@@ -241,6 +243,53 @@ describe("tui session actions", () => {
     expect(updateHeader).toHaveBeenCalledTimes(1);
     expect(state.currentAgentId).toBe("main");
     expect(state.agents).toEqual([{ id: "main", kind: undefined, name: "Current Agent" }]);
+  });
+
+  it("does not apply a roster when its only picker owner is superseded", async () => {
+    const pendingRoster = createDeferred<{
+      defaultId: string;
+      mainKey: string;
+      scope: "per-sender";
+      agents: Array<{ id: string; name: string }>;
+    }>();
+    const cachedAgents = [{ id: "cached", name: "Cached Agent" }];
+    const state = createBaseState({
+      agentDefaultId: "cached",
+      sessionMainKey: "cached-main",
+      sessionScope: "global",
+      agents: cachedAgents,
+      currentAgentId: "cached",
+    });
+    const agentNames = new Map([["cached", "Cached Agent"]]);
+    const updateHeader = vi.fn();
+    const updateFooter = vi.fn();
+    let pickerIsCurrent = true;
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents: vi.fn(() => pendingRoster.promise) } as unknown as TuiBackend,
+      state,
+      agentNames,
+      updateHeader,
+      updateFooter,
+    });
+
+    const refresh = refreshAgents({ ownsRefresh: () => pickerIsCurrent });
+    pickerIsCurrent = false;
+    pendingRoster.resolve({
+      defaultId: "replacement",
+      mainKey: "replacement-main",
+      scope: "per-sender",
+      agents: [{ id: "replacement", name: "Replacement Agent" }],
+    });
+    await expect(refresh).resolves.toEqual({ ok: true, value: undefined });
+
+    expect(state.currentAgentId).toBe("cached");
+    expect(state.agents).toBe(cachedAgents);
+    expect(state.agentDefaultId).toBe("cached");
+    expect(state.sessionMainKey).toBe("cached-main");
+    expect(state.sessionScope).toBe("global");
+    expect([...agentNames]).toEqual([["cached", "Cached Agent"]]);
+    expect(updateHeader).not.toHaveBeenCalled();
+    expect(updateFooter).not.toHaveBeenCalled();
   });
 
   it("shares a failed roster refresh once and allows the next caller to retry", async () => {
@@ -282,7 +331,7 @@ describe("tui session actions", () => {
       chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
     });
 
-    const refresh = refreshAgents({ shouldReportError: () => pickerIsCurrent });
+    const refresh = refreshAgents({ ownsRefresh: () => pickerIsCurrent });
     pickerIsCurrent = false;
     pendingFailure.reject(new Error("obsolete roster request failed"));
     await expect(refresh).resolves.toEqual({
@@ -302,7 +351,7 @@ describe("tui session actions", () => {
       chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
     });
 
-    const pickerRefresh = refreshAgents({ shouldReportError: () => pickerIsCurrent });
+    const pickerRefresh = refreshAgents({ ownsRefresh: () => pickerIsCurrent });
     const reconnectRefresh = refreshAgents();
     pickerIsCurrent = false;
     pendingFailure.reject(new Error("gateway unavailable"));
@@ -320,8 +369,8 @@ describe("tui session actions", () => {
       chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
     });
 
-    const olderPicker = refreshAgents({ shouldReportError: () => false });
-    const currentPicker = refreshAgents({ shouldReportError: () => true });
+    const olderPicker = refreshAgents({ ownsRefresh: () => false });
+    const currentPicker = refreshAgents({ ownsRefresh: () => true });
     pendingFailure.reject(new Error("current roster request failed"));
     await Promise.all([olderPicker, currentPicker]);
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -210,6 +210,125 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(1);
   });
 
+  it("shares overlapping agent refreshes before either can publish a stale roster", async () => {
+    const pendingRoster = createDeferred<{
+      defaultId: string;
+      mainKey: string;
+      agents: Array<{ id: string; name: string }>;
+    }>();
+    const listAgents = vi.fn(() => pendingRoster.promise);
+    const state = createBaseState({
+      agents: [{ id: "cached", name: "Cached Agent" }],
+      currentAgentId: "cached",
+    });
+    const updateHeader = vi.fn();
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents } as unknown as TuiBackend,
+      state,
+      updateHeader,
+    });
+
+    const reconnectRefresh = refreshAgents();
+    const pickerRefresh = refreshAgents();
+    pendingRoster.resolve({
+      defaultId: "main",
+      mainKey: "main",
+      agents: [{ id: "main", name: "Current Agent" }],
+    });
+    await Promise.all([reconnectRefresh, pickerRefresh]);
+
+    expect(listAgents).toHaveBeenCalledTimes(1);
+    expect(updateHeader).toHaveBeenCalledTimes(1);
+    expect(state.currentAgentId).toBe("main");
+    expect(state.agents).toEqual([{ id: "main", kind: undefined, name: "Current Agent" }]);
+  });
+
+  it("shares a failed roster refresh once and allows the next caller to retry", async () => {
+    const pendingFailure = createDeferred<never>();
+    const listAgents = vi
+      .fn()
+      .mockReturnValueOnce(pendingFailure.promise)
+      .mockResolvedValueOnce({
+        defaultId: "main",
+        mainKey: "main",
+        agents: [{ id: "main", name: "Recovered Agent" }],
+      });
+    const addSystem = vi.fn();
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents } as unknown as TuiBackend,
+      chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    const reconnectRefresh = refreshAgents();
+    const pickerRefresh = refreshAgents();
+    pendingFailure.reject(new Error("gateway unavailable"));
+    await expect(Promise.all([reconnectRefresh, pickerRefresh])).resolves.toEqual([
+      { ok: false, error: "gateway unavailable" },
+      { ok: false, error: "gateway unavailable" },
+    ]);
+
+    expect(listAgents).toHaveBeenCalledTimes(1);
+    expect(addSystem).toHaveBeenCalledTimes(1);
+    await expect(refreshAgents()).resolves.toEqual({ ok: true, value: undefined });
+    expect(listAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses a failed roster refresh when its only picker consumer is superseded", async () => {
+    const pendingFailure = createDeferred<never>();
+    const addSystem = vi.fn();
+    let pickerIsCurrent = true;
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents: vi.fn(() => pendingFailure.promise) } as unknown as TuiBackend,
+      chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    const refresh = refreshAgents({ shouldReportError: () => pickerIsCurrent });
+    pickerIsCurrent = false;
+    pendingFailure.reject(new Error("obsolete roster request failed"));
+    await expect(refresh).resolves.toEqual({
+      ok: false,
+      error: "obsolete roster request failed",
+    });
+
+    expect(addSystem).not.toHaveBeenCalled();
+  });
+
+  it("reports a shared reconnect failure even when its picker consumer is superseded", async () => {
+    const pendingFailure = createDeferred<never>();
+    const addSystem = vi.fn();
+    let pickerIsCurrent = true;
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents: vi.fn(() => pendingFailure.promise) } as unknown as TuiBackend,
+      chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    const pickerRefresh = refreshAgents({ shouldReportError: () => pickerIsCurrent });
+    const reconnectRefresh = refreshAgents();
+    pickerIsCurrent = false;
+    pendingFailure.reject(new Error("gateway unavailable"));
+    await Promise.all([pickerRefresh, reconnectRefresh]);
+
+    expect(addSystem).toHaveBeenCalledTimes(1);
+    expect(addSystem).toHaveBeenCalledWith("agents list failed: gateway unavailable");
+  });
+
+  it("reports a shared picker failure once when its latest picker still owns the request", async () => {
+    const pendingFailure = createDeferred<never>();
+    const addSystem = vi.fn();
+    const { refreshAgents } = createTestSessionActions({
+      client: { listAgents: vi.fn(() => pendingFailure.promise) } as unknown as TuiBackend,
+      chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    const olderPicker = refreshAgents({ shouldReportError: () => false });
+    const currentPicker = refreshAgents({ shouldReportError: () => true });
+    pendingFailure.reject(new Error("current roster request failed"));
+    await Promise.all([olderPicker, currentPicker]);
+
+    expect(addSystem).toHaveBeenCalledTimes(1);
+    expect(addSystem).toHaveBeenCalledWith("agents list failed: current roster request failed");
+  });
+
   it("queues session refreshes and applies the latest result", async () => {
     let resolveFirst: ((value: unknown) => void) | undefined;
     let resolveSecond: ((value: unknown) => void) | undefined;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -186,11 +186,11 @@ export function createSessionActions(context: SessionActionContext) {
     updateFooter();
   };
 
-  const refreshAgents = () =>
+  const refreshAgents = (ownsRefresh: () => boolean = () => true) =>
     refreshTuiAgentList({
       load: () => client.listAgents(),
-      apply: applyAgentsResult,
-      reportError: (message) => chatLog.addSystem(`agents list failed: ${message}`),
+      apply: (result) => ownsRefresh() && applyAgentsResult(result),
+      reportError: (error) => ownsRefresh() && chatLog.addSystem(`agents list failed: ${error}`),
     });
 
   const updateAgentFromSessionKey = (key: string) => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -111,6 +111,10 @@ export function createSessionActions(context: SessionActionContext) {
     clearLocalRunIds,
     rememberSessionKey,
   } = context;
+  let refreshAgentsInFlight: {
+    promise: ReturnType<typeof refreshTuiAgentList>;
+    errorOwners: Array<() => boolean>;
+  } | null = null;
   let refreshSessionInfoInFlight: Promise<void> | null = null;
   let refreshSessionInfoQueued = false;
   let historyLoadGeneration = 0;
@@ -173,12 +177,34 @@ export function createSessionActions(context: SessionActionContext) {
     updateFooter();
   };
 
-  const refreshAgents = () =>
-    refreshTuiAgentList({
+  const refreshAgents = (options?: { shouldReportError?: () => boolean }) => {
+    const ownsError = options?.shouldReportError ?? (() => true);
+    if (refreshAgentsInFlight) {
+      refreshAgentsInFlight.errorOwners.push(ownsError);
+      return refreshAgentsInFlight.promise;
+    }
+    const errorOwners = [ownsError];
+    const refresh = refreshTuiAgentList({
       load: () => client.listAgents(),
       apply: applyAgentsResult,
-      reportError: (message) => chatLog.addSystem(`agents list failed: ${message}`),
+      reportError: (message) => {
+        if (errorOwners.some((ownsRefreshError) => ownsRefreshError())) {
+          chatLog.addSystem(`agents list failed: ${message}`);
+        }
+      },
     });
+    const activeRefresh = { promise: refresh, errorOwners };
+    refreshAgentsInFlight = activeRefresh;
+    const releaseRefresh = () => {
+      if (refreshAgentsInFlight === activeRefresh) {
+        refreshAgentsInFlight = null;
+      }
+    };
+    // Reconnect and live picker consumers share one roster and one failure;
+    // superseded pickers must not publish errors after their overlay is gone.
+    void refresh.then(releaseRefresh, releaseRefresh);
+    return refresh;
+  };
 
   const updateAgentFromSessionKey = (key: string) => {
     const parsed = parseAgentSessionKey(key);

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -155,23 +155,20 @@ export function createSessionActions(context: SessionActionContext) {
         agentNames.set(agent.id, agent.name);
       }
     }
-    if (!state.initialSessionApplied) {
-      if (initialSessionAgentId) {
-        if (state.agents.some((agent) => agent.id === initialSessionAgentId)) {
-          state.currentAgentId = initialSessionAgentId;
-        }
-      } else if (!state.agents.some((agent) => agent.id === state.currentAgentId)) {
-        state.currentAgentId =
-          state.agents[0]?.id ?? normalizeAgentId(result.defaultId ?? state.currentAgentId);
+    if (!state.initialSessionApplied && initialSessionAgentId) {
+      if (state.agents.some((agent) => agent.id === initialSessionAgentId)) {
+        state.currentAgentId = initialSessionAgentId;
       }
+    } else if (!state.agents.some((agent) => agent.id === state.currentAgentId)) {
+      state.currentAgentId =
+        state.agents[0]?.id ?? normalizeAgentId(result.defaultId ?? state.currentAgentId);
+    }
+    if (!state.initialSessionApplied) {
       const nextSessionKey = resolveSessionKey(initialSessionInput);
       if (nextSessionKey !== state.currentSessionKey) {
         state.currentSessionKey = nextSessionKey;
       }
       state.initialSessionApplied = true;
-    } else if (!state.agents.some((agent) => agent.id === state.currentAgentId)) {
-      state.currentAgentId =
-        state.agents[0]?.id ?? normalizeAgentId(result.defaultId ?? state.currentAgentId);
     }
     updateHeader();
     updateFooter();
@@ -193,10 +190,9 @@ export function createSessionActions(context: SessionActionContext) {
         }
       },
     });
-    const activeRefresh = { promise: refresh, errorOwners };
-    refreshAgentsInFlight = activeRefresh;
+    refreshAgentsInFlight = { promise: refresh, errorOwners };
     const releaseRefresh = () => {
-      if (refreshAgentsInFlight === activeRefresh) {
+      if (refreshAgentsInFlight?.promise === refresh) {
         refreshAgentsInFlight = null;
       }
     };
@@ -208,12 +204,8 @@ export function createSessionActions(context: SessionActionContext) {
 
   const updateAgentFromSessionKey = (key: string) => {
     const parsed = parseAgentSessionKey(key);
-    if (!parsed) {
-      return;
-    }
-    const next = normalizeAgentId(parsed.agentId);
-    if (next !== state.currentAgentId) {
-      state.currentAgentId = next;
+    if (parsed) {
+      state.currentAgentId = normalizeAgentId(parsed.agentId);
     }
   };
 
@@ -262,38 +254,27 @@ export function createSessionActions(context: SessionActionContext) {
     }
 
     const next = { ...state.sessionInfo };
-    if (entry?.thinkingLevel !== undefined) {
-      next.thinkingLevel = entry.thinkingLevel;
+    for (const key of [
+      "thinkingLevel",
+      "agentRuntime",
+      "fastMode",
+      "verboseLevel",
+      "traceLevel",
+      "reasoningLevel",
+      "responseUsage",
+      "effectiveResponseUsage",
+      "inputTokens",
+      "outputTokens",
+      "displayName",
+      "updatedAt",
+    ] as const) {
+      const value = entry?.[key];
+      if (value !== undefined) {
+        Object.assign(next, { [key]: value });
+      }
     }
     if (entry?.thinkingLevels !== undefined || defaults?.thinkingLevels !== undefined) {
       next.thinkingLevels = entry?.thinkingLevels ?? defaults?.thinkingLevels;
-    }
-    if (entry?.agentRuntime !== undefined) {
-      next.agentRuntime = entry.agentRuntime;
-    }
-    if (entry?.fastMode !== undefined) {
-      next.fastMode = entry.fastMode;
-    }
-    if (entry?.verboseLevel !== undefined) {
-      next.verboseLevel = entry.verboseLevel;
-    }
-    if (entry?.traceLevel !== undefined) {
-      next.traceLevel = entry.traceLevel;
-    }
-    if (entry?.reasoningLevel !== undefined) {
-      next.reasoningLevel = entry.reasoningLevel;
-    }
-    if (entry?.responseUsage !== undefined) {
-      next.responseUsage = entry.responseUsage;
-    }
-    if (entry?.effectiveResponseUsage !== undefined) {
-      next.effectiveResponseUsage = entry.effectiveResponseUsage;
-    }
-    if (entry?.inputTokens !== undefined) {
-      next.inputTokens = entry.inputTokens;
-    }
-    if (entry?.outputTokens !== undefined) {
-      next.outputTokens = entry.outputTokens;
     }
     if (entry?.totalTokens !== undefined) {
       next.totalTokens = entry.totalTokens;
@@ -324,13 +305,6 @@ export function createSessionActions(context: SessionActionContext) {
       next.contextTokens =
         entry?.contextTokens ?? defaults?.contextTokens ?? state.sessionInfo.contextTokens;
     }
-    if (entry?.displayName !== undefined) {
-      next.displayName = entry.displayName;
-    }
-    if (entry?.updatedAt !== undefined) {
-      next.updatedAt = entry.updatedAt;
-    }
-
     const selection = resolveModelSelection(entry);
     if (selection.modelProvider !== undefined) {
       next.modelProvider = selection.modelProvider;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -113,7 +113,7 @@ export function createSessionActions(context: SessionActionContext) {
   } = context;
   let refreshAgentsInFlight: {
     promise: ReturnType<typeof refreshTuiAgentList>;
-    errorOwners: Array<() => boolean>;
+    owners: Array<() => boolean>;
   } | null = null;
   let refreshSessionInfoInFlight: Promise<void> | null = null;
   let refreshSessionInfoQueued = false;
@@ -174,30 +174,34 @@ export function createSessionActions(context: SessionActionContext) {
     updateFooter();
   };
 
-  const refreshAgents = (options?: { shouldReportError?: () => boolean }) => {
-    const ownsError = options?.shouldReportError ?? (() => true);
+  const refreshAgents = (options?: { ownsRefresh?: () => boolean }) => {
+    const ownsRefresh = options?.ownsRefresh ?? (() => true);
     if (refreshAgentsInFlight) {
-      refreshAgentsInFlight.errorOwners.push(ownsError);
+      refreshAgentsInFlight.owners.push(ownsRefresh);
       return refreshAgentsInFlight.promise;
     }
-    const errorOwners = [ownsError];
+    const owners = [ownsRefresh];
     const refresh = refreshTuiAgentList({
       load: () => client.listAgents(),
-      apply: applyAgentsResult,
+      apply: (result) => {
+        if (owners.some((ownsResult) => ownsResult())) {
+          applyAgentsResult(result);
+        }
+      },
       reportError: (message) => {
-        if (errorOwners.some((ownsRefreshError) => ownsRefreshError())) {
+        if (owners.some((ownsResult) => ownsResult())) {
           chatLog.addSystem(`agents list failed: ${message}`);
         }
       },
     });
-    refreshAgentsInFlight = { promise: refresh, errorOwners };
+    refreshAgentsInFlight = { promise: refresh, owners };
     const releaseRefresh = () => {
       if (refreshAgentsInFlight?.promise === refresh) {
         refreshAgentsInFlight = null;
       }
     };
-    // Reconnect and live picker consumers share one roster and one failure;
-    // superseded pickers must not publish errors after their overlay is gone.
+    // One live subscriber owns roster publication and failures; reconnects
+    // remain authoritative after their shared picker is superseded.
     void refresh.then(releaseRefresh, releaseRefresh);
     return refresh;
   };
@@ -209,8 +213,8 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const resolveModelSelection = (entry?: SessionInfoEntry) => {
-    return resolveSessionInfoModelSelection({
+  const resolveModelSelection = (entry?: SessionInfoEntry) =>
+    resolveSessionInfoModelSelection({
       currentProvider: state.sessionInfo.modelProvider,
       currentModel: state.sessionInfo.model,
       defaultProvider: lastSessionDefaults?.modelProvider,
@@ -220,7 +224,6 @@ export function createSessionActions(context: SessionActionContext) {
       overrideProvider: entry?.providerOverride,
       overrideModel: entry?.modelOverride,
     });
-  };
 
   const applySessionInfo = (params: {
     entry?: SessionInfoEntry | null;
@@ -268,9 +271,8 @@ export function createSessionActions(context: SessionActionContext) {
       "displayName",
       "updatedAt",
     ] as const) {
-      const value = entry?.[key];
-      if (value !== undefined) {
-        Object.assign(next, { [key]: value });
+      if (entry?.[key] !== undefined) {
+        Object.assign(next, { [key]: entry[key] });
       }
     }
     if (entry?.thinkingLevels !== undefined || defaults?.thinkingLevels !== undefined) {
@@ -287,11 +289,10 @@ export function createSessionActions(context: SessionActionContext) {
       next.totalTokensFresh = true;
     }
     if (params.clearMissingUsage) {
-      if (entry?.inputTokens === undefined) {
-        next.inputTokens = null;
-      }
-      if (entry?.outputTokens === undefined) {
-        next.outputTokens = null;
+      for (const key of ["inputTokens", "outputTokens"] as const) {
+        if (entry?.[key] === undefined) {
+          next[key] = null;
+        }
       }
       if (entry?.totalTokens === undefined && entry?.totalTokensFresh !== true) {
         next.totalTokens = null;


### PR DESCRIPTION
## What Problem This Solves

Overlapping terminal model, agent, session, context, and settings pickers could allow an obsolete request to stack a stale overlay or publish an outdated agent roster. In the user-visible failure, a delayed `/agents` response changed the selected agent and session after a newer `/sessions` picker had already opened.

## Why This Change Was Made

Make the current picker request the canonical owner of its exact overlay and async roster refresh. Beginning a newer picker retires the previous overlay; obsolete model/session completions and superseded agent refresh results or errors cannot publish after ownership changes. The existing picker and roster owners are reused without new configuration, dependencies, compatibility paths, or production lines.

## User Impact

The latest picker remains authoritative, stale roster replies cannot silently replace the selected agent or session, and Escape or selection closes only the current overlay. Model, agent, session, context, and settings pickers retain their existing behavior.

## Evidence

- Frozen reviewed base: `295809df988c9fb94822e0e4d47f3676a4c3cfa8`.
- Pushed exact head: `53db8f9c0efd732d232d41db2f74148fc21ad70e`.
- Focused owner suites: **243 passing tests** covering stale/success/failure roster publication, five picker families, latest-overlay replacement, and session identity.
- Real pseudo-terminal integration: **4 passing PTY scenarios**.
- The actual locked `@earendil-works/pi-tui@0.84.2` overlay and real session-action/command-handler overlap reproduce stale behavior before the fix and pass afterward.
- Type-aware lint, formatting, and `git diff --check` passed.
- Fresh authenticated autoreview: **CLEAN**, confidence **0.99**.
- Separate independent final-diff challenge: **CLEAN**.
- Production LOC: **+47/-47 (net 0)**; tests: **+107**. Exactly four existing TUI owner/test files.
- Exact-head hosted CI is pending after publication; landing waits for a successful required gate.
