### PR TITLE
fix(agents): preserve canonical compaction user turns

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -329,6 +329,14 @@ beforeEach(() => {
 });
 
 describe("compactEmbeddedAgentSessionDirect hooks", () => {
+  const prompt = "please run the deployment status check for production";
+  const liveUserTurn = (timestamp: number, overrides: Record<string, unknown> = {}) => ({
+    role: "user" as const,
+    content: prompt,
+    timestamp,
+    ...overrides,
+  });
+
   beforeEach(() => {
     ensureRuntimePluginsLoaded.mockReset();
     triggerInternalHook.mockClear();
@@ -344,6 +352,112 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       details: { ok: true },
     });
     resetCompactSessionStateMocks();
+  });
+
+  it.each([
+    {
+      name: "participants identified only by their display names",
+      messages: [
+        liveUserTurn(1_000, { __openclaw: { senderName: "Alice" } }),
+        liveUserTurn(2_000, { __openclaw: { senderName: "Bob" } }),
+      ],
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "case-sensitive operator corrections",
+      messages: [
+        liveUserTurn(1_000, { content: "set the deployment token to SecretValueForProduction" }),
+        liveUserTurn(2_000, { content: "set the deployment token to secretvalueforproduction" }),
+      ],
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "interleaved normal and backdated retries",
+      messages: [90_000, 1_000, 91_000, 2_000, 92_000, 3_000].map((timestamp) =>
+        liveUserTurn(timestamp),
+      ),
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "retries from the timeline before a distant forward jump",
+      messages: [1_000, 90_000, 2_000].map((timestamp) => liveUserTurn(timestamp)),
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "late retries after a window-edge primary update",
+      messages: [1_000, 61_000, 2_000].map((timestamp) => liveUserTurn(timestamp)),
+      expectedIndexes: [0],
+    },
+    {
+      name: "late retries after sliding primary updates",
+      messages: [1_000, 2_000, 61_000, 3_000].map((timestamp) => liveUserTurn(timestamp)),
+      expectedIndexes: [0],
+    },
+    {
+      name: "retries from three independently interleaved timelines",
+      messages: [1_000, 90_000, 200_000, 2_000, 91_000, 201_000].map((timestamp) =>
+        liveUserTurn(timestamp),
+      ),
+      expectedIndexes: [0, 1, 2],
+    },
+    {
+      name: "provider-native nontext attachment blocks",
+      messages: [
+        liveUserTurn(1_000, {
+          content: [
+            { type: "text", text: prompt },
+            { type: "input_image", source: "first-attachment" },
+          ],
+        }),
+        liveUserTurn(2_000, {
+          content: [
+            { type: "text", text: prompt },
+            { type: "input_image", source: "second-attachment" },
+          ],
+        }),
+      ],
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "canonical persisted media attachments",
+      messages: [
+        liveUserTurn(1_000, {
+          __openclaw: { media: [{ path: "/tmp/first.png", contentType: "image/png" }] },
+        }),
+        liveUserTurn(2_000, {
+          __openclaw: { media: [{ path: "/tmp/second.png", contentType: "image/png" }] },
+        }),
+      ],
+      expectedIndexes: [0, 1],
+    },
+    {
+      name: "actual repeated text turns",
+      messages: [liveUserTurn(1_000), liveUserTurn(2_000)],
+      expectedIndexes: [0],
+    },
+  ])("preserves $name in the actual live session before compaction hooks", async ({
+    messages,
+    expectedIndexes,
+  }) => {
+    sessionMessages.splice(0, sessionMessages.length, ...messages);
+    hookRunner.hasHooks.mockReturnValue(true);
+    let observedMessages: unknown[] | undefined;
+    hookRunner.runBeforeCompaction.mockImplementationOnce(async () => {
+      const created = await createAgentSessionMock.mock.results[0]?.value;
+      if (!created) {
+        throw new Error("expected the live compaction session to exist");
+      }
+      observedMessages = structuredClone(created.session.agent.state.messages);
+    });
+
+    const result = await compactEmbeddedAgentSessionDirect(wrappedCompactionArgs());
+
+    expect(result).toMatchObject({ ok: true, compacted: true });
+    expect(observedMessages).toEqual(expectedIndexes.map((index) => messages[index]));
+    expect(hookRunner.runBeforeCompaction).toHaveBeenCalledOnce();
+    expect(mockCallArg(hookRunner.runBeforeCompaction)).toMatchObject({
+      messageCount: expectedIndexes.length,
+    });
   });
 
   it("acquires the normal session lock without process-wide reentry", async () => {

--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
@@ -1,15 +1,23 @@
 // Regression coverage for pruning duplicate user turns before compaction.
 import { describe, expect, it } from "vitest";
+import { Agent } from "../../../packages/agent-core/src/agent.js";
+import { SessionManager } from "../sessions/session-manager.js";
 import { dedupeDuplicateUserMessagesForCompaction } from "./compaction-duplicate-user-messages.js";
 
 const LONG_PROMPT = "please run the deployment status check for production";
 
-function userMessage(params: { timestamp: number; senderId?: string; content?: string }) {
+function userMessage(params: {
+  timestamp: number;
+  senderId?: string;
+  content?: unknown;
+  metadata?: Record<string, unknown>;
+}) {
+  const metadata = params.metadata ?? (params.senderId ? { senderId: params.senderId } : undefined);
   return {
     role: "user" as const,
     content: params.content ?? LONG_PROMPT,
     timestamp: params.timestamp,
-    ...(params.senderId ? { __openclaw: { senderId: params.senderId } } : {}),
+    ...(metadata ? { __openclaw: metadata } : {}),
   };
 }
 
@@ -71,6 +79,245 @@ describe("compaction duplicate user message pruning", () => {
       alice,
       bob,
     ]);
+  });
+
+  it.each([
+    [
+      "username-only and display-name-only participants",
+      [
+        userMessage({ timestamp: 1_000, metadata: { senderUsername: "Alice" } }),
+        userMessage({ timestamp: 2_000, metadata: { senderUsername: "Bob" } }),
+        userMessage({ timestamp: 3_000, metadata: { senderName: "Alice" } }),
+        userMessage({ timestamp: 4_000, metadata: { senderName: "Bob" } }),
+      ],
+      [0, 1, 2, 3],
+    ],
+    [
+      "case-sensitive corrections",
+      [
+        userMessage({
+          timestamp: 1_000,
+          content: "set deployment token to SecretValueForProduction",
+        }),
+        userMessage({
+          timestamp: 2_000,
+          content: "set deployment token to secretvalueforproduction",
+        }),
+      ],
+      [0, 1],
+    ],
+    [
+      "independent normal and backdated retry streams",
+      [90_000, 1_000, 91_000, 2_000, 92_000, 3_000].map((timestamp) => userMessage({ timestamp })),
+      [0, 1],
+    ],
+    [
+      "retries after distant chronological jumps",
+      [1_000, 90_000, 2_000].map((timestamp) => userMessage({ timestamp })),
+      [0, 1],
+    ],
+    [
+      "late retries after a window-edge primary update",
+      [1_000, 61_000, 2_000].map((timestamp) => userMessage({ timestamp })),
+      [0],
+    ],
+    [
+      "late retries after sliding primary updates",
+      [1_000, 2_000, 61_000, 3_000].map((timestamp) => userMessage({ timestamp })),
+      [0],
+    ],
+    [
+      "retries from three independently interleaved timelines",
+      [1_000, 90_000, 200_000, 2_000, 91_000, 201_000].map((timestamp) =>
+        userMessage({ timestamp }),
+      ),
+      [0, 1, 2],
+    ],
+    [
+      "provider-native attachment blocks and canonical persisted media",
+      [
+        userMessage({
+          timestamp: 1_000,
+          content: [{ type: "text", text: LONG_PROMPT }, { type: "input_image", source: "first" }],
+        }),
+        userMessage({
+          timestamp: 2_000,
+          content: [{ type: "text", text: LONG_PROMPT }, { type: "input_image", source: "second" }],
+        }),
+        userMessage({ timestamp: 3_000, metadata: { media: [{ path: "/tmp/first.png" }] } }),
+        userMessage({ timestamp: 4_000, metadata: { media: [{ path: "/tmp/second.png" }] } }),
+      ],
+      [0, 1, 2, 3],
+    ],
+    [
+      "actual duplicate retries",
+      [userMessage({ timestamp: 1_000 }), userMessage({ timestamp: 2_000 })],
+      [0],
+    ],
+  ] as const)(
+    "preserves %s through the real session and model boundary",
+    async (_, messages, keptIndexes) => {
+      const sessionManager = SessionManager.inMemory();
+      for (const message of messages) {
+        sessionManager.appendMessage(message as Parameters<SessionManager["appendMessage"]>[0]);
+      }
+      const agent = new Agent({
+        initialState: { messages: sessionManager.buildSessionContext().messages },
+        streamFn: () => {
+          throw new Error("compaction proof must not start a provider request");
+        },
+      });
+      agent.state.messages = dedupeDuplicateUserMessagesForCompaction(agent.state.messages);
+      const expectedMessages = keptIndexes.map((index) => messages[index]);
+
+      expect(agent.state.messages).toEqual(expectedMessages);
+      expect(await agent.convertToLlm(agent.state.messages)).toEqual(expectedMessages);
+    },
+  );
+
+  it.each([
+    ["distinct usernames", { senderUsername: "Alice" }, { senderUsername: "Bob" }, true],
+    ["distinct display names", { senderName: "Alice" }, { senderName: "Bob" }, true],
+    [
+      "normalized sender identity",
+      { senderUsername: " Alice " },
+      { senderUsername: "Alice" },
+      false,
+    ],
+    [
+      "stable sender id after display rename",
+      { senderId: " stable-sender ", senderUsername: "before", senderName: "Before" },
+      { senderId: "stable-sender", senderUsername: "after", senderName: "After" },
+      false,
+    ],
+    [
+      "blank sender ids with distinct usernames",
+      { senderId: "  ", senderUsername: "alice" },
+      { senderId: "", senderUsername: "bob" },
+      true,
+    ],
+    [
+      "matching sender id and username values",
+      { senderId: "alice" },
+      { senderUsername: "alice" },
+      true,
+    ],
+  ] as const)("keys retries by canonical sender identity: %s", (_, first, second, keepSecond) => {
+    const original = userMessage({ timestamp: 1_000, metadata: first });
+    const candidate = userMessage({ timestamp: 2_000, metadata: second });
+
+    expect(dedupeDuplicateUserMessagesForCompaction([original, candidate])).toEqual(
+      keepSecond ? [original, candidate] : [original],
+    );
+  });
+
+  it.each([
+    ["primary retries", [90_000, 1_000, 91_000], [0, 1]],
+    ["backdated retries", [90_000, 1_000, 2_000], [0, 1]],
+    ["retries after a distant forward jump", [1_000, 90_000, 2_000], [0, 1]],
+    ["seeded interleaved retry streams", [1_000, 90_000, 2_000, 91_000, 3_000], [0, 1]],
+    ["preserved seed across repeated jumps", [1_000, 90_000, 200_000, 2_000], [0, 1, 2]],
+    ["preserved active late timeline", [90_000, 1_000, 200_000, 2_000], [0, 1, 2]],
+    ["window-edge primary retries", [1_000, 61_000, 2_000], [0]],
+    ["sliding primary retries", [1_000, 2_000, 61_000, 3_000], [0]],
+    ["previous-bucket latest timestamps", [0, 59_000, 61_000], [0]],
+    ["current-bucket earliest timestamps", [59_000, 1_000, 2_000], [0, 1]],
+    ["inclusive duplicate-window boundaries", [0, 60_000], [0]],
+    ["outside duplicate-window boundaries", [0, 60_001], [0, 1]],
+    ["negative epoch timestamps", [-1_000, -120_000, -119_000], [0, 1]],
+    [
+      "three independently interleaved timelines",
+      [1_000, 90_000, 200_000, 2_000, 91_000, 201_000],
+      [0, 1, 2],
+    ],
+    ["interleaved retry streams", [90_000, 1_000, 91_000, 2_000, 92_000, 3_000], [0, 1]],
+    ["restarted backdated streams", [90_000, 20_000, 1_000, 2_000], [0, 1, 2]],
+  ] as const)("tracks independent chronology watermarks for %s", (_, timestamps, keptIndexes) => {
+    const messages = timestamps.map((timestamp) => userMessage({ timestamp }));
+
+    expect(dedupeDuplicateUserMessagesForCompaction(messages)).toEqual(
+      keptIndexes.map((index) => messages[index]),
+    );
+  });
+
+  it.each([
+    ["exact timestamps", 0, [1_000, 1_000, 2_000], [0, 2]],
+    ["negative windows", -1, [1_000, 1_000, 2_000], [0, 1, 2]],
+    ["invalid windows", Number.NaN, [1_000, 1_000, 2_000], [0, 1, 2]],
+    ["infinite windows", Number.POSITIVE_INFINITY, [1_000, 2_000, 90_000], [0]],
+    ["inclusive fractional windows", 2.5, [0, 2.5], [0]],
+    ["outside fractional windows", 2.5, [0, 2.5001], [0, 1]],
+    ["backdated fractional windows", 2.5, [2.4, 0.1, 0.2], [0, 1]],
+  ] as const)("supports %s", (_, windowMs, timestamps, keptIndexes) => {
+    const messages = timestamps.map((timestamp) => userMessage({ timestamp }));
+
+    expect(dedupeDuplicateUserMessagesForCompaction(messages, { windowMs })).toEqual(
+      keptIndexes.map((index) => messages[index]),
+    );
+  });
+
+  it("preserves non-finite timestamps without poisoning ordinary retries", () => {
+    const messages = [
+      1_000,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      2_000,
+    ].map((timestamp) => userMessage({ timestamp }));
+
+    expect(dedupeDuplicateUserMessagesForCompaction(messages)).toEqual(messages.slice(0, -1));
+  });
+
+  it.each([
+    "image",
+    "image_url",
+    "input_image",
+    "input_audio",
+    "audio",
+    "file",
+    "document",
+    "future_attachment",
+  ])("preserves distinct %s attachments", (type) => {
+    const first = userMessage({
+      timestamp: 1_000,
+      content: [{ type: "text", text: LONG_PROMPT }, { type, source: "first-attachment" }],
+    });
+    const second = userMessage({
+      timestamp: 2_000,
+      content: [{ type: "text", text: LONG_PROMPT }, { type, source: "second-attachment" }],
+    });
+
+    expect(dedupeDuplicateUserMessagesForCompaction([first, second])).toEqual([first, second]);
+  });
+
+  it.each([
+    { name: "meaningful persisted media", media: [{ path: "/tmp/attachment.png" }], keep: true },
+    { name: "empty media alignment", media: [{}], keep: false },
+  ])("handles canonical persisted attachment identity: $name", ({ media, keep }) => {
+    const first = userMessage({ timestamp: 1_000, metadata: { media } });
+    const second = userMessage({ timestamp: 2_000, metadata: { media } });
+
+    expect(dedupeDuplicateUserMessagesForCompaction([first, second])).toEqual(
+      keep ? [first, second] : [first],
+    );
+  });
+
+  it.each([
+    {
+      name: "Unicode-equivalent plain text",
+      first: "please deploy the café service to production now",
+      second: "please deploy the cafe\u0301 service to production now",
+    },
+    {
+      name: "pure text-block content",
+      first: [{ type: "text", text: LONG_PROMPT }],
+      second: [{ type: "text", text: ` ${LONG_PROMPT} ` }],
+    },
+  ])("still removes legitimate retries with $name", ({ first, second }) => {
+    const original = userMessage({ timestamp: 1_000, content: first });
+    const retry = userMessage({ timestamp: 2_000, content: second });
+
+    expect(dedupeDuplicateUserMessagesForCompaction([original, retry])).toEqual([original]);
   });
 
   it("does not collide when sender ids and text contain the old delimiter", () => {

--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
@@ -2,6 +2,8 @@
  * Removes short-window duplicate user turns from compaction summaries.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasPersistedMedia } from "../../sessions/user-turn-media.js";
 
 const DEFAULT_DUPLICATE_USER_MESSAGE_WINDOW_MS = 60_000;
 const MIN_DUPLICATE_USER_MESSAGE_CHARS = 24;
@@ -17,6 +19,11 @@ type DuplicateUserMessageOptions = {
   windowMs?: number;
 };
 
+type DuplicateUserMessageTimestampBucket = {
+  earliest: number;
+  latest: number;
+};
+
 function normalizeUserMessageContent(content: unknown): string | undefined {
   if (typeof content === "string") {
     return content.replace(/\s+/g, " ").trim();
@@ -26,15 +33,10 @@ function normalizeUserMessageContent(content: unknown): string | undefined {
   }
   const textParts: string[] = [];
   for (const block of content) {
-    if (!isRecord(block)) {
+    if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") {
       return undefined;
     }
-    if (block.type === "image") {
-      return undefined;
-    }
-    if (block.type === "text" && typeof block.text === "string") {
-      textParts.push(block.text);
-    }
+    textParts.push(block.text);
   }
   return textParts.join("\n").replace(/\s+/g, " ").trim();
 }
@@ -44,16 +46,20 @@ function duplicateSignature(message: unknown): { key: string; timestamp: number 
     return undefined;
   }
   const text = normalizeUserMessageContent(message.content);
-  if (!text || text.length < MIN_DUPLICATE_USER_MESSAGE_CHARS) {
+  if (!text || text.length < MIN_DUPLICATE_USER_MESSAGE_CHARS || hasPersistedMedia(message)) {
     return undefined;
   }
   // Persisted sender identity keeps distinct participants separate while senderless legacy
   // turns retain the old retry behavior. A JSON tuple avoids sender/text delimiter collisions.
-  const metadata = message["__openclaw"];
-  const senderId =
-    isRecord(metadata) && typeof metadata.senderId === "string" ? metadata.senderId : "";
+  const rawMetadata = message["__openclaw"];
+  const metadata = isRecord(rawMetadata) ? rawMetadata : undefined;
+  const senderId = normalizeOptionalString(metadata?.senderId);
+  const senderUsername = normalizeOptionalString(metadata?.senderUsername);
+  const senderName = normalizeOptionalString(metadata?.senderName);
+  const senderSource = senderId ? "id" : senderUsername ? "username" : senderName ? "name" : "";
+  const senderIdentity = senderId ?? senderUsername ?? senderName ?? "";
   return {
-    key: JSON.stringify([senderId, text.normalize("NFC").toLowerCase()]),
+    key: JSON.stringify([senderSource, senderIdentity, text.normalize("NFC")]),
     timestamp: message.timestamp,
   };
 }
@@ -64,18 +70,42 @@ export function dedupeDuplicateUserMessagesForCompaction<T extends MessageLike>(
   options: DuplicateUserMessageOptions = {},
 ): T[] {
   const windowMs = options.windowMs ?? DEFAULT_DUPLICATE_USER_MESSAGE_WINDOW_MS;
-  const lastSeenAtByKey = new Map<string, number>();
+  if (windowMs < 0 || Number.isNaN(windowMs)) {
+    return [...messages];
+  }
+  const seenBucketsByKey = new Map<string, Map<number, DuplicateUserMessageTimestampBucket>>();
   let removed = 0;
   const result: T[] = [];
   for (const message of messages) {
     const signature = duplicateSignature(message);
-    if (!signature) {
+    if (!signature || !Number.isFinite(signature.timestamp)) {
       result.push(message);
       continue;
     }
-    const lastSeenAt = lastSeenAtByKey.get(signature.key);
-    lastSeenAtByKey.set(signature.key, signature.timestamp);
-    if (typeof lastSeenAt === "number" && signature.timestamp - lastSeenAt <= windowMs) {
+    let buckets = seenBucketsByKey.get(signature.key);
+    if (!buckets) {
+      buckets = new Map();
+      seenBucketsByKey.set(signature.key, buckets);
+    }
+    const bucketId =
+      windowMs === 0 ? signature.timestamp : Math.floor(signature.timestamp / windowMs);
+    const currentBucket = buckets.get(bucketId);
+    const previousBucket = windowMs > 0 ? buckets.get(bucketId - 1) : undefined;
+    // Looking backward only preserves genuine backdated turns; bucket extrema
+    // still detect every earlier retry without losing independently late streams.
+    const previousElapsedMs = previousBucket
+      ? signature.timestamp - previousBucket.latest
+      : undefined;
+    const duplicate =
+      (currentBucket !== undefined && currentBucket.earliest <= signature.timestamp) ||
+      (previousElapsedMs !== undefined && previousElapsedMs >= 0 && previousElapsedMs <= windowMs);
+    if (currentBucket) {
+      currentBucket.earliest = Math.min(currentBucket.earliest, signature.timestamp);
+      currentBucket.latest = Math.max(currentBucket.latest, signature.timestamp);
+    } else {
+      buckets.set(bucketId, { earliest: signature.timestamp, latest: signature.timestamp });
+    }
+    if (duplicate) {
       // Keep the first prompt and drop only later repeats. The first copy anchors the summarized
       // branch while duplicate retries no longer inflate compaction context.
       removed += 1;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users participating in shared conversations, correcting case-sensitive instructions, sending different attachments, or receiving delayed and reordered retries could silently lose real conversation turns during session compaction. The lost turns were removed from the model-visible compaction session, not merely hidden from diagnostics.

## Why This Change Was Made

Refactor the canonical compaction deduplication owner to distinguish persisted sender identities by their actual identity source, preserve case-sensitive Unicode-normalized instructions, and exempt both provider-native attachment blocks and meaningful canonical persisted media. Replace the lossy single-timestamp retry watermark with bounded per-signature time buckets, whose current-bucket minimum and preceding-bucket maximum correctly recognize retries across arbitrarily interleaved chronological and delayed message streams.

## User Impact

Different participants, case-sensitive corrections, and distinct attachments survive compaction and remain available to the model. Genuine repeated transport retries still collapse, including out-of-order retries, while invalid timestamps and unsupported deduplication windows cannot silently corrupt unrelated conversation history.

## Evidence

- Four independently reproduced root causes: sender identity collisions; case-sensitive instruction loss; reordered/backdated retry chronology; and attachment-bearing user-turn loss across both native blocks and canonical persisted media.
- Before repair, an exploratory real `Agent` + `SessionManager.inMemory()` + model-conversion proof ran 18 checks and exposed 12 failures on baseline `2358566c299de9c731caa26add6ae9f9f97ce481`; the final committed fixture consolidates that evidence and adds three independently interleaved timestamp bands.
- Committed regressions cover a genuine production `Agent`, in-memory `SessionManager`, and `convertToLlm`, plus the real `compactEmbeddedAgentSessionDirect` control flow and before-compaction hook; the latter uses the existing mocked agent-session harness.
- Exact immutable candidate: `64de9c69f28f14f36eb21724304d20c236c11bee`; three existing files only; canonical production owner +47/-17 lines. Current canonical main `8b7fad18ecc59aae8a8a2f318a5b4a5f491dab4f` has no changed owner paths and merges without conflict.
- Genuine pre-commit and exact-commit independent autoreviews used `gpt-5.6-sol`, high reasoning, full P0-P3 scope, and real TruffleHog scans; both reported no findings. Four additional independent whole-owner hostile reviews reported no P0-P3 findings.
- Required exact-head focused owner tests and hosted CI have **not run yet** because of the active disk-space execution hold. This PR must not land until those gates pass.
