### PR TITLE
fix(cli): avoid duplicate config reads during plugin registration

### DIFF
--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable: vi.fn(),
   resolvePluginMetadataSnapshot: vi.fn(),
   loadConfig: vi.fn(),
+  getRuntimeConfigSnapshot: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
 }));
 
@@ -38,6 +39,7 @@ vi.mock("./plugin-metadata-snapshot.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: (...args: unknown[]) => mocks.loadConfig(...args),
+  getRuntimeConfigSnapshot: (...args: unknown[]) => mocks.getRuntimeConfigSnapshot(...args),
   loadConfig: (...args: unknown[]) => mocks.loadConfig(...args),
   readConfigFileSnapshot: (...args: unknown[]) => mocks.readConfigFileSnapshot(...args),
 }));
@@ -173,10 +175,13 @@ describe("registerPluginCliCommands", () => {
     }));
     mocks.loadConfig.mockReset();
     mocks.loadConfig.mockReturnValue({} as OpenClawConfig);
+    mocks.getRuntimeConfigSnapshot.mockReset();
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(null);
     mocks.readConfigFileSnapshot.mockReset();
     mocks.readConfigFileSnapshot.mockResolvedValue({
       valid: true,
       config: {},
+      runtimeConfig: {},
     });
   });
 
@@ -542,26 +547,42 @@ describe("registerPluginCliCommands", () => {
     expect(program.commands.map((command) => command.name())).not.toContain("missing-command");
   });
 
-  it("returns null for validated plugin CLI config when the snapshot is invalid", async () => {
+  it("reuses the validated cold snapshot runtime config without a second config read", async () => {
+    const snapshotConfig = { plugins: { enabled: true } } as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: {},
+      runtimeConfig: snapshotConfig,
+    });
+
+    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(snapshotConfig);
+    expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("preserves an already-active runtime config snapshot", async () => {
+    const snapshotConfig = { plugins: { enabled: true } } as OpenClawConfig;
+    const activeConfig = { plugins: { enabled: false } } as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: {},
+      runtimeConfig: snapshotConfig,
+    });
+    mocks.getRuntimeConfigSnapshot.mockReturnValueOnce(activeConfig);
+
+    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(activeConfig);
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits validated plugin CLI config when the snapshot is invalid", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValueOnce({
       valid: false,
       config: { plugins: { load: { paths: ["/tmp/evil"] } } },
     });
 
     await expect(loadValidatedConfigForPluginRegistration()).resolves.toBeNull();
+    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadConfig).not.toHaveBeenCalled();
-  });
-
-  it("loads validated plugin CLI config when the snapshot is valid", async () => {
-    const loadedConfig = { plugins: { enabled: true } } as OpenClawConfig;
-    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
-      valid: true,
-      config: loadedConfig,
-    });
-    mocks.loadConfig.mockReturnValueOnce(loadedConfig);
-
-    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(loadedConfig);
-    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
   });
 
   it("skips plugin CLI registration from validated config when the snapshot is invalid", async () => {
@@ -571,6 +592,7 @@ describe("registerPluginCliCommands", () => {
     });
 
     await expect(registerPluginCliCommandsFromValidatedConfig(createProgram())).resolves.toBeNull();
+    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,6 +1,6 @@
 // Registers plugin-related CLI commands.
 import type { Command } from "commander";
-import { getRuntimeConfig, readConfigFileSnapshot } from "../config/config.js";
+import { getRuntimeConfigSnapshot, readConfigFileSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createPluginCliLogger,
@@ -81,7 +81,7 @@ export const loadValidatedConfigForPluginRegistration =
     if (!snapshot.valid) {
       return null;
     }
-    return getRuntimeConfig();
+    return getRuntimeConfigSnapshot() ?? snapshot.runtimeConfig;
   };
 
 export async function getPluginCliCommandDescriptors(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI startup could read and normalize the same configuration twice before registering plugin-owned commands.

## Why This Change Was Made

Plugin CLI registration now reuses the validated runtime configuration returned by the initial snapshot read, while preserving an already-active runtime snapshot when the process has one. Invalid configuration still stops registration before any plugin runtime is loaded.

## User Impact

Commands that register plugin CLI surfaces avoid one redundant config read and normalization pass during startup, with unchanged validation and plugin-loading behavior.

## Evidence

- Focused Vitest coverage: 22/22 tests passed at the rebased head.
- Added regression coverage for cold snapshot reuse, active snapshot preservation, and invalid-config short-circuiting.
- Relevant changed checks, typecheck, lint, formatting, and `git diff --check` passed.
- Local autoreview found no actionable issues and rated patch correctness at 0.99.
