### PR TITLE
fix(models): avoid waiting on promotions before listing models

### DIFF
--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -400,23 +400,68 @@ describe("modelsListCommand forward-compat", () => {
 
     it("preserves the human-readable message for an empty model list", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
+      const refreshToken = { nowMs: 1, statePromise: Promise.resolve() };
+      mocks.startPromotionsFeedRefresh.mockReturnValueOnce(refreshToken);
       const runtime = createRuntime();
 
       await modelsListCommand({ provider: "autoqa-no-such-provider" }, runtime as never);
 
       expect(runtime.log).toHaveBeenCalledWith("No models found.");
       expect(mocks.printModelTable).not.toHaveBeenCalled();
+      expect(mocks.startPromotionsFeedRefresh).toHaveBeenCalledOnce();
+      expect(mocks.printAvailablePromotionsSection).toHaveBeenCalledWith(
+        expect.objectContaining({ refresh: refreshToken }),
+      );
     });
   });
 
   describe("promotion refresh scheduling", () => {
-    it("constructs rows before refresh resolves and appends promotion output after the table", async () => {
+    it("does not start refresh when config resolution fails", async () => {
+      mocks.loadModelsConfigWithSource.mockRejectedValueOnce(new Error("config failed"));
+
+      await expect(modelsListCommand({}, createRuntime() as never)).rejects.toThrow(
+        "config failed",
+      );
+
+      expect(mocks.startPromotionsFeedRefresh).not.toHaveBeenCalled();
+    });
+
+    it("does not start refresh when registry loading fails", async () => {
+      mocks.loadModelRegistry.mockRejectedValueOnce(new Error("registry failed"));
+      const runtime = createRuntime();
+
+      await modelsListCommand({ all: true }, runtime as never);
+
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("registry failed"));
+      expect(mocks.startPromotionsFeedRefresh).not.toHaveBeenCalled();
+      expect(mocks.printAvailablePromotionsSection).not.toHaveBeenCalled();
+    });
+
+    it.each([{ json: true }, { plain: true }])(
+      "does not start refresh for machine output",
+      async (options) => {
+        await modelsListCommand(options, createRuntime() as never);
+
+        expect(mocks.startPromotionsFeedRefresh).not.toHaveBeenCalled();
+        expect(mocks.printAvailablePromotionsSection).not.toHaveBeenCalled();
+      },
+    );
+
+    it("starts refresh before row construction finishes and appends output after the table", async () => {
       const refresh = createDeferred();
+      const rowConstructionStarted = createDeferred();
+      const releaseRowConstruction = createDeferred();
       const tablePrinted = createDeferred();
-      mocks.startPromotionsFeedRefresh.mockReturnValueOnce({
+      const refreshToken = {
         nowMs: 1,
         statePromise: refresh.promise,
+      };
+      mocks.loadModelCatalog.mockImplementationOnce(async () => {
+        rowConstructionStarted.resolve();
+        await releaseRowConstruction.promise;
+        return [];
       });
+      mocks.startPromotionsFeedRefresh.mockReturnValueOnce(refreshToken);
       mocks.printModelTable.mockImplementationOnce((_rows, runtime) => {
         runtime.log("model table");
         tablePrinted.resolve();
@@ -430,16 +475,45 @@ describe("modelsListCommand forward-compat", () => {
       const runtime = createRuntime();
 
       const commandPromise = modelsListCommand({}, runtime as never);
+      await rowConstructionStarted.promise;
+
+      expect(mocks.startPromotionsFeedRefresh).toHaveBeenCalledOnce();
+      expect(mocks.printModelTable).not.toHaveBeenCalled();
+
+      releaseRowConstruction.resolve();
       await tablePrinted.promise;
 
       expectRowKeys(lastPrintedRows<{ key: string }>(), ["openai/gpt-5.4"]);
-      expect(mocks.startPromotionsFeedRefresh).toHaveBeenCalledOnce();
       expect(runtime.log.mock.calls).toEqual([["model table"]]);
 
       refresh.resolve();
       await commandPromise;
 
       expect(runtime.log.mock.calls).toEqual([["model table"], ["promotion section"]]);
+      expect(mocks.printAvailablePromotionsSection).toHaveBeenCalledWith(
+        expect.objectContaining({ refresh: refreshToken }),
+      );
+    });
+
+    it("keeps a rejected refresh fail-silent", async () => {
+      const refresh = createDeferred();
+      const sectionStarted = createDeferred();
+      mocks.startPromotionsFeedRefresh.mockReturnValueOnce({
+        nowMs: 1,
+        statePromise: refresh.promise,
+      });
+      mocks.printAvailablePromotionsSection.mockImplementationOnce(
+        async ({ refresh: pendingRefresh }) => {
+          sectionStarted.resolve();
+          await pendingRefresh.statePromise;
+        },
+      );
+
+      const commandPromise = modelsListCommand({}, createRuntime() as never);
+      await sectionStarted.promise;
+      refresh.reject(new Error("refresh failed"));
+
+      await expect(commandPromise).resolves.toBeUndefined();
     });
   });
 

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -1,5 +1,6 @@
 // Model list forward-compat tests cover list command behavior with future catalog shapes.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test-utils/deferred.js";
 
 const OPENAI_CODEX_MODEL = {
   provider: "openai",
@@ -92,6 +93,9 @@ const mocks = vi.hoisted(() => {
     loadModelCatalog: vi.fn(),
     resolveConfiguredEntries: vi.fn(),
     printModelTable: vi.fn(),
+    applyPromotionClaimTags: vi.fn(),
+    startPromotionsFeedRefresh: vi.fn(),
+    printAvailablePromotionsSection: vi.fn(),
     resolveModelWithRegistry: vi.fn(),
     readPersistedInstalledPluginIndexSync: vi.fn(),
     loadManifestMetadataSnapshot: vi.fn(),
@@ -127,6 +131,9 @@ function resetMocks() {
     ],
   });
   mocks.printModelTable.mockReset();
+  mocks.applyPromotionClaimTags.mockReset();
+  mocks.startPromotionsFeedRefresh.mockReset();
+  mocks.printAvailablePromotionsSection.mockReset();
   mocks.resolveModelWithRegistry.mockReturnValue({ ...OPENAI_CODEX_MODEL });
   mocks.readPersistedInstalledPluginIndexSync.mockReturnValue(null);
   mocks.loadManifestMetadataSnapshot.mockReturnValue(mocks.emptyPluginMetadataSnapshot);
@@ -215,6 +222,12 @@ function installModelsListCommandForwardCompatMocks() {
 
   vi.doMock("./list.table.js", () => ({
     printModelTable: mocks.printModelTable,
+  }));
+
+  vi.doMock("./list.promotions.js", () => ({
+    applyPromotionClaimTags: mocks.applyPromotionClaimTags,
+    startPromotionsFeedRefresh: mocks.startPromotionsFeedRefresh,
+    printAvailablePromotionsSection: mocks.printAvailablePromotionsSection,
   }));
 
   vi.doMock("./list.registry-load.js", () => ({
@@ -381,6 +394,7 @@ describe("modelsListCommand forward-compat", () => {
       await modelsListCommand(opts, runtime as never);
 
       expect(mocks.printModelTable).toHaveBeenCalledWith([], runtime, opts);
+      expect(mocks.startPromotionsFeedRefresh).not.toHaveBeenCalled();
       expect(runtime.log).not.toHaveBeenCalledWith("No models found.");
     });
 
@@ -392,6 +406,40 @@ describe("modelsListCommand forward-compat", () => {
 
       expect(runtime.log).toHaveBeenCalledWith("No models found.");
       expect(mocks.printModelTable).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("promotion refresh scheduling", () => {
+    it("constructs rows before refresh resolves and appends promotion output after the table", async () => {
+      const refresh = createDeferred();
+      const tablePrinted = createDeferred();
+      mocks.startPromotionsFeedRefresh.mockReturnValueOnce({
+        nowMs: 1,
+        statePromise: refresh.promise,
+      });
+      mocks.printModelTable.mockImplementationOnce((_rows, runtime) => {
+        runtime.log("model table");
+        tablePrinted.resolve();
+      });
+      mocks.printAvailablePromotionsSection.mockImplementationOnce(
+        async ({ refresh: pendingRefresh, runtime }) => {
+          await pendingRefresh.statePromise;
+          runtime.log("promotion section");
+        },
+      );
+      const runtime = createRuntime();
+
+      const commandPromise = modelsListCommand({}, runtime as never);
+      await tablePrinted.promise;
+
+      expectRowKeys(lastPrintedRows<{ key: string }>(), ["openai/gpt-5.4"]);
+      expect(mocks.startPromotionsFeedRefresh).toHaveBeenCalledOnce();
+      expect(runtime.log.mock.calls).toEqual([["model table"]]);
+
+      refresh.resolve();
+      await commandPromise;
+
+      expect(runtime.log.mock.calls).toEqual([["model table"], ["promotion section"]]);
     });
   });
 

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -72,7 +72,6 @@ export async function modelsListCommand(
     return;
   }
   const humanReadable = !opts.json && !opts.plain;
-  const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
   const [
     { loadAuthProfileStoreWithoutExternalProfiles },
     { resolveAgentWorkspaceDir, resolveDefaultAgentDir, resolveDefaultAgentId },
@@ -102,9 +101,6 @@ export async function modelsListCommand(
       })
     : undefined;
   const { entries } = resolveConfiguredEntries(cfg, metadataSnapshot);
-  const promotionsRefreshPromise = promotionsModulePromise?.then((promotionsModule) =>
-    promotionsModule.startPromotionsFeedRefresh(),
-  );
   const authIndex = createModelListAuthIndex({
     cfg,
     authStore,
@@ -188,6 +184,10 @@ export async function modelsListCommand(
     process.exitCode = 1;
     return;
   }
+  const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
+  const promotionsRefreshPromise = promotionsModulePromise
+    ?.then((promotionsModule) => promotionsModule.startPromotionsFeedRefresh())
+    .catch(() => undefined);
   const buildRowContext = (skipRuntimeModelSuppression: boolean) => ({
     cfg,
     agentId,
@@ -255,11 +255,14 @@ export async function modelsListCommand(
     // the configured entries, not the rendered rows — filtered and --all
     // listings show a different set.
     try {
-      await promotionsModule.printAvailablePromotionsSection({
-        configuredKeys: new Set(entries.map((entry) => entry.key)),
-        refresh: await promotionsRefreshPromise,
-        runtime,
-      });
+      const refresh = await promotionsRefreshPromise;
+      if (refresh) {
+        await promotionsModule.printAvailablePromotionsSection({
+          configuredKeys: new Set(entries.map((entry) => entry.key)),
+          refresh,
+          runtime,
+        });
+      }
     } catch {
       // Passive discovery must never fail the listing.
     }

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -71,6 +71,8 @@ export async function modelsListCommand(
   if (parsedProviderFilter === null) {
     return;
   }
+  const humanReadable = !opts.json && !opts.plain;
+  const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
   const [
     { loadAuthProfileStoreWithoutExternalProfiles },
     { resolveAgentWorkspaceDir, resolveDefaultAgentDir, resolveDefaultAgentId },
@@ -100,6 +102,9 @@ export async function modelsListCommand(
       })
     : undefined;
   const { entries } = resolveConfiguredEntries(cfg, metadataSnapshot);
+  const promotionsRefreshPromise = promotionsModulePromise?.then((promotionsModule) =>
+    promotionsModule.startPromotionsFeedRefresh(),
+  );
   const authIndex = createModelListAuthIndex({
     cfg,
     authStore,
@@ -233,7 +238,7 @@ export async function modelsListCommand(
   // Promotion decorations are best-effort: claim tags come from local
   // provenance, and the discovery section reads a cadence-gated feed cache.
   // Neither may break the core listing; stale refreshes have a short timeout.
-  const promotionsModule = await promotionsModuleLoader.load();
+  const promotionsModule = await (promotionsModulePromise ?? promotionsModuleLoader.load());
   try {
     promotionsModule.applyPromotionClaimTags(rows);
   } catch {
@@ -244,7 +249,7 @@ export async function modelsListCommand(
   } else {
     printModelTable(rows, runtime, opts);
   }
-  if (!opts.json && !opts.plain) {
+  if (promotionsRefreshPromise) {
     // Runs on the empty listing too: a fresh install with zero configured
     // models is exactly the user passive discovery is for. Compares against
     // the configured entries, not the rendered rows — filtered and --all
@@ -252,6 +257,7 @@ export async function modelsListCommand(
     try {
       await promotionsModule.printAvailablePromotionsSection({
         configuredKeys: new Set(entries.map((entry) => entry.key)),
+        refresh: await promotionsRefreshPromise,
         runtime,
       });
     } catch {

--- a/src/commands/models/list.promotions.test.ts
+++ b/src/commands/models/list.promotions.test.ts
@@ -8,7 +8,11 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
-import { applyPromotionClaimTags, printAvailablePromotionsSection } from "./list.promotions.js";
+import {
+  applyPromotionClaimTags,
+  printAvailablePromotionsSection,
+  startPromotionsFeedRefresh,
+} from "./list.promotions.js";
 import type { ModelRow } from "./list.types.js";
 
 const NOW = Date.parse("2026-07-05T12:00:00.000Z");
@@ -116,8 +120,8 @@ describe("models list promotion decorations", () => {
     const { runtime, lines } = makeRuntime();
     await printAvailablePromotionsSection({
       configuredKeys: new Set(["other/model"]),
+      refresh: startPromotionsFeedRefresh(NOW),
       runtime,
-      nowMs: NOW,
     });
     const text = lines.join("\n");
     expect(text).toContain("Available via promotion:");
@@ -133,8 +137,8 @@ describe("models list promotion decorations", () => {
     const first = makeRuntime();
     await printAvailablePromotionsSection({
       configuredKeys: configured,
+      refresh: startPromotionsFeedRefresh(NOW),
       runtime: first.runtime,
-      nowMs: NOW,
     });
     const firstText = first.lines.join("\n");
     expect(firstText).not.toContain("Available via promotion:");
@@ -143,8 +147,8 @@ describe("models list promotion decorations", () => {
     const second = makeRuntime();
     await printAvailablePromotionsSection({
       configuredKeys: configured,
+      refresh: startPromotionsFeedRefresh(NOW),
       runtime: second.runtime,
-      nowMs: NOW,
     });
     expect(second.lines.join("\n")).toBe("");
   });
@@ -152,7 +156,11 @@ describe("models list promotion decorations", () => {
   it("renders the section for an empty model list (fresh install)", async () => {
     await seedFeedCache([liveEntry]);
     const { runtime, lines } = makeRuntime();
-    await printAvailablePromotionsSection({ configuredKeys: new Set(), runtime, nowMs: NOW });
+    await printAvailablePromotionsSection({
+      configuredKeys: new Set(),
+      refresh: startPromotionsFeedRefresh(NOW),
+      runtime,
+    });
     const text = lines.join("\n");
     expect(text).toContain("Available via promotion:");
     expect(text).toContain("openclaw promos claim example-models-launch");
@@ -163,8 +171,8 @@ describe("models list promotion decorations", () => {
     const { runtime, lines } = makeRuntime();
     await printAvailablePromotionsSection({
       configuredKeys: new Set(["other/model"]),
+      refresh: startPromotionsFeedRefresh(NOW),
       runtime,
-      nowMs: NOW,
     });
     expect(lines.join("\n")).toBe("");
   });

--- a/src/commands/models/list.promotions.ts
+++ b/src/commands/models/list.promotions.ts
@@ -14,6 +14,19 @@ import type { ModelRow } from "./list.types.js";
 
 const PROMOTIONS_SECTION_MAX_ENTRIES = 3;
 
+type PromotionsFeedRefresh = {
+  nowMs: number;
+  statePromise: ReturnType<typeof maybeRefreshPromotionsFeed>;
+};
+
+/** Starts the passive feed refresh so callers can overlap it with model row construction. */
+export function startPromotionsFeedRefresh(nowMs = Date.now()): PromotionsFeedRefresh {
+  return {
+    nowMs,
+    statePromise: maybeRefreshPromotionsFeed({ nowMs }),
+  };
+}
+
 /**
  * Tag configured rows that were registered by `promos claim`, flipping to
  * "promo ended" once the window passes so users learn why a model stopped
@@ -64,11 +77,13 @@ function canonicalPromotionModelKey(
  */
 export async function printAvailablePromotionsSection(params: {
   configuredKeys: ReadonlySet<string>;
+  refresh?: PromotionsFeedRefresh;
   runtime: RuntimeEnv;
   nowMs?: number;
 }): Promise<void> {
-  const nowMs = params.nowMs ?? Date.now();
-  const state = await maybeRefreshPromotionsFeed({ nowMs });
+  const refresh = params.refresh ?? startPromotionsFeedRefresh(params.nowMs);
+  const nowMs = params.nowMs ?? refresh.nowMs;
+  const state = await refresh.statePromise;
   const live = listLivePromotionEntries(state, nowMs);
   if (live.length === 0) {
     return;

--- a/src/commands/models/list.promotions.ts
+++ b/src/commands/models/list.promotions.ts
@@ -16,14 +16,14 @@ const PROMOTIONS_SECTION_MAX_ENTRIES = 3;
 
 type PromotionsFeedRefresh = {
   nowMs: number;
-  statePromise: ReturnType<typeof maybeRefreshPromotionsFeed>;
+  statePromise: Promise<Awaited<ReturnType<typeof maybeRefreshPromotionsFeed>> | undefined>;
 };
 
 /** Starts the passive feed refresh so callers can overlap it with model row construction. */
 export function startPromotionsFeedRefresh(nowMs = Date.now()): PromotionsFeedRefresh {
   return {
     nowMs,
-    statePromise: maybeRefreshPromotionsFeed({ nowMs }),
+    statePromise: maybeRefreshPromotionsFeed({ nowMs }).catch(() => undefined),
   };
 }
 
@@ -77,13 +77,15 @@ function canonicalPromotionModelKey(
  */
 export async function printAvailablePromotionsSection(params: {
   configuredKeys: ReadonlySet<string>;
-  refresh?: PromotionsFeedRefresh;
+  refresh: PromotionsFeedRefresh;
   runtime: RuntimeEnv;
-  nowMs?: number;
 }): Promise<void> {
-  const refresh = params.refresh ?? startPromotionsFeedRefresh(params.nowMs);
-  const nowMs = params.nowMs ?? refresh.nowMs;
+  const { refresh } = params;
+  const nowMs = refresh.nowMs;
   const state = await refresh.statePromise;
+  if (!state) {
+    return;
+  }
   const live = listLivePromotionEntries(state, nowMs);
   if (live.length === 0) {
     return;


### PR DESCRIPTION
Related: #116920
Depends on: #117323

## What Problem This Solves

Human-readable `openclaw models list` could wait for the optional promotions feed refresh after model rows were already prepared, adding the feed timeout directly to command latency.

## Why This Change Was Made

The command now starts the best-effort promotions refresh after configuration, authentication indexing, and required registry loading succeed, then overlaps it with model row construction.

The refresh is represented by an explicit token containing the captured time and fail-silent state promise. The table still prints before the optional promotions section. JSON and plain output do not import or refresh promotions, and config or registry failures do not start the optional work.

Refresh cadence, timeout, cache, and notification behavior remain unchanged. Rejected refresh promises are now contained at the refresh boundary, so passive discovery cannot create an unhandled rejection or fail the listing.

## User Impact

Human-readable model listing returns its core table sooner when the optional promotions feed is slow, without changing machine-readable output or the rendered promotions section.

## Evidence

- Exact head: `ed9c67f1b7f14bb35bf49ae35f4ae7d55cc8db76`.
- Parent model-list optimization landed as #117323 at `5ae401d9084f76ef4908b584bfff44962fa271f4`.
- The Kova reproduction held model-list duration near `2.16s`; an isolated promotions fetch on the same path consumed about `1.8s`, identifying this latency issue separately from the catalog RSS regression: https://github.com/openclaw/openclaw/actions/runs/30692963688.
- 44 focused tests passed across `list.list-command.forward-compat.test.ts` and `list.promotions.test.ts`.
- Coverage proves refresh starts before row construction finishes, output remains table-first, machine output skips refresh, config/registry failures do not start refresh, and a rejected refresh stays fail-silent.
- Targeted `oxfmt`, direct touched-file `oxlint`, and `git diff --check` passed.
- The repository lint wrapper currently stops before linting on an unrelated inherited declaration error in `packages/terminal-core/src/ansi.ts`; exact GitHub CI is the authoritative broad gate.
- Exact-head GitHub CI run `30707263927` completed successfully: 57 jobs passed and `openclaw/ci-gate` is green.
- Exact-head Kova run `30707279461` completed successfully: all six jobs passed, including five mock release scenarios and the live OpenAI candidate scenario.
- The deep-profile report's RSS threshold records were accepted by the workflow's trusted report adapter as profiling-affected resource thresholds with no baseline regression; they are broad runtime measurements unrelated to this four-file model-list scheduling change.
- The source probe exposed a separate canonical internal-hook first-boot delay; that fix is tracked independently in #117493.
- Clean merge tree against current `origin/main` `ae1ab269eb364faf4bba995c93aadabb4950c0c1`: `6e14055ba4400288c008dad43e2d10a726661e01`.

## Merge Gate

Do not merge until exact-head GitHub CI and Kova proof are green and every exact-head ClawSweeper `Before merge`, finding, security, owner-decision, merge-risk, and blocking rank-up item is resolved.
