### PR TITLE
fix(sessions): distinguish transient lookup failures from policy denials

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -442,7 +442,13 @@ function resetSessionStore(inputStore: Record<string, SessionEntry>) {
     if (request.method === "sessions.resolve") {
       const key = typeof request.params?.key === "string" ? request.params.key.trim() : "";
       if (key && store[key]) {
-        return { key };
+        const spawnedBy =
+          typeof request.params?.spawnedBy === "string" ? request.params.spawnedBy.trim() : "";
+        const entry = store[key];
+        if (!spawnedBy || entry.spawnedBy === spawnedBy || entry.parentSessionKey === spawnedBy) {
+          return { key };
+        }
+        return {};
       }
       const sessionId =
         typeof request.params?.sessionId === "string" ? request.params.sessionId.trim() : "";
@@ -508,9 +514,23 @@ function installSameAgentVisibility(visibility: "self" | "tree" | "agent") {
 
 function mockSpawnedSessionList(
   resolveSessions: (spawnedBy: string | undefined) => Array<Record<string, unknown>>,
+  resolveSessionId?: (sessionId: string) => string | undefined,
 ) {
   callGatewayMock.mockImplementation(async (opts: unknown) => {
     const request = opts as { method?: string; params?: Record<string, unknown> };
+    if (request.method === "sessions.resolve") {
+      const key = typeof request.params?.key === "string" ? request.params.key.trim() : "";
+      const spawnedBy = request.params?.spawnedBy as string | undefined;
+      if (key && resolveSessions(spawnedBy).some((session) => session.key === key)) {
+        return { key };
+      }
+      const sessionId =
+        typeof request.params?.sessionId === "string" ? request.params.sessionId.trim() : "";
+      if (sessionId && !spawnedBy) {
+        return { key: resolveSessionId?.(sessionId) };
+      }
+      return {};
+    }
     if (request.method === "sessions.list") {
       return { sessions: resolveSessions(request.params?.spawnedBy as string | undefined) };
     }
@@ -518,18 +538,14 @@ function mockSpawnedSessionList(
   });
 }
 
-function expectSpawnedSessionLookupCalls(spawnedBy: string) {
-  const expectedCall = {
-    method: "sessions.list",
-    params: {
-      includeGlobal: false,
-      includeUnknown: false,
-      spawnedBy,
-    },
-  };
-  expect(callGatewayMock).toHaveBeenCalledTimes(2);
-  expect(callGatewayMock).toHaveBeenNthCalledWith(1, expectedCall);
-  expect(callGatewayMock).toHaveBeenNthCalledWith(2, expectedCall);
+function expectSpawnedSessionLookupCalls(spawnedBy: string, targetKeys: string[]) {
+  expect(callGatewayMock).toHaveBeenCalledTimes(targetKeys.length);
+  for (const [index, key] of targetKeys.entries()) {
+    expect(callGatewayMock).toHaveBeenNthCalledWith(index + 1, {
+      method: "sessions.resolve",
+      params: { agentId: "main", allowMissing: true, key, spawnedBy },
+    });
+  }
 }
 
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
@@ -2246,7 +2262,7 @@ describe("session_status tool", () => {
     const tool = getSessionStatusTool("agent:main:main");
 
     await expect(tool.execute("call5", { sessionKey: "agent:other:main" })).rejects.toThrow(
-      "Agent-to-agent status is disabled",
+      "Session status visibility is restricted",
     );
   });
 
@@ -2302,10 +2318,11 @@ describe("session_status tool", () => {
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock).toHaveBeenCalledWith({
-      method: "sessions.list",
+      method: "sessions.resolve",
       params: {
-        includeGlobal: false,
-        includeUnknown: false,
+        agentId: "main",
+        allowMissing: true,
+        key: "agent:main:main",
         spawnedBy: "agent:main:subagent:child",
       },
     });
@@ -2390,7 +2407,10 @@ describe("session_status tool", () => {
 
     expect(loadSessionStoreMock).not.toHaveBeenCalled();
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
-    expectSpawnedSessionLookupCalls("agent:main:subagent:child");
+    expectSpawnedSessionLookupCalls("agent:main:subagent:child", [
+      "agent:main:main",
+      "agent:main:subagent:missing",
+    ]);
   });
 
   it("blocks sandboxed child bare main session_status access outside its tree", async () => {
@@ -2424,10 +2444,11 @@ describe("session_status tool", () => {
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock).toHaveBeenCalledWith({
-      method: "sessions.list",
+      method: "sessions.resolve",
       params: {
-        includeGlobal: false,
-        includeUnknown: false,
+        agentId: "main",
+        allowMissing: true,
+        key: "main",
         spawnedBy: "agent:main:subagent:child",
       },
     });
@@ -2438,13 +2459,15 @@ describe("session_status tool", () => {
       name: "blocks sandboxed child session_status access to another agent sessionId before store lookup",
       sessionId: "s-other",
       callId: "call6-session-id",
+      expectedError: "Session status visibility is restricted.",
     },
     {
       name: "blocks sandboxed child session_status parent sessionId access outside its tree",
       sessionId: "s-parent",
       callId: "call7-parent-session-id",
+      expectedError: "Session status visibility is restricted to the current session tree",
     },
-  ])("$name", async ({ sessionId, callId }) => {
+  ])("$name", async ({ sessionId, callId, expectedError }) => {
     resetSessionStore({
       "agent:main:subagent:child": {
         sessionId: "s-child",
@@ -2459,12 +2482,19 @@ describe("session_status tool", () => {
         : {}),
     });
     installSandboxedSessionStatusConfig();
-    mockSpawnedSessionList(() => []);
+    mockSpawnedSessionList(
+      () => [],
+      (value) =>
+        value === sessionId
+          ? sessionId === "s-other"
+            ? "agent:other:main"
+            : "agent:main:main"
+          : undefined,
+    );
 
     const tool = getSessionStatusTool("agent:main:subagent:child", {
       sandboxed: true,
     });
-    const expectedError = "Session status visibility is restricted to the current session tree";
 
     await expect(
       tool.execute(callId, {
@@ -2476,28 +2506,30 @@ describe("session_status tool", () => {
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
     expect(callGatewayMock).toHaveBeenCalledTimes(3);
     expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
-      method: "sessions.list",
+      method: "sessions.resolve",
       params: {
-        includeGlobal: false,
-        includeUnknown: false,
-        spawnedBy: "agent:main:subagent:child",
+        agentId: "main",
+        key: sessionId,
+        spawnedBy: undefined,
       },
     });
     expect(callGatewayMock).toHaveBeenNthCalledWith(2, {
       method: "sessions.resolve",
       params: {
-        agentId: "main",
-        key: sessionId,
-        spawnedBy: "agent:main:subagent:child",
+        agentId: undefined,
+        sessionId,
+        spawnedBy: undefined,
+        includeGlobal: true,
+        includeUnknown: true,
       },
     });
     expect(callGatewayMock).toHaveBeenNthCalledWith(3, {
       method: "sessions.resolve",
       params: {
-        sessionId,
+        agentId: sessionId === "s-other" ? "other" : "main",
+        allowMissing: true,
+        key: sessionId === "s-other" ? "agent:other:main" : "agent:main:main",
         spawnedBy: "agent:main:subagent:child",
-        includeGlobal: false,
-        includeUnknown: false,
       },
     });
   });
@@ -2534,7 +2566,7 @@ describe("session_status tool", () => {
     expect(childDetails.ok).toBe(true);
     expect(childDetails.sessionKey).toBe("agent:main:subagent:child");
 
-    expectSpawnedSessionLookupCalls("main");
+    expectSpawnedSessionLookupCalls("main", ["agent:main:subagent:child"]);
   });
 
   it("scopes bare session keys to the requester agent", async () => {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -2343,6 +2343,39 @@ describe("session_status tool", () => {
     expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks explicit incognito session_status before opening its store", async () => {
+    const incognitoSessionKey = "agent:main:dashboard:incognito-private";
+    resetSessionStore({
+      "agent:main:main": { sessionId: "s-main", updatedAt: 10 },
+      [incognitoSessionKey]: {
+        sessionId: "s-incognito",
+        updatedAt: 20,
+        incognito: true,
+      },
+    });
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        sessions: { visibility: "agent" },
+        agentToAgent: { enabled: true, allow: ["*"] },
+      },
+      agents: { defaults: { model: { primary: "openai/gpt-5.4" }, models: {} } },
+    };
+
+    const tool = getSessionStatusTool("agent:main:main");
+
+    await expect(
+      tool.execute("call-incognito-status", {
+        sessionKey: incognitoSessionKey,
+        model: "default",
+      }),
+    ).rejects.toThrow(`Session not visible from session tools: ${incognitoSessionKey}`);
+
+    expect(loadSessionStoreMock).not.toHaveBeenCalled();
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(buildStatusMessageMock).not.toHaveBeenCalled();
+  });
+
   it("blocks unsandboxed sessionId session_status outside tree visibility before mutation", async () => {
     installSameAgentVisibility("tree");
     callGatewayMock.mockImplementation(async (opts: unknown) => {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -2493,14 +2493,16 @@ describe("session_status tool", () => {
       sessionId: "s-other",
       callId: "call6-session-id",
       expectedError: "Session status visibility is restricted.",
+      checksOwnership: false,
     },
     {
       name: "blocks sandboxed child session_status parent sessionId access outside its tree",
       sessionId: "s-parent",
       callId: "call7-parent-session-id",
       expectedError: "Session status visibility is restricted to the current session tree",
+      checksOwnership: true,
     },
-  ])("$name", async ({ sessionId, callId, expectedError }) => {
+  ])("$name", async ({ sessionId, callId, expectedError, checksOwnership }) => {
     resetSessionStore({
       "agent:main:subagent:child": {
         sessionId: "s-child",
@@ -2537,7 +2539,7 @@ describe("session_status tool", () => {
 
     expect(loadSessionStoreMock).not.toHaveBeenCalled();
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
-    expect(callGatewayMock).toHaveBeenCalledTimes(3);
+    expect(callGatewayMock).toHaveBeenCalledTimes(checksOwnership ? 3 : 2);
     expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
       method: "sessions.resolve",
       params: {
@@ -2556,15 +2558,17 @@ describe("session_status tool", () => {
         includeUnknown: true,
       },
     });
-    expect(callGatewayMock).toHaveBeenNthCalledWith(3, {
-      method: "sessions.resolve",
-      params: {
-        agentId: sessionId === "s-other" ? "other" : "main",
-        allowMissing: true,
-        key: sessionId === "s-other" ? "agent:other:main" : "agent:main:main",
-        spawnedBy: "agent:main:subagent:child",
-      },
-    });
+    if (checksOwnership) {
+      expect(callGatewayMock).toHaveBeenNthCalledWith(3, {
+        method: "sessions.resolve",
+        params: {
+          agentId: "main",
+          allowMissing: true,
+          key: "agent:main:main",
+          spawnedBy: "agent:main:subagent:child",
+        },
+      });
+    }
   });
 
   it("keeps legacy main requester keys for sandboxed session tree checks", async () => {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -2373,6 +2373,46 @@ describe("session_status tool", () => {
 
     expect(loadSessionStoreMock).not.toHaveBeenCalled();
     expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(buildStatusMessageMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "semantic current", args: { sessionKey: "current" } },
+    { label: "implicit no-arg", args: {} },
+  ])("blocks $label incognito live-run status before opening its store", async ({ args }) => {
+    const requesterSessionKey = "agent:main:telegram:default:direct:1234";
+    const incognitoSessionKey = "agent:main:dashboard:incognito-live-run";
+    resetSessionStore({
+      [requesterSessionKey]: { sessionId: "s-requester", updatedAt: 10 },
+      [incognitoSessionKey]: {
+        sessionId: "s-incognito-live-run",
+        updatedAt: 20,
+        incognito: true,
+      },
+    });
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        sessions: { visibility: "agent" },
+        agentToAgent: { enabled: true, allow: ["*"] },
+      },
+      agents: { defaults: { model: { primary: "openai/gpt-5.4" }, models: {} } },
+    };
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: requesterSessionKey,
+      runSessionKey: incognitoSessionKey,
+      config: mockConfig as never,
+    });
+
+    await expect(
+      tool.execute(`call-incognito-${args.sessionKey ?? "implicit"}`, args),
+    ).rejects.toThrow(`Session not visible from session tools: ${incognitoSessionKey}`);
+
+    expect(loadSessionStoreMock).not.toHaveBeenCalled();
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).not.toHaveBeenCalled();
     expect(buildStatusMessageMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -56,11 +56,11 @@ describe("sessions tools visibility", () => {
       tools: { agentToAgent: { enabled: false } },
     };
     mockGatewayWithHistory((req) => {
-      if (req.method === "sessions.list" && req.params?.spawnedBy === "main") {
-        return { sessions: [{ key: "subagent:child-1" }] };
-      }
       if (req.method === "sessions.resolve") {
         const key = typeof req.params?.key === "string" ? req.params.key : "";
+        if (req.params?.spawnedBy === "main" && key !== "subagent:child-1") {
+          return {};
+        }
         return { key };
       }
       return undefined;
@@ -100,8 +100,8 @@ describe("sessions tools visibility", () => {
       agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
     };
     mockGatewayWithHistory((req) => {
-      if (req.method === "sessions.list" && req.params?.spawnedBy === "main") {
-        return { sessions: [] };
+      if (req.method === "sessions.resolve" && req.params?.spawnedBy === "main") {
+        return {};
       }
       return undefined;
     });

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1205,7 +1205,7 @@ describe("sessions tools", () => {
         delivery: { status: "skipped", mode: "announce" },
         watched: false,
       });
-      expect(calls.map((call) => call.method)).toEqual(["sessions.resolve", "agent"]);
+      expect(calls.map((call) => call.method)).toEqual(["agent"]);
     } finally {
       unregister();
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1205,11 +1205,7 @@ describe("sessions tools", () => {
         delivery: { status: "skipped", mode: "announce" },
         watched: false,
       });
-      expect(calls.map((call) => call.method)).toEqual([
-        "sessions.resolve",
-        "sessions.list",
-        "agent",
-      ]);
+      expect(calls.map((call) => call.method)).toEqual(["sessions.resolve", "agent"]);
     } finally {
       unregister();
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -91,11 +91,11 @@ import {
 } from "./session-status-session-resolve.js";
 import {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
   resolveCurrentSessionClientAlias,
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxedSessionToolContext,
   resolveSessionReference,
+  resolveSessionToolAccess,
   resolveVisibleSessionReference,
   shouldResolveSessionIdInput,
 } from "./sessions-helpers.js";
@@ -589,11 +589,12 @@ export function createSessionStatusTool(opts?: {
       const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
       const changesSince = readNonNegativeIntegerParam(params, "changesSince");
       const cfg = opts?.config ?? getRuntimeConfig();
-      const { mainKey, alias, effectiveRequesterKey } = resolveSandboxedSessionToolContext({
-        cfg,
-        agentSessionKey: opts?.agentSessionKey,
-        sandboxed: opts?.sandboxed,
-      });
+      const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
+        resolveSandboxedSessionToolContext({
+          cfg,
+          agentSessionKey: opts?.agentSessionKey,
+          sandboxed: opts?.sandboxed,
+        });
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const requesterAgentId = resolveSessionAgentIds({
         config: cfg,
@@ -639,18 +640,63 @@ export function createSessionStatusTool(opts?: {
         }
         return trimmed;
       };
-      const visibilityGuard = await createSessionVisibilityGuard({
-        action: "status",
-        defaultAgentId: requesterAgentId,
-        requesterAgentId,
-        requesterSessionKey: visibilityRequesterKey,
-        visibility: resolveEffectiveSessionToolsVisibility({
-          cfg,
-          sandboxed: opts?.sandboxed === true,
-        }),
-        a2aPolicy,
-        callGateway: gatewayCall,
+      const sessionVisibility = resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: opts?.sandboxed === true,
       });
+      const accessByTarget = new Map<
+        string,
+        Awaited<ReturnType<typeof resolveSessionToolAccess>>
+      >();
+      const checkVisibilityAccess = async (target: {
+        targetSessionKey: string;
+        targetAgentId: string;
+        authorizationTargetSessionKey: string;
+        requesterOwned: boolean;
+      }) => {
+        const cacheKey = `${target.requesterOwned ? "owned" : "unowned"}:${target.targetAgentId}:${target.targetSessionKey}:${target.authorizationTargetSessionKey}`;
+        const cached = accessByTarget.get(cacheKey);
+        if (cached) {
+          return cached;
+        }
+        let access = await resolveSessionToolAccess({
+          action: "status",
+          defaultAgentId: configuredDefaultAgentId,
+          requesterAgentId,
+          requesterSessionKey: visibilityRequesterKey,
+          authorizationTargetSessionKey: target.authorizationTargetSessionKey,
+          targetAgentId: target.targetAgentId,
+          targetSessionKey: target.targetSessionKey,
+          requesterOwned: target.requesterOwned,
+          visibility: sessionVisibility,
+          a2aPolicy,
+          callGateway: gatewayCall,
+        });
+        if (
+          !access.allowed &&
+          target.targetAgentId !== requesterAgentId &&
+          !target.requesterOwned &&
+          !target.authorizationTargetSessionKey.startsWith("agent:") &&
+          !access.error.includes("ownership lookup failed")
+        ) {
+          if (!a2aPolicy.enabled) {
+            access = {
+              allowed: false,
+              status: "forbidden",
+              error:
+                "Agent-to-agent status is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent access.",
+            };
+          } else if (!a2aPolicy.isAllowed(requesterAgentId, target.targetAgentId)) {
+            access = {
+              allowed: false,
+              status: "forbidden",
+              error: "Agent-to-agent session status denied by tools.agentToAgent.allow.",
+            };
+          }
+        }
+        accessByTarget.set(cacheKey, access);
+        return access;
+      };
 
       const requestedKeyParam = readToolStringParam(params, "sessionKey");
       const isImplicitRunSessionStatus =
@@ -698,36 +744,7 @@ export function createSessionStatusTool(opts?: {
         throw new Error("sessionKey required");
       }
       requestedKeyRaw = requestedKeyInput;
-      const ensureAgentAccess = (targetAgentId: string) => {
-        if (targetAgentId === requesterAgentId) {
-          return;
-        }
-        // Gate cross-agent access behind tools.agentToAgent settings.
-        if (!a2aPolicy.enabled) {
-          throw new Error(
-            "Agent-to-agent status is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent access.",
-          );
-        }
-        if (!a2aPolicy.isAllowed(requesterAgentId, targetAgentId)) {
-          throw new Error("Agent-to-agent session status denied by tools.agentToAgent.allow.");
-        }
-      };
-
-      if (requestedKeyInput.startsWith("agent:") && !isSemanticCurrentRequest) {
-        const requestedAgentId = resolveAgentIdFromSessionKey(
-          requestedKeyInput,
-          configuredDefaultAgentId,
-        );
-        ensureAgentAccess(requestedAgentId);
-        const visibilityTargetKey = normalizeVisibilityTargetSessionKey(
-          requestedKeyInput,
-          requestedAgentId,
-        );
-        const access = visibilityGuard.check(visibilityTargetKey);
-        if (!access.allowed) {
-          throw new Error(access.error);
-        }
-      }
+      let resolvedRequesterOwned = false;
 
       const deferTargetOwnerResolution =
         !isSemanticCurrentRequest && shouldResolveSessionIdInput(requestedKeyInput);
@@ -739,7 +756,18 @@ export function createSessionStatusTool(opts?: {
             requesterAgentId,
           });
       if (!isSemanticCurrentRequest && !deferTargetOwnerResolution) {
-        ensureAgentAccess(agentId);
+        const access = await checkVisibilityAccess({
+          targetSessionKey: requestedKeyInput,
+          targetAgentId: agentId,
+          authorizationTargetSessionKey: normalizeVisibilityTargetSessionKey(
+            requestedKeyInput,
+            agentId,
+          ),
+          requesterOwned: false,
+        });
+        if (!access.allowed) {
+          throw new Error(access.error);
+        }
       }
       let storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
       let storeScopedRequesterKey = resolveStoreScopedRequesterKey({
@@ -766,13 +794,14 @@ export function createSessionStatusTool(opts?: {
         (requestedKeyInput === "current" || shouldResolveSessionIdInput(requestedKeyInput))
       ) {
         const resolvedSession = await resolveSessionReference({
+          action: "status",
           sessionKey: requestedKeyInput,
           ...(requestedKeyInput === "current" ? { agentId: requesterAgentId } : {}),
           keyAgentId: requesterAgentId,
           alias,
           mainKey,
           requesterInternalKey: effectiveRequesterKey,
-          restrictToSpawned: opts?.sandboxed === true,
+          restrictToSpawned,
           callGateway: gatewayCall,
         });
         if (resolvedSession.ok) {
@@ -790,14 +819,27 @@ export function createSessionStatusTool(opts?: {
             // watched-group carve-out); a local string here would drift from it.
             throw new Error(visibleSession.error);
           }
-          // If resolution points at another agent, enforce A2A policy before switching stores.
           const visibleAgentId = resolveSessionToolTargetAgentId({
             cfg,
             targetSessionKey: visibleSession.key,
             resolvedAgentId: visibleSession.agentId,
             requesterAgentId,
           });
-          ensureAgentAccess(visibleAgentId);
+          if (opts?.sandboxed === true || visibleAgentId !== requesterAgentId) {
+            const access = await checkVisibilityAccess({
+              targetSessionKey: visibleSession.key,
+              targetAgentId: visibleAgentId,
+              authorizationTargetSessionKey: normalizeVisibilityTargetSessionKey(
+                visibleSession.key,
+                visibleAgentId,
+              ),
+              requesterOwned: visibleSession.requesterOwned,
+            });
+            if (!access.allowed) {
+              throw new Error(access.error);
+            }
+          }
+          resolvedRequesterOwned = visibleSession.requesterOwned;
           resolvedViaSessionId = resolvedSession.resolvedViaSessionId;
           requestedKeyRaw = visibleSession.key;
           requestedKeyInput = requestedKeyRaw.trim();
@@ -816,8 +858,11 @@ export function createSessionStatusTool(opts?: {
             mainKey,
             requesterInternalKey: storeScopedRequesterKey,
           });
-        } else if (!resolvedSession.ok && opts?.sandboxed === true) {
-          throw new Error("Session status visibility is restricted to the current session tree.");
+        } else if (
+          !resolvedSession.ok &&
+          (!resolvedSession.notFound || resolvedSession.status === "forbidden")
+        ) {
+          throw new Error(resolvedSession.error);
         }
       }
 
@@ -900,7 +945,12 @@ export function createSessionStatusTool(opts?: {
       const visibilityTargetKey = shouldTreatVisibilityTargetAsSelf
         ? visibilityRequesterKey
         : normalizeVisibilityTargetSessionKey(resolved.key, agentId);
-      const access = visibilityGuard.check(visibilityTargetKey);
+      const access = await checkVisibilityAccess({
+        targetSessionKey: resolved.key,
+        targetAgentId: agentId,
+        authorizationTargetSessionKey: visibilityTargetKey,
+        requesterOwned: resolvedRequesterOwned,
+      });
       if (!access.allowed) {
         throw new Error(access.error);
       }

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -27,6 +27,7 @@ import {
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   buildAgentMainSessionKey,
+  isIncognitoSessionKey,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
@@ -755,7 +756,11 @@ export function createSessionStatusTool(opts?: {
             targetSessionKey: requestedKeyInput,
             requesterAgentId,
           });
-      if (!isSemanticCurrentRequest && !deferTargetOwnerResolution) {
+      // Semantic current is self for ordinary visibility, but its live-run key can
+      // still be process-only. Preserve that target for the shared guard before storage.
+      const mustCheckRequestedKeyBeforeStore =
+        !isSemanticCurrentRequest || isIncognitoSessionKey(requestedKeyInput);
+      if (mustCheckRequestedKeyBeforeStore && !deferTargetOwnerResolution) {
         const access = await checkVisibilityAccess({
           targetSessionKey: requestedKeyInput,
           targetAgentId: agentId,
@@ -942,9 +947,10 @@ export function createSessionStatusTool(opts?: {
         (!resolvedViaSessionId &&
           (requestedKeyInput === "current" ||
             (resolved.key === requestedKeyInput && agentId === requesterAgentId)));
-      const visibilityTargetKey = shouldTreatVisibilityTargetAsSelf
-        ? visibilityRequesterKey
-        : normalizeVisibilityTargetSessionKey(resolved.key, agentId);
+      const visibilityTargetKey =
+        shouldTreatVisibilityTargetAsSelf && !isIncognitoSessionKey(resolved.key)
+          ? visibilityRequesterKey
+          : normalizeVisibilityTargetSessionKey(resolved.key, agentId);
       const access = await checkVisibilityAccess({
         targetSessionKey: resolved.key,
         targetAgentId: agentId,

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -505,19 +505,26 @@ describe("createSessionVisibilityGuard", () => {
   });
 
   it("blocks cross-agent send when agent-to-agent is disabled", async () => {
-    const guard = await createSessionVisibilityGuard({
-      action: "send",
-      requesterSessionKey: "agent:main:main",
-      visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => ({ sessions: [] })) as never,
     });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "send",
+        requesterSessionKey: "agent:main:main",
+        visibility: "all",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
 
-    expect(guard.check("agent:ops:main")).toEqual({
-      allowed: false,
-      status: "forbidden",
-      error:
-        "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
-    });
+      expect(guard.check("agent:ops:main")).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error:
+          "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+      });
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
   });
 
   it("enforces self visibility for same-agent sessions", async () => {
@@ -562,22 +569,32 @@ describe("createSessionVisibilityGuard", () => {
 
   it.each([
     {
-      name: "cross-agent ACP child",
+      name: "cross-agent ACP child under tree visibility",
       target: "agent:codex:acp:child-1",
+      visibility: "tree" as const,
+      error:
+        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+    },
+    {
+      name: "cross-agent ACP child under all visibility",
+      target: "agent:codex:acp:child-1",
+      visibility: "all" as const,
       error:
         "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
     },
     {
       name: "malformed agent key",
       target: "agent:",
+      visibility: "tree" as const,
       error: "Session history denied because target agent ownership is unavailable.",
     },
     {
       name: "unscoped alias without a default agent",
       target: "main",
+      visibility: "tree" as const,
       error: "Session history denied because target agent ownership is unavailable.",
     },
-  ])("handles $name when the ownership lookup fails", async ({ target, error }) => {
+  ])("handles $name when the ownership lookup fails", async ({ target, visibility, error }) => {
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
@@ -591,7 +608,7 @@ describe("createSessionVisibilityGuard", () => {
       const guard = await createSessionVisibilityGuard({
         action: "history",
         requesterSessionKey: "agent:main:main",
-        visibility: "tree",
+        visibility,
         a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       });
 

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -537,6 +537,43 @@ describe("createSessionVisibilityGuard", () => {
     });
   });
 
+  it("preserves cross-agent policy denials when the spawned lookup fails", async () => {
+    // A failed spawned ownership lookup must not relabel a deterministic
+    // cross-agent denial as retryable: retrying the lookup cannot make a known
+    // `agent:other:*` target eligible, so the cross-visibility refusal is
+    // preserved as-is (review P2: preserve cross-agent policy denials).
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => {
+        throw new GatewayClientRequestError({
+          code: "UNAVAILABLE",
+          message: "transport timeout",
+          retryable: true,
+        });
+      }) as never,
+    });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
+
+      const result = guard.check("agent:other:main");
+      expect(result).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error:
+          "Session history visibility is restricted. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access; use tools.agentToAgent.allow to restrict permitted agent pairs.",
+      });
+      // The cross-agent refusal must not be relabeled as a retryable lookup failure.
+      expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
+      expect(result.allowed ? "" : result.error).not.toMatch(/ownership lookup failed/i);
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
+  });
+
   it("reports a transient tree-visibility lookup failure distinctly", async () => {
     loggerMocks.logWarn.mockClear();
     sessionsResolutionTesting.setDepsForTest({

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { GatewayCredentialsRequiredError } from "../../gateway/call.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import {
   createAgentToAgentPolicy,
@@ -586,10 +587,9 @@ describe("createSessionVisibilityGuard", () => {
     // fail-closes.
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async () => {
-        throw new GatewayClientRequestError({
-          code: "PERMISSION_DENIED",
-          message: "gateway sessions.list requires credentials before opening a websocket",
-          retryable: false,
+        throw new GatewayCredentialsRequiredError({
+          method: "sessions.list",
+          configPath: "/tmp/openclaw.json",
         });
       }) as never,
     });
@@ -610,6 +610,33 @@ describe("createSessionVisibilityGuard", () => {
       });
       // A permanent failure must never tell the caller to retry.
       expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
+  });
+
+  it("keeps unknown lookup failures generic under tree visibility", async () => {
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => {
+        throw new Error("failed to decode session row");
+      }) as never,
+    });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
+
+      const result = guard.check("agent:main:subagent:child-1");
+      expect(result).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error:
+          "Session history denied because spawned-session ownership lookup failed; check gateway logs for the reported error.",
+      });
+      expect(result.allowed ? "" : result.error).not.toMatch(/credentials|retry/i);
     } finally {
       sessionsResolutionTesting.setDepsForTest();
     }

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -606,7 +606,7 @@ describe("createSessionVisibilityGuard", () => {
         allowed: false,
         status: "forbidden",
         error:
-          "Session history denied because spawned-session ownership lookup failed; check gateway configuration and credentials.",
+          "Session history denied because spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.",
       });
       // A permanent failure must never tell the caller to retry.
       expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
@@ -634,7 +634,7 @@ describe("createSessionVisibilityGuard", () => {
         allowed: false,
         status: "forbidden",
         error:
-          "Session history denied because spawned-session ownership lookup failed; check gateway logs for the reported error.",
+          "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
       });
       expect(result.allowed ? "" : result.error).not.toMatch(/credentials|retry/i);
     } finally {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -537,11 +537,47 @@ describe("createSessionVisibilityGuard", () => {
     });
   });
 
-  it("preserves cross-agent policy denials when the spawned lookup fails", async () => {
-    // A failed spawned ownership lookup must not relabel a deterministic
-    // cross-agent denial as retryable: retrying the lookup cannot make a known
-    // `agent:other:*` target eligible, so the cross-visibility refusal is
-    // preserved as-is (review P2: preserve cross-agent policy denials).
+  it("preserves cross-agent policy denials after a successful empty ownership lookup", async () => {
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => ({ sessions: [] })) as never,
+    });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
+
+      expect(guard.check("agent:other:main")).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error:
+          "Session history visibility is restricted. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access; use tools.agentToAgent.allow to restrict permitted agent pairs.",
+      });
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
+  });
+
+  it.each([
+    {
+      name: "cross-agent ACP child",
+      target: "agent:codex:acp:child-1",
+      error:
+        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+    },
+    {
+      name: "malformed agent key",
+      target: "agent:",
+      error: "Session history denied because target agent ownership is unavailable.",
+    },
+    {
+      name: "unscoped alias without a default agent",
+      target: "main",
+      error: "Session history denied because target agent ownership is unavailable.",
+    },
+  ])("handles $name when the ownership lookup fails", async ({ target, error }) => {
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
@@ -559,16 +595,11 @@ describe("createSessionVisibilityGuard", () => {
         a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       });
 
-      const result = guard.check("agent:other:main");
-      expect(result).toEqual({
+      expect(guard.check(target)).toEqual({
         allowed: false,
         status: "forbidden",
-        error:
-          "Session history visibility is restricted. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access; use tools.agentToAgent.allow to restrict permitted agent pairs.",
+        error,
       });
-      // The cross-agent refusal must not be relabeled as a retryable lookup failure.
-      expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
-      expect(result.allowed ? "" : result.error).not.toMatch(/ownership lookup failed/i);
     } finally {
       sessionsResolutionTesting.setDepsForTest();
     }
@@ -578,9 +609,6 @@ describe("createSessionVisibilityGuard", () => {
     loggerMocks.logWarn.mockClear();
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async () => {
-        // A retryable request-level transport failure must surface the
-        // "transient; retry" denial so callers can distinguish it from a
-        // genuine policy refusal (review P1: classify before prescribing retry).
         throw new GatewayClientRequestError({
           code: "UNAVAILABLE",
           message: "transport timeout Authorization: Bearer sk-evidence-secret-9f3a2c",
@@ -597,7 +625,6 @@ describe("createSessionVisibilityGuard", () => {
       });
 
       const result = guard.check("agent:main:subagent:child-1");
-      // Fail-closed: still denied, but distinguishable from a policy denial.
       expect(result.allowed).toBe(false);
       expect(result).toMatchObject({
         status: "forbidden",
@@ -606,9 +633,7 @@ describe("createSessionVisibilityGuard", () => {
         expect(result.error).toMatch(/ownership lookup failed/i);
         expect(result.error).toMatch(/transient\); retry/i);
       }
-      // The warn log must carry the requester key and the underlying error, but
-      // sensitive text inside the error must go through the repository's
-      // redacting formatter (P1 security finding).
+      // Diagnostics identify the requester without leaking sensitive error text.
       const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
       expect(warnText).toContain("requester=agent:main:main");
       expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
@@ -618,10 +643,6 @@ describe("createSessionVisibilityGuard", () => {
   });
 
   it("classifies a permanent credential lookup failure as non-retryable under tree visibility", async () => {
-    // A credentials/configuration failure surfaces before a socket is opened
-    // and will not recover through retry, so the guard must NOT prescribe retry
-    // (review P1: classify before prescribing retry). The denial still
-    // fail-closes.
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async () => {
         throw new GatewayCredentialsRequiredError({
@@ -717,8 +738,7 @@ describe("createSessionVisibilityGuard", () => {
           a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
         });
 
-        // The durable watched-group allowance does not depend on the spawned
-        // lookup; it must survive a failed lookup (P1 regression guard).
+        // Durable watched-group allowance does not depend on spawned ownership lookup.
         expect(guard.check(watchedSessionKey)).toEqual({ allowed: true });
         // A non-watched, non-spawned same-agent target still fails closed, but
         // the denial is distinguishable from a genuine policy denial.

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityGuard,
@@ -18,6 +19,12 @@ import {
 } from "../../sessions/session-state-events.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
+
+const loggerMocks = vi.hoisted(() => ({ logWarn: vi.fn() }));
+vi.mock("../../logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../logger.js")>()),
+  logWarn: loggerMocks.logWarn,
+}));
 
 describe("resolveSessionToolsVisibility", () => {
   it("defaults to tree when unset or invalid", () => {
@@ -527,5 +534,144 @@ describe("createSessionVisibilityGuard", () => {
       error:
         "Session history visibility is restricted to the current session (tools.sessions.visibility=self).",
     });
+  });
+
+  it("reports a transient tree-visibility lookup failure distinctly", async () => {
+    loggerMocks.logWarn.mockClear();
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => {
+        // A retryable request-level transport failure must surface the
+        // "transient; retry" denial so callers can distinguish it from a
+        // genuine policy refusal (review P1: classify before prescribing retry).
+        throw new GatewayClientRequestError({
+          code: "UNAVAILABLE",
+          message: "transport timeout Authorization: Bearer sk-evidence-secret-9f3a2c",
+          retryable: true,
+        });
+      }) as never,
+    });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
+
+      const result = guard.check("agent:main:subagent:child-1");
+      // Fail-closed: still denied, but distinguishable from a policy denial.
+      expect(result.allowed).toBe(false);
+      expect(result).toMatchObject({
+        status: "forbidden",
+      });
+      if (!result.allowed) {
+        expect(result.error).toMatch(/ownership lookup failed/i);
+        expect(result.error).toMatch(/transient\); retry/i);
+      }
+      // The warn log must carry the requester key and the underlying error, but
+      // sensitive text inside the error must go through the repository's
+      // redacting formatter (P1 security finding).
+      const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(warnText).toContain("requester=agent:main:main");
+      expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
+  });
+
+  it("classifies a permanent credential lookup failure as non-retryable under tree visibility", async () => {
+    // A credentials/configuration failure surfaces before a socket is opened
+    // and will not recover through retry, so the guard must NOT prescribe retry
+    // (review P1: classify before prescribing retry). The denial still
+    // fail-closes.
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => {
+        throw new GatewayClientRequestError({
+          code: "PERMISSION_DENIED",
+          message: "gateway sessions.list requires credentials before opening a websocket",
+          retryable: false,
+        });
+      }) as never,
+    });
+    try {
+      const guard = await createSessionVisibilityGuard({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      });
+
+      const result = guard.check("agent:main:subagent:child-1");
+      expect(result).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error:
+          "Session history denied because spawned-session ownership lookup failed; check gateway configuration and credentials.",
+      });
+      // A permanent failure must never tell the caller to retry.
+      expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
+  });
+
+  it("keeps watched same-agent group reads allowed when the spawned lookup throws", async () => {
+    const tempDirs: string[] = [];
+    const stateDir = makeTempDir(tempDirs, "openclaw-session-visibility-");
+    closeOpenClawStateDatabaseForTest();
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      const requesterSessionKey = "agent:main:main";
+      const watchedSessionKey = "agent:main:telegram:group:watched";
+      expect(
+        registerMainSessionGroupWatch({
+          sessionKey: watchedSessionKey,
+          agentId: "main",
+          entry: { sessionId: "watched", updatedAt: Date.now(), chatType: "group" },
+          dmScope: "main",
+        }),
+      ).toBe(true);
+      expect(listAmbientGroupWatchTargets(requesterSessionKey)).toEqual(
+        new Set([watchedSessionKey]),
+      );
+
+      sessionsResolutionTesting.setDepsForTest({
+        callGateway: vi.fn(async () => {
+          throw new GatewayClientRequestError({
+            code: "UNAVAILABLE",
+            message: "transport timeout",
+            retryable: true,
+          });
+        }) as never,
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const guard = await createSessionVisibilityGuard({
+          action: "history",
+          requesterSessionKey,
+          visibility: "tree",
+          a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+        });
+
+        // The durable watched-group allowance does not depend on the spawned
+        // lookup; it must survive a failed lookup (P1 regression guard).
+        expect(guard.check(watchedSessionKey)).toEqual({ allowed: true });
+        // A non-watched, non-spawned same-agent target still fails closed, but
+        // the denial is distinguishable from a genuine policy denial.
+        expect(guard.check("agent:main:telegram:group:unwatched")).toEqual({
+          allowed: false,
+          status: "forbidden",
+          error:
+            "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+        });
+      } finally {
+        warnSpy.mockRestore();
+        sessionsResolutionTesting.setDepsForTest();
+      }
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      vi.unstubAllEnvs();
+      cleanupTempDirs(tempDirs);
+    }
   });
 });

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -19,7 +19,7 @@ import {
   registerSessionStateWatch,
 } from "../../sessions/session-state-events.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
+import { resolveSandboxedSessionToolContext, resolveSessionToolAccess } from "./sessions-access.js";
 
 const loggerMocks = vi.hoisted(() => ({ logWarn: vi.fn() }));
 vi.mock("../../logger.js", async (importOriginal) => ({
@@ -476,55 +476,43 @@ describe("createSessionVisibilityGuard", () => {
   });
 
   it("does not block exact same-agent spawned targets that fall past the spawned list cap", async () => {
-    const callGateway = vi.fn(async (request: { method?: string; params?: { key?: string } }) => {
+    const gateway = vi.fn(async (request: { method?: string; params?: { key?: string } }) => {
       if (request.method === "sessions.resolve") {
         return { key: request.params?.key };
-      }
-      if (request.method === "sessions.list") {
-        return {
-          sessions: [
-            ...Array.from({ length: 500 }, (_, index) => ({
-              key: `agent:main:subagent:worker-${index}`,
-            })),
-            { key: "agent:main:subagent:worker-999" },
-          ],
-        };
       }
       return {};
     });
 
-    const guard = await createSessionVisibilityGuard({
+    const access = await resolveSessionToolAccess({
       action: "history",
       requesterSessionKey: "agent:main:main",
+      targetSessionKey: "agent:main:subagent:worker-999",
+      requesterOwned: false,
       visibility: "tree",
       a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      callGateway: callGateway as never,
+      callGateway: gateway as never,
     });
 
-    expect(guard.check("agent:main:subagent:worker-999")).toEqual({ allowed: true });
+    expect(access).toEqual({ allowed: true });
+    expect(gateway).toHaveBeenCalledTimes(1);
+    expect(gateway).toHaveBeenCalledWith(expect.objectContaining({ method: "sessions.resolve" }));
   });
 
   it("blocks cross-agent send when agent-to-agent is disabled", async () => {
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "send",
+      requesterSessionKey: "agent:main:main",
+      visibility: "all",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => ({ sessions: [] })) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "send",
-        requesterSessionKey: "agent:main:main",
-        visibility: "all",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      expect(guard.check("agent:ops:main")).toEqual({
-        allowed: false,
-        status: "forbidden",
-        error:
-          "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
-      });
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
-    }
+    expect(guard.check("agent:ops:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+    });
   });
 
   it("enforces self visibility for same-agent sessions", async () => {
@@ -545,26 +533,20 @@ describe("createSessionVisibilityGuard", () => {
   });
 
   it("preserves cross-agent policy denials after a successful empty ownership lookup", async () => {
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => ({ sessions: [] })) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "history",
-        requesterSessionKey: "agent:main:main",
-        visibility: "tree",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      expect(guard.check("agent:other:main")).toEqual({
-        allowed: false,
-        status: "forbidden",
-        error:
-          "Session history visibility is restricted. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access; use tools.agentToAgent.allow to restrict permitted agent pairs.",
-      });
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
-    }
+    expect(guard.check("agent:other:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history visibility is restricted. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access; use tools.agentToAgent.allow to restrict permitted agent pairs.",
+    });
   });
 
   it.each([
@@ -573,14 +555,14 @@ describe("createSessionVisibilityGuard", () => {
       target: "agent:codex:acp:child-1",
       visibility: "tree" as const,
       error:
-        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+        "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
     },
     {
       name: "cross-agent ACP child under all visibility",
       target: "agent:codex:acp:child-1",
       visibility: "all" as const,
       error:
-        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+        "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
     },
     {
       name: "malformed agent key",
@@ -595,7 +577,11 @@ describe("createSessionVisibilityGuard", () => {
       error: "Session history denied because target agent ownership is unavailable.",
     },
   ])("handles $name when the ownership lookup fails", async ({ target, visibility, error }) => {
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility,
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
           code: "UNAVAILABLE",
@@ -604,27 +590,21 @@ describe("createSessionVisibilityGuard", () => {
         });
       }) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "history",
-        requesterSessionKey: "agent:main:main",
-        visibility,
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      expect(guard.check(target)).toEqual({
-        allowed: false,
-        status: "forbidden",
-        error,
-      });
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
-    }
+    expect(guard.check(target)).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error,
+    });
   });
 
   it("reports a transient tree-visibility lookup failure distinctly", async () => {
     loggerMocks.logWarn.mockClear();
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
           code: "UNAVAILABLE",
@@ -633,34 +613,25 @@ describe("createSessionVisibilityGuard", () => {
         });
       }) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "history",
-        requesterSessionKey: "agent:main:main",
-        visibility: "tree",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      const result = guard.check("agent:main:subagent:child-1");
-      expect(result.allowed).toBe(false);
-      expect(result).toMatchObject({
-        status: "forbidden",
-      });
-      if (!result.allowed) {
-        expect(result.error).toMatch(/ownership lookup failed/i);
-        expect(result.error).toMatch(/transient\); retry/i);
-      }
-      // Diagnostics identify the requester without leaking sensitive error text.
-      const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
-      expect(warnText).toContain("requester=agent:main:main");
-      expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
+    const result = guard.check("agent:main:subagent:child-1");
+    expect(result.allowed).toBe(false);
+    expect(result).toMatchObject({ status: "forbidden" });
+    if (!result.allowed) {
+      expect(result.error).toMatch(/ownership lookup failed/i);
+      expect(result.error).toMatch(/transient\); retry/i);
     }
+    const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(warnText).toContain("requester=agent:main:main");
+    expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
   });
 
   it("classifies a permanent credential lookup failure as non-retryable under tree visibility", async () => {
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => {
         throw new GatewayCredentialsRequiredError({
           method: "sessions.list",
@@ -668,56 +639,57 @@ describe("createSessionVisibilityGuard", () => {
         });
       }) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "history",
-        requesterSessionKey: "agent:main:main",
-        visibility: "tree",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      const result = guard.check("agent:main:subagent:child-1");
-      expect(result).toEqual({
-        allowed: false,
-        status: "forbidden",
-        error:
-          "Session history denied because spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.",
-      });
-      // A permanent failure must never tell the caller to retry.
-      expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
-    }
+    const result = guard.check("agent:main:subagent:child-1");
+    expect(result).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.",
+    });
+    expect(result.allowed ? "" : result.error).not.toMatch(/retry/i);
   });
 
   it("keeps unknown lookup failures generic under tree visibility", async () => {
-    sessionsResolutionTesting.setDepsForTest({
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
       callGateway: vi.fn(async () => {
         throw new Error("failed to decode session row");
       }) as never,
     });
-    try {
-      const guard = await createSessionVisibilityGuard({
-        action: "history",
-        requesterSessionKey: "agent:main:main",
-        visibility: "tree",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
-      });
 
-      const result = guard.check("agent:main:subagent:child-1");
-      expect(result).toEqual({
-        allowed: false,
-        status: "forbidden",
-        error:
-          "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
-      });
-      expect(result.allowed ? "" : result.error).not.toMatch(/credentials|retry/i);
-    } finally {
-      sessionsResolutionTesting.setDepsForTest();
-    }
+    const result = guard.check("agent:main:subagent:child-1");
+    expect(result).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
+    });
+    expect(result.allowed ? "" : result.error).not.toMatch(/credentials|retry/i);
+  });
+
+  it("classifies a malformed sessions.list response as an unknown lookup failure", async () => {
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      callGateway: vi.fn(async () => ({})) as never,
+    });
+
+    expect(guard.check("agent:main:subagent:child-1")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
+    });
   });
 
   it("keeps watched same-agent group reads allowed when the spawned lookup throws", async () => {
+    loggerMocks.logWarn.mockClear();
     const tempDirs: string[] = [];
     const stateDir = makeTempDir(tempDirs, "openclaw-session-visibility-");
     closeOpenClawStateDatabaseForTest();
@@ -737,15 +709,6 @@ describe("createSessionVisibilityGuard", () => {
         new Set([watchedSessionKey]),
       );
 
-      sessionsResolutionTesting.setDepsForTest({
-        callGateway: vi.fn(async () => {
-          throw new GatewayClientRequestError({
-            code: "UNAVAILABLE",
-            message: "transport timeout",
-            retryable: true,
-          });
-        }) as never,
-      });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         const guard = await createSessionVisibilityGuard({
@@ -753,21 +716,29 @@ describe("createSessionVisibilityGuard", () => {
           requesterSessionKey,
           visibility: "tree",
           a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+          callGateway: vi.fn(async () => {
+            throw new GatewayClientRequestError({
+              code: "UNAVAILABLE",
+              message: "transport timeout",
+              retryable: true,
+            });
+          }) as never,
         });
 
         // Durable watched-group allowance does not depend on spawned ownership lookup.
+        expect(loggerMocks.logWarn).not.toHaveBeenCalled();
         expect(guard.check(watchedSessionKey)).toEqual({ allowed: true });
+        expect(loggerMocks.logWarn).not.toHaveBeenCalled();
         // A non-watched, non-spawned same-agent target still fails closed, but
         // the denial is distinguishable from a genuine policy denial.
         expect(guard.check("agent:main:telegram:group:unwatched")).toEqual({
           allowed: false,
           status: "forbidden",
           error:
-            "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+            "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
         });
       } finally {
         warnSpy.mockRestore();
-        sessionsResolutionTesting.setDepsForTest();
       }
     } finally {
       closeOpenClawStateDatabaseForTest();

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -7,6 +7,7 @@ import { GatewayCredentialsRequiredError } from "../../gateway/call.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import {
   createAgentToAgentPolicy,
+  createSessionVisibilityChecker,
   createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   resolveEffectiveSessionToolsVisibility,
@@ -558,6 +559,65 @@ describe("createSessionVisibilityGuard", () => {
         "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
     });
     expect(gateway).not.toHaveBeenCalled();
+  });
+
+  it("does not apply a bare-key scoped grant to another agent's session", async () => {
+    const targets: string[] = [];
+    const unregister = createSessionVisibilityChecker.registerScopedAccessProvider((request) => {
+      targets.push(request.targetSessionKey);
+      return request.targetSessionKey === "shared" ? { expectedSessionId: "agent-a" } : undefined;
+    });
+    try {
+      const gateway = vi.fn();
+      const access = await resolveSessionToolAccess({
+        action: "history",
+        requesterAgentId: "main",
+        requesterSessionKey: "agent:main:main",
+        authorizationTargetSessionKey: "agent:ops:shared",
+        targetAgentId: "ops",
+        targetSessionKey: "shared",
+        requesterOwned: false,
+        visibility: "self",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+        callGateway: gateway as never,
+      });
+
+      expect(access.allowed).toBe(false);
+      expect(targets).toEqual(["agent:ops:shared"]);
+      expect(gateway).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("keeps incognito targets hidden from scoped grants", async () => {
+    const targetSessionKey = "agent:main:dashboard:incognito-private";
+    const unregister = createSessionVisibilityChecker.registerScopedAccessProvider(() => ({
+      expectedSessionId: "incognito-incarnation",
+    }));
+    try {
+      const gateway = vi.fn();
+      const access = await resolveSessionToolAccess({
+        action: "history",
+        requesterAgentId: "main",
+        requesterSessionKey: "agent:main:main",
+        targetAgentId: "main",
+        targetSessionKey,
+        requesterOwned: true,
+        visibility: "all",
+        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+        callGateway: gateway as never,
+      });
+
+      expect(access).toEqual({
+        allowed: false,
+        status: "forbidden",
+        error: `Session not visible from session tools: ${targetSessionKey}`,
+      });
+      expect(gateway).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
   });
 
   it("retains lookup-failure guidance for a cross-agent ACP child candidate", async () => {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -622,7 +622,8 @@ describe("createSessionVisibilityGuard", () => {
       expect(result.error).toMatch(/transient\); retry/i);
     }
     const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(warnText).toContain("requester=agent:main:main");
+    expect(warnText).toMatch(/requester=sha256:[a-f0-9]{12}/u);
+    expect(warnText).not.toContain("agent:main:main");
     expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
   });
 

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -1,7 +1,7 @@
 // Sessions access tests cover session-tool visibility policy, sandbox clamps,
 // and agent-to-agent allow rules.
-import { describe, expect, it, vi } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { GatewayCredentialsRequiredError } from "../../gateway/call.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
@@ -239,9 +239,10 @@ describe("createAgentToAgentPolicy", () => {
 });
 
 describe("createSessionVisibilityGuard", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   it("allows watched group reads under tree while denying unwatched peers", () => {
-    const tempDirs: string[] = [];
-    const stateDir = makeTempDir(tempDirs, "openclaw-session-visibility-");
+    const stateDir = tempDirs.make("openclaw-session-visibility-");
     closeOpenClawStateDatabaseForTest();
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     try {
@@ -309,7 +310,6 @@ describe("createSessionVisibilityGuard", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
       vi.unstubAllEnvs();
-      cleanupTempDirs(tempDirs);
     }
   });
 
@@ -485,7 +485,9 @@ describe("createSessionVisibilityGuard", () => {
 
     const access = await resolveSessionToolAccess({
       action: "history",
+      requesterAgentId: "main",
       requesterSessionKey: "agent:main:main",
+      targetAgentId: "main",
       targetSessionKey: "agent:main:subagent:worker-999",
       requesterOwned: false,
       visibility: "tree",
@@ -496,6 +498,96 @@ describe("createSessionVisibilityGuard", () => {
     expect(access).toEqual({ allowed: true });
     expect(gateway).toHaveBeenCalledTimes(1);
     expect(gateway).toHaveBeenCalledWith(expect.objectContaining({ method: "sessions.resolve" }));
+  });
+
+  it("falls back to spawned-session listing when the exact resolver is unavailable", async () => {
+    const gateway = vi.fn(async (request: { method?: string }) => {
+      if (request.method === "sessions.resolve") {
+        throw new GatewayClientRequestError({
+          code: "INVALID_REQUEST",
+          message: "unknown method: sessions.resolve",
+        });
+      }
+      return { sessions: [{ key: "agent:main:subagent:worker" }] };
+    });
+
+    const access = await resolveSessionToolAccess({
+      action: "history",
+      requesterAgentId: "main",
+      requesterSessionKey: "agent:main:main",
+      targetAgentId: "main",
+      targetSessionKey: "agent:main:subagent:worker",
+      requesterOwned: false,
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      callGateway: gateway as never,
+    });
+
+    expect(access).toEqual({ allowed: true });
+    expect(gateway.mock.calls.map(([request]) => request.method)).toEqual([
+      "sessions.resolve",
+      "sessions.list",
+    ]);
+  });
+
+  it("preserves an ordinary cross-agent denial when exact ownership lookup fails", async () => {
+    const gateway = vi.fn(async () => {
+      throw new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "transport timeout",
+        retryable: true,
+      });
+    });
+
+    const access = await resolveSessionToolAccess({
+      action: "send",
+      requesterAgentId: "main",
+      requesterSessionKey: "agent:main:main",
+      targetAgentId: "ops",
+      targetSessionKey: "agent:ops:main",
+      requesterOwned: false,
+      visibility: "all",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      callGateway: gateway as never,
+    });
+
+    expect(access).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+    });
+    expect(gateway).not.toHaveBeenCalled();
+  });
+
+  it("retains lookup-failure guidance for a cross-agent ACP child candidate", async () => {
+    const gateway = vi.fn(async () => {
+      throw new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "transport timeout",
+        retryable: true,
+      });
+    });
+
+    const access = await resolveSessionToolAccess({
+      action: "history",
+      requesterAgentId: "main",
+      requesterSessionKey: "agent:main:main",
+      targetAgentId: "codex",
+      targetSessionKey: "agent:codex:acp:child-1",
+      requesterOwned: false,
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      callGateway: gateway as never,
+    });
+
+    expect(access).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
+    });
+    expect(gateway).toHaveBeenCalledTimes(1);
   });
 
   it("blocks cross-agent send when agent-to-agent is disabled", async () => {
@@ -691,8 +783,7 @@ describe("createSessionVisibilityGuard", () => {
 
   it("keeps watched same-agent group reads allowed when the spawned lookup throws", async () => {
     loggerMocks.logWarn.mockClear();
-    const tempDirs: string[] = [];
-    const stateDir = makeTempDir(tempDirs, "openclaw-session-visibility-");
+    const stateDir = tempDirs.make("openclaw-session-visibility-");
     closeOpenClawStateDatabaseForTest();
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     try {
@@ -744,7 +835,6 @@ describe("createSessionVisibilityGuard", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
       vi.unstubAllEnvs();
-      cleanupTempDirs(tempDirs);
     }
   });
 });

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -18,7 +18,7 @@ import {
   type SessionAccessResult,
   type SessionToolsVisibility,
 } from "../../plugin-sdk/session-visibility.js";
-import { isSubagentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import type { AgentToolGatewayRequestCaller } from "./in-process-gateway.js";
 import {
   lookupRequesterSessionOwnership,
@@ -40,7 +40,7 @@ export async function resolveSessionToolAccess(params: {
   requesterAgentId: string;
   requesterSessionKey: string;
   authorizationTargetSessionKey?: string;
-  targetAgentId?: string;
+  targetAgentId: string;
   targetSessionKey: string;
   requesterOwned: boolean;
   visibility: SessionToolsVisibility;
@@ -70,7 +70,7 @@ export async function resolveSessionToolAccess(params: {
   const check = (requesterOwned: boolean) =>
     rowChecker.check({
       key: authorizationTargetSessionKey,
-      ...(params.targetAgentId ? { agentId: params.targetAgentId } : {}),
+      agentId: params.targetAgentId,
       ...(requesterOwned ? { spawnedBy: params.requesterSessionKey } : {}),
     });
   const initial = check(false);
@@ -86,27 +86,11 @@ export async function resolveSessionToolAccess(params: {
   if (!requesterOwnedAccess.allowed) {
     return initial;
   }
-  if (params.visibility !== "tree" && params.visibility !== "all") {
-    return initial;
-  }
-  if (
-    params.targetSessionKey === params.requesterSessionKey ||
-    params.targetSessionKey === "current"
-  ) {
-    return initial;
-  }
-  try {
-    resolveAgentIdFromSessionKey(params.targetSessionKey, params.defaultAgentId);
-  } catch {
-    return initial;
-  }
   const ownership = await lookupRequesterSessionOwnership({
     requesterSessionKey: params.requesterSessionKey,
     requesterAgentId: params.requesterAgentId,
     targetSessionKey: params.targetSessionKey,
-    targetAgentId:
-      params.targetAgentId ??
-      resolveAgentIdFromSessionKey(params.targetSessionKey, params.defaultAgentId),
+    targetAgentId: params.targetAgentId,
     callGateway: params.callGateway,
   });
   if (!ownership.ok) {

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -53,7 +53,9 @@ export async function resolveSessionToolAccess(params: {
     const scoped = createSessionVisibilityChecker.resolveScopedAccess({
       action: params.action,
       requesterSessionKey: params.requesterSessionKey,
-      targetSessionKey: params.targetSessionKey,
+      // A bare key is not globally unique under explicit ownership. Callers
+      // qualify cross-agent targets so a grant cannot cross store owners.
+      targetSessionKey: authorizationTargetSessionKey,
     });
     if (scoped) {
       return { allowed: true, expectedSessionId: scoped.expectedSessionId };

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -5,16 +5,123 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveSandboxSessionToolsVisibility } from "../../plugin-sdk/session-visibility.js";
-import { isSubagentSessionKey } from "../../routing/session-key.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-resolution.js";
+import {
+  logSessionOwnershipLookupFailure,
+  lookupFailedDenialMessage,
+} from "../../plugin-sdk/session-visibility-internal.js";
+import {
+  createSessionVisibilityChecker,
+  createSessionVisibilityRowChecker,
+  resolveSandboxSessionToolsVisibility,
+  type AgentToAgentPolicy,
+  type SessionAccessAction,
+  type SessionAccessResult,
+  type SessionToolsVisibility,
+} from "../../plugin-sdk/session-visibility.js";
+import { isSubagentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import type { AgentToolGatewayRequestCaller } from "./in-process-gateway.js";
+import {
+  lookupRequesterSessionOwnership,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./sessions-resolution.js";
 
 export {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   resolveEffectiveSessionToolsVisibility,
 } from "../../plugin-sdk/session-visibility.js";
+
+/** Check one prepared target without re-listing the requester's spawned sessions. */
+export async function resolveSessionToolAccess(params: {
+  action: SessionAccessAction;
+  displayAction?: SessionAccessAction | "search";
+  defaultAgentId?: string;
+  requesterAgentId: string;
+  requesterSessionKey: string;
+  authorizationTargetSessionKey?: string;
+  targetAgentId?: string;
+  targetSessionKey: string;
+  requesterOwned: boolean;
+  visibility: SessionToolsVisibility;
+  a2aPolicy: AgentToAgentPolicy;
+  callGateway?: AgentToolGatewayRequestCaller;
+}): Promise<SessionAccessResult> {
+  const authorizationTargetSessionKey =
+    params.authorizationTargetSessionKey ?? params.targetSessionKey;
+  if (params.action !== "list") {
+    const scoped = createSessionVisibilityChecker.resolveScopedAccess({
+      action: params.action,
+      requesterSessionKey: params.requesterSessionKey,
+      targetSessionKey: params.targetSessionKey,
+    });
+    if (scoped) {
+      return { allowed: true, expectedSessionId: scoped.expectedSessionId };
+    }
+  }
+  const rowChecker = createSessionVisibilityRowChecker({
+    action: params.action,
+    defaultAgentId: params.targetAgentId ?? params.defaultAgentId,
+    requesterAgentId: params.requesterAgentId,
+    requesterSessionKey: params.requesterSessionKey,
+    visibility: params.visibility,
+    a2aPolicy: params.a2aPolicy,
+  });
+  const check = (requesterOwned: boolean) =>
+    rowChecker.check({
+      key: authorizationTargetSessionKey,
+      ...(params.targetAgentId ? { agentId: params.targetAgentId } : {}),
+      ...(requesterOwned ? { spawnedBy: params.requesterSessionKey } : {}),
+    });
+  const initial = check(false);
+  if (initial.allowed || params.action === "list") {
+    return initial;
+  }
+  const requesterOwnedAccess = check(true);
+  if (params.requesterOwned) {
+    return requesterOwnedAccess;
+  }
+  // Ownership proof can only widen tree visibility; do not let an operational
+  // lookup failure replace a deterministic self/A2A policy denial.
+  if (!requesterOwnedAccess.allowed) {
+    return initial;
+  }
+  if (params.visibility !== "tree" && params.visibility !== "all") {
+    return initial;
+  }
+  if (
+    params.targetSessionKey === params.requesterSessionKey ||
+    params.targetSessionKey === "current"
+  ) {
+    return initial;
+  }
+  try {
+    resolveAgentIdFromSessionKey(params.targetSessionKey, params.defaultAgentId);
+  } catch {
+    return initial;
+  }
+  const ownership = await lookupRequesterSessionOwnership({
+    requesterSessionKey: params.requesterSessionKey,
+    requesterAgentId: params.requesterAgentId,
+    targetSessionKey: params.targetSessionKey,
+    targetAgentId:
+      params.targetAgentId ??
+      resolveAgentIdFromSessionKey(params.targetSessionKey, params.defaultAgentId),
+    callGateway: params.callGateway,
+  });
+  if (!ownership.ok) {
+    logSessionOwnershipLookupFailure({
+      requesterSessionKey: params.requesterSessionKey,
+      failure: ownership.error,
+    });
+    return {
+      allowed: false,
+      status: "forbidden",
+      error: lookupFailedDenialMessage(params.displayAction ?? params.action, ownership.error.kind),
+    };
+  }
+  return ownership.value ? requesterOwnedAccess : initial;
+}
 
 /** Resolves the requester context used to filter sandboxed session-tool access. */
 export function resolveSandboxedSessionToolContext(params: {

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -5,10 +5,10 @@
  */
 export {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxedSessionToolContext,
+  resolveSessionToolAccess,
 } from "./sessions-access.js";
 import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
 export {
@@ -18,6 +18,7 @@ export {
   resolveMainSessionAlias,
   resolveSessionReference,
   resolveVisibleSessionReference,
+  isExpectedSessionLookupMiss,
   shouldResolveSessionIdInput,
 } from "./sessions-resolution.js";
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -515,11 +515,7 @@ describe("sessions_history redaction", () => {
         sessionKey: targetSessionKey,
         messages: [{ role: "assistant", content: "visible" }],
       });
-      expect(requests.map((request) => request.method)).toEqual([
-        "sessions.resolve",
-        "sessions.list",
-        "chat.history",
-      ]);
+      expect(requests.map((request) => request.method)).toEqual(["chat.history"]);
     } finally {
       unregister();
     }

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -209,11 +209,7 @@ describe("sessions_history redaction", () => {
       messages: [],
       bytes: 2,
     });
-    expect(requests.map((request) => request.method)).toEqual([
-      "sessions.resolve",
-      "sessions.list",
-      "chat.history",
-    ]);
+    expect(requests.map((request) => request.method)).toEqual(["sessions.resolve", "chat.history"]);
   });
 
   it("redacts recalled session text even when log redaction is disabled", async () => {
@@ -538,7 +534,7 @@ describe("sessions_history redaction", () => {
         return undefined;
       }
       grantChecks += 1;
-      if (grantChecks === 2) {
+      if (grantChecks === 1) {
         replaceSessionEntrySync(
           { storePath, sessionKey: targetSessionKey },
           { sessionId: "replacement-incarnation", updatedAt: 2 },
@@ -592,7 +588,7 @@ describe("sessions_history redaction", () => {
         return undefined;
       }
       grantChecks += 1;
-      if (grantChecks === 2) {
+      if (grantChecks === 1) {
         replaceSessionEntrySync(
           { storePath, sessionKey: targetSessionKey },
           { sessionId: expectedSessionId, updatedAt: 2, archivedAt: 2 },

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -37,12 +37,12 @@ import {
   runWithScopedSessionAccess,
 } from "./scoped-session-access.js";
 import {
-  createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   createAgentToAgentPolicy,
   resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
   resolveSandboxedSessionToolContext,
+  resolveSessionToolAccess,
   resolveVisibleSessionReference,
   shouldResolveSessionIdInput,
 } from "./sessions-helpers.js";
@@ -412,6 +412,7 @@ export function createSessionsHistoryTool(opts?: {
           ? { kind: "none" as const }
           : resolvePersistedSessionStoreOwnerForKey(cfg, sessionKeyParam);
       const resolvedSession = await resolveSessionReference({
+        action: "history",
         sessionKey: sessionKeyParam,
         ...(isCurrentSession
           ? { agentId: requesterAgentId }
@@ -469,20 +470,23 @@ export function createSessionsHistoryTool(opts?: {
         requesterAgentId,
       });
 
-      const visibilityGuard = await createSessionVisibilityGuard({
-        action: "history",
-        defaultAgentId: requesterAgentId,
-        requesterAgentId,
-        requesterSessionKey: effectiveRequesterKey,
-        visibility,
-        a2aPolicy,
-        callGateway: gatewayCall,
-      });
       const authorizationKey =
         targetAgentId !== requesterAgentId && !parseAgentSessionKey(resolvedKey)
           ? `agent:${targetAgentId}:${resolvedKey}`
           : resolvedKey;
-      const access = visibilityGuard.check(authorizationKey);
+      const access = await resolveSessionToolAccess({
+        action: "history",
+        defaultAgentId: requesterAgentId,
+        requesterAgentId,
+        requesterSessionKey: effectiveRequesterKey,
+        authorizationTargetSessionKey: authorizationKey,
+        targetAgentId,
+        targetSessionKey: resolvedKey,
+        requesterOwned: visibleSession.requesterOwned,
+        visibility,
+        a2aPolicy,
+        callGateway: gatewayCall,
+      });
       if (!access.allowed) {
         return jsonResult({
           status: access.status,

--- a/src/agents/tools/sessions-resolution.strict.test.ts
+++ b/src/agents/tools/sessions-resolution.strict.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
 describe("strict explicit session resolution", () => {
   it("resolves current to the requester before any ownership lookup", async () => {
     const result = await resolveSessionReference({
+      action: "status",
       sessionKey: "current",
       keyAgentId: "ops",
       alias: "main",
@@ -34,6 +35,7 @@ describe("strict explicit session resolution", () => {
       key: "agent:research:subagent:child",
       displayKey: "agent:research:subagent:child",
       resolvedViaSessionId: false,
+      requesterOwned: true,
     });
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
@@ -41,6 +43,7 @@ describe("strict explicit session resolution", () => {
   it("still rejects an unknown non-alias explicit key", async () => {
     callGatewayMock.mockRejectedValueOnce(new Error("No session found: agent:main:missing"));
     const resolvedSession = await resolveSessionReference({
+      action: "history",
       sessionKey: "agent:main:missing",
       keyAgentId: "main",
       alias: "main",
@@ -79,6 +82,7 @@ describe("strict explicit session resolution", () => {
   it("carries an allowed missing fact only for deliberate main bootstrap", async () => {
     callGatewayMock.mockResolvedValueOnce({});
     const resolvedSession = await resolveSessionReference({
+      action: "send",
       sessionKey: "agent:main:main",
       keyAgentId: "main",
       alias: "main",
@@ -106,6 +110,7 @@ describe("strict explicit session resolution", () => {
       key: "agent:main:main",
       displayKey: "agent:main:main",
       missing: true,
+      requesterOwned: false,
     });
   });
 });

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -4,8 +4,17 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { looksLikeSessionId } from "../../sessions/session-id.js";
 const callGatewayMock = vi.fn();
-vi.mock("../../gateway/call.js", () => ({
-  callGateway: (opts: unknown) => callGatewayMock(opts),
+vi.mock("../../gateway/call.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../gateway/call.js")>();
+  return {
+    ...actual,
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  };
+});
+const loggerMocks = vi.hoisted(() => ({ logWarn: vi.fn() }));
+vi.mock("../../logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../logger.js")>()),
+  logWarn: loggerMocks.logWarn,
 }));
 let resolveCurrentSessionClientAlias: typeof import("./sessions-resolution.js").resolveCurrentSessionClientAlias;
 let resolveDisplaySessionKey: typeof import("./sessions-resolution.js").resolveDisplaySessionKey;
@@ -296,11 +305,162 @@ describe("resolved session visibility checks", () => {
         requesterAgentId: "main",
         restrictToSpawned: true,
         visibilitySessionKey: "agent:main:subagent:worker",
+        callGateway: callGatewayMock,
       }),
     ).resolves.toMatchObject({ ok: false, status: "forbidden" });
     expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual([
       "sessions.resolve",
     ]);
+  });
+
+  it("redacts sensitive text in resolve-fallback and spawned-lookup warnings", async () => {
+    loggerMocks.logWarn.mockClear();
+    callGatewayMock.mockImplementation(async () => {
+      // A retryable request-level failure keeps the "transient; retry" denial
+      // text while still routing the underlying error through the redacting
+      // formatter (review P1: classify before prescribing retry).
+      throw new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "gateway refused Authorization: Bearer sk-evidence-secret-9f3a2c",
+        retryable: true,
+      });
+    });
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession: {
+        ok: true,
+        key: "agent:main:worker",
+        displayKey: "agent:main:worker",
+        resolvedViaSessionId: false,
+      },
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: true,
+      visibilitySessionKey: "agent:main:worker",
+      callGateway: callGatewayMock,
+    });
+    // Fail closed with the same retryable classification as the direct guard,
+    // not the generic sandboxed-session denial.
+    expect(result).toMatchObject({
+      ok: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+    });
+
+    // Both new warn paths must use the repository's redacting formatter.
+    const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(warnText).toContain("sessions-resolution: sessions.resolve threw");
+    expect(warnText).toContain("listSpawnedSessionKeys failed");
+    expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
+  });
+
+  it("classifies a permanent credential lookup failure as non-retryable through the sandboxed resolver", async () => {
+    // A credentials/config failure surfaces before a socket is opened and will
+    // not recover through retry, so the resolver must NOT prescribe retry
+    // (review P1: classify before prescribing retry).
+    callGatewayMock.mockImplementation(async () => {
+      throw new GatewayClientRequestError({
+        code: "PERMISSION_DENIED",
+        message: "gateway sessions.list requires credentials before opening a websocket",
+        retryable: false,
+      });
+    });
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession: {
+        ok: true,
+        key: "agent:main:worker",
+        displayKey: "agent:main:worker",
+        resolvedViaSessionId: false,
+      },
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: true,
+      visibilitySessionKey: "agent:main:worker",
+      callGateway: callGatewayMock,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; check gateway configuration and credentials.",
+    });
+    // A permanent failure must never tell the caller to retry.
+    expect(result.ok ? "" : result.error).not.toMatch(/retry/i);
+  });
+
+  it("does not warn on an ordinary non-owned target miss from the speculative resolve probe", async () => {
+    // A valid target outside the requester's spawned set is an EXPECTED miss on
+    // the speculative sessions.resolve probe, not an operational lookup failure.
+    // It must not produce a warn (review P2: avoid warning on ordinary
+    // non-owned sessions), or routine sandbox policy denials would bury the real
+    // failures this PR diagnoses. Simulate the older-gateway path where
+    // allowMissing is rejected and the retry surfaces "No session found".
+    loggerMocks.logWarn.mockClear();
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "sessions.resolve") {
+        throw new GatewayClientRequestError({
+          code: "INVALID_REQUEST",
+          message: "No session found: agent:main:worker",
+        });
+      }
+      if (request.method === "sessions.list") {
+        return { sessions: [] };
+      }
+      return {};
+    });
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession: {
+        ok: true,
+        key: "agent:main:worker",
+        displayKey: "agent:main:worker",
+        resolvedViaSessionId: false,
+      },
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: true,
+      visibilitySessionKey: "agent:main:worker",
+      callGateway: callGatewayMock,
+    });
+    // Generic sandboxed denial for a successful-but-not-owned lookup.
+    expect(result).toMatchObject({
+      ok: false,
+      status: "forbidden",
+    });
+    // No warn for the expected miss.
+    expect(loggerMocks.logWarn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the generic sandboxed denial when the lookup succeeds but the target is not owned", async () => {
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "sessions.resolve") {
+        throw new Error("resolve unavailable");
+      }
+      if (request.method === "sessions.list") {
+        return { sessions: [] };
+      }
+      return {};
+    });
+
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession: {
+        ok: true,
+        key: "agent:main:worker",
+        displayKey: "agent:main:worker",
+        resolvedViaSessionId: false,
+      },
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: true,
+      visibilitySessionKey: "agent:main:worker",
+      callGateway: callGatewayMock,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "forbidden",
+      error: "Session not visible from this sandboxed agent session: agent:main:worker",
+      displayKey: "agent:main:worker",
+    });
   });
 });
 

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -315,7 +315,7 @@ describe("resolved session visibility checks", () => {
     ]);
   });
 
-  it("redacts sensitive text in resolve-fallback and spawned-lookup warnings", async () => {
+  it("redacts sensitive text in spawned-lookup warnings", async () => {
     loggerMocks.logWarn.mockClear();
     callGatewayMock.mockImplementation(async () => {
       // A retryable request-level failure keeps the "transient; retry" denial
@@ -349,9 +349,8 @@ describe("resolved session visibility checks", () => {
         "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
     });
 
-    // Both new warn paths must use the repository's redacting formatter.
+    // The authoritative list failure must use the repository's redacting formatter.
     const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(warnText).toContain("sessions-resolution: sessions.resolve threw");
     expect(warnText).toContain("listSpawnedSessionKeys failed");
     expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
   });
@@ -383,7 +382,7 @@ describe("resolved session visibility checks", () => {
       ok: false,
       status: "forbidden",
       error:
-        "Session history denied because spawned-session ownership lookup failed; check gateway configuration and credentials.",
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.",
     });
     // A permanent failure must never tell the caller to retry.
     expect(result.ok ? "" : result.error).not.toMatch(/retry/i);
@@ -407,7 +406,7 @@ describe("resolved session visibility checks", () => {
       ok: false,
       status: "forbidden",
       error:
-        "Session history denied because spawned-session ownership lookup failed; check gateway logs for the reported error.",
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
     });
     expect(result.ok ? "" : result.error).not.toMatch(/credentials|retry/i);
   });

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -289,35 +289,6 @@ describe("resolved session visibility checks", () => {
     });
   });
 
-  it("propagates strict explicit-key resolution failures without a list fallback", async () => {
-    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "sessions.resolve") {
-        throw new Error("unsupported sessions.resolve shape");
-      }
-      return { sessions: [{ key: "agent:main:subagent:worker" }] };
-    });
-
-    await expect(
-      resolveVisibleSessionReference({
-        action: "history",
-        resolvedSession: {
-          ok: true,
-          key: "agent:main:subagent:worker",
-          displayKey: "agent:main:subagent:worker",
-          resolvedViaSessionId: false,
-        },
-        requesterSessionKey: "agent:main:main",
-        requesterAgentId: "main",
-        restrictToSpawned: true,
-        visibilitySessionKey: "agent:main:subagent:worker",
-        callGateway: callGatewayMock,
-      }),
-    ).resolves.toMatchObject({ ok: false, status: "forbidden" });
-    expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual([
-      "sessions.resolve",
-    ]);
-  });
-
   it("redacts sensitive text in spawned-lookup warnings", async () => {
     loggerMocks.logWarn.mockClear();
     callGatewayMock.mockImplementation(async () => {
@@ -355,6 +326,8 @@ describe("resolved session visibility checks", () => {
     // The authoritative list failure must use the repository's redacting formatter.
     const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
     expect(warnText).toContain("spawned-session ownership lookup failed");
+    expect(warnText).toMatch(/requester=sha256:[a-f0-9]{12}/u);
+    expect(warnText).not.toContain("agent:main:main");
     expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
   });
 

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -165,7 +165,7 @@ describe("session reference shape detection", () => {
 });
 
 describe("resolved session visibility checks", () => {
-  it("rejects incognito targets even when the requester is the same session", async () => {
+  it("rejects incognito targets without consulting Gateway", async () => {
     const sessionKey = "agent:main:dashboard:incognito-private";
 
     await expect(
@@ -551,5 +551,215 @@ describe("resolveSessionReference", () => {
       resolvedViaSessionId: false,
     });
     expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the main alias without probing configured-main bootstrap", async () => {
+    const result = await resolveSessionReference({
+      action: "history",
+      sessionKey: "main",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:dashboard:requester",
+      restrictToSpawned: false,
+    });
+
+    expectResolvedSessionReference(result, {
+      key: "main",
+      displayKey: "main",
+      resolvedViaSessionId: false,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("defers explicit-key lookup to action-aware visibility resolution", async () => {
+    const result = await resolveSessionReference({
+      action: "history",
+      sessionKey: "agent:main:worker",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:main",
+      restrictToSpawned: false,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      key: "agent:main:worker",
+      displayKey: "agent:main:worker",
+      resolvedViaSessionId: false,
+      requesterOwned: false,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown explicit session key for history", async () => {
+    callGatewayMock.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message: "No session found: agent:main:missing",
+      }),
+    );
+
+    const resolvedSession = await resolveSessionReference({
+      action: "history",
+      sessionKey: "agent:main:missing",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:main",
+      restrictToSpawned: false,
+    });
+    if (!resolvedSession.ok) {
+      throw new Error("Expected session reference");
+    }
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession,
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: false,
+      visibilitySessionKey: "agent:main:missing",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "error",
+      error: "No session found: agent:main:missing",
+      displayKey: "agent:main:missing",
+    });
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "sessions.resolve",
+      params: {
+        key: "agent:main:missing",
+        spawnedBy: undefined,
+      },
+    });
+  });
+
+  it("canonicalizes an existing explicit session key", async () => {
+    callGatewayMock.mockResolvedValueOnce({ key: "agent:ops:main" });
+
+    const resolvedSession = await resolveSessionReference({
+      action: "send",
+      sessionKey: "agent:OPS:main",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:main",
+      restrictToSpawned: false,
+    });
+    if (!resolvedSession.ok) {
+      throw new Error("Expected session reference");
+    }
+    const result = await resolveVisibleSessionReference({
+      action: "send",
+      resolvedSession,
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: false,
+      visibilitySessionKey: "agent:OPS:main",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      key: "agent:ops:main",
+      displayKey: "agent:ops:main",
+      requesterOwned: false,
+    });
+  });
+
+  it("rejects an explicit key that canonicalizes to an incognito session", async () => {
+    callGatewayMock.mockResolvedValueOnce({ key: "agent:ops:dashboard:incognito-private" });
+
+    const resolvedSession = await resolveSessionReference({
+      action: "history",
+      sessionKey: "agent:OPS:dashboard:private",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:main",
+      restrictToSpawned: false,
+    });
+    if (!resolvedSession.ok) {
+      throw new Error("Expected session reference");
+    }
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession,
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: false,
+      visibilitySessionKey: "agent:OPS:dashboard:private",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "forbidden",
+      error: "Session not visible from session tools: agent:OPS:dashboard:private",
+      displayKey: "agent:ops:dashboard:incognito-private",
+    });
+  });
+
+  it("propagates explicit-key gateway failures", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+
+    const resolvedSession = await resolveSessionReference({
+      action: "send",
+      sessionKey: "agent:main:worker",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:main",
+      restrictToSpawned: false,
+    });
+    if (!resolvedSession.ok) {
+      throw new Error("Expected session reference");
+    }
+    const result = await resolveVisibleSessionReference({
+      action: "send",
+      resolvedSession,
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: false,
+      visibilitySessionKey: "agent:main:worker",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "error",
+      error: "gateway unavailable",
+      displayKey: "agent:main:worker",
+    });
+  });
+
+  it("reports an allowed missing explicit key for deliberate bootstrap", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+
+    const resolvedSession = await resolveSessionReference({
+      action: "send",
+      sessionKey: "agent:main:main",
+      alias: "main",
+      mainKey: "main",
+      requesterInternalKey: "agent:main:dashboard:requester",
+      restrictToSpawned: false,
+    });
+    if (!resolvedSession.ok) {
+      throw new Error("Expected session reference");
+    }
+    const result = await resolveVisibleSessionReference({
+      action: "send",
+      resolvedSession,
+      requesterSessionKey: "agent:main:dashboard:requester",
+      restrictToSpawned: false,
+      visibilitySessionKey: "agent:main:main",
+      allowMissingKey: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      key: "agent:main:main",
+      displayKey: "agent:main:main",
+      missing: true,
+      requesterOwned: false,
+    });
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "sessions.resolve",
+      params: {
+        key: "agent:main:main",
+        spawnedBy: undefined,
+        allowMissing: true,
+      },
+    });
   });
 });

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -2,6 +2,8 @@
 // verification, and requester-spawned access checks.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { GatewayCredentialsRequiredError } from "../../gateway/call.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import { looksLikeSessionId } from "../../sessions/session-id.js";
 const callGatewayMock = vi.fn();
 vi.mock("../../gateway/call.js", async (importOriginal) => {
@@ -359,10 +361,9 @@ describe("resolved session visibility checks", () => {
     // not recover through retry, so the resolver must NOT prescribe retry
     // (review P1: classify before prescribing retry).
     callGatewayMock.mockImplementation(async () => {
-      throw new GatewayClientRequestError({
-        code: "PERMISSION_DENIED",
-        message: "gateway sessions.list requires credentials before opening a websocket",
-        retryable: false,
+      throw new GatewayCredentialsRequiredError({
+        method: "sessions.list",
+        configPath: "/tmp/openclaw.json",
       });
     });
     const result = await resolveVisibleSessionReference({
@@ -386,6 +387,29 @@ describe("resolved session visibility checks", () => {
     });
     // A permanent failure must never tell the caller to retry.
     expect(result.ok ? "" : result.error).not.toMatch(/retry/i);
+  });
+
+  it("keeps unknown lookup failures generic through the sandboxed resolver", async () => {
+    callGatewayMock.mockRejectedValue(new Error("failed to decode session row"));
+    const result = await resolveVisibleSessionReference({
+      action: "history",
+      resolvedSession: {
+        ok: true,
+        key: "agent:main:worker",
+        displayKey: "agent:main:worker",
+        resolvedViaSessionId: false,
+      },
+      requesterSessionKey: "agent:main:main",
+      restrictToSpawned: true,
+      visibilitySessionKey: "agent:main:worker",
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      status: "forbidden",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; check gateway logs for the reported error.",
+    });
+    expect(result.ok ? "" : result.error).not.toMatch(/credentials|retry/i);
   });
 
   it("does not warn on an ordinary non-owned target miss from the speculative resolve probe", async () => {

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -1,8 +1,6 @@
-// Sessions resolution tests cover alias mapping, session-id lookup, visibility
-// verification, and requester-spawned access checks.
+// Sessions resolution tests cover alias mapping, session-id lookup, and visibility normalization.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { GatewayCredentialsRequiredError } from "../../gateway/call.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import { looksLikeSessionId } from "../../sessions/session-id.js";
 const callGatewayMock = vi.fn();
@@ -13,11 +11,6 @@ vi.mock("../../gateway/call.js", async (importOriginal) => {
     callGateway: (opts: unknown) => callGatewayMock(opts),
   };
 });
-const loggerMocks = vi.hoisted(() => ({ logWarn: vi.fn() }));
-vi.mock("../../logger.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../logger.js")>()),
-  logWarn: loggerMocks.logWarn,
-}));
 let resolveCurrentSessionClientAlias: typeof import("./sessions-resolution.js").resolveCurrentSessionClientAlias;
 let resolveDisplaySessionKey: typeof import("./sessions-resolution.js").resolveDisplaySessionKey;
 let resolveInternalSessionKey: typeof import("./sessions-resolution.js").resolveInternalSessionKey;
@@ -185,283 +178,6 @@ describe("resolved session visibility checks", () => {
     ).resolves.toMatchObject({ ok: false, status: "forbidden" });
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
-
-  it("requires spawned-session verification only for sandboxed key-based cross-session access", async () => {
-    const cases = [
-      {
-        requesterSessionKey: "agent:main:main",
-        targetSessionKey: "agent:main:worker",
-        restrictToSpawned: true,
-        resolvedViaSessionId: false,
-        expectsGateway: true,
-      },
-      {
-        requesterSessionKey: "agent:main:main",
-        targetSessionKey: "agent:main:worker",
-        restrictToSpawned: false,
-        resolvedViaSessionId: false,
-        expectsGateway: true,
-      },
-      {
-        requesterSessionKey: "agent:main:main",
-        targetSessionKey: "agent:main:worker",
-        restrictToSpawned: true,
-        resolvedViaSessionId: true,
-        expectsGateway: false,
-      },
-      {
-        requesterSessionKey: "agent:main:main",
-        targetSessionKey: "agent:main:main",
-        restrictToSpawned: true,
-        resolvedViaSessionId: false,
-        expectsGateway: false,
-      },
-    ];
-
-    for (const testCase of cases) {
-      callGatewayMock.mockResolvedValueOnce({ key: testCase.targetSessionKey });
-      const result = resolveVisibleSessionReference({
-        action: "history",
-        resolvedSession: {
-          ok: true,
-          key: testCase.targetSessionKey,
-          displayKey: testCase.targetSessionKey,
-          resolvedViaSessionId: testCase.resolvedViaSessionId,
-        },
-        requesterSessionKey: testCase.requesterSessionKey,
-        requesterAgentId: "main",
-        restrictToSpawned: testCase.restrictToSpawned,
-        visibilitySessionKey: testCase.targetSessionKey,
-      });
-
-      await expect(result).resolves.toEqual({
-        ok: true,
-        agentId: "main",
-        key: testCase.targetSessionKey,
-        displayKey: testCase.targetSessionKey,
-        requesterOwned:
-          testCase.restrictToSpawned || testCase.requesterSessionKey === testCase.targetSessionKey,
-      });
-      expect(callGatewayMock).toHaveBeenCalledTimes(testCase.expectsGateway ? 1 : 0);
-      callGatewayMock.mockReset();
-    }
-  });
-
-  it("does not hide an exact spawned target behind the sessions.list visibility cap", async () => {
-    // Exact spawned-session resolution should not depend on a truncated list
-    // response; otherwise high-volume session stores hide valid children.
-    callGatewayMock.mockImplementation(
-      async (request: { method?: string; params?: { key?: string } }) => {
-        if (request.method === "sessions.resolve") {
-          return { key: request.params?.key };
-        }
-        if (request.method === "sessions.list") {
-          return {
-            sessions: Array.from({ length: 500 }, (_, index) => ({
-              key: `agent:main:subagent:worker-${index}`,
-            })),
-          };
-        }
-        return {};
-      },
-    );
-
-    await expect(
-      resolveVisibleSessionReference({
-        action: "history",
-        resolvedSession: {
-          ok: true,
-          key: "agent:main:subagent:worker-999",
-          displayKey: "agent:main:subagent:worker-999",
-          resolvedViaSessionId: false,
-        },
-        requesterSessionKey: "agent:main:main",
-        requesterAgentId: "main",
-        restrictToSpawned: true,
-        visibilitySessionKey: "agent:main:subagent:worker-999",
-      }),
-    ).resolves.toEqual({
-      ok: true,
-      agentId: "main",
-      key: "agent:main:subagent:worker-999",
-      displayKey: "agent:main:subagent:worker-999",
-      requesterOwned: true,
-    });
-  });
-
-  it("redacts sensitive text in spawned-lookup warnings", async () => {
-    loggerMocks.logWarn.mockClear();
-    callGatewayMock.mockImplementation(async () => {
-      // A retryable request-level failure keeps the "transient; retry" denial
-      // text while still routing the underlying error through the redacting
-      // formatter (review P1: classify before prescribing retry).
-      throw new GatewayClientRequestError({
-        code: "UNAVAILABLE",
-        message: "gateway refused Authorization: Bearer sk-evidence-secret-9f3a2c",
-        retryable: true,
-      });
-    });
-    const result = await resolveVisibleSessionReference({
-      action: "history",
-      resolvedSession: {
-        ok: true,
-        key: "agent:main:worker",
-        displayKey: "agent:main:worker",
-        resolvedViaSessionId: false,
-      },
-      requesterSessionKey: "agent:main:main",
-      restrictToSpawned: true,
-      visibilitySessionKey: "agent:main:worker",
-      callGateway: callGatewayMock,
-    });
-    // Fail closed with the same retryable classification as the direct guard,
-    // not the generic sandboxed-session denial.
-    expect(result).toMatchObject({
-      ok: false,
-      status: "forbidden",
-      error:
-        "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
-    });
-
-    // The authoritative list failure must use the repository's redacting formatter.
-    const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(warnText).toContain("spawned-session ownership lookup failed");
-    expect(warnText).toMatch(/requester=sha256:[a-f0-9]{12}/u);
-    expect(warnText).not.toContain("agent:main:main");
-    expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
-  });
-
-  it("classifies a permanent credential lookup failure as non-retryable through the sandboxed resolver", async () => {
-    // A credentials/config failure surfaces before a socket is opened and will
-    // not recover through retry, so the resolver must NOT prescribe retry
-    // (review P1: classify before prescribing retry).
-    callGatewayMock.mockImplementation(async () => {
-      throw new GatewayCredentialsRequiredError({
-        method: "sessions.list",
-        configPath: "/tmp/openclaw.json",
-      });
-    });
-    const result = await resolveVisibleSessionReference({
-      action: "history",
-      resolvedSession: {
-        ok: true,
-        key: "agent:main:worker",
-        displayKey: "agent:main:worker",
-        resolvedViaSessionId: false,
-      },
-      requesterSessionKey: "agent:main:main",
-      restrictToSpawned: true,
-      visibilitySessionKey: "agent:main:worker",
-      callGateway: callGatewayMock,
-    });
-    expect(result).toMatchObject({
-      ok: false,
-      status: "forbidden",
-      error:
-        "Session history denied because spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.",
-    });
-    // A permanent failure must never tell the caller to retry.
-    expect(result.ok ? "" : result.error).not.toMatch(/retry/i);
-  });
-
-  it("keeps unknown lookup failures generic through the sandboxed resolver", async () => {
-    callGatewayMock.mockRejectedValue(new Error("failed to decode session row"));
-    const result = await resolveVisibleSessionReference({
-      action: "history",
-      resolvedSession: {
-        ok: true,
-        key: "agent:main:worker",
-        displayKey: "agent:main:worker",
-        resolvedViaSessionId: false,
-      },
-      requesterSessionKey: "agent:main:main",
-      restrictToSpawned: true,
-      visibilitySessionKey: "agent:main:worker",
-    });
-    expect(result).toMatchObject({
-      ok: false,
-      status: "forbidden",
-      error:
-        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
-    });
-    expect(result.ok ? "" : result.error).not.toMatch(/credentials|retry/i);
-  });
-
-  it("does not warn on an ordinary non-owned target miss from the speculative resolve probe", async () => {
-    // A valid target outside the requester's spawned set is an EXPECTED miss on
-    // the speculative sessions.resolve probe, not an operational lookup failure.
-    // It must not produce a warn (review P2: avoid warning on ordinary
-    // non-owned sessions), or routine sandbox policy denials would bury the real
-    // failures this PR diagnoses. Simulate the older-gateway path where
-    // allowMissing is rejected and the retry surfaces "No session found".
-    loggerMocks.logWarn.mockClear();
-    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "sessions.resolve") {
-        throw new GatewayClientRequestError({
-          code: "INVALID_REQUEST",
-          message: "No session found: agent:main:worker",
-        });
-      }
-      if (request.method === "sessions.list") {
-        return { sessions: [] };
-      }
-      return {};
-    });
-    const result = await resolveVisibleSessionReference({
-      action: "history",
-      resolvedSession: {
-        ok: true,
-        key: "agent:main:worker",
-        displayKey: "agent:main:worker",
-        resolvedViaSessionId: false,
-      },
-      requesterSessionKey: "agent:main:main",
-      restrictToSpawned: true,
-      visibilitySessionKey: "agent:main:worker",
-      callGateway: callGatewayMock,
-    });
-    // Generic sandboxed denial for a successful-but-not-owned lookup.
-    expect(result).toMatchObject({
-      ok: false,
-      status: "forbidden",
-    });
-    // No warn for the expected miss.
-    expect(loggerMocks.logWarn).not.toHaveBeenCalled();
-  });
-
-  it("keeps operational resolve failures distinct from successful non-ownership", async () => {
-    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "sessions.resolve") {
-        throw new Error("resolve unavailable");
-      }
-      if (request.method === "sessions.list") {
-        return { sessions: [] };
-      }
-      return {};
-    });
-
-    const result = await resolveVisibleSessionReference({
-      action: "history",
-      resolvedSession: {
-        ok: true,
-        key: "agent:main:worker",
-        displayKey: "agent:main:worker",
-        resolvedViaSessionId: false,
-      },
-      requesterSessionKey: "agent:main:main",
-      restrictToSpawned: true,
-      visibilitySessionKey: "agent:main:worker",
-      callGateway: callGatewayMock,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      status: "forbidden",
-      error:
-        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
-      displayKey: "agent:main:worker",
-    });
-  });
 });
 
 describe("resolveSessionReference", () => {
@@ -614,6 +330,7 @@ describe("resolveSessionReference", () => {
       action: "history",
       resolvedSession,
       requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
       restrictToSpawned: false,
       visibilitySessionKey: "agent:main:missing",
     });
@@ -628,6 +345,7 @@ describe("resolveSessionReference", () => {
       method: "sessions.resolve",
       params: {
         key: "agent:main:missing",
+        agentId: "main",
         spawnedBy: undefined,
       },
     });
@@ -651,12 +369,14 @@ describe("resolveSessionReference", () => {
       action: "send",
       resolvedSession,
       requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
       restrictToSpawned: false,
       visibilitySessionKey: "agent:OPS:main",
     });
 
     expect(result).toEqual({
       ok: true,
+      agentId: "ops",
       key: "agent:ops:main",
       displayKey: "agent:ops:main",
       requesterOwned: false,
@@ -681,6 +401,7 @@ describe("resolveSessionReference", () => {
       action: "history",
       resolvedSession,
       requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
       restrictToSpawned: false,
       visibilitySessionKey: "agent:OPS:dashboard:private",
     });
@@ -711,6 +432,7 @@ describe("resolveSessionReference", () => {
       action: "send",
       resolvedSession,
       requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
       restrictToSpawned: false,
       visibilitySessionKey: "agent:main:worker",
     });
@@ -741,6 +463,7 @@ describe("resolveSessionReference", () => {
       action: "send",
       resolvedSession,
       requesterSessionKey: "agent:main:dashboard:requester",
+      requesterAgentId: "main",
       restrictToSpawned: false,
       visibilitySessionKey: "agent:main:main",
       allowMissingKey: true,
@@ -748,6 +471,7 @@ describe("resolveSessionReference", () => {
 
     expect(result).toEqual({
       ok: true,
+      agentId: "main",
       key: "agent:main:main",
       displayKey: "agent:main:main",
       missing: true,
@@ -757,6 +481,7 @@ describe("resolveSessionReference", () => {
       method: "sessions.resolve",
       params: {
         key: "agent:main:main",
+        agentId: "main",
         spawnedBy: undefined,
         allowMissing: true,
       },

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -214,7 +214,7 @@ describe("resolved session visibility checks", () => {
         targetSessionKey: "agent:main:main",
         restrictToSpawned: true,
         resolvedViaSessionId: false,
-        expectsGateway: true,
+        expectsGateway: false,
       },
     ];
 
@@ -239,6 +239,8 @@ describe("resolved session visibility checks", () => {
         agentId: "main",
         key: testCase.targetSessionKey,
         displayKey: testCase.targetSessionKey,
+        requesterOwned:
+          testCase.restrictToSpawned || testCase.requesterSessionKey === testCase.targetSessionKey,
       });
       expect(callGatewayMock).toHaveBeenCalledTimes(testCase.expectsGateway ? 1 : 0);
       callGatewayMock.mockReset();
@@ -283,6 +285,7 @@ describe("resolved session visibility checks", () => {
       agentId: "main",
       key: "agent:main:subagent:worker-999",
       displayKey: "agent:main:subagent:worker-999",
+      requesterOwned: true,
     });
   });
 
@@ -346,12 +349,12 @@ describe("resolved session visibility checks", () => {
       ok: false,
       status: "forbidden",
       error:
-        "Session history denied because spawned-session ownership lookup failed (transient); retry the operation.",
+        "Session history denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
     });
 
     // The authoritative list failure must use the repository's redacting formatter.
     const warnText = loggerMocks.logWarn.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(warnText).toContain("listSpawnedSessionKeys failed");
+    expect(warnText).toContain("spawned-session ownership lookup failed");
     expect(warnText).not.toContain("sk-evidence-secret-9f3a2c");
   });
 
@@ -453,7 +456,7 @@ describe("resolved session visibility checks", () => {
     expect(loggerMocks.logWarn).not.toHaveBeenCalled();
   });
 
-  it("keeps the generic sandboxed denial when the lookup succeeds but the target is not owned", async () => {
+  it("keeps operational resolve failures distinct from successful non-ownership", async () => {
     callGatewayMock.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "sessions.resolve") {
         throw new Error("resolve unavailable");
@@ -481,7 +484,8 @@ describe("resolved session visibility checks", () => {
     expect(result).toEqual({
       ok: false,
       status: "forbidden",
-      error: "Session not visible from this sandboxed agent session: agent:main:worker",
+      error:
+        "Session history denied because spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.",
       displayKey: "agent:main:worker",
     });
   });
@@ -498,6 +502,7 @@ describe("resolveSessionReference", () => {
     );
 
     const result = await resolveSessionReference({
+      action: "history",
       sessionKey: "Agent:ops:main",
       keyAgentId: "main",
       agentId: "main",
@@ -516,6 +521,7 @@ describe("resolveSessionReference", () => {
 
   it("resolves current directly to the requester without probing another owner", async () => {
     const result = await resolveSessionReference({
+      action: "history",
       sessionKey: "current",
       alias: "main",
       mainKey: "main",
@@ -530,8 +536,36 @@ describe("resolveSessionReference", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("does not reinterpret a failed custom-key lookup as a sessionId miss", async () => {
+    callGatewayMock.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "gateway unavailable",
+        retryable: true,
+      }),
+    );
+
+    await expect(
+      resolveSessionReference({
+        action: "send",
+        sessionKey: "custom-selector",
+        alias: "main",
+        mainKey: "main",
+        requesterInternalKey: "agent:main:main",
+        restrictToSpawned: true,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: "forbidden",
+      error:
+        "Session send denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
   it("treats the TUI client label as the requester session", async () => {
     const result = await resolveSessionReference({
+      action: "history",
       sessionKey: "openclaw-tui",
       alias: "main",
       mainKey: "main",

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -9,11 +9,14 @@ import {
   normalizeGatewayClientId,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { logWarn } from "../../logger.js";
 import {
-  createSessionVisibilityChecker,
-  listSpawnedSessionKeys,
-} from "../../plugin-sdk/session-visibility.js";
+  listSpawnedSessionKeysWithResult,
+  lookupFailedDenialSuffix,
+} from "../../plugin-sdk/session-visibility-internal.js";
+import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
 import {
   isAcpSessionKey,
   isIncognitoSessionKey,
@@ -87,43 +90,87 @@ export function resolveCurrentSessionClientAlias(params: {
   return requesterKey;
 }
 
+type SpawnedVisibilityOutcome =
+  | { kind: "visible" }
+  | { kind: "not-owned" }
+  | { kind: "lookup-failed"; retryable: boolean };
+
+/**
+ * Detects the expected "No session found" miss from the speculative
+ * `sessions.resolve` probe in {@link isRequesterSpawnedSessionVisible}. A valid
+ * target outside the requester's spawned set is a normal policy miss, not an
+ * operational lookup failure, so it must not trigger the warn trail (review P2).
+ */
+function isExpectedSessionResolveMiss(error: unknown): boolean {
+  if (!(error instanceof GatewayClientRequestError)) {
+    return false;
+  }
+  if (error.gatewayCode !== "INVALID_REQUEST") {
+    return false;
+  }
+  return Boolean(error.message?.includes("No session found"));
+}
+
 async function isRequesterSpawnedSessionVisible(params: {
   requesterSessionKey: string;
   requesterAgentId: string;
   targetSessionKey: string;
   targetAgentId?: string;
   callGateway?: GatewayCaller;
-}): Promise<boolean> {
+}): Promise<SpawnedVisibilityOutcome> {
   if (
     params.requesterSessionKey === params.targetSessionKey &&
     params.targetAgentId === params.requesterAgentId
   ) {
-    return true;
+    return { kind: "visible" };
   }
   const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
   try {
-    const resolved = await gatewayCall({
-      method: "sessions.resolve",
-      params: {
+    // A successful no-match is a policy miss. Operational failures remain
+    // distinct and observable instead of collapsing into a denial.
+    const resolved = await requestResolvedSession(
+      {
         key: params.targetSessionKey,
         agentId: params.targetAgentId,
         spawnedBy: params.requesterSessionKey,
+        allowMissing: true,
       },
-    });
-    if (normalizeOptionalString(resolved?.key) === params.targetSessionKey) {
-      return true;
+      gatewayCall,
+    );
+    if (resolved?.key === params.targetSessionKey) {
+      return { kind: "visible" };
     }
-  } catch {
-    // Older Gateways can reject exact spawned-session resolution.
+  } catch (error) {
+    // A valid target outside the requester's spawned set is an EXPECTED miss
+    // on this speculative probe (the resolver deliberately falls back to
+    // `sessions.list` below). On newer gateways `allowMissing: true` makes the
+    // server return a successful no-match response so no error is thrown; on
+    // older gateways that reject the additive field the retry surfaces the
+    // normal "No session found" INVALID_REQUEST. Either way this is not an
+    // operational lookup failure, so suppress the warn and fall back quietly —
+    // logging it would bury the real failures this PR is meant to diagnose
+    // (review P2). Only a genuine transport/credential error is logged.
+    if (!isExpectedSessionResolveMiss(error)) {
+      logWarn(
+        `sessions-resolution: sessions.resolve threw for requester=${params.requesterSessionKey} target=${params.targetSessionKey}: ${formatErrorMessage(error)}`,
+      );
+    }
   }
-  const keys = await listSpawnedSessionKeys({
+  const result = await listSpawnedSessionKeysWithResult({
     requesterSessionKey: params.requesterSessionKey,
     callGateway: gatewayCall,
   });
-  return (
-    (!params.targetAgentId || params.targetAgentId === params.requesterAgentId) &&
-    keys.has(params.targetSessionKey)
-  );
+  // A failed lookup fail-closes as a distinct outcome carrying retryability, so
+  // a transient transport failure (retry) is distinguishable from a permanent
+  // credential/configuration failure (do not retry); it must not collapse into
+  // the generic sandboxed-session denial (review P1: classify before prescribing retry).
+  if (!result.ok) {
+    return { kind: "lookup-failed", retryable: result.retryable };
+  }
+  return (!params.targetAgentId || params.targetAgentId === params.requesterAgentId) &&
+    result.keys.has(params.targetSessionKey)
+    ? { kind: "visible" }
+    : { kind: "not-owned" };
 }
 
 function looksLikeSessionKey(value: string): boolean {
@@ -182,6 +229,19 @@ type VisibleSessionReferenceResolution =
       error: string;
       displayKey: string;
     };
+
+function resolutionActionPrefix(action: "history" | "send" | "status" | "list"): string {
+  if (action === "history") {
+    return "Session history";
+  }
+  if (action === "send") {
+    return "Session send";
+  }
+  if (action === "status") {
+    return "Session status";
+  }
+  return "Session list";
+}
 
 function buildResolvedSessionReference(params: {
   agentId?: string;
@@ -451,24 +511,30 @@ export async function resolveVisibleSessionReference(params: {
           requesterSessionKey: params.requesterSessionKey,
           targetSessionKey: resolvedKey,
         });
-  const visible =
-    Boolean(scopedAccess) ||
-    verifiedSpawnedVisibility ||
-    !shouldVerifySpawnedVisibility ||
-    (await isRequesterSpawnedSessionVisible({
+  if (!scopedAccess && shouldVerifySpawnedVisibility && !verifiedSpawnedVisibility) {
+    const spawnedOutcome = await isRequesterSpawnedSessionVisible({
       requesterSessionKey: params.requesterSessionKey,
       requesterAgentId: params.requesterAgentId,
       targetSessionKey: resolvedKey,
       targetAgentId: resolvedAgentId,
       callGateway: params.callGateway,
-    }));
-  if (!visible) {
-    return {
-      ok: false,
-      status: "forbidden",
-      error: `Session not visible from this sandboxed agent session: ${params.visibilitySessionKey}`,
-      displayKey,
-    };
+    });
+    if (spawnedOutcome.kind === "lookup-failed") {
+      return {
+        ok: false,
+        status: "forbidden",
+        error: `${resolutionActionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedOutcome.retryable)}`,
+        displayKey,
+      };
+    }
+    if (spawnedOutcome.kind === "not-owned") {
+      return {
+        ok: false,
+        status: "forbidden",
+        error: `Session not visible from this sandboxed agent session: ${params.visibilitySessionKey}`,
+        displayKey,
+      };
+    }
   }
   return {
     ok: true,

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -3,19 +3,22 @@
  *
  * Normalizes display/internal/current-session aliases and resolves session-id inputs through Gateway.
  */
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_IDS,
   normalizeGatewayClientId,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
-  listSpawnedSessionKeysWithResult,
+  logSessionOwnershipLookupFailure,
   lookupFailedDenialMessage,
-  type LookupFailureKind,
+  lookupFailedOperationMessage,
+  sessionOwnershipLookupFailure,
+  type SessionOwnershipLookupFailure,
 } from "../../plugin-sdk/session-visibility-internal.js";
-import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
 import {
   isAcpSessionKey,
   isIncognitoSessionKey,
@@ -89,28 +92,29 @@ export function resolveCurrentSessionClientAlias(params: {
   return requesterKey;
 }
 
-type SpawnedVisibilityOutcome =
-  | { kind: "visible" }
-  | { kind: "not-owned" }
-  | { kind: "lookup-failed"; failureKind: LookupFailureKind };
+export function isExpectedSessionLookupMiss(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("No session found") &&
+    (!(error instanceof GatewayClientRequestError) || error.gatewayCode === "INVALID_REQUEST")
+  );
+}
 
-async function isRequesterSpawnedSessionVisible(params: {
+export async function lookupRequesterSessionOwnership(params: {
   requesterSessionKey: string;
   requesterAgentId: string;
   targetSessionKey: string;
   targetAgentId?: string;
   callGateway?: GatewayCaller;
-}): Promise<SpawnedVisibilityOutcome> {
+}): Promise<Result<boolean, SessionOwnershipLookupFailure>> {
   if (
     params.requesterSessionKey === params.targetSessionKey &&
     params.targetAgentId === params.requesterAgentId
   ) {
-    return { kind: "visible" };
+    return ok(true);
   }
   const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
   try {
-    // A successful no-match is a policy miss. Operational failures remain
-    // distinct and observable instead of collapsing into a denial.
     const resolved = await requestResolvedSession(
       {
         key: params.targetSessionKey,
@@ -120,23 +124,13 @@ async function isRequesterSpawnedSessionVisible(params: {
       },
       gatewayCall,
     );
-    if (resolved?.key === params.targetSessionKey) {
-      return { kind: "visible" };
+    return ok(resolved?.key === params.targetSessionKey);
+  } catch (error) {
+    if (isExpectedSessionLookupMiss(error)) {
+      return ok(false);
     }
-  } catch {
-    // The list query below is authoritative for spawned ownership.
+    return err(sessionOwnershipLookupFailure(error));
   }
-  const result = await listSpawnedSessionKeysWithResult({
-    requesterSessionKey: params.requesterSessionKey,
-    callGateway: gatewayCall,
-  });
-  if (!result.ok) {
-    return { kind: "lookup-failed", failureKind: result.failureKind };
-  }
-  return (!params.targetAgentId || params.targetAgentId === params.requesterAgentId) &&
-    result.keys.has(params.targetSessionKey)
-    ? { kind: "visible" }
-    : { kind: "not-owned" };
 }
 
 function looksLikeSessionKey(value: string): boolean {
@@ -178,8 +172,11 @@ type SessionReferenceResolution =
       key: string;
       displayKey: string;
       resolvedViaSessionId: boolean;
+      requesterOwned?: boolean;
     }
-  | { ok: false; status: "error" | "forbidden"; error: string };
+  | { ok: false; status: "error" | "forbidden"; error: string; notFound?: boolean };
+
+type SessionReferenceAction = "history" | "send" | "status" | "list" | "search";
 
 type VisibleSessionReferenceResolution =
   | {
@@ -188,6 +185,7 @@ type VisibleSessionReferenceResolution =
       key: string;
       displayKey: string;
       missing?: true;
+      requesterOwned: boolean;
     }
   | {
       ok: false;
@@ -202,6 +200,7 @@ function buildResolvedSessionReference(params: {
   alias: string;
   mainKey: string;
   resolvedViaSessionId: boolean;
+  requesterOwned: boolean;
 }): Extract<SessionReferenceResolution, { ok: true }> {
   return {
     ok: true,
@@ -213,6 +212,7 @@ function buildResolvedSessionReference(params: {
       mainKey: params.mainKey,
     }),
     resolvedViaSessionId: params.resolvedViaSessionId,
+    requesterOwned: params.requesterOwned,
   };
 }
 
@@ -277,7 +277,108 @@ function buildSessionResolveQuery(params: {
   };
 }
 
+type ResolvedReference = Extract<SessionReferenceResolution, { ok: true }>;
+type ReferenceLookupResult = Result<ResolvedReference | null, SessionOwnershipLookupFailure>;
+
+async function lookupSessionReference(params: {
+  input: string;
+  kind: "key" | "sessionId";
+  keyAgentId?: string;
+  agentId?: string;
+  alias: string;
+  mainKey: string;
+  requesterInternalKey?: string;
+  restrictToSpawned: boolean;
+  allowMissing?: boolean;
+  callGateway: GatewayCaller;
+}): Promise<ReferenceLookupResult> {
+  try {
+    const resolved = await requestResolvedSession(
+      buildSessionResolveQuery({
+        input: params.input,
+        kind: params.kind,
+        agentId:
+          params.kind === "key"
+            ? (parseAgentSessionKey(params.input)?.agentId ??
+              params.keyAgentId ??
+              params.agentId)
+            : params.agentId,
+        requesterInternalKey: params.requesterInternalKey,
+        restrictToSpawned: params.restrictToSpawned,
+        allowMissing: params.allowMissing,
+      }),
+      params.callGateway,
+    );
+    if (!resolved) {
+      return ok(null);
+    }
+    return ok(
+      buildResolvedSessionReference({
+        ...resolved,
+        alias: params.alias,
+        mainKey: params.mainKey,
+        resolvedViaSessionId: params.kind === "sessionId",
+        requesterOwned: params.restrictToSpawned,
+      }),
+    );
+  } catch (error) {
+    if (isExpectedSessionLookupMiss(error)) {
+      return ok(null);
+    }
+    return err(sessionOwnershipLookupFailure(error));
+  }
+}
+
+async function resolveSessionReferenceByKeyOrSessionId(params: {
+  raw: string;
+  keyAgentId?: string;
+  agentId?: string;
+  alias: string;
+  mainKey: string;
+  requesterInternalKey?: string;
+  restrictToSpawned: boolean;
+  allowMissing?: boolean;
+  skipKeyLookup?: boolean;
+  forceSessionIdLookup?: boolean;
+  callGateway: GatewayCaller;
+}): Promise<ReferenceLookupResult> {
+  if (!params.skipKeyLookup) {
+    // Prefer key resolution to avoid misclassifying custom keys as sessionIds.
+    const resolvedByKey = await lookupSessionReference({
+      input: params.raw,
+      kind: "key",
+      keyAgentId: params.keyAgentId,
+      agentId: params.agentId,
+      alias: params.alias,
+      mainKey: params.mainKey,
+      requesterInternalKey: params.requesterInternalKey,
+      restrictToSpawned: params.restrictToSpawned,
+      allowMissing: params.allowMissing,
+      callGateway: params.callGateway,
+    });
+    if (!resolvedByKey.ok || resolvedByKey.value) {
+      return resolvedByKey;
+    }
+  }
+  if (!(params.forceSessionIdLookup || shouldResolveSessionIdInput(params.raw))) {
+    return ok(null);
+  }
+  return await lookupSessionReference({
+    input: params.raw,
+    kind: "sessionId",
+    keyAgentId: params.keyAgentId,
+    agentId: params.agentId,
+    alias: params.alias,
+    mainKey: params.mainKey,
+    requesterInternalKey: params.requesterInternalKey,
+    restrictToSpawned: params.restrictToSpawned,
+    allowMissing: params.allowMissing,
+    callGateway: params.callGateway,
+  });
+}
+
 export async function resolveSessionReference(params: {
+  action: SessionReferenceAction;
   sessionKey: string;
   /** Owner already selected for literal key lookup; session-id lookup remains cross-agent. */
   keyAgentId?: string;
@@ -289,36 +390,18 @@ export async function resolveSessionReference(params: {
   callGateway?: GatewayCaller;
 }): Promise<SessionReferenceResolution> {
   const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
-  const buildReference = (
-    resolved: { agentId?: string; key: string },
-    resolvedViaSessionId: boolean,
-  ) =>
-    buildResolvedSessionReference({
-      ...resolved,
-      alias: params.alias,
-      mainKey: params.mainKey,
-      resolvedViaSessionId,
+  const failedLookup = (failure: SessionOwnershipLookupFailure): SessionReferenceResolution => {
+    logSessionOwnershipLookupFailure({
+      requesterSessionKey: params.requesterInternalKey ?? "unknown",
+      failure,
     });
-  const tryResolve = async (input: string, kind: "key" | "sessionId", allowMissing = false) => {
-    try {
-      const resolved = await requestResolvedSession(
-        buildSessionResolveQuery({
-          input,
-          kind,
-          agentId:
-            kind === "key"
-              ? (parseAgentSessionKey(input)?.agentId ?? params.keyAgentId ?? params.agentId)
-              : params.agentId,
-          requesterInternalKey: params.requesterInternalKey,
-          restrictToSpawned: params.restrictToSpawned,
-          allowMissing,
-        }),
-        gatewayCall,
-      );
-      return resolved ? buildReference(resolved, kind === "sessionId") : null;
-    } catch {
-      return null;
-    }
+    return {
+      ok: false,
+      status: params.restrictToSpawned ? "forbidden" : "error",
+      error: params.restrictToSpawned
+        ? lookupFailedDenialMessage(params.action, failure.kind)
+        : lookupFailedOperationMessage(params.action, failure.kind),
+    };
   };
   const rawInput =
     resolveCurrentSessionClientAlias({
@@ -328,28 +411,30 @@ export async function resolveSessionReference(params: {
   const raw =
     rawInput === "current" && params.requesterInternalKey ? params.requesterInternalKey : rawInput;
   if (shouldResolveSessionIdInput(raw)) {
-    const resolvedByKey = await tryResolve(raw, "key");
-    if (resolvedByKey) {
-      return resolvedByKey;
+    const resolvedByGateway = await resolveSessionReferenceByKeyOrSessionId({
+      raw,
+      keyAgentId: params.keyAgentId,
+      agentId: params.agentId,
+      alias: params.alias,
+      mainKey: params.mainKey,
+      requesterInternalKey: params.requesterInternalKey,
+      restrictToSpawned: params.restrictToSpawned,
+      callGateway: gatewayCall,
+    });
+    if (!resolvedByGateway.ok) {
+      return failedLookup(resolvedByGateway.error);
     }
-    try {
-      const resolved = await requestResolvedSession(
-        buildSessionResolveQuery({
-          input: raw,
-          kind: "sessionId",
-          agentId: params.agentId,
-          requesterInternalKey: params.requesterInternalKey,
-          restrictToSpawned: params.restrictToSpawned,
-        }),
-        gatewayCall,
-      );
-      if (!resolved) {
-        throw new Error(`Session not found: ${raw} (use the full sessionKey from sessions_list)`);
-      }
-      return buildReference(resolved, true);
-    } catch (error) {
-      return buildFailedSessionReference(error, raw, params.restrictToSpawned);
+    if (resolvedByGateway.value) {
+      return resolvedByGateway.value;
     }
+    return {
+      ok: false,
+      status: params.restrictToSpawned ? "forbidden" : "error",
+      notFound: true,
+      error: params.restrictToSpawned
+        ? `Session not visible from this sandboxed agent session: ${raw}`
+        : `Session not found: ${raw} (use the full sessionKey from sessions_list)`,
+    };
   }
 
   const resolvedKey = resolveInternalSessionKey({
@@ -365,14 +450,27 @@ export async function resolveSessionReference(params: {
       : rawInput === "main" || rawInput === params.mainKey
         ? params.keyAgentId
         : undefined);
-  return buildReference(
-    { key: resolvedKey, ...(semanticAliasAgentId ? { agentId: semanticAliasAgentId } : {}) },
-    false,
-  );
+  const displayKey = resolveDisplaySessionKey({
+    key: resolvedKey,
+    alias: params.alias,
+    mainKey: params.mainKey,
+  });
+  return {
+    ok: true,
+    ...(semanticAliasAgentId ? { agentId: semanticAliasAgentId } : {}),
+    key: resolvedKey,
+    displayKey,
+    resolvedViaSessionId: false,
+    requesterOwned:
+      resolvedKey === params.requesterInternalKey &&
+      (!semanticAliasAgentId ||
+        semanticAliasAgentId ===
+          (parseAgentSessionKey(params.requesterInternalKey ?? "")?.agentId ?? params.keyAgentId)),
+  };
 }
 
 export async function resolveVisibleSessionReference(params: {
-  action: "history" | "send" | "status" | "list";
+  action: SessionReferenceAction;
   resolvedSession: Extract<SessionReferenceResolution, { ok: true }>;
   requesterSessionKey: string;
   requesterAgentId: string;
@@ -387,7 +485,9 @@ export async function resolveVisibleSessionReference(params: {
     params.resolvedSession.agentId ?? parseAgentSessionKey(resolvedKey)?.agentId;
   let displayKey = params.resolvedSession.displayKey;
   let missing = false;
-  let verifiedSpawnedVisibility = false;
+  const requesterOwnedByResolution =
+    params.resolvedSession.requesterOwned ??
+    (params.restrictToSpawned && params.resolvedSession.resolvedViaSessionId);
   // Cross-session tools persist their results into the caller transcript; an
   // incognito target must remain unreachable even from an incognito requester.
   if (isIncognitoSessionKey(resolvedKey)) {
@@ -406,7 +506,11 @@ export async function resolveVisibleSessionReference(params: {
     input !== "global" &&
     input !== "unknown" &&
     !shouldResolveSessionIdInput(input);
-  if (isExplicitKey && (params.action === "history" || params.action === "send")) {
+  if (
+    isExplicitKey &&
+    !params.restrictToSpawned &&
+    (params.action === "history" || params.action === "send")
+  ) {
     try {
       const resolved = await requestResolvedSession(
         buildSessionResolveQuery({
@@ -423,7 +527,6 @@ export async function resolveVisibleSessionReference(params: {
         resolvedKey = resolved.key;
         resolvedAgentId = resolved.agentId ?? parseAgentSessionKey(resolved.key)?.agentId;
         displayKey = resolved.key;
-        verifiedSpawnedVisibility = params.restrictToSpawned;
       } else if (params.allowMissingKey) {
         missing = true;
       }
@@ -452,48 +555,15 @@ export async function resolveVisibleSessionReference(params: {
       displayKey,
     };
   }
-  const shouldVerifySpawnedVisibility =
-    params.restrictToSpawned &&
-    !params.resolvedSession.resolvedViaSessionId &&
-    (params.requesterSessionKey !== resolvedKey || resolvedAgentId !== params.requesterAgentId);
-  const scopedAccess =
-    params.action === "list"
-      ? undefined
-      : createSessionVisibilityChecker.resolveScopedAccess({
-          action: params.action,
-          requesterSessionKey: params.requesterSessionKey,
-          targetSessionKey: resolvedKey,
-        });
-  if (!scopedAccess && shouldVerifySpawnedVisibility && !verifiedSpawnedVisibility) {
-    const spawnedOutcome = await isRequesterSpawnedSessionVisible({
-      requesterSessionKey: params.requesterSessionKey,
-      requesterAgentId: params.requesterAgentId,
-      targetSessionKey: resolvedKey,
-      targetAgentId: resolvedAgentId,
-      callGateway: params.callGateway,
-    });
-    if (spawnedOutcome.kind === "lookup-failed") {
-      return {
-        ok: false,
-        status: "forbidden",
-        error: lookupFailedDenialMessage(params.action, spawnedOutcome.failureKind),
-        displayKey,
-      };
-    }
-    if (spawnedOutcome.kind === "not-owned") {
-      return {
-        ok: false,
-        status: "forbidden",
-        error: `Session not visible from this sandboxed agent session: ${params.visibilitySessionKey}`,
-        displayKey,
-      };
-    }
-  }
   return {
     ok: true,
     ...(resolvedAgentId ? { agentId: resolvedAgentId } : {}),
     key: resolvedKey,
     displayKey,
+    requesterOwned:
+      requesterOwnedByResolution ||
+      (params.requesterSessionKey === resolvedKey &&
+        resolvedAgentId === params.requesterAgentId),
     ...(missing ? { missing: true } : {}),
   };
 }

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -15,6 +15,7 @@ import { logWarn } from "../../logger.js";
 import {
   listSpawnedSessionKeysWithResult,
   lookupFailedDenialSuffix,
+  type LookupFailureKind,
 } from "../../plugin-sdk/session-visibility-internal.js";
 import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
 import {
@@ -93,7 +94,7 @@ export function resolveCurrentSessionClientAlias(params: {
 type SpawnedVisibilityOutcome =
   | { kind: "visible" }
   | { kind: "not-owned" }
-  | { kind: "lookup-failed"; retryable: boolean };
+  | { kind: "lookup-failed"; failureKind: LookupFailureKind };
 
 /**
  * Detects the expected "No session found" miss from the speculative
@@ -160,12 +161,10 @@ async function isRequesterSpawnedSessionVisible(params: {
     requesterSessionKey: params.requesterSessionKey,
     callGateway: gatewayCall,
   });
-  // A failed lookup fail-closes as a distinct outcome carrying retryability, so
-  // a transient transport failure (retry) is distinguishable from a permanent
-  // credential/configuration failure (do not retry); it must not collapse into
-  // the generic sandboxed-session denial (review P1: classify before prescribing retry).
+  // A failed lookup fail-closes as a distinct outcome carrying only guidance
+  // supported by the caught error; it must not collapse into a policy denial.
   if (!result.ok) {
-    return { kind: "lookup-failed", retryable: result.retryable };
+    return { kind: "lookup-failed", failureKind: result.failureKind };
   }
   return (!params.targetAgentId || params.targetAgentId === params.requesterAgentId) &&
     result.keys.has(params.targetSessionKey)
@@ -523,7 +522,7 @@ export async function resolveVisibleSessionReference(params: {
       return {
         ok: false,
         status: "forbidden",
-        error: `${resolutionActionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedOutcome.retryable)}`,
+        error: `${resolutionActionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedOutcome.failureKind)}`,
         displayKey,
       };
     }

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -271,11 +271,32 @@ async function requestResolvedSession(
     const agentId = normalizeOptionalString(result?.agentId);
     return { key, ...(agentId ? { agentId } : {}) };
   };
-  const result = await callGateway<{ agentId?: unknown; key?: unknown }>({
-    method: "sessions.resolve",
-    params,
-  });
-  return toResolvedSession(result);
+  try {
+    const result = await callGateway<{ agentId?: unknown; key?: unknown }>({
+      method: "sessions.resolve",
+      params,
+    });
+    return toResolvedSession(result);
+  } catch (error) {
+    const olderGatewayRejectedProbe =
+      params.allowMissing === true &&
+      error instanceof GatewayClientRequestError &&
+      error.gatewayCode === "INVALID_REQUEST" &&
+      error.message.includes("invalid sessions.resolve params") &&
+      error.message.includes("unexpected property 'allowMissing'");
+    if (!olderGatewayRejectedProbe) {
+      throw error;
+    }
+    // Protocol v4 gateways predating allowMissing reject the additive field.
+    // Retry without it for mixed-version correctness; remove at the next protocol break.
+    const legacyParams: Record<string, unknown> = { ...params };
+    delete legacyParams.allowMissing;
+    const result = await callGateway<{ agentId?: unknown; key?: unknown }>({
+      method: "sessions.resolve",
+      params: legacyParams,
+    });
+    return toResolvedSession(result);
+  }
 }
 
 function buildSessionResolveQuery(params: {

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -343,9 +343,7 @@ async function lookupSessionReference(params: {
         kind: params.kind,
         agentId:
           params.kind === "key"
-            ? (parseAgentSessionKey(params.input)?.agentId ??
-              params.keyAgentId ??
-              params.agentId)
+            ? (parseAgentSessionKey(params.input)?.agentId ?? params.keyAgentId ?? params.agentId)
             : params.agentId,
         requesterInternalKey: params.requesterInternalKey,
         restrictToSpawned: params.restrictToSpawned,
@@ -606,8 +604,7 @@ export async function resolveVisibleSessionReference(params: {
     displayKey,
     requesterOwned:
       requesterOwnedByResolution ||
-      (params.requesterSessionKey === resolvedKey &&
-        resolvedAgentId === params.requesterAgentId),
+      (params.requesterSessionKey === resolvedKey && resolvedAgentId === params.requesterAgentId),
     ...(missing ? { missing: true } : {}),
   };
 }

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -9,12 +9,10 @@ import {
   normalizeGatewayClientId,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { GatewayClientRequestError } from "../../gateway/client.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { logWarn } from "../../logger.js";
 import {
   listSpawnedSessionKeysWithResult,
-  lookupFailedDenialSuffix,
+  lookupFailedDenialMessage,
   type LookupFailureKind,
 } from "../../plugin-sdk/session-visibility-internal.js";
 import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
@@ -96,22 +94,6 @@ type SpawnedVisibilityOutcome =
   | { kind: "not-owned" }
   | { kind: "lookup-failed"; failureKind: LookupFailureKind };
 
-/**
- * Detects the expected "No session found" miss from the speculative
- * `sessions.resolve` probe in {@link isRequesterSpawnedSessionVisible}. A valid
- * target outside the requester's spawned set is a normal policy miss, not an
- * operational lookup failure, so it must not trigger the warn trail (review P2).
- */
-function isExpectedSessionResolveMiss(error: unknown): boolean {
-  if (!(error instanceof GatewayClientRequestError)) {
-    return false;
-  }
-  if (error.gatewayCode !== "INVALID_REQUEST") {
-    return false;
-  }
-  return error.message?.includes("No session found") ?? false;
-}
-
 async function isRequesterSpawnedSessionVisible(params: {
   requesterSessionKey: string;
   requesterAgentId: string;
@@ -141,28 +123,13 @@ async function isRequesterSpawnedSessionVisible(params: {
     if (resolved?.key === params.targetSessionKey) {
       return { kind: "visible" };
     }
-  } catch (error) {
-    // A valid target outside the requester's spawned set is an EXPECTED miss
-    // on this speculative probe (the resolver deliberately falls back to
-    // `sessions.list` below). On newer gateways `allowMissing: true` makes the
-    // server return a successful no-match response so no error is thrown; on
-    // older gateways that reject the additive field the retry surfaces the
-    // normal "No session found" INVALID_REQUEST. Either way this is not an
-    // operational lookup failure, so suppress the warn and fall back quietly —
-    // logging it would bury the real failures this PR is meant to diagnose
-    // (review P2). Only a genuine transport/credential error is logged.
-    if (!isExpectedSessionResolveMiss(error)) {
-      logWarn(
-        `sessions-resolution: sessions.resolve threw for requester=${params.requesterSessionKey} target=${params.targetSessionKey}: ${formatErrorMessage(error)}`,
-      );
-    }
+  } catch {
+    // The list query below is authoritative for spawned ownership.
   }
   const result = await listSpawnedSessionKeysWithResult({
     requesterSessionKey: params.requesterSessionKey,
     callGateway: gatewayCall,
   });
-  // A failed lookup fail-closes as a distinct outcome carrying only guidance
-  // supported by the caught error; it must not collapse into a policy denial.
   if (!result.ok) {
     return { kind: "lookup-failed", failureKind: result.failureKind };
   }
@@ -228,19 +195,6 @@ type VisibleSessionReferenceResolution =
       error: string;
       displayKey: string;
     };
-
-function resolutionActionPrefix(action: "history" | "send" | "status" | "list"): string {
-  if (action === "history") {
-    return "Session history";
-  }
-  if (action === "send") {
-    return "Session send";
-  }
-  if (action === "status") {
-    return "Session status";
-  }
-  return "Session list";
-}
 
 function buildResolvedSessionReference(params: {
   agentId?: string;
@@ -522,7 +476,7 @@ export async function resolveVisibleSessionReference(params: {
       return {
         ok: false,
         status: "forbidden",
-        error: `${resolutionActionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedOutcome.failureKind)}`,
+        error: lookupFailedDenialMessage(params.action, spawnedOutcome.failureKind),
         displayKey,
       };
     }

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  listSpawnedSessionKeysWithResult,
   logSessionOwnershipLookupFailure,
   lookupFailedDenialMessage,
   lookupFailedOperationMessage,
@@ -100,6 +101,14 @@ export function isExpectedSessionLookupMiss(error: unknown): boolean {
   );
 }
 
+function isUnsupportedSpawnedSessionResolve(error: unknown): boolean {
+  return (
+    error instanceof GatewayClientRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    error.message === "unknown method: sessions.resolve"
+  );
+}
+
 export async function lookupRequesterSessionOwnership(params: {
   requesterSessionKey: string;
   requesterAgentId: string;
@@ -128,6 +137,20 @@ export async function lookupRequesterSessionOwnership(params: {
   } catch (error) {
     if (isExpectedSessionLookupMiss(error)) {
       return ok(false);
+    }
+    if (isUnsupportedSpawnedSessionResolve(error)) {
+      // Older gateways may lack the exact spawned-session selector. Preserve
+      // their list-based contract without hiding operational resolver failures.
+      const listed = await listSpawnedSessionKeysWithResult({
+        requesterSessionKey: params.requesterSessionKey,
+        callGateway: gatewayCall,
+      });
+      return listed.ok
+        ? ok(
+            params.targetAgentId === params.requesterAgentId &&
+              listed.value.has(params.targetSessionKey),
+          )
+        : err(listed.error);
     }
     return err(sessionOwnershipLookupFailure(error));
   }

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -108,7 +108,7 @@ function isExpectedSessionResolveMiss(error: unknown): boolean {
   if (error.gatewayCode !== "INVALID_REQUEST") {
     return false;
   }
-  return Boolean(error.message?.includes("No session found"));
+  return error.message?.includes("No session found") ?? false;
 }
 
 async function isRequesterSpawnedSessionVisible(params: {

--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -1,7 +1,15 @@
 /** sessions_search visibility, bounds, redaction, and input tests. */
+import path from "node:path";
 import { Value } from "typebox/value";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  applySessionStoreProjection,
+  replaceSessionEntrySync,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { callGateway as gatewayCall } from "../../gateway/call.js";
+import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { createSessionsSearchTool } from "./sessions-search-tool.js";
 
@@ -86,6 +94,8 @@ function createTool(params: {
 }
 
 describe("sessions_search tool", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   it("rejects a literal global target owned by another fixed-store agent", async () => {
     const requests: CallGatewayRequest[] = [];
     const tool = createTool({
@@ -418,5 +428,58 @@ describe("sessions_search tool", () => {
       method: "sessions.search",
       params: { agentId: "main", query: "text", sessionKeys: ["main"], limit: 25 },
     });
+  });
+
+  it("rejects a scoped grant when the target incarnation changes before search", async () => {
+    const requesterSessionKey = "agent:main:clickclack:discussion-race";
+    const targetSessionKey = "agent:main:main";
+    const expectedSessionId = "old-incarnation";
+    const storePath = path.join(tempDirs.make("openclaw-sessions-search-"), "sessions.sqlite");
+    await applySessionStoreProjection({
+      storePath,
+      skipMaintenance: true,
+      update: (store) => {
+        store[targetSessionKey] = { sessionId: expectedSessionId, updatedAt: 1 };
+        return { persist: true, result: undefined };
+      },
+    });
+    const requests: CallGatewayRequest[] = [];
+    const unregister = createSessionVisibilityChecker.registerScopedAccessProvider((request) => {
+      if (
+        request.requesterSessionKey !== requesterSessionKey ||
+        request.targetSessionKey !== targetSessionKey
+      ) {
+        return undefined;
+      }
+      replaceSessionEntrySync(
+        { storePath, sessionKey: targetSessionKey },
+        { sessionId: "replacement-incarnation", updatedAt: 2 },
+      );
+      return { expectedSessionId };
+    });
+    try {
+      const tool = createSessionsSearchTool({
+        agentSessionKey: requesterSessionKey,
+        sandboxed: true,
+        config: {
+          session: { store: storePath },
+          tools: { sessions: { visibility: "self" } },
+          agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
+        } as OpenClawConfig,
+        callGateway: async <T = Record<string, unknown>>(
+          request: CallGatewayRequest,
+        ): Promise<T> => {
+          requests.push(request);
+          return { results: [hit({ sessionKey: targetSessionKey })] } as T;
+        },
+      });
+
+      await expect(
+        tool.execute("scoped-grant-race", { query: "text", sessionKey: targetSessionKey }),
+      ).rejects.toThrow(`Session "${targetSessionKey}" changed after access was granted.`);
+      expect(requests.some((request) => request.method === "sessions.search")).toBe(false);
+    } finally {
+      unregister();
+    }
   });
 });

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -370,9 +370,7 @@ export function createSessionsSearchTool(opts?: {
         agentId: opts?.agentId,
       });
 
-      let sessionKey: string | undefined;
-      let sessionAgentId: string | undefined;
-      let requesterOwned = false;
+      let sessionTarget: { agentId: string; key: string; requesterOwned: boolean } | undefined;
       if (requestedSessionKey) {
         const normalizedRequestedKey = requestedSessionKey.trim();
         const semanticTargetAgentId =
@@ -414,14 +412,16 @@ export function createSessionsSearchTool(opts?: {
         if (!visible.ok) {
           return jsonResult({ status: visible.status, error: visible.error });
         }
-        sessionKey = visible.key;
-        sessionAgentId = resolveSessionToolTargetAgentId({
-          cfg,
-          targetSessionKey: visible.key,
-          resolvedAgentId: visible.agentId ?? semanticTargetAgentId,
-          requesterAgentId,
-        });
-        requesterOwned = visible.requesterOwned;
+        sessionTarget = {
+          key: visible.key,
+          agentId: resolveSessionToolTargetAgentId({
+            cfg,
+            targetSessionKey: visible.key,
+            resolvedAgentId: visible.agentId ?? semanticTargetAgentId,
+            requesterAgentId,
+          }),
+          requesterOwned: visible.requesterOwned,
+        };
       }
 
       const visibility = resolveEffectiveSessionToolsVisibility({
@@ -438,11 +438,12 @@ export function createSessionsSearchTool(opts?: {
         visibility,
         a2aPolicy,
       });
-      if (sessionKey) {
+      if (sessionTarget) {
+        const { agentId, key, requesterOwned } = sessionTarget;
         const authorizationTargetSessionKey =
-          sessionAgentId && sessionAgentId !== requesterAgentId && !parseAgentSessionKey(sessionKey)
-            ? `agent:${sessionAgentId}:${sessionKey}`
-            : sessionKey;
+          agentId !== requesterAgentId && !parseAgentSessionKey(key)
+            ? `agent:${agentId}:${key}`
+            : key;
         const access = await resolveSessionToolAccess({
           action: "history",
           displayAction: "search",
@@ -450,8 +451,8 @@ export function createSessionsSearchTool(opts?: {
           requesterAgentId,
           requesterSessionKey: effectiveRequesterKey,
           authorizationTargetSessionKey,
-          targetAgentId: sessionAgentId,
-          targetSessionKey: sessionKey,
+          targetAgentId: agentId,
+          targetSessionKey: key,
           requesterOwned,
           visibility,
           a2aPolicy,
@@ -462,13 +463,13 @@ export function createSessionsSearchTool(opts?: {
         }
       }
       const searchSessions = (
-        sessionKey
+        sessionTarget
           ? [
               {
-                key: sessionKey,
+                key: sessionTarget.key,
                 access: "authorized" as const,
-                ...(!parseAgentSessionKey(sessionKey) && sessionAgentId
-                  ? { agentId: sessionAgentId }
+                ...(!parseAgentSessionKey(sessionTarget.key)
+                  ? { agentId: sessionTarget.agentId }
                   : {}),
               },
             ]

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -440,9 +440,7 @@ export function createSessionsSearchTool(opts?: {
       });
       if (sessionKey) {
         const authorizationTargetSessionKey =
-          sessionAgentId &&
-          sessionAgentId !== requesterAgentId &&
-          !parseAgentSessionKey(sessionKey)
+          sessionAgentId && sessionAgentId !== requesterAgentId && !parseAgentSessionKey(sessionKey)
             ? `agent:${sessionAgentId}:${sessionKey}`
             : sessionKey;
         const access = await resolveSessionToolAccess({

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -27,7 +27,10 @@ import {
   callAgentToolGatewayRequest,
   type AgentToolGatewayRequestCaller,
 } from "./in-process-gateway.js";
-import { resolveSessionToolTargetAgentId } from "./scoped-session-access.js";
+import {
+  resolveSessionToolTargetAgentId,
+  runWithScopedSessionAccess,
+} from "./scoped-session-access.js";
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityRowChecker,
@@ -110,6 +113,7 @@ type SearchSessionCandidate = {
   key: string;
   access: "authorized" | "row";
   agentId?: string;
+  expectedSessionId?: string;
   ownerSessionKey?: string;
   parentSessionKey?: string;
   spawnedBy?: string;
@@ -370,7 +374,14 @@ export function createSessionsSearchTool(opts?: {
         agentId: opts?.agentId,
       });
 
-      let sessionTarget: { agentId: string; key: string; requesterOwned: boolean } | undefined;
+      let sessionTarget:
+        | {
+            agentId: string;
+            key: string;
+            requesterOwned: boolean;
+            expectedSessionId?: string;
+          }
+        | undefined;
       if (requestedSessionKey) {
         const normalizedRequestedKey = requestedSessionKey.trim();
         const semanticTargetAgentId =
@@ -461,6 +472,9 @@ export function createSessionsSearchTool(opts?: {
         if (!access.allowed) {
           return jsonResult({ status: access.status, error: access.error });
         }
+        if (access.expectedSessionId) {
+          sessionTarget.expectedSessionId = access.expectedSessionId;
+        }
       }
       const searchSessions = (
         sessionTarget
@@ -468,6 +482,9 @@ export function createSessionsSearchTool(opts?: {
               {
                 key: sessionTarget.key,
                 access: "authorized" as const,
+                ...(sessionTarget.expectedSessionId
+                  ? { expectedSessionId: sessionTarget.expectedSessionId }
+                  : {}),
                 ...(!parseAgentSessionKey(sessionTarget.key)
                   ? { agentId: sessionTarget.agentId }
                   : {}),
@@ -509,19 +526,30 @@ export function createSessionsSearchTool(opts?: {
           offset += SESSIONS_SEARCH_MAX_SESSION_KEYS
         ) {
           const chunk = candidates.slice(offset, offset + SESSIONS_SEARCH_MAX_SESSION_KEYS);
-          const result = await gatewayCall<{
-            results?: GatewaySearchHit[];
-            indexing?: boolean;
-            truncated?: boolean;
-          }>({
-            method: "sessions.search",
-            params: {
-              agentId,
-              query,
-              limit: SESSIONS_SEARCH_MAX_LIMIT,
-              sessionKeys: chunk.map((candidate) => candidate.key),
-            },
-          });
+          const runSearch = () =>
+            gatewayCall<{
+              results?: GatewaySearchHit[];
+              indexing?: boolean;
+              truncated?: boolean;
+            }>({
+              method: "sessions.search",
+              params: {
+                agentId,
+                query,
+                limit: SESSIONS_SEARCH_MAX_LIMIT,
+                sessionKeys: chunk.map((candidate) => candidate.key),
+              },
+            });
+          const scopedCandidate = chunk.length === 1 ? chunk[0] : undefined;
+          const result = scopedCandidate?.expectedSessionId
+            ? await runWithScopedSessionAccess({
+                cfg,
+                agentId,
+                expectedSessionId: scopedCandidate.expectedSessionId,
+                targetSessionKey: scopedCandidate.key,
+                run: runSearch,
+              })
+            : await runSearch();
           indexing ||= result.indexing === true;
           backendTruncated ||= result.truncated === true;
           for (const hit of Array.isArray(result.results) ? result.results : []) {

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -30,12 +30,12 @@ import {
 import { resolveSessionToolTargetAgentId } from "./scoped-session-access.js";
 import {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   resolveDisplaySessionKey,
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxedSessionToolContext,
   resolveSessionReference,
+  resolveSessionToolAccess,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
 
@@ -108,7 +108,7 @@ type SanitizedSearchHit = {
 
 type SearchSessionCandidate = {
   key: string;
-  access: "direct" | "row";
+  access: "authorized" | "row";
   agentId?: string;
   ownerSessionKey?: string;
   parentSessionKey?: string;
@@ -372,6 +372,7 @@ export function createSessionsSearchTool(opts?: {
 
       let sessionKey: string | undefined;
       let sessionAgentId: string | undefined;
+      let requesterOwned = false;
       if (requestedSessionKey) {
         const normalizedRequestedKey = requestedSessionKey.trim();
         const semanticTargetAgentId =
@@ -389,6 +390,7 @@ export function createSessionsSearchTool(opts?: {
                 })
               : undefined;
         const resolved = await resolveSessionReference({
+          action: "search",
           sessionKey: requestedSessionKey,
           keyAgentId: semanticTargetAgentId ?? requesterAgentId,
           alias,
@@ -401,7 +403,7 @@ export function createSessionsSearchTool(opts?: {
           return jsonResult({ status: resolved.status, error: resolved.error });
         }
         const visible = await resolveVisibleSessionReference({
-          action: "list",
+          action: "search",
           resolvedSession: resolved,
           requesterSessionKey: effectiveRequesterKey,
           requesterAgentId,
@@ -419,6 +421,7 @@ export function createSessionsSearchTool(opts?: {
           resolvedAgentId: visible.agentId ?? semanticTargetAgentId,
           requesterAgentId,
         });
+        requesterOwned = visible.requesterOwned;
       }
 
       const visibility = resolveEffectiveSessionToolsVisibility({
@@ -435,20 +438,27 @@ export function createSessionsSearchTool(opts?: {
         visibility,
         a2aPolicy,
       });
-      const directGuard = await createSessionVisibilityGuard({
-        action: "history",
-        defaultAgentId,
-        requesterAgentId,
-        requesterSessionKey: effectiveRequesterKey,
-        visibility,
-        a2aPolicy,
-        callGateway: gatewayCall,
-      });
       if (sessionKey) {
-        const parsedSessionKey = parseAgentSessionKey(sessionKey);
-        const access = parsedSessionKey
-          ? directGuard.check(sessionKey)
-          : rowGuard.check({ key: sessionKey, agentId: sessionAgentId });
+        const authorizationTargetSessionKey =
+          sessionAgentId &&
+          sessionAgentId !== requesterAgentId &&
+          !parseAgentSessionKey(sessionKey)
+            ? `agent:${sessionAgentId}:${sessionKey}`
+            : sessionKey;
+        const access = await resolveSessionToolAccess({
+          action: "history",
+          displayAction: "search",
+          defaultAgentId,
+          requesterAgentId,
+          requesterSessionKey: effectiveRequesterKey,
+          authorizationTargetSessionKey,
+          targetAgentId: sessionAgentId,
+          targetSessionKey: sessionKey,
+          requesterOwned,
+          visibility,
+          a2aPolicy,
+          callGateway: gatewayCall,
+        });
         if (!access.allowed) {
           return jsonResult({ status: access.status, error: access.error });
         }
@@ -458,7 +468,7 @@ export function createSessionsSearchTool(opts?: {
           ? [
               {
                 key: sessionKey,
-                access: "direct" as const,
+                access: "authorized" as const,
                 ...(!parseAgentSessionKey(sessionKey) && sessionAgentId
                   ? { agentId: sessionAgentId }
                   : {}),
@@ -529,10 +539,9 @@ export function createSessionsSearchTool(opts?: {
             }
             const { candidate, visibilityKey } = candidateMatch;
             const access =
-              candidate.access === "row" ||
-              (candidate.agentId !== undefined && !parseAgentSessionKey(candidate.key))
-                ? rowGuard.check(candidate)
-                : directGuard.check(visibilityKey);
+              candidate.access === "authorized"
+                ? { allowed: true as const }
+                : rowGuard.check(candidate);
             if (!access.allowed) {
               continue;
             }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -719,14 +719,7 @@ export function createSessionsSendTool(opts?: {
         resolvedKeyAgentId ??
         (isLiteralUnscopedMainTarget ? requesterAgentId : undefined) ??
         compatibilityTargetAgentId;
-      const mayUseRequesterForLiteralSentinel =
-        isLiteralUnscopedMainTarget &&
-        (!targetAgentId || normalizeAgentId(targetAgentId) === requesterAgentId);
-      if (
-        !targetAgentId &&
-        !resolvedKeyAgentId &&
-        (!isUnscopedSessionKeySentinel(resolvedKey) || resolvedSession.resolvedViaSessionId)
-      ) {
+      if (!targetAgentId) {
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "forbidden",
@@ -735,6 +728,8 @@ export function createSessionsSendTool(opts?: {
           sessionKey: unresolvedDisplayKey,
         });
       }
+      const mayUseRequesterForLiteralSentinel =
+        isLiteralUnscopedMainTarget && normalizeAgentId(targetAgentId) === requesterAgentId;
       const rawRequesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
       const parsedRequesterSessionKey = parseAgentSessionKey(rawRequesterSessionKey);
       const requesterRouteBindings = cfg.bindings?.filter(

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -18,6 +18,12 @@ import type { AgentRouteBinding } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  logSessionOwnershipLookupFailure,
+  lookupFailedDenialMessage,
+  lookupFailedOperationMessage,
+  sessionOwnershipLookupFailure,
+} from "../../plugin-sdk/session-visibility-internal.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { normalizeRouteBindingChannelId } from "../../routing/binding-scope.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
@@ -70,11 +76,13 @@ import {
 } from "./in-process-gateway.js";
 import { runWithScopedSessionAccess } from "./scoped-session-access.js";
 import {
-  createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
   createAgentToAgentPolicy,
+  isExpectedSessionLookupMiss,
+  resolveDisplaySessionKey,
   resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
+  resolveSessionToolAccess,
   resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
@@ -496,6 +504,7 @@ export function createSessionsSendTool(opts?: {
 
       let sessionKey = sessionKeyParam;
       let resolvedTargetAgentId: string | undefined;
+      let resolvedLabelKey: string | undefined;
       if (!sessionKey && !labelParam && labelAgentIdParam) {
         const agentMainKey = resolveConfiguredAgentMainSessionKey({
           cfg,
@@ -557,19 +566,22 @@ export function createSessionsSendTool(opts?: {
           resolvedKey = normalizeOptionalString(resolved?.key) ?? "";
           resolvedTargetAgentId = normalizeOptionalString(resolved?.agentId);
         } catch (err) {
-          const msg = formatErrorMessage(err);
-          if (restrictToSpawned) {
+          if (isExpectedSessionLookupMiss(err)) {
+            resolvedKey = "";
+          } else {
+            const failure = sessionOwnershipLookupFailure(err);
+            logSessionOwnershipLookupFailure({
+              requesterSessionKey: effectiveRequesterKey,
+              failure,
+            });
             return jsonResult({
               runId: crypto.randomUUID(),
-              status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
+              status: restrictToSpawned ? "forbidden" : "error",
+              error: restrictToSpawned
+                ? lookupFailedDenialMessage("send", failure.kind)
+                : lookupFailedOperationMessage("send", failure.kind),
             });
           }
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "error",
-            error: msg || `No session found with label: ${labelParam}`,
-          });
         }
 
         if (!resolvedKey) {
@@ -587,6 +599,7 @@ export function createSessionsSendTool(opts?: {
           });
         }
         sessionKey = resolvedKey;
+        resolvedLabelKey = resolvedKey;
       }
 
       if (!sessionKey) {
@@ -601,15 +614,25 @@ export function createSessionsSendTool(opts?: {
         sessionKey,
         mainKey,
       });
-      const resolvedSession = await resolveSessionReference({
-        sessionKey,
-        keyAgentId: requesterAgentId,
-        alias,
-        mainKey,
-        requesterInternalKey: effectiveRequesterKey,
-        restrictToSpawned,
-        callGateway: gatewayCall,
-      });
+      const resolvedSession = resolvedLabelKey
+        ? {
+            ok: true as const,
+            ...(resolvedTargetAgentId ? { agentId: resolvedTargetAgentId } : {}),
+            key: resolvedLabelKey,
+            displayKey: resolveDisplaySessionKey({ key: resolvedLabelKey, alias, mainKey }),
+            resolvedViaSessionId: false,
+            requesterOwned: restrictToSpawned,
+          }
+        : await resolveSessionReference({
+            action: "send",
+            sessionKey,
+            keyAgentId: requesterAgentId,
+            alias,
+            mainKey,
+            requesterInternalKey: effectiveRequesterKey,
+            restrictToSpawned,
+            callGateway: gatewayCall,
+          });
       if (!resolvedSession.ok) {
         return jsonResult({
           runId: crypto.randomUUID(),
@@ -837,20 +860,24 @@ export function createSessionsSendTool(opts?: {
           sessionKey: unresolvedDisplayKey,
         });
       }
-      const visibilityGuard = await createSessionVisibilityGuard({
-        action: "send",
-        requesterAgentId,
-        requesterSessionKey: effectiveRequesterKey,
-        visibility: sessionVisibility,
-        a2aPolicy,
-        callGateway: gatewayCall,
-      });
       const authorizationTargetKey = mayUseRequesterForLiteralSentinel
         ? effectiveRequesterKey
         : targetAgentId && !parseAgentSessionKey(resolvedKey)
           ? `agent:${targetAgentId}:${resolvedKey}`
           : resolvedKey;
-      const access = visibilityGuard.check(authorizationTargetKey);
+      const access = await resolveSessionToolAccess({
+        action: "send",
+        defaultAgentId: requesterAgentId,
+        requesterAgentId,
+        requesterSessionKey: effectiveRequesterKey,
+        targetAgentId,
+        targetSessionKey: resolvedKey,
+        authorizationTargetSessionKey: authorizationTargetKey,
+        requesterOwned: visibleSession.requesterOwned,
+        visibility: sessionVisibility,
+        a2aPolicy,
+        callGateway: gatewayCall,
+      });
       if (!access.allowed) {
         return jsonResult({
           runId: crypto.randomUUID(),

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -36,8 +36,8 @@ import {
 import { resolveSessionToolTargetAgentId } from "./scoped-session-access.js";
 import {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
   resolveEffectiveSessionToolsVisibility,
+  resolveSessionToolAccess,
 } from "./sessions-access.js";
 import { resolveSessionToolContext } from "./sessions-helpers.js";
 import { resolveSessionReference, shouldResolveSessionIdInput } from "./sessions-resolution.js";
@@ -234,6 +234,7 @@ async function resolvePatchTarget(
           requesterAgentId,
         });
   const resolved = await resolveSessionReference({
+    action: "status",
     sessionKey: rawKey,
     agentId: inputAgentId,
     keyAgentId: requesterAgentId,
@@ -260,11 +261,19 @@ async function resolvePatchTarget(
   if (!isRequesterSession) {
     // Session visibility is the configured read/write scope for session tools;
     // the action only selects error copy. Owner gating remains separate.
-    const guard = await createSessionVisibilityGuard({
+    const authorizationKey =
+      agentId !== requesterAgentId && !parseAgentSessionKey(resolved.key)
+        ? `agent:${agentId}:${resolved.key}`
+        : resolved.key;
+    const access = await resolveSessionToolAccess({
       action: "status",
       defaultAgentId: requesterAgentId,
       requesterSessionKey: context.effectiveRequesterKey,
+      authorizationTargetSessionKey: authorizationKey,
       requesterAgentId,
+      targetAgentId: agentId,
+      targetSessionKey: resolved.key,
+      requesterOwned: resolved.requesterOwned === true,
       visibility: resolveEffectiveSessionToolsVisibility({
         cfg: context.cfg,
         sandboxed: opts.sandboxed === true,
@@ -272,11 +281,6 @@ async function resolvePatchTarget(
       a2aPolicy: createAgentToAgentPolicy(context.cfg),
       callGateway,
     });
-    const authorizationKey =
-      agentId !== requesterAgentId && !parseAgentSessionKey(resolved.key)
-        ? `agent:${agentId}:${resolved.key}`
-        : resolved.key;
-    const access = guard.check(authorizationKey);
     if (!access.allowed) {
       throw new ToolAuthorizationError(access.error);
     }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -15,6 +15,7 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractStoredAssistantText, sanitizeTextContent } from "./chat-history-text.js";
@@ -39,9 +40,13 @@ const facadeRuntimeMock = vi.hoisted(() => ({
   >(),
 }));
 
-vi.mock("../../gateway/call.js", () => ({
-  callGateway: (opts: unknown) => callGatewayMock(opts),
-}));
+vi.mock("../../gateway/call.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../gateway/call.js")>();
+  return {
+    ...actual,
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  };
+});
 vi.mock("./in-process-gateway.js", () => ({
   callAgentToolGatewayRequest: (opts: unknown) => inProcessGatewayRequestMock(opts),
   callInProcessGatewayToolWithCreation: (method: unknown, params: unknown, creation: unknown) =>
@@ -1208,6 +1213,47 @@ describe("sessions_send gating", () => {
     expect(requireGatewayRequest().method).toBe("sessions.resolve");
     expect(requireGatewayRequest(1).method).toBe("sessions.list");
     expect(requireDetails(result).status).toBe("forbidden");
+  });
+
+  it("classifies a failed spawned-lookup as lookup-failed for sandboxed sends", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
+      tools: { agentToAgent: { enabled: false }, sessions: { visibility: "all" } },
+    });
+    callGatewayMock.mockImplementation(async () => {
+      // A retryable request-level failure preserves the PR's evidence semantics
+      // (transient store read error) while exercising the retryable
+      // classification path (review P1: classify before prescribing retry).
+      throw new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "simulated transient store read error (evidence)",
+        retryable: true,
+      });
+    });
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentChannel: MAIN_AGENT_CHANNEL,
+      sandboxed: true,
+    });
+
+    const result = await tool.execute("call-lookup-failed", {
+      sessionKey: "agent:main:subagent:worker-1",
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+
+    // sessions_send hits the resolution preflight before the direct guard; the
+    // failed lookup must surface the same retryable classification, not the
+    // generic sandboxed-session denial.
+    const details = requireDetails(result);
+    expect(details.status).toBe("forbidden");
+    expect(String(details.error)).toBe(
+      "Session send denied because spawned-session ownership lookup failed (transient); retry the operation.",
+    );
+    expect(String(details.error)).not.toContain(
+      "Session not visible from this sandboxed agent session",
+    );
   });
 
   it("rejects direct thread session targets before dispatching an agent run", async () => {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -445,7 +445,10 @@ it("fails closed for cross-agent and resolution-derived bare keys", async () => 
         return {};
       }
       if (request.params?.key) {
-        throw new Error("not a session key");
+        throw new GatewayClientRequestError({
+          code: "INVALID_REQUEST",
+          message: `No session found: ${String(request.params.key)}`,
+        });
       }
       return request.params?.sessionId ? { key: "incident-42" } : {};
     });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1170,7 +1170,13 @@ describe("sessions_send gating", () => {
       const request = opts as { method?: string; params?: Record<string, unknown> };
       if (request.method === "sessions.resolve") {
         if (request.params?.key === "session-id-only") {
-          throw new Error("not a session key");
+          throw new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message: "No session found: session-id-only",
+          });
+        }
+        if (request.params?.spawnedBy === MAIN_AGENT_SESSION_KEY) {
+          return {};
         }
         return { key: "agent:other:main" };
       }
@@ -1209,9 +1215,8 @@ describe("sessions_send gating", () => {
       timeoutSeconds: 0,
     });
 
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(requireGatewayRequest().method).toBe("sessions.resolve");
-    expect(requireGatewayRequest(1).method).toBe("sessions.list");
     expect(requireDetails(result).status).toBe("forbidden");
   });
 
@@ -1249,7 +1254,7 @@ describe("sessions_send gating", () => {
     const details = requireDetails(result);
     expect(details.status).toBe("forbidden");
     expect(String(details.error)).toBe(
-      "Session send denied because spawned-session ownership lookup failed (transient); retry the operation.",
+      "Session send denied because spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.",
     );
     expect(String(details.error)).not.toContain(
       "Session not visible from this sandboxed agent session",

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -447,7 +447,7 @@ it("fails closed for cross-agent and resolution-derived bare keys", async () => 
       if (request.params?.key) {
         throw new GatewayClientRequestError({
           code: "INVALID_REQUEST",
-          message: `No session found: ${String(request.params.key)}`,
+          message: `No session found: ${request.params.key}`,
         });
       }
       return request.params?.sessionId ? { key: "incident-42" } : {};

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -371,26 +371,36 @@ function registerExternalChatSetupPlugin(pluginId = "@vendor/external-chat-plugi
   );
 }
 
-function registerSyntheticUseEnvSetupPlugin(channelId: ChannelPlugin["id"], envVar: string): void {
-  const plugin = {
-    ...createChannelTestPluginBase({ id: channelId }),
-    setupContract: defineChannelSetupContract({
-      fields: {
-        useEnv: {
-          kind: "boolean",
-          cli: { flags: "--use-env", description: "Use environment credentials" },
-          envVars: [envVar],
-        },
+function registerEnvContractTestPlugin(channelId: string, envVars: readonly string[]): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: channelId,
+        plugin: {
+          ...createChannelTestPluginBase({ id: channelId, label: channelId }),
+          setupContract: defineChannelSetupContract({
+            fields: {
+              useEnv: {
+                kind: "boolean",
+                cli: { flags: "--use-env", description: "Use environment credentials" },
+                envVars,
+              },
+            },
+            adapter: {
+              applyAccountConfig: ({ cfg }) => ({
+                ...cfg,
+                channels: {
+                  ...cfg.channels,
+                  [channelId]: { enabled: true },
+                },
+              }),
+            },
+          }),
+        } as ChannelPlugin,
+        source: "test",
       },
-      adapter: {
-        applyAccountConfig: ({ cfg }) => ({
-          ...cfg,
-          channels: { ...cfg.channels, [channelId]: { enabled: true } },
-        }),
-      },
-    }),
-  } as ChannelPlugin;
-  setActivePluginRegistry(createTestRegistry([{ pluginId: channelId, plugin, source: "test" }]));
+    ]),
+  );
 }
 
 type SignalAfterAccountConfigWritten = NonNullable<
@@ -532,35 +542,30 @@ describe("channelsAddCommand", () => {
 
   it.each([
     {
-      channel: "telegram",
-      options: {},
-      env: { TELEGRAM_BOT_TOKEN: "" },
-      missing: ["TELEGRAM_BOT_TOKEN"],
+      channel: "single-env-chat",
+      env: { SINGLE_CHAT_TOKEN: "" },
+      missing: ["SINGLE_CHAT_TOKEN"],
     },
     {
-      channel: "slack",
-      options: {},
-      env: { SLACK_BOT_TOKEN: "" },
-      missing: ["SLACK_BOT_TOKEN"],
+      channel: "multi-env-chat",
+      env: { MULTI_CHAT_TOKEN: "token", MULTI_CHAT_SECOND_TOKEN: "" },
+      missing: ["MULTI_CHAT_SECOND_TOKEN"],
     },
     {
-      channel: "buzz",
-      options: {},
-      env: { BUZZ_PRIVATE_KEY: "" },
-      missing: ["BUZZ_PRIVATE_KEY"],
+      channel: "private-key-chat",
+      env: { PRIVATE_CHAT_KEY: "" },
+      missing: ["PRIVATE_CHAT_KEY"],
     },
   ])("rejects $channel --use-env when declared env vars are missing", async (testCase) => {
     for (const [name, value] of Object.entries(testCase.env)) {
       vi.stubEnv(name, value);
     }
-    registerSyntheticUseEnvSetupPlugin(testCase.channel, testCase.missing[0] as string);
+    registerEnvContractTestPlugin(testCase.channel, Object.keys(testCase.env));
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
-    await channelsAddCommand(
-      { channel: testCase.channel, useEnv: true, ...testCase.options },
-      runtime,
-      { hasFlags: true },
-    );
+    await channelsAddCommand({ channel: testCase.channel, useEnv: true }, runtime, {
+      hasFlags: true,
+    });
 
     for (const missing of testCase.missing) {
       expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(missing));
@@ -571,18 +576,18 @@ describe("channelsAddCommand", () => {
 
   it.each([
     {
-      channel: "telegram",
-      env: { TELEGRAM_BOT_TOKEN: "telegram-token" },
+      channel: "single-env-chat",
+      env: { SINGLE_CHAT_TOKEN: "token" },
     },
     {
-      channel: "slack",
-      env: { SLACK_BOT_TOKEN: "xoxb-token" },
+      channel: "multi-env-chat",
+      env: { MULTI_CHAT_TOKEN: "token", MULTI_CHAT_SECOND_TOKEN: "second-token" },
     },
   ])("commits $channel --use-env config when declared env vars are present", async (testCase) => {
     for (const [name, value] of Object.entries(testCase.env)) {
       vi.stubEnv(name, value);
     }
-    registerSyntheticUseEnvSetupPlugin(testCase.channel, Object.keys(testCase.env)[0] as string);
+    registerEnvContractTestPlugin(testCase.channel, Object.keys(testCase.env));
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
     await channelsAddCommand({ channel: testCase.channel, useEnv: true }, runtime, {
@@ -590,6 +595,24 @@ describe("channelsAddCommand", () => {
     });
 
     expect(writtenChannel(testCase.channel)).toEqual({ enabled: true });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("does not demand env vars outside the selected setup contract", async () => {
+    vi.stubEnv("DECLARED_TOKEN", "declared-token");
+    vi.stubEnv("CONDITIONAL_TOKEN", "");
+    registerEnvContractTestPlugin("conditional-chat", ["DECLARED_TOKEN"]);
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand({ channel: "conditional-chat", useEnv: true }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(writtenChannel("conditional-chat")).toMatchObject({
+      enabled: true,
+    });
+    expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("CONDITIONAL_TOKEN"));
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
   });

--- a/src/gateway/session-companion.test.ts
+++ b/src/gateway/session-companion.test.ts
@@ -687,7 +687,9 @@ describe("session companion tool scope", () => {
 
     const targetAccess = await resolveSessionToolAccess({
       action: "history",
+      requesterAgentId: "main",
       requesterSessionKey: "agent:main:target",
+      targetAgentId: "main",
       targetSessionKey: "agent:main:target",
       requesterOwned: false,
       visibility: "self",
@@ -696,7 +698,9 @@ describe("session companion tool scope", () => {
     expect(targetAccess).toMatchObject({ allowed: true });
     const differentAccess = await resolveSessionToolAccess({
       action: "history",
+      requesterAgentId: "main",
       requesterSessionKey: "agent:main:target",
+      targetAgentId: "main",
       targetSessionKey: "agent:main:different",
       requesterOwned: false,
       visibility: "self",

--- a/src/gateway/session-companion.test.ts
+++ b/src/gateway/session-companion.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createAgentToAgentPolicy,
-  createSessionVisibilityGuard,
-} from "../agents/tools/sessions-helpers.js";
+  resolveSessionToolAccess,
+} from "../agents/tools/sessions-access.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { SessionCompanionAskError } from "./session-companion-ask.js";
 import type { SessionCompanionContextReader } from "./session-companion-context.js";
@@ -685,14 +685,24 @@ describe("session companion tool scope", () => {
     expect(cfg.tools?.toolSearch).toMatchObject({ enabled: false });
     expect(cfg.tools?.codeMode).toMatchObject({ enabled: false });
 
-    const guard = await createSessionVisibilityGuard({
+    const targetAccess = await resolveSessionToolAccess({
       action: "history",
       requesterSessionKey: "agent:main:target",
+      targetSessionKey: "agent:main:target",
+      requesterOwned: false,
       visibility: "self",
       a2aPolicy: createAgentToAgentPolicy(cfg),
     });
-    expect(guard.check("agent:main:target")).toMatchObject({ allowed: true });
-    expect(guard.check("agent:main:different")).toMatchObject({
+    expect(targetAccess).toMatchObject({ allowed: true });
+    const differentAccess = await resolveSessionToolAccess({
+      action: "history",
+      requesterSessionKey: "agent:main:target",
+      targetSessionKey: "agent:main:different",
+      requesterOwned: false,
+      visibility: "self",
+      a2aPolicy: createAgentToAgentPolicy(cfg),
+    });
+    expect(differentAccess).toMatchObject({
       allowed: false,
       status: "forbidden",
     });

--- a/src/plugin-sdk/session-visibility-internal.ts
+++ b/src/plugin-sdk/session-visibility-internal.ts
@@ -10,7 +10,14 @@
  * from here. See issue #114653.
  */
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
-import { isGatewayTransportError, callGateway as defaultCallGateway } from "../gateway/call.js";
+import {
+  GatewayCredentialsRequiredError,
+  GatewayExplicitAuthRequiredError,
+  GatewayLocalBackendSharedAuthUnavailableError,
+  GatewayStoredDeviceAuthUnavailableError,
+  isGatewayTransportError,
+  callGateway as defaultCallGateway,
+} from "../gateway/call.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
@@ -18,47 +25,55 @@ import { logWarn } from "../logger.js";
 type GatewayCaller = typeof defaultCallGateway;
 
 /**
- * Classify whether a spawned-session ownership lookup failure is worth retrying.
+ * Classify a spawned-session ownership lookup failure for caller guidance.
  *
- * Only known temporary failures are retryable: transport-level closes/timeouts,
- * and request-level errors the gateway itself marked `retryable`. Credential,
- * auth, and configuration failures surface before a socket is opened and will
- * not recover through retry, so they are non-retryable. Unknown errors are
- * treated as non-retryable so callers are not told to retry a failure that may
- * be permanent (review P1: classify before prescribing retry). See issue #114653.
+ * Only known temporary failures prescribe retry. Credential guidance is
+ * reserved for the explicit pre-connect auth errors; all other failures remain
+ * fail-closed with generic diagnostics instead of guessing at their cause.
  */
-export function classifyLookupRetryable(error: unknown): boolean {
+export type LookupFailureKind = "transient" | "credentials" | "unknown";
+
+export function classifyLookupFailure(error: unknown): LookupFailureKind {
   if (isGatewayTransportError(error)) {
-    return true;
+    return "transient";
   }
-  if (error instanceof GatewayClientRequestError) {
-    return (error as { retryable?: unknown }).retryable === true;
+  if (error instanceof GatewayClientRequestError && error.retryable) {
+    return "transient";
   }
-  return false;
+  if (
+    error instanceof GatewayCredentialsRequiredError ||
+    error instanceof GatewayExplicitAuthRequiredError ||
+    error instanceof GatewayStoredDeviceAuthUnavailableError ||
+    error instanceof GatewayLocalBackendSharedAuthUnavailableError
+  ) {
+    return "credentials";
+  }
+  return "unknown";
 }
 
 /**
- * Shared denial suffix for a failed ownership lookup, parameterized by
- * retryability so the direct guard and the sandboxed resolver render the same
- * distinct text. See issue #114653.
+ * Shared denial suffix for a failed ownership lookup so direct and sandboxed
+ * guards render the same cause-appropriate recovery guidance.
  */
-export function lookupFailedDenialSuffix(retryable: boolean): string {
-  return retryable
-    ? "spawned-session ownership lookup failed (transient); retry the operation."
-    : "spawned-session ownership lookup failed; check gateway configuration and credentials.";
+export function lookupFailedDenialSuffix(kind: LookupFailureKind): string {
+  if (kind === "transient") {
+    return "spawned-session ownership lookup failed (transient); retry the operation.";
+  }
+  if (kind === "credentials") {
+    return "spawned-session ownership lookup failed; check gateway configuration and credentials.";
+  }
+  return "spawned-session ownership lookup failed; check gateway logs for the reported error.";
 }
 
 /**
  * Result of listing spawned-session keys. Distinguishes a successful (possibly
  * empty) lookup from a failed one so the visibility guard can tell a genuine
- * policy denial apart from a lookup failure. The `retryable` flag on a failed
- * lookup carries the classification from {@link classifyLookupRetryable} so the
- * denial text can tell transient transport failures (retry) apart from
- * permanent credential/configuration failures (do not retry). See issue #114653.
+ * policy denial apart from a lookup failure. The failure kind preserves only
+ * guidance supported by the caught error; unknown failures remain generic.
  */
 export type SpawnedSessionKeysResult =
   | { ok: true; keys: Set<string> }
-  | { ok: false; error: unknown; retryable: boolean };
+  | { ok: false; error: unknown; failureKind: LookupFailureKind };
 
 /** List sessions spawned by the requester through the gateway session list method. */
 export async function listSpawnedSessionKeysWithResult(params: {
@@ -90,13 +105,11 @@ export async function listSpawnedSessionKeysWithResult(params: {
     // collapse into a genuine policy denial (issue #114653). Retry behavior is
     // intentionally not added here — retrying transient lookup failures is a
     // maintainer product decision (see the issue's maintainer-review labels),
-    // so this PR only classifies and logs the failure. The retryable flag
-    // distinguishes temporary transport failures from permanent credential /
-    // configuration failures so callers are not told to retry a non-retryable
-    // access failure (review P1).
+    // so this path only classifies and logs the failure. Keep unknown causes
+    // distinct from confirmed auth failures so recovery text never guesses.
     logWarn(
       `session-visibility: listSpawnedSessionKeys failed for requester=${params.requesterSessionKey}: ${formatErrorMessage(error)}`,
     );
-    return { ok: false, error, retryable: classifyLookupRetryable(error) };
+    return { ok: false, error, failureKind: classifyLookupFailure(error) };
   }
 }

--- a/src/plugin-sdk/session-visibility-internal.ts
+++ b/src/plugin-sdk/session-visibility-internal.ts
@@ -11,6 +11,7 @@ import { GatewayClientRequestError } from "../gateway/client.js";
 import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
+import { redactIdentifier } from "../logging/redact-identifier.js";
 
 type GatewayCaller = typeof defaultCallGateway;
 
@@ -85,7 +86,7 @@ export function logSessionOwnershipLookupFailure(params: {
   failure: SessionOwnershipLookupFailure;
 }): void {
   logWarn(
-    `session-visibility: spawned-session ownership lookup failed for requester=${params.requesterSessionKey}: ${params.failure.diagnostic}`,
+    `session-visibility: spawned-session ownership lookup failed for requester=${redactIdentifier(params.requesterSessionKey)}: ${params.failure.diagnostic}`,
   );
 }
 

--- a/src/plugin-sdk/session-visibility-internal.ts
+++ b/src/plugin-sdk/session-visibility-internal.ts
@@ -1,0 +1,102 @@
+/**
+ * Core-private shared implementation for the spawned-session ownership lookup.
+ *
+ * This module is deliberately NOT part of the public plugin-sdk surface: it is
+ * not listed in `scripts/lib/plugin-sdk-entrypoints.json`, so the three-state
+ * result type and helper below are not published to plugins. The public
+ * `openclaw/plugin-sdk/session-visibility` entrypoint keeps the legacy
+ * Set-returning `listSpawnedSessionKeys` contract unchanged; the visibility
+ * guard and the sandboxed session resolver import the discriminated variant
+ * from here. See issue #114653.
+ */
+import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
+import { isGatewayTransportError, callGateway as defaultCallGateway } from "../gateway/call.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { logWarn } from "../logger.js";
+
+type GatewayCaller = typeof defaultCallGateway;
+
+/**
+ * Classify whether a spawned-session ownership lookup failure is worth retrying.
+ *
+ * Only known temporary failures are retryable: transport-level closes/timeouts,
+ * and request-level errors the gateway itself marked `retryable`. Credential,
+ * auth, and configuration failures surface before a socket is opened and will
+ * not recover through retry, so they are non-retryable. Unknown errors are
+ * treated as non-retryable so callers are not told to retry a failure that may
+ * be permanent (review P1: classify before prescribing retry). See issue #114653.
+ */
+export function classifyLookupRetryable(error: unknown): boolean {
+  if (isGatewayTransportError(error)) {
+    return true;
+  }
+  if (error instanceof GatewayClientRequestError) {
+    return (error as { retryable?: unknown }).retryable === true;
+  }
+  return false;
+}
+
+/**
+ * Shared denial suffix for a failed ownership lookup, parameterized by
+ * retryability so the direct guard and the sandboxed resolver render the same
+ * distinct text. See issue #114653.
+ */
+export function lookupFailedDenialSuffix(retryable: boolean): string {
+  return retryable
+    ? "spawned-session ownership lookup failed (transient); retry the operation."
+    : "spawned-session ownership lookup failed; check gateway configuration and credentials.";
+}
+
+/**
+ * Result of listing spawned-session keys. Distinguishes a successful (possibly
+ * empty) lookup from a failed one so the visibility guard can tell a genuine
+ * policy denial apart from a lookup failure. The `retryable` flag on a failed
+ * lookup carries the classification from {@link classifyLookupRetryable} so the
+ * denial text can tell transient transport failures (retry) apart from
+ * permanent credential/configuration failures (do not retry). See issue #114653.
+ */
+export type SpawnedSessionKeysResult =
+  | { ok: true; keys: Set<string> }
+  | { ok: false; error: unknown; retryable: boolean };
+
+/** List sessions spawned by the requester through the gateway session list method. */
+export async function listSpawnedSessionKeysWithResult(params: {
+  requesterSessionKey: string;
+  limit?: number;
+  callGateway?: GatewayCaller;
+}): Promise<SpawnedSessionKeysResult> {
+  const limit =
+    typeof params.limit === "number" && Number.isFinite(params.limit)
+      ? Math.max(1, Math.floor(params.limit))
+      : undefined;
+  try {
+    const list = await (params.callGateway ?? defaultCallGateway)<{
+      sessions: Array<{ key?: unknown }>;
+    }>({
+      method: "sessions.list",
+      params: {
+        includeGlobal: false,
+        includeUnknown: false,
+        ...(limit !== undefined ? { limit } : {}),
+        spawnedBy: params.requesterSessionKey,
+      },
+    });
+    const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
+    const keys = normalizeTrimmedStringList(sessions.map((entry) => entry?.key));
+    return { ok: true, keys: new Set(keys) };
+  } catch (error) {
+    // Fail closed and stay observable: a failed ownership lookup must not
+    // collapse into a genuine policy denial (issue #114653). Retry behavior is
+    // intentionally not added here — retrying transient lookup failures is a
+    // maintainer product decision (see the issue's maintainer-review labels),
+    // so this PR only classifies and logs the failure. The retryable flag
+    // distinguishes temporary transport failures from permanent credential /
+    // configuration failures so callers are not told to retry a non-retryable
+    // access failure (review P1).
+    logWarn(
+      `session-visibility: listSpawnedSessionKeys failed for requester=${params.requesterSessionKey}: ${formatErrorMessage(error)}`,
+    );
+    return { ok: false, error, retryable: classifyLookupRetryable(error) };
+  }
+}

--- a/src/plugin-sdk/session-visibility-internal.ts
+++ b/src/plugin-sdk/session-visibility-internal.ts
@@ -1,68 +1,56 @@
-/**
- * Core-private shared implementation for the spawned-session ownership lookup.
- *
- * This module is deliberately NOT part of the public plugin-sdk surface: it is
- * not listed in `scripts/lib/plugin-sdk-entrypoints.json`, so the three-state
- * result type and helper below are not published to plugins. The public
- * `openclaw/plugin-sdk/session-visibility` entrypoint keeps the legacy
- * Set-returning `listSpawnedSessionKeys` contract unchanged; the visibility
- * guard and the sandboxed session resolver import the discriminated variant
- * from here. See issue #114653.
- */
+/** Core-private spawned-session ownership lookup; not a published plugin SDK subpath. */
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
 import {
   GatewayCredentialsRequiredError,
   GatewayExplicitAuthRequiredError,
-  GatewayLocalBackendSharedAuthUnavailableError,
-  GatewayStoredDeviceAuthUnavailableError,
   isGatewayTransportError,
   callGateway as defaultCallGateway,
 } from "../gateway/call.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
+import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 
 type GatewayCaller = typeof defaultCallGateway;
 
-/**
- * Classify a spawned-session ownership lookup failure for caller guidance.
- *
- * Only known temporary failures prescribe retry. Credential guidance is
- * reserved for the explicit pre-connect auth errors; all other failures remain
- * fail-closed with generic diagnostics instead of guessing at their cause.
- */
 export type LookupFailureKind = "transient" | "credentials" | "unknown";
 
 export function classifyLookupFailure(error: unknown): LookupFailureKind {
-  if (isGatewayTransportError(error)) {
+  if (error instanceof GatewayClientRequestError && error.retryable) {
     return "transient";
   }
-  if (error instanceof GatewayClientRequestError && error.retryable) {
+  if (
+    isGatewayTransportError(error) &&
+    (error.kind === "timeout" || error.code === 1006 || error.code === 1013)
+  ) {
     return "transient";
   }
   if (
     error instanceof GatewayCredentialsRequiredError ||
     error instanceof GatewayExplicitAuthRequiredError ||
-    error instanceof GatewayStoredDeviceAuthUnavailableError ||
-    error instanceof GatewayLocalBackendSharedAuthUnavailableError
+    error instanceof GatewaySecretRefUnavailableError
   ) {
     return "credentials";
   }
   return "unknown";
 }
 
-/**
- * Shared denial suffix for a failed ownership lookup so direct and sandboxed
- * guards render the same cause-appropriate recovery guidance.
- */
 export function lookupFailedDenialSuffix(kind: LookupFailureKind): string {
   if (kind === "transient") {
     return "spawned-session ownership lookup failed (transient); retry the operation.";
   }
   if (kind === "credentials") {
-    return "spawned-session ownership lookup failed; check gateway configuration and credentials.";
+    return "spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.";
   }
-  return "spawned-session ownership lookup failed; check gateway logs for the reported error.";
+  return "spawned-session ownership lookup failed; ask the operator to inspect OpenClaw logs.";
+}
+
+export function lookupFailedDenialMessage(
+  action: "history" | "send" | "status" | "list",
+  kind: LookupFailureKind,
+): string {
+  const label = action === "list" ? "Session list" : `Session ${action}`;
+  return `${label} denied because ${lookupFailedDenialSuffix(kind)}`;
 }
 
 /**
@@ -73,7 +61,7 @@ export function lookupFailedDenialSuffix(kind: LookupFailureKind): string {
  */
 export type SpawnedSessionKeysResult =
   | { ok: true; keys: Set<string> }
-  | { ok: false; error: unknown; failureKind: LookupFailureKind };
+  | { ok: false; failureKind: LookupFailureKind };
 
 /** List sessions spawned by the requester through the gateway session list method. */
 export async function listSpawnedSessionKeysWithResult(params: {
@@ -101,15 +89,9 @@ export async function listSpawnedSessionKeysWithResult(params: {
     const keys = normalizeTrimmedStringList(sessions.map((entry) => entry?.key));
     return { ok: true, keys: new Set(keys) };
   } catch (error) {
-    // Fail closed and stay observable: a failed ownership lookup must not
-    // collapse into a genuine policy denial (issue #114653). Retry behavior is
-    // intentionally not added here — retrying transient lookup failures is a
-    // maintainer product decision (see the issue's maintainer-review labels),
-    // so this path only classifies and logs the failure. Keep unknown causes
-    // distinct from confirmed auth failures so recovery text never guesses.
     logWarn(
       `session-visibility: listSpawnedSessionKeys failed for requester=${params.requesterSessionKey}: ${formatErrorMessage(error)}`,
     );
-    return { ok: false, error, failureKind: classifyLookupFailure(error) };
+    return { ok: false, failureKind: classifyLookupFailure(error) };
   }
 }

--- a/src/plugin-sdk/session-visibility-internal.ts
+++ b/src/plugin-sdk/session-visibility-internal.ts
@@ -1,4 +1,5 @@
 /** Core-private spawned-session ownership lookup; not a published plugin SDK subpath. */
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
 import {
   GatewayCredentialsRequiredError,
@@ -37,7 +38,7 @@ export function classifyLookupFailure(error: unknown): LookupFailureKind {
 
 export function lookupFailedDenialSuffix(kind: LookupFailureKind): string {
   if (kind === "transient") {
-    return "spawned-session ownership lookup failed (transient); retry the operation.";
+    return "spawned-session ownership lookup failed (transient); retry once, then ask the operator to inspect OpenClaw logs.";
   }
   if (kind === "credentials") {
     return "spawned-session ownership lookup failed; ask the operator to check gateway configuration and credentials.";
@@ -46,29 +47,54 @@ export function lookupFailedDenialSuffix(kind: LookupFailureKind): string {
 }
 
 export function lookupFailedDenialMessage(
-  action: "history" | "send" | "status" | "list",
+  action: "history" | "send" | "status" | "list" | "search",
   kind: LookupFailureKind,
 ): string {
   const label = action === "list" ? "Session list" : `Session ${action}`;
   return `${label} denied because ${lookupFailedDenialSuffix(kind)}`;
 }
 
-/**
- * Result of listing spawned-session keys. Distinguishes a successful (possibly
- * empty) lookup from a failed one so the visibility guard can tell a genuine
- * policy denial apart from a lookup failure. The failure kind preserves only
- * guidance supported by the caught error; unknown failures remain generic.
- */
-export type SpawnedSessionKeysResult =
-  | { ok: true; keys: Set<string> }
-  | { ok: false; failureKind: LookupFailureKind };
+export function lookupFailedOperationMessage(
+  action: "history" | "send" | "status" | "list" | "search",
+  kind: LookupFailureKind,
+): string {
+  const label = action === "list" ? "Session list" : `Session ${action}`;
+  const guidance =
+    kind === "transient"
+      ? "retry once, then ask the operator to inspect OpenClaw logs"
+      : kind === "credentials"
+        ? "ask the operator to check gateway configuration and credentials"
+        : "ask the operator to inspect OpenClaw logs";
+  return `${label} failed because session lookup failed${kind === "transient" ? " (transient)" : ""}; ${guidance}.`;
+}
+
+export type SessionOwnershipLookupFailure = {
+  kind: LookupFailureKind;
+  diagnostic: string;
+};
+
+export function sessionOwnershipLookupFailure(error: unknown): SessionOwnershipLookupFailure {
+  return {
+    kind: classifyLookupFailure(error),
+    diagnostic: formatErrorMessage(error),
+  };
+}
+
+export function logSessionOwnershipLookupFailure(params: {
+  requesterSessionKey: string;
+  failure: SessionOwnershipLookupFailure;
+}): void {
+  logWarn(
+    `session-visibility: spawned-session ownership lookup failed for requester=${params.requesterSessionKey}: ${params.failure.diagnostic}`,
+  );
+}
 
 /** List sessions spawned by the requester through the gateway session list method. */
 export async function listSpawnedSessionKeysWithResult(params: {
   requesterSessionKey: string;
   limit?: number;
   callGateway?: GatewayCaller;
-}): Promise<SpawnedSessionKeysResult> {
+}): Promise<Result<Set<string>, SessionOwnershipLookupFailure>> {
   const limit =
     typeof params.limit === "number" && Number.isFinite(params.limit)
       ? Math.max(1, Math.floor(params.limit))
@@ -85,13 +111,16 @@ export async function listSpawnedSessionKeysWithResult(params: {
         spawnedBy: params.requesterSessionKey,
       },
     });
-    const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
+    if (!Array.isArray(list?.sessions)) {
+      return err({
+        kind: "unknown",
+        diagnostic: "gateway sessions.list returned an invalid response",
+      });
+    }
+    const sessions = list.sessions;
     const keys = normalizeTrimmedStringList(sessions.map((entry) => entry?.key));
-    return { ok: true, keys: new Set(keys) };
+    return ok(new Set(keys));
   } catch (error) {
-    logWarn(
-      `session-visibility: listSpawnedSessionKeys failed for requester=${params.requesterSessionKey}: ${formatErrorMessage(error)}`,
-    );
-    return { ok: false, failureKind: classifyLookupFailure(error) };
+    return err(sessionOwnershipLookupFailure(error));
   }
 }

--- a/src/plugin-sdk/session-visibility.test.ts
+++ b/src/plugin-sdk/session-visibility.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { GatewayCredentialsRequiredError } from "../gateway/call.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
-import {
-  classifyLookupFailure,
-  lookupFailedDenialSuffix,
-} from "./session-visibility-internal.js";
+import { classifyLookupFailure, lookupFailedDenialSuffix } from "./session-visibility-internal.js";
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityChecker,
@@ -199,15 +196,18 @@ describe("classifyLookupFailure", () => {
     { kind: "closed", code: 1006, expected: "transient" },
     { kind: "closed", code: 1013, expected: "transient" },
     { kind: "closed", code: 1008, expected: "unknown" },
-  ] as const)("classifies gateway transport $kind/$code as $expected", ({ kind, code, expected }) => {
-    const error = Object.assign(new Error("gateway transport failed"), {
-      name: "GatewayTransportError",
-      kind,
-      connectionDetails: {},
-      ...(code === undefined ? {} : { code }),
-    });
-    expect(classifyLookupFailure(error)).toBe(expected);
-  });
+  ] as const)(
+    "classifies gateway transport $kind/$code as $expected",
+    ({ kind, code, expected }) => {
+      const error = Object.assign(new Error("gateway transport failed"), {
+        name: "GatewayTransportError",
+        kind,
+        connectionDetails: {},
+        ...(code === undefined ? {} : { code }),
+      });
+      expect(classifyLookupFailure(error)).toBe(expected);
+    },
+  );
 
   it("classifies an explicit pre-connect auth failure as credentials", () => {
     const error = new GatewayCredentialsRequiredError({

--- a/src/plugin-sdk/session-visibility.test.ts
+++ b/src/plugin-sdk/session-visibility.test.ts
@@ -161,6 +161,41 @@ describe("scoped session access providers", () => {
     expect(history.check(target).allowed).toBe(false);
   });
 
+  it("keeps incognito sessions hidden from scoped and ownership grants", () => {
+    const requesterSessionKey = "agent:main:main";
+    const targetSessionKey = "agent:main:dashboard:incognito-private";
+    const expected = {
+      allowed: false,
+      status: "forbidden",
+      error: `Session not visible from session tools: ${targetSessionKey}`,
+    } as const;
+    const unregister = createSessionVisibilityChecker.registerScopedAccessProvider(() => ({
+      expectedSessionId: "incognito-incarnation",
+    }));
+    try {
+      const direct = createSessionVisibilityChecker({
+        action: "history",
+        requesterSessionKey,
+        visibility: "all",
+        a2aPolicy: createAgentToAgentPolicy({}),
+        spawnedKeys: new Set([targetSessionKey]),
+      });
+      const row = createSessionVisibilityRowChecker({
+        action: "history",
+        requesterSessionKey,
+        visibility: "all",
+        a2aPolicy: createAgentToAgentPolicy({}),
+      });
+
+      expect(direct.check(targetSessionKey)).toEqual(expected);
+      expect(row.check({ key: targetSessionKey, spawnedBy: requesterSessionKey })).toEqual(
+        expected,
+      );
+    } finally {
+      unregister();
+    }
+  });
+
   it("fails closed when a provider throws", () => {
     const unregister = createSessionVisibilityChecker.registerScopedAccessProvider(() => {
       throw new Error("provider failure");

--- a/src/plugin-sdk/session-visibility.test.ts
+++ b/src/plugin-sdk/session-visibility.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { GatewayCredentialsRequiredError } from "../gateway/call.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
 import {
-  classifyLookupRetryable,
+  classifyLookupFailure,
   lookupFailedDenialSuffix,
 } from "./session-visibility-internal.js";
 import {
@@ -183,38 +184,42 @@ describe("scoped session access providers", () => {
   });
 });
 
-describe("classifyLookupRetryable", () => {
-  // Locks the retryability classification contract so a future refactor cannot
-  // silently collapse permanent credential/config failures into a retryable
-  // "transient" denial (review P1: classify before prescribing retry).
-  it("treats a retryable gateway request error as retryable", () => {
+describe("classifyLookupFailure", () => {
+  it("classifies a retryable gateway request error as transient", () => {
     const error = new GatewayClientRequestError({
       code: "UNAVAILABLE",
       message: "transport timeout",
       retryable: true,
     });
-    expect(classifyLookupRetryable(error)).toBe(true);
+    expect(classifyLookupFailure(error)).toBe("transient");
   });
 
-  it("treats a non-retryable gateway request error as non-retryable", () => {
-    const error = new GatewayClientRequestError({
-      code: "PERMISSION_DENIED",
-      message: "requires credentials before opening a websocket",
+  it("classifies an explicit pre-connect auth failure as credentials", () => {
+    const error = new GatewayCredentialsRequiredError({
+      method: "sessions.list",
+      configPath: "/tmp/openclaw.json",
+    });
+    expect(classifyLookupFailure(error)).toBe("credentials");
+  });
+
+  it("keeps unknown and non-retryable request failures generic", () => {
+    const requestError = new GatewayClientRequestError({
+      code: "INTERNAL_ERROR",
+      message: "failed to decode session row",
       retryable: false,
     });
-    expect(classifyLookupRetryable(error)).toBe(false);
+    expect(classifyLookupFailure(requestError)).toBe("unknown");
+    expect(classifyLookupFailure(new Error("something else"))).toBe("unknown");
+    expect(classifyLookupFailure(null)).toBe("unknown");
+    expect(classifyLookupFailure(undefined)).toBe("unknown");
   });
 
-  it("treats an unknown error as non-retryable", () => {
-    expect(classifyLookupRetryable(new Error("something else"))).toBe(false);
-    expect(classifyLookupRetryable(null)).toBe(false);
-    expect(classifyLookupRetryable(undefined)).toBe(false);
-  });
-
-  it("renders distinct denial suffixes per retryability", () => {
-    expect(lookupFailedDenialSuffix(true)).toMatch(/transient\); retry/i);
-    expect(lookupFailedDenialSuffix(false)).toMatch(/check gateway configuration and credentials/i);
-    // A permanent failure must never prescribe retry.
-    expect(lookupFailedDenialSuffix(false)).not.toMatch(/retry/i);
+  it("renders cause-appropriate denial suffixes", () => {
+    expect(lookupFailedDenialSuffix("transient")).toMatch(/transient\); retry/i);
+    expect(lookupFailedDenialSuffix("credentials")).toMatch(
+      /check gateway configuration and credentials/i,
+    );
+    expect(lookupFailedDenialSuffix("unknown")).toMatch(/check gateway logs/i);
+    expect(lookupFailedDenialSuffix("unknown")).not.toMatch(/credentials|retry/i);
   });
 });

--- a/src/plugin-sdk/session-visibility.test.ts
+++ b/src/plugin-sdk/session-visibility.test.ts
@@ -194,6 +194,21 @@ describe("classifyLookupFailure", () => {
     expect(classifyLookupFailure(error)).toBe("transient");
   });
 
+  it.each([
+    { kind: "timeout", code: undefined, expected: "transient" },
+    { kind: "closed", code: 1006, expected: "transient" },
+    { kind: "closed", code: 1013, expected: "transient" },
+    { kind: "closed", code: 1008, expected: "unknown" },
+  ] as const)("classifies gateway transport $kind/$code as $expected", ({ kind, code, expected }) => {
+    const error = Object.assign(new Error("gateway transport failed"), {
+      name: "GatewayTransportError",
+      kind,
+      connectionDetails: {},
+      ...(code === undefined ? {} : { code }),
+    });
+    expect(classifyLookupFailure(error)).toBe(expected);
+  });
+
   it("classifies an explicit pre-connect auth failure as credentials", () => {
     const error = new GatewayCredentialsRequiredError({
       method: "sessions.list",
@@ -219,7 +234,7 @@ describe("classifyLookupFailure", () => {
     expect(lookupFailedDenialSuffix("credentials")).toMatch(
       /check gateway configuration and credentials/i,
     );
-    expect(lookupFailedDenialSuffix("unknown")).toMatch(/check gateway logs/i);
+    expect(lookupFailedDenialSuffix("unknown")).toMatch(/inspect OpenClaw logs/i);
     expect(lookupFailedDenialSuffix("unknown")).not.toMatch(/credentials|retry/i);
   });
 });

--- a/src/plugin-sdk/session-visibility.test.ts
+++ b/src/plugin-sdk/session-visibility.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
+import {
+  classifyLookupRetryable,
+  lookupFailedDenialSuffix,
+} from "./session-visibility-internal.js";
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityChecker,
@@ -39,6 +44,24 @@ describe("scoped session access providers", () => {
       allowed: false,
       status: "forbidden",
       error: "Session history denied because target agent ownership is unavailable.",
+    });
+  });
+
+  it("accepts a legacy Set spawnedKeys input on the exported checker", () => {
+    const checker = createSessionVisibilityChecker({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({}),
+      spawnedKeys: new Set(["agent:main:subagent:child-1"]),
+    });
+
+    expect(checker.check("agent:main:subagent:child-1")).toEqual({ allowed: true });
+    expect(checker.check("agent:main:subagent:unrelated")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history visibility is restricted to the current session tree and any watched same-agent group sessions (tools.sessions.visibility=tree).",
     });
   });
 
@@ -157,5 +180,41 @@ describe("scoped session access providers", () => {
     } finally {
       unregister();
     }
+  });
+});
+
+describe("classifyLookupRetryable", () => {
+  // Locks the retryability classification contract so a future refactor cannot
+  // silently collapse permanent credential/config failures into a retryable
+  // "transient" denial (review P1: classify before prescribing retry).
+  it("treats a retryable gateway request error as retryable", () => {
+    const error = new GatewayClientRequestError({
+      code: "UNAVAILABLE",
+      message: "transport timeout",
+      retryable: true,
+    });
+    expect(classifyLookupRetryable(error)).toBe(true);
+  });
+
+  it("treats a non-retryable gateway request error as non-retryable", () => {
+    const error = new GatewayClientRequestError({
+      code: "PERMISSION_DENIED",
+      message: "requires credentials before opening a websocket",
+      retryable: false,
+    });
+    expect(classifyLookupRetryable(error)).toBe(false);
+  });
+
+  it("treats an unknown error as non-retryable", () => {
+    expect(classifyLookupRetryable(new Error("something else"))).toBe(false);
+    expect(classifyLookupRetryable(null)).toBe(false);
+    expect(classifyLookupRetryable(undefined)).toBe(false);
+  });
+
+  it("renders distinct denial suffixes per retryability", () => {
+    expect(lookupFailedDenialSuffix(true)).toMatch(/transient\); retry/i);
+    expect(lookupFailedDenialSuffix(false)).toMatch(/check gateway configuration and credentials/i);
+    // A permanent failure must never prescribe retry.
+    expect(lookupFailedDenialSuffix(false)).not.toMatch(/retry/i);
   });
 });

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -6,7 +6,12 @@ import {
 } from "../../packages/normalization-core/src/string-coerce.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway as defaultCallGateway } from "../gateway/call.js";
-import { isIncognitoSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import {
+  isAcpSessionKey,
+  isIncognitoSessionKey,
+  isSubagentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
 import {
   listSpawnedSessionKeysWithResult,
@@ -359,14 +364,18 @@ function createSessionVisibilityCheckerWithResult(
       spawnedBy: isSpawnedSession ? params.requesterSessionKey : undefined,
     });
     if (!result.allowed) {
-      // Valid targets may still be requester-owned; malformed targets keep the row checker's
-      // deterministic ownership error instead of being relabeled as a lookup failure.
+      const ownedResult = rowChecker.check({
+        key: targetSessionKey,
+        spawnedBy: params.requesterSessionKey,
+      });
+      // Preserve denials that ownership cannot change; only ownership-dependent
+      // denials should be replaced by lookup-failure guidance.
       const lookupFailed =
         spawnedKeys !== null &&
         !spawnedKeys.ok &&
         targetSessionKey !== params.requesterSessionKey &&
         targetSessionKey !== "current" &&
-        hasResolvableTargetAgent(targetSessionKey, params.defaultAgentId);
+        ownedResult.allowed;
       if (lookupFailed) {
         if (!lookupFailureLogged) {
           lookupFailureLogged = true;
@@ -386,19 +395,6 @@ function createSessionVisibilityCheckerWithResult(
   };
 
   return { check };
-}
-
-function hasResolvableTargetAgent(
-  targetSessionKey: string,
-  defaultAgentId: string | undefined,
-): boolean {
-  try {
-    resolveAgentIdFromSessionKey(targetSessionKey, defaultAgentId);
-    return true;
-  } catch {
-    // The row checker already owns the deterministic target-ownership denial.
-    return false;
-  }
 }
 
 /** Create a direct session-key visibility checker for one requester/action pair. */
@@ -477,16 +473,21 @@ export function createSessionVisibilityRowChecker(params: {
         targetSessionKey,
       );
     const isRequesterOwned = rowOwnedByRequester(row, params.requesterSessionKey) || isWatchedRead;
+    const isCrossAgent = targetAgentId !== requesterAgentId;
     // Row ownership is stronger than agent ids: ACP children may use a backend
-    // agent id while still belonging to the requester that spawned them.
+    // agent id while still belonging to the requester that spawned them. Only
+    // native child namespaces can cross that agent boundary; ordinary sessions
+    // remain subject to A2A policy even if malformed lineage claims otherwise.
     if (
       !isRequesterSession &&
       isRequesterOwned &&
+      (!isCrossAgent ||
+        isAcpSessionKey(targetSessionKey) ||
+        isSubagentSessionKey(targetSessionKey)) &&
       (params.visibility === "tree" || params.visibility === "all")
     ) {
       return { allowed: true };
     }
-    const isCrossAgent = targetAgentId !== requesterAgentId;
     if (isCrossAgent) {
       if (params.visibility !== "all") {
         return {

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -335,7 +335,6 @@ function createSessionVisibilityCheckerWithResult(
       const lookupFailed =
         spawnedKeys !== null &&
         !spawnedKeys.ok &&
-        params.visibility === "tree" &&
         targetSessionKey !== params.requesterSessionKey &&
         targetSessionKey !== "current" &&
         hasResolvableTargetAgent(targetSessionKey, params.defaultAgentId);

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -3,11 +3,17 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../../packages/normalization-core/src/string-coerce.js";
-import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway as defaultCallGateway } from "../gateway/call.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { logWarn } from "../logger.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
+import {
+  listSpawnedSessionKeysWithResult,
+  lookupFailedDenialSuffix,
+  type SpawnedSessionKeysResult,
+} from "./session-visibility-internal.js";
 
 type GatewayCaller = typeof defaultCallGateway;
 
@@ -58,8 +64,11 @@ function resolveScopedSessionAccess(
       if (expectedSessionId) {
         return { expectedSessionId };
       }
-    } catch {
+    } catch (error) {
       // Access providers fail closed; normal visibility evaluation still runs.
+      logWarn(
+        `session-visibility: scoped access provider threw for requester=${request.requesterSessionKey} target=${request.targetSessionKey} action=${request.action}: ${formatErrorMessage(error)}`,
+      );
     }
   }
   return undefined;
@@ -74,34 +83,24 @@ export type SessionVisibilityRow = {
   parentSessionKey?: string;
 };
 
-/** List sessions spawned by the requester through the gateway session list method. */
+/**
+ * List sessions spawned by the requester through the gateway session list
+ * method.
+ *
+ * Public plugin-SDK contract: always resolves to a `Set<string>` so existing
+ * plugin callers that use `.has()` keep working. A failed lookup collapses to
+ * an empty set (fail-closed) exactly like previous releases; the failure is
+ * still logged. The visibility guard uses
+ * {@link listSpawnedSessionKeysWithResult} (core-private) so it can
+ * distinguish a failed lookup from a genuine policy denial (issue #114653).
+ */
 export async function listSpawnedSessionKeys(params: {
   requesterSessionKey: string;
   limit?: number;
   callGateway?: GatewayCaller;
 }): Promise<Set<string>> {
-  const limit =
-    typeof params.limit === "number" && Number.isFinite(params.limit)
-      ? Math.max(1, Math.floor(params.limit))
-      : undefined;
-  try {
-    const list = await (params.callGateway ?? defaultCallGateway)<{
-      sessions: Array<{ key?: unknown }>;
-    }>({
-      method: "sessions.list",
-      params: {
-        includeGlobal: false,
-        includeUnknown: false,
-        ...(limit !== undefined ? { limit } : {}),
-        spawnedBy: params.requesterSessionKey,
-      },
-    });
-    const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
-    const keys = normalizeTrimmedStringList(sessions.map((entry) => entry?.key));
-    return new Set(keys);
-  } catch {
-    return new Set();
-  }
+  const result = await listSpawnedSessionKeysWithResult(params);
+  return result.ok ? result.keys : new Set();
 }
 
 /** Resolve configured session-tool visibility, defaulting invalid or missing values to tree. */
@@ -304,16 +303,18 @@ function treeVisibilityMessage(action: SessionAccessAction): string {
   return `${actionPrefix(action)} visibility is restricted to the current session tree and any watched same-agent group sessions (tools.sessions.visibility=tree).`;
 }
 
-/** Create a direct session-key visibility checker for one requester/action pair. */
-function createSessionVisibilityCheckerImpl(params: {
+type SessionVisibilityCheckerParams = {
   action: SessionAccessAction;
   defaultAgentId?: string;
   requesterAgentId?: string;
   requesterSessionKey: string;
   visibility: SessionToolsVisibility;
   a2aPolicy: AgentToAgentPolicy;
-  spawnedKeys: Set<string> | null;
-}): { check: (targetSessionKey: string) => SessionAccessResult } {
+};
+
+function createSessionVisibilityCheckerWithResult(
+  params: SessionVisibilityCheckerParams & { spawnedKeys: SpawnedSessionKeysResult | null },
+): { check: (targetSessionKey: string) => SessionAccessResult } {
   const spawnedKeys = params.spawnedKeys;
   const rowChecker = createSessionVisibilityRowChecker({
     action: params.action,
@@ -335,14 +336,55 @@ function createSessionVisibilityCheckerImpl(params: {
         return { allowed: true, expectedSessionId: scoped.expectedSessionId };
       }
     }
-    const isSpawnedSession = spawnedKeys?.has(targetSessionKey) === true;
-    return rowChecker.check({
+    const spawnedKeySet = spawnedKeys?.ok ? spawnedKeys.keys : undefined;
+    const isSpawnedSession = spawnedKeySet?.has(targetSessionKey) === true;
+    const result = rowChecker.check({
       key: targetSessionKey,
       spawnedBy: isSpawnedSession ? params.requesterSessionKey : undefined,
     });
+    if (!result.allowed) {
+      // A failed ownership lookup fail-closes as a denial under tree visibility,
+      // where direct-key targets rely on the spawned-session set to prove
+      // ownership. It is marked distinct from a policy denial so callers can
+      // tell a transient lookup failure apart from a genuine authorization
+      // refusal. The row checker still runs first so durable watched same-agent
+      // group reads (and self/current targets) keep their existing allowance:
+      // those grants do not depend on the spawned-session set. Under "all"
+      // visibility this override does not apply — cross-agent targets are
+      // evaluated by the agent-to-agent policy regardless of spawned ownership.
+      // See issue #114653.
+      const lookupFailed =
+        spawnedKeys !== null &&
+        !spawnedKeys.ok &&
+        params.visibility === "tree" &&
+        targetSessionKey !== params.requesterSessionKey &&
+        targetSessionKey !== "current";
+      if (lookupFailed) {
+        // The denial text carries the lookup's retryability so a transient
+        // transport failure (retry) is distinguishable from a permanent
+        // credential/configuration failure (do not retry). Both still fail
+        // closed. See issue #114653 (review P1: classify before prescribing retry).
+        return {
+          allowed: false,
+          status: "forbidden",
+          error: `${actionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedKeys.retryable)}`,
+        };
+      }
+    }
+    return result;
   };
 
   return { check };
+}
+
+/** Create a direct session-key visibility checker for one requester/action pair. */
+function createSessionVisibilityCheckerImpl(
+  params: SessionVisibilityCheckerParams & { spawnedKeys: Set<string> | null },
+): { check: (targetSessionKey: string) => SessionAccessResult } {
+  return createSessionVisibilityCheckerWithResult({
+    ...params,
+    spawnedKeys: params.spawnedKeys ? { ok: true, keys: params.spawnedKeys } : null,
+  });
 }
 
 /** Direct-key visibility checker plus registration for narrow host-owned grants. */
@@ -480,12 +522,12 @@ export async function createSessionVisibilityGuard(params: {
   // this lookup until every caller can pass a normalized session row.
   const spawnedKeys =
     params.action !== "list" && (params.visibility === "tree" || params.visibility === "all")
-      ? await listSpawnedSessionKeys({
+      ? await listSpawnedSessionKeysWithResult({
           requesterSessionKey: params.requesterSessionKey,
           callGateway: params.callGateway,
         })
       : null;
-  return createSessionVisibilityChecker({
+  return createSessionVisibilityCheckerWithResult({
     action: params.action,
     defaultAgentId: params.defaultAgentId,
     requesterAgentId: params.requesterAgentId,

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -330,14 +330,15 @@ function createSessionVisibilityCheckerWithResult(
       spawnedBy: isSpawnedSession ? params.requesterSessionKey : undefined,
     });
     if (!result.allowed) {
-      // Preserve grants that do not depend on spawned ownership; otherwise fail closed with cause.
+      // Valid targets may still be requester-owned; malformed targets keep the row checker's
+      // deterministic ownership error instead of being relabeled as a lookup failure.
       const lookupFailed =
         spawnedKeys !== null &&
         !spawnedKeys.ok &&
         params.visibility === "tree" &&
         targetSessionKey !== params.requesterSessionKey &&
         targetSessionKey !== "current" &&
-        !isCrossAgentTarget(params, targetSessionKey);
+        hasResolvableTargetAgent(targetSessionKey, params.defaultAgentId);
       if (lookupFailed) {
         return {
           allowed: false,
@@ -352,38 +353,17 @@ function createSessionVisibilityCheckerWithResult(
   return { check };
 }
 
-/**
- * Whether a direct-key target resolves to a different agent than the requester.
- *
- * Mirrors the row checker's agent resolution so the lookup-failure override can
- * avoid clobbering deterministic cross-agent policy denials: retrying a spawned
- * ownership lookup cannot make a known `agent:other:*` target eligible, so those
- * denials must be preserved as-is instead of being relabeled as retryable lookup
- * failures. Returns true only when the target agent is known and differs.
- */
-function isCrossAgentTarget(
-  params: SessionVisibilityCheckerParams,
+function hasResolvableTargetAgent(
   targetSessionKey: string,
+  defaultAgentId: string | undefined,
 ): boolean {
-  const requesterAgentId =
-    normalizeLowercaseStringOrEmpty(params.requesterAgentId) ||
-    resolveAgentIdFromSessionKey(params.requesterSessionKey, params.defaultAgentId);
-  let targetAgentId: string | undefined;
   try {
-    targetAgentId = resolveAgentIdFromSessionKey(targetSessionKey, params.defaultAgentId);
+    resolveAgentIdFromSessionKey(targetSessionKey, defaultAgentId);
+    return true;
   } catch {
-    // If the target agent cannot be resolved, the row checker has already
-    // returned a deterministic "agent ownership unavailable" denial that does
-    // not depend on spawned ownership; do not relabel it.
+    // The row checker already owns the deterministic target-ownership denial.
     return false;
   }
-  // Both ids are resolved strings here; an empty requester id means the
-  // requester itself is unscoped, in which case the row checker's own denial
-  // already applies and we must not relabel it.
-  if (!requesterAgentId || !targetAgentId) {
-    return false;
-  }
-  return targetAgentId !== requesterAgentId;
 }
 
 /** Create a direct session-key visibility checker for one requester/action pair. */

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -6,8 +6,6 @@ import {
 } from "../../packages/normalization-core/src/string-coerce.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway as defaultCallGateway } from "../gateway/call.js";
-import { formatErrorMessage } from "../infra/errors.js";
-import { logWarn } from "../logger.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
 import {

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -377,7 +377,13 @@ function isCrossAgentTarget(
     // not depend on spawned ownership; do not relabel it.
     return false;
   }
-  return !!targetAgentId && !!requesterAgentId && targetAgentId !== requesterAgentId;
+  // Both ids are resolved strings here; an empty requester id means the
+  // requester itself is unscoped, in which case the row checker's own denial
+  // already applies and we must not relabel it.
+  if (!requesterAgentId || !targetAgentId) {
+    return false;
+  }
+  return targetAgentId !== requesterAgentId;
 }
 
 /** Create a direct session-key visibility checker for one requester/action pair. */

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -336,7 +336,8 @@ function createSessionVisibilityCheckerWithResult(
         !spawnedKeys.ok &&
         params.visibility === "tree" &&
         targetSessionKey !== params.requesterSessionKey &&
-        targetSessionKey !== "current";
+        targetSessionKey !== "current" &&
+        !isCrossAgentTarget(params, targetSessionKey);
       if (lookupFailed) {
         return {
           allowed: false,
@@ -349,6 +350,34 @@ function createSessionVisibilityCheckerWithResult(
   };
 
   return { check };
+}
+
+/**
+ * Whether a direct-key target resolves to a different agent than the requester.
+ *
+ * Mirrors the row checker's agent resolution so the lookup-failure override can
+ * avoid clobbering deterministic cross-agent policy denials: retrying a spawned
+ * ownership lookup cannot make a known `agent:other:*` target eligible, so those
+ * denials must be preserved as-is instead of being relabeled as retryable lookup
+ * failures. Returns true only when the target agent is known and differs.
+ */
+function isCrossAgentTarget(
+  params: SessionVisibilityCheckerParams,
+  targetSessionKey: string,
+): boolean {
+  const requesterAgentId =
+    normalizeLowercaseStringOrEmpty(params.requesterAgentId) ||
+    resolveAgentIdFromSessionKey(params.requesterSessionKey, params.defaultAgentId);
+  let targetAgentId: string | undefined;
+  try {
+    targetAgentId = resolveAgentIdFromSessionKey(targetSessionKey, params.defaultAgentId);
+  } catch {
+    // If the target agent cannot be resolved, the row checker has already
+    // returned a deterministic "agent ownership unavailable" denial that does
+    // not depend on spawned ownership; do not relabel it.
+    return false;
+  }
+  return !!targetAgentId && !!requesterAgentId && targetAgentId !== requesterAgentId;
 }
 
 /** Create a direct session-key visibility checker for one requester/action pair. */

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -367,7 +367,7 @@ function createSessionVisibilityCheckerWithResult(
         return {
           allowed: false,
           status: "forbidden",
-          error: `${actionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedKeys.retryable)}`,
+          error: `${actionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedKeys.failureKind)}`,
         };
       }
     }

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -11,7 +11,7 @@ import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
 import {
   listSpawnedSessionKeysWithResult,
-  lookupFailedDenialSuffix,
+  lookupFailedDenialMessage,
   type SpawnedSessionKeysResult,
 } from "./session-visibility-internal.js";
 
@@ -64,11 +64,8 @@ function resolveScopedSessionAccess(
       if (expectedSessionId) {
         return { expectedSessionId };
       }
-    } catch (error) {
+    } catch {
       // Access providers fail closed; normal visibility evaluation still runs.
-      logWarn(
-        `session-visibility: scoped access provider threw for requester=${request.requesterSessionKey} target=${request.targetSessionKey} action=${request.action}: ${formatErrorMessage(error)}`,
-      );
     }
   }
   return undefined;
@@ -83,17 +80,7 @@ export type SessionVisibilityRow = {
   parentSessionKey?: string;
 };
 
-/**
- * List sessions spawned by the requester through the gateway session list
- * method.
- *
- * Public plugin-SDK contract: always resolves to a `Set<string>` so existing
- * plugin callers that use `.has()` keep working. A failed lookup collapses to
- * an empty set (fail-closed) exactly like previous releases; the failure is
- * still logged. The visibility guard uses
- * {@link listSpawnedSessionKeysWithResult} (core-private) so it can
- * distinguish a failed lookup from a genuine policy denial (issue #114653).
- */
+/** Public compatibility wrapper; direct guards use the richer private result. */
 export async function listSpawnedSessionKeys(params: {
   requesterSessionKey: string;
   limit?: number;
@@ -343,16 +330,7 @@ function createSessionVisibilityCheckerWithResult(
       spawnedBy: isSpawnedSession ? params.requesterSessionKey : undefined,
     });
     if (!result.allowed) {
-      // A failed ownership lookup fail-closes as a denial under tree visibility,
-      // where direct-key targets rely on the spawned-session set to prove
-      // ownership. It is marked distinct from a policy denial so callers can
-      // tell a transient lookup failure apart from a genuine authorization
-      // refusal. The row checker still runs first so durable watched same-agent
-      // group reads (and self/current targets) keep their existing allowance:
-      // those grants do not depend on the spawned-session set. Under "all"
-      // visibility this override does not apply — cross-agent targets are
-      // evaluated by the agent-to-agent policy regardless of spawned ownership.
-      // See issue #114653.
+      // Preserve grants that do not depend on spawned ownership; otherwise fail closed with cause.
       const lookupFailed =
         spawnedKeys !== null &&
         !spawnedKeys.ok &&
@@ -360,14 +338,10 @@ function createSessionVisibilityCheckerWithResult(
         targetSessionKey !== params.requesterSessionKey &&
         targetSessionKey !== "current";
       if (lookupFailed) {
-        // The denial text carries the lookup's retryability so a transient
-        // transport failure (retry) is distinguishable from a permanent
-        // credential/configuration failure (do not retry). Both still fail
-        // closed. See issue #114653 (review P1: classify before prescribing retry).
         return {
           allowed: false,
           status: "forbidden",
-          error: `${actionPrefix(params.action)} denied because ${lookupFailedDenialSuffix(spawnedKeys.failureKind)}`,
+          error: lookupFailedDenialMessage(params.action, spawnedKeys.failureKind),
         };
       }
     }

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -1,3 +1,4 @@
+import type { Result } from "@openclaw/normalization-core/result";
 // Session visibility helpers decide which plugin sessions appear in user-facing lists.
 import {
   normalizeLowercaseStringOrEmpty,
@@ -11,8 +12,9 @@ import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
 import {
   listSpawnedSessionKeysWithResult,
+  logSessionOwnershipLookupFailure,
   lookupFailedDenialMessage,
-  type SpawnedSessionKeysResult,
+  type SessionOwnershipLookupFailure,
 } from "./session-visibility-internal.js";
 
 type GatewayCaller = typeof defaultCallGateway;
@@ -87,7 +89,14 @@ export async function listSpawnedSessionKeys(params: {
   callGateway?: GatewayCaller;
 }): Promise<Set<string>> {
   const result = await listSpawnedSessionKeysWithResult(params);
-  return result.ok ? result.keys : new Set();
+  if (!result.ok) {
+    logSessionOwnershipLookupFailure({
+      requesterSessionKey: params.requesterSessionKey,
+      failure: result.error,
+    });
+    return new Set();
+  }
+  return result.value;
 }
 
 /** Resolve configured session-tool visibility, defaulting invalid or missing values to tree. */
@@ -300,9 +309,12 @@ type SessionVisibilityCheckerParams = {
 };
 
 function createSessionVisibilityCheckerWithResult(
-  params: SessionVisibilityCheckerParams & { spawnedKeys: SpawnedSessionKeysResult | null },
+  params: SessionVisibilityCheckerParams & {
+    spawnedKeys: Result<Set<string>, SessionOwnershipLookupFailure> | null;
+  },
 ): { check: (targetSessionKey: string) => SessionAccessResult } {
   const spawnedKeys = params.spawnedKeys;
+  let lookupFailureLogged = false;
   const rowChecker = createSessionVisibilityRowChecker({
     action: params.action,
     defaultAgentId: params.defaultAgentId,
@@ -323,7 +335,7 @@ function createSessionVisibilityCheckerWithResult(
         return { allowed: true, expectedSessionId: scoped.expectedSessionId };
       }
     }
-    const spawnedKeySet = spawnedKeys?.ok ? spawnedKeys.keys : undefined;
+    const spawnedKeySet = spawnedKeys?.ok ? spawnedKeys.value : undefined;
     const isSpawnedSession = spawnedKeySet?.has(targetSessionKey) === true;
     const result = rowChecker.check({
       key: targetSessionKey,
@@ -339,10 +351,17 @@ function createSessionVisibilityCheckerWithResult(
         targetSessionKey !== "current" &&
         hasResolvableTargetAgent(targetSessionKey, params.defaultAgentId);
       if (lookupFailed) {
+        if (!lookupFailureLogged) {
+          lookupFailureLogged = true;
+          logSessionOwnershipLookupFailure({
+            requesterSessionKey: params.requesterSessionKey,
+            failure: spawnedKeys.error,
+          });
+        }
         return {
           allowed: false,
           status: "forbidden",
-          error: lookupFailedDenialMessage(params.action, spawnedKeys.failureKind),
+          error: lookupFailedDenialMessage(params.action, spawnedKeys.error.kind),
         };
       }
     }
@@ -371,7 +390,7 @@ function createSessionVisibilityCheckerImpl(
 ): { check: (targetSessionKey: string) => SessionAccessResult } {
   return createSessionVisibilityCheckerWithResult({
     ...params,
-    spawnedKeys: params.spawnedKeys ? { ok: true, keys: params.spawnedKeys } : null,
+    spawnedKeys: params.spawnedKeys ? { ok: true, value: params.spawnedKeys } : null,
   });
 }
 

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -6,7 +6,7 @@ import {
 } from "../../packages/normalization-core/src/string-coerce.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway as defaultCallGateway } from "../gateway/call.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { isIncognitoSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { listAmbientGroupWatchTargets } from "../sessions/session-state-events.js";
 import {
   listSpawnedSessionKeysWithResult,
@@ -297,6 +297,21 @@ function treeVisibilityMessage(action: SessionAccessAction): string {
   return `${actionPrefix(action)} visibility is restricted to the current session tree and any watched same-agent group sessions (tools.sessions.visibility=tree).`;
 }
 
+function resolveIncognitoSessionAccessDenial(
+  targetSessionKey: string,
+): SessionAccessResult | undefined {
+  // Session-tool output is persisted into the caller transcript. Process-only
+  // incognito sessions must stay hidden even from owners and scoped grants.
+  if (!isIncognitoSessionKey(targetSessionKey)) {
+    return undefined;
+  }
+  return {
+    allowed: false,
+    status: "forbidden",
+    error: `Session not visible from session tools: ${targetSessionKey}`,
+  };
+}
+
 type SessionVisibilityCheckerParams = {
   action: SessionAccessAction;
   defaultAgentId?: string;
@@ -323,6 +338,10 @@ function createSessionVisibilityCheckerWithResult(
   });
 
   const check = (targetSessionKey: string): SessionAccessResult => {
+    const incognitoDenial = resolveIncognitoSessionAccessDenial(targetSessionKey);
+    if (incognitoDenial) {
+      return incognitoDenial;
+    }
     if (params.action !== "list") {
       const scoped = resolveScopedSessionAccess({
         action: params.action,
@@ -422,6 +441,10 @@ export function createSessionVisibilityRowChecker(params: {
 
   const check = (row: SessionVisibilityRow): SessionAccessResult => {
     const targetSessionKey = row.key;
+    const incognitoDenial = resolveIncognitoSessionAccessDenial(targetSessionKey);
+    if (incognitoDenial) {
+      return incognitoDenial;
+    }
     const isRequesterSession =
       targetSessionKey === params.requesterSessionKey || targetSessionKey === "current";
     let targetAgentId = normalizeLowercaseStringOrEmpty(row.agentId);

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -62,6 +62,11 @@ function registerScopedSessionAccessProvider(provider: ScopedSessionAccessProvid
 function resolveScopedSessionAccess(
   request: ScopedSessionAccessRequest,
 ): ScopedSessionAccessGrant | undefined {
+  // Incognito transcripts must never be re-persisted through another session,
+  // including host-scoped access paths that bypass normal visibility policy.
+  if (resolveIncognitoSessionAccessDenial(request.targetSessionKey)) {
+    return undefined;
+  }
   for (const provider of scopedSessionAccessProviders) {
     try {
       const grant = provider(request);


### PR DESCRIPTION
## Maintainer cleanup — 2026-08-13

Rebased onto `main` at `2dffeae1269`; current head is `be9eb717f5c`. Contributor authorship and commit order are preserved. This cleanup does not merge the PR.

## What Problem This Solves

Direct session tools previously collapsed operational ownership-lookup failures into policy denials. They could also discard exact ownership already established by `sessions.resolve` and authorize against a capped `sessions.list` window instead.

The canonical access path now carries typed `transient` / `credentials` / `unknown` failures plus explicit session-owner and requester-ownership facts through history, send, search, status, and mutation checks. Confirmed misses remain ordinary not-found outcomes.

Maintainer review also repaired three connected authorization gaps:

- semantic-current and no-argument `session_status` cannot bypass the shared incognito guard;
- scoped host grants resolve against the owner-qualified authorization key, so the same bare key under another agent cannot reuse a grant;
- incognito remains non-overridable for scoped grants, and `sessions_search` revalidates the granted session incarnation before reading it.

## Architecture and compatibility

- Gateway resolution records exact key and owner facts.
- Shared Plugin SDK visibility owns incognito and row policy.
- `resolveSessionToolAccess` is the single direct-target authorization owner; tool consumers carry its prepared facts forward.
- Scoped grants remain narrow host capabilities and are linearized against reset/archive/replacement for history, send, search, and status.
- An older Gateway without exact `sessions.resolve` support retains the existing `sessions.list` fallback only for ownership-dependent candidates.
- No config, default, protocol, SQLite schema, storage migration, or new public plugin subpath is added.

## ClawSweeper feedback

- Deterministic A2A/policy denials are preserved when ownership lookup cannot change the result.
- Semantic-current and implicit status targets are checked against the live incognito key before Gateway or store access.
- The requested lightweight Slack HTTP `--use-env` contract is now covered by `extensions/slack/src/channel-actions-setup-status.contract.test.ts` without restoring heavyweight bundled-runtime loading in the command test.
- The owner-qualified scoped-grant, scoped-incognito, and search-incarnation findings discovered during final maintainer review are covered by focused regressions.

## LOC review metric

- Production: `+856/-307` (`+549` net).
- Tests: `+1134/-270` (`+864` net).
- Total: `+1990/-577` (`+1413` net).

This is large for a bug fix. The remaining production growth is concentrated in the typed lookup-result contract, explicit multi-agent owner propagation, one canonical direct-access helper, and the status/search integrations that consume those prepared facts. Duplicate resolver-level ownership policy was removed. Reducing it further would either drop the operational-failure distinction or recreate authorization policy in individual tools.

## Evidence

- Focused exact-head Vitest: 6 files / 167 tests passed across access, visibility, history, search, send, and status surfaces.
- Exact-head core production and test typechecks passed.
- Exact-head changed-file type-aware lint and formatting passed.
- Branch autoreview: no accepted/actionable findings; correctness 0.92.
- Independent owner-boundary re-review: no remaining P0/P1.
- Delegated `pnpm check:changed`: every PR-owned gate passed, including conflict/config ratchets, formatting, dead code, SDK API/surface/boundary checks, all four core/extension typecheck lanes, and changed-core lint. The final full-extension lint was blocked by an unrelated current-`main` max-lines failure in `extensions/discord/src/send.creates-thread.test.ts`; this branch does not modify that file. [Run 31671439673](https://github.com/openclaw/openclaw/actions/runs/31671439673), Testbox `tbx_01kzwtffjwzhswvcrmxrtt706w`.

## Regression coverage

- Exact child beyond a 100-row list window and legacy exact-resolver fallback.
- Transient, credential, unknown, malformed-response, and confirmed-miss outcomes.
- Ordinary cross-agent deterministic denial versus ownership-dependent ACP/native child lookup guidance.
- Same bare key under different explicit owners.
- Scoped grants versus incognito and target incarnation replacement.
- Explicit, semantic-current, and implicit incognito status denial before Gateway/store access.
- History, send, search, status, list/access mutation, sandbox, and session-companion paths.

Related: #114653, #114180.