### PR TITLE
fix(update): keep rolled-back Git installs runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Git update rollback safety:** rebuild and verify the original checkout after post-build update failures, and keep the managed Gateway stopped when recovery cannot prove source, dependencies, build provenance, runtime stamps, CLI entry, and Control UI assets are coherent.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Git update rollback safety:** rebuild and verify the original checkout after post-build update failures, and keep the managed Gateway stopped when recovery cannot prove source, dependencies, build provenance, runtime stamps, CLI entry, and Control UI assets are coherent.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.
 - **Buzz plugin packaging:** keep the live QA runner on the shipped QA runner SDK surface and remove the obsolete package shrinkwrap so standalone npm and ClawHub package builds use current host exports and dependency resolutions. Thanks @shakkernerd.
 - **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  restart: vi.fn(async () => undefined),
+  restoreWindowsAutoStart: vi.fn(async () => true),
+  writeSentinel: vi.fn(async () => undefined),
+}));
+
+vi.mock("./progress.js", () => ({ printResult: vi.fn() }));
+vi.mock("./update-command-service.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./update-command-service.js")>()),
+  maybeRestartServiceAfterFailedMutableUpdate: mocks.restart,
+  restoreWindowsTaskAutoStartOrExit: mocks.restoreWindowsAutoStart,
+}));
+vi.mock("./update-command-post-core.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./update-command-post-core.js")>()),
+  writeControlPlaneUpdateRestartSentinelBestEffort: mocks.writeSentinel,
+}));
+
+import { finishUpdate } from "./update-command-post-update.js";
+
+type FinishUpdateParams = Parameters<typeof finishUpdate>[0];
+
+function failedResult(recovery: UpdateRunResult["recovery"]): UpdateRunResult {
+  return {
+    status: "error",
+    mode: "git",
+    reason: "doctor-failed",
+    recovery,
+    steps: [],
+    durationMs: 1,
+  };
+}
+
+async function finishFailedUpdate(result: UpdateRunResult): Promise<void> {
+  await finishUpdate({
+    result,
+    opts: {},
+    showProgress: false,
+    preManagedServiceStop: { stopped: true, serviceEnv: {} },
+    controlPlaneUpdateSentinelMeta: undefined,
+  } as FinishUpdateParams);
+}
+
+describe("failed Git update recovery restart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("restarts a managed Gateway after verified rollback recovery", async () => {
+    await finishFailedUpdate(failedResult({ serviceRestartSafe: true }));
+
+    expect(mocks.restart).toHaveBeenCalledOnce();
+  });
+
+  it("leaves a managed Gateway stopped after unverified rollback recovery", async () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+
+    await finishFailedUpdate(
+      failedResult({ serviceRestartSafe: false, reason: "runtime-verification-failed" }),
+    );
+
+    expect(mocks.restart).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Managed gateway remains stopped"));
+  });
+});

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -41,7 +41,7 @@ async function finishFailedUpdate(result: UpdateRunResult): Promise<void> {
     showProgress: false,
     preManagedServiceStop: { stopped: true, serviceEnv: {} },
     controlPlaneUpdateSentinelMeta: undefined,
-  } as FinishUpdateParams);
+  } as unknown as FinishUpdateParams);
 }
 
 describe("failed Git update recovery restart", () => {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -115,10 +115,20 @@ export async function finishUpdate(params: {
       result: params.result,
       jsonMode: Boolean(params.opts.json),
     });
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      preManagedServiceStop: params.preManagedServiceStop,
-      jsonMode: Boolean(params.opts.json),
-    });
+    if (params.result.recovery?.serviceRestartSafe === false) {
+      if (!params.opts.json) {
+        defaultRuntime.log(
+          theme.warn(
+            `Managed gateway remains stopped because update recovery could not prove a runnable installation (${params.result.recovery.reason}).`,
+          ),
+        );
+      }
+    } else {
+      await maybeRestartServiceAfterFailedMutableUpdate({
+        preManagedServiceStop: params.preManagedServiceStop,
+        jsonMode: Boolean(params.opts.json),
+      });
+    }
     defaultRuntime.exit(1);
     return;
   }

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveControlUiDistIndexHealth } from "./control-ui-assets.js";
+import { trimLogTail } from "./restart-sentinel.js";
+import type { UpdateChannel } from "./update-channels.js";
+import {
+  managerInstallArgs,
+  managerScriptArgs,
+  resolveUpdateBuildManager,
+} from "./update-package-manager.js";
+import { MAX_LOG_CHARS } from "./update-runner-command.js";
+import {
+  resolveBuildEnv,
+  resolveInstallEnv,
+  resolveRetryInstallArgs,
+  shouldRetryWindowsInstallIgnoringScripts,
+} from "./update-runner-git-commands.js";
+import type { CommandRunner, UpdateStepResult } from "./update-runner-types.js";
+
+type RecoveryReason =
+  | "manager-unavailable"
+  | "deps-install-failed"
+  | "build-failed"
+  | "runtime-verification-failed";
+
+type GitRuntimeRecovery =
+  | { serviceRestartSafe: true }
+  | { serviceRestartSafe: false; reason: RecoveryReason };
+
+async function readHead(filePath: string, field: "commit" | "head"): Promise<string | null> {
+  try {
+    const value = JSON.parse(await fs.readFile(filePath, "utf8")) as Record<string, unknown>;
+    return typeof value[field] === "string" ? value[field] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function rebuildRolledBackGitRuntime(params: {
+  gitRoot: string;
+  expectedSha: string;
+  channel: UpdateChannel;
+  runCommand: CommandRunner;
+  defaultCommandEnv: NodeJS.ProcessEnv | undefined;
+  timeoutMs: number;
+  steps: UpdateStepResult[];
+}): Promise<GitRuntimeRecovery> {
+  const appendStep = async (name: string, argv: string[], env?: NodeJS.ProcessEnv) => {
+    const started = Date.now();
+    const result = await params.runCommand(argv, {
+      cwd: params.gitRoot,
+      timeoutMs: params.timeoutMs,
+      env,
+    });
+    params.steps.push({
+      name,
+      command: argv.join(" "),
+      cwd: params.gitRoot,
+      durationMs: Date.now() - started,
+      exitCode: result.code,
+      stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
+      stderrTail: trimLogTail(result.stderr, MAX_LOG_CHARS),
+    });
+    return result.code === 0;
+  };
+  const appendFailure = (reason: RecoveryReason, detail: string): GitRuntimeRecovery => {
+    params.steps.push({
+      name: "git rollback runtime verify",
+      command: `verify rollback runtime ${params.expectedSha}`,
+      cwd: params.gitRoot,
+      durationMs: 0,
+      exitCode: 1,
+      stderrTail: detail,
+    });
+    return { serviceRestartSafe: false, reason };
+  };
+
+  const manager = await resolveUpdateBuildManager(
+    (argv, options) => params.runCommand(argv, { timeoutMs: options.timeoutMs, env: options.env }),
+    params.gitRoot,
+    params.timeoutMs,
+    params.defaultCommandEnv,
+    "require-preferred",
+  );
+  if (manager.kind === "missing-required") {
+    return appendFailure("manager-unavailable", manager.reason);
+  }
+  try {
+    const installEnv = resolveInstallEnv(manager.manager, manager.env);
+    let installed = await appendStep(
+      "git rollback deps install",
+      managerInstallArgs(manager.manager, {
+        compatFallback: manager.fallback && manager.manager === "npm",
+      }),
+      installEnv,
+    );
+    if (!installed && shouldRetryWindowsInstallIgnoringScripts(manager.manager)) {
+      const retryArgv = resolveRetryInstallArgs(manager.manager);
+      installed = retryArgv
+        ? await appendStep("git rollback deps install (ignore scripts)", retryArgv, installEnv)
+        : false;
+    }
+    if (!installed) {
+      return appendFailure("deps-install-failed", "failed to restore dependencies");
+    }
+    const built = await appendStep(
+      "git rollback build",
+      managerScriptArgs(manager.manager, "build"),
+      resolveBuildEnv(
+        manager.env,
+        params.channel === "dev"
+          ? path.join(params.gitRoot, ".artifacts", "build-all-cache")
+          : undefined,
+      ),
+    );
+    if (!built) {
+      return appendFailure("build-failed", "failed to rebuild the original checkout");
+    }
+
+    const distRoot = path.join(params.gitRoot, "dist");
+    const [commit, buildHead, runtimeHead, entryExists, uiHealth] = await Promise.all([
+      readHead(path.join(distRoot, "build-info.json"), "commit"),
+      readHead(path.join(distRoot, ".buildstamp"), "head"),
+      readHead(path.join(distRoot, ".runtime-postbuildstamp"), "head"),
+      Promise.any([
+        fs.stat(path.join(distRoot, "entry.js")),
+        fs.stat(path.join(distRoot, "entry.mjs")),
+      ]).then(
+        () => true,
+        () => false,
+      ),
+      resolveControlUiDistIndexHealth({ root: params.gitRoot }),
+    ]);
+    const verified =
+      commit === params.expectedSha &&
+      buildHead === params.expectedSha &&
+      runtimeHead === params.expectedSha &&
+      entryExists &&
+      uiHealth.exists;
+    params.steps.push({
+      name: "git rollback runtime verify",
+      command: `verify rollback runtime ${params.expectedSha}`,
+      cwd: params.gitRoot,
+      durationMs: 0,
+      exitCode: verified ? 0 : 1,
+      ...(verified
+        ? {}
+        : {
+            stderrTail: `rollback runtime mismatch (build=${commit ?? "missing"}, buildStamp=${buildHead ?? "missing"}, runtimeStamp=${runtimeHead ?? "missing"}, entry=${entryExists}, ui=${uiHealth.exists})`,
+          }),
+    });
+    return verified
+      ? { serviceRestartSafe: true }
+      : { serviceRestartSafe: false, reason: "runtime-verification-failed" };
+  } finally {
+    await manager.cleanup?.();
+  }
+}

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -27,6 +27,7 @@ import {
   shouldRetryWindowsInstallIgnoringScripts,
 } from "./update-runner-git-commands.js";
 import { runGitDevPreflight } from "./update-runner-git-preflight.js";
+import { rebuildRolledBackGitRuntime } from "./update-runner-git-recovery.js";
 import {
   prepareGitMutation,
   readBranchName,
@@ -94,6 +95,8 @@ export async function runGitUpdate(params: {
   let allowGatewayActivation = opts.allowGatewayActivation === true;
   let mutationPrepared = false;
   let createdDevBranchDuringUpdate = false;
+  let liveBuildStarted = false;
+  let recovery: UpdateRunResult["recovery"];
   const prepareMutation = async (revision: string) => {
     if (mutationPrepared) {
       return;
@@ -119,6 +122,7 @@ export async function runGitUpdate(params: {
     root: gitRoot,
     reason,
     before: { sha: beforeSha, version: beforeVersion },
+    ...(recovery ? { recovery } : {}),
     steps,
     durationMs: Date.now() - startedAt,
   });
@@ -141,22 +145,52 @@ export async function runGitUpdate(params: {
     });
     return result.code === 0;
   };
+  const verifyRollbackHead = async () => {
+    if (!beforeSha) {
+      return false;
+    }
+    const started = Date.now();
+    const result = await runCommand(["git", "-C", gitRoot, "rev-parse", "HEAD"], {
+      cwd: gitRoot,
+      timeoutMs,
+    });
+    const verified = result.code === 0 && result.stdout.trim() === beforeSha;
+    steps.push({
+      name: "git rollback verify HEAD",
+      command: `git -C ${gitRoot} rev-parse HEAD`,
+      cwd: gitRoot,
+      durationMs: Date.now() - started,
+      exitCode: verified ? 0 : 1,
+      stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
+      stderrTail: verified
+        ? trimLogTail(result.stderr, MAX_LOG_CHARS)
+        : `expected ${beforeSha}, found ${result.stdout.trim() || "unreadable HEAD"}`,
+    });
+    return verified;
+  };
   const rollback = async () => {
     if (!beforeSha) {
-      return;
+      return false;
     }
-    await appendRecoveryStep("git rollback clean", ["git", "-C", gitRoot, "reset", "--hard"]);
-    // Preflight requires a clean checkout outside generated Control UI assets,
-    // so preserve that excluded directory while removing update-created paths.
-    await appendRecoveryStep("git rollback clean untracked", [
+    let restored = await appendRecoveryStep("git rollback clean", [
       "git",
       "-C",
       gitRoot,
-      "clean",
-      "-fd",
-      "-e",
-      "dist/control-ui/",
+      "reset",
+      "--hard",
     ]);
+    // Preflight requires a clean checkout outside generated Control UI assets,
+    // so preserve that excluded directory while removing update-created paths.
+    restored =
+      (await appendRecoveryStep("git rollback clean untracked", [
+        "git",
+        "-C",
+        gitRoot,
+        "clean",
+        "-fd",
+        "-e",
+        "dist/control-ui/",
+      ])) && restored;
     if (branch && branch !== "HEAD") {
       const checkedOut = await appendRecoveryStep("git rollback checkout", [
         "git",
@@ -167,14 +201,15 @@ export async function runGitUpdate(params: {
         branch,
       ]);
       if (checkedOut) {
-        await appendRecoveryStep("git rollback reset", [
-          "git",
-          "-C",
-          gitRoot,
-          "reset",
-          "--hard",
-          beforeSha,
-        ]);
+        restored =
+          (await appendRecoveryStep("git rollback reset", [
+            "git",
+            "-C",
+            gitRoot,
+            "reset",
+            "--hard",
+            beforeSha,
+          ])) && restored;
         if (createdDevBranchDuringUpdate) {
           await appendRecoveryStep(`git rollback delete ${DEV_BRANCH}`, [
             "git",
@@ -186,16 +221,18 @@ export async function runGitUpdate(params: {
           ]);
         }
       }
-      return;
+      const verified = await verifyRollbackHead();
+      return restored && checkedOut && verified;
     }
-    await appendRecoveryStep("git rollback checkout", [
-      "git",
-      "-C",
-      gitRoot,
-      "checkout",
-      "--detach",
-      beforeSha,
-    ]);
+    restored =
+      (await appendRecoveryStep("git rollback checkout", [
+        "git",
+        "-C",
+        gitRoot,
+        "checkout",
+        "--detach",
+        beforeSha,
+      ])) && restored;
     if (createdDevBranchDuringUpdate) {
       await appendRecoveryStep(`git rollback delete ${DEV_BRANCH}`, [
         "git",
@@ -206,9 +243,27 @@ export async function runGitUpdate(params: {
         DEV_BRANCH,
       ]);
     }
+    const verified = await verifyRollbackHead();
+    return restored && verified;
   };
   const rollbackError = async (reason: string) => {
-    await rollback();
+    const sourceRestored = await rollback();
+    if (mutationPrepared) {
+      recovery = sourceRestored
+        ? { serviceRestartSafe: true }
+        : { serviceRestartSafe: false, reason: "source-rollback-failed" };
+    }
+    if (sourceRestored && liveBuildStarted && beforeSha) {
+      recovery = await rebuildRolledBackGitRuntime({
+        gitRoot,
+        expectedSha: beforeSha,
+        channel,
+        runCommand,
+        defaultCommandEnv,
+        timeoutMs,
+        steps,
+      });
+    }
     return buildError(reason);
   };
 
@@ -384,6 +439,7 @@ export async function runGitUpdate(params: {
     if (installStep.exitCode !== 0) {
       return await rollbackError("deps-install-failed");
     }
+    liveBuildStarted = true;
     const buildStep = await runStep(
       step(
         "build",

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -29,6 +29,17 @@ export type UpdateRunResult = {
   after?: { sha?: string | null; version?: string | null };
   steps: UpdateStepResult[];
   durationMs: number;
+  recovery?:
+    | { serviceRestartSafe: true }
+    | {
+        serviceRestartSafe: false;
+        reason:
+          | "source-rollback-failed"
+          | "manager-unavailable"
+          | "deps-install-failed"
+          | "build-failed"
+          | "runtime-verification-failed";
+      };
   postUpdate?: {
     plugins?: {
       status: "ok" | "warning" | "skipped" | "error";

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -3302,6 +3302,103 @@ describe("runGatewayUpdate", () => {
     expect(result.steps.at(-1)?.name).toMatch(/^git rollback/);
   });
 
+  it("rebuilds and verifies the original runtime before allowing restart after rollback", async () => {
+    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+    const beforeSha = "a".repeat(40);
+    const targetSha = "b".repeat(40);
+    const stableTag = "v1.0.1-1";
+    let currentHead = beforeSha;
+    let buildCount = 0;
+    const calls: string[] = [];
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const writeRuntime = async (head: string) => {
+      const distRoot = path.join(tempDir, "dist");
+      await fs.mkdir(path.join(distRoot, "control-ui"), { recursive: true });
+      await Promise.all([
+        fs.writeFile(path.join(distRoot, "entry.js"), "export {};\n", "utf8"),
+        fs.writeFile(
+          path.join(distRoot, "build-info.json"),
+          `${JSON.stringify({ commit: head })}\n`,
+          "utf8",
+        ),
+        fs.writeFile(path.join(distRoot, ".buildstamp"), `${JSON.stringify({ head })}\n`, "utf8"),
+        fs.writeFile(
+          path.join(distRoot, ".runtime-postbuildstamp"),
+          `${JSON.stringify({ head })}\n`,
+          "utf8",
+        ),
+        fs.writeFile(path.join(distRoot, "control-ui", "index.html"), "<html></html>", "utf8"),
+      ]);
+    };
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      calls.push(key);
+      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
+        return toCommandResult({ stdout: tempDir });
+      }
+      if (key === `git -C ${tempDir} rev-parse HEAD`) {
+        return toCommandResult({ stdout: `${currentHead}\n` });
+      }
+      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
+        return toCommandResult({ stdout: "main\n" });
+      }
+      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+        return toCommandResult();
+      }
+      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+        return toCommandResult();
+      }
+      if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
+        return toCommandResult({ stdout: `${stableTag}\n` });
+      }
+      if (key === `git -C ${tempDir} checkout --detach ${stableTag}`) {
+        currentHead = targetSha;
+        return toCommandResult();
+      }
+      if (key === `git -C ${tempDir} checkout --force main`) {
+        return toCommandResult();
+      }
+      if (key === `git -C ${tempDir} reset --hard ${beforeSha}`) {
+        currentHead = beforeSha;
+        return toCommandResult();
+      }
+      if (key === "pnpm install") {
+        return toCommandResult();
+      }
+      if (key === "pnpm build") {
+        buildCount += 1;
+        await writeRuntime(currentHead);
+        return toCommandResult();
+      }
+      if (key === doctorCommand) {
+        return toCommandResult({ code: 1, stderr: "doctor failed after build" });
+      }
+      return toCommandResult();
+    };
+
+    const result = await runWithCommand(runCommand, { channel: "stable" });
+
+    expect(result).toMatchObject({
+      status: "error",
+      reason: "doctor-failed",
+      recovery: { serviceRestartSafe: true },
+    });
+    expect(buildCount).toBe(2);
+    expect(currentHead).toBe(beforeSha);
+    expect(
+      JSON.parse(await fs.readFile(path.join(tempDir, "dist", "build-info.json"), "utf8")),
+    ).toMatchObject({ commit: beforeSha });
+    expect(result.steps.at(-1)).toMatchObject({
+      name: "git rollback runtime verify",
+      exitCode: 0,
+    });
+    expect(calls.indexOf(doctorCommand)).toBeLessThan(
+      calls.lastIndexOf(`git -C ${tempDir} rev-parse HEAD`),
+    );
+    expect(calls.lastIndexOf("pnpm install")).toBeLessThan(calls.lastIndexOf("pnpm build"));
+  });
+
   it("repairs UI assets when doctor run removes control-ui files", async () => {
     await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
     const uiIndexPath = await setupUiIndex();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Git-based update could build the new checkout, fail during doctor or post-build validation, roll source back to the original commit, and then restart the managed Gateway with the newer build output still on disk. That mixed source/build installation could crash-loop instead of recovering the previous working Gateway.

## Why This Change Was Made

Git rollback now owns runtime recovery as one transaction. Once a live build has started, it restores the original commit, resolves that commit's package manager, reinstalls dependencies, rebuilds the original runtime, and verifies the build commit, both local build stamps, CLI entry, and Control UI assets against the original SHA. The update result records whether service restart is safe; an unverified recovery leaves the managed Gateway stopped with explicit guidance.

This keeps the existing fast path and preflight build-cache optimization unchanged. Recovery work runs only after a failed mutable update whose live build started.

## User Impact

Operators get the previous runnable installation back after a post-build Git update failure. If that recovery itself fails, OpenClaw no longer guesses that restart is safe or starts a mixed installation.

## Evidence

- Reproduced before the fix in a real temporary Git checkout: doctor failure left old source with the new `dist` marker.
- `node scripts/run-vitest.mjs src/infra/update-runner.test.ts` — 66/66 tests passed after rebasing onto current `main`.
- New regression exercises new-build success → doctor failure → Git rollback → original dependency install/build → exact original runtime verification.
- Blacksmith Testbox changed gate passed: core and core-test typechecks, changed-file lint, formatting, dead-export scan, plugin boundaries, import-cycle guard, SQLite/schema guards, and related repository checks. Run: https://github.com/openclaw/openclaw/actions/runs/30690793261
- Codex autoreview: clean, no accepted/actionable findings.
