### PR TITLE
fix(workboard): diagnose archived cards still in an active status (#116359)

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -375,6 +375,7 @@ Diagnostics are computed from local card metadata. Built-in checks flag:
 | `repeated_failures`         | Card's tracked failure count reaches 2 or more.                                |
 | `missing_proof`             | `done` card with no proof, artifacts, or attachments.                          |
 | `orphaned_session`          | `running` card with a `sessionKey` but no `execution` metadata.                |
+| `archived_but_active`       | Archived card remains in any non-`done` lifecycle status.                      |
 
 ## Permissions
 

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -140,6 +140,20 @@ describe("registerWorkboardCli", () => {
     expect(defaultOutput).not.toContain("Archived card");
     expect(includeOutput).toContain("Active card");
     expect(includeOutput).toContain("Archived card");
+    expect(includeOutput).toContain("(archived)");
+  });
+
+  it("marks archived cards in show output", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const archived = await store.create({ title: "Archived card", status: "ready" });
+    await store.archive(archived.id, true);
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "show", archived.id], { from: "user" });
+    });
+
+    expect(output).toContain("Archived card (archived)");
   });
 
   it("preserves archived cards in JSON list output by default", async () => {

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -69,7 +69,8 @@ function isWorkboardStatus(value: string): value is WorkboardStatus {
 function formatCardLine(card: WorkboardCard): string {
   const boardId = card.metadata?.automation?.boardId ?? "default";
   const agent = card.agentId ? ` ${card.agentId}` : "";
-  return `${card.id.slice(0, 8)}  ${card.status.padEnd(8)}  ${card.priority.padEnd(6)}  ${boardId}${agent}  ${card.title}`;
+  const archived = card.metadata?.archivedAt ? " (archived)" : "";
+  return `${card.id.slice(0, 8)}  ${card.status.padEnd(8)}  ${card.priority.padEnd(6)}  ${boardId}${agent}  ${card.title}${archived}`;
 }
 
 function redactDispatchResult(result: WorkboardDispatchResult): WorkboardDispatchResult {

--- a/extensions/workboard/src/command.test.ts
+++ b/extensions/workboard/src/command.test.ts
@@ -291,6 +291,19 @@ describe("handleWorkboardCommand", () => {
     await expect(store.get(card.id)).resolves.toMatchObject({ status: "ready" });
   });
 
+  it("shows when an archived card is excluded from dispatch", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const api = createApi();
+    const card = await store.create({ title: "Archived slash card", status: "ready" });
+    await store.archive(card.id, true);
+
+    await expect(runWorkboardCommand({ api, store, args: `show ${card.id}` })).resolves.toEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("archived: yes (excluded from dispatch)"),
+      }),
+    );
+  });
+
   it("moves claimed cards for operators on slash-command surfaces", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const api = createApi();

--- a/extensions/workboard/src/command.ts
+++ b/extensions/workboard/src/command.ts
@@ -58,6 +58,9 @@ function formatCardDetails(card: WorkboardCard): string {
   if (card.runId) {
     lines.push(`run: ${card.runId}`);
   }
+  if (card.metadata?.archivedAt) {
+    lines.push("archived: yes (excluded from dispatch)");
+  }
   if (card.notes) {
     lines.push("", card.notes);
   }

--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -395,6 +395,25 @@ export function mergeDiagnostics(
 
 export function computeCardDiagnostics(card: WorkboardCard, now: number): WorkboardDiagnostic[] {
   if (card.metadata?.archivedAt) {
+    // An archived card is correctly excluded from automation, but if it is
+    // still in an active status (not done) it is silently undispatchable with
+    // no signal on any surface. Surface a diagnostic so `workboard show` and
+    // `store.diagnostics()` report it instead of leaving the operator to find
+    // it by reading the database (#116359).
+    if (card.status !== "done") {
+      return [
+        diagnostic(
+          {
+            kind: "archived_but_active",
+            severity: "warning",
+            title: "Archived card is still in an active status",
+            detail: `Card status is "${card.status}" but it is archived, so it is excluded from dispatch without any start failure or error. Unarchive it or move it to "done" to stop the silent skip.`,
+            actions: [{ kind: "unarchive", label: "Unarchive" }],
+          },
+          now,
+        ),
+      ];
+    }
     return [];
   }
   const diagnostics: WorkboardDiagnostic[] = [];

--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -395,11 +395,8 @@ export function mergeDiagnostics(
 
 export function computeCardDiagnostics(card: WorkboardCard, now: number): WorkboardDiagnostic[] {
   if (card.metadata?.archivedAt) {
-    // An archived card is correctly excluded from automation, but if it is
-    // still in an active status (not done) it is silently undispatchable with
-    // no signal on any surface. Surface a diagnostic so `workboard show` and
-    // `store.diagnostics()` report it instead of leaving the operator to find
-    // it by reading the database (#116359).
+    // Archived cards intentionally skip automation. Keep nonterminal cards
+    // visible as a transient diagnostic without rewriting archived metadata.
     if (card.status !== "done") {
       return [
         diagnostic(
@@ -408,7 +405,7 @@ export function computeCardDiagnostics(card: WorkboardCard, now: number): Workbo
             severity: "warning",
             title: "Archived card is still in an active status",
             detail: `Card status is "${card.status}" but it is archived, so it is excluded from dispatch without any start failure or error. Unarchive it or move it to "done" to stop the silent skip.`,
-            actions: [{ kind: "unarchive", label: "Unarchive" }],
+            actions: [],
           },
           now,
         ),

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { WORKBOARD_STATUSES } from "@openclaw/workboard-contract";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -2618,31 +2619,57 @@ describe("WorkboardStore", () => {
     });
   });
 
-  it("diagnoses archived cards that are still in an active status", async () => {
-    // An archived card with an active status (ready) is silently excluded from
-    // dispatch with no signal. computeCardDiagnostics must surface an
-    // archived_but_active warning so workboard show / store.diagnostics report
-    // it (#116359).
+  it.each(WORKBOARD_STATUSES)(
+    "reports archived %s cards according to terminal state",
+    async (status) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const card = await store.create({ title: `Archived ${status}`, status });
+
+      await store.archive(card.id, true);
+
+      const result = await store.diagnostics(Date.now());
+      if (status === "done") {
+        expect(result).toEqual({ diagnostics: [], count: 0 });
+        return;
+      }
+      expect(result).toMatchObject({
+        diagnostics: [
+          expect.objectContaining({
+            card: expect.objectContaining({ id: card.id }),
+            diagnostics: [
+              expect.objectContaining({
+                kind: "archived_but_active",
+                severity: "warning",
+                actions: [],
+              }),
+            ],
+          }),
+        ],
+        count: 1,
+      });
+    },
+  );
+
+  it("keeps archived-card diagnostics transient across lifecycle changes", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Archived but ready", status: "ready" });
     const now = Date.now();
 
     await store.archive(card.id, true);
 
+    await expect(store.refreshDiagnostics(now)).resolves.toEqual({ diagnostics: [], count: 0 });
+    await expect(store.get(card.id)).resolves.not.toHaveProperty("metadata.diagnostics");
     await expect(store.diagnostics(now)).resolves.toMatchObject({
-      diagnostics: [
-        expect.objectContaining({
-          card: expect.objectContaining({ id: card.id }),
-          diagnostics: [
-            expect.objectContaining({
-              kind: "archived_but_active",
-              severity: "warning",
-            }),
-          ],
-        }),
-      ],
+      diagnostics: [expect.objectContaining({ card: expect.objectContaining({ id: card.id }) })],
       count: 1,
     });
+
+    await store.archive(card.id, false);
+    await expect(store.diagnostics(now + 1)).resolves.toEqual({ diagnostics: [], count: 0 });
+
+    await store.archive(card.id, true);
+    await store.move(card.id, "done", undefined);
+    await expect(store.diagnostics(now + 2)).resolves.toEqual({ diagnostics: [], count: 0 });
   });
 
   it("does not drop concurrent updates while refreshing diagnostics", async () => {

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -2618,6 +2618,33 @@ describe("WorkboardStore", () => {
     });
   });
 
+  it("diagnoses archived cards that are still in an active status", async () => {
+    // An archived card with an active status (ready) is silently excluded from
+    // dispatch with no signal. computeCardDiagnostics must surface an
+    // archived_but_active warning so workboard show / store.diagnostics report
+    // it (#116359).
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Archived but ready", status: "ready" });
+    const now = Date.now();
+
+    await store.archive(card.id, true);
+
+    await expect(store.diagnostics(now)).resolves.toMatchObject({
+      diagnostics: [
+        expect.objectContaining({
+          card: expect.objectContaining({ id: card.id }),
+          diagnostics: [
+            expect.objectContaining({
+              kind: "archived_but_active",
+              severity: "warning",
+            }),
+          ],
+        }),
+      ],
+      count: 1,
+    });
+  });
+
   it("does not drop concurrent updates while refreshing diagnostics", async () => {
     let proofPromise: Promise<unknown> | undefined;
     let triggered = false;

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -71,6 +71,7 @@ export const WORKBOARD_DIAGNOSTIC_KINDS = [
   "repeated_failures",
   "missing_proof",
   "orphaned_session",
+  "archived_but_active",
 ] as const;
 export const WORKBOARD_DIAGNOSTIC_SEVERITIES = ["warning", "error", "critical"] as const;
 export const WORKBOARD_NOTIFICATION_KINDS = ["completed", "failed", "stale"] as const;
@@ -205,7 +206,15 @@ export type WorkboardClaim = {
 };
 
 export type WorkboardDiagnosticAction = {
-  kind: "claim" | "unblock" | "promote" | "reclaim" | "reassign" | "add_proof" | "open_session";
+  kind:
+    | "claim"
+    | "unblock"
+    | "promote"
+    | "reclaim"
+    | "reassign"
+    | "add_proof"
+    | "open_session"
+    | "unarchive";
   label: string;
 };
 

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -206,15 +206,7 @@ export type WorkboardClaim = {
 };
 
 export type WorkboardDiagnosticAction = {
-  kind:
-    | "claim"
-    | "unblock"
-    | "promote"
-    | "reclaim"
-    | "reassign"
-    | "add_proof"
-    | "open_session"
-    | "unarchive";
+  kind: "claim" | "unblock" | "promote" | "reclaim" | "reassign" | "add_proof" | "open_session";
   label: string;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Archived nonterminal Workboard cards are correctly excluded from dispatch, but current behavior gives operators no reason for the skip: dispatch starts nothing, diagnostics are empty, and text detail output does not mark the card as archived.

Fixes https://github.com/openclaw/openclaw/issues/116359

## Root Cause

The archive safety change in https://github.com/openclaw/openclaw/commit/ee9bc9a502c44c57e72d1697175156ea8f563aaf added the correct dispatch exclusion and an unconditional archived-card early return in `computeCardDiagnostics`. That commit is present in `v2026.7.2-beta.5` and `v2026.7.2-beta.6`. The exclusion was recorded nowhere operators could see.

## Canonical Fix

- Emit transient `archived_but_active` diagnostics for every archived non-`done` card.
- Mark archived cards in `openclaw workboard show` and `list --include-archived` text output.
- Show `archived: yes (excluded from dispatch)` in `/workboard show`.
- Keep `refreshDiagnostics` from rewriting archived metadata.
- Keep diagnostic `actions: []`; this PR does not invent an unsupported `unarchive` action contract.
- Add the shared diagnostic kind, docs, all-status coverage, lifecycle coverage, and CLI/chat output regressions.

This is the best owner-boundary repair: diagnostics record the exclusion reason where it occurs, while direct text surfaces expose the authoritative archive fact. It does not misclassify a non-attempt as `startFailures`, add storage/config/schema changes, or create a second recovery path.

## Evidence

Reviewed head: `b552c068c70a18adfe363b0a7e7361a5f1f0aafc`, rebased onto `main` `98c0d9deca5dff8346677c2a5ae5824301cb3516`.

This base includes PTY observability fix https://github.com/openclaw/openclaw/pull/117405 (`deabae48d3375dfb426e29e19ca625ba9cf2fcdc`). `git range-diff` reports both Workboard commits unchanged from the previously reviewed stack. Fresh exact-head evidence:

- Sanitized AWS focused Workboard lane: 3 files, 150/150 tests passed ([run_ecdd749592a9](https://crabbox.openclaw.ai/portal/runs/run_ecdd749592a9)).
- Sanitized AWS operator proof: CLI shows `(archived)`, `/workboard show` reports `archived: yes (excluded from dispatch)`, and diagnostics emit `archived_but_active` with `actions: []` ([run_519928b1e73e](https://crabbox.openclaw.ai/portal/runs/run_519928b1e73e)).
- Hosted real-behavior proof passed on the exact head.
- ClawSweeper reviewed the exact head at diamond 5/6 with sufficient proof and no findings.
- The first PR CI event hit GitHub’s zero-job merge-ref startup race; the repository’s bounded close/reopen recovery re-fired exact-head CI as [run 30737788192](https://github.com/openclaw/openclaw/actions/runs/30737788192). All selected jobs passed except the unrelated `checks-node-compact-large-2` gateway startup timing test, which exceeded its 120-second timeout after printing the expected proof sequence on both the initial attempt and the single failed-job retry. This PR does not touch `src/gateway`; the test is identical to current `main`, and the same shard passed on [main run 30736871812](https://github.com/openclaw/openclaw/actions/runs/30736871812). The required CI gate therefore remains red pending CI-owner resolution.

## Scope And Compatibility

Source: +22/-1 across four production files. Tests: +81. Docs: +1. The sole public contract change is one additive diagnostic kind. Built-in persistence and UI normalizers consume the same shared kind list in this change. There is no SQLite schema, persisted-shape, config, default, protocol-version, migration, or changelog change.

The contributor commit remains authored by @ruel225. The missing renderer idea from https://github.com/openclaw/openclaw/pull/116524 is credited here via @sloptop-the-terrible; that sibling PR should remain open until this canonical fix lands.