### PR TITLE
fix(feishu): cancel unread streaming-card error bodies before release

### DIFF
--- a/extensions/feishu/src/streaming-card.error-release.test.ts
+++ b/extensions/feishu/src/streaming-card.error-release.test.ts
@@ -1,0 +1,151 @@
+// Feishu streaming card tests exercise error-path response body cancellation
+// through a real guarded HTTP transport against a loopback server.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loopback = vi.hoisted(() => ({
+  baseUrl: "",
+  releases: [] as Array<{ bodyIsNull: boolean; bodyUsed: boolean }>,
+  authStatus: 200,
+  createStatus: 200,
+  settingsStatus: 200,
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (...args: Parameters<typeof actual.fetchWithSsrFGuard>) => {
+      const [params] = args;
+      const url = new URL(params.url);
+      const redirected = new URL(`${url.pathname}${url.search}`, loopback.baseUrl).toString();
+      const guarded = await actual.fetchWithSsrFGuard({
+        ...params,
+        policy: { allowPrivateNetwork: true },
+        url: redirected,
+      });
+      return {
+        ...guarded,
+        release: async () => {
+          loopback.releases.push({
+            bodyIsNull: guarded.response.body === null,
+            bodyUsed: guarded.response.bodyUsed,
+          });
+          await guarded.release();
+        },
+      };
+    },
+  };
+});
+
+const { FeishuStreamingSession } = await import("./streaming-card.js");
+
+function writeJson(res: import("node:http").ServerResponse, payload: unknown, status = 200): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+let server: Server;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname.includes("/auth/")) {
+      if (loopback.authStatus === 200) {
+        writeJson(res, { code: 0, msg: "ok", tenant_access_token: "token", expire: 3600 });
+      } else {
+        writeJson(res, { error: "tenant token rejected" }, loopback.authStatus);
+      }
+      return;
+    }
+    if (url.pathname.endsWith("/settings")) {
+      if (loopback.settingsStatus === 200) {
+        writeJson(res, { code: 0, msg: "ok" });
+      } else {
+        writeJson(res, { error: "settings rejected" }, loopback.settingsStatus);
+      }
+      return;
+    }
+    if (loopback.createStatus === 200) {
+      writeJson(res, { code: 0, msg: "ok", data: { card_id: "card_1" } });
+    } else {
+      writeJson(res, { error: "card create rejected" }, loopback.createStatus);
+    }
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  loopback.baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+beforeEach(() => {
+  loopback.releases = [];
+  loopback.authStatus = 200;
+  loopback.createStatus = 200;
+  loopback.settingsStatus = 200;
+});
+
+describe("feishu streaming card error-path body release", () => {
+  it("cancels the unread tenant-token error body before release", async () => {
+    loopback.authStatus = 500;
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_error_token",
+      appSecret: "secret",
+    });
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      "Token request failed with HTTP 500",
+    );
+
+    expect(loopback.releases).toEqual([{ bodyIsNull: false, bodyUsed: true }]);
+  });
+
+  it("cancels the unread create-card error body before release", async () => {
+    loopback.createStatus = 500;
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_error_create",
+      appSecret: "secret",
+    });
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      "Create card request failed with HTTP 500",
+    );
+
+    expect(loopback.releases).toEqual([
+      { bodyIsNull: false, bodyUsed: true },
+      { bodyIsNull: false, bodyUsed: true },
+    ]);
+  });
+
+  it("cancels the unread close-settings error body before release", async () => {
+    const client = {
+      im: {
+        message: {
+          create: async () => ({ code: 0, data: { message_id: "msg_1" } }),
+        },
+      },
+    };
+    const session = new FeishuStreamingSession(client as never, {
+      appId: "app_error_close",
+      appSecret: "secret",
+    });
+    await session.start("chat_id", "open_id");
+    loopback.settingsStatus = 500;
+
+    await expect(session.close()).resolves.toBe(false);
+
+    expect(loopback.releases).toEqual([
+      { bodyIsNull: false, bodyUsed: true },
+      { bodyIsNull: false, bodyUsed: true },
+      { bodyIsNull: false, bodyUsed: true },
+    ]);
+  });
+});

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -128,12 +128,22 @@ function resolveAllowedHostnames(domain?: FeishuDomain): string[] {
   return ["open.feishu.cn"];
 }
 
+function cancelUnreadResponseBody(response: Response): void {
+  // A rejected response leaves its body unread; start cancellation before the
+  // guarded dispatcher is released so the connection is not leaked. Do not
+  // await: debug capture can tee the stream and deadlock a waiter.
+  if (!response.bodyUsed) {
+    void response.body?.cancel().catch(() => undefined);
+  }
+}
+
 async function assertSuccessfulCardKitResponse(
   response: Response,
   auditContext: string,
   action: string,
 ): Promise<void> {
   if (!response.ok) {
+    cancelUnreadResponseBody(response);
     throw new Error(`${action} failed with HTTP ${response.status}`);
   }
   const data = await readFeishuJsonResponse<CardKitResponse>(response, auditContext);
@@ -174,6 +184,7 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
   };
   try {
     if (!response.ok) {
+      cancelUnreadResponseBody(response);
       throw new Error(`Token request failed with HTTP ${response.status}`);
     }
     data = await readFeishuJsonResponse(response, "feishu.streaming-card.token");
@@ -328,6 +339,7 @@ export class FeishuStreamingSession {
     };
     try {
       if (!createRes.ok) {
+        cancelUnreadResponseBody(createRes);
         throw new Error(`Create card request failed with HTTP ${createRes.status}`);
       }
       createData = await readFeishuJsonResponse(createRes, "feishu.streaming-card.create");


### PR DESCRIPTION
## Summary

Cancel unread Feishu streaming-card error response bodies before releasing the SSRF-guarded dispatcher, so rejected token/create/close requests do not leave connections dangling until the dispatcher-destroy backstop fires.

## What Problem This Solves

`extensions/feishu/src/streaming-card.ts` issues guarded CardKit requests on every streaming message: tenant-token fetch (`getToken`, :186), card creation (:341), and every update/close via `assertSuccessfulCardKitResponse` (:145, reused by update, replace, note, and close paths).

On a non-2xx response all three sites throw **before reading the body**, and the `finally` block only awaits `release()`. `release()` closes the dispatcher, which cannot cleanly close while a response body is still unread — the connection dangles until the destroy backstop (100ms) force-kills it. Streaming cards issue these requests per message update, so a Feishu outage or expired app credential turns every streaming reply into a series of dangling connections. This is the same shape as the Google Chat auth transport fix in #115873.

**Code evidence**: `streaming-card.ts:186` and `:341` threw on `!response.ok` with the body untouched; `assertSuccessfulCardKitResponse` (:145) did the same for all four CardKit mutation paths.

## Root Cause

- Introduced by commit bf5c9d174822 (2026-07-06, "fix(feishu): bound Feishu API JSON response reads to prevent OOM"), which added early-throw status guards in front of the bounded body readers without cancelling the unread stream.
- Violated invariant: the guarded-fetch contract expects the caller to consume or cancel the body before `release()`; the status guards broke that ordering on exactly the paths where the body is never read.
- Trigger: any non-2xx CardKit response — expired app credentials (token 403), Feishu-side 5xx, rate limiting.

## Why This Fix

- Add `cancelUnreadResponseBody(response)` (`if (!response.bodyUsed) { void response.body?.cancel().catch(() => undefined); }`) at the three throw sites — byte-for-byte the pattern established by #115873 for the same guard contract.
- Not awaited on purpose: awaiting cancellation can deadlock when debug capture tees the stream (documented in #115873).
- Alternative considered: reading and discarding the error body — wastes the bounded-read work on a path that only needs the status, and still couples to body size.

## User Impact

- Affected operations: Feishu streaming card replies (token refresh, card create, every streaming update/close) whenever CardKit answers non-2xx.
- Before: each rejected request left a connection dangling until the 100ms destroy backstop; under an outage this multiplies across per-message updates.
- After: the error body is cancelled immediately and the dispatcher closes cleanly.

## Evidence

- **Before**: a real local HTTP server streams an endless 500 body; the failing token request leaves it unread — the server keeps writing chunks (11 chunks, socket still open 150ms+ after the error) → FAIL
- **After**: the same failing request cancels the body — the socket dies almost immediately (2 chunks, alive 60ms) → PASS

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
caught: Token request failed with HTTP 500
server_chunks_sent=11 socket_alive_ms=-1
FAIL: unread error body left the connection dangling until the dispatcher-destroy backstop
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
caught: Token request failed with HTTP 500
server_chunks_sent=2 socket_alive_ms=60
PASS: unread error body cancelled, connection closed immediately
```

## Tests and Validation

- `pnpm check` passed
- Added `extensions/feishu/src/streaming-card.error-release.test.ts`: drives the real guarded transport against a loopback server and asserts every error path reaches `release()` with the body consumed/cancelled — covers token, create, and close-settings rejections; all 26 pre-existing streaming-card cases still pass
- Proof above runs against a real local HTTP server through the real `FeishuStreamingSession` code path; no external services involved
