### PR TITLE
fix(sessions): preserve restart drafts on durable tail

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
@@ -373,16 +373,16 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
     expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
   });
 
-  it("repairs an exact durable user leaf when persistence is not recorder-confirmed", () => {
+  it("adopts an exact durable user leaf after recorder state is lost on restart", () => {
     const currentUser = {
       role: "user" as const,
       content: "current prompt",
       idempotencyKey: "current-run:user",
       timestamp: 1,
     };
-    const repairedMessages: AgentMessage[] = [currentUser];
     const { activeSession } = createActiveSession([]);
     const branch = vi.fn();
+    const resetLeaf = vi.fn();
     const clearNextUserMessagePersistenceSuppression = vi.fn();
     const onUserMessagePersistenceInvalidated = vi.fn();
     const sessionManager = createSessionManager({
@@ -394,8 +394,8 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
         message: currentUser,
       }),
       branch,
+      resetLeaf,
       clearNextUserMessagePersistenceSuppression,
-      buildSessionContext: () => ({ messages: repairedMessages }),
     });
     const recorder = {
       hasPersisted: () => false,
@@ -420,11 +420,12 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       setActiveSessionSystemPrompt: vi.fn(),
     });
 
-    expect(boundary.orphanRepair?.removeLeaf).toBe(true);
-    expect(branch).toHaveBeenCalledWith("previous-assistant");
-    expect(clearNextUserMessagePersistenceSuppression).toHaveBeenCalledOnce();
-    expect(onUserMessagePersistenceInvalidated).toHaveBeenCalledOnce();
-    expect(activeSession.agent.state.messages).toBe(repairedMessages);
+    expect(boundary.orphanRepair).toBeUndefined();
+    expect(branch).not.toHaveBeenCalled();
+    expect(resetLeaf).not.toHaveBeenCalled();
+    expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
+    expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
+    expect(activeSession.agent.state.messages).toEqual([]);
   });
 
   it("repairs a durable user leaf that does not match the admitted current user", () => {

--- a/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
+++ b/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
@@ -17,9 +17,6 @@ export function reconcilePrePersistedCurrentUserTurn(params: {
   preparedUserTurnMessage: AgentMessage | undefined;
   userTurnAlreadyPersisted: boolean;
 }): boolean {
-  if (!params.userTurnAlreadyPersisted) {
-    return false;
-  }
   const idempotencyKey = (
     params.preparedUserTurnMessage as { idempotencyKey?: unknown } | undefined
   )?.idempotencyKey;
@@ -29,10 +26,16 @@ export function reconcilePrePersistedCurrentUserTurn(params: {
   const durableIdempotencyKey = (
     params.durableUserTurnMessage as { idempotencyKey?: unknown } | undefined
   )?.idempotencyKey;
+  // Recorder state is process-local; after restart the durable keyed leaf is the
+  // authoritative proof that this exact admitted turn was already persisted.
+  const durableTurnMatches = durableIdempotencyKey === idempotencyKey;
+  if (!params.userTurnAlreadyPersisted && !durableTurnMatches) {
+    return false;
+  }
   const messages = params.activeSession.agent.state.messages;
   const tail = messages.at(-1) as (AgentMessage & { idempotencyKey?: unknown }) | undefined;
   const activeTailMatches = tail?.role === "user" && tail.idempotencyKey === idempotencyKey;
-  if (!activeTailMatches && durableIdempotencyKey !== idempotencyKey) {
+  if (!activeTailMatches && !durableTurnMatches) {
     return false;
   }
   if (activeTailMatches) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a user prompt preserved across a real Gateway restart could fail before reaching the model with `Session transcript parent entry was not persisted`. The TUI stayed reconnected but surfaced an LLM request error instead of sending the draft.

## Why This Change Was Made

The admission recorder is process-local and is lost on restart, while the durable transcript keeps the already-persisted keyed user leaf. When that leaf's idempotency key exactly matches the current admitted turn, the durable leaf is now authoritative persistence proof. The session boundary adopts it instead of branching it away, invalidating persistence, and colliding with the same SQLite row on reappend.

Different keys and non-durable in-memory tails retain the existing repair/reappend behavior, so duplicate-turn rejection stays fail-closed.

## User Impact

Drafts sent during a Gateway restart continue through the reconnected session once, reach the model, and preserve transcript parentage instead of failing after reconnection.

## Evidence

- Reproduced twice in exact-head CI on separate PRs with the same persisted-parent error.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts src/agents/sessions/session-manager.user-idempotency.test.ts` — 17/17 passed.
- Exact failing behavior: `node scripts/run-vitest.mjs src/tui/tui-pty-local.e2e.test.ts -- -t 'preserves a disconnected draft across a real Gateway restart'` — passed (1 passed, 15 skipped).
- Blacksmith Testbox changed gate passed core/core-test typechecks, lint, dead exports, plugin boundaries, import cycles, and SQLite/schema guards: https://github.com/openclaw/openclaw/actions/runs/30691968184
- Codex autoreview: clean, no accepted/actionable findings.
