### PR TITLE
fix(canvas): honor canonical action deadlines

### DIFF
--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -19,11 +19,11 @@ function createCanvasCliDeps() {
   };
   const deps: CanvasCliDependencies = {
     defaultRuntime: runtime,
-    nodesCallOpts: (cmd) =>
+    nodesCallOpts: (cmd, defaults) =>
       cmd
         .option("--url <url>", "Gateway WebSocket URL")
         .option("--token <token>", "Gateway token")
-        .option("--timeout <ms>", "Timeout in ms", "10000")
+        .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 10_000))
         .option("--json", "Output JSON", false),
     runNodesCommand: async (_label, action) => {
       await action();
@@ -99,6 +99,12 @@ const canvasAcknowledgementCommands = [
   },
 ] as const;
 
+const canvasInvocationCommands = [
+  ...canvasAcknowledgementCommands,
+  { args: ["snapshot"], command: "canvas.snapshot" },
+  { args: ["eval", "1 + 1"], command: "canvas.eval" },
+] as const;
+
 describe("canvas CLI", () => {
   it("registers under nodes and captures a snapshot media path", async () => {
     const program = new Command();
@@ -117,7 +123,7 @@ describe("canvas CLI", () => {
       {
         node: "ios-node",
         format: "jpg",
-        timeout: "10000",
+        timeout: "60000",
         json: false,
         invokeTimeout: "20000",
       },
@@ -131,6 +137,7 @@ describe("canvas CLI", () => {
         },
         timeoutMs: 20000,
       },
+      { transportTimeoutMs: 60_000 },
     );
     expect(writtenFiles).toHaveLength(1);
     const [writtenFile] = writtenFiles;
@@ -220,6 +227,149 @@ describe("canvas CLI", () => {
 
     expect(runtime.log).toHaveBeenCalledWith("");
     expect(runtime.log).not.toHaveBeenCalledWith("canvas eval ok");
+  });
+
+  it.each(canvasInvocationCommands)(
+    "keeps the default $command Gateway deadline longer than the node deadline",
+    async ({ args, command }) => {
+      const program = new Command();
+      program.exitOverride();
+      const { deps } = createCanvasCliDeps();
+
+      registerNodesCanvasCommands(program.command("nodes"), deps);
+      await program.parseAsync(["nodes", "canvas", ...args, "--node", "ios-node"], {
+        from: "user",
+      });
+
+      const invokeTimeoutMs = command === "canvas.snapshot" ? 20_000 : 30_000;
+      const transportTimeoutMs = command === "canvas.snapshot" ? 60_000 : 40_000;
+      expect(deps.callGatewayCli).toHaveBeenCalledWith(
+        "node.invoke",
+        expect.any(Object),
+        expect.objectContaining({ command, timeoutMs: invokeTimeoutMs }),
+        { transportTimeoutMs },
+      );
+    },
+  );
+
+  it.each(canvasInvocationCommands)(
+    "keeps an explicit $command Gateway deadline longer than the node deadline",
+    async ({ args, command }) => {
+      const program = new Command();
+      program.exitOverride();
+      const { deps } = createCanvasCliDeps();
+
+      registerNodesCanvasCommands(program.command("nodes"), deps);
+      await program.parseAsync(
+        ["nodes", "canvas", ...args, "--node", "ios-node", "--invoke-timeout", "35000"],
+        { from: "user" },
+      );
+
+      expect(deps.callGatewayCli).toHaveBeenCalledWith(
+        "node.invoke",
+        expect.any(Object),
+        expect.objectContaining({ command, timeoutMs: 35_000 }),
+        { transportTimeoutMs: command === "canvas.snapshot" ? 60_000 : 45_000 },
+      );
+    },
+  );
+
+  it("preserves an explicit Gateway timeout longer than the node deadline and grace", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const { deps } = createCanvasCliDeps();
+
+    registerNodesCanvasCommands(program.command("nodes"), deps);
+    await program.parseAsync(
+      [
+        "nodes",
+        "canvas",
+        "present",
+        "--node",
+        "ios-node",
+        "--invoke-timeout",
+        "35000",
+        "--timeout",
+        "120000",
+      ],
+      { from: "user" },
+    );
+
+    expect(deps.callGatewayCli).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.objectContaining({ timeout: "120000" }),
+      expect.objectContaining({ timeoutMs: 35_000 }),
+      { transportTimeoutMs: 120_000 },
+    );
+  });
+
+  it("preserves the snapshot command's existing longer Gateway timeout", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const { deps } = createCanvasCliDeps();
+    deps.nodesCallOpts = createDefaultCanvasCliDependencies().nodesCallOpts;
+
+    registerNodesCanvasCommands(program.command("nodes"), deps);
+    await program.parseAsync(["nodes", "canvas", "snapshot", "--node", "ios-node"], {
+      from: "user",
+    });
+
+    expect(deps.callGatewayCli).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.objectContaining({ timeout: "60000" }),
+      expect.objectContaining({ timeoutMs: 20_000 }),
+      { transportTimeoutMs: 60_000 },
+    );
+  });
+
+  it("preserves an invalid explicit Gateway timeout for its existing validation", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const { deps } = createCanvasCliDepsWithDefaultParsers();
+    deps.callGatewayCli = vi.fn(async (_method, _opts, _params, callOpts) => {
+      if (callOpts?.transportTimeoutMs !== undefined) {
+        throw new Error("invalid Gateway timeout was replaced");
+      }
+      throw new Error('Invalid --timeout. Received: "20ms".');
+    });
+
+    registerNodesCanvasCommands(program.command("nodes"), deps);
+
+    await expect(
+      program.parseAsync(
+        ["nodes", "canvas", "present", "--node", "ios-node", "--timeout", "20ms"],
+        {
+          from: "user",
+        },
+      ),
+    ).rejects.toThrow('Invalid --timeout. Received: "20ms".');
+  });
+
+  it("caps oversized node and Gateway deadlines to the timer-safe maximum", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const { deps } = createCanvasCliDepsWithDefaultParsers();
+
+    registerNodesCanvasCommands(program.command("nodes"), deps);
+    await program.parseAsync(
+      [
+        "nodes",
+        "canvas",
+        "present",
+        "--node",
+        "ios-node",
+        "--invoke-timeout",
+        String(Number.MAX_SAFE_INTEGER),
+      ],
+      { from: "user" },
+    );
+
+    expect(deps.callGatewayCli).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.any(Object),
+      expect.objectContaining({ timeoutMs: 2_147_000_000 }),
+      { transportTimeoutMs: 2_147_000_000 },
+    );
   });
 
   it.each(canvasAcknowledgementCommands)(
@@ -328,6 +478,7 @@ describe("canvas CLI", () => {
           quality: Number(quality),
         }),
       }),
+      { transportTimeoutMs: 60_000 },
     );
   });
 

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -12,6 +12,8 @@ import {
   type NodeMatchCandidate,
 } from "openclaw/plugin-sdk/gateway-runtime";
 import {
+  addTimerTimeoutGraceMs,
+  clampPositiveTimerTimeoutMs,
   parseStrictFiniteNumber,
   parseStrictPositiveInteger,
 } from "openclaw/plugin-sdk/number-runtime";
@@ -79,6 +81,9 @@ export type CanvasCliDependencies = {
 
 type CanvasNodeCandidate = NodeMatchCandidate;
 type CanvasSnapshotRequestFormat = "png" | "jpeg";
+
+const DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS = 30_000;
+const CANVAS_NODE_INVOKE_TRANSPORT_GRACE_MS = 10_000;
 
 function parseCanvasSnapshotRequestFormat(raw: unknown): CanvasSnapshotRequestFormat {
   const format = normalizeLowercaseStringOrEmpty(normalizeOptionalString(raw) ?? "jpg");
@@ -257,18 +262,24 @@ async function invokeCanvas(
   command: string,
   params?: Record<string, unknown>,
 ) {
-  const timeoutMs = deps.parseTimeoutMs(opts.invokeTimeout);
+  const timeoutMs =
+    clampPositiveTimerTimeoutMs(
+      deps.parseTimeoutMs(opts.invokeTimeout) ?? DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
+    ) ?? DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS;
   const nodeId = await deps.resolveNodeId(opts, normalizeOptionalString(opts.node) ?? "");
-  return await deps.callGatewayCli(
-    "node.invoke",
-    opts,
-    deps.buildNodeInvokeParams({
-      nodeId,
-      command,
-      params,
-      timeoutMs: typeof timeoutMs === "number" ? timeoutMs : undefined,
-    }),
+  const invokeParams = deps.buildNodeInvokeParams({ nodeId, command, params, timeoutMs });
+  const configuredGatewayTimeoutMs = parseStrictPositiveInteger(opts.timeout ?? 10_000);
+  if (configuredGatewayTimeoutMs === undefined) {
+    // Preserve the existing Gateway parser's actionable invalid --timeout error.
+    return await deps.callGatewayCli("node.invoke", opts, invokeParams);
+  }
+  // Node work owns its deadline; Gateway transport needs extra time to deliver that result.
+  const transportTimeoutMs = Math.max(
+    clampPositiveTimerTimeoutMs(configuredGatewayTimeoutMs) ??
+      DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
+    addTimerTimeoutGraceMs(timeoutMs, CANVAS_NODE_INVOKE_TRANSPORT_GRACE_MS) ?? timeoutMs,
   );
+  return await deps.callGatewayCli("node.invoke", opts, invokeParams, { transportTimeoutMs });
 }
 
 /** Prints the complete invocation response for machines or the existing human acknowledgement. */

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -20,6 +20,16 @@ const VALID_A2UI_V08_JSONL = [
   JSON.stringify({ beginRendering: { surfaceId: "main", root: "root" } }),
 ].join("\n");
 
+const canvasToolInvocationActions = [
+  { args: { action: "present" }, command: "canvas.present" },
+  { args: { action: "hide" }, command: "canvas.hide" },
+  { args: { action: "navigate", url: "https://example.com" }, command: "canvas.navigate" },
+  { args: { action: "eval", javaScript: "1 + 1" }, command: "canvas.eval" },
+  { args: { action: "snapshot" }, command: "canvas.snapshot" },
+  { args: { action: "a2ui_push", jsonl: VALID_A2UI_V08_JSONL }, command: "canvas.a2ui.pushJSONL" },
+  { args: { action: "a2ui_reset" }, command: "canvas.a2ui.reset" },
+] as const;
+
 const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
   imageResultFromFile: vi.fn(async (params) => ({ content: [], details: params })),
@@ -55,6 +65,58 @@ describe("Canvas tool", () => {
       await rm(tempRoot, { recursive: true, force: true });
       tempRoot = undefined;
     }
+  });
+
+  it.each(canvasToolInvocationActions)(
+    "forwards the default $command node deadline with Gateway transport grace",
+    async ({ args, command }) => {
+      mocks.callGatewayTool.mockResolvedValue({
+        payload: { format: "png", base64: "aGk=" },
+      });
+
+      await createCanvasTool().execute("tool-call", args);
+
+      expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+        "node.invoke",
+        { timeoutMs: 40_000 },
+        expect.objectContaining({ command, timeoutMs: 30_000 }),
+      );
+      expect(mocks.listNodes).toHaveBeenCalledWith({ timeoutMs: undefined });
+    },
+  );
+
+  it.each(canvasToolInvocationActions)(
+    "forwards an explicit $command node deadline with Gateway transport grace",
+    async ({ args, command }) => {
+      mocks.callGatewayTool.mockResolvedValue({
+        payload: { format: "png", base64: "aGk=" },
+      });
+
+      await createCanvasTool().execute("tool-call", { ...args, timeoutMs: 120_000 });
+
+      expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+        "node.invoke",
+        { timeoutMs: 130_000 },
+        expect.objectContaining({ command, timeoutMs: 120_000 }),
+      );
+      expect(mocks.listNodes).toHaveBeenCalledWith({ timeoutMs: 120_000 });
+    },
+  );
+
+  it("caps oversized tool invocation and transport deadlines to the timer-safe maximum", async () => {
+    mocks.callGatewayTool.mockResolvedValue({});
+
+    await createCanvasTool().execute("tool-call", {
+      action: "hide",
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 2_147_000_000 },
+      expect.objectContaining({ command: "canvas.hide", timeoutMs: 2_147_000_000 }),
+    );
+    expect(mocks.listNodes).toHaveBeenCalledWith({ timeoutMs: Number.MAX_SAFE_INTEGER });
   });
 
   it.skipIf(process.platform === "win32")(
@@ -168,9 +230,10 @@ describe("Canvas tool", () => {
 
     expect(mocks.callGatewayTool).toHaveBeenLastCalledWith(
       "node.invoke",
-      { timeoutMs: 1500 },
+      { timeoutMs: 11_500 },
       expect.objectContaining({
         command: "canvas.present",
+        timeoutMs: 1500,
         params: {
           placement: {
             x: 10.5,
@@ -190,9 +253,10 @@ describe("Canvas tool", () => {
 
     expect(mocks.callGatewayTool).toHaveBeenLastCalledWith(
       "node.invoke",
-      {},
+      { timeoutMs: 40_000 },
       expect.objectContaining({
         command: "canvas.snapshot",
+        timeoutMs: 30_000,
         params: {
           format: "png",
           maxWidth: 800,
@@ -228,11 +292,12 @@ describe("Canvas tool", () => {
     expect(mocks.callGatewayTool).toHaveBeenCalledTimes(1);
     expect(mocks.callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",
-      {},
+      { timeoutMs: 40_000 },
       {
         nodeId: "node-1",
         command: "canvas.a2ui.pushJSONL",
         params: { jsonl: VALID_A2UI_V08_JSONL },
+        timeoutMs: 30_000,
         idempotencyKey: expect.any(String),
         sessionKey: "agent:main:canvas",
       },

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -15,6 +15,10 @@ import {
   jsonResult,
   readStringParam,
 } from "openclaw/plugin-sdk/channel-actions";
+import {
+  addTimerTimeoutGraceMs,
+  clampPositiveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { AnyAgentTool, OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
@@ -34,6 +38,8 @@ type CanvasImageSanitizationLimits = {
 };
 
 export const CANVAS_JSONL_MAX_BYTES = 16 * 1024 * 1024;
+const DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS = 30_000;
+const CANVAS_NODE_INVOKE_TRANSPORT_GRACE_MS = 10_000;
 
 function readGatewayCallOptions(params: Record<string, unknown>) {
   return {
@@ -113,13 +119,25 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
 
       const invoke = async (command: string, invokeParams?: Record<string, unknown>) => {
         const nodeId = await resolveNodeId(gatewayOpts, nodeQuery, true);
-        return await callGatewayTool("node.invoke", gatewayOpts, {
-          nodeId,
-          command,
-          params: invokeParams,
-          idempotencyKey: randomUUID(),
-          ...(options?.agentSessionKey ? { sessionKey: options.agentSessionKey } : {}),
-        });
+        const timeoutMs =
+          clampPositiveTimerTimeoutMs(
+            gatewayOpts.timeoutMs ?? DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
+          ) ?? DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS;
+        // Preserve the node lookup budget while letting Gateway outlive node execution.
+        const transportTimeoutMs =
+          addTimerTimeoutGraceMs(timeoutMs, CANVAS_NODE_INVOKE_TRANSPORT_GRACE_MS) ?? timeoutMs;
+        return await callGatewayTool(
+          "node.invoke",
+          { ...gatewayOpts, timeoutMs: transportTimeoutMs },
+          {
+            nodeId,
+            command,
+            params: invokeParams,
+            timeoutMs,
+            idempotencyKey: randomUUID(),
+            ...(options?.agentSessionKey ? { sessionKey: options.agentSessionKey } : {}),
+          },
+        );
       };
 
       switch (action) {


### PR DESCRIPTION
## What Problem This Solves

Canvas has two broken invocation-deadline producers. Its CLI can terminate the Gateway request before the paired node finishes, and its model-facing tool applies a requested timeout only to Gateway transport while leaving the node at its unrelated default deadline. Every Canvas action is affected.

## Why This Change Was Made

Both existing plugin-owned invocation helpers now record the real node deadline, retain the canonical 30-second default, and give Gateway transport the existing timer-safe 10-second forwarding grace. Explicit longer Gateway deadlines, the snapshot command’s 60-second transport, malformed-timeout errors, node lookup options, timer limits, and existing JSON/human output are preserved. No Gateway protocol, plugin SDK, configuration, or native contracts change.

## User Impact

`openclaw nodes canvas present|hide|navigate|eval|snapshot|a2ui push|a2ui reset` and all seven model-facing Canvas actions now complete within their intended paired-node deadlines. Operator-selected execution timeouts reach the node; Gateway transport no longer races a valid node result.

## Evidence

- Genuine tests-first regression on both existing owner suites: 32 failures and 49 passes before the fix; all 81 focused tests pass afterward in one cache-disabled combined run.
- Source-blind authenticated localhost Gateway proof: unchanged main fails all seven real CLI actions and all seven real agent-tool actions; the exact candidate succeeds on all 14, across 30 authenticated WebSocket connections and 15 real `node.invoke` requests per run.
- Exact tests cover all seven actions in both default and explicit timeout modes, preserved 60-second snapshot transport, larger operator-selected transport, malformed timeout rejection, unchanged node lookup options, and safe saturation at 2,147,000,000 ms.
- Four independent hostile P0–P3 reviews: zero findings; one complete Codex Sol/high structured P0–P3 review with real TruffleHog: zero findings, confidence 0.93.
- Existing targeted oxfmt and oxlint checks pass; exact four-file diff is clean and merges without conflicts into exact current main (03698f98881f7abdff9f168cd4d26d27c42a6dfa); all 31 owner, caller, Gateway, SDK, native, and documentation blobs remain unchanged.
