### PR TITLE
fix(agents): reject malformed base64 MCP App resource blobs

### DIFF
--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -147,6 +147,30 @@ describe("MCP App UI resources", () => {
     }
   });
 
+  it("rejects malformed base64 blob content instead of rendering corrupted HTML", async () => {
+    const valid = Buffer.from("<html>demo</html>", "utf8").toString("base64");
+    // One out-of-alphabet character mid-stream: Node would silently drop it and
+    // decode the remaining bytes into corrupted HTML.
+    const malformed = `${valid.slice(0, 4)}!${valid.slice(5)}`;
+    const result = await fetchMcpAppView({
+      runtime: runtime(async () => ({
+        contents: [
+          {
+            uri: "ui://demo/app",
+            mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+            blob: malformed,
+          },
+        ],
+      })),
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+    expect(result).toBeUndefined();
+  });
+
   it("bounds concurrent app bridge requests", () => {
     const view = {
       requestWindowStartedAtMs: 0,

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -171,6 +171,28 @@ describe("MCP App UI resources", () => {
     expect(result).toBeUndefined();
   });
 
+  it("keeps an empty blob as a valid zero-byte resource", async () => {
+    const sessionRuntime = runtime(async () => ({
+      contents: [
+        {
+          uri: "ui://demo/app",
+          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+          blob: "",
+        },
+      ],
+    }));
+    const result = await fetchMcpAppView({
+      runtime: sessionRuntime,
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+    expect(result?.viewId).toMatch(/^mcp-app-/u);
+    expect(getMcpAppViewLease(result?.viewId ?? "", sessionRuntime)).toMatchObject({ html: "" });
+  });
+
   it("bounds concurrent app bridge requests", () => {
     const view = {
       requestWindowStartedAtMs: 0,

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -171,8 +171,8 @@ describe("MCP App UI resources", () => {
     expect(result).toBeUndefined();
   });
 
-  it("keeps empty and whitespace-only blobs as valid zero-byte resources", async () => {
-    for (const blob of ["", " \n\t"]) {
+  it("keeps empty and ASCII-whitespace-only blobs as valid zero-byte resources", async () => {
+    for (const blob of ["", " \n\t", "\x1c\x1f \n"]) {
       const sessionRuntime = runtime(async () => ({
         contents: [
           {

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -171,26 +171,28 @@ describe("MCP App UI resources", () => {
     expect(result).toBeUndefined();
   });
 
-  it("keeps an empty blob as a valid zero-byte resource", async () => {
-    const sessionRuntime = runtime(async () => ({
-      contents: [
-        {
-          uri: "ui://demo/app",
-          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
-          blob: "",
-        },
-      ],
-    }));
-    const result = await fetchMcpAppView({
-      runtime: sessionRuntime,
-      serverName: "demo",
-      toolName: "show",
-      uiResourceUri: "ui://demo/app",
-      toolInput: {},
-      toolResult: { content: [] },
-    });
-    expect(result?.viewId).toMatch(/^mcp-app-/u);
-    expect(getMcpAppViewLease(result?.viewId ?? "", sessionRuntime)).toMatchObject({ html: "" });
+  it("keeps empty and whitespace-only blobs as valid zero-byte resources", async () => {
+    for (const blob of ["", " \n\t"]) {
+      const sessionRuntime = runtime(async () => ({
+        contents: [
+          {
+            uri: "ui://demo/app",
+            mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+            blob,
+          },
+        ],
+      }));
+      const result = await fetchMcpAppView({
+        runtime: sessionRuntime,
+        serverName: "demo",
+        toolName: "show",
+        uiResourceUri: "ui://demo/app",
+        toolInput: {},
+        toolResult: { content: [] },
+      });
+      expect(result?.viewId).toMatch(/^mcp-app-/u);
+      expect(getMcpAppViewLease(result?.viewId ?? "", sessionRuntime)).toMatchObject({ html: "" });
+    }
   });
 
   it("bounds concurrent app bridge requests", () => {

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
@@ -178,7 +179,13 @@ function decodeResourceHtml(content: Record<string, unknown>): string {
   if (content.blob.length > maxEncodedBytes) {
     throw new Error(`MCP App resource exceeds ${MCP_APP_RESOURCE_MAX_BYTES} bytes`);
   }
-  const decoded = Buffer.from(content.blob, "base64");
+  // Buffer.from silently drops out-of-alphabet characters, which would render
+  // corrupted HTML without any error. Canonicalize first and reject outright.
+  const canonicalBlob = canonicalizeBase64(content.blob);
+  if (!canonicalBlob) {
+    throw new Error("MCP App resource returned malformed base64 blob content");
+  }
+  const decoded = Buffer.from(canonicalBlob, "base64");
   if (decoded.byteLength > MCP_APP_RESOURCE_MAX_BYTES) {
     throw new Error(`MCP App resource exceeds ${MCP_APP_RESOURCE_MAX_BYTES} bytes`);
   }

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -165,6 +165,16 @@ function normalizePermissions(value: unknown): McpAppPermissions | undefined {
   return Object.keys(permissions).length > 0 ? permissions : undefined;
 }
 
+/** Matches the whitespace rule shared by the base64 helpers: code points at or below 0x20. */
+function isAsciiWhitespaceOnly(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) > 0x20) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function decodeResourceHtml(content: Record<string, unknown>): string {
   if (typeof content.text === "string") {
     if (Buffer.byteLength(content.text, "utf8") > MCP_APP_RESOURCE_MAX_BYTES) {
@@ -181,9 +191,10 @@ function decodeResourceHtml(content: Record<string, unknown>): string {
   }
   // Buffer.from silently drops out-of-alphabet characters, which would render
   // corrupted HTML without any error. Canonicalize first and reject outright.
-  // An empty or whitespace-only blob decodes to zero bytes with Node's lenient
-  // decoder; keep that existing valid zero-byte resource behavior.
-  const canonicalBlob = content.blob.trim() === "" ? "" : canonicalizeBase64(content.blob);
+  // A blob carrying only characters at or below 0x20 (the canonicalizer's
+  // whitespace rule, e.g. spaces, tabs, newlines, C0 controls) decodes to zero
+  // bytes with Node's lenient decoder; keep that existing valid behavior.
+  const canonicalBlob = isAsciiWhitespaceOnly(content.blob) ? "" : canonicalizeBase64(content.blob);
   if (canonicalBlob === undefined) {
     throw new Error("MCP App resource returned malformed base64 blob content");
   }

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -181,8 +181,9 @@ function decodeResourceHtml(content: Record<string, unknown>): string {
   }
   // Buffer.from silently drops out-of-alphabet characters, which would render
   // corrupted HTML without any error. Canonicalize first and reject outright.
-  const canonicalBlob = canonicalizeBase64(content.blob);
-  if (!canonicalBlob) {
+  // An empty blob is a valid zero-byte resource, not malformed content.
+  const canonicalBlob = content.blob === "" ? "" : canonicalizeBase64(content.blob);
+  if (canonicalBlob === undefined) {
     throw new Error("MCP App resource returned malformed base64 blob content");
   }
   const decoded = Buffer.from(canonicalBlob, "base64");

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -181,8 +181,9 @@ function decodeResourceHtml(content: Record<string, unknown>): string {
   }
   // Buffer.from silently drops out-of-alphabet characters, which would render
   // corrupted HTML without any error. Canonicalize first and reject outright.
-  // An empty blob is a valid zero-byte resource, not malformed content.
-  const canonicalBlob = content.blob === "" ? "" : canonicalizeBase64(content.blob);
+  // An empty or whitespace-only blob decodes to zero bytes with Node's lenient
+  // decoder; keep that existing valid zero-byte resource behavior.
+  const canonicalBlob = content.blob.trim() === "" ? "" : canonicalizeBase64(content.blob);
   if (canonicalBlob === undefined) {
     throw new Error("MCP App resource returned malformed base64 blob content");
   }


### PR DESCRIPTION
## Summary

Validate MCP App resource `blob` payloads as base64 before decoding, so a malformed blob is rejected with a clear error instead of being silently decoded into corrupted HTML that gets retained and rendered as an app view. Blobs carrying no base64 data at all (empty, whitespace-only, or ASCII-control-only — every code point at or below 0x20) remain valid zero-byte resources, preserving existing behavior.

## What Problem This Solves

`decodeResourceHtml` in `src/agents/mcp-ui-resource.ts` decodes MCP App UI resource blobs with `Buffer.from(content.blob, "base64")`. Node's base64 decoder **does not throw on out-of-alphabet characters — it silently drops them** and decodes whatever remains. A damaged or malicious MCP server response therefore produces byte-shifted, corrupted HTML, and `fetchMcpAppView` retains that garbage as the app view HTML (`mcp-ui-resource.ts:255`) and serves it into the sandboxed app frame. The size guards still pass, so there is no signal anything went wrong. This is the same decode-without-validation class fixed for Signal attachments in #114883.

**Code evidence**: `mcp-ui-resource.ts:181` (upstream/main) decoded the blob straight after the length checks with no character-set validation.

## Root Cause

- Introduced by commit f3971bbd56e4 (2026-07-12), which added the blob branch with only size guards.
- Violated invariant: the decoder assumes a well-formed base64 alphabet, but `Buffer.from(..., "base64")` never enforces it — the function's contract ("return the resource HTML") breaks the moment any out-of-alphabet byte appears.
- Trigger: any MCP App server whose `resources/read` response carries a `blob` with whitespace-free but out-of-alphabet characters (transport corruption, buggy encoders, hostile servers).

## Why This Fix

- Route the blob through the repo-standard `canonicalizeBase64` (`@openclaw/media-core/base64`) — the same helper #114883 used for Signal attachments — and reject with a descriptive error when it returns `undefined`. One line of validation at the single decode site; the legitimate fast path is unchanged.
- `canonicalizeBase64` returns `undefined` whenever no base64 data remains after skipping characters at or below 0x20, but Node's lenient decoder accepts those data-less blobs (empty, ordinary whitespace, or C0 control characters like `\x1c`–`\x1f`) as zero-byte resources and leases an empty view. Such inputs are therefore special-cased before validation with the same code-point rule the helper uses, so established valid outcomes are not turned into refusals; only payloads that actually carry malformed base64 data are rejected.
- Alternatives considered: (a) hand-rolled regex validation — duplicates the canonical helper's rules and risks drift; (b) post-decode round-trip comparison — same coverage, more code, no clearer signal.

## User Impact

- Affected operations: any MCP App tool whose UI resource is served as base64 `blob` content.
- Before: a corrupted blob renders as garbled HTML in the app view with no error anywhere — users see a broken app and cannot tell why.
- After: the view is refused with `MCP App resource returned malformed base64 blob content`, surfacing the server-side data problem immediately. Servers that legitimately return a data-less blob (empty or ASCII-whitespace-only) keep rendering their blank app view exactly as on main.

## Evidence

- **Before**: the real `fetchMcpAppView` entry point receives a blob with one out-of-alphabet character → a view is leased whose HTML is byte-shifted garbage (`"<ht[\u000f�\u0019[[�\u000b�\u001d\u001b[\u000f"`) → FAIL; empty, whitespace-only, and ASCII-control-only blobs are retained as zero-byte views → PASS (existing behavior that must be preserved)
- **After**: the same malformed blob is rejected (`MCP App resource returned malformed base64 blob content`) and no view is retained → PASS; empty, whitespace-only, and ASCII-control-only blobs are still retained as zero-byte views → PASS (compatibility preserved)

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
serving blob: PGh0!Ww+ZGVtbzwvaHRtbD4=
retained view html: "<ht[\u000f�\u0019[[�\u000b�\u001d\u001b[\u000f"
FAIL: corrupted HTML silently retained from a malformed base64 blob
serving blob: <empty string>
PASS: empty blob retained as a zero-byte view (existing behavior preserved)
serving blob: <whitespace only " \n\t">
PASS: whitespace-only blob retained as a zero-byte view (existing behavior preserved)
serving blob: <ASCII controls only "\x1c\x1f \n">
PASS: ASCII-control-only blob retained as a zero-byte view (existing behavior preserved)
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
serving blob: PGh0!Ww+ZGVtbzwvaHRtbD4=
[mcp-app] failed to prepare ui://demo/app from "demo": MCP App resource returned malformed base64 blob content
PASS: malformed base64 blob rejected, no corrupted HTML retained
serving blob: <empty string>
PASS: empty blob retained as a zero-byte view (existing behavior preserved)
serving blob: <whitespace only " \n\t">
PASS: whitespace-only blob retained as a zero-byte view (existing behavior preserved)
serving blob: <ASCII controls only "\x1c\x1f \n">
PASS: ASCII-control-only blob retained as a zero-byte view (existing behavior preserved)
```

## Tests and Validation

- `pnpm check` passed
- Added regression coverage in `src/agents/mcp-ui-resource.test.ts`: a blob with one mid-stream out-of-alphabet character must not lease a view, and empty, whitespace-only, plus ASCII-control-only blobs must still lease a zero-byte view; all 12 cases in the file pass
- Proof above exercises the real `fetchMcpAppView` / `decodeResourceHtml` code path; no external services involved
