### PR TITLE
feat(ci): relay guard reads through Octopool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /test/scripts/security-sensitive-guard-script.test.ts @openclaw/openclaw-secops
 /scripts/github/dependency-guard.mjs @openclaw/openclaw-secops
 /scripts/github/security-sensitive-guard.mjs @openclaw/openclaw-secops
+/scripts/github/octopool-read.mjs @openclaw/openclaw-secops
 /.gitignore @openclaw/openclaw-secops
 /package-lock.json @openclaw/openclaw-secops
 /extensions/*/package-lock.json @openclaw/openclaw-secops

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -33,6 +33,9 @@ jobs:
         id: guard
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OCTOPOOL_POOL: ${{ vars.OCTOPOOL_POOL }}
+          OCTOPOOL_TOKEN: ${{ secrets.OCTOPOOL_TOKEN }}
+          OCTOPOOL_URL: ${{ vars.OCTOPOOL_URL }}
           OPENCLAW_DEPENDENCY_GUARD_MODE: detect
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
           OPENCLAW_SECURITY_TEAM_SLUG: openclaw-secops
@@ -80,6 +83,9 @@ jobs:
       - name: Remove package lockfile changes
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OCTOPOOL_POOL: ${{ vars.OCTOPOOL_POOL }}
+          OCTOPOOL_TOKEN: ${{ secrets.OCTOPOOL_TOKEN }}
+          OCTOPOOL_URL: ${{ vars.OCTOPOOL_URL }}
           OPENCLAW_DEPENDENCY_GUARD_AUTOSCRUB_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
           OPENCLAW_DEPENDENCY_GUARD_MODE: autoscrub
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
@@ -103,6 +109,9 @@ jobs:
       - name: Enforce dependency guard
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OCTOPOOL_POOL: ${{ vars.OCTOPOOL_POOL }}
+          OCTOPOOL_TOKEN: ${{ secrets.OCTOPOOL_TOKEN }}
+          OCTOPOOL_URL: ${{ vars.OCTOPOOL_URL }}
           OPENCLAW_DEPENDENCY_GUARD_MODE: enforce
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
           OPENCLAW_SECURITY_TEAM_SLUG: openclaw-secops

--- a/.github/workflows/security-sensitive-guard.yml
+++ b/.github/workflows/security-sensitive-guard.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Detect security-sensitive changes
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OCTOPOOL_POOL: ${{ vars.OCTOPOOL_POOL }}
+          OCTOPOOL_TOKEN: ${{ secrets.OCTOPOOL_TOKEN }}
+          OCTOPOOL_URL: ${{ vars.OCTOPOOL_URL }}
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
           OPENCLAW_SECURITY_SENSITIVE_GUARD_MODE: detect
           OPENCLAW_SECURITY_TEAM_SLUG: openclaw-secops
@@ -49,6 +52,9 @@ jobs:
       - name: Enforce security-sensitive guard
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OCTOPOOL_POOL: ${{ vars.OCTOPOOL_POOL }}
+          OCTOPOOL_TOKEN: ${{ secrets.OCTOPOOL_TOKEN }}
+          OCTOPOOL_URL: ${{ vars.OCTOPOOL_URL }}
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
           OPENCLAW_SECURITY_SENSITIVE_GUARD_MODE: enforce
           OPENCLAW_SECURITY_TEAM_SLUG: openclaw-secops

--- a/scripts/github/dependency-guard.d.mts
+++ b/scripts/github/dependency-guard.d.mts
@@ -97,10 +97,23 @@ export function githubApi(
   token: string,
   options?: {
     fetchImpl?: typeof fetch;
+    readTransport?: {
+      supports(path: string): boolean;
+      get(
+        path: string,
+        options?: {
+          routeHint?: { pr_head_sha: string };
+          signal?: AbortSignal;
+        },
+      ): Promise<unknown>;
+    };
     responseMaxBodyBytes?: number;
     retryDelaysMs?: readonly number[];
     timeoutMs?: number;
   },
-): { request(path: string, options?: Record<string, unknown>): Promise<unknown> };
+): {
+  request(path: string, options?: Record<string, unknown>): Promise<unknown>;
+  paginate(path: string, options?: Record<string, unknown>): Promise<unknown[]>;
+};
 export function createAutoscrubCommit(...args: unknown[]): Promise<unknown>;
 export function readBoundedGitHubErrorText(...args: unknown[]): Promise<string>;

--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -16,6 +16,7 @@ import {
   readBoundedGitHubErrorText,
   readBoundedGitHubJson,
 } from "./guard-shared.mjs";
+import { createOctopoolReadClientFromEnv } from "./octopool-read.mjs";
 
 /** Marker used to identify dependency guard comments. */
 const dependencyChangeMarker = "<!-- openclaw:dependency-guard -->";
@@ -456,7 +457,11 @@ function renderManifestChangeLine(change) {
 }
 
 export function githubApi(token, options = {}) {
-  const api = createGitHubApi(token, { ...options, userAgent: "openclaw-dependency-guard" });
+  const api = createGitHubApi(token, {
+    ...options,
+    readTransport: options.readTransport ?? createOctopoolReadClientFromEnv(),
+    userAgent: "openclaw-dependency-guard",
+  });
   return {
     ...api,
     graphql: async (query, variables) => {
@@ -651,7 +656,9 @@ async function main() {
   const pullPath = `/repos/${owner}/${repo}/pulls/${eventPullRequest.number}`;
   const pullRequest = await api.request(pullPath);
   const mode = process.env.OPENCLAW_DEPENDENCY_GUARD_MODE ?? "enforce";
-  const files = await api.paginate(`${pullPath}/files`);
+  const files = await api.paginate(`${pullPath}/files`, {
+    routeHint: { pr_head_sha: pullRequest.head?.sha },
+  });
   const dependencyFiles = files
     .map((file) => file.filename)
     .filter((filename) => typeof filename === "string" && isDependencyFile(filename))

--- a/scripts/github/guard-shared.mjs
+++ b/scripts/github/guard-shared.mjs
@@ -7,6 +7,7 @@ export const GITHUB_API_REQUEST_TIMEOUT_MS = 30_000;
 
 const githubApiRetryStatuses = new Set([502, 503, 504]);
 const githubApiRetryDelaysMs = [1_000, 2_000, 4_000];
+const githubPaginationMaxPages = 100;
 
 export function guardTrustedActorCandidates({ pullRequest, event, currentHeadSha }) {
   const eventHeadSha = event?.pull_request?.head?.sha;
@@ -236,6 +237,7 @@ export function createGitHubApi(token, options = {}) {
   const timeoutMs = options.timeoutMs ?? GITHUB_API_REQUEST_TIMEOUT_MS;
   const retryDelaysMs = options.retryDelaysMs ?? githubApiRetryDelaysMs;
   const responseMaxBodyBytes = options.responseMaxBodyBytes ?? GITHUB_RESPONSE_BODY_MAX_BYTES;
+  const readTransport = options.readTransport;
   const baseHeaders = {
     accept: "application/vnd.github+json",
     authorization: `Bearer ${token}`,
@@ -244,6 +246,8 @@ export function createGitHubApi(token, options = {}) {
   };
   const request = async (path, requestOptions = {}) => {
     const method = (requestOptions.method ?? "GET").toUpperCase();
+    const { routeHint, ...fetchOptions } = requestOptions;
+    const useReadTransport = method === "GET" && readTransport?.supports(path);
     const timeoutController = new AbortController();
     const requestSignal = combineAbortSignals([requestOptions.signal, timeoutController.signal]);
     let timeout;
@@ -256,10 +260,24 @@ export function createGitHubApi(token, options = {}) {
     });
     const operationPromise = (async () => {
       for (let attempt = 0; ; attempt += 1) {
+        if (useReadTransport) {
+          try {
+            return await readTransport.get(path, {
+              routeHint,
+              signal: requestSignal,
+            });
+          } catch (error) {
+            if (githubApiRetryStatuses.has(error?.status) && attempt < retryDelaysMs.length) {
+              await wait(retryDelaysMs[attempt], undefined, { signal: requestSignal });
+              continue;
+            }
+            throw error;
+          }
+        }
         const response = await fetchImpl(`https://api.github.com${path}`, {
-          ...requestOptions,
+          ...fetchOptions,
           signal: requestSignal,
-          headers: { ...baseHeaders, ...requestOptions.headers },
+          headers: { ...baseHeaders, ...fetchOptions.headers },
         });
         if (response.status === 204) {
           return null;
@@ -302,16 +320,25 @@ export function createGitHubApi(token, options = {}) {
   };
   return {
     request,
-    paginate: async (path) => {
+    paginate: async (path, paginateOptions = {}) => {
       const items = [];
-      for (let page = 1; ; page += 1) {
+      for (let page = 1; page <= githubPaginationMaxPages; page += 1) {
         const separator = path.includes("?") ? "&" : "?";
-        const pageItems = await request(`${path}${separator}per_page=100&page=${page}`);
+        const pageItems = await request(
+          `${path}${separator}per_page=100&page=${page}`,
+          paginateOptions,
+        );
+        if (!Array.isArray(pageItems)) {
+          throw new Error(`GitHub API returned a non-array page for ${path}.`);
+        }
         items.push(...pageItems);
         if (pageItems.length < 100) {
           return items;
         }
       }
+      throw new Error(
+        `GitHub API pagination exceeded ${githubPaginationMaxPages} pages for ${path}.`,
+      );
     },
   };
 }

--- a/scripts/github/octopool-read.d.mts
+++ b/scripts/github/octopool-read.d.mts
@@ -1,0 +1,16 @@
+export function createOctopoolReadClient(options: {
+  url: string;
+  pool: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): {
+  supports(path: string): boolean;
+  get(
+    path: string,
+    options?: { routeHint?: { pr_head_sha: string }; signal?: AbortSignal },
+  ): Promise<unknown>;
+};
+export function createOctopoolReadClientFromEnv(
+  environment?: NodeJS.ProcessEnv,
+  options?: { fetchImpl?: typeof fetch },
+): ReturnType<typeof createOctopoolReadClient> | null;

--- a/scripts/github/octopool-read.mjs
+++ b/scripts/github/octopool-read.mjs
@@ -1,0 +1,138 @@
+// Direct Octopool transport for the guards' compatible GitHub REST reads.
+import { readBoundedResponseText } from "../lib/bounded-response.mjs";
+
+const octopoolResponseMaxBytes = 1024 * 1024;
+const guardReadRoutes = [
+  /^\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/u,
+  /^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/files$/u,
+  /^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/comments$/u,
+  /^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/labels$/u,
+  /^\/repos\/[^/]+\/[^/]+\/contents\/.+$/u,
+  /^\/repos\/[^/]+\/[^/]+\/git\/blobs\/[0-9a-f]+$/iu,
+];
+
+function required(value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} is required for Octopool GitHub reads.`);
+  }
+  return value.trim();
+}
+
+function parseGuardReadPath(path) {
+  if (
+    typeof path !== "string" ||
+    !path.startsWith("/") ||
+    path.includes("://") ||
+    path.includes("\\") ||
+    path.includes("#") ||
+    /(?:^|\/)\.{1,2}(?:\/|$)/u.test(path) ||
+    /%(?:2e|5c)/iu.test(path)
+  ) {
+    return null;
+  }
+  const url = new URL(path, "https://api.github.com");
+  if (!guardReadRoutes.some((route) => route.test(url.pathname))) {
+    return null;
+  }
+  const query = Object.fromEntries(url.searchParams);
+  return {
+    path: url.pathname,
+    ...(Object.keys(query).length > 0 ? { query } : {}),
+  };
+}
+
+function relayError(path, status) {
+  const error = new Error(`Octopool GET ${path} failed with ${status}.`);
+  error.status = status;
+  return error;
+}
+
+export function createOctopoolReadClient({ url, pool, token, fetchImpl = fetch } = {}) {
+  const baseUrl = new URL(required(url, "OCTOPOOL_URL"));
+  if (
+    baseUrl.protocol !== "https:" ||
+    baseUrl.username ||
+    baseUrl.password ||
+    baseUrl.search ||
+    baseUrl.hash
+  ) {
+    throw new Error("OCTOPOOL_URL must be an https origin.");
+  }
+  const endpoint = new URL("/v1/github/request", baseUrl);
+  const relayPool = required(pool, "OCTOPOOL_POOL");
+  const relayToken = required(token, "OCTOPOOL_TOKEN");
+
+  return {
+    supports: (path) => parseGuardReadPath(path) !== null,
+    async get(path, { routeHint, signal } = {}) {
+      const request = parseGuardReadPath(path);
+      if (!request) {
+        throw new Error(`Octopool does not allow GitHub route: ${path}`);
+      }
+      if (
+        routeHint !== undefined &&
+        (!/\/pulls\/\d+\/files$/u.test(request.path) ||
+          !/^[a-f0-9]{40}$/iu.test(routeHint.pr_head_sha ?? ""))
+      ) {
+        throw new Error("Octopool pr_head_sha is valid only for pull-request file reads.");
+      }
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        signal,
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${relayToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          pool: relayPool,
+          method: "GET",
+          ...request,
+          headers: {
+            accept: "application/vnd.github+json",
+            "x-github-api-version": "2022-11-28",
+          },
+          ...(routeHint === undefined ? {} : { route_hint: routeHint }),
+        }),
+      });
+      let envelope;
+      try {
+        envelope = JSON.parse(
+          await readBoundedResponseText(response, "Octopool", octopoolResponseMaxBytes, { signal }),
+        );
+      } catch {
+        if (!response.ok) {
+          throw relayError(request.path, response.status);
+        }
+        throw new Error(`Octopool returned an invalid response for ${request.path}.`);
+      }
+      if (!envelope || typeof envelope !== "object" || !Number.isInteger(envelope.status)) {
+        throw new Error(`Octopool returned an invalid response for ${request.path}.`);
+      }
+      if (!response.ok || envelope.status < 200 || envelope.status >= 300) {
+        throw relayError(request.path, envelope.status);
+      }
+      if (envelope.body_encoding !== "json") {
+        throw new Error(`Octopool returned non-JSON data for ${request.path}.`);
+      }
+      const relay = envelope.relay ?? {};
+      console.info(
+        `Octopool GET ${request.path}: status=${envelope.status} route=${relay.route_kind ?? "unknown"} cache=${relay.cache ?? "unknown"}`,
+      );
+      return envelope.body;
+    },
+  };
+}
+
+export function createOctopoolReadClientFromEnv(environment = process.env, options = {}) {
+  const values = [environment.OCTOPOOL_URL, environment.OCTOPOOL_POOL, environment.OCTOPOOL_TOKEN];
+  if (values.every((value) => value === undefined)) {
+    return null;
+  }
+  return createOctopoolReadClient({
+    url: environment.OCTOPOOL_URL,
+    pool: environment.OCTOPOOL_POOL,
+    token: environment.OCTOPOOL_TOKEN,
+    ...options,
+  });
+}

--- a/scripts/github/security-sensitive-guard.mjs
+++ b/scripts/github/security-sensitive-guard.mjs
@@ -16,6 +16,7 @@ import {
   readBoundedGitHubErrorText,
   readBoundedGitHubJson,
 } from "./guard-shared.mjs";
+import { createOctopoolReadClientFromEnv } from "./octopool-read.mjs";
 
 /** Marker used to identify security-sensitive guard comments. */
 export const securitySensitiveGuardMarker = "<!-- openclaw:security-sensitive-guard -->";
@@ -323,6 +324,7 @@ export async function findTrustedSecuritySensitiveGuardActor({
 export function githubApi(token, options = {}) {
   return createGitHubApi(token, {
     ...options,
+    readTransport: options.readTransport ?? createOctopoolReadClientFromEnv(),
     userAgent: "openclaw-security-sensitive-guard",
   });
 }
@@ -360,7 +362,9 @@ async function main() {
   const pullPath = `/repos/${owner}/${repo}/pulls/${eventPullRequest.number}`;
   const pullRequest = await api.request(pullPath);
   const mode = process.env.OPENCLAW_SECURITY_SENSITIVE_GUARD_MODE ?? "enforce";
-  const files = await api.paginate(`${pullPath}/files`);
+  const files = await api.paginate(`${pullPath}/files`, {
+    routeHint: { pr_head_sha: pullRequest.head?.sha },
+  });
   const securitySensitiveChanges = collectSecuritySensitiveChanges(files);
 
   const [comments, labels] = await Promise.all([

--- a/test/scripts/dependency-guard-script.test.ts
+++ b/test/scripts/dependency-guard-script.test.ts
@@ -31,6 +31,7 @@ import {
   securityApproverSet,
   shouldAutoscrubDependencyLockfiles,
 } from "../../scripts/github/dependency-guard.mjs";
+import { createOctopoolReadClient } from "../../scripts/github/octopool-read.mjs";
 
 const headSha = "a".repeat(40);
 const staleSha = "b".repeat(40);
@@ -682,6 +683,108 @@ describe("dependency guard script", () => {
       ),
     ).resolves.toEqual({ ok: true });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("relays only allowlisted guard GETs and keeps writes on the native client", async () => {
+    const readTransport = {
+      get: vi.fn().mockResolvedValue({ number: 1 }),
+      supports: vi.fn((path) => path === "/repos/openclaw/openclaw/pulls/1"),
+    };
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ ok: true }));
+    const api = githubApi("token", { fetchImpl, readTransport });
+
+    await expect(api.request("/repos/openclaw/openclaw/pulls/1")).resolves.toEqual({
+      number: 1,
+    });
+    await expect(
+      api.request("/repos/openclaw/openclaw/issues/1/comments", { method: "POST", body: "{}" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(readTransport.get).toHaveBeenCalledWith("/repos/openclaw/openclaw/pulls/1", {
+      routeHint: undefined,
+      signal: expect.any(AbortSignal),
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/repos/openclaw/openclaw/issues/1/comments",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("passes the immutable head SHA to relay-backed PR file pagination", async () => {
+    const readTransport = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce(Array.from({ length: 100 }, () => ({ filename: "a.ts" })))
+        .mockResolvedValueOnce([]),
+      supports: vi.fn().mockReturnValue(true),
+    };
+    const api = githubApi("token", { readTransport });
+
+    await expect(
+      api.paginate("/repos/openclaw/openclaw/pulls/1/files", {
+        routeHint: { pr_head_sha: headSha },
+      }),
+    ).resolves.toHaveLength(100);
+    expect(readTransport.get).toHaveBeenNthCalledWith(
+      1,
+      "/repos/openclaw/openclaw/pulls/1/files?per_page=100&page=1",
+      {
+        routeHint: { pr_head_sha: headSha },
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+
+  it("retries transient relay failures without falling back to native GitHub reads", async () => {
+    const unavailable = Object.assign(new Error("unavailable"), { status: 503 });
+    const readTransport = {
+      get: vi.fn().mockRejectedValueOnce(unavailable).mockResolvedValueOnce({ number: 1 }),
+      supports: vi.fn().mockReturnValue(true),
+    };
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      githubApi("token", { fetchImpl, readTransport, retryDelaysMs: [0] }).request(
+        "/repos/openclaw/openclaw/pulls/1",
+      ),
+    ).resolves.toEqual({ number: 1 });
+    expect(readTransport.get).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("sends an allowlisted guard read through the Octopool GET relay", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json({
+        status: 200,
+        body: [{ filename: "a.ts" }],
+        body_encoding: "json",
+        relay: { cache: "hit", route_kind: "pr_files" },
+      }),
+    );
+    const client = createOctopoolReadClient({
+      url: "https://octopool.example.test",
+      pool: "maintainers",
+      token: "relay-token",
+      fetchImpl,
+    });
+
+    await expect(
+      client.get("/repos/openclaw/openclaw/pulls/1/files?per_page=100", {
+        routeHint: { pr_head_sha: headSha },
+      }),
+    ).resolves.toEqual([{ filename: "a.ts" }]);
+
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toEqual({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/1/files",
+      query: { per_page: "100" },
+      headers: {
+        accept: "application/vnd.github+json",
+        "x-github-api-version": "2022-11-28",
+      },
+      route_hint: { pr_head_sha: headSha },
+    });
   });
 
   it("does not retry non-idempotent GitHub API requests", async () => {

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -138,6 +138,7 @@ describe("dependency guard workflow", () => {
     const autoscrubRunStep = workflowStep(autoscrubSteps, 3, "dependency guard autoscrub run step");
     const finalRunStep = workflowStep(finalSteps, 1, "dependency guard final run step");
     expect(detectRunStep.env?.OPENCLAW_DEPENDENCY_GUARD_MODE).toBe("detect");
+    expect(detectRunStep.env?.OCTOPOOL_TOKEN).toBe("${{ secrets.OCTOPOOL_TOKEN }}");
     expect(primaryTokenStep.uses).toBe(
       "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
     );
@@ -163,7 +164,9 @@ describe("dependency guard workflow", () => {
       "${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}",
     );
     expect(autoscrubRunStep.env?.OPENCLAW_DEPENDENCY_GUARD_MODE).toBe("autoscrub");
+    expect(autoscrubRunStep.env?.OCTOPOOL_TOKEN).toBe("${{ secrets.OCTOPOOL_TOKEN }}");
     expect(finalRunStep.env?.OPENCLAW_DEPENDENCY_GUARD_MODE).toBe("enforce");
+    expect(finalRunStep.env?.OCTOPOOL_TOKEN).toBe("${{ secrets.OCTOPOOL_TOKEN }}");
   });
 
   it("preserves dependency-guard as the final required check", () => {

--- a/test/scripts/security-sensitive-guard-workflow.test.ts
+++ b/test/scripts/security-sensitive-guard-workflow.test.ts
@@ -99,7 +99,9 @@ describe("security-sensitive guard workflow", () => {
     expect(finalJob?.needs).toEqual(["security-sensitive-guard-detect"]);
     expect(finalJob?.if).toContain("always()");
     expect(detectSteps.at(-1)?.env?.OPENCLAW_SECURITY_SENSITIVE_GUARD_MODE).toBe("detect");
+    expect(detectSteps.at(-1)?.env?.OCTOPOOL_TOKEN).toBe("${{ secrets.OCTOPOOL_TOKEN }}");
     expect(finalSteps.at(-1)?.env?.OPENCLAW_SECURITY_SENSITIVE_GUARD_MODE).toBe("enforce");
+    expect(finalSteps.at(-1)?.env?.OCTOPOOL_TOKEN).toBe("${{ secrets.OCTOPOOL_TOKEN }}");
     expect(finalSteps.at(-1)?.env?.OPENCLAW_SECURITY_TEAM_SLUG).toBe("openclaw-secops");
     expect(finalSteps.at(-1)?.env?.OPENCLAW_SECURITY_APPROVERS).toBe(
       "vincentkoc,steipete,joshavant",


### PR DESCRIPTION
## What Problem This Solves

Dependency Guard and Security Sensitive Guard repeatedly spend GitHub REST quota on trusted `pull_request_target` reads.

## Change

Routes only the guards' allowlisted GETs (PR, PR files, issue comments/labels; Dependency Guard also contents and blobs) through Octopool's direct HTTPS relay. GraphQL, membership/permission checks, and writes remain native. Missing or partial relay configuration fails the trusted job rather than silently falling back.

The relay adapter is deliberately narrow: the existing guard client retains its timeout, retry, response handling, and pagination behavior.

## Evidence

- Focused guard workflow/script tests: 63 passing.
- `pnpm check:script-declarations`: 249 declaration contracts match.
- `pnpm tsgo:test:root` and `git diff --check` passed.
- `autoreview --mode branch --base origin/main`: clean; no accepted/actionable P0 findings.
- Remote check routing was unavailable because Testbox authentication is missing; focused proof ran locally.

Deployment still requires repository variables `OCTOPOOL_URL`, `OCTOPOOL_POOL` and secret `OCTOPOOL_TOKEN`, plus a deployed-pool canary.

AI-assisted with Codex.