### PR TITLE
fix(models): avoid repeated plugin scans in static catalog lookup

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
@@ -5,7 +5,9 @@ import { getModelProviderMetadataOwners } from "../provider-request-config.js";
 const mocks = vi.hoisted(() => ({
   loadPluginManifestRegistry: vi.fn(),
   normalizePluginDiscoveryResult: vi.fn(),
+  resolveActivatableProviderOwnerPluginIds: vi.fn(),
   resolveBundledProviderCompatPluginIds: vi.fn(),
+  resolveOwningPluginIdsForProviderRef: vi.fn(),
   resolveRuntimePluginDiscoveryProviders: vi.fn(),
   runProviderStaticCatalog: vi.fn(),
 }));
@@ -31,9 +33,9 @@ vi.mock("../../plugins/manifest.js", () => ({
 }));
 
 vi.mock("../../plugins/providers.js", () => ({
-  resolveActivatableProviderOwnerPluginIds: vi.fn(),
+  resolveActivatableProviderOwnerPluginIds: mocks.resolveActivatableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds: mocks.resolveBundledProviderCompatPluginIds,
-  resolveOwningPluginIdsForProviderRef: vi.fn(),
+  resolveOwningPluginIdsForProviderRef: mocks.resolveOwningPluginIdsForProviderRef,
 }));
 
 vi.mock("../../plugins/provider-discovery.js", () => ({
@@ -42,7 +44,10 @@ vi.mock("../../plugins/provider-discovery.js", () => ({
   runProviderStaticCatalog: mocks.runProviderStaticCatalog,
 }));
 
-import { loadBundledProviderStaticCatalogContextModels } from "./model.static-catalog.js";
+import {
+  createBundledProviderStaticCatalogContextResolver,
+  loadBundledProviderStaticCatalogContextModels,
+} from "./model.static-catalog.js";
 
 const cfg = { plugins: { entries: { google: { enabled: true } } } };
 const provider = {
@@ -61,15 +66,20 @@ const unconfiguredProvider = {
 };
 
 function createMetadataSnapshot(pluginIds: string[]): PluginMetadataSnapshot {
+  const plugins = pluginIds.map((id) => ({
+    id,
+    origin: "bundled" as const,
+    providerDiscoverySource: `/fixtures/${id}/provider-discovery.ts`,
+  }));
   return {
+    index: {
+      plugins: pluginIds.map((pluginId) => ({ pluginId })),
+    },
     manifestRegistry: {
       diagnostics: [],
-      plugins: pluginIds.map((id) => ({
-        id,
-        origin: "bundled",
-        providerDiscoverySource: `/fixtures/${id}/provider-discovery.ts`,
-      })),
+      plugins,
     },
+    plugins,
     owners: {
       providerEndpoints: [],
       providerRequests: new Map(),
@@ -80,7 +90,11 @@ function createMetadataSnapshot(pluginIds: string[]): PluginMetadataSnapshot {
 describe("prepared bundled provider static catalogs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveActivatableProviderOwnerPluginIds.mockImplementation(
+      ({ pluginIds }: { pluginIds: string[] }) => pluginIds,
+    );
     mocks.resolveBundledProviderCompatPluginIds.mockReturnValue(["google"]);
+    mocks.resolveOwningPluginIdsForProviderRef.mockReturnValue(["google"]);
     mocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
@@ -90,6 +104,94 @@ describe("prepared bundled provider static catalogs", () => {
         },
       ],
     });
+  });
+
+  it("keeps provider-scoped lookup on the prepared metadata generation", async () => {
+    const metadataSnapshot = createMetadataSnapshot(["google"]);
+    mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
+    mocks.runProviderStaticCatalog.mockResolvedValue({ marker: "static-result" });
+    mocks.normalizePluginDiscoveryResult.mockReturnValue({
+      google: {
+        models: [{ id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 }],
+      },
+    });
+
+    await expect(
+      loadBundledProviderStaticCatalogContextModels({
+        cfg,
+        metadataSnapshot,
+        providerIds: ["google"],
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "gemini-3.1-pro-preview", provider: "google" }),
+    ]);
+
+    expect(mocks.resolveOwningPluginIdsForProviderRef).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataSnapshot }),
+    );
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registry: metadataSnapshot.index,
+        manifestRegistry: metadataSnapshot.manifestRegistry,
+      }),
+    );
+    expect(mocks.resolveBundledProviderCompatPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({ manifestRegistry: metadataSnapshot.manifestRegistry }),
+    );
+    expect(mocks.resolveRuntimePluginDiscoveryProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginMetadataSnapshot: metadataSnapshot }),
+    );
+  });
+
+  it("keeps nested provider ownership on the prepared metadata generation", async () => {
+    const metadataSnapshot = createMetadataSnapshot(["shared", "unrelated"]);
+    mocks.resolveOwningPluginIdsForProviderRef.mockImplementation(
+      ({ provider: providerId }: { provider: string }) =>
+        providerId === "outer"
+          ? ["shared"]
+          : providerId === "nested"
+            ? ["shared", "unrelated"]
+            : undefined,
+    );
+    mocks.resolveBundledProviderCompatPluginIds.mockReturnValue(["shared", "unrelated"]);
+    mocks.resolveRuntimePluginDiscoveryProviders.mockImplementation(
+      async ({ onlyPluginIds }: { onlyPluginIds: string[] }) =>
+        onlyPluginIds.map((pluginId) => ({
+          id: pluginId,
+          pluginId,
+          label: pluginId,
+          auth: [],
+        })),
+    );
+    mocks.normalizePluginDiscoveryResult.mockImplementation(
+      ({ provider: catalogProvider }: { provider: { pluginId: string } }) =>
+        catalogProvider.pluginId === "shared"
+          ? {
+              nested: {
+                models: [{ id: "model", contextWindow: 256_000 }],
+              },
+            }
+          : {},
+    );
+
+    const resolveContext = createBundledProviderStaticCatalogContextResolver({
+      cfg,
+      metadataSnapshot,
+    });
+    await expect(resolveContext({ provider: "outer", modelId: "nested/model" })).resolves.toEqual({
+      contextWindow: 256_000,
+    });
+
+    expect(mocks.resolveOwningPluginIdsForProviderRef).toHaveBeenCalledTimes(3);
+    for (const [params] of mocks.resolveOwningPluginIdsForProviderRef.mock.calls) {
+      expect(params).toEqual(expect.objectContaining({ metadataSnapshot }));
+    }
+    expect(mocks.resolveRuntimePluginDiscoveryProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["shared"],
+        pluginMetadataSnapshot: metadataSnapshot,
+      }),
+    );
   });
 
   it("projects prepared rows without rerunning hooks", async () => {

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -385,12 +385,14 @@ function resolveBundledProviderStaticCatalogPluginIds(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }): string[] {
   const pluginIds = resolveOwningPluginIdsForProviderRef({
     provider: params.provider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
   });
   if (!pluginIds || pluginIds.length === 0) {
     return [];
@@ -400,6 +402,12 @@ function resolveBundledProviderStaticCatalogPluginIds(params: {
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    ...(params.metadataSnapshot
+      ? {
+          registry: params.metadataSnapshot.index,
+          manifestRegistry: params.metadataSnapshot.manifestRegistry,
+        }
+      : {}),
   });
   if (activatablePluginIds.length === 0) {
     return [];
@@ -409,6 +417,9 @@ function resolveBundledProviderStaticCatalogPluginIds(params: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      ...(params.metadataSnapshot
+        ? { manifestRegistry: params.metadataSnapshot.manifestRegistry }
+        : {}),
     }),
   );
   return activatablePluginIds.filter((pluginId) => bundledPluginIds.has(pluginId)).toSorted();
@@ -421,6 +432,7 @@ async function loadBundledProviderStaticCatalogModels(params: {
   env: NodeJS.ProcessEnv;
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
   providerMetadataOwners?: PluginMetadataSnapshot["owners"];
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
 }): Promise<Map<string, ProviderRuntimeModel[]>> {
   const pluginIds = new Set(params.pluginIds);
   const preparedProviders = (params.preparedStaticProviderCatalog?.providers ?? []).filter(
@@ -444,6 +456,9 @@ async function loadBundledProviderStaticCatalogModels(params: {
           requireCompleteDiscoveryEntryCoverage: true,
           discoveryEntriesOnly: true,
           includeManifestModelCatalogProviders: false,
+          ...(params.pluginMetadataSnapshot
+            ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+            : {}),
         });
   const providers = [...preparedProviders, ...discoveredProviders];
   const preparedEntries = params.preparedStaticProviderCatalog?.entries.filter(
@@ -520,6 +535,7 @@ export async function loadBundledProviderStaticCatalogContextModels(
       cfg: params.cfg,
       workspaceDir: params.workspaceDir,
       env,
+      ...(metadataSnapshot ? { metadataSnapshot } : {}),
     }),
   );
   const candidatePluginIds =
@@ -528,6 +544,7 @@ export async function loadBundledProviderStaticCatalogContextModels(
           config: params.cfg,
           workspaceDir: params.workspaceDir,
           env,
+          ...(metadataSnapshot ? { manifestRegistry: metadataSnapshot.manifestRegistry } : {}),
         })
       : providerScopedPluginIds;
   const pluginIds = [...new Set(candidatePluginIds)]
@@ -548,6 +565,7 @@ export async function loadBundledProviderStaticCatalogContextModels(
             ? { preparedStaticProviderCatalog: params.preparedStaticProviderCatalog }
             : {}),
           ...(metadataSnapshot ? { providerMetadataOwners: metadataSnapshot.owners } : {}),
+          ...(metadataSnapshot ? { pluginMetadataSnapshot: metadataSnapshot } : {}),
         }),
     ),
   );
@@ -583,6 +601,7 @@ function createScopedBundledProviderStaticCatalogModelResolver(
         cfg: params.cfg,
         workspaceDir: params.workspaceDir,
         env,
+        ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
       });
       providerPluginIds.set(provider, pluginIds);
     }
@@ -597,6 +616,15 @@ function createScopedBundledProviderStaticCatalogModelResolver(
         cfg: params.cfg,
         workspaceDir: params.workspaceDir,
         env,
+        ...(params.preparedStaticProviderCatalog
+          ? { preparedStaticProviderCatalog: params.preparedStaticProviderCatalog }
+          : {}),
+        ...(params.metadataSnapshot
+          ? {
+              providerMetadataOwners: params.metadataSnapshot.owners,
+              pluginMetadataSnapshot: params.metadataSnapshot,
+            }
+          : {}),
       });
       pluginCatalogs.set(catalogKey, catalog);
     }
@@ -643,6 +671,9 @@ function resolveOwnedNestedProviderLookup(params: {
       cfg: params.resolverParams.cfg,
       workspaceDir: params.resolverParams.workspaceDir,
       env: params.env,
+      ...(params.resolverParams.metadataSnapshot
+        ? { metadataSnapshot: params.resolverParams.metadataSnapshot }
+        : {}),
     });
   const nestedProviderOwners = new Set(resolveBundledOwners(nestedProvider));
   const sharedPluginIds = resolveBundledOwners(provider).filter((pluginId) =>


### PR DESCRIPTION
Related: #117130

## What Problem This Solves

Fixes an issue where users resolving model metadata could trigger repeated plugin metadata discovery during static catalog lookup, even when the current agent run had already prepared the exact plugin metadata generation.

## Why This Change Was Made

The static catalog path now carries the lifecycle-owned plugin metadata snapshot through provider ownership, activation, compatibility, runtime discovery, and nested-provider lookup. It adds no cache, config surface, or public API; every lookup remains tied to the prepared snapshot supplied by the caller.

## User Impact

Cold model selection and context-window lookup avoid redundant plugin scans while preserving the existing catalog results and workspace boundaries.

## Evidence

- Focused Vitest coverage: 42 tests passed across the prepared metadata, snapshot-cache, and static-catalog suites at the final rebased head.
- Added regression coverage for provider-scoped and nested-provider lookups using one prepared metadata generation.
- `oxfmt` and `git diff --check` passed.
- Local autoreview found no actionable issues and rated patch correctness at 0.97.
- The broad changed gate could not acquire the configured Testbox backend; exact-head GitHub CI remains the broad validation gate.
