### PR TITLE
fix(models): reduce default model-list memory use

### DIFF
--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -58,6 +58,7 @@ import {
   buildOpenAICodexProviderHooks,
 } from "./openai-chatgpt-provider.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { resolveAuthoredOpenAIProviderConfig } from "./provider-policy-api.js";
 import {
   buildOpenAIResponsesProviderHooks,
   buildOpenAISyntheticCatalogEntry,
@@ -664,27 +665,7 @@ function resolveAuthoredOpenAIConfigRoute(params: {
 }):
   | { configuredModel?: ModelDefinitionConfig; configuredProvider: ModelProviderConfig }
   | undefined {
-  if (normalizeProviderId(params.provider) !== PROVIDER_ID) {
-    return undefined;
-  }
-  const providers = Object.entries(params.config?.models?.providers ?? {});
-  const requestedProvider = params.provider.trim();
-  const providerKey =
-    providers.find(([providerId]) => providerId.trim() === requestedProvider)?.[0].trim() ??
-    providers.find(([providerId]) => normalizeProviderId(providerId) === PROVIDER_ID)?.[0].trim();
-  let providerConfig: ModelProviderConfig | undefined;
-  for (const [providerId, candidate] of providers) {
-    if (providerId.trim() !== providerKey || !candidate) {
-      continue;
-    }
-    providerConfig = providerConfig
-      ? {
-          ...providerConfig,
-          ...candidate,
-          models: candidate.models ?? providerConfig.models,
-        }
-      : candidate;
-  }
+  const providerConfig = resolveAuthoredOpenAIProviderConfig(params);
   if (!providerConfig) {
     return undefined;
   }

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeModelCatalogId,
+  projectConfiguredModelRow,
   resolveModelRoutes,
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
@@ -13,6 +14,51 @@ describe("OpenAI provider policy artifact", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it("skips runtime normalization for canonical Responses rows", () => {
+    expect(
+      projectConfiguredModelRow({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: {
+          provider: "openai",
+          id: "gpt-5.5",
+          api: "openai-responses",
+          baseUrl: "http://127.0.0.1:8080/v1",
+          input: ["text"],
+          name: "GPT-5.5",
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 96_000,
+          maxTokens: 128_000,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["openai-completions", "https://api.openai.com/v1"],
+    ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex"],
+  ] as const)("keeps runtime normalization for %s rows", (api, baseUrl) => {
+    expect(
+      projectConfiguredModelRow({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: {
+          provider: "openai",
+          id: "gpt-5.5",
+          api,
+          baseUrl,
+          input: ["text"],
+          name: "GPT-5.5",
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 96_000,
+          maxTokens: 128_000,
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it("normalizes the legacy Codex model alias at the provider boundary", () => {

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -41,7 +41,6 @@ describe("OpenAI provider policy artifact", () => {
     ["openai-completions", "https://api.openai.com/v1", "gpt-5.5"],
     ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
     ["openai-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
-    [undefined, "https://api.openai.com/v1", "gpt-5.5"],
     ["anthropic-messages", "https://api.openai.com/v1", "gpt-5.5"],
     ["openai-responses", "https://api.openai.com/v1", "gpt-5.4-codex"],
   ] as const)(

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeModelCatalogId,
-  projectConfiguredModelRow,
   resolveModelRoutes,
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
@@ -15,57 +14,6 @@ describe("OpenAI provider policy artifact", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
-
-  it("skips runtime normalization for canonical Responses rows", () => {
-    expect(
-      projectConfiguredModelRow({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        model: {
-          provider: "openai",
-          id: "gpt-5.5",
-          api: "openai-responses",
-          baseUrl: "http://127.0.0.1:8080/v1",
-          input: ["text"],
-          name: "GPT-5.5",
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 96_000,
-          maxTokens: 128_000,
-        },
-      }),
-    ).toBeNull();
-  });
-
-  it.each([
-    ["openai-completions", "https://api.openai.com/v1", "gpt-5.5"],
-    ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
-    ["openai-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
-    ["anthropic-messages", "https://api.openai.com/v1", "gpt-5.5"],
-    ["openai-responses", "https://api.openai.com/v1", "gpt-5.4-codex"],
-  ] as const)(
-    "keeps runtime normalization for api=%s baseUrl=%s model=%s",
-    (api, baseUrl, modelId) => {
-      expect(
-        projectConfiguredModelRow({
-          provider: "openai",
-          modelId,
-          model: {
-            provider: "openai",
-            id: modelId,
-            api,
-            baseUrl,
-            input: ["text"],
-            name: "OpenAI model",
-            reasoning: true,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 96_000,
-            maxTokens: 128_000,
-          },
-        }),
-      ).toBeUndefined();
-    },
-  );
 
   it("normalizes the legacy Codex model alias at the provider boundary", () => {
     expect(normalizeModelCatalogId({ provider: " OpenAI ", modelId: "openai/GPT-5.4-CODEX" })).toBe(

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeModelCatalogId,
-  projectConfiguredModelRow,
   resolveModelRoutes,
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
@@ -14,51 +13,6 @@ describe("OpenAI provider policy artifact", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-  });
-
-  it("skips runtime normalization for canonical Responses rows", () => {
-    expect(
-      projectConfiguredModelRow({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        model: {
-          provider: "openai",
-          id: "gpt-5.5",
-          api: "openai-responses",
-          baseUrl: "http://127.0.0.1:8080/v1",
-          input: ["text"],
-          name: "GPT-5.5",
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 96_000,
-          maxTokens: 128_000,
-        },
-      }),
-    ).toBeNull();
-  });
-
-  it.each([
-    ["openai-completions", "https://api.openai.com/v1"],
-    ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex"],
-  ] as const)("keeps runtime normalization for %s rows", (api, baseUrl) => {
-    expect(
-      projectConfiguredModelRow({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        model: {
-          provider: "openai",
-          id: "gpt-5.5",
-          api,
-          baseUrl,
-          input: ["text"],
-          name: "GPT-5.5",
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 96_000,
-          maxTokens: 128_000,
-        },
-      }),
-    ).toBeUndefined();
   });
 
   it("normalizes the legacy Codex model alias at the provider boundary", () => {

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeModelCatalogId,
+  projectConfiguredModelRow,
   resolveModelRoutes,
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
@@ -14,6 +15,58 @@ describe("OpenAI provider policy artifact", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
+
+  it("skips runtime normalization for canonical Responses rows", () => {
+    expect(
+      projectConfiguredModelRow({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: {
+          provider: "openai",
+          id: "gpt-5.5",
+          api: "openai-responses",
+          baseUrl: "http://127.0.0.1:8080/v1",
+          input: ["text"],
+          name: "GPT-5.5",
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 96_000,
+          maxTokens: 128_000,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["openai-completions", "https://api.openai.com/v1", "gpt-5.5"],
+    ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
+    ["openai-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
+    [undefined, "https://api.openai.com/v1", "gpt-5.5"],
+    ["anthropic-messages", "https://api.openai.com/v1", "gpt-5.5"],
+    ["openai-responses", "https://api.openai.com/v1", "gpt-5.4-codex"],
+  ] as const)(
+    "keeps runtime normalization for api=%s baseUrl=%s model=%s",
+    (api, baseUrl, modelId) => {
+      expect(
+        projectConfiguredModelRow({
+          provider: "openai",
+          modelId,
+          model: {
+            provider: "openai",
+            id: modelId,
+            api,
+            baseUrl,
+            input: ["text"],
+            name: "OpenAI model",
+            reasoning: true,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 96_000,
+            maxTokens: 128_000,
+          },
+        }),
+      ).toBeUndefined();
+    },
+  );
 
   it("normalizes the legacy Codex model alias at the provider boundary", () => {
     expect(normalizeModelCatalogId({ provider: " OpenAI ", modelId: "openai/GPT-5.4-CODEX" })).toBe(

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -27,6 +27,7 @@ import { resolveUnifiedOpenAIThinkingProfile } from "./thinking-policy.js";
 const OPENAI_RESPONSES_API = "openai-responses";
 const OPENAI_COMPLETIONS_API = "openai-completions";
 const OPENAI_CHATGPT_RESPONSES_API = "openai-chatgpt-responses";
+const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_AGENT_RUNTIME_ID = "openclaw";
 const CODEX_AGENT_RUNTIME_ID = "codex";
 const OPENCLAW_RUNTIME_COMPATIBLE_IDS = [OPENAI_AGENT_RUNTIME_ID] as const;
@@ -49,9 +50,40 @@ function normalizeOptionalRouteBaseUrl(value: unknown): string | undefined {
 
 /** Canonical logical id for OpenAI catalog projection. */
 export function normalizeModelCatalogId(params: ProviderNormalizeModelCatalogIdContext) {
-  return params.provider.trim().toLowerCase() === "openai"
+  return params.provider.trim().toLowerCase() === OPENAI_PROVIDER_ID
     ? normalizeOpenAIModelRouteId(params.modelId)
     : null;
+}
+
+/** Resolves authored OpenAI provider config without activating the runtime plugin. */
+export function resolveAuthoredOpenAIProviderConfig(params: {
+  provider: string;
+  config?: { models?: { providers?: Record<string, ModelProviderConfig | undefined> } };
+}): ModelProviderConfig | undefined {
+  if (params.provider.trim().toLowerCase() !== OPENAI_PROVIDER_ID) {
+    return undefined;
+  }
+  const providers = Object.entries(params.config?.models?.providers ?? {});
+  const requestedProvider = params.provider.trim();
+  const providerKey =
+    providers.find(([providerId]) => providerId.trim() === requestedProvider)?.[0].trim() ??
+    providers
+      .find(([providerId]) => providerId.trim().toLowerCase() === OPENAI_PROVIDER_ID)?.[0]
+      .trim();
+  let providerConfig: ModelProviderConfig | undefined;
+  for (const [providerId, candidate] of providers) {
+    if (providerId.trim() !== providerKey || !candidate) {
+      continue;
+    }
+    providerConfig = providerConfig
+      ? {
+          ...providerConfig,
+          ...candidate,
+          models: candidate.models ?? providerConfig.models,
+        }
+      : candidate;
+  }
+  return providerConfig;
 }
 
 /**
@@ -59,13 +91,16 @@ export function normalizeModelCatalogId(params: ProviderNormalizeModelCatalogIdC
  * Transport-sensitive routes and legacy model aliases still use the runtime hook.
  */
 export function projectConfiguredModelRow(ctx: ProviderNormalizeResolvedModelContext) {
-  if (ctx.provider.trim().toLowerCase() !== "openai") {
+  if (ctx.provider.trim().toLowerCase() !== OPENAI_PROVIDER_ID) {
     return undefined;
   }
+  const configuredProvider = resolveAuthoredOpenAIProviderConfig(ctx);
+  const configuredApi = normalizeOptionalRouteApi(configuredProvider?.api);
   const modelId = ctx.model.id;
   const canonicalModelId = normalizeOpenAIModelRouteId(modelId);
   const canonicalRouteId = normalizeOpenAIModelRouteId(ctx.modelId);
   if (
+    (configuredApi !== undefined && configuredApi !== OPENAI_RESPONSES_API) ||
     ctx.model.api !== OPENAI_RESPONSES_API ||
     isOpenAICodexBaseUrl(ctx.model.baseUrl) ||
     canonicalModelId !== modelId ||

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,6 +1,5 @@
 // Openai API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
-import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   ModelApi,
   ModelProviderConfig,
@@ -12,7 +11,6 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-types";
 import {
   classifyOpenAIBaseUrl,
-  isOpenAICodexBaseUrl,
   OPENAI_API_BASE_URL,
   OPENAI_CODEX_RESPONSES_BASE_URL,
 } from "./base-url.js";
@@ -52,22 +50,6 @@ export function normalizeModelCatalogId(params: ProviderNormalizeModelCatalogIdC
   return params.provider.trim().toLowerCase() === "openai"
     ? normalizeOpenAIModelRouteId(params.modelId)
     : null;
-}
-
-/**
- * Projects configured rows without activating the full OpenAI runtime.
- * Null means the explicit Responses row is already canonical; undefined asks
- * the caller to preserve runtime normalization for transport-sensitive routes.
- */
-export function projectConfiguredModelRow(ctx: ProviderNormalizeResolvedModelContext) {
-  if (ctx.provider.trim().toLowerCase() !== "openai") {
-    return undefined;
-  }
-  const requiresRuntimeNormalization =
-    ctx.model.api === OPENAI_COMPLETIONS_API ||
-    ctx.model.api === OPENAI_CHATGPT_RESPONSES_API ||
-    isOpenAICodexBaseUrl(ctx.model.baseUrl);
-  return requiresRuntimeNormalization ? undefined : null;
 }
 
 function firstRouteBaseUrl(...values: unknown[]): unknown {

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,5 +1,6 @@
 // Openai API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
+import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   ModelApi,
   ModelProviderConfig,
@@ -11,6 +12,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-types";
 import {
   classifyOpenAIBaseUrl,
+  isOpenAICodexBaseUrl,
   OPENAI_API_BASE_URL,
   OPENAI_CODEX_RESPONSES_BASE_URL,
 } from "./base-url.js";
@@ -50,6 +52,22 @@ export function normalizeModelCatalogId(params: ProviderNormalizeModelCatalogIdC
   return params.provider.trim().toLowerCase() === "openai"
     ? normalizeOpenAIModelRouteId(params.modelId)
     : null;
+}
+
+/**
+ * Projects configured rows without activating the full OpenAI runtime.
+ * Null means the explicit Responses row is already canonical; undefined asks
+ * the caller to preserve runtime normalization for transport-sensitive routes.
+ */
+export function projectConfiguredModelRow(ctx: ProviderNormalizeResolvedModelContext) {
+  if (ctx.provider.trim().toLowerCase() !== "openai") {
+    return undefined;
+  }
+  const requiresRuntimeNormalization =
+    ctx.model.api === OPENAI_COMPLETIONS_API ||
+    ctx.model.api === OPENAI_CHATGPT_RESPONSES_API ||
+    isOpenAICodexBaseUrl(ctx.model.baseUrl);
+  return requiresRuntimeNormalization ? undefined : null;
 }
 
 function firstRouteBaseUrl(...values: unknown[]): unknown {

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,5 +1,6 @@
 // Openai API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
+import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   ModelApi,
   ModelProviderConfig,
@@ -11,6 +12,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-types";
 import {
   classifyOpenAIBaseUrl,
+  isOpenAICodexBaseUrl,
   OPENAI_API_BASE_URL,
   OPENAI_CODEX_RESPONSES_BASE_URL,
 } from "./base-url.js";
@@ -50,6 +52,28 @@ export function normalizeModelCatalogId(params: ProviderNormalizeModelCatalogIdC
   return params.provider.trim().toLowerCase() === "openai"
     ? normalizeOpenAIModelRouteId(params.modelId)
     : null;
+}
+
+/**
+ * Skips full runtime loading only when OpenAI normalization is provably a no-op.
+ * Transport-sensitive routes and legacy model aliases still use the runtime hook.
+ */
+export function projectConfiguredModelRow(ctx: ProviderNormalizeResolvedModelContext) {
+  if (ctx.provider.trim().toLowerCase() !== "openai") {
+    return undefined;
+  }
+  const modelId = ctx.model.id;
+  const canonicalModelId = normalizeOpenAIModelRouteId(modelId);
+  const canonicalRouteId = normalizeOpenAIModelRouteId(ctx.modelId);
+  if (
+    ctx.model.api !== OPENAI_RESPONSES_API ||
+    isOpenAICodexBaseUrl(ctx.model.baseUrl) ||
+    canonicalModelId !== modelId ||
+    canonicalRouteId !== ctx.modelId
+  ) {
+    return undefined;
+  }
+  return null;
 }
 
 function firstRouteBaseUrl(...values: unknown[]): unknown {

--- a/extensions/openai/provider-policy-projection.test.ts
+++ b/extensions/openai/provider-policy-projection.test.ts
@@ -1,0 +1,107 @@
+import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
+import type { ModelApi } from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it } from "vitest";
+import { projectConfiguredModelRow } from "./provider-policy-api.js";
+
+function createProjectionContext(params?: {
+  modelId?: string;
+  rowApi?: ModelApi;
+  rowBaseUrl?: string;
+  providerApi?: ModelApi;
+  configuredModelApi?: ModelApi;
+}): ProviderNormalizeResolvedModelContext {
+  const modelId = params?.modelId ?? "gpt-5.5";
+  return {
+    provider: "openai",
+    modelId,
+    ...(params?.providerApi
+      ? {
+          config: {
+            models: {
+              providers: {
+                openai: {
+                  api: params.providerApi,
+                  baseUrl: "https://api.openai.com/v1",
+                  models: [
+                    {
+                      id: modelId,
+                      name: "Configured OpenAI model",
+                      reasoning: true,
+                      input: ["text" as const],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 96_000,
+                      maxTokens: 128_000,
+                      ...(params.configuredModelApi ? { api: params.configuredModelApi } : {}),
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      : {}),
+    model: {
+      provider: "openai",
+      id: modelId,
+      api: params?.rowApi ?? ("openai-responses" as const),
+      baseUrl: params?.rowBaseUrl ?? "https://api.openai.com/v1",
+      input: ["text" as const],
+      name: "OpenAI model",
+      reasoning: true,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 96_000,
+      maxTokens: 128_000,
+    },
+  };
+}
+
+describe("OpenAI configured-row projection", () => {
+  it("skips runtime normalization for canonical Responses rows", () => {
+    expect(projectConfiguredModelRow(createProjectionContext())).toBeNull();
+  });
+
+  it.each([
+    {
+      source: "provider",
+      providerApi: "openai-completions" as const,
+      configuredModelApi: undefined,
+      rowApi: undefined,
+    },
+    {
+      source: "model",
+      providerApi: "openai-responses" as const,
+      configuredModelApi: "openai-completions" as const,
+      rowApi: "openai-completions" as const,
+    },
+    {
+      source: "provider ChatGPT",
+      providerApi: "openai-chatgpt-responses" as const,
+      configuredModelApi: undefined,
+      rowApi: undefined,
+    },
+  ])(
+    "keeps runtime normalization for a $source configured route",
+    ({ providerApi, configuredModelApi, rowApi }) => {
+      expect(
+        projectConfiguredModelRow(
+          createProjectionContext({ providerApi, configuredModelApi, rowApi }),
+        ),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ["openai-completions", "https://api.openai.com/v1", "gpt-5.5"],
+    ["openai-chatgpt-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
+    ["openai-responses", "https://chatgpt.com/backend-api/codex", "gpt-5.5"],
+    ["anthropic-messages", "https://api.openai.com/v1", "gpt-5.5"],
+    ["openai-responses", "https://api.openai.com/v1", "gpt-5.4-codex"],
+  ] as const)(
+    "keeps runtime normalization for api=%s baseUrl=%s model=%s",
+    (rowApi, rowBaseUrl, modelId) => {
+      expect(
+        projectConfiguredModelRow(createProjectionContext({ modelId, rowApi, rowBaseUrl })),
+      ).toBeUndefined();
+    },
+  );
+});

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -33,7 +33,10 @@ import {
 } from "./auth-profiles/read-only-availability.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 import { isProfileInCooldown } from "./auth-profiles/usage-state.js";
-import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
+import {
+  listProviderEnvAuthLookupKeys,
+  resolveProviderEnvAuthLookupMaps,
+} from "./model-auth-env-vars.js";
 import { resolveProviderEnvAuthEvidence } from "./model-auth-env.js";
 import { isKnownEnvApiKeyMarker, isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import {
@@ -88,6 +91,7 @@ export type ModelAuthAvailabilityEvaluation = {
   evidence?: ModelAuthAvailabilityEvidence;
 };
 export type ModelAuthAvailabilityResolver = {
+  providerDiscoveryProviderIds: readonly string[];
   evaluateModelAuth(
     provider: string,
     ref?: ModelAuthAvailabilityRef,
@@ -1005,7 +1009,50 @@ export function createModelAuthAvailabilityResolver(
       selectedRoute,
     };
   };
+  const providerDiscoveryProviderIds = new Set<string>();
+  const addProviderDiscoveryProviderId = (provider: string | undefined) => {
+    if (!provider) {
+      return;
+    }
+    const normalized = normalizeProvider(provider);
+    if (normalized) {
+      providerDiscoveryProviderIds.add(normalized);
+    }
+  };
+  for (const credential of Object.values(store.profiles)) {
+    addProviderDiscoveryProviderId(credential.provider);
+  }
+  for (const profile of Object.values(params.cfg.auth?.profiles ?? {})) {
+    addProviderDiscoveryProviderId(profile.provider);
+  }
+  for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
+    if (envAuth(provider)) {
+      addProviderDiscoveryProviderId(provider);
+    }
+  }
+  for (const plugin of params.metadataSnapshot?.index?.plugins ?? []) {
+    if (
+      !plugin.enabled ||
+      !(plugin.syntheticAuthRefs ?? []).some((ref) =>
+        synthetic.has(normalizeProviderIdForAuth(ref)),
+      )
+    ) {
+      continue;
+    }
+    for (const provider of [
+      ...(plugin.contributions?.providers ?? []),
+      ...(plugin.contributions?.modelCatalogProviders ?? []),
+    ]) {
+      addProviderDiscoveryProviderId(provider);
+    }
+  }
+  if (synthetic.has("codex")) {
+    addProviderDiscoveryProviderId(OPENAI_PROVIDER_ID);
+  }
   return {
+    providerDiscoveryProviderIds: [...providerDiscoveryProviderIds].toSorted((left, right) =>
+      left.localeCompare(right),
+    ),
     evaluateModelAuth,
     resolveProviderAuthAvailability,
     hasSyntheticAuth: (provider) =>

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -15,15 +15,12 @@ import type {
 } from "../plugin-sdk/provider-model-types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isValidSecretRef } from "../secrets/ref-contract.js";
-import {
-  isConfiguredAwsSdkAuthProfileForProvider,
-  getRuntimeAuthProfileStoreSnapshot,
-  resolveAuthProfileEligibility,
-} from "./auth-profiles.js";
 import { hasUsableOAuthCredential } from "./auth-profiles/credential-state.js";
 import { resolveExternalCliAuthProfiles } from "./auth-profiles/external-cli-sync.js";
 import {
   type AuthProfileOrderResolution,
+  isConfiguredAwsSdkAuthProfileForProvider,
+  resolveAuthProfileEligibility,
   resolveAuthProfileOrderWithMetadata,
 } from "./auth-profiles/order.js";
 import {
@@ -31,6 +28,7 @@ import {
   resolveSecretRefReadOnlyAvailability,
   resolveStoredCredentialReadOnlyAvailability,
 } from "./auth-profiles/read-only-availability.js";
+import { getRuntimeAuthProfileStoreSnapshot } from "./auth-profiles/runtime-snapshots.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 import { isProfileInCooldown } from "./auth-profiles/usage-state.js";
 import {
@@ -40,12 +38,12 @@ import {
 import { resolveProviderEnvAuthEvidence } from "./model-auth-env.js";
 import { isKnownEnvApiKeyMarker, isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import {
-  hasUsableCustomProviderApiKey,
-  hasRuntimeAvailableProviderAuth,
   hasSyntheticLocalProviderAuthConfig,
+  hasUsableCustomProviderApiKey,
   resolveProviderEntryApiKeyProfileReference,
   shouldPreferExplicitConfigApiKeyAuth,
-} from "./model-auth.js";
+} from "./model-auth-provider-config.js";
+import { resolveManagedSecretRefRuntimeProviderAuth } from "./model-auth-runtime-config.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   createOpenAIModelRoutesResolver,
@@ -538,14 +536,8 @@ export function createModelAuthAvailabilityResolver(
       const managed = typeof apiKey === "string" && isSecretRefHeaderValueMarker(apiKey);
       return {
         availability: managed
-          ? hasRuntimeAvailableProviderAuth({
-              provider,
-              modelApi: target.api ?? undefined,
-              cfg: params.cfg,
-              workspaceDir: params.workspaceDir,
-              env,
-              allowPluginSyntheticAuth: false,
-            }) || undefined
+          ? Boolean(resolveManagedSecretRefRuntimeProviderAuth({ provider, cfg: params.cfg })) ||
+            undefined
           : undefined,
         selectedAuthMode: configuredBearerMode,
         evidence: managed ? "runtime" : "synthetic",
@@ -560,14 +552,9 @@ export function createModelAuthAvailabilityResolver(
         };
       }
       const available = resolveSecretRefReadOnlyAvailability(apiKeyRef, params.cfg, env);
-      const runtimeAvailable = hasRuntimeAvailableProviderAuth({
-        provider,
-        modelApi: target.api ?? undefined,
-        cfg: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env,
-        allowPluginSyntheticAuth: false,
-      });
+      const runtimeAvailable = Boolean(
+        resolveManagedSecretRefRuntimeProviderAuth({ provider, cfg: params.cfg }),
+      );
       return {
         availability: runtimeAvailable ? true : available,
         selectedAuthMode: configuredBearerMode,

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -1,6 +1,7 @@
 /**
  * Formats user-facing auth labels for resolved provider/model credentials.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -21,7 +22,6 @@ import {
   resolveProviderEntryApiKeyProfileReference,
   resolveUsableCustomProviderApiKey,
 } from "./model-auth.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 // Builds concise auth labels for UI/status surfaces without exposing credential
 // values. Resolution follows profile override, provider profiles, env, CLI, then

--- a/src/agents/model-auth-model.ts
+++ b/src/agents/model-auth-model.ts
@@ -1,6 +1,7 @@
 /**
  * Model-level auth diagnostics and request-header preparation.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
   getRuntimeConfigSnapshot,
@@ -34,7 +35,6 @@ import {
 } from "./model-auth-provider.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { resolveSyntheticLocalProviderAuth } from "./model-auth-runtime.js";
-import { normalizeProviderId } from "./model-selection.js";
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,

--- a/src/agents/model-auth-openai.ts
+++ b/src/agents/model-auth-openai.ts
@@ -1,6 +1,6 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -1,6 +1,7 @@
 /**
  * Provider-entry configuration and stored-profile binding for model auth.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
@@ -32,7 +33,6 @@ import {
 } from "./model-auth-markers.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { isLocalProviderBaseUrl } from "./model-provider-local.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 const MODEL_AUTH_LOCAL_HOST_ALIASES = new Set([
   "docker.orb.internal",

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -17,12 +17,10 @@ import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import {
-  type AuthProfileCredential,
-  type AuthProfileStore,
   isConfiguredAwsSdkAuthProfileForProvider,
   isStoredCredentialCompatibleWithAuthProvider,
-  resolveApiKeyForProfile,
-} from "./auth-profiles.js";
+} from "./auth-profiles/order.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveEnvApiKey, type EnvApiKeyResult } from "./model-auth-env.js";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
@@ -221,6 +219,35 @@ export function shouldPreferExplicitConfigApiKeyAuth(
     providerConfig !== undefined &&
     hasExplicitProviderApiKeyConfig(providerConfig)
   );
+}
+
+/** True when a custom local provider can use a synthetic no-auth placeholder. */
+export function hasSyntheticLocalProviderAuthConfig(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+}): boolean {
+  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+  if (!providerConfig) {
+    return false;
+  }
+  const hasApiConfig =
+    Boolean(providerConfig.api?.trim()) ||
+    Boolean(providerConfig.baseUrl?.trim()) ||
+    (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
+  if (!hasApiConfig) {
+    return false;
+  }
+  const authOverride = resolveProviderAuthOverride(params.cfg, params.provider);
+  if (authOverride && authOverride !== "api-key") {
+    return false;
+  }
+  if (
+    !isCustomLocalProviderConfig(providerConfig) ||
+    hasExplicitProviderApiKeyConfig(providerConfig)
+  ) {
+    return false;
+  }
+  return Boolean(providerConfig.baseUrl && isLocalAuthProviderBaseUrl(providerConfig.baseUrl));
 }
 
 export function resolveProviderAuthOverride(
@@ -435,6 +462,7 @@ export async function resolveProviderEntryApiKeyBinding(params: {
     return reference;
   }
   try {
+    const { resolveApiKeyForProfile } = await import("./auth-profiles/oauth.js");
     const resolved = await resolveApiKeyForProfile({
       cfg: params.cfg,
       store: params.store,

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -511,18 +511,18 @@ export function resolveConfiguredAwsSdkProfileAuth(params: {
   };
 }
 
-export function isLocalAuthProviderBaseUrl(baseUrl: string): boolean {
+function isLocalAuthProviderBaseUrl(baseUrl: string): boolean {
   return isLocalProviderBaseUrl(baseUrl, MODEL_AUTH_LOCAL_HOST_ALIASES);
 }
 
-export function hasExplicitProviderApiKeyConfig(providerConfig: ModelProviderConfig): boolean {
+function hasExplicitProviderApiKeyConfig(providerConfig: ModelProviderConfig): boolean {
   return (
     normalizeOptionalSecretInput(providerConfig.apiKey) !== undefined ||
     coerceSecretRef(providerConfig.apiKey) !== null
   );
 }
 
-export function isCustomLocalProviderConfig(providerConfig: ModelProviderConfig): boolean {
+function isCustomLocalProviderConfig(providerConfig: ModelProviderConfig): boolean {
   return (
     typeof providerConfig.baseUrl === "string" &&
     providerConfig.baseUrl.trim().length > 0 &&

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -27,12 +27,12 @@ import { OAuthRefreshFailureError } from "./auth-profiles/oauth-refresh-failure.
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { assertAuthModeAllowedForModel, isAuthModeAllowedForModel } from "./model-auth-openai.js";
 import * as authConfig from "./model-auth-provider-config.js";
-import { ProviderAuthError, type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import {
   assertRuntimeProviderSecretOwnerAvailable,
   resolveManagedSecretRefRuntimeProviderAuth,
-  resolveSyntheticLocalProviderAuth,
-} from "./model-auth-runtime.js";
+} from "./model-auth-runtime-config.js";
+import { ProviderAuthError, type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
+import { resolveSyntheticLocalProviderAuth } from "./model-auth-runtime.js";
 
 export type ProviderCredentialPrecedence = "profile-first" | "env-first";
 

--- a/src/agents/model-auth-runtime-config.ts
+++ b/src/agents/model-auth-runtime-config.ts
@@ -1,0 +1,89 @@
+/**
+ * Runtime-config-backed provider auth that does not require plugin activation.
+ */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  findActiveDegradedSecretOwner,
+  SecretSurfaceUnavailableError,
+} from "../secrets/runtime-degraded-state.js";
+import { mintSecretSentinel } from "../secrets/sentinel.js";
+import * as authConfig from "./model-auth-provider-config.js";
+import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
+
+/** Reads a runtime-resolved credential for a SecretRef-backed provider entry. */
+export function resolveManagedSecretRefRuntimeProviderAuth(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  secretSentinels?: boolean;
+}): ResolvedProviderAuth | undefined {
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  if (params.cfg && params.cfg !== runtimeConfig && !runtimeSourceConfig) {
+    return undefined;
+  }
+  const applicableConfig = selectApplicableRuntimeConfig({
+    inputConfig: params.cfg,
+    runtimeConfig,
+    runtimeSourceConfig,
+  });
+  const usesRuntimeProvider =
+    applicableConfig === runtimeConfig ||
+    authConfig.providerConfigMatchesRuntimeSnapshot({
+      inputConfig: params.cfg,
+      runtimeConfig,
+      provider: params.provider,
+    });
+  const sourceConfig = usesRuntimeProvider ? (runtimeSourceConfig ?? undefined) : params.cfg;
+  if (!authConfig.hasSecretRefProviderApiKey(sourceConfig, params.provider)) {
+    return undefined;
+  }
+  if (!runtimeConfig || !usesRuntimeProvider) {
+    return undefined;
+  }
+  const resolved = authConfig.resolveLiteralProviderConfigApiKeyAuth({
+    cfg: runtimeConfig,
+    provider: params.provider,
+  });
+  if (!resolved?.apiKey) {
+    return undefined;
+  }
+  return {
+    ...resolved,
+    apiKey: params.secretSentinels
+      ? mintSecretSentinel(resolved.apiKey, {
+          label: `model-auth:${params.provider}`,
+        })
+      : resolved.apiKey,
+  };
+}
+
+export function assertRuntimeProviderSecretOwnerAvailable(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+}): void {
+  const provider = normalizeProviderId(params.provider);
+  const degraded = findActiveDegradedSecretOwner("provider", provider);
+  if (!degraded) {
+    return;
+  }
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  const usesRuntimeProvider =
+    !params.cfg ||
+    params.cfg === runtimeConfig ||
+    params.cfg === runtimeSourceConfig ||
+    authConfig.providerConfigMatchesRuntimeSnapshot({
+      inputConfig: params.cfg,
+      runtimeConfig,
+      provider,
+    });
+  if (usesRuntimeProvider) {
+    throw new SecretSurfaceUnavailableError(degraded);
+  }
+}

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -3,25 +3,23 @@
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
-import {
-  getRuntimeConfigSnapshot,
-  getRuntimeConfigSourceSnapshot,
-  selectApplicableRuntimeConfig,
-} from "../config/config.js";
+import { getRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
-import {
-  findActiveDegradedSecretOwner,
-  SecretSurfaceUnavailableError,
-} from "../secrets/runtime-degraded-state.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import { resolveEnvApiKey, type EnvApiKeyLookupOptions } from "./model-auth-env.js";
 import { CUSTOM_LOCAL_AUTH_MARKER, isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { isAuthModeAllowedForModel } from "./model-auth-openai.js";
 import * as authConfig from "./model-auth-provider-config.js";
+import { resolveManagedSecretRefRuntimeProviderAuth } from "./model-auth-runtime-config.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
+
+export {
+  assertRuntimeProviderSecretOwnerAvailable,
+  resolveManagedSecretRefRuntimeProviderAuth,
+} from "./model-auth-runtime-config.js";
 
 /** Precomputed provider-auth lookup tables reused during one runtime turn. */
 export type RuntimeProviderAuthLookup = {
@@ -101,111 +99,6 @@ function resolveRuntimeEnvApiKeyLookupOptions(params: {
     ...envApiKey,
     ...(skipSetupProviderFallback !== undefined ? { skipSetupProviderFallback } : {}),
   };
-}
-
-/** Reads a literal or env-secret marker for a custom provider entry. */
-export function resolveManagedSecretRefRuntimeProviderAuth(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-  secretSentinels?: boolean;
-}): ResolvedProviderAuth | undefined {
-  const runtimeConfig = getRuntimeConfigSnapshot();
-  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
-  if (params.cfg && params.cfg !== runtimeConfig && !runtimeSourceConfig) {
-    return undefined;
-  }
-  const applicableConfig = selectApplicableRuntimeConfig({
-    inputConfig: params.cfg,
-    runtimeConfig,
-    runtimeSourceConfig,
-  });
-  const usesRuntimeProvider =
-    applicableConfig === runtimeConfig ||
-    authConfig.providerConfigMatchesRuntimeSnapshot({
-      inputConfig: params.cfg,
-      runtimeConfig,
-      provider: params.provider,
-    });
-  const sourceConfig = usesRuntimeProvider ? (runtimeSourceConfig ?? undefined) : params.cfg;
-  if (!authConfig.hasSecretRefProviderApiKey(sourceConfig, params.provider)) {
-    return undefined;
-  }
-  if (!runtimeConfig || !usesRuntimeProvider) {
-    return undefined;
-  }
-  const resolved = authConfig.resolveLiteralProviderConfigApiKeyAuth({
-    cfg: runtimeConfig,
-    provider: params.provider,
-  });
-  if (!resolved?.apiKey) {
-    return undefined;
-  }
-  return {
-    ...resolved,
-    apiKey: params.secretSentinels
-      ? mintSecretSentinel(resolved.apiKey, {
-          label: `model-auth:${params.provider}`,
-        })
-      : resolved.apiKey,
-  };
-}
-
-export function assertRuntimeProviderSecretOwnerAvailable(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-}): void {
-  const provider = normalizeProviderId(params.provider);
-  const degraded = findActiveDegradedSecretOwner("provider", provider);
-  if (!degraded) {
-    return;
-  }
-  const runtimeConfig = getRuntimeConfigSnapshot();
-  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
-  const usesRuntimeProvider =
-    !params.cfg ||
-    params.cfg === runtimeConfig ||
-    params.cfg === runtimeSourceConfig ||
-    authConfig.providerConfigMatchesRuntimeSnapshot({
-      inputConfig: params.cfg,
-      runtimeConfig,
-      provider,
-    });
-  if (usesRuntimeProvider) {
-    throw new SecretSurfaceUnavailableError(degraded);
-  }
-}
-
-/** True when a custom local provider can use a synthetic no-auth placeholder. */
-export function hasSyntheticLocalProviderAuthConfig(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-}): boolean {
-  const providerConfig = authConfig.resolveProviderConfig(params.cfg, params.provider);
-  if (!providerConfig) {
-    return false;
-  }
-
-  const hasApiConfig =
-    Boolean(providerConfig.api?.trim()) ||
-    Boolean(providerConfig.baseUrl?.trim()) ||
-    (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
-  if (!hasApiConfig) {
-    return false;
-  }
-
-  const authOverride = authConfig.resolveProviderAuthOverride(params.cfg, params.provider);
-  if (authOverride && authOverride !== "api-key") {
-    return false;
-  }
-  if (!authConfig.isCustomLocalProviderConfig(providerConfig)) {
-    return false;
-  }
-  if (authConfig.hasExplicitProviderApiKeyConfig(providerConfig)) {
-    return false;
-  }
-  return Boolean(
-    providerConfig.baseUrl && authConfig.isLocalAuthProviderBaseUrl(providerConfig.baseUrl),
-  );
 }
 
 function listProviderSyntheticAuthRefs(params: {
@@ -288,7 +181,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
   if (resolveManagedSecretRefRuntimeProviderAuth({ cfg: params.cfg, provider })) {
     return true;
   }
-  if (hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider })) {
+  if (authConfig.hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider })) {
     return true;
   }
   if (
@@ -398,7 +291,7 @@ export function resolveSyntheticLocalProviderAuth(params: {
   // Custom providers pointing at a local server (e.g. llama.cpp, vLLM, LocalAI)
   // typically don't require auth. Synthesize a local key so the auth resolver
   // doesn't reject them when the user left the API key blank during setup.
-  if (hasSyntheticLocalProviderAuthConfig(params)) {
+  if (authConfig.hasSyntheticLocalProviderAuthConfig(params)) {
     return {
       apiKey: CUSTOM_LOCAL_AUTH_MARKER,
       source: `models.providers.${params.provider} (synthetic local key)`,

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -1,6 +1,7 @@
 /**
  * Snapshot-aware and synthetic provider-auth availability.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   getRuntimeConfigSnapshot,
@@ -21,7 +22,6 @@ import { CUSTOM_LOCAL_AUTH_MARKER, isNonSecretApiKeyMarker } from "./model-auth-
 import { isAuthModeAllowedForModel } from "./model-auth-openai.js";
 import * as authConfig from "./model-auth-provider-config.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 /** Precomputed provider-auth lookup tables reused during one runtime turn. */
 export type RuntimeProviderAuthLookup = {

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -16,11 +16,6 @@ import * as authConfig from "./model-auth-provider-config.js";
 import { resolveManagedSecretRefRuntimeProviderAuth } from "./model-auth-runtime-config.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 
-export {
-  assertRuntimeProviderSecretOwnerAvailable,
-  resolveManagedSecretRefRuntimeProviderAuth,
-} from "./model-auth-runtime-config.js";
-
 /** Precomputed provider-auth lookup tables reused during one runtime turn. */
 export type RuntimeProviderAuthLookup = {
   envApiKey: Pick<

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -20,6 +20,7 @@ export type { ModelAuthMode } from "./model-auth-model.js";
 export {
   canUseProfileAsProviderEntryApiKey,
   getCustomProviderApiKey,
+  hasSyntheticLocalProviderAuthConfig,
   hasUsableCustomProviderApiKey,
   resolveProviderEntryApiKeyBinding,
   resolveProviderEntryApiKeyProfileReference,
@@ -32,7 +33,6 @@ export type { ProviderCredentialPrecedence } from "./model-auth-provider.js";
 export {
   createRuntimeProviderAuthLookup,
   hasRuntimeAvailableProviderAuth,
-  hasSyntheticLocalProviderAuthConfig,
 } from "./model-auth-runtime.js";
 export type { RuntimeProviderAuthLookup } from "./model-auth-runtime.js";
 export {

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -50,6 +50,9 @@ vi.mock("./prepared-model-runtime.js", () => {
 
 vi.mock("./prepared-model-runtime.facts.js", () => ({
   isPreparedModelCatalogFull: (...args: unknown[]) => mocks.isFullCatalog(...args),
+}));
+
+vi.mock("./prepared-model-runtime.scoped-catalog.js", () => ({
   prepareScopedReadOnlyModelCatalog: (...args: unknown[]) => mocks.prepareScopedCatalog(...args),
 }));
 

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   getSnapshot: vi.fn(),
   loadSnapshot: vi.fn(),
   prepareSnapshot: vi.fn(),
+  prepareScopedCatalog: vi.fn(),
+  isFullCatalog: vi.fn(),
   releaseSnapshot: vi.fn(),
 }));
 
@@ -46,6 +48,11 @@ vi.mock("./prepared-model-runtime.js", () => {
   };
 });
 
+vi.mock("./prepared-model-runtime.facts.js", () => ({
+  isPreparedModelCatalogFull: (...args: unknown[]) => mocks.isFullCatalog(...args),
+  prepareScopedReadOnlyModelCatalog: (...args: unknown[]) => mocks.prepareScopedCatalog(...args),
+}));
+
 import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import {
   getPreparedModelCatalogSnapshot,
@@ -77,6 +84,8 @@ describe("prepared model catalog access", () => {
     mocks.getSnapshot.mockReset();
     mocks.loadSnapshot.mockReset();
     mocks.prepareSnapshot.mockReset();
+    mocks.prepareScopedCatalog.mockReset();
+    mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
   });
 
@@ -103,6 +112,48 @@ describe("prepared model catalog access", () => {
     expect(mocks.prepareSnapshot.mock.calls[0]?.[0]).not.toHaveProperty("readOnly");
     expect(mocks.loadSnapshot).not.toHaveBeenCalled();
     expect(mocks.releaseSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("reuses a published full generation for a provider-scoped read-only load", async () => {
+    mocks.prepareSnapshot.mockResolvedValue(fullSnapshot);
+    mocks.isFullCatalog.mockReturnValue(true);
+
+    await expect(
+      loadPreparedModelCatalogSnapshot({
+        readOnly: true,
+        providerDiscoveryProviderIds: ["anthropic"],
+      }),
+    ).resolves.toBe(fullSnapshot.modelCatalog);
+
+    expect(mocks.isFullCatalog).toHaveBeenCalledWith(fullSnapshot.modelCatalog);
+    expect(mocks.prepareScopedCatalog).not.toHaveBeenCalled();
+  });
+
+  it("builds a scoped catalog when the published generation is configured-only", async () => {
+    const scopedCatalog = {
+      entries: [{ provider: "anthropic", id: "claude", name: "Claude" }],
+      routeVariants: [],
+    };
+    mocks.prepareSnapshot.mockResolvedValue(readOnlySnapshot);
+    mocks.isFullCatalog.mockReturnValue(false);
+    mocks.prepareScopedCatalog.mockResolvedValue(scopedCatalog);
+
+    await expect(
+      loadPreparedModelCatalogSnapshot({
+        readOnly: true,
+        providerDiscoveryProviderIds: ["anthropic"],
+      }),
+    ).resolves.toBe(scopedCatalog);
+
+    expect(mocks.prepareSnapshot).toHaveBeenCalledTimes(2);
+    expect(mocks.prepareScopedCatalog).toHaveBeenCalledOnce();
+    expect(mocks.prepareScopedCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readOnly: true,
+        workspaceDir: "/tmp/prepared-model-catalog-workspace",
+      }),
+      ["anthropic"],
+    );
   });
 
   it("keeps read-only catalog reads on configured facts and materializes full reads once", async () => {

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -12,10 +12,7 @@ import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.ty
 import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
 import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import type { ResolvedPublishedModelCatalogOwner } from "./prepared-model-catalog.types.js";
-import {
-  isPreparedModelCatalogFull,
-  prepareScopedReadOnlyModelCatalog,
-} from "./prepared-model-runtime.facts.js";
+import { isPreparedModelCatalogFull } from "./prepared-model-runtime.facts.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
@@ -27,6 +24,7 @@ import {
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.js";
+import { prepareScopedReadOnlyModelCatalog } from "./prepared-model-runtime.scoped-catalog.js";
 
 export type LoadPreparedModelCatalogParams = {
   agentId?: string;

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -13,6 +13,10 @@ import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owne
 import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import type { ResolvedPublishedModelCatalogOwner } from "./prepared-model-catalog.types.js";
 import {
+  isPreparedModelCatalogFull,
+  prepareScopedReadOnlyModelCatalog,
+} from "./prepared-model-runtime.facts.js";
+import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
@@ -31,6 +35,7 @@ export type LoadPreparedModelCatalogParams = {
   readOnly?: boolean;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerDiscoveryProviderIds?: readonly string[];
 };
 
 type PreparedModelCatalogConfigPolicy = "exact" | "published";
@@ -231,6 +236,33 @@ async function loadPreparedModelCatalogOwnerSnapshotWithPolicy(
   );
 }
 
+async function loadScopedReadOnlyModelCatalog(
+  params: LoadPreparedModelCatalogParams,
+): Promise<ModelCatalogSnapshot> {
+  const { activationExact, activationFull, full } = resolveInputs(params);
+  const fullCandidates =
+    activationFull.workspaceDir === full.workspaceDir ? [full] : [full, activationFull];
+  for (const candidate of fullCandidates) {
+    try {
+      const prepared = await prepareModelRuntimeSnapshot(candidate);
+      if (!preparedModelRuntimeConfigsMatch(prepared.config, candidate.config)) {
+        throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
+      }
+      if (isPreparedModelCatalogFull(prepared.modelCatalog)) {
+        return prepared.modelCatalog;
+      }
+    } catch (error) {
+      if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
+        throw error;
+      }
+    }
+  }
+  return prepareScopedReadOnlyModelCatalog(
+    activationExact,
+    params.providerDiscoveryProviderIds ?? [],
+  );
+}
+
 /** Resolves the lifecycle owner for an exact caller-supplied config. */
 export async function loadPreparedModelCatalogOwnerSnapshot(
   params: LoadPreparedModelCatalogParams = {},
@@ -258,6 +290,9 @@ export async function loadResolvedPublishedModelCatalogOwner(
 export async function loadPreparedModelCatalogSnapshot(
   params: LoadPreparedModelCatalogParams = {},
 ): Promise<ModelCatalogSnapshot> {
+  if (params.readOnly && params.providerDiscoveryProviderIds) {
+    return loadScopedReadOnlyModelCatalog(params);
+  }
   return (await loadPreparedModelCatalogOwnerSnapshot(params)).modelCatalog;
 }
 

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -62,6 +62,7 @@ import type { ModelRegistry } from "./sessions/model-registry.js";
 import { stableStringify } from "./stable-stringify.js";
 
 const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
+const fullModelCatalogSnapshots = new WeakSet<ModelCatalogSnapshot>();
 
 type PreparedModelRuntimeAgentBaseFacts = {
   input: PreparedModelRuntimeInput;
@@ -111,6 +112,7 @@ function prepareAgentFacts(
   input: PreparedModelRuntimeInput,
   catalogMode: PreparedModelRuntimeCatalogMode,
   ambientCredentials: Readonly<AgentCredentialMap>,
+  additionalProviderIds: readonly string[] = [],
 ): PreparedModelRuntimeAgentBaseFacts {
   const env = input.env ?? process.env;
   const templateAuthStorage = discoverAuthStorage(input.agentDir, {
@@ -137,12 +139,17 @@ function prepareAgentFacts(
     configuredModelRefs,
     // Gateway startup prepares only providers named by config/model selection. An unrelated
     // stored credential must not pull that provider's complete catalog into the admission path.
-    providerIds: collectPreparedModelRuntimeProviderIds(
-      input.config,
-      credentials,
-      catalogMode === "live",
-      configuredModelRefs,
-    ),
+    providerIds: [
+      ...new Set([
+        ...collectPreparedModelRuntimeProviderIds(
+          input.config,
+          credentials,
+          catalogMode === "live",
+          configuredModelRefs,
+        ),
+        ...additionalProviderIds.map(normalizeProviderId).filter(Boolean),
+      ]),
+    ].toSorted((left, right) => left.localeCompare(right)),
   };
 }
 
@@ -194,6 +201,7 @@ export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntim
 export async function prepareWorkspaceBuildGroup(
   inputs: readonly PreparedModelRuntimeInput[],
   catalogMode: PreparedModelRuntimeCatalogMode,
+  options: { providerDiscoveryProviderIds?: readonly string[] } = {},
 ): Promise<{
   agentFacts: PreparedModelRuntimeAgentFacts[];
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
@@ -261,12 +269,22 @@ export async function prepareWorkspaceBuildGroup(
     configuredManifestModels.set(key, model);
     return model;
   };
-  const configuredProviderIds = collectPreparedModelRuntimeProviderIds(input.config, {}, false);
-  const staticCatalogProviderIds = collectConfiguredProviderIdsNeedingStaticCatalog({
-    config: input.config,
-    matchesStaticModelId,
-    resolveStaticCatalogModel: resolveConfiguredManifestModel,
-  });
+  const configuredProviderIds = [
+    ...new Set([
+      ...collectPreparedModelRuntimeProviderIds(input.config, {}, false),
+      ...(options.providerDiscoveryProviderIds ?? []).map(normalizeProviderId).filter(Boolean),
+    ]),
+  ].toSorted((left, right) => left.localeCompare(right));
+  const staticCatalogProviderIds = [
+    ...new Set([
+      ...collectConfiguredProviderIdsNeedingStaticCatalog({
+        config: input.config,
+        matchesStaticModelId,
+        resolveStaticCatalogModel: resolveConfiguredManifestModel,
+      }),
+      ...(options.providerDiscoveryProviderIds ?? []).map(normalizeProviderId).filter(Boolean),
+    ]),
+  ].toSorted((left, right) => left.localeCompare(right));
   const staticProviderCatalogStartedAt = performance.now();
   const preparedStaticProviderCatalog =
     catalogMode === "static"
@@ -312,7 +330,12 @@ export async function prepareWorkspaceBuildGroup(
   const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
   const agentFactsStartedAt = performance.now();
   const agentBaseFacts = inputs.map((candidate) =>
-    prepareAgentFacts(candidate, catalogMode, ambientCredentials),
+    prepareAgentFacts(
+      candidate,
+      catalogMode,
+      ambientCredentials,
+      options.providerDiscoveryProviderIds,
+    ),
   );
   const agentFactsMs = performance.now() - agentFactsStartedAt;
   const configuredProjectionStartedAt = performance.now();
@@ -460,12 +483,45 @@ export async function prepareFullCatalogFacts(
     }
   }
   const staticEntries = [...staticModels.values()].map(toStaticCatalogEntry);
+  const completeModelCatalog = { ...modelCatalog, staticEntries };
+  if (catalogMode === "live") {
+    fullModelCatalogSnapshots.add(completeModelCatalog);
+  }
   return {
     templateModelRegistry,
-    modelCatalog: { ...modelCatalog, staticEntries },
+    modelCatalog: completeModelCatalog,
     configuredRuntimeModels,
     inlineProviderModels: workspaceFacts.inlineProviderModels,
   };
+}
+
+/** Reports whether a catalog came from the complete prepared-catalog build path. */
+export function isPreparedModelCatalogFull(snapshot: ModelCatalogSnapshot): boolean {
+  return fullModelCatalogSnapshots.has(snapshot);
+}
+
+/** Builds a request-scoped read-only catalog from configured and auth-candidate providers. */
+export async function prepareScopedReadOnlyModelCatalog(
+  input: PreparedModelRuntimeInput,
+  providerDiscoveryProviderIds: readonly string[],
+): Promise<ModelCatalogSnapshot> {
+  const scopedInput = input.readOnly ? input : { ...input, readOnly: true };
+  const { agentFacts, workspaceFacts } = await prepareWorkspaceBuildGroup([scopedInput], "static", {
+    providerDiscoveryProviderIds,
+  });
+  const agentFactsForInput = agentFacts[0];
+  if (!agentFactsForInput) {
+    throw new Error("scoped prepared model catalog facts are missing");
+  }
+  const catalogSource = await prepareAgentCatalogSource(
+    agentFactsForInput,
+    workspaceFacts,
+    "static",
+    false,
+  );
+  return (
+    await prepareFullCatalogFacts(agentFactsForInput, workspaceFacts, "static", catalogSource)
+  ).modelCatalog;
 }
 
 function modelCatalogEntryKey(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -500,30 +500,6 @@ export function isPreparedModelCatalogFull(snapshot: ModelCatalogSnapshot): bool
   return fullModelCatalogSnapshots.has(snapshot);
 }
 
-/** Builds a request-scoped read-only catalog from configured and auth-candidate providers. */
-export async function prepareScopedReadOnlyModelCatalog(
-  input: PreparedModelRuntimeInput,
-  providerDiscoveryProviderIds: readonly string[],
-): Promise<ModelCatalogSnapshot> {
-  const scopedInput = input.readOnly ? input : { ...input, readOnly: true };
-  const { agentFacts, workspaceFacts } = await prepareWorkspaceBuildGroup([scopedInput], "static", {
-    providerDiscoveryProviderIds,
-  });
-  const agentFactsForInput = agentFacts[0];
-  if (!agentFactsForInput) {
-    throw new Error("scoped prepared model catalog facts are missing");
-  }
-  const catalogSource = await prepareAgentCatalogSource(
-    agentFactsForInput,
-    workspaceFacts,
-    "static",
-    false,
-  );
-  return (
-    await prepareFullCatalogFacts(agentFactsForInput, workspaceFacts, "static", catalogSource)
-  ).modelCatalog;
-}
-
 function modelCatalogEntryKey(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
   return `${normalizeProviderId(entry.provider)}\0${entry.id.trim().toLowerCase()}`;
 }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -691,6 +691,7 @@ export async function prepareAgentCatalogSource(
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts,
   catalogMode: PreparedModelRuntimeCatalogMode,
   persist = true,
+  sourceOptions: { providerDiscoveryProviderIds?: readonly string[] } = {},
 ): Promise<PreparedModelRuntimeCatalogSource> {
   const { env, input, providerIds } = agentFacts;
   const options = {
@@ -703,10 +704,13 @@ export async function prepareAgentCatalogSource(
     ...(catalogMode === "static"
       ? {
           providerDiscoveryEntriesOnly: true as const,
-          providerDiscoveryProviderIds: providerIds,
+          providerDiscoveryProviderIds: sourceOptions.providerDiscoveryProviderIds ?? providerIds,
         }
       : {
           providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
+          ...(sourceOptions.providerDiscoveryProviderIds
+            ? { providerDiscoveryProviderIds: sourceOptions.providerDiscoveryProviderIds }
+            : {}),
         }),
   };
   if (!persist) {

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -1,0 +1,31 @@
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import {
+  prepareAgentCatalogSource,
+  prepareFullCatalogFacts,
+  prepareWorkspaceBuildGroup,
+} from "./prepared-model-runtime.facts.js";
+import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+
+/** Builds a request-scoped read-only catalog from configured and auth-candidate providers. */
+export async function prepareScopedReadOnlyModelCatalog(
+  input: PreparedModelRuntimeInput,
+  providerDiscoveryProviderIds: readonly string[],
+): Promise<ModelCatalogSnapshot> {
+  const scopedInput = input.readOnly ? input : { ...input, readOnly: true };
+  const { agentFacts, workspaceFacts } = await prepareWorkspaceBuildGroup([scopedInput], "static", {
+    providerDiscoveryProviderIds,
+  });
+  const agentFactsForInput = agentFacts[0];
+  if (!agentFactsForInput) {
+    throw new Error("scoped prepared model catalog facts are missing");
+  }
+  const catalogSource = await prepareAgentCatalogSource(
+    agentFactsForInput,
+    workspaceFacts,
+    "static",
+    false,
+  );
+  return (
+    await prepareFullCatalogFacts(agentFactsForInput, workspaceFacts, "static", catalogSource)
+  ).modelCatalog;
+}

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -4,17 +4,22 @@ import {
   prepareFullCatalogFacts,
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
-import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeCatalogMode,
+  PreparedModelRuntimeInput,
+} from "./prepared-model-runtime.types.js";
 
-/** Builds a request-scoped read-only catalog from configured and auth-candidate providers. */
-export async function prepareScopedReadOnlyModelCatalog(
+async function prepareScopedReadOnlyModelCatalogWithMode(
   input: PreparedModelRuntimeInput,
   providerDiscoveryProviderIds: readonly string[],
+  catalogMode: PreparedModelRuntimeCatalogMode,
 ): Promise<ModelCatalogSnapshot> {
   const scopedInput = input.readOnly ? input : { ...input, readOnly: true };
-  const { agentFacts, workspaceFacts } = await prepareWorkspaceBuildGroup([scopedInput], "static", {
-    providerDiscoveryProviderIds,
-  });
+  const { agentFacts, workspaceFacts } = await prepareWorkspaceBuildGroup(
+    [scopedInput],
+    catalogMode,
+    { providerDiscoveryProviderIds },
+  );
   const agentFactsForInput = agentFacts[0];
   if (!agentFactsForInput) {
     throw new Error("scoped prepared model catalog facts are missing");
@@ -22,10 +27,27 @@ export async function prepareScopedReadOnlyModelCatalog(
   const catalogSource = await prepareAgentCatalogSource(
     agentFactsForInput,
     workspaceFacts,
-    "static",
+    catalogMode,
     false,
+    catalogMode === "live" ? { providerDiscoveryProviderIds } : {},
   );
   return (
-    await prepareFullCatalogFacts(agentFactsForInput, workspaceFacts, "static", catalogSource)
+    await prepareFullCatalogFacts(agentFactsForInput, workspaceFacts, catalogMode, catalogSource)
   ).modelCatalog;
+}
+
+/** Builds a request-scoped read-only catalog without executing live provider discovery. */
+export function prepareScopedReadOnlyModelCatalog(
+  input: PreparedModelRuntimeInput,
+  providerDiscoveryProviderIds: readonly string[],
+): Promise<ModelCatalogSnapshot> {
+  return prepareScopedReadOnlyModelCatalogWithMode(input, providerDiscoveryProviderIds, "static");
+}
+
+/** Builds a request-scoped read-only catalog with live discovery for selected providers. */
+export function prepareScopedReadOnlyLiveModelCatalog(
+  input: PreparedModelRuntimeInput,
+  providerDiscoveryProviderIds: readonly string[],
+): Promise<ModelCatalogSnapshot> {
+  return prepareScopedReadOnlyModelCatalogWithMode(input, providerDiscoveryProviderIds, "live");
 }

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -163,7 +163,7 @@ vi.mock("../logging/subsystem.js", () => ({
 
 const { getPreparedModelRuntimeSnapshot, refreshPreparedModelRuntimeSnapshots } =
   await import("./prepared-model-runtime.js");
-const { prepareScopedReadOnlyModelCatalog } =
+const { prepareScopedReadOnlyLiveModelCatalog, prepareScopedReadOnlyModelCatalog } =
   await import("./prepared-model-runtime.scoped-catalog.js");
 const { resetPreparedModelRuntimeSnapshotsForTest } =
   await import("./prepared-model-runtime.test-support.js");
@@ -206,6 +206,40 @@ describe("prepared model runtime Gateway catalog mode", () => {
         providerDiscoveryEntriesOnly: true,
         providerDiscoveryProviderIds: ["anthropic", "local-runtime", "openai"],
       }),
+    );
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+
+  it("uses live provider catalogs for an explicit read-only list scope", async () => {
+    const config = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+    };
+
+    await prepareScopedReadOnlyLiveModelCatalog(
+      {
+        agentId: "default",
+        agentDir: "/tmp/prepared-live-agent",
+        config,
+        inheritedAuthDir: "/tmp/prepared-live-agent",
+        workspaceDir: "/tmp/prepared-live-workspace",
+        env: {},
+        readOnly: true,
+      },
+      ["anthropic"],
+    );
+
+    expect(mocks.planOpenClawModelsJsonSource).toHaveBeenCalledWith(
+      config,
+      "/tmp/prepared-live-agent",
+      expect.objectContaining({
+        providerDiscoveryProviderIds: ["anthropic"],
+        providerDiscoveryTimeoutMs: expect.any(Number),
+      }),
+    );
+    expect(mocks.planOpenClawModelsJsonSource).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ providerDiscoveryEntriesOnly: true }),
     );
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -163,6 +163,7 @@ vi.mock("../logging/subsystem.js", () => ({
 
 const { getPreparedModelRuntimeSnapshot, refreshPreparedModelRuntimeSnapshots } =
   await import("./prepared-model-runtime.js");
+const { prepareScopedReadOnlyModelCatalog } = await import("./prepared-model-runtime.facts.js");
 const { resetPreparedModelRuntimeSnapshotsForTest } =
   await import("./prepared-model-runtime.test-support.js");
 
@@ -173,6 +174,41 @@ beforeEach(() => {
 });
 
 describe("prepared model runtime Gateway catalog mode", () => {
+  it("imports and materializes only configured and auth-candidate providers", async () => {
+    const config = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+    };
+
+    await prepareScopedReadOnlyModelCatalog(
+      {
+        agentId: "default",
+        agentDir: "/tmp/prepared-static-agent",
+        config,
+        inheritedAuthDir: "/tmp/prepared-static-agent",
+        workspaceDir: "/tmp/prepared-static-workspace",
+        env: {},
+        readOnly: true,
+      },
+      ["anthropic", "local-runtime"],
+    );
+
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerDiscoveryProviderIds: ["anthropic", "local-runtime", "openai"],
+        staticCatalogProviderIds: ["anthropic", "local-runtime", "openai"],
+      }),
+    );
+    expect(mocks.planOpenClawModelsJsonSource).toHaveBeenCalledWith(
+      config,
+      "/tmp/prepared-static-agent",
+      expect.objectContaining({
+        providerDiscoveryEntriesOnly: true,
+        providerDiscoveryProviderIds: ["anthropic", "local-runtime", "openai"],
+      }),
+    );
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+
   it("does not publish a static catalog generation superseded while its hook is running", async () => {
     const staleConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const latestConfig = { agents: { defaults: { model: "openai/gpt-5.6" } } };

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -163,7 +163,8 @@ vi.mock("../logging/subsystem.js", () => ({
 
 const { getPreparedModelRuntimeSnapshot, refreshPreparedModelRuntimeSnapshots } =
   await import("./prepared-model-runtime.js");
-const { prepareScopedReadOnlyModelCatalog } = await import("./prepared-model-runtime.facts.js");
+const { prepareScopedReadOnlyModelCatalog } =
+  await import("./prepared-model-runtime.scoped-catalog.js");
 const { resetPreparedModelRuntimeSnapshotsForTest } =
   await import("./prepared-model-runtime.test-support.js");
 

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -15,7 +15,7 @@ import {
   type SupportedGatewaySecretInputPath,
 } from "../gateway/secret-input-paths.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
+import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry-contributions.js";
 import {
   analyzeCommandSecretAssignmentsFromSnapshot,
   type UnresolvedCommandSecretAssignment,

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -74,6 +74,7 @@ vi.mock("../agents/auth-profiles/profile-list.js", () => ({
 }));
 
 vi.mock("../agents/auth-profiles/store.js", () => ({
+  ensureAuthProfileStore,
   getRuntimeAuthProfileStoreSnapshot: vi.fn(() => undefined),
   loadAuthProfileStoreWithoutExternalProfiles: ensureAuthProfileStore,
   updateAuthProfileStoreWithLock: vi.fn(async () => ensureAuthProfileStore()),
@@ -258,7 +259,7 @@ beforeEach(() => {
   getRuntimeConfig.mockReset();
   getRuntimeConfig.mockReturnValue({});
   listProfilesForProvider.mockReturnValue([]);
-  loadModelCatalog.mockClear();
+  loadModelCatalog.mockReset();
   loadModelCatalog.mockResolvedValue([]);
   shouldSuppressBuiltInModel.mockReset();
   shouldSuppressBuiltInModel.mockReturnValue(false);
@@ -378,8 +379,12 @@ describe("models list/status", () => {
     await modelsListCommand({ all: true, provider, json: true }, runtime);
 
     const payload = parseJsonLog(runtime);
-    expect(payload.count).toBe(1);
-    expect(payload.models[0]?.key).toBe("zai/glm-4.7");
+    expect(payload.count).toBe(payload.models.length);
+    expect(payload.models.length).toBeGreaterThan(0);
+    expect(payload.models.map((model: { key: string }) => model.key)).toContain("zai/glm-4.7");
+    expect(payload.models.every((model: { key: string }) => model.key.startsWith("zai/"))).toBe(
+      true,
+    );
   }
 
   function setDefaultZaiRegistry(params: { available?: boolean } = {}) {
@@ -600,7 +605,6 @@ describe("models list/status", () => {
 
   it("models list all includes catalog rows with unknown auth availability", async () => {
     setDefaultZaiRegistry({ available: false });
-    loadModelCatalog.mockResolvedValueOnce([MOONSHOT_MODEL]);
     const runtime = makeRuntime();
 
     await withEnvAsync(
@@ -609,11 +613,14 @@ describe("models list/status", () => {
     );
 
     const payload = parseJsonLog(runtime);
-    expect(loadModelCatalog).toHaveBeenCalledOnce();
-    expect(payload.models).toHaveLength(1);
-    const model = payload.models[0];
-    expect(model.key).toBe("moonshot/kimi-k2.6");
-    expect(model.name).toBe("Kimi K2.6");
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(payload.models.length).toBeGreaterThan(0);
+    const model = payload.models.find(
+      (candidate: { key: string }) => candidate.key === "moonshot/kimi-k3",
+    );
+    expect(model).toBeDefined();
+    expect(model.key).toBe("moonshot/kimi-k3");
+    expect(model.name).toBe("Kimi K3");
     expect(model.available).toBeNull();
     expect(model.missing).toBe(false);
   });
@@ -653,7 +660,9 @@ describe("models list/status", () => {
       code: "MODEL_AVAILABILITY_UNAVAILABLE",
     });
     const runtime = makeRuntime();
-    await modelsListCommand({ json: true }, runtime);
+    await withEnvAsync({ OPENAI_API_KEY: undefined }, () =>
+      modelsListCommand({ json: true }, runtime),
+    );
 
     expect(runtime.error).not.toHaveBeenCalled();
     const payload = parseJsonLog(runtime);

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -155,6 +155,10 @@ vi.mock("../agents/agent-model-discovery.js", () => {
       return modelRegistryState.available;
     }
 
+    getProviderMetadataOwners() {
+      return undefined;
+    }
+
     hasConfiguredAuth(model: { provider: string; id: string }) {
       return modelRegistryState.available.some(
         (available) => available.provider === model.provider && available.id === model.id,
@@ -530,7 +534,9 @@ describe("models list/status", () => {
     await modelsListCommand({ all: true, json: true }, runtime);
 
     const payload = parseJsonLog(runtime);
-    expect(payload.models[0]?.available).toBe(false);
+    expect(
+      payload.models.find((model: { key?: string }) => model.key === "zai/glm-4.7")?.available,
+    ).toBe(false);
   });
 
   it("models list uses trusted workspace plugin auth evidence for configured rows", async () => {

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -55,6 +55,7 @@ const modelRegistryState = {
   findError: undefined as unknown,
 };
 let previousExitCode: typeof process.exitCode;
+let previousOpenAiApiKey: string | undefined;
 
 vi.mock("./models/load-config.js", () => ({
   loadModelsConfigWithSource: vi.fn(async () => {
@@ -251,6 +252,8 @@ async function loadSourceConfigSnapshotForTest(fallback: unknown): Promise<unkno
 beforeEach(() => {
   previousExitCode = process.exitCode;
   process.exitCode = undefined;
+  previousOpenAiApiKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
   modelRegistryState.models = [];
   modelRegistryState.available = [];
   modelRegistryState.getAllError = undefined;
@@ -274,6 +277,11 @@ beforeEach(() => {
 
 afterEach(() => {
   process.exitCode = previousExitCode;
+  if (previousOpenAiApiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = previousOpenAiApiKey;
+  }
 });
 
 describe("models list/status", () => {

--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -7,41 +7,32 @@ import { createModelListAuthIndex } from "./list.auth-index.js";
 type ExternalCliProfilesResolver =
   typeof import("../../agents/auth-profiles/external-cli-sync.js").resolveExternalCliAuthProfiles;
 
-type PluginSnapshotResult = {
-  source: "persisted" | "provided" | "derived";
-  snapshot: {
-    plugins: Array<{ enabled?: boolean; syntheticAuthRefs?: string[] }>;
-  };
-  diagnostics: [];
-};
-
-const pluginRegistryMocks = vi.hoisted(() => ({
-  loadPluginRegistrySnapshotWithMetadata: vi.fn(
-    (): PluginSnapshotResult => ({
-      source: "persisted",
-      snapshot: { plugins: [] },
-      diagnostics: [],
-    }),
-  ),
-}));
 const externalCliMocks = vi.hoisted(() => ({
   resolveExternalCliAuthProfiles: vi.fn<ExternalCliProfilesResolver>(() => []),
 }));
-
-vi.mock("../../plugins/plugin-registry.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../plugins/plugin-registry.js")>();
-  return {
-    ...actual,
-    loadPluginRegistrySnapshotWithMetadata:
-      pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata,
-  };
-});
 
 vi.mock("../../agents/auth-profiles/external-cli-sync.js", () => ({
   resolveExternalCliAuthProfiles: externalCliMocks.resolveExternalCliAuthProfiles,
 }));
 
 const emptyStore: AuthProfileStore = { version: 1, profiles: {} };
+const emptyMetadataSnapshot = {
+  registrySource: "persisted",
+  registryDiagnostics: [],
+  plugins: [],
+  index: { plugins: [] },
+} as unknown as PluginMetadataSnapshot;
+
+function createTestModelListAuthIndex(
+  params: Omit<Parameters<typeof createModelListAuthIndex>[0], "metadataSnapshot"> & {
+    metadataSnapshot?: PluginMetadataSnapshot;
+  },
+) {
+  return createModelListAuthIndex({
+    metadataSnapshot: emptyMetadataSnapshot,
+    ...params,
+  });
+}
 
 const dualRouteResolverFactory = (() => () => ({
   kind: "routes",
@@ -68,16 +59,10 @@ describe("createModelListAuthIndex", () => {
   beforeEach(() => {
     externalCliMocks.resolveExternalCliAuthProfiles.mockReset();
     externalCliMocks.resolveExternalCliAuthProfiles.mockReturnValue([]);
-    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReset();
-    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "persisted",
-      snapshot: { plugins: [] },
-      diagnostics: [],
-    });
   });
 
   it("keeps a fresh auth scope empty", () => {
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -88,7 +73,7 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("scopes provider discovery to concrete API-key evidence", () => {
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: { ANTHROPIC_API_KEY: "test-key" },
@@ -111,7 +96,7 @@ describe("createModelListAuthIndex", () => {
         },
       },
     ]);
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -123,7 +108,7 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("scopes provider discovery to stored credential profiles", () => {
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: {
         version: 1,
@@ -143,7 +128,7 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("scopes provider discovery to configured auth profiles", () => {
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {
         auth: {
           profiles: {
@@ -163,7 +148,7 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("forwards route-aware evaluation through the command adapter", () => {
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: {
         version: 1,
@@ -188,21 +173,23 @@ describe("createModelListAuthIndex", () => {
     expect(index.providerDiscoveryProviderIds).toEqual(["openai"]);
   });
 
-  it("uses enabled synthetic refs from a persisted plugin snapshot", () => {
-    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "persisted",
-      snapshot: {
+  it("uses enabled synthetic refs from prepared persisted metadata", () => {
+    const metadataSnapshot = {
+      registrySource: "persisted",
+      registryDiagnostics: [],
+      plugins: [],
+      index: {
         plugins: [
           { enabled: true, syntheticAuthRefs: ["codex"] },
           { enabled: false, syntheticAuthRefs: ["disabled-provider"] },
         ],
       },
-      diagnostics: [],
-    });
-    const index = createModelListAuthIndex({
+    } as unknown as PluginMetadataSnapshot;
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
+      metadataSnapshot,
       routeResolverFactory: dualRouteResolverFactory,
     });
 
@@ -227,7 +214,7 @@ describe("createModelListAuthIndex", () => {
         ],
       },
     } as unknown as PluginMetadataSnapshot;
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -240,7 +227,6 @@ describe("createModelListAuthIndex", () => {
       evidence: "synthetic",
     });
     expect(index.evaluateModelAuth("disabled-provider").availability).toBeUndefined();
-    expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
   });
 
   it("maps synthetic auth refs to their configured plugin catalog providers", () => {
@@ -262,7 +248,7 @@ describe("createModelListAuthIndex", () => {
         ],
       },
     } as unknown as PluginMetadataSnapshot;
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -277,17 +263,19 @@ describe("createModelListAuthIndex", () => {
   it.each(["derived" as const, "persisted" as const])(
     "does not trust unusable synthetic refs from a %s snapshot",
     (source) => {
-      pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-        source,
-        snapshot: {
+      const metadataSnapshot = {
+        registrySource: source,
+        registryDiagnostics: [],
+        plugins: [],
+        index: {
           plugins: [{ enabled: source === "derived", syntheticAuthRefs: ["codex"] }],
         },
-        diagnostics: [],
-      });
-      const index = createModelListAuthIndex({
+      } as unknown as PluginMetadataSnapshot;
+      const index = createTestModelListAuthIndex({
         cfg: {},
         authStore: emptyStore,
         env: {},
+        metadataSnapshot,
         routeResolverFactory: dualRouteResolverFactory,
       });
 
@@ -302,7 +290,7 @@ describe("createModelListAuthIndex", () => {
       registrySource: "persisted",
       plugins: [],
     } as unknown as PluginMetadataSnapshot;
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -312,7 +300,6 @@ describe("createModelListAuthIndex", () => {
     });
 
     expect(index.evaluateModelAuth("openai").evidence).toBe("synthetic");
-    expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
   });
 
   it("fails closed before loading refs from a diagnostic-bearing metadata snapshot", () => {
@@ -321,7 +308,7 @@ describe("createModelListAuthIndex", () => {
       plugins: [{ enabled: true, syntheticAuthRefs: ["codex"] }],
       registryDiagnostics: [{ level: "error", message: "invalid plugin metadata" }],
     } as unknown as PluginMetadataSnapshot;
-    const index = createModelListAuthIndex({
+    const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
@@ -330,6 +317,5 @@ describe("createModelListAuthIndex", () => {
     });
 
     expect(index.evaluateModelAuth("openai").availability).toBe(false);
-    expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -4,6 +4,9 @@ import type { createOpenAIModelRoutesResolver } from "../../agents/openai-model-
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { createModelListAuthIndex } from "./list.auth-index.js";
 
+type ExternalCliProfilesResolver =
+  typeof import("../../agents/auth-profiles/external-cli-sync.js").resolveExternalCliAuthProfiles;
+
 type PluginSnapshotResult = {
   source: "persisted" | "provided" | "derived";
   snapshot: {
@@ -21,6 +24,9 @@ const pluginRegistryMocks = vi.hoisted(() => ({
     }),
   ),
 }));
+const externalCliMocks = vi.hoisted(() => ({
+  resolveExternalCliAuthProfiles: vi.fn<ExternalCliProfilesResolver>(() => []),
+}));
 
 vi.mock("../../plugins/plugin-registry.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../plugins/plugin-registry.js")>();
@@ -30,6 +36,10 @@ vi.mock("../../plugins/plugin-registry.js", async (importOriginal) => {
       pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata,
   };
 });
+
+vi.mock("../../agents/auth-profiles/external-cli-sync.js", () => ({
+  resolveExternalCliAuthProfiles: externalCliMocks.resolveExternalCliAuthProfiles,
+}));
 
 const emptyStore: AuthProfileStore = { version: 1, profiles: {} };
 
@@ -56,12 +66,60 @@ const dualRouteResolverFactory = (() => () => ({
 
 describe("createModelListAuthIndex", () => {
   beforeEach(() => {
+    externalCliMocks.resolveExternalCliAuthProfiles.mockReset();
+    externalCliMocks.resolveExternalCliAuthProfiles.mockReturnValue([]);
     pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReset();
     pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
       source: "persisted",
       snapshot: { plugins: [] },
       diagnostics: [],
     });
+  });
+
+  it("keeps a fresh auth scope empty", () => {
+    const index = createModelListAuthIndex({
+      cfg: {},
+      authStore: emptyStore,
+      env: {},
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual([]);
+  });
+
+  it("scopes provider discovery to concrete API-key evidence", () => {
+    const index = createModelListAuthIndex({
+      cfg: {},
+      authStore: emptyStore,
+      env: { ANTHROPIC_API_KEY: "test-key" },
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual(["anthropic", "anthropic-openai"]);
+  });
+
+  it("scopes provider discovery to external CLI credentials", () => {
+    externalCliMocks.resolveExternalCliAuthProfiles.mockReturnValue([
+      {
+        profileId: "openai:codex-cli",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "external-cli",
+          refresh: "external-cli-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    ]);
+    const index = createModelListAuthIndex({
+      cfg: {},
+      authStore: emptyStore,
+      env: {},
+      externalCliProviderIds: ["openai"],
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual(["openai"]);
   });
 
   it("forwards route-aware evaluation through the command adapter", () => {
@@ -142,6 +200,37 @@ describe("createModelListAuthIndex", () => {
     });
     expect(index.evaluateModelAuth("disabled-provider").availability).toBeUndefined();
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+  });
+
+  it("maps synthetic auth refs to their configured plugin catalog providers", () => {
+    const metadataSnapshot = {
+      registrySource: "persisted",
+      registryDiagnostics: [],
+      plugins: [],
+      index: {
+        plugins: [
+          {
+            pluginId: "local-runtime",
+            enabled: true,
+            syntheticAuthRefs: ["local-cli"],
+            contributions: {
+              providers: ["local-runtime"],
+              modelCatalogProviders: ["local-catalog"],
+            },
+          },
+        ],
+      },
+    } as unknown as PluginMetadataSnapshot;
+    const index = createModelListAuthIndex({
+      cfg: {},
+      authStore: emptyStore,
+      env: {},
+      metadataSnapshot,
+      syntheticAuthProviderRefs: ["local-cli"],
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual(["local-catalog", "local-runtime"]);
   });
 
   it.each(["derived" as const, "persisted" as const])(

--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -122,6 +122,46 @@ describe("createModelListAuthIndex", () => {
     expect(index.providerDiscoveryProviderIds).toEqual(["openai"]);
   });
 
+  it("scopes provider discovery to stored credential profiles", () => {
+    const index = createModelListAuthIndex({
+      cfg: {},
+      authStore: {
+        version: 1,
+        profiles: {
+          "moonshot:stored": {
+            type: "api_key",
+            provider: "moonshot",
+            key: "stored-key",
+          },
+        },
+      },
+      env: {},
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual(["moonshot"]);
+  });
+
+  it("scopes provider discovery to configured auth profiles", () => {
+    const index = createModelListAuthIndex({
+      cfg: {
+        auth: {
+          profiles: {
+            "openrouter:configured": {
+              provider: "openrouter",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      authStore: emptyStore,
+      env: {},
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.providerDiscoveryProviderIds).toEqual(["openrouter"]);
+  });
+
   it("forwards route-aware evaluation through the command adapter", () => {
     const index = createModelListAuthIndex({
       cfg: {},
@@ -145,6 +185,7 @@ describe("createModelListAuthIndex", () => {
       selectedProfileId: "openai:platform",
       selectedRoute: { authRequirement: "api-key" },
     });
+    expect(index.providerDiscoveryProviderIds).toEqual(["openai"]);
   });
 
   it("uses enabled synthetic refs from a persisted plugin snapshot", () => {

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -14,6 +14,7 @@ export type ModelListAuthRef = ModelAuthAvailabilityRef;
 export type ModelListAuthEvaluation = ModelAuthAvailabilityEvaluation;
 
 export type ModelListAuthIndex = {
+  providerDiscoveryProviderIds?: readonly string[];
   evaluateModelAuth(provider: string, ref?: ModelListAuthRef): ModelListAuthEvaluation;
 };
 
@@ -87,6 +88,7 @@ export function createModelListAuthIndex(
       }),
   });
   return {
+    providerDiscoveryProviderIds: resolver.providerDiscoveryProviderIds,
     evaluateModelAuth: (provider, ref) => resolver.evaluateModelAuth(provider, ref),
   };
 }

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -8,7 +8,6 @@ import {
 import type { createOpenAIModelRoutesResolver } from "../../agents/openai-model-routes.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { loadPluginRegistrySnapshotWithMetadata } from "../../plugins/plugin-registry.js";
 
 export type ModelListAuthRef = ModelAuthAvailabilityRef;
 export type ModelListAuthEvaluation = ModelAuthAvailabilityEvaluation;
@@ -25,41 +24,22 @@ type CreateModelListAuthIndexParams = {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   syntheticAuthProviderRefs?: readonly string[];
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot: PluginMetadataSnapshot;
   externalCliProviderIds?: readonly string[];
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
 };
 
 function listValidatedSyntheticAuthProviderRefs(params: {
-  cfg: OpenClawConfig;
-  workspaceDir?: string;
-  env: NodeJS.ProcessEnv;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot: PluginMetadataSnapshot;
 }): readonly string[] {
-  if (params.metadataSnapshot) {
-    if (
-      params.metadataSnapshot.registryDiagnostics.length > 0 ||
-      (params.metadataSnapshot.registrySource !== "persisted" &&
-        params.metadataSnapshot.registrySource !== "provided")
-    ) {
-      return [];
-    }
-    return params.metadataSnapshot.index.plugins
-      .filter((plugin) => plugin.enabled)
-      .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
-  }
-  const result = loadPluginRegistrySnapshotWithMetadata({
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
   if (
-    result.diagnostics.length > 0 ||
-    (result.source !== "persisted" && result.source !== "provided")
+    params.metadataSnapshot.registryDiagnostics.length > 0 ||
+    (params.metadataSnapshot.registrySource !== "persisted" &&
+      params.metadataSnapshot.registrySource !== "provided")
   ) {
     return [];
   }
-  return result.snapshot.plugins
+  return params.metadataSnapshot.index.plugins
     .filter((plugin) => plugin.enabled)
     .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
 }
@@ -81,9 +61,6 @@ export function createModelListAuthIndex(
     syntheticAuthProviderRefs:
       params.syntheticAuthProviderRefs ??
       listValidatedSyntheticAuthProviderRefs({
-        cfg: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env,
         metadataSnapshot: params.metadataSnapshot,
       }),
   });

--- a/src/commands/models/list.configured.ts
+++ b/src/commands/models/list.configured.ts
@@ -1,9 +1,11 @@
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { modelKey } from "../../agents/model-ref-shared.js";
 /** Resolves configured model refs and tags for model-list rows. */
 import {
   buildModelAliasIndex,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
-} from "../../agents/model-selection.js";
+} from "../../agents/model-selection-shared.js";
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
@@ -12,7 +14,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { ConfiguredEntry } from "./list.types.js";
 import { createModelCatalogProviderAliasCanonicalizer } from "./provider-aliases.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER, modelKey } from "./shared.js";
 
 const DISPLAY_MODEL_PARSE_OPTIONS = { allowPluginNormalization: false } as const;
 

--- a/src/commands/models/list.format.test.ts
+++ b/src/commands/models/list.format.test.ts
@@ -1,7 +1,28 @@
 // Model list formatting tests cover fixed-width terminal cell helpers.
 import { describe, expect, it } from "vitest";
 import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
-import { pad, truncate } from "./list.format.js";
+import { formatTokenK, pad, truncate } from "./list.format.js";
+
+describe("formatTokenK", () => {
+  it("renders token context windows in decimal K", () => {
+    expect(formatTokenK(200_000)).toBe("200k");
+    expect(formatTokenK(128_000)).toBe("128k");
+    expect(formatTokenK(1_000_000)).toBe("1000k");
+    expect(formatTokenK(195_000)).toBe("195k");
+  });
+
+  it("passes small counts through and switches to K at 1000", () => {
+    expect(formatTokenK(999)).toBe("999");
+    expect(formatTokenK(1_000)).toBe("1k");
+  });
+
+  it("returns a dash for missing or non-finite values", () => {
+    expect(formatTokenK(undefined)).toBe("-");
+    expect(formatTokenK(null)).toBe("-");
+    expect(formatTokenK(0)).toBe("-");
+    expect(formatTokenK(Number.NaN)).toBe("-");
+  });
+});
 
 describe("truncate", () => {
   it("preserves existing ASCII truncation with an ellipsis suffix", () => {

--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -5,6 +5,18 @@ import { isRich as isRichTerminal, theme } from "../../../packages/terminal-core
 
 const TRUNCATED_SUFFIX = "...";
 
+/** Formats token counts as compact decimal-K labels. */
+export const formatTokenK = (value?: number | null) => {
+  if (!value || !Number.isFinite(value)) {
+    return "-";
+  }
+  // Provider context windows use decimal K, so 200000 must stay "200k".
+  if (value < 1000) {
+    return `${Math.round(value)}`;
+  }
+  return `${Math.round(value / 1000)}k`;
+};
+
 /** Enables rich formatting only for non-machine-readable output. */
 export const isRich = (opts?: { json?: boolean; plain?: boolean }) =>
   isRichTerminal() && !opts?.json && !opts?.plain;

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -689,6 +689,11 @@ describe("modelsListCommand forward-compat", () => {
             provider: "google",
             key: "google-fixture",
           },
+          "openai:platform": {
+            type: "api_key",
+            provider: "openai",
+            key: "openai-fixture",
+          },
         },
         order: {},
       });

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -276,6 +276,16 @@ function installModelsListCommandForwardCompatMocks() {
     },
   }));
 
+  vi.doMock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
+    prepareScopedReadOnlyModelCatalog: async (
+      _input: unknown,
+      providerDiscoveryProviderIds: readonly string[],
+    ) => {
+      const entries = await mocks.loadModelCatalog({ providerDiscoveryProviderIds });
+      return { entries, routeVariants: entries };
+    },
+  }));
+
   vi.doMock("../../agents/embedded-agent-runner/model.js", () => ({
     resolveModelWithRegistry: mocks.resolveModelWithRegistry,
   }));

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -276,12 +276,13 @@ function installModelsListCommandForwardCompatMocks() {
     },
   }));
 
-  vi.doMock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
-    prepareScopedReadOnlyModelCatalog: async (
-      _input: unknown,
-      providerDiscoveryProviderIds: readonly string[],
-    ) => {
-      const entries = await mocks.loadModelCatalog({ providerDiscoveryProviderIds });
+  vi.doMock("./list.scoped-catalog.js", () => ({
+    loadScopedListModelCatalogSnapshot: async ({
+      providerIds,
+    }: {
+      providerIds: readonly string[];
+    }) => {
+      const entries = await mocks.loadModelCatalog({ providerDiscoveryProviderIds: providerIds });
       return { entries, routeVariants: entries };
     },
   }));

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -277,12 +277,16 @@ function installModelsListCommandForwardCompatMocks() {
   }));
 
   vi.doMock("./list.scoped-catalog.js", () => ({
-    loadScopedListModelCatalogSnapshot: async ({
-      providerIds,
-    }: {
+    loadScopedListModelCatalogSnapshot: async (params: {
       providerIds: readonly string[];
+      runtimeProviderIds?: readonly string[];
+      manifestFallbackProviderIds?: readonly string[];
     }) => {
-      const entries = await mocks.loadModelCatalog({ providerDiscoveryProviderIds: providerIds });
+      const entries = await mocks.loadModelCatalog({
+        providerDiscoveryProviderIds: params.providerIds,
+        providerRuntimeDiscoveryProviderIds: params.runtimeProviderIds,
+        providerManifestFallbackProviderIds: params.manifestFallbackProviderIds,
+      });
       return { entries, routeVariants: entries };
     },
   }));
@@ -712,6 +716,13 @@ describe("modelsListCommand forward-compat", () => {
       await modelsListCommand({ json: true }, runtime as never);
 
       expect(mocks.loadModelRegistry).not.toHaveBeenCalled();
+      expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerDiscoveryProviderIds: ["google", "openai", "xiaomi"],
+          providerRuntimeDiscoveryProviderIds: [],
+          providerManifestFallbackProviderIds: ["google", "openai"],
+        }),
+      );
       const rows = lastPrintedRows<{ key: string; name: string; available: boolean }>();
       expectRowKeys(rows, [
         "xiaomi/mimo-v2.5-pro",

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -1144,6 +1144,11 @@ describe("modelsListCommand forward-compat", () => {
       expect(modelRegistryOptions().normalizeModels).toBe(false);
       expect(mocks.resolveModelWithRegistry).not.toHaveBeenCalled();
       expect(mocks.loadModelCatalog).toHaveBeenCalledOnce();
+      expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          providerDiscoveryProviderIds: expect.anything(),
+        }),
+      );
       expectRowKeys(lastPrintedRows<{ key: string }>(), ["openai/gpt-5.4", "moonshot/kimi-k2.6"]);
     });
 
@@ -1164,6 +1169,11 @@ describe("modelsListCommand forward-compat", () => {
       expect(modelRegistryOptions().providerFilter).toBe("openai");
       expect(modelRegistryOptions().normalizeModels).toBe(true);
       expect(mocks.loadModelCatalog).toHaveBeenCalledOnce();
+      expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerDiscoveryProviderIds: ["openai"],
+        }),
+      );
       const rows = lastPrintedRows<{ key: string; available: boolean }>();
       expectRowKeys(rows, ["openai/gpt-5.4"]);
       expectRowFields(rows, "openai/gpt-5.4", { available: true });

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -120,12 +120,21 @@ export async function modelsListCommand(
   // The default configured view remains lazy; full and filtered views share
   // the registry and the same committed model generation as the Gateway.
   const includePreparedCatalog = Boolean(opts.all || providerFilter);
-  const providerDiscoveryProviderIds =
-    opts.all && !providerFilter
-      ? undefined
-      : providerFilter
-        ? [providerFilter]
-        : authIndex.providerDiscoveryProviderIds;
+  const providerDiscoveryProviderIds = (() => {
+    if (opts.all && !providerFilter) {
+      return undefined;
+    }
+    if (providerFilter) {
+      return [providerFilter];
+    }
+    return [
+      ...new Set([
+        ...(authIndex.providerDiscoveryProviderIds ?? []),
+        ...entries.map((entry) => entry.ref.provider),
+        ...Object.keys(cfg.models?.providers ?? {}),
+      ]),
+    ].toSorted((left, right) => left.localeCompare(right));
+  })();
   const loadRegistryState = async (optsLocal?: {
     normalizeModels?: boolean;
     loadAvailability?: boolean;

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -135,6 +135,11 @@ export async function modelsListCommand(
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
   })();
+  const providerRuntimeDiscoveryProviderIds = providerFilter
+    ? [providerFilter]
+    : opts.all
+      ? undefined
+      : authIndex.providerDiscoveryProviderIds;
   const loadRegistryState = async (optsLocal?: {
     normalizeModels?: boolean;
     loadAvailability?: boolean;
@@ -181,6 +186,7 @@ export async function modelsListCommand(
     inheritedAuthDir: agentDir,
     authIndex,
     providerDiscoveryProviderIds,
+    providerRuntimeDiscoveryProviderIds,
     availableKeys,
     configuredByKey,
     discoveredKeys,

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -139,7 +139,11 @@ export async function modelsListCommand(
     ? [providerFilter]
     : opts.all
       ? undefined
-      : authIndex.providerDiscoveryProviderIds;
+      : [];
+  // Default lists use authenticated providers' authored fallback rows. Live
+  // account discovery remains explicit because it imports full provider runtimes.
+  const providerManifestFallbackProviderIds =
+    !providerFilter && !opts.all ? authIndex.providerDiscoveryProviderIds : undefined;
   const loadRegistryState = async (optsLocal?: {
     normalizeModels?: boolean;
     loadAvailability?: boolean;
@@ -187,6 +191,7 @@ export async function modelsListCommand(
     authIndex,
     providerDiscoveryProviderIds,
     providerRuntimeDiscoveryProviderIds,
+    providerManifestFallbackProviderIds,
     availableKeys,
     configuredByKey,
     discoveredKeys,

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -119,6 +119,12 @@ export async function modelsListCommand(
   // The default configured view remains lazy; full and filtered views share
   // the registry and the same committed model generation as the Gateway.
   const includePreparedCatalog = Boolean(opts.all || providerFilter);
+  const providerDiscoveryProviderIds =
+    opts.all && !providerFilter
+      ? undefined
+      : providerFilter
+        ? [providerFilter]
+        : authIndex.providerDiscoveryProviderIds;
   const loadRegistryState = async (optsLocal?: {
     normalizeModels?: boolean;
     loadAvailability?: boolean;
@@ -163,6 +169,7 @@ export async function modelsListCommand(
     agentId,
     agentDir,
     authIndex,
+    providerDiscoveryProviderIds,
     availableKeys,
     configuredByKey,
     discoveredKeys,

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -169,6 +169,7 @@ export async function modelsListCommand(
     cfg,
     agentId,
     agentDir,
+    inheritedAuthDir: agentDir,
     authIndex,
     providerDiscoveryProviderIds,
     availableKeys,

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -1,6 +1,7 @@
 /** Implementation of `openclaw models list`. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { parseModelRef } from "../../agents/model-selection.js";
+import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { parseModelRef } from "../../agents/model-selection-normalize.js";
 import { requestExitAfterOneShotOutput } from "../../cli/one-shot-exit.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
@@ -10,11 +11,11 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { createModelListAuthIndex } from "./list.auth-index.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
+import { ensureFlagCompatibility } from "./list.options.js";
 import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
-import { DEFAULT_PROVIDER, ensureFlagCompatibility } from "./shared.js";
 
 const DISPLAY_MODEL_PARSE_OPTIONS = { allowPluginNormalization: false } as const;
 

--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -119,6 +119,28 @@ describe("loadStaticManifestCatalogRowsForList", () => {
     ).toEqual(["moonshot/kimi-k2.6"]);
   });
 
+  it("loads runtime manifest rows for an explicitly scoped lightweight view", async () => {
+    const { loadManifestCatalogRowsForList } = await import("./list.manifest-catalog.js");
+    const manifestRegistry = {
+      plugins: [openaiRuntimePlugin, moonshotPlugin],
+      diagnostics: [],
+    };
+    const metadataSnapshot = {
+      index: { plugins: [], diagnostics: [] },
+      manifestRegistry,
+      plugins: manifestRegistry.plugins,
+    };
+
+    expect(
+      loadManifestCatalogRowsForList({
+        cfg: {},
+        metadataSnapshot: metadataSnapshot as unknown as Parameters<
+          typeof loadManifestCatalogRowsForList
+        >[0]["metadataSnapshot"],
+      }).map((row) => row.ref),
+    ).toEqual(["moonshot/kimi-k2.6", "openai/gpt-known"]);
+  });
+
   it("does not expose runtime overlay rows as static manifest models", async () => {
     const { loadStaticManifestCatalogRowsForList } = await import("./list.manifest-catalog.js");
     const manifestRegistry = {

--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -9,8 +9,11 @@ const mocks = vi.hoisted(() => ({
   getRemoteModelCatalogOverlay: vi.fn(),
 }));
 
-vi.mock("../../plugins/plugin-registry.js", () => ({
+vi.mock("../../plugins/plugin-registry-contributions.js", () => ({
   resolvePluginContributionOwners: mocks.resolvePluginContributionOwners,
+}));
+
+vi.mock("../../plugins/plugin-registry-snapshot.js", () => ({
   getPluginRecord: mocks.getPluginRecord,
   isPluginEnabled: mocks.isPluginEnabled,
 }));
@@ -26,6 +29,7 @@ vi.mock("../../model-catalog/remote-overlay.js", () => ({
 
 const moonshotPlugin = {
   id: "moonshot",
+  origin: "bundled",
   providers: ["moonshot"],
   modelCatalog: {
     providers: {
@@ -41,6 +45,7 @@ const moonshotPlugin = {
 
 const openrouterPlugin = {
   id: "openrouter",
+  origin: "bundled",
   providers: ["openrouter"],
   modelCatalog: {
     providers: {
@@ -56,6 +61,7 @@ const openrouterPlugin = {
 
 const openaiRuntimePlugin = {
   id: "openai",
+  origin: "bundled",
   providers: ["openai"],
   modelCatalog: {
     providers: {
@@ -65,6 +71,23 @@ const openaiRuntimePlugin = {
     },
     discovery: {
       openai: "runtime",
+    },
+  },
+};
+
+const anthropicRuntimeAugmentPlugin = {
+  id: "anthropic",
+  origin: "bundled",
+  providers: ["anthropic"],
+  modelCatalog: {
+    runtimeAugment: true,
+    providers: {
+      anthropic: {
+        models: [{ id: "claude-known", name: "Known Claude" }],
+      },
+    },
+    discovery: {
+      anthropic: "refreshable",
     },
   },
 };
@@ -191,5 +214,91 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       }).map((row) => row.ref),
     ).toEqual(["moonshot/kimi-k2.6"]);
     expect(mocks.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveManifestCatalogCoverageForList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPluginRecord.mockImplementation(({ pluginId }: { pluginId: string }) => ({
+      pluginId,
+    }));
+    mocks.isPluginEnabled.mockReturnValue(true);
+    mocks.resolvePluginContributionOwners.mockImplementation(({ matches }: { matches: string }) => [
+      matches,
+    ]);
+  });
+
+  it("marks only static non-augment owners as complete", async () => {
+    const { resolveManifestCatalogCoverageForList } = await import("./list.manifest-catalog.js");
+    const metadataSnapshot = {
+      index: { plugins: [], diagnostics: [] },
+      manifestRegistry: {
+        plugins: [
+          anthropicRuntimeAugmentPlugin,
+          moonshotPlugin,
+          openrouterPlugin,
+          openaiRuntimePlugin,
+        ],
+        diagnostics: [],
+      },
+    };
+
+    const coverage = resolveManifestCatalogCoverageForList({
+      cfg: {},
+      providerIds: new Set(["anthropic", "moonshot", "openrouter", "openai"]),
+      metadataSnapshot: metadataSnapshot as never,
+    });
+
+    expect(coverage.ownedProviderIds).toEqual(
+      new Set(["anthropic", "moonshot", "openrouter", "openai"]),
+    );
+    expect(coverage.completeProviderIds).toEqual(new Set(["moonshot"]));
+  });
+
+  it("requires runtime augmentation for external provider plugins", async () => {
+    const { resolveManifestCatalogCoverageForList } = await import("./list.manifest-catalog.js");
+    const externalPlugin = {
+      ...moonshotPlugin,
+      id: "external-moonshot",
+      origin: "external",
+    };
+    const metadataSnapshot = {
+      index: { plugins: [], diagnostics: [] },
+      manifestRegistry: {
+        plugins: [externalPlugin],
+        diagnostics: [],
+      },
+    };
+    mocks.resolvePluginContributionOwners.mockReturnValue(["external-moonshot"]);
+    mocks.getPluginRecord.mockReturnValue(undefined);
+
+    const coverage = resolveManifestCatalogCoverageForList({
+      cfg: {},
+      providerIds: new Set(["moonshot"]),
+      metadataSnapshot: metadataSnapshot as never,
+    });
+
+    expect(coverage.ownedProviderIds).toEqual(new Set(["moonshot"]));
+    expect(coverage.completeProviderIds).toEqual(new Set());
+  });
+
+  it("treats replace mode as explicit opt-out from provider discovery", async () => {
+    const { resolveManifestCatalogCoverageForList } = await import("./list.manifest-catalog.js");
+    const metadataSnapshot = {
+      index: { plugins: [], diagnostics: [] },
+      manifestRegistry: {
+        plugins: [openaiRuntimePlugin],
+        diagnostics: [],
+      },
+    };
+
+    const coverage = resolveManifestCatalogCoverageForList({
+      cfg: { models: { mode: "replace" } },
+      providerIds: new Set(["openai"]),
+      metadataSnapshot: metadataSnapshot as never,
+    });
+
+    expect(coverage.completeProviderIds).toEqual(new Set(["openai"]));
   });
 });

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -1,6 +1,7 @@
 /** Manifest-backed model catalog row loaders for `openclaw models list`. */
 import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
 import type { ManifestModelCatalogRowSelection } from "../../model-catalog/manifest-planner.js";
@@ -72,6 +73,89 @@ function resolveDeclaredModelCatalogPluginIds(params: {
     contribution: "modelCatalogProviders",
     matches: params.providerFilter,
   });
+}
+
+function resolveModelCatalogPluginIdsForProvider(params: {
+  cfg: OpenClawConfig;
+  index: PluginRegistrySnapshot;
+  provider: string;
+}): readonly string[] {
+  return [
+    ...new Set([
+      ...resolveConventionModelCatalogPluginIds({
+        cfg: params.cfg,
+        index: params.index,
+        providerFilter: params.provider,
+      }),
+      ...resolveDeclaredModelCatalogPluginIds({
+        cfg: params.cfg,
+        index: params.index,
+        providerFilter: params.provider,
+      }),
+    ]),
+  ];
+}
+
+/**
+ * Resolves provider ownership and whether static manifest rows require runtime
+ * augmentation before they can be treated as complete catalog coverage.
+ */
+export function resolveManifestCatalogCoverageForList(params: {
+  cfg: OpenClawConfig;
+  providerIds: ReadonlySet<string>;
+  env?: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): {
+  ownedProviderIds: ReadonlySet<string>;
+  completeProviderIds: ReadonlySet<string>;
+} {
+  const snapshot =
+    params.metadataSnapshot ??
+    loadManifestMetadataSnapshot({
+      config: params.cfg,
+      env: params.env ?? process.env,
+    });
+  const pluginsById = new Map(
+    snapshot.manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]),
+  );
+  const ownedProviderIds = new Set<string>();
+  const completeProviderIds = new Set<string>();
+  for (const rawProvider of params.providerIds) {
+    const provider = normalizeProviderId(rawProvider);
+    if (!provider) {
+      continue;
+    }
+    const pluginIds = resolveModelCatalogPluginIdsForProvider({
+      cfg: params.cfg,
+      index: snapshot.index,
+      provider,
+    });
+    if (pluginIds.length === 0) {
+      continue;
+    }
+    ownedProviderIds.add(provider);
+    const complete = pluginIds.every((pluginId) => {
+      const plugin = pluginsById.get(pluginId);
+      if (!plugin) {
+        return false;
+      }
+      if (plugin.modelCatalog?.runtimeAugment === true || plugin.origin !== "bundled") {
+        return false;
+      }
+      const aliasTarget = plugin.modelCatalog?.aliases?.[provider]?.provider;
+      const discoveryProvider = normalizeProviderId(aliasTarget ?? provider);
+      return plugin.modelCatalog?.discovery?.[discoveryProvider] === "static";
+    });
+    if (complete) {
+      completeProviderIds.add(provider);
+    }
+  }
+  if (params.cfg.models?.mode === "replace") {
+    for (const provider of params.providerIds) {
+      completeProviderIds.add(normalizeProviderId(provider));
+    }
+  }
+  return { ownedProviderIds, completeProviderIds };
 }
 
 function loadManifestCatalogRowsForListSelection(params: {

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -3,6 +3,7 @@ import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/mo
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
+import type { ManifestModelCatalogRowSelection } from "../../model-catalog/manifest-planner.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -13,11 +14,12 @@ import {
   type PluginRegistrySnapshot,
 } from "../../plugins/plugin-registry.js";
 
-function loadManifestCatalogRowsForPluginIds(params: {
+function planManifestCatalogRowsForPluginIds(params: {
   cfg: OpenClawConfig;
   registry: PluginManifestRegistry;
   pluginIds?: readonly string[];
   providerFilter?: string;
+  selection?: ManifestModelCatalogRowSelection;
 }): readonly NormalizedModelCatalogRow[] {
   if (params.pluginIds && params.pluginIds.length === 0) {
     return [];
@@ -33,7 +35,7 @@ function loadManifestCatalogRowsForPluginIds(params: {
     registry,
     config: params.cfg,
     ...(params.providerFilter ? { providerFilter: params.providerFilter } : {}),
-    selection: "static",
+    ...(params.selection ? { selection: params.selection } : {}),
   }).rows;
 }
 
@@ -72,12 +74,12 @@ function resolveDeclaredModelCatalogPluginIds(params: {
   });
 }
 
-/** Loads authoritative static manifest catalog rows for model-list output. */
-export function loadStaticManifestCatalogRowsForList(params: {
+function loadManifestCatalogRowsForListSelection(params: {
   cfg: OpenClawConfig;
   providerFilter?: string;
   env?: NodeJS.ProcessEnv;
   metadataSnapshot?: PluginMetadataSnapshot;
+  selection?: ManifestModelCatalogRowSelection;
 }): readonly NormalizedModelCatalogRow[] {
   const providerFilter = params.providerFilter
     ? normalizeModelCatalogProviderId(params.providerFilter)
@@ -90,12 +92,13 @@ export function loadStaticManifestCatalogRowsForList(params: {
     });
   const index = snapshot.index;
   if (!providerFilter) {
-    return loadManifestCatalogRowsForPluginIds({
+    return planManifestCatalogRowsForPluginIds({
       cfg: params.cfg,
       registry: snapshot.manifestRegistry,
+      ...(params.selection ? { selection: params.selection } : {}),
     });
   }
-  const conventionRows = loadManifestCatalogRowsForPluginIds({
+  const conventionRows = planManifestCatalogRowsForPluginIds({
     cfg: params.cfg,
     registry: snapshot.manifestRegistry,
     pluginIds: resolveConventionModelCatalogPluginIds({
@@ -104,11 +107,12 @@ export function loadStaticManifestCatalogRowsForList(params: {
       providerFilter,
     }),
     providerFilter,
+    ...(params.selection ? { selection: params.selection } : {}),
   });
   if (conventionRows.length > 0) {
     return conventionRows;
   }
-  return loadManifestCatalogRowsForPluginIds({
+  return planManifestCatalogRowsForPluginIds({
     cfg: params.cfg,
     registry: snapshot.manifestRegistry,
     pluginIds: resolveDeclaredModelCatalogPluginIds({
@@ -117,5 +121,26 @@ export function loadStaticManifestCatalogRowsForList(params: {
       providerFilter,
     }),
     providerFilter,
+    ...(params.selection ? { selection: params.selection } : {}),
   });
+}
+
+/** Loads manifest catalog rows without importing provider runtimes. */
+export function loadManifestCatalogRowsForList(params: {
+  cfg: OpenClawConfig;
+  providerFilter?: string;
+  env?: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): readonly NormalizedModelCatalogRow[] {
+  return loadManifestCatalogRowsForListSelection(params);
+}
+
+/** Loads authoritative static manifest catalog rows for model-list output. */
+export function loadStaticManifestCatalogRowsForList(params: {
+  cfg: OpenClawConfig;
+  providerFilter?: string;
+  env?: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): readonly NormalizedModelCatalogRow[] {
+  return loadManifestCatalogRowsForListSelection({ ...params, selection: "static" });
 }

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -7,12 +7,12 @@ import type { ManifestModelCatalogRowSelection } from "../../model-catalog/manif
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolvePluginContributionOwners } from "../../plugins/plugin-registry-contributions.js";
 import {
   getPluginRecord,
   isPluginEnabled,
-  resolvePluginContributionOwners,
   type PluginRegistrySnapshot,
-} from "../../plugins/plugin-registry.js";
+} from "../../plugins/plugin-registry-snapshot.js";
 
 function planManifestCatalogRowsForPluginIds(params: {
   cfg: OpenClawConfig;

--- a/src/commands/models/list.model-projection.ts
+++ b/src/commands/models/list.model-projection.ts
@@ -1,0 +1,72 @@
+import { resolveProviderPolicySurface } from "../../plugins/provider-public-artifacts.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { ListRowModel } from "./list.model-row.js";
+import type { RowBuilderContext } from "./list.rows.js";
+
+type ProviderRuntimeModule = typeof import("../../plugins/provider-runtime.js");
+
+const providerRuntimeModuleLoader = createLazyImportLoader<ProviderRuntimeModule>(
+  () => import("../../plugins/provider-runtime.js"),
+);
+
+function toListRowInput(input: readonly string[] | undefined): ListRowModel["input"] {
+  const parsed = input?.filter(
+    (item): item is NonNullable<ListRowModel["input"]>[number] =>
+      item === "text" || item === "image" || item === "document",
+  );
+  return parsed?.length ? parsed : ["text"];
+}
+
+function mergeNormalizedListRow(
+  model: ListRowModel,
+  normalized: ProviderRuntimeModel,
+): ListRowModel {
+  return {
+    ...model,
+    id: normalized.id,
+    name: normalized.name,
+    provider: normalized.provider,
+    api: normalized.api ?? model.api,
+    baseUrl: normalized.baseUrl ?? model.baseUrl,
+    input: toListRowInput(normalized.input),
+    contextWindow: normalized.contextWindow,
+    contextTokens: normalized.contextTokens,
+  };
+}
+
+/** Projects one authored provider row while keeping full runtime loading optional. */
+export async function normalizeConfiguredProviderListRow(params: {
+  model: ListRowModel;
+  context: RowBuilderContext;
+}): Promise<ListRowModel> {
+  const normalizationContext = {
+    config: params.context.cfg,
+    agentDir: params.context.agentDir,
+    workspaceDir: params.context.workspaceDir,
+    provider: params.model.provider,
+    modelId: params.model.id,
+    model: params.model as ProviderRuntimeModel,
+  };
+  const policySurface = resolveProviderPolicySurface(params.model.provider, {
+    manifestRegistry: params.context.metadataSnapshot?.manifestRegistry,
+  });
+  if (policySurface?.projectConfiguredModelRow) {
+    const projected = policySurface.projectConfiguredModelRow(normalizationContext);
+    if (projected === null) {
+      return params.model;
+    }
+    if (projected !== undefined) {
+      return mergeNormalizedListRow(params.model, projected);
+    }
+  }
+  const { normalizeProviderResolvedModelWithPlugin } = await providerRuntimeModuleLoader.load();
+  const normalized = normalizeProviderResolvedModelWithPlugin({
+    provider: params.model.provider,
+    config: params.context.cfg,
+    workspaceDir: params.context.workspaceDir,
+    pluginMetadataSnapshot: params.context.metadataSnapshot,
+    context: normalizationContext,
+  });
+  return normalized ? mergeNormalizedListRow(params.model, normalized) : params.model;
+}

--- a/src/commands/models/list.model-projection.ts
+++ b/src/commands/models/list.model-projection.ts
@@ -2,7 +2,7 @@ import { resolveProviderPolicySurface } from "../../plugins/provider-public-arti
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ListRowModel } from "./list.model-row.js";
-import type { RowBuilderContext } from "./list.rows.js";
+import type { RowBuilderContext } from "./list.row-context.js";
 
 type ProviderRuntimeModule = typeof import("../../plugins/provider-runtime.js");
 

--- a/src/commands/models/list.model-projection.ts
+++ b/src/commands/models/list.model-projection.ts
@@ -1,4 +1,4 @@
-import { resolveProviderPolicySurface } from "../../plugins/provider-public-artifacts.js";
+import { resolveBundledProviderPolicySurface } from "../../plugins/provider-public-artifacts.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ListRowModel } from "./list.model-row.js";
@@ -48,7 +48,7 @@ export async function normalizeConfiguredProviderListRow(params: {
     modelId: params.model.id,
     model: params.model as ProviderRuntimeModel,
   };
-  const policySurface = resolveProviderPolicySurface(params.model.provider, {
+  const policySurface = resolveBundledProviderPolicySurface(params.model.provider, {
     manifestRegistry: params.context.metadataSnapshot?.manifestRegistry,
   });
   if (policySurface?.projectConfiguredModelRow) {

--- a/src/commands/models/list.options.ts
+++ b/src/commands/models/list.options.ts
@@ -1,0 +1,6 @@
+/** Rejects conflicting machine-readable output modes. */
+export function ensureFlagCompatibility(opts: { json?: boolean; plain?: boolean }): void {
+  if (opts.json && opts.plain) {
+    throw new Error("Choose either --json or --plain, not both.");
+  }
+}

--- a/src/commands/models/list.persisted-catalog.test.ts
+++ b/src/commands/models/list.persisted-catalog.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadPersistedPluginModelCatalogsReadOnly: vi.fn(),
+  isGeneratedPluginModelCatalog: vi.fn(
+    (value: unknown) =>
+      typeof value === "object" &&
+      value !== null &&
+      (value as { generatedBy?: unknown }).generatedBy === "openclaw-plugin-model-catalog-v1",
+  ),
+  filterGeneratedPluginModelCatalogProviders: vi.fn(
+    ({ providers }: { providers: Record<string, unknown> }) => providers,
+  ),
+}));
+
+vi.mock("../../agents/plugin-model-catalog.js", () => ({
+  loadPersistedPluginModelCatalogsReadOnly: mocks.loadPersistedPluginModelCatalogsReadOnly,
+  isGeneratedPluginModelCatalog: mocks.isGeneratedPluginModelCatalog,
+  filterGeneratedPluginModelCatalogProviders: mocks.filterGeneratedPluginModelCatalogProviders,
+}));
+
+import { loadPersistedListCatalogEntries } from "./list.persisted-catalog.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("loadPersistedListCatalogEntries", () => {
+  it("projects valid generated provider rows with provider transport defaults", () => {
+    mocks.loadPersistedPluginModelCatalogsReadOnly.mockReturnValueOnce([
+      {
+        pluginId: "openai",
+        contents: JSON.stringify({
+          generatedBy: "openclaw-plugin-model-catalog-v1",
+          providers: {
+            openai: {
+              api: "openai-chatgpt-responses",
+              baseUrl: "https://chatgpt.com/backend-api/codex",
+              models: [
+                {
+                  id: "gpt-5.6",
+                  name: "GPT-5.6",
+                  input: ["text", "image", "invalid"],
+                  reasoning: true,
+                  contextWindow: 400_000,
+                },
+              ],
+            },
+          },
+        }),
+      },
+    ]);
+
+    expect(
+      loadPersistedListCatalogEntries({
+        agentDir: "/tmp/openclaw-agent",
+        providerIds: new Set(["openai"]),
+      }),
+    ).toEqual([
+      {
+        provider: "openai",
+        id: "gpt-5.6",
+        name: "GPT-5.6",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        input: ["text", "image"],
+        reasoning: true,
+        contextWindow: 400_000,
+      },
+    ]);
+  });
+
+  it("skips malformed, unscoped, and transportless rows", () => {
+    mocks.loadPersistedPluginModelCatalogsReadOnly.mockReturnValueOnce([
+      { pluginId: "bad-json", contents: "{" },
+      {
+        pluginId: "catalog",
+        contents: JSON.stringify({
+          generatedBy: "openclaw-plugin-model-catalog-v1",
+          providers: {
+            openai: { models: [{ id: "missing-api" }] },
+            google: {
+              api: "google-generative-ai",
+              models: [{ id: "gemini-live" }],
+            },
+          },
+        }),
+      },
+    ]);
+
+    expect(
+      loadPersistedListCatalogEntries({
+        agentDir: "/tmp/openclaw-agent",
+        providerIds: new Set(["openai"]),
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/commands/models/list.persisted-catalog.ts
+++ b/src/commands/models/list.persisted-catalog.ts
@@ -1,0 +1,113 @@
+/** Reads persisted generated catalogs without constructing a model registry. */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ModelCatalogEntry, ModelInputType } from "../../agents/model-catalog.types.js";
+import {
+  filterGeneratedPluginModelCatalogProviders,
+  isGeneratedPluginModelCatalog,
+  loadPersistedPluginModelCatalogsReadOnly,
+} from "../../agents/plugin-model-catalog.js";
+import { MODEL_APIS, type ModelApi } from "../../config/types.models.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+
+const modelApis = new Set<string>(MODEL_APIS);
+const modelInputs = new Set<ModelInputType>(["text", "image", "audio", "video", "document"]);
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function readModelApi(value: unknown): ModelApi | undefined {
+  const api = readString(value);
+  return api && modelApis.has(api) ? (api as ModelApi) : undefined;
+}
+
+function readModelInput(value: unknown): ModelInputType[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const input = value.filter(
+    (item): item is ModelInputType =>
+      typeof item === "string" && modelInputs.has(item as ModelInputType),
+  );
+  return input.length > 0 ? input : undefined;
+}
+
+function parseProviderModels(params: {
+  providerId: string;
+  provider: unknown;
+}): ModelCatalogEntry[] {
+  if (!isRecord(params.provider) || !Array.isArray(params.provider.models)) {
+    return [];
+  }
+  const providerApi = readModelApi(params.provider.api);
+  const providerBaseUrl = readString(params.provider.baseUrl);
+  return params.provider.models.flatMap((model) => {
+    if (!isRecord(model)) {
+      return [];
+    }
+    const id = readString(model.id);
+    const api = readModelApi(model.api) ?? providerApi;
+    if (!id || !api) {
+      return [];
+    }
+    const baseUrl = readString(model.baseUrl) ?? providerBaseUrl;
+    const input = readModelInput(model.input);
+    const contextWindow = readPositiveNumber(model.contextWindow);
+    const contextTokens = readPositiveNumber(model.contextTokens);
+    return [
+      {
+        id,
+        name: readString(model.name) ?? id,
+        provider: normalizeProviderId(params.providerId),
+        api,
+        ...(baseUrl ? { baseUrl } : {}),
+        ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(contextTokens !== undefined ? { contextTokens } : {}),
+        ...(typeof model.reasoning === "boolean" ? { reasoning: model.reasoning } : {}),
+        ...(input ? { input } : {}),
+      },
+    ];
+  });
+}
+
+/** Loads valid provider-owned rows from the agent's generated catalog cache. */
+export function loadPersistedListCatalogEntries(params: {
+  agentDir: string;
+  providerIds: ReadonlySet<string>;
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): ModelCatalogEntry[] {
+  const entries: ModelCatalogEntry[] = [];
+  for (const catalog of loadPersistedPluginModelCatalogsReadOnly(params.agentDir)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(catalog.contents) as unknown;
+    } catch {
+      continue;
+    }
+    if (
+      !isRecord(parsed) ||
+      !isGeneratedPluginModelCatalog(parsed) ||
+      !isRecord(parsed.providers)
+    ) {
+      continue;
+    }
+    const providers = filterGeneratedPluginModelCatalogProviders({
+      catalogPluginId: catalog.pluginId,
+      parsedCatalog: parsed,
+      pluginMetadataSnapshot: params.metadataSnapshot,
+      providers: parsed.providers,
+    });
+    for (const [providerId, provider] of Object.entries(providers)) {
+      if (!params.providerIds.has(normalizeProviderId(providerId))) {
+        continue;
+      }
+      entries.push(...parseProviderModels({ providerId, provider }));
+    }
+  }
+  return entries;
+}

--- a/src/commands/models/list.registry-load.ts
+++ b/src/commands/models/list.registry-load.ts
@@ -1,3 +1,4 @@
+import { modelKey } from "../../agents/model-ref-shared.js";
 import { shouldSuppressBuiltInModel } from "../../agents/model-suppression.js";
 /** Registry-loading adapters for model-list row construction. */
 import { loadPreparedAgentModelRegistry as loadAgentModelRegistry } from "../../agents/prepared-model-registry.js";
@@ -6,7 +7,6 @@ import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
 import { loadModelRegistry } from "./list.registry.js";
 import type { ConfiguredEntry } from "./list.types.js";
-import { modelKey } from "./shared.js";
 
 /** Loads the full model registry and tracks discovered provider/model keys. */
 export async function loadListModelRegistry(

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -1,3 +1,4 @@
+import { modelKey } from "../../agents/model-ref-shared.js";
 import {
   shouldSuppressBuiltInModel,
   shouldSuppressBuiltInModelFromManifest,
@@ -12,7 +13,6 @@ import {
   MODEL_AVAILABILITY_UNAVAILABLE_CODE,
   shouldFallbackToAuthHeuristics,
 } from "./list.errors.js";
-import { modelKey } from "./shared.js";
 
 function createAvailabilityUnavailableError(message: string): Error {
   const err = new Error(message);

--- a/src/commands/models/list.row-context.ts
+++ b/src/commands/models/list.row-context.ts
@@ -1,0 +1,27 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import type { ModelListAuthIndex } from "./list.auth-index.js";
+import type { ConfiguredEntry } from "./list.types.js";
+
+type RowFilter = {
+  provider?: string;
+  local?: boolean;
+};
+
+/** Context shared by every model-list row source builder. */
+export type RowBuilderContext = {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentDir: string;
+  inheritedAuthDir?: string;
+  authIndex: ModelListAuthIndex;
+  providerDiscoveryProviderIds?: readonly string[];
+  providerRuntimeDiscoveryProviderIds?: readonly string[];
+  availableKeys?: Set<string>;
+  configuredByKey: Map<string, ConfiguredEntry>;
+  discoveredKeys: Set<string>;
+  filter: RowFilter;
+  skipRuntimeModelSuppression?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
+  workspaceDir?: string;
+};

--- a/src/commands/models/list.row-context.ts
+++ b/src/commands/models/list.row-context.ts
@@ -17,6 +17,7 @@ export type RowBuilderContext = {
   authIndex: ModelListAuthIndex;
   providerDiscoveryProviderIds?: readonly string[];
   providerRuntimeDiscoveryProviderIds?: readonly string[];
+  providerManifestFallbackProviderIds?: readonly string[];
   availableKeys?: Set<string>;
   configuredByKey: Map<string, ConfiguredEntry>;
   discoveredKeys: Set<string>;

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -5,7 +5,7 @@ import type { ModelRow } from "./list.types.js";
 
 const mocks = vi.hoisted(() => ({
   loadModelCatalogSnapshot: vi.fn(),
-  prepareScopedModelCatalog: vi.fn(),
+  loadScopedModelCatalogSnapshot: vi.fn(),
   normalizeProviderResolvedModelWithPlugin: vi.fn(() => undefined),
   shouldSuppressBuiltInModel: vi.fn(() => {
     throw new Error("runtime model suppression should be skipped");
@@ -22,8 +22,8 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogSnapshot: mocks.loadModelCatalogSnapshot,
 }));
 
-vi.mock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
-  prepareScopedReadOnlyModelCatalog: mocks.prepareScopedModelCatalog,
+vi.mock("./list.scoped-catalog.js", () => ({
+  loadScopedListModelCatalogSnapshot: mocks.loadScopedModelCatalogSnapshot,
 }));
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
@@ -239,7 +239,7 @@ describe("appendPreparedModelCatalogRows", () => {
       provider: "anthropic",
       input: ["text"] as "text"[],
     };
-    mocks.prepareScopedModelCatalog.mockResolvedValueOnce({
+    mocks.loadScopedModelCatalogSnapshot.mockReturnValueOnce({
       entries: [entry],
       routeVariants: [entry],
     });
@@ -266,17 +266,10 @@ describe("appendPreparedModelCatalogRows", () => {
     });
 
     expect(requireOnlyRow(rows).key).toBe("anthropic/claude-opus-4-7");
-    expect(mocks.prepareScopedModelCatalog).toHaveBeenCalledExactlyOnceWith(
-      {
-        config: {},
-        agentId: "worker",
-        agentDir: "/tmp/openclaw-worker",
-        inheritedAuthDir: "/tmp/openclaw-default",
-        workspaceDir: "/tmp/openclaw-workspace",
-        readOnly: true,
-      },
-      ["anthropic"],
-    );
+    expect(mocks.loadScopedModelCatalogSnapshot).toHaveBeenCalledExactlyOnceWith({
+      cfg: {},
+      providerIds: ["anthropic"],
+    });
     expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
   });
 });
@@ -911,7 +904,10 @@ describe("appendAuthenticatedCatalogRows", () => {
         maxTokens: 4096,
       },
     ];
-    mocks.prepareScopedModelCatalog.mockResolvedValueOnce({ entries, routeVariants: entries });
+    mocks.loadScopedModelCatalogSnapshot.mockReturnValueOnce({
+      entries,
+      routeVariants: entries,
+    });
     const rows: ModelRow[] = [];
 
     await appendAuthenticatedCatalogRows({
@@ -941,16 +937,10 @@ describe("appendAuthenticatedCatalogRows", () => {
       local: true,
       available: true,
     });
-    expect(mocks.prepareScopedModelCatalog).toHaveBeenCalledWith(
-      {
-        config: {},
-        agentDir: "/tmp/openclaw-agent",
-        inheritedAuthDir: "/tmp/openclaw-agent",
-        workspaceDir: "/tmp/openclaw-workspace",
-        readOnly: true,
-      },
-      ["local-openai"],
-    );
+    expect(mocks.loadScopedModelCatalogSnapshot).toHaveBeenCalledWith({
+      cfg: {},
+      providerIds: ["local-openai"],
+    });
   });
 
   it("still drops catalog rows with unresolved non-synthetic auth", async () => {

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   loadModelCatalogSnapshot: vi.fn(),
   loadScopedModelCatalogSnapshot: vi.fn(),
   normalizeProviderResolvedModelWithPlugin: vi.fn(() => undefined),
+  resolveProviderPolicySurface: vi.fn(() => null),
   shouldSuppressBuiltInModel: vi.fn(() => {
     throw new Error("runtime model suppression should be skipped");
   }),
@@ -28,6 +29,10 @@ vi.mock("./list.scoped-catalog.js", () => ({
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
   normalizeProviderResolvedModelWithPlugin: mocks.normalizeProviderResolvedModelWithPlugin,
+}));
+
+vi.mock("../../plugins/provider-public-artifacts.js", () => ({
+  resolveProviderPolicySurface: mocks.resolveProviderPolicySurface,
 }));
 
 import {
@@ -738,6 +743,50 @@ describe("prepared provider catalog projection", () => {
 });
 
 describe("appendConfiguredProviderRows", () => {
+  it("skips provider runtime normalization when lightweight policy proves the row canonical", async () => {
+    mocks.resolveProviderPolicySurface.mockReturnValueOnce({
+      projectConfiguredModelRow: () => null,
+    } as never);
+    const rows: ModelRow[] = [];
+
+    await appendConfiguredProviderRows({
+      rows,
+      seenKeys: new Set(),
+      context: {
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                baseUrl: "http://127.0.0.1:8080/v1",
+                models: [
+                  {
+                    id: "gpt-5.5",
+                    name: "GPT-5.5",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 96_000,
+                    maxTokens: 128_000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        authIndex,
+        configuredByKey: new Map(),
+        discoveredKeys: new Set(),
+        filter: { provider: "openai", local: false },
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    expect(mocks.normalizeProviderResolvedModelWithPlugin).not.toHaveBeenCalled();
+    expect(requireOnlyRow(rows).input).toBe("text");
+  });
+
   it("keeps provider normalization for configured provider models", async () => {
     mocks.normalizeProviderResolvedModelWithPlugin.mockReturnValueOnce({
       provider: "anthropic",

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -248,7 +248,10 @@ describe("appendPreparedModelCatalogRows", () => {
         agentId: "worker",
         agentDir: "/tmp/openclaw-worker",
         workspaceDir: "/tmp/openclaw-workspace",
-        authIndex: { evaluateModelAuth: () => authEvaluation(true) },
+        providerDiscoveryProviderIds: ["anthropic"],
+        authIndex: {
+          evaluateModelAuth: () => authEvaluation(true),
+        },
         configuredByKey: new Map(),
         discoveredKeys: new Set(),
         filter: { provider: "anthropic" },
@@ -262,6 +265,7 @@ describe("appendPreparedModelCatalogRows", () => {
       agentId: "worker",
       agentDir: "/tmp/openclaw-worker",
       workspaceDir: "/tmp/openclaw-workspace",
+      providerDiscoveryProviderIds: ["anthropic"],
       readOnly: true,
     });
   });
@@ -907,6 +911,7 @@ describe("appendAuthenticatedCatalogRows", () => {
         cfg: {},
         agentDir: "/tmp/openclaw-agent",
         workspaceDir: "/tmp/openclaw-workspace",
+        providerDiscoveryProviderIds: ["local-openai"],
         authIndex: {
           evaluateModelAuth: () => ({
             availability: undefined,
@@ -930,6 +935,7 @@ describe("appendAuthenticatedCatalogRows", () => {
       config: {},
       agentDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/openclaw-workspace",
+      providerDiscoveryProviderIds: ["local-openai"],
       readOnly: true,
     });
   });

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -268,7 +268,12 @@ describe("appendPreparedModelCatalogRows", () => {
     expect(requireOnlyRow(rows).key).toBe("anthropic/claude-opus-4-7");
     expect(mocks.loadScopedModelCatalogSnapshot).toHaveBeenCalledExactlyOnceWith({
       cfg: {},
+      agentId: "worker",
+      agentDir: "/tmp/openclaw-worker",
+      inheritedAuthDir: "/tmp/openclaw-default",
+      workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["anthropic"],
+      configuredKeys: [],
     });
     expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
   });
@@ -939,7 +944,11 @@ describe("appendAuthenticatedCatalogRows", () => {
     });
     expect(mocks.loadScopedModelCatalogSnapshot).toHaveBeenCalledWith({
       cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      inheritedAuthDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["local-openai"],
+      configuredKeys: [],
     });
   });
 

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   loadModelCatalogSnapshot: vi.fn(),
   loadScopedModelCatalogSnapshot: vi.fn(),
   normalizeProviderResolvedModelWithPlugin: vi.fn(() => undefined),
-  resolveProviderPolicySurface: vi.fn(() => null),
+  resolveBundledProviderPolicySurface: vi.fn(() => null),
   shouldSuppressBuiltInModel: vi.fn(() => {
     throw new Error("runtime model suppression should be skipped");
   }),
@@ -32,7 +32,7 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
 }));
 
 vi.mock("../../plugins/provider-public-artifacts.js", () => ({
-  resolveProviderPolicySurface: mocks.resolveProviderPolicySurface,
+  resolveBundledProviderPolicySurface: mocks.resolveBundledProviderPolicySurface,
 }));
 
 import {
@@ -746,7 +746,7 @@ describe("prepared provider catalog projection", () => {
 
 describe("appendConfiguredProviderRows", () => {
   it("skips provider runtime normalization when lightweight policy proves the row canonical", async () => {
-    mocks.resolveProviderPolicySurface.mockReturnValueOnce({
+    mocks.resolveBundledProviderPolicySurface.mockReturnValueOnce({
       projectConfiguredModelRow: () => null,
     } as never);
     const rows: ModelRow[] = [];

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -5,6 +5,7 @@ import type { ModelRow } from "./list.types.js";
 
 const mocks = vi.hoisted(() => ({
   loadModelCatalogSnapshot: vi.fn(),
+  prepareScopedModelCatalog: vi.fn(),
   normalizeProviderResolvedModelWithPlugin: vi.fn(() => undefined),
   shouldSuppressBuiltInModel: vi.fn(() => {
     throw new Error("runtime model suppression should be skipped");
@@ -19,6 +20,10 @@ vi.mock("../../agents/model-suppression.js", () => ({
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogSnapshot: mocks.loadModelCatalogSnapshot,
+}));
+
+vi.mock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
+  prepareScopedReadOnlyModelCatalog: mocks.prepareScopedModelCatalog,
 }));
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
@@ -234,7 +239,7 @@ describe("appendPreparedModelCatalogRows", () => {
       provider: "anthropic",
       input: ["text"] as "text"[],
     };
-    mocks.loadModelCatalogSnapshot.mockResolvedValueOnce({
+    mocks.prepareScopedModelCatalog.mockResolvedValueOnce({
       entries: [entry],
       routeVariants: [entry],
     });
@@ -247,6 +252,7 @@ describe("appendPreparedModelCatalogRows", () => {
         cfg: {},
         agentId: "worker",
         agentDir: "/tmp/openclaw-worker",
+        inheritedAuthDir: "/tmp/openclaw-default",
         workspaceDir: "/tmp/openclaw-workspace",
         providerDiscoveryProviderIds: ["anthropic"],
         authIndex: {
@@ -260,14 +266,18 @@ describe("appendPreparedModelCatalogRows", () => {
     });
 
     expect(requireOnlyRow(rows).key).toBe("anthropic/claude-opus-4-7");
-    expect(mocks.loadModelCatalogSnapshot).toHaveBeenCalledExactlyOnceWith({
-      config: {},
-      agentId: "worker",
-      agentDir: "/tmp/openclaw-worker",
-      workspaceDir: "/tmp/openclaw-workspace",
-      providerDiscoveryProviderIds: ["anthropic"],
-      readOnly: true,
-    });
+    expect(mocks.prepareScopedModelCatalog).toHaveBeenCalledExactlyOnceWith(
+      {
+        config: {},
+        agentId: "worker",
+        agentDir: "/tmp/openclaw-worker",
+        inheritedAuthDir: "/tmp/openclaw-default",
+        workspaceDir: "/tmp/openclaw-workspace",
+        readOnly: true,
+      },
+      ["anthropic"],
+    );
+    expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
   });
 });
 
@@ -901,7 +911,7 @@ describe("appendAuthenticatedCatalogRows", () => {
         maxTokens: 4096,
       },
     ];
-    mocks.loadModelCatalogSnapshot.mockResolvedValueOnce({ entries, routeVariants: entries });
+    mocks.prepareScopedModelCatalog.mockResolvedValueOnce({ entries, routeVariants: entries });
     const rows: ModelRow[] = [];
 
     await appendAuthenticatedCatalogRows({
@@ -931,13 +941,16 @@ describe("appendAuthenticatedCatalogRows", () => {
       local: true,
       available: true,
     });
-    expect(mocks.loadModelCatalogSnapshot).toHaveBeenCalledWith({
-      config: {},
-      agentDir: "/tmp/openclaw-agent",
-      workspaceDir: "/tmp/openclaw-workspace",
-      providerDiscoveryProviderIds: ["local-openai"],
-      readOnly: true,
-    });
+    expect(mocks.prepareScopedModelCatalog).toHaveBeenCalledWith(
+      {
+        config: {},
+        agentDir: "/tmp/openclaw-agent",
+        inheritedAuthDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+        readOnly: true,
+      },
+      ["local-openai"],
+    );
   });
 
   it("still drops catalog rows with unresolved non-synthetic auth", async () => {

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -260,6 +260,7 @@ describe("appendPreparedModelCatalogRows", () => {
         inheritedAuthDir: "/tmp/openclaw-default",
         workspaceDir: "/tmp/openclaw-workspace",
         providerDiscoveryProviderIds: ["anthropic"],
+        providerRuntimeDiscoveryProviderIds: ["anthropic"],
         authIndex: {
           evaluateModelAuth: () => authEvaluation(true),
         },
@@ -278,6 +279,7 @@ describe("appendPreparedModelCatalogRows", () => {
       inheritedAuthDir: "/tmp/openclaw-default",
       workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["anthropic"],
+      runtimeProviderIds: ["anthropic"],
       configuredKeys: [],
     });
     expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
@@ -972,6 +974,7 @@ describe("appendAuthenticatedCatalogRows", () => {
         agentDir: "/tmp/openclaw-agent",
         workspaceDir: "/tmp/openclaw-workspace",
         providerDiscoveryProviderIds: ["local-openai"],
+        providerRuntimeDiscoveryProviderIds: ["local-openai"],
         authIndex: {
           evaluateModelAuth: () => ({
             availability: undefined,
@@ -997,6 +1000,7 @@ describe("appendAuthenticatedCatalogRows", () => {
       inheritedAuthDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["local-openai"],
+      runtimeProviderIds: ["local-openai"],
       configuredKeys: [],
     });
   });

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -261,6 +261,7 @@ describe("appendPreparedModelCatalogRows", () => {
         workspaceDir: "/tmp/openclaw-workspace",
         providerDiscoveryProviderIds: ["anthropic"],
         providerRuntimeDiscoveryProviderIds: ["anthropic"],
+        providerManifestFallbackProviderIds: ["anthropic"],
         authIndex: {
           evaluateModelAuth: () => authEvaluation(true),
         },
@@ -280,6 +281,7 @@ describe("appendPreparedModelCatalogRows", () => {
       workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["anthropic"],
       runtimeProviderIds: ["anthropic"],
+      manifestFallbackProviderIds: ["anthropic"],
       configuredKeys: [],
     });
     expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -37,6 +37,8 @@ import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 
 type ConfiguredByKey = Map<string, ConfiguredEntry>;
 type ModelCatalogModule = typeof import("../../agents/prepared-model-catalog.js");
+type ScopedModelCatalogModule =
+  typeof import("../../agents/prepared-model-runtime.scoped-catalog.js");
 type ModelResolverModule = typeof import("../../agents/embedded-agent-runner/model.js");
 
 type RowFilter = {
@@ -49,6 +51,7 @@ export type RowBuilderContext = {
   cfg: OpenClawConfig;
   agentId?: string;
   agentDir: string;
+  inheritedAuthDir?: string;
   authIndex: ModelListAuthIndex;
   providerDiscoveryProviderIds?: readonly string[];
   availableKeys?: Set<string>;
@@ -63,11 +66,18 @@ export type RowBuilderContext = {
 const modelCatalogModuleLoader = createLazyImportLoader<ModelCatalogModule>(
   () => import("../../agents/prepared-model-catalog.js"),
 );
+const scopedModelCatalogModuleLoader = createLazyImportLoader<ScopedModelCatalogModule>(
+  () => import("../../agents/prepared-model-runtime.scoped-catalog.js"),
+);
 const modelResolverModuleLoader = createLazyImportLoader<ModelResolverModule>(
   () => import("../../agents/embedded-agent-runner/model.js"),
 );
 function loadPreparedModelCatalogModule(): Promise<ModelCatalogModule> {
   return modelCatalogModuleLoader.load();
+}
+
+function loadScopedModelCatalogModule(): Promise<ScopedModelCatalogModule> {
+  return scopedModelCatalogModuleLoader.load();
 }
 
 function loadModelResolverModule(): Promise<ModelResolverModule> {
@@ -456,16 +466,27 @@ function toFallbackConfiguredListModel(
 export async function loadListModelCatalogSnapshot(
   context: RowBuilderContext,
 ): Promise<ModelCatalogSnapshot> {
-  const { loadPreparedModelCatalogSnapshot } = await loadPreparedModelCatalogModule();
   const workspaceDir = context.workspaceDir ?? context.metadataSnapshot?.workspaceDir;
+  if (context.providerDiscoveryProviderIds) {
+    const { prepareScopedReadOnlyModelCatalog } = await loadScopedModelCatalogModule();
+    return prepareScopedReadOnlyModelCatalog(
+      {
+        config: context.cfg,
+        ...(context.agentId ? { agentId: context.agentId } : {}),
+        agentDir: context.agentDir,
+        inheritedAuthDir: context.inheritedAuthDir ?? context.agentDir,
+        ...(workspaceDir ? { workspaceDir } : {}),
+        readOnly: true,
+      },
+      context.providerDiscoveryProviderIds,
+    );
+  }
+  const { loadPreparedModelCatalogSnapshot } = await loadPreparedModelCatalogModule();
   return loadPreparedModelCatalogSnapshot({
     config: context.cfg,
     ...(context.agentId ? { agentId: context.agentId } : {}),
     agentDir: context.agentDir,
     ...(workspaceDir ? { workspaceDir } : {}),
-    ...(context.providerDiscoveryProviderIds
-      ? { providerDiscoveryProviderIds: context.providerDiscoveryProviderIds }
-      : {}),
     readOnly: true,
   });
 }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -50,6 +50,7 @@ export type RowBuilderContext = {
   agentId?: string;
   agentDir: string;
   authIndex: ModelListAuthIndex;
+  providerDiscoveryProviderIds?: readonly string[];
   availableKeys?: Set<string>;
   configuredByKey: ConfiguredByKey;
   discoveredKeys: Set<string>;
@@ -462,6 +463,9 @@ export async function loadListModelCatalogSnapshot(
     ...(context.agentId ? { agentId: context.agentId } : {}),
     agentDir: context.agentDir,
     ...(workspaceDir ? { workspaceDir } : {}),
+    ...(context.providerDiscoveryProviderIds
+      ? { providerDiscoveryProviderIds: context.providerDiscoveryProviderIds }
+      : {}),
     readOnly: true,
   });
 }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -474,7 +474,12 @@ export async function loadListModelCatalogSnapshot(
     const { loadScopedListModelCatalogSnapshot } = await loadScopedModelCatalogModule();
     return loadScopedListModelCatalogSnapshot({
       cfg: context.cfg,
+      ...(context.agentId ? { agentId: context.agentId } : {}),
+      agentDir: context.agentDir,
+      inheritedAuthDir: context.inheritedAuthDir ?? context.agentDir,
+      ...(workspaceDir ? { workspaceDir } : {}),
       providerIds: context.providerDiscoveryProviderIds,
+      configuredKeys: [...context.configuredByKey.keys()],
       ...(context.metadataSnapshot ? { metadataSnapshot: context.metadataSnapshot } : {}),
     });
   }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -17,50 +17,23 @@ import {
 } from "../../agents/model-suppression.js";
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
-import type {
-  ModelListAuthEvaluation,
-  ModelListAuthIndex,
-  ModelListAuthRef,
-} from "./list.auth-index.js";
+import type { ModelListAuthEvaluation, ModelListAuthRef } from "./list.auth-index.js";
 import { isLocalBaseUrl } from "./list.local-url.js";
 import { normalizeConfiguredProviderListRow } from "./list.model-projection.js";
 import type { ListRowModel } from "./list.model-row.js";
 import { toModelRow } from "./list.model-row.js";
+import type { RowBuilderContext } from "./list.row-context.js";
 import type { ConfiguredEntry, ModelRow } from "./list.types.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 
-type ConfiguredByKey = Map<string, ConfiguredEntry>;
 type ModelCatalogModule = typeof import("../../agents/prepared-model-catalog.js");
 type ModelResolverModule = typeof import("../../agents/embedded-agent-runner/model.js");
 type ScopedModelCatalogModule = typeof import("./list.scoped-catalog.js");
 
-type RowFilter = {
-  provider?: string;
-  local?: boolean;
-};
-
-/** Context shared by every model-list row source builder. */
-export type RowBuilderContext = {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  agentDir: string;
-  inheritedAuthDir?: string;
-  authIndex: ModelListAuthIndex;
-  providerDiscoveryProviderIds?: readonly string[];
-  providerRuntimeDiscoveryProviderIds?: readonly string[];
-  availableKeys?: Set<string>;
-  configuredByKey: ConfiguredByKey;
-  discoveredKeys: Set<string>;
-  filter: RowFilter;
-  skipRuntimeModelSuppression?: boolean;
-  metadataSnapshot?: PluginMetadataSnapshot;
-  workspaceDir?: string;
-};
+export type { RowBuilderContext } from "./list.row-context.js";
 
 const modelCatalogModuleLoader = createLazyImportLoader<ModelCatalogModule>(
   () => import("../../agents/prepared-model-catalog.js"),

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -686,8 +686,6 @@ export async function appendConfiguredRows(params: {
       }
       continue;
     }
-    // Registry and catalog sources already carry canonical ids. Provider
-    // runtime normalization is reserved for explicit models.providers rows.
     await appendVisibleRow({
       rows: params.rows,
       model: resolvedModel,
@@ -695,6 +693,7 @@ export async function appendConfiguredRows(params: {
       context: params.context,
       ...(routeIndex ? { routeIndex } : {}),
       configuredEntry: entry,
+      normalizeWithProviderPlugin: true,
       allowAuthAvailabilityOverride: !params.context.discoveredKeys.has(
         modelKey(resolvedModel.provider, resolvedModel.id),
       ),

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -17,6 +17,7 @@ import {
 } from "../../agents/model-suppression.js";
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -52,6 +52,7 @@ export type RowBuilderContext = {
   inheritedAuthDir?: string;
   authIndex: ModelListAuthIndex;
   providerDiscoveryProviderIds?: readonly string[];
+  providerRuntimeDiscoveryProviderIds?: readonly string[];
   availableKeys?: Set<string>;
   configuredByKey: ConfiguredByKey;
   discoveredKeys: Set<string>;
@@ -440,6 +441,7 @@ export async function loadListModelCatalogSnapshot(
       inheritedAuthDir: context.inheritedAuthDir ?? context.agentDir,
       ...(workspaceDir ? { workspaceDir } : {}),
       providerIds: context.providerDiscoveryProviderIds,
+      runtimeProviderIds: context.providerRuntimeDiscoveryProviderIds,
       configuredKeys: [...context.configuredByKey.keys()],
       ...(context.metadataSnapshot ? { metadataSnapshot: context.metadataSnapshot } : {}),
     });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -21,7 +21,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type {
   ModelListAuthEvaluation,
@@ -29,6 +28,7 @@ import type {
   ModelListAuthRef,
 } from "./list.auth-index.js";
 import { isLocalBaseUrl } from "./list.local-url.js";
+import { normalizeConfiguredProviderListRow } from "./list.model-projection.js";
 import type { ListRowModel } from "./list.model-row.js";
 import { toModelRow } from "./list.model-row.js";
 import type { ConfiguredEntry, ModelRow } from "./list.types.js";
@@ -37,7 +37,6 @@ import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 type ConfiguredByKey = Map<string, ConfiguredEntry>;
 type ModelCatalogModule = typeof import("../../agents/prepared-model-catalog.js");
 type ModelResolverModule = typeof import("../../agents/embedded-agent-runner/model.js");
-type ProviderRuntimeModule = typeof import("../../plugins/provider-runtime.js");
 type ScopedModelCatalogModule = typeof import("./list.scoped-catalog.js");
 
 type RowFilter = {
@@ -70,9 +69,6 @@ const scopedModelCatalogModuleLoader = createLazyImportLoader<ScopedModelCatalog
 );
 const modelResolverModuleLoader = createLazyImportLoader<ModelResolverModule>(
   () => import("../../agents/embedded-agent-runner/model.js"),
-);
-const providerRuntimeModuleLoader = createLazyImportLoader<ProviderRuntimeModule>(
-  () => import("../../plugins/provider-runtime.js"),
 );
 function loadPreparedModelCatalogModule(): Promise<ModelCatalogModule> {
   return modelCatalogModuleLoader.load();
@@ -268,41 +264,6 @@ function shouldSuppressListModel(params: {
   });
 }
 
-async function normalizeListRowWithProviderPlugin(params: {
-  model: ListRowModel;
-  context: RowBuilderContext;
-}): Promise<ListRowModel> {
-  const { normalizeProviderResolvedModelWithPlugin } = await providerRuntimeModuleLoader.load();
-  const normalized = normalizeProviderResolvedModelWithPlugin({
-    provider: params.model.provider,
-    config: params.context.cfg,
-    workspaceDir: params.context.workspaceDir,
-    pluginMetadataSnapshot: params.context.metadataSnapshot,
-    context: {
-      config: params.context.cfg,
-      agentDir: params.context.agentDir,
-      workspaceDir: params.context.workspaceDir,
-      provider: params.model.provider,
-      modelId: params.model.id,
-      model: params.model as ProviderRuntimeModel,
-    },
-  });
-  if (!normalized) {
-    return params.model;
-  }
-  return {
-    ...params.model,
-    id: normalized.id,
-    name: normalized.name,
-    provider: normalized.provider,
-    api: normalized.api ?? params.model.api,
-    baseUrl: normalized.baseUrl ?? params.model.baseUrl,
-    input: toListRowInput(normalized.input),
-    contextWindow: normalized.contextWindow,
-    contextTokens: normalized.contextTokens,
-  };
-}
-
 async function appendVisibleRow(params: {
   rows: ModelRow[];
   model: ListRowModel;
@@ -320,7 +281,7 @@ async function appendVisibleRow(params: {
     return false;
   }
   const model = params.normalizeWithProviderPlugin
-    ? await normalizeListRowWithProviderPlugin({
+    ? await normalizeConfiguredProviderListRow({
         model: params.model,
         context: params.context,
       })

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -416,6 +416,7 @@ export async function loadListModelCatalogSnapshot(
       ...(workspaceDir ? { workspaceDir } : {}),
       providerIds: context.providerDiscoveryProviderIds,
       runtimeProviderIds: context.providerRuntimeDiscoveryProviderIds,
+      manifestFallbackProviderIds: context.providerManifestFallbackProviderIds,
       configuredKeys: [...context.configuredByKey.keys()],
       ...(context.metadataSnapshot ? { metadataSnapshot: context.metadataSnapshot } : {}),
     });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -22,7 +22,6 @@ import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
-import { normalizeProviderResolvedModelWithPlugin } from "../../plugins/provider-runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type {
   ModelListAuthEvaluation,
@@ -37,9 +36,9 @@ import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 
 type ConfiguredByKey = Map<string, ConfiguredEntry>;
 type ModelCatalogModule = typeof import("../../agents/prepared-model-catalog.js");
-type ScopedModelCatalogModule =
-  typeof import("../../agents/prepared-model-runtime.scoped-catalog.js");
 type ModelResolverModule = typeof import("../../agents/embedded-agent-runner/model.js");
+type ProviderRuntimeModule = typeof import("../../plugins/provider-runtime.js");
+type ScopedModelCatalogModule = typeof import("./list.scoped-catalog.js");
 
 type RowFilter = {
   provider?: string;
@@ -67,10 +66,13 @@ const modelCatalogModuleLoader = createLazyImportLoader<ModelCatalogModule>(
   () => import("../../agents/prepared-model-catalog.js"),
 );
 const scopedModelCatalogModuleLoader = createLazyImportLoader<ScopedModelCatalogModule>(
-  () => import("../../agents/prepared-model-runtime.scoped-catalog.js"),
+  () => import("./list.scoped-catalog.js"),
 );
 const modelResolverModuleLoader = createLazyImportLoader<ModelResolverModule>(
   () => import("../../agents/embedded-agent-runner/model.js"),
+);
+const providerRuntimeModuleLoader = createLazyImportLoader<ProviderRuntimeModule>(
+  () => import("../../plugins/provider-runtime.js"),
 );
 function loadPreparedModelCatalogModule(): Promise<ModelCatalogModule> {
   return modelCatalogModuleLoader.load();
@@ -266,10 +268,11 @@ function shouldSuppressListModel(params: {
   });
 }
 
-function normalizeListRowWithProviderPlugin(params: {
+async function normalizeListRowWithProviderPlugin(params: {
   model: ListRowModel;
   context: RowBuilderContext;
-}): ListRowModel {
+}): Promise<ListRowModel> {
+  const { normalizeProviderResolvedModelWithPlugin } = await providerRuntimeModuleLoader.load();
   const normalized = normalizeProviderResolvedModelWithPlugin({
     provider: params.model.provider,
     config: params.context.cfg,
@@ -317,7 +320,7 @@ async function appendVisibleRow(params: {
     return false;
   }
   const model = params.normalizeWithProviderPlugin
-    ? normalizeListRowWithProviderPlugin({
+    ? await normalizeListRowWithProviderPlugin({
         model: params.model,
         context: params.context,
       })
@@ -468,18 +471,12 @@ export async function loadListModelCatalogSnapshot(
 ): Promise<ModelCatalogSnapshot> {
   const workspaceDir = context.workspaceDir ?? context.metadataSnapshot?.workspaceDir;
   if (context.providerDiscoveryProviderIds) {
-    const { prepareScopedReadOnlyModelCatalog } = await loadScopedModelCatalogModule();
-    return prepareScopedReadOnlyModelCatalog(
-      {
-        config: context.cfg,
-        ...(context.agentId ? { agentId: context.agentId } : {}),
-        agentDir: context.agentDir,
-        inheritedAuthDir: context.inheritedAuthDir ?? context.agentDir,
-        ...(workspaceDir ? { workspaceDir } : {}),
-        readOnly: true,
-      },
-      context.providerDiscoveryProviderIds,
-    );
+    const { loadScopedListModelCatalogSnapshot } = await loadScopedModelCatalogModule();
+    return loadScopedListModelCatalogSnapshot({
+      cfg: context.cfg,
+      providerIds: context.providerDiscoveryProviderIds,
+      ...(context.metadataSnapshot ? { metadataSnapshot: context.metadataSnapshot } : {}),
+    });
   }
   const { loadPreparedModelCatalogSnapshot } = await loadPreparedModelCatalogModule();
   return loadPreparedModelCatalogSnapshot({
@@ -723,21 +720,17 @@ export async function appendConfiguredRows(params: {
       }
       continue;
     }
-    // Normalize before the availability decision so the discovered-keys check
-    // uses the same canonical key the registry rows carry.
-    const model = normalizeListRowWithProviderPlugin({
-      model: resolvedModel,
-      context: params.context,
-    });
+    // Registry and catalog sources already carry canonical ids. Provider
+    // runtime normalization is reserved for explicit models.providers rows.
     await appendVisibleRow({
       rows: params.rows,
-      model,
+      model: resolvedModel,
       key: entry.key,
       context: params.context,
       ...(routeIndex ? { routeIndex } : {}),
       configuredEntry: entry,
       allowAuthAvailabilityOverride: !params.context.discoveredKeys.has(
-        modelKey(model.provider, model.id),
+        modelKey(resolvedModel.provider, resolvedModel.id),
       ),
     });
   }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -9,6 +9,7 @@ import {
   resolveConfiguredModelCatalogOverrides,
 } from "../../agents/model-catalog-route.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import { modelKey } from "../../agents/model-ref-shared.js";
 import { modelCatalogLogicalKey } from "../../agents/model-selection-shared.js";
 import {
   shouldSuppressBuiltInModel,
@@ -33,7 +34,6 @@ import type { ListRowModel } from "./list.model-row.js";
 import { toModelRow } from "./list.model-row.js";
 import type { ConfiguredEntry, ModelRow } from "./list.types.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
-import { modelKey } from "./shared.js";
 
 type ConfiguredByKey = Map<string, ConfiguredEntry>;
 type ModelCatalogModule = typeof import("../../agents/prepared-model-catalog.js");

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -218,6 +218,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       },
       agentDir: "/tmp/openclaw-agent",
       providerIds: ["custom"],
+      runtimeProviderIds: ["custom"],
       configuredKeys: ["custom/custom-model"],
     });
 
@@ -225,6 +226,26 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       expect.objectContaining({ readOnly: true }),
       ["custom"],
     );
+  });
+
+  it("does not runtime-discover providers included only to enrich configured refs", async () => {
+    mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["google-antigravity"],
+      runtimeProviderIds: [],
+      configuredKeys: ["google-antigravity/claude-opus-4-6-thinking"],
+    });
+
+    expect(snapshot).toEqual({
+      entries: [],
+      routeVariants: [],
+      staticEntries: [],
+    });
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
   });
 
   it("falls back to scoped provider discovery only for providers with no lightweight rows", async () => {

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -3,11 +3,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   loadManifestCatalogRowsForList: vi.fn(),
   loadStaticManifestCatalogRowsForList: vi.fn(),
+  loadPersistedListCatalogEntries: vi.fn(),
+  prepareScopedReadOnlyModelCatalog: vi.fn(),
 }));
 
 vi.mock("./list.manifest-catalog.js", () => ({
   loadManifestCatalogRowsForList: mocks.loadManifestCatalogRowsForList,
   loadStaticManifestCatalogRowsForList: mocks.loadStaticManifestCatalogRowsForList,
+}));
+
+vi.mock("./list.persisted-catalog.js", () => ({
+  loadPersistedListCatalogEntries: mocks.loadPersistedListCatalogEntries,
+}));
+
+vi.mock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
+  prepareScopedReadOnlyModelCatalog: mocks.prepareScopedReadOnlyModelCatalog,
 }));
 
 import { loadScopedListModelCatalogSnapshot } from "./list.scoped-catalog.js";
@@ -43,23 +53,39 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.loadManifestCatalogRowsForList.mockReturnValue([runtimeRow, staticRow]);
   mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([staticRow]);
+  mocks.loadPersistedListCatalogEntries.mockReturnValue([]);
+  mocks.prepareScopedReadOnlyModelCatalog.mockResolvedValue({
+    entries: [],
+    routeVariants: [],
+  });
 });
 
 describe("loadScopedListModelCatalogSnapshot", () => {
-  it("returns an empty snapshot without loading manifest catalogs for an empty auth scope", () => {
-    expect(loadScopedListModelCatalogSnapshot({ cfg: {}, providerIds: [] })).toEqual({
+  it("returns an empty snapshot without loading catalog sources for an empty scope", async () => {
+    await expect(
+      loadScopedListModelCatalogSnapshot({
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+        providerIds: [],
+        configuredKeys: [],
+      }),
+    ).resolves.toEqual({
       entries: [],
       routeVariants: [],
       staticEntries: [],
     });
     expect(mocks.loadManifestCatalogRowsForList).not.toHaveBeenCalled();
     expect(mocks.loadStaticManifestCatalogRowsForList).not.toHaveBeenCalled();
+    expect(mocks.loadPersistedListCatalogEntries).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
   });
 
-  it("admits runtime manifest rows only for authenticated providers", () => {
-    const snapshot = loadScopedListModelCatalogSnapshot({
+  it("uses runtime manifest rows to enrich configured model ids", async () => {
+    const snapshot = await loadScopedListModelCatalogSnapshot({
       cfg: {},
+      agentDir: "/tmp/openclaw-agent",
       providerIds: ["openai"],
+      configuredKeys: ["openai/gpt-5.6"],
     });
 
     expect(snapshot.entries).toEqual([
@@ -72,17 +98,95 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     ]);
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
     expect(snapshot.staticEntries).toEqual([]);
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
   });
 
-  it("keeps static rows in the scoped snapshot", () => {
-    const snapshot = loadScopedListModelCatalogSnapshot({
+  it("keeps static rows in the scoped snapshot", async () => {
+    const snapshot = await loadScopedListModelCatalogSnapshot({
       cfg: {},
+      agentDir: "/tmp/openclaw-agent",
       providerIds: ["moonshot"],
+      configuredKeys: [],
     });
 
     expect(snapshot.entries).toEqual([
       expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6" }),
     ]);
     expect(snapshot.staticEntries).toEqual(snapshot.entries);
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("uses persisted runtime rows and manifest metadata without loading provider runtimes", async () => {
+    mocks.loadPersistedListCatalogEntries.mockReturnValueOnce([
+      {
+        provider: "openai",
+        id: "gpt-5.6",
+        name: "Account GPT-5.6",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+    ]);
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["openai"],
+      configuredKeys: [],
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.6",
+        name: "Account GPT-5.6",
+        api: "openai-chatgpt-responses",
+        contextWindow: 1_050_000,
+      }),
+    ]);
+    expect(snapshot.routeVariants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ api: "openai-chatgpt-responses" }),
+        expect.objectContaining({ api: "openai-responses" }),
+      ]),
+    );
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("falls back to scoped provider discovery only for providers with no lightweight rows", async () => {
+    const discovered = {
+      provider: "google",
+      id: "gemini-live",
+      name: "Gemini Live",
+      api: "google-generative-ai" as const,
+    };
+    mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.prepareScopedReadOnlyModelCatalog.mockResolvedValueOnce({
+      entries: [discovered],
+      routeVariants: [discovered],
+    });
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      agentId: "main",
+      agentDir: "/tmp/openclaw-agent",
+      inheritedAuthDir: "/tmp/openclaw-default",
+      workspaceDir: "/tmp/openclaw-workspace",
+      providerIds: ["google"],
+      configuredKeys: [],
+    });
+
+    expect(snapshot.entries).toEqual([discovered]);
+    expect(mocks.prepareScopedReadOnlyModelCatalog).toHaveBeenCalledWith(
+      {
+        config: {},
+        agentId: "main",
+        agentDir: "/tmp/openclaw-agent",
+        inheritedAuthDir: "/tmp/openclaw-default",
+        workspaceDir: "/tmp/openclaw-workspace",
+        readOnly: true,
+      },
+      ["google"],
+    );
   });
 });

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -152,6 +152,81 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("does not discover providers whose explicit models are emitted by the configured row source", async () => {
+    mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:3000/v1",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT-5.5",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["openai"],
+      configuredKeys: ["openai/gpt-5.5"],
+    });
+
+    expect(snapshot).toEqual({
+      entries: [],
+      routeVariants: [],
+      staticEntries: [],
+    });
+    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("still discovers configured providers without a listable API route", async () => {
+    mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
+
+    await loadScopedListModelCatalogSnapshot({
+      cfg: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "http://127.0.0.1:3000/v1",
+              models: [
+                {
+                  id: "custom-model",
+                  name: "Custom Model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["custom"],
+      configuredKeys: ["custom/custom-model"],
+    });
+
+    expect(mocks.prepareScopedReadOnlyModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      ["custom"],
+    );
+  });
+
   it("falls back to scoped provider discovery only for providers with no lightweight rows", async () => {
     const discovered = {
       provider: "google",

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadManifestCatalogRowsForList: vi.fn(),
+  loadStaticManifestCatalogRowsForList: vi.fn(),
+}));
+
+vi.mock("./list.manifest-catalog.js", () => ({
+  loadManifestCatalogRowsForList: mocks.loadManifestCatalogRowsForList,
+  loadStaticManifestCatalogRowsForList: mocks.loadStaticManifestCatalogRowsForList,
+}));
+
+import { loadScopedListModelCatalogSnapshot } from "./list.scoped-catalog.js";
+
+const runtimeRow = {
+  provider: "openai",
+  id: "gpt-5.6",
+  ref: "openai/gpt-5.6",
+  mergeKey: "openai::gpt-5.6",
+  name: "GPT-5.6",
+  source: "manifest" as const,
+  input: ["text", "image"] as const,
+  reasoning: true,
+  status: "available" as const,
+  api: "openai-responses" as const,
+  baseUrl: "https://api.openai.com/v1",
+  contextWindow: 1_050_000,
+};
+
+const staticRow = {
+  provider: "moonshot",
+  id: "kimi-k2.6",
+  ref: "moonshot/kimi-k2.6",
+  mergeKey: "moonshot::kimi-k2.6",
+  name: "Kimi K2.6",
+  source: "manifest" as const,
+  input: ["text"] as const,
+  reasoning: false,
+  status: "available" as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.loadManifestCatalogRowsForList.mockReturnValue([runtimeRow, staticRow]);
+  mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([staticRow]);
+});
+
+describe("loadScopedListModelCatalogSnapshot", () => {
+  it("returns an empty snapshot without loading manifest catalogs for an empty auth scope", () => {
+    expect(loadScopedListModelCatalogSnapshot({ cfg: {}, providerIds: [] })).toEqual({
+      entries: [],
+      routeVariants: [],
+      staticEntries: [],
+    });
+    expect(mocks.loadManifestCatalogRowsForList).not.toHaveBeenCalled();
+    expect(mocks.loadStaticManifestCatalogRowsForList).not.toHaveBeenCalled();
+  });
+
+  it("admits runtime manifest rows only for authenticated providers", () => {
+    const snapshot = loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      providerIds: ["openai"],
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.6",
+        api: "openai-responses",
+        contextWindow: 1_050_000,
+      }),
+    ]);
+    expect(snapshot.routeVariants).toEqual(snapshot.entries);
+    expect(snapshot.staticEntries).toEqual([]);
+  });
+
+  it("keeps static rows in the scoped snapshot", () => {
+    const snapshot = loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      providerIds: ["moonshot"],
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6" }),
+    ]);
+    expect(snapshot.staticEntries).toEqual(snapshot.entries);
+  });
+});

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -110,6 +110,29 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     );
   });
 
+  it("uses authenticated manifest fallback rows without loading provider runtime", async () => {
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["openai"],
+      runtimeProviderIds: [],
+      manifestFallbackProviderIds: ["openai"],
+      configuredKeys: [],
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.6",
+        api: "openai-responses",
+        contextWindow: 1_050_000,
+      }),
+    ]);
+    expect(snapshot.routeVariants).toEqual(snapshot.entries);
+    expect(snapshot.staticEntries).toEqual([]);
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("keeps static rows in the scoped snapshot", async () => {
     mocks.resolveManifestCatalogCoverageForList.mockReturnValueOnce({
       ownedProviderIds: new Set(["moonshot"]),

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -3,13 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   loadManifestCatalogRowsForList: vi.fn(),
   loadStaticManifestCatalogRowsForList: vi.fn(),
+  resolveManifestCatalogCoverageForList: vi.fn(),
   loadPersistedListCatalogEntries: vi.fn(),
-  prepareScopedReadOnlyModelCatalog: vi.fn(),
+  prepareScopedReadOnlyLiveModelCatalog: vi.fn(),
 }));
 
 vi.mock("./list.manifest-catalog.js", () => ({
   loadManifestCatalogRowsForList: mocks.loadManifestCatalogRowsForList,
   loadStaticManifestCatalogRowsForList: mocks.loadStaticManifestCatalogRowsForList,
+  resolveManifestCatalogCoverageForList: mocks.resolveManifestCatalogCoverageForList,
 }));
 
 vi.mock("./list.persisted-catalog.js", () => ({
@@ -17,7 +19,7 @@ vi.mock("./list.persisted-catalog.js", () => ({
 }));
 
 vi.mock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
-  prepareScopedReadOnlyModelCatalog: mocks.prepareScopedReadOnlyModelCatalog,
+  prepareScopedReadOnlyLiveModelCatalog: mocks.prepareScopedReadOnlyLiveModelCatalog,
 }));
 
 import { loadScopedListModelCatalogSnapshot } from "./list.scoped-catalog.js";
@@ -53,8 +55,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.loadManifestCatalogRowsForList.mockReturnValue([runtimeRow, staticRow]);
   mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([staticRow]);
+  mocks.resolveManifestCatalogCoverageForList.mockReturnValue({
+    ownedProviderIds: new Set(),
+    completeProviderIds: new Set(),
+  });
   mocks.loadPersistedListCatalogEntries.mockReturnValue([]);
-  mocks.prepareScopedReadOnlyModelCatalog.mockResolvedValue({
+  mocks.prepareScopedReadOnlyLiveModelCatalog.mockResolvedValue({
     entries: [],
     routeVariants: [],
   });
@@ -77,10 +83,10 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     expect(mocks.loadManifestCatalogRowsForList).not.toHaveBeenCalled();
     expect(mocks.loadStaticManifestCatalogRowsForList).not.toHaveBeenCalled();
     expect(mocks.loadPersistedListCatalogEntries).not.toHaveBeenCalled();
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).not.toHaveBeenCalled();
   });
 
-  it("uses runtime manifest rows to enrich configured model ids", async () => {
+  it("uses runtime manifest rows as seeds while retaining live provider discovery", async () => {
     const snapshot = await loadScopedListModelCatalogSnapshot({
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
@@ -98,10 +104,17 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     ]);
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
     expect(snapshot.staticEntries).toEqual([]);
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      ["openai"],
+    );
   });
 
   it("keeps static rows in the scoped snapshot", async () => {
+    mocks.resolveManifestCatalogCoverageForList.mockReturnValueOnce({
+      ownedProviderIds: new Set(["moonshot"]),
+      completeProviderIds: new Set(["moonshot"]),
+    });
     const snapshot = await loadScopedListModelCatalogSnapshot({
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
@@ -113,10 +126,10 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6" }),
     ]);
     expect(snapshot.staticEntries).toEqual(snapshot.entries);
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).not.toHaveBeenCalled();
   });
 
-  it("uses persisted runtime rows and manifest metadata without loading provider runtimes", async () => {
+  it("keeps persisted rows as seeds while adding runtime-only models", async () => {
     mocks.loadPersistedListCatalogEntries.mockReturnValueOnce([
       {
         provider: "openai",
@@ -126,6 +139,17 @@ describe("loadScopedListModelCatalogSnapshot", () => {
         baseUrl: "https://chatgpt.com/backend-api/codex",
       },
     ]);
+    mocks.prepareScopedReadOnlyLiveModelCatalog.mockResolvedValueOnce({
+      entries: [
+        {
+          provider: "openai",
+          id: "gpt-runtime-only",
+          name: "Runtime-only GPT",
+          api: "openai-responses",
+        },
+      ],
+      routeVariants: [],
+    });
 
     const snapshot = await loadScopedListModelCatalogSnapshot({
       cfg: {},
@@ -142,6 +166,10 @@ describe("loadScopedListModelCatalogSnapshot", () => {
         api: "openai-chatgpt-responses",
         contextWindow: 1_050_000,
       }),
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-runtime-only",
+      }),
     ]);
     expect(snapshot.routeVariants).toEqual(
       expect.arrayContaining([
@@ -149,10 +177,13 @@ describe("loadScopedListModelCatalogSnapshot", () => {
         expect.objectContaining({ api: "openai-responses" }),
       ]),
     );
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      ["openai"],
+    );
   });
 
-  it("does not discover providers whose explicit models are emitted by the configured row source", async () => {
+  it("does not discover unowned providers whose explicit models are emitted by the configured row source", async () => {
     mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
     mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
 
@@ -160,7 +191,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       cfg: {
         models: {
           providers: {
-            openai: {
+            custom: {
               baseUrl: "http://127.0.0.1:3000/v1",
               api: "openai-responses",
               models: [
@@ -179,8 +210,8 @@ describe("loadScopedListModelCatalogSnapshot", () => {
         },
       },
       agentDir: "/tmp/openclaw-agent",
-      providerIds: ["openai"],
-      configuredKeys: ["openai/gpt-5.5"],
+      providerIds: ["custom"],
+      configuredKeys: ["custom/gpt-5.5"],
     });
 
     expect(snapshot).toEqual({
@@ -188,7 +219,100 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       routeVariants: [],
       staticEntries: [],
     });
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("still discovers owned providers when explicit config contains only part of the catalog", async () => {
+    mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
+    mocks.resolveManifestCatalogCoverageForList.mockReturnValueOnce({
+      ownedProviderIds: new Set(["openai"]),
+      completeProviderIds: new Set(),
+    });
+    mocks.prepareScopedReadOnlyLiveModelCatalog.mockResolvedValueOnce({
+      entries: [
+        {
+          provider: "openai",
+          id: "gpt-runtime-only",
+          name: "Runtime-only GPT",
+          api: "openai-responses",
+        },
+      ],
+      routeVariants: [],
+    });
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "gpt-configured",
+                  name: "Configured GPT",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["openai"],
+      runtimeProviderIds: ["openai"],
+      configuredKeys: ["openai/gpt-configured"],
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({ provider: "openai", id: "gpt-runtime-only" }),
+    ]);
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      ["openai"],
+    );
+  });
+
+  it("runtime-augments partial static catalogs instead of hiding runtime-only rows", async () => {
+    mocks.resolveManifestCatalogCoverageForList.mockReturnValueOnce({
+      ownedProviderIds: new Set(["moonshot"]),
+      completeProviderIds: new Set(),
+    });
+    mocks.prepareScopedReadOnlyLiveModelCatalog.mockResolvedValueOnce({
+      entries: [
+        {
+          provider: "moonshot",
+          id: "kimi-runtime-only",
+          name: "Runtime-only Kimi",
+          api: "openai-completions",
+        },
+      ],
+      routeVariants: [],
+    });
+
+    const snapshot = await loadScopedListModelCatalogSnapshot({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      providerIds: ["moonshot"],
+      runtimeProviderIds: ["moonshot"],
+      configuredKeys: [],
+    });
+
+    expect(snapshot.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6" }),
+        expect.objectContaining({ provider: "moonshot", id: "kimi-runtime-only" }),
+      ]),
+    );
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      ["moonshot"],
+    );
   });
 
   it("still discovers configured providers without a listable API route", async () => {
@@ -222,7 +346,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       configuredKeys: ["custom/custom-model"],
     });
 
-    expect(mocks.prepareScopedReadOnlyModelCatalog).toHaveBeenCalledWith(
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
       expect.objectContaining({ readOnly: true }),
       ["custom"],
     );
@@ -245,7 +369,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       routeVariants: [],
       staticEntries: [],
     });
-    expect(mocks.prepareScopedReadOnlyModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).not.toHaveBeenCalled();
   });
 
   it("falls back to scoped provider discovery only for providers with no lightweight rows", async () => {
@@ -257,7 +381,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     };
     mocks.loadManifestCatalogRowsForList.mockReturnValueOnce([]);
     mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([]);
-    mocks.prepareScopedReadOnlyModelCatalog.mockResolvedValueOnce({
+    mocks.prepareScopedReadOnlyLiveModelCatalog.mockResolvedValueOnce({
       entries: [discovered],
       routeVariants: [discovered],
     });
@@ -273,7 +397,7 @@ describe("loadScopedListModelCatalogSnapshot", () => {
     });
 
     expect(snapshot.entries).toEqual([discovered]);
-    expect(mocks.prepareScopedReadOnlyModelCatalog).toHaveBeenCalledWith(
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog).toHaveBeenCalledWith(
       {
         config: {},
         agentId: "main",

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -150,6 +150,7 @@ export async function loadScopedListModelCatalogSnapshot(params: {
   workspaceDir?: string;
   providerIds: readonly string[];
   runtimeProviderIds?: readonly string[];
+  manifestFallbackProviderIds?: readonly string[];
   configuredKeys: readonly string[];
   metadataSnapshot?: PluginMetadataSnapshot;
 }): Promise<ModelCatalogSnapshot> {
@@ -167,6 +168,11 @@ export async function loadScopedListModelCatalogSnapshot(params: {
   ).map(toCatalogEntry);
   const manifestByKey = new Map(manifestEntries.map((entry) => [entryKey(entry), entry]));
   const configuredKeys = new Set(params.configuredKeys.map((key) => key.trim().toLowerCase()));
+  const manifestFallbackProviderIds = new Set(
+    (params.manifestFallbackProviderIds ?? [])
+      .map(normalizeProviderId)
+      .filter((provider) => providerIds.has(provider)),
+  );
   const staticEntries = selectProviderRows(
     loadStaticManifestCatalogRowsForList(loaderParams),
     providerIds,
@@ -187,7 +193,11 @@ export async function loadScopedListModelCatalogSnapshot(params: {
     admittedEntries.set(entryKey(entry), entry);
   }
   for (const entry of manifestEntries) {
-    if (configuredKeys.has(entryKey(entry)) && !admittedEntries.has(entryKey(entry))) {
+    if (
+      (configuredKeys.has(entryKey(entry)) ||
+        manifestFallbackProviderIds.has(normalizeProviderId(entry.provider))) &&
+      !admittedEntries.has(entryKey(entry))
+    ) {
       admittedEntries.set(entryKey(entry), entry);
     }
   }

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -9,6 +9,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   loadManifestCatalogRowsForList,
   loadStaticManifestCatalogRowsForList,
+  resolveManifestCatalogCoverageForList,
 } from "./list.manifest-catalog.js";
 
 type PersistedCatalogModule = typeof import("./list.persisted-catalog.js");
@@ -60,18 +61,20 @@ function routeKey(entry: ModelCatalogEntry): string {
 function resolveConfiguredProviderCoverage(
   cfg: OpenClawConfig,
   providerIds: ReadonlySet<string>,
+  ownedProviderIds: ReadonlySet<string>,
 ): ReadonlySet<string> {
   const coveredProviders = new Set<string>();
   for (const [provider, providerConfig] of Object.entries(cfg.models?.providers ?? {})) {
     const normalizedProvider = normalizeProviderId(provider);
     if (
       providerIds.has(normalizedProvider) &&
+      !ownedProviderIds.has(normalizedProvider) &&
       (providerConfig.models ?? []).some(
         (model) => providerConfig.api !== undefined || model.api !== undefined,
       )
     ) {
-      // Explicit provider rows are emitted by appendConfiguredProviderRows.
-      // Runtime discovery here would duplicate that source and load the full provider runtime.
+      // Unowned custom providers have no runtime catalog beyond their explicit rows.
+      // Plugin-owned providers remain discoverable unless models.mode is replace.
       coveredProviders.add(normalizedProvider);
     }
   }
@@ -174,6 +177,11 @@ export async function loadScopedListModelCatalogSnapshot(params: {
     providerIds,
     ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
   }).map((entry) => enrichPersistedEntry(entry, manifestByKey.get(entryKey(entry))));
+  const { ownedProviderIds, completeProviderIds } = resolveManifestCatalogCoverageForList({
+    cfg: params.cfg,
+    providerIds,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+  });
   const admittedEntries = new Map<string, ModelCatalogEntry>();
   for (const entry of [...staticEntries, ...persistedEntries]) {
     admittedEntries.set(entryKey(entry), entry);
@@ -196,8 +204,8 @@ export async function loadScopedListModelCatalogSnapshot(params: {
     staticEntries,
   };
   const coveredProviders = new Set([
-    ...lightweightSnapshot.entries.map((entry) => normalizeProviderId(entry.provider)),
-    ...resolveConfiguredProviderCoverage(params.cfg, providerIds),
+    ...completeProviderIds,
+    ...resolveConfiguredProviderCoverage(params.cfg, providerIds, ownedProviderIds),
   ]);
   const runtimeProviderIds = new Set(
     (params.runtimeProviderIds ?? params.providerIds)
@@ -210,8 +218,8 @@ export async function loadScopedListModelCatalogSnapshot(params: {
   if (uncoveredProviders.length === 0) {
     return mergeSnapshotEntries([lightweightSnapshot]);
   }
-  const { prepareScopedReadOnlyModelCatalog } = await preparedScopedCatalogModuleLoader.load();
-  const fallbackSnapshot = await prepareScopedReadOnlyModelCatalog(
+  const { prepareScopedReadOnlyLiveModelCatalog } = await preparedScopedCatalogModuleLoader.load();
+  const fallbackSnapshot = await prepareScopedReadOnlyLiveModelCatalog(
     {
       config: params.cfg,
       ...(params.agentId ? { agentId: params.agentId } : {}),

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -1,0 +1,65 @@
+import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
+/** Dependency-light model catalog snapshots for default model-list views. */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import {
+  loadManifestCatalogRowsForList,
+  loadStaticManifestCatalogRowsForList,
+} from "./list.manifest-catalog.js";
+
+function toCatalogEntry(row: NormalizedModelCatalogRow): ModelCatalogEntry {
+  return {
+    id: row.id,
+    name: row.name,
+    provider: row.provider,
+    api: row.api,
+    ...(row.baseUrl ? { baseUrl: row.baseUrl } : {}),
+    ...(row.contextWindow !== undefined ? { contextWindow: row.contextWindow } : {}),
+    ...(row.contextTokens !== undefined ? { contextTokens: row.contextTokens } : {}),
+    reasoning: row.reasoning,
+    input: [...row.input],
+    ...(row.compat ? { compat: row.compat } : {}),
+    ...(row.mediaInput ? { mediaInput: row.mediaInput } : {}),
+    status: row.status,
+    ...(row.statusReason ? { statusReason: row.statusReason } : {}),
+    ...(row.replaces ? { replaces: [...row.replaces] } : {}),
+    ...(row.replacedBy ? { replacedBy: row.replacedBy } : {}),
+  };
+}
+
+function selectProviderRows(
+  rows: readonly NormalizedModelCatalogRow[],
+  providerIds: ReadonlySet<string>,
+): NormalizedModelCatalogRow[] {
+  return rows.filter((row) => providerIds.has(normalizeProviderId(row.provider)));
+}
+
+/** Builds an auth-scoped snapshot from manifest metadata already loaded by the command. */
+export function loadScopedListModelCatalogSnapshot(params: {
+  cfg: OpenClawConfig;
+  providerIds: readonly string[];
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): ModelCatalogSnapshot {
+  const providerIds = new Set(params.providerIds.map(normalizeProviderId).filter(Boolean));
+  if (providerIds.size === 0) {
+    return { entries: [], routeVariants: [], staticEntries: [] };
+  }
+  const loaderParams = {
+    cfg: params.cfg,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+  };
+  const entries = selectProviderRows(loadManifestCatalogRowsForList(loaderParams), providerIds).map(
+    toCatalogEntry,
+  );
+  const staticEntries = selectProviderRows(
+    loadStaticManifestCatalogRowsForList(loaderParams),
+    providerIds,
+  ).map(toCatalogEntry);
+  return {
+    entries,
+    routeVariants: [...entries],
+    staticEntries,
+  };
+}

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -2,12 +2,25 @@ import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/mod
 /** Dependency-light model catalog snapshots for default model-list views. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import { modelKey } from "../../agents/model-ref-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   loadManifestCatalogRowsForList,
   loadStaticManifestCatalogRowsForList,
 } from "./list.manifest-catalog.js";
+
+type PersistedCatalogModule = typeof import("./list.persisted-catalog.js");
+type PreparedScopedCatalogModule =
+  typeof import("../../agents/prepared-model-runtime.scoped-catalog.js");
+
+const persistedCatalogModuleLoader = createLazyImportLoader<PersistedCatalogModule>(
+  () => import("./list.persisted-catalog.js"),
+);
+const preparedScopedCatalogModuleLoader = createLazyImportLoader<PreparedScopedCatalogModule>(
+  () => import("../../agents/prepared-model-runtime.scoped-catalog.js"),
+);
 
 function toCatalogEntry(row: NormalizedModelCatalogRow): ModelCatalogEntry {
   return {
@@ -36,12 +49,85 @@ function selectProviderRows(
   return rows.filter((row) => providerIds.has(normalizeProviderId(row.provider)));
 }
 
+function entryKey(entry: Pick<ModelCatalogEntry, "provider" | "id">): string {
+  return modelKey(normalizeProviderId(entry.provider), entry.id.trim().toLowerCase());
+}
+
+function routeKey(entry: ModelCatalogEntry): string {
+  return `${entryKey(entry)}\0${entry.api ?? ""}\0${entry.baseUrl ?? ""}`;
+}
+
+function enrichPersistedEntry(
+  entry: ModelCatalogEntry,
+  manifestEntry: ModelCatalogEntry | undefined,
+): ModelCatalogEntry {
+  if (!manifestEntry) {
+    return entry;
+  }
+  return {
+    ...manifestEntry,
+    ...entry,
+    name: entry.name || manifestEntry.name,
+    ...(entry.contextWindow === undefined && manifestEntry.contextWindow !== undefined
+      ? { contextWindow: manifestEntry.contextWindow }
+      : {}),
+    ...(entry.contextTokens === undefined && manifestEntry.contextTokens !== undefined
+      ? { contextTokens: manifestEntry.contextTokens }
+      : {}),
+    ...(entry.reasoning === undefined && manifestEntry.reasoning !== undefined
+      ? { reasoning: manifestEntry.reasoning }
+      : {}),
+    ...(entry.input === undefined && manifestEntry.input !== undefined
+      ? { input: manifestEntry.input }
+      : {}),
+  };
+}
+
+function mergeSnapshotEntries(snapshots: readonly ModelCatalogSnapshot[]): ModelCatalogSnapshot {
+  const entries = new Map<string, ModelCatalogEntry>();
+  const staticEntries = new Map<string, ModelCatalogEntry>();
+  const routeVariants = new Map<string, ModelCatalogEntry>();
+  for (const snapshot of snapshots) {
+    for (const entry of snapshot.entries) {
+      entries.set(entryKey(entry), entry);
+    }
+    for (const entry of snapshot.staticEntries ?? []) {
+      staticEntries.set(entryKey(entry), entry);
+    }
+    for (const entry of snapshot.routeVariants) {
+      routeVariants.set(routeKey(entry), entry);
+    }
+  }
+  return {
+    entries: [...entries.values()].toSorted(
+      (left, right) =>
+        left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
+    ),
+    routeVariants: [...routeVariants.values()].toSorted(
+      (left, right) =>
+        left.provider.localeCompare(right.provider) ||
+        left.id.localeCompare(right.id) ||
+        (left.api ?? "").localeCompare(right.api ?? "") ||
+        (left.baseUrl ?? "").localeCompare(right.baseUrl ?? ""),
+    ),
+    staticEntries: [...staticEntries.values()].toSorted(
+      (left, right) =>
+        left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
+    ),
+  };
+}
+
 /** Builds an auth-scoped snapshot from manifest metadata already loaded by the command. */
-export function loadScopedListModelCatalogSnapshot(params: {
+export async function loadScopedListModelCatalogSnapshot(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
+  agentDir: string;
+  inheritedAuthDir?: string;
+  workspaceDir?: string;
   providerIds: readonly string[];
+  configuredKeys: readonly string[];
   metadataSnapshot?: PluginMetadataSnapshot;
-}): ModelCatalogSnapshot {
+}): Promise<ModelCatalogSnapshot> {
   const providerIds = new Set(params.providerIds.map(normalizeProviderId).filter(Boolean));
   if (providerIds.size === 0) {
     return { entries: [], routeVariants: [], staticEntries: [] };
@@ -50,16 +136,61 @@ export function loadScopedListModelCatalogSnapshot(params: {
     cfg: params.cfg,
     ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
   };
-  const entries = selectProviderRows(loadManifestCatalogRowsForList(loaderParams), providerIds).map(
-    toCatalogEntry,
-  );
+  const manifestEntries = selectProviderRows(
+    loadManifestCatalogRowsForList(loaderParams),
+    providerIds,
+  ).map(toCatalogEntry);
+  const manifestByKey = new Map(manifestEntries.map((entry) => [entryKey(entry), entry]));
+  const configuredKeys = new Set(params.configuredKeys.map((key) => key.trim().toLowerCase()));
   const staticEntries = selectProviderRows(
     loadStaticManifestCatalogRowsForList(loaderParams),
     providerIds,
   ).map(toCatalogEntry);
-  return {
-    entries,
-    routeVariants: [...entries],
+  const { loadPersistedListCatalogEntries } = await persistedCatalogModuleLoader.load();
+  const persistedEntries = loadPersistedListCatalogEntries({
+    agentDir: params.agentDir,
+    providerIds,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+  }).map((entry) => enrichPersistedEntry(entry, manifestByKey.get(entryKey(entry))));
+  const admittedEntries = new Map<string, ModelCatalogEntry>();
+  for (const entry of [...staticEntries, ...persistedEntries]) {
+    admittedEntries.set(entryKey(entry), entry);
+  }
+  for (const entry of manifestEntries) {
+    if (configuredKeys.has(entryKey(entry)) && !admittedEntries.has(entryKey(entry))) {
+      admittedEntries.set(entryKey(entry), entry);
+    }
+  }
+  const admittedKeys = new Set(admittedEntries.keys());
+  const routeVariants = [...persistedEntries];
+  for (const entry of manifestEntries) {
+    if (admittedKeys.has(entryKey(entry))) {
+      routeVariants.push(entry);
+    }
+  }
+  const lightweightSnapshot: ModelCatalogSnapshot = {
+    entries: [...admittedEntries.values()],
+    routeVariants,
     staticEntries,
   };
+  const coveredProviders = new Set(
+    lightweightSnapshot.entries.map((entry) => normalizeProviderId(entry.provider)),
+  );
+  const uncoveredProviders = [...providerIds].filter((provider) => !coveredProviders.has(provider));
+  if (uncoveredProviders.length === 0) {
+    return mergeSnapshotEntries([lightweightSnapshot]);
+  }
+  const { prepareScopedReadOnlyModelCatalog } = await preparedScopedCatalogModuleLoader.load();
+  const fallbackSnapshot = await prepareScopedReadOnlyModelCatalog(
+    {
+      config: params.cfg,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      agentDir: params.agentDir,
+      inheritedAuthDir: params.inheritedAuthDir ?? params.agentDir,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      readOnly: true,
+    },
+    uncoveredProviders,
+  );
+  return mergeSnapshotEntries([lightweightSnapshot, fallbackSnapshot]);
 }

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -146,6 +146,7 @@ export async function loadScopedListModelCatalogSnapshot(params: {
   inheritedAuthDir?: string;
   workspaceDir?: string;
   providerIds: readonly string[];
+  runtimeProviderIds?: readonly string[];
   configuredKeys: readonly string[];
   metadataSnapshot?: PluginMetadataSnapshot;
 }): Promise<ModelCatalogSnapshot> {
@@ -198,7 +199,14 @@ export async function loadScopedListModelCatalogSnapshot(params: {
     ...lightweightSnapshot.entries.map((entry) => normalizeProviderId(entry.provider)),
     ...resolveConfiguredProviderCoverage(params.cfg, providerIds),
   ]);
-  const uncoveredProviders = [...providerIds].filter((provider) => !coveredProviders.has(provider));
+  const runtimeProviderIds = new Set(
+    (params.runtimeProviderIds ?? params.providerIds)
+      .map(normalizeProviderId)
+      .filter((provider) => providerIds.has(provider)),
+  );
+  const uncoveredProviders = [...runtimeProviderIds].filter(
+    (provider) => !coveredProviders.has(provider),
+  );
   if (uncoveredProviders.length === 0) {
     return mergeSnapshotEntries([lightweightSnapshot]);
   }

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -57,6 +57,27 @@ function routeKey(entry: ModelCatalogEntry): string {
   return `${entryKey(entry)}\0${entry.api ?? ""}\0${entry.baseUrl ?? ""}`;
 }
 
+function resolveConfiguredProviderCoverage(
+  cfg: OpenClawConfig,
+  providerIds: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const coveredProviders = new Set<string>();
+  for (const [provider, providerConfig] of Object.entries(cfg.models?.providers ?? {})) {
+    const normalizedProvider = normalizeProviderId(provider);
+    if (
+      providerIds.has(normalizedProvider) &&
+      (providerConfig.models ?? []).some(
+        (model) => providerConfig.api !== undefined || model.api !== undefined,
+      )
+    ) {
+      // Explicit provider rows are emitted by appendConfiguredProviderRows.
+      // Runtime discovery here would duplicate that source and load the full provider runtime.
+      coveredProviders.add(normalizedProvider);
+    }
+  }
+  return coveredProviders;
+}
+
 function enrichPersistedEntry(
   entry: ModelCatalogEntry,
   manifestEntry: ModelCatalogEntry | undefined,
@@ -173,9 +194,10 @@ export async function loadScopedListModelCatalogSnapshot(params: {
     routeVariants,
     staticEntries,
   };
-  const coveredProviders = new Set(
-    lightweightSnapshot.entries.map((entry) => normalizeProviderId(entry.provider)),
-  );
+  const coveredProviders = new Set([
+    ...lightweightSnapshot.entries.map((entry) => normalizeProviderId(entry.provider)),
+    ...resolveConfiguredProviderCoverage(params.cfg, providerIds),
+  ]);
   const uncoveredProviders = [...providerIds].filter((provider) => !coveredProviders.has(provider));
   if (uncoveredProviders.length === 0) {
     return mergeSnapshotEntries([lightweightSnapshot]);

--- a/src/commands/models/list.table.ts
+++ b/src/commands/models/list.table.ts
@@ -2,9 +2,8 @@
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { colorize, theme } from "../../../packages/terminal-core/src/theme.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
-import { formatTag, isRich, pad, truncate } from "./list.format.js";
+import { formatTag, formatTokenK, isRich, pad, truncate } from "./list.format.js";
 import type { ModelRow } from "./list.types.js";
-import { formatTokenK } from "./shared.js";
 
 const MODEL_PAD = 42;
 const INPUT_PAD = 10;

--- a/src/commands/models/provider-aliases.ts
+++ b/src/commands/models/provider-aliases.ts
@@ -1,7 +1,7 @@
 /** Provider alias canonicalization for model catalog rows. */
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeProviderId } from "../../agents/model-selection.js";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   loadPluginManifestRegistry,

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -1,7 +1,7 @@
 // Model command shared tests cover shared config and provider helper behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { formatTokenK, loadValidConfigOrThrow, updateConfig } from "./shared.js";
+import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -93,28 +93,5 @@ describe("models/shared", () => {
     const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
     expect(replaceParams?.nextConfig).toEqual(sourceConfig);
     expect(replaceParams?.baseHash).toBe("config-2");
-  });
-
-  describe("formatTokenK", () => {
-    // Token context windows are decimal, so round windows must not shrink
-    // (regression: /1024 rendered 200000 as "195k" instead of "200k").
-    it("renders round token context windows in decimal K", () => {
-      expect(formatTokenK(200_000)).toBe("200k");
-      expect(formatTokenK(128_000)).toBe("128k");
-      expect(formatTokenK(1_000_000)).toBe("1000k");
-      expect(formatTokenK(195_000)).toBe("195k");
-    });
-
-    it("passes small counts through and switches to K at 1000", () => {
-      expect(formatTokenK(999)).toBe("999");
-      expect(formatTokenK(1_000)).toBe("1k");
-    });
-
-    it("returns a dash for missing or non-finite values", () => {
-      expect(formatTokenK(undefined)).toBe("-");
-      expect(formatTokenK(null)).toBe("-");
-      expect(formatTokenK(0)).toBe("-");
-      expect(formatTokenK(Number.NaN)).toBe("-");
-    });
   });
 });

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -20,24 +20,8 @@ import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { canonicalizeModelCatalogProviderRef } from "./provider-aliases.js";
 
-export const ensureFlagCompatibility = (opts: { json?: boolean; plain?: boolean }) => {
-  if (opts.json && opts.plain) {
-    throw new Error("Choose either --json or --plain, not both.");
-  }
-};
-
-/** Formats token counts as compact K-suffixed labels. */
-export const formatTokenK = (value?: number | null) => {
-  if (!value || !Number.isFinite(value)) {
-    return "-";
-  }
-  // Token counts use decimal-K (/1000), matching formatTokenCount and how
-  // providers advertise context windows (e.g. 200000 -> "200k", not "195k").
-  if (value < 1000) {
-    return `${Math.round(value)}`;
-  }
-  return `${Math.round(value / 1000)}k`;
-};
+export { formatTokenK } from "./list.format.js";
+export { ensureFlagCompatibility } from "./list.options.js";
 
 /** Formats millisecond durations for model command output. */
 export const formatMs = (value?: number | null) => {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -16,7 +16,7 @@ import {
   type ModelAuthAvailabilityEvaluation,
   type ModelAuthAvailabilityResolver,
 } from "../../agents/model-auth-availability.js";
-import { hasSyntheticLocalProviderAuthConfig } from "../../agents/model-auth.js";
+import { hasSyntheticLocalProviderAuthConfig } from "../../agents/model-auth-provider-config.js";
 import {
   buildProviderConfigModelCatalogForBrowse,
   loadPreparedModelCatalogSnapshotForBrowse,

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -21,8 +21,8 @@ const { loadPluginRegistrySnapshotWithMetadata, loadPluginManifestRegistryForIns
     };
   });
 
-vi.mock("./plugin-registry.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./plugin-registry.js")>();
+vi.mock("./plugin-registry-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-registry-snapshot.js")>();
   return {
     ...actual,
     loadPluginRegistrySnapshotWithMetadata: (params: unknown) =>

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -23,7 +23,7 @@ import type {
   ResolvePluginMetadataSnapshotParams,
 } from "./plugin-metadata-snapshot.types.js";
 import { createPluginRegistryIdNormalizer } from "./plugin-registry-id-normalizer.js";
-import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
+import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
 
 const PLUGIN_METADATA_ENV_KEYS = [

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -1,5 +1,5 @@
 /** Control-plane provider discovery helpers that keep runtime imports lazy until catalog hooks run. */
-import { normalizeProviderId } from "../agents/model-selection.js";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -23,7 +23,6 @@ import {
 } from "./public-surface-loader.js";
 
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
-const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
 
 type ProviderProjectConfiguredModelRowContext = {
   config?: OpenClawConfig;
@@ -34,8 +33,8 @@ type ProviderProjectConfiguredModelRowContext = {
   model: ProviderRuntimeModel;
 };
 
-/** Provider policy hooks loaded from bundled plugin public artifacts. */
-export type BundledProviderPolicySurface = {
+/** Provider policy hooks supported by bundled and trusted official plugins. */
+export type ProviderPolicySurface = {
   normalizeConfig?: (ctx: ProviderNormalizeConfigContext) => ModelProviderConfig | null | undefined;
   applyConfigDefaults?: (
     ctx: ProviderApplyConfigDefaultsContext,
@@ -50,40 +49,70 @@ export type BundledProviderPolicySurface = {
   normalizeModelCatalogId?: (
     ctx: ProviderNormalizeModelCatalogIdContext,
   ) => string | null | undefined;
+};
+
+/** Provider policy hooks loaded only from bundled plugin public artifacts. */
+export type BundledProviderPolicySurface = ProviderPolicySurface & {
   projectConfiguredModelRow?: (
     ctx: ProviderProjectConfiguredModelRowContext,
   ) => ProviderRuntimeModel | null | undefined;
 };
 
-function hasProviderPolicyHook(
-  mod: Record<string, unknown>,
-): mod is Record<string, unknown> & BundledProviderPolicySurface {
-  return (
-    typeof mod.normalizeConfig === "function" ||
-    typeof mod.applyConfigDefaults === "function" ||
-    typeof mod.resolveConfigApiKey === "function" ||
-    typeof mod.resolveThinkingProfile === "function" ||
-    typeof mod.resolveModelRoutes === "function" ||
-    typeof mod.normalizeModelCatalogId === "function" ||
-    typeof mod.projectConfiguredModelRow === "function"
-  );
+const bundledProviderPolicySurfaceByPluginId = new Map<
+  string,
+  BundledProviderPolicySurface | null
+>();
+const externalProviderPolicySurfaceByPluginId = new Map<string, ProviderPolicySurface | null>();
+
+const PROVIDER_POLICY_HOOK_KEYS = [
+  "normalizeConfig",
+  "applyConfigDefaults",
+  "resolveConfigApiKey",
+  "resolveThinkingProfile",
+  "resolveModelRoutes",
+  "normalizeModelCatalogId",
+] as const satisfies readonly (keyof ProviderPolicySurface)[];
+
+function extractProviderPolicySurface(mod: Record<string, unknown>): ProviderPolicySurface | null {
+  const surface: ProviderPolicySurface = {};
+  for (const key of PROVIDER_POLICY_HOOK_KEYS) {
+    const hook = mod[key];
+    if (typeof hook === "function") {
+      Object.assign(surface, { [key]: hook });
+    }
+  }
+  return Object.keys(surface).length > 0 ? surface : null;
 }
 
-function resolveCachedProviderPolicySurface(params: {
+function extractBundledProviderPolicySurface(
+  mod: Record<string, unknown>,
+): BundledProviderPolicySurface | null {
+  const surface: BundledProviderPolicySurface = extractProviderPolicySurface(mod) ?? {};
+  if (typeof mod.projectConfiguredModelRow === "function") {
+    surface.projectConfiguredModelRow =
+      mod.projectConfiguredModelRow as BundledProviderPolicySurface["projectConfiguredModelRow"];
+  }
+  return Object.keys(surface).length > 0 ? surface : null;
+}
+
+function resolveCachedProviderPolicySurface<T extends ProviderPolicySurface>(params: {
+  cache: Map<string, T | null>;
   cacheKey: string;
   loadModule: (artifactBasename: string) => Record<string, unknown>;
   missingSurfacePrefix: string;
-}): BundledProviderPolicySurface | null {
-  const cached = providerPolicySurfaceByPluginId.get(params.cacheKey);
+  extractSurface: (mod: Record<string, unknown>) => T | null;
+}): T | null {
+  const cached = params.cache.get(params.cacheKey);
   if (cached !== undefined) {
     return cached;
   }
   for (const artifactBasename of PROVIDER_POLICY_ARTIFACT_CANDIDATES) {
     try {
       const mod = params.loadModule(artifactBasename);
-      if (hasProviderPolicyHook(mod)) {
-        providerPolicySurfaceByPluginId.set(params.cacheKey, mod);
-        return mod;
+      const surface = params.extractSurface(mod);
+      if (surface) {
+        params.cache.set(params.cacheKey, surface);
+        return surface;
       }
     } catch (error) {
       if (error instanceof Error && error.message.startsWith(params.missingSurfacePrefix)) {
@@ -92,7 +121,7 @@ function resolveCachedProviderPolicySurface(params: {
       throw error;
     }
   }
-  providerPolicySurfaceByPluginId.set(params.cacheKey, null);
+  params.cache.set(params.cacheKey, null);
   return null;
 }
 
@@ -112,6 +141,7 @@ export function resolveDirectBundledProviderPolicySurface(
     return null;
   }
   return resolveCachedProviderPolicySurface({
+    cache: bundledProviderPolicySurfaceByPluginId,
     cacheKey: `${resolveBundledPluginsDir() ?? ""}\0${pluginId}`,
     loadModule: (artifactBasename) =>
       loadBundledPluginPublicArtifactModuleSync<Record<string, unknown>>({
@@ -119,6 +149,7 @@ export function resolveDirectBundledProviderPolicySurface(
         artifactBasename,
       }),
     missingSurfacePrefix: "Unable to resolve bundled plugin public surface ",
+    extractSurface: extractBundledProviderPolicySurface,
   });
 }
 
@@ -127,11 +158,12 @@ export function resolveTrustedExternalProviderPolicySurface(params: {
   pluginId: string;
   pluginRoot: string;
   trustedOfficialInstall?: boolean;
-}): BundledProviderPolicySurface | null {
+}): ProviderPolicySurface | null {
   if (params.trustedOfficialInstall !== true) {
     return null;
   }
   return resolveCachedProviderPolicySurface({
+    cache: externalProviderPolicySurfaceByPluginId,
     cacheKey: `${params.pluginRoot}\0${params.pluginId}`,
     loadModule: (artifactBasename) =>
       loadPluginPublicArtifactModuleSync<Record<string, unknown>>({
@@ -139,5 +171,6 @@ export function resolveTrustedExternalProviderPolicySurface(params: {
         artifactBasename,
       }),
     missingSurfacePrefix: "Unable to resolve plugin public surface ",
+    extractSurface: extractProviderPolicySurface,
   });
 }

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -12,6 +12,7 @@ import type {
   ProviderNormalizeConfigContext,
   ProviderResolveConfigApiKeyContext,
 } from "./provider-config-context.types.js";
+import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
@@ -23,6 +24,15 @@ import {
 
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
 const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
+
+export type ProviderProjectConfiguredModelRowContext = {
+  config?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  provider: string;
+  modelId: string;
+  model: ProviderRuntimeModel;
+};
 
 /** Provider policy hooks loaded from bundled plugin public artifacts. */
 export type BundledProviderPolicySurface = {
@@ -40,6 +50,9 @@ export type BundledProviderPolicySurface = {
   normalizeModelCatalogId?: (
     ctx: ProviderNormalizeModelCatalogIdContext,
   ) => string | null | undefined;
+  projectConfiguredModelRow?: (
+    ctx: ProviderProjectConfiguredModelRowContext,
+  ) => ProviderRuntimeModel | null | undefined;
 };
 
 function hasProviderPolicyHook(
@@ -51,7 +64,8 @@ function hasProviderPolicyHook(
     typeof mod.resolveConfigApiKey === "function" ||
     typeof mod.resolveThinkingProfile === "function" ||
     typeof mod.resolveModelRoutes === "function" ||
-    typeof mod.normalizeModelCatalogId === "function"
+    typeof mod.normalizeModelCatalogId === "function" ||
+    typeof mod.projectConfiguredModelRow === "function"
   );
 }
 

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -25,7 +25,7 @@ import {
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
 const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
 
-export type ProviderProjectConfiguredModelRowContext = {
+type ProviderProjectConfiguredModelRowContext = {
   config?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -21,6 +21,7 @@ function writeExternalPolicyFixture(): string {
       '    ? { levels: [{ id: "off" }, { id: "high" }, { id: "max" }], defaultLevel: "off" }',
       '    : { levels: [{ id: "off" }, { id: "low", label: "on" }], defaultLevel: "off" };',
       "}",
+      "export function projectConfiguredModelRow() { return null; }",
       "",
     ].join("\n"),
     "utf8",
@@ -65,6 +66,7 @@ describe("provider public artifacts", () => {
   it("loads a lightweight bundled provider policy artifact smoke", () => {
     const surface = resolveBundledProviderPolicySurface("openai");
     expect(surface?.normalizeConfig).toBeTypeOf("function");
+    expect(surface?.projectConfiguredModelRow).toBeTypeOf("function");
 
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.openai.com/v1",
@@ -222,6 +224,7 @@ describe("provider public artifacts", () => {
           ?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "legacy" })
           ?.levels.map((level) => level.label),
       ).toEqual([undefined, "on"]);
+      expect(surface).not.toHaveProperty("projectConfiguredModelRow");
     } finally {
       restoreBundledPluginEnv();
       fs.rmSync(pluginRoot, { recursive: true, force: true });

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -7,6 +7,7 @@ import {
   resolveDirectBundledProviderPolicySurface,
   resolveTrustedExternalProviderPolicySurface,
   type BundledProviderPolicySurface,
+  type ProviderPolicySurface,
 } from "./provider-policy-surface.js";
 
 function resolveBundledProviderPolicyPlugin(
@@ -93,7 +94,7 @@ export function resolveBundledProviderPolicySurface(
 export function resolveProviderPolicySurface(
   providerId: string,
   options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
-): BundledProviderPolicySurface | null {
+): ProviderPolicySurface | null {
   const bundledSurface = resolveBundledProviderPolicySurface(providerId, options);
   if (bundledSurface) {
     return bundledSurface;


### PR DESCRIPTION
Related: #116920

## What Problem This Solves

The default `openclaw models list` path could exceed the release RSS budget because a read-only command activated every compatible bundled provider runtime, even when only a small provider set was configured or authenticated.

## Why This Change Was Made

The default unfiltered list now builds a lightweight scoped catalog from configured model references, provider config, stored credentials, concrete environment or external CLI auth, persisted catalog rows, provider-manifest rows, and synthetic-auth metadata.

Explicit `--provider <id>` retains provider-owned live discovery, while bare `--all` retains the complete catalog. The process-wide prepared runtime catalog remains complete; request-scoped projections are read-only.

Configured rows still use provider-owned runtime normalization unless the lightweight provider policy proves that normalization is a no-op. The OpenAI policy shares the runtime's authored provider-config resolver and defers to the runtime for provider-level non-Responses routes; authored model-level routes remain visible on the projected row and also defer to the runtime, including explicit `openai-completions`.

## User Impact

Default model listing performs substantially less startup work and memory allocation without hiding configured or authenticated models. Operators can still request live provider discovery or the exhaustive catalog explicitly.

## Evidence

- Final exact OpenClaw head: `31d55217113e661889a3ad39a77462d7ab36fb58`.
- Frozen latest-main baseline: `93d99bbb083b472f95951b7bb72f7494e5af5f82`; clean merge tree: `7ad6cf59d30a09444fabe1bfcb700f8ee02aa229`.
- Current-main follow-up: `83208eb4a96addc4d58f7d09d926634e7d93abd5`; clean merge tree: `bbdaf79cfa0993955351030aa7cfc20515e2d785`; zero touched-file overlap since the frozen baseline.
- 161 focused tests passed after rebasing onto current main across scoped catalog planning, row projection, configured list behavior, and the OpenAI provider runtime/policy surfaces.
- The configured-route regression proves that a Responses-tagged row still loads runtime normalization when effective provider or model config selects `openai-completions` or ChatGPT Responses.
- Exact synthetic-merge runtime artifact proof from CI run `30706599837` built commit `df238969e76cdcbe63c3de985a6956cbbed371ea` with parents current main `b83a966c056288adaef187e3e5826188d9f67724` and PR head `31d55217113e661889a3ad39a77462d7ab36fb58`. A terminal probe of the bundled OpenAI policy reported:
  - `provider_level_openai_completions=runtime-normalization-required`
  - `model_level_openai_completions=runtime-normalization-required`
  - `canonical_openai_responses=lightweight-projection`
- Targeted `oxfmt`, direct `oxlint`, `git diff --check`, the exact extension test typecheck, and autoreview passed. The local changed-check router could not acquire Crabbox/Testbox; exact GitHub CI is the authoritative broad gate.
- Direct sibling Codex source inspection at `openai/codex@bb1af235ea2822d7a40f75ef52e4d6a2cde84da2`:
  - `codex-rs/model-provider-info/src/lib.rs:35-60` confirms canonical provider id `openai` and Responses as the wire API.
  - `codex-rs/core/tests/suite/cli_stream.rs:73-78,155-164` confirms the configured OpenAI base URL routes to `/api/codex/responses`.
- Kova run `30705009279` on product head `10c9816b58f953799432f21e8c5c30b38bed8ccb` measured model-list RSS at 464.1, 467.0, and 463.3 MB, with a 467.0 MB maximum against the 650 MB limit. This was a 210.7 MB / 31.1% reduction from the compared main run.
- Final exact-head Kova release run `30706599924` completed successfully on `31d55217113e661889a3ad39a77462d7ab36fb58`: five mock-provider scenarios passed, the live OpenAI candidate passed, source probes passed, deep profiling passed, and artifact-only verification passed.
- Final exact-head GitHub CI: https://github.com/openclaw/openclaw/actions/runs/30706599837.
- Final exact-head Kova release proof: https://github.com/openclaw/openclaw/actions/runs/30706599924.
- `CHANGELOG.md` is intentionally unchanged because release notes are release-owned.
- No persistent data schema changes: the persisted-catalog path reads existing artifacts only and adds no state writer, SQLite schema, migration, or serialized compatibility surface.

## Merge Gate

Do not merge until exact-head GitHub CI is green and the durable exact-head ClawSweeper review has no unresolved `Before merge`, finding, security, owner-decision, merge-risk, or blocking rank-up item.
