### PR TITLE
fix(line): preserve ordered oversized table delivery

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test-helpers.ts
+++ b/extensions/line/src/auto-reply-delivery.test-helpers.ts
@@ -39,7 +39,7 @@ const createLocationMessage = (location: {
 });
 
 export function createDeps(overrides?: Partial<LineAutoReplyDeps>) {
-  const replyMessageLine = vi.fn(async () => ({}));
+  const replyMessageLine = vi.fn<LineAutoReplyDeps["replyMessageLine"]>(async () => ({}));
   const createQuickReplyItems = vi.fn((labels: string[]) => ({ items: labels }));
   const buildMediaMessage: LineAutoReplyDeps["buildMediaMessage"] = vi.fn(
     async (mediaUrl, options) => {
@@ -66,7 +66,7 @@ export function createDeps(overrides?: Partial<LineAutoReplyDeps>) {
       }
     },
   );
-  const pushMessagesLine = vi.fn(async () => ({
+  const pushMessagesLine = vi.fn<LineAutoReplyDeps["pushMessagesLine"]>(async () => ({
     messageId: "push",
     chatId: "u1",
     receipt: createLineSendReceipt({ messageId: "push", chatId: "u1", kind: "text" }),

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 // Line tests cover auto reply delivery plugin behavior.
 import { describe, expect, it, vi } from "vitest";
@@ -34,11 +35,17 @@ describe("deliverLineAutoReply", () => {
 
     const calls = [
       ...replyMessageLine.mock.calls.map((args, index) => ({
-        position: replyMessageLine.mock.invocationCallOrder[index],
+        position: expectDefined(
+          replyMessageLine.mock.invocationCallOrder[index],
+          "LINE reply delivery call order",
+        ),
         messages: args[1],
       })),
       ...pushMessagesLine.mock.calls.map((args, index) => ({
-        position: pushMessagesLine.mock.invocationCallOrder[index],
+        position: expectDefined(
+          pushMessagesLine.mock.invocationCallOrder[index],
+          "LINE push delivery call order",
+        ),
         messages: args[1],
       })),
     ].toSorted((left, right) => left.position - right.position);
@@ -49,7 +56,7 @@ describe("deliverLineAutoReply", () => {
           ? message.altText === "Code"
             ? "code-card"
             : "valid-table-card"
-          : message.text.includes("Large")
+          : message.type === "text" && message.text.includes("Large")
             ? "oversized-table-text"
             : undefined,
       )

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -1,3 +1,4 @@
+import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 // Line tests cover auto reply delivery plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
@@ -9,10 +10,66 @@ import {
   LINE_TEST_CFG,
   type LineAutoReplyDeps,
 } from "./auto-reply-delivery.test-helpers.js";
+import { processLineMessage as processOrderedLineMessage } from "./markdown-to-line.js";
 import { buildLineMediaMessage } from "./outbound-media.js";
 import { createFlexMessage as createProviderFlexMessage } from "./send.js";
 
 describe("deliverLineAutoReply", () => {
+  it.each([
+    { name: "without quick replies", quickReplies: [] as string[] },
+    { name: "with final quick replies", quickReplies: ["Continue"] },
+  ])("keeps oversized Markdown tables in source order $name", async ({ quickReplies }) => {
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const markdown = `First\n\n| Small | Value |\n|---|---|\n| Kept | card |\n\nBetween\n\n| Name | Value |\n|---|---|\n| Large | ${"x".repeat(30_000)} |\n\nAfter\n\n\`\`\`js\nconsole.log("still a card")\n\`\`\``;
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      lineData: quickReplies.length > 0 ? { quickReplies } : {},
+      deps,
+    });
+
+    const calls = [
+      ...replyMessageLine.mock.calls.map((args, index) => ({
+        position: replyMessageLine.mock.invocationCallOrder[index],
+        messages: args[1],
+      })),
+      ...pushMessagesLine.mock.calls.map((args, index) => ({
+        position: pushMessagesLine.mock.invocationCallOrder[index],
+        messages: args[1],
+      })),
+    ].toSorted((left, right) => left.position - right.position);
+    const sequence = calls
+      .flatMap((call) => call.messages)
+      .map((message) =>
+        message.type === "flex"
+          ? message.altText === "Code"
+            ? "code-card"
+            : "valid-table-card"
+          : message.text.includes("Large")
+            ? "oversized-table-text"
+            : undefined,
+      )
+      .filter(Boolean);
+
+    expect(sequence).toEqual(["valid-table-card", "oversized-table-text", "code-card"]);
+    expect(calls.every((call) => call.messages.length <= 5)).toBe(true);
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(pushMessagesLine.mock.calls.length).toBeGreaterThan(0);
+    if (quickReplies.length > 0) {
+      const messages = calls.flatMap((call) => call.messages);
+      expect(messages.at(-1)).toMatchObject({
+        type: "flex",
+        altText: "Code",
+        quickReply: { items: quickReplies },
+      });
+      expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
+    }
+  });
+
   it("sends text and rich messages on one reply token instead of pushing the rich bubble", async () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -257,7 +257,9 @@ export async function deliverLineAutoReply(params: {
     }
   }
 
-  const orderedMessages = processed.segments?.flatMap<messagingApi.Message>((segment) =>
+  const orderedMessages = processed.segments?.flatMap<
+    messagingApi.FlexMessage | messagingApi.TextMessage
+  >((segment) =>
     segment.type === "flex"
       ? [deps.createFlexMessage(segment.message.altText, segment.message.contents)]
       : deps

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -251,11 +251,24 @@ export async function deliverLineAutoReply(params: {
     ? deps.processLineMessage(visibleText)
     : { text: "", flexMessages: [] };
 
-  for (const flexMsg of processed.flexMessages) {
-    richMessages.push(deps.createFlexMessage(flexMsg.altText, flexMsg.contents));
+  if (!processed.segments) {
+    for (const flexMsg of processed.flexMessages) {
+      richMessages.push(deps.createFlexMessage(flexMsg.altText, flexMsg.contents));
+    }
   }
 
-  const chunks = processed.text ? deps.chunkMarkdownText(processed.text, textLimit) : [];
+  const orderedMessages = processed.segments?.flatMap((segment) =>
+    segment.type === "flex"
+      ? [deps.createFlexMessage(segment.message.altText, segment.message.contents)]
+      : deps
+          .chunkMarkdownText(segment.text, textLimit)
+          .map((text) => ({ type: "text" as const, text })),
+  );
+  const chunks = orderedMessages
+    ? orderedMessages.flatMap((message) => (message.type === "text" ? [message.text] : []))
+    : processed.text
+      ? deps.chunkMarkdownText(processed.text, textLimit)
+      : [];
 
   // Match the push path (outbound.ts): honor channelData.line.mediaKind and the
   // other LINE media options so a reply-token video/audio is not silently
@@ -293,7 +306,11 @@ export async function deliverLineAutoReply(params: {
     });
   }
   if (hasQuickReplies) {
-    const targetMessages = textMessages.length > 0 ? textMessages : richMediaMessages;
+    const targetMessages = orderedMessages?.length
+      ? orderedMessages
+      : textMessages.length > 0
+        ? textMessages
+        : richMediaMessages;
     const lastIndex = targetMessages.length - 1;
     const target = expectDefined(targetMessages[lastIndex], "last LINE auto-reply message");
     targetMessages[lastIndex] = {
@@ -305,8 +322,8 @@ export async function deliverLineAutoReply(params: {
   // Quick replies disappear when a newer message arrives, so rich/media parts
   // lead and the action-bearing text remains final across reply/push batches.
   const messages = hasQuickReplies
-    ? [...richMediaMessages, ...textMessages]
-    : [...textMessages, ...richMediaMessages];
+    ? [...richMediaMessages, ...(orderedMessages ?? textMessages)]
+    : [...(orderedMessages ?? textMessages), ...richMediaMessages];
   try {
     // A reply token carries five messages without consuming push quota. The
     // canonical batcher owns overflow and reply failure fallback for every payload.

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -257,7 +257,7 @@ export async function deliverLineAutoReply(params: {
     }
   }
 
-  const orderedMessages = processed.segments?.flatMap((segment) =>
+  const orderedMessages = processed.segments?.flatMap<messagingApi.Message>((segment) =>
     segment.type === "flex"
       ? [deps.createFlexMessage(segment.message.altText, segment.message.contents)]
       : deps

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -5,6 +5,7 @@ import {
   verifyChannelMessageAdapterCapabilityProofs,
   verifyChannelMessageReceiveAckPolicyAdapterProofs,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { chunkMarkdownText as chunkMarkdownTextForLine } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../api.js";
 import { linePlugin } from "./channel.js";
@@ -139,6 +140,63 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
 }
 
 describe("line outbound sendPayload", () => {
+  it.each([
+    { name: "without quick replies", quickReplies: [] as string[] },
+    { name: "with final quick replies", quickReplies: ["Continue"] },
+  ])("sends oversized tables in their source position $name", async ({ quickReplies }) => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    mocks.resolveTextChunkLimit.mockReturnValue(5000);
+    mocks.chunkMarkdownText.mockImplementation((text: string) =>
+      chunkMarkdownTextForLine(text, 5000),
+    );
+    const markdown = `First\n\n| Small | Value |\n|---|---|\n| Kept | card |\n\nBetween\n\n| Name | Value |\n|---|---|\n| Large | ${"x".repeat(30_000)} |\n\nAfter\n\n\`\`\`js\nconsole.log("still a card")\n\`\`\``;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:ordered",
+      text: markdown,
+      payload: {
+        text: markdown,
+        ...(quickReplies.length > 0 ? { channelData: { line: { quickReplies } } } : {}),
+      },
+      accountId: "default",
+      cfg: { channels: { line: {} } } as OpenClawConfig,
+    });
+
+    const messages = [
+      ...mocks.pushFlexMessage.mock.calls.map((args, index) => ({
+        position: mocks.pushFlexMessage.mock.invocationCallOrder[index],
+        type: args[1] === "Code" ? "code-card" : "valid-table-card",
+      })),
+      ...mocks.pushMessageLine.mock.calls.map((args, index) => ({
+        position: mocks.pushMessageLine.mock.invocationCallOrder[index],
+        type: String(args[1]).includes("Large") ? "oversized-table-text" : "text",
+      })),
+      ...mocks.pushMessagesLine.mock.calls.flatMap((args, index) =>
+        args[1].map((message: { type: string; altText?: string }) => ({
+          position: mocks.pushMessagesLine.mock.invocationCallOrder[index],
+          type: message.altText === "Code" ? "code-card" : message.type,
+        })),
+      ),
+    ]
+      .toSorted((left, right) => left.position - right.position)
+      .map((message) => message.type)
+      .filter((type) => type !== "text");
+
+    expect(messages).toEqual(["valid-table-card", "oversized-table-text", "code-card"]);
+    expect(mocks.pushMessageLine.mock.calls.every((args) => String(args[1]).length <= 5000)).toBe(
+      true,
+    );
+    if (quickReplies.length > 0) {
+      expect(mocks.pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
+        "line:user:ordered",
+        [expect.objectContaining({ altText: "Code", quickReply: { items: quickReplies } })],
+        expect.any(Object),
+      );
+      expect(mocks.pushTextMessageWithQuickReplies).not.toHaveBeenCalled();
+    }
+  });
+
   it.each([
     { name: "empty", text: "" },
     { name: "whitespace-only", text: "   " },

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -255,6 +255,74 @@ print("done")
     expect(result.text).not.toContain("[here]");
   });
 
+  it("keeps an oversized table visible as canonical bullet text instead of an invalid Flex bubble", () => {
+    const value = "x".repeat(30_000);
+    const result = processLineMessage(
+      `Before\n\n| Name | Value |\n|---|---|\n| Account | ${value} |\n\nAfter`,
+    );
+
+    expect(result.flexMessages).toHaveLength(0);
+    expect(result.text).toContain("Account");
+    expect(result.text).toContain(`• Value: ${value}`);
+    expect(result.text.indexOf("Before")).toBeLessThan(result.text.indexOf("Account"));
+    expect(result.text.indexOf("Account")).toBeLessThan(result.text.indexOf("After"));
+  });
+
+  it("measures serialized Flex bubbles in UTF-8 bytes instead of UTF-16 text units", () => {
+    const value = "😀".repeat(7_600);
+    const result = processLineMessage(`| Name | Value |\n|---|---|\n| Unicode | ${value} |`);
+
+    expect(value.length).toBeLessThan(30_000);
+    expect(Buffer.byteLength(value, "utf8")).toBeGreaterThan(30_000);
+    expect(result.flexMessages).toHaveLength(0);
+    expect(result.text).toContain(`• Value: ${value}`);
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(result.text),
+    ).toBe(false);
+  });
+
+  it("keeps valid tables and code cards while downgrading only an oversized sibling table", () => {
+    const value = "z".repeat(30_000);
+    const result = processLineMessage(
+      `First\n\n| Small | Value |\n|---|---|\n| Kept | card |\n\nBetween\n\n| Name | Value |\n|---|---|\n| Large | [${value}](https://example.test/report) |\n\nAfter\n\n\`\`\`js\nconsole.log("still a card");\n\`\`\``,
+    );
+
+    expect(result.flexMessages.map((message) => message.altText)).toEqual(["Table", "Code"]);
+    expect(result.text).not.toContain("Kept");
+    expect(result.text).toContain(`• Value: ${value} (https://example.test/report)`);
+    expect(result.text.indexOf("First")).toBeLessThan(result.text.indexOf("Between"));
+    expect(result.text.indexOf("Between")).toBeLessThan(result.text.indexOf("Large"));
+    expect(result.text.indexOf("Large")).toBeLessThan(result.text.indexOf("After"));
+    expect(
+      result.segments
+        ?.map((segment) =>
+          segment.type === "flex"
+            ? segment.message.altText
+            : segment.text.includes("Large")
+              ? "oversized-table-text"
+              : undefined,
+        )
+        .filter(Boolean),
+    ).toEqual(["Table", "oversized-table-text", "Code"]);
+    expect(
+      result.flexMessages.every(
+        (message) => Buffer.byteLength(JSON.stringify(message.contents), "utf8") <= 30_000,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps provider-valid large tables as Flex bubbles", () => {
+    const value = "y".repeat(20_000);
+    const result = processLineMessage(`| Name | Value |\n|---|---|\n| Preserved | ${value} |`);
+
+    expect(result.flexMessages).toHaveLength(1);
+    expect(
+      Buffer.byteLength(JSON.stringify(result.flexMessages[0]?.contents), "utf8"),
+    ).toBeLessThanOrEqual(30_000);
+    expect(result.text).toBe("");
+    expect(result.segments).toBeUndefined();
+  });
+
   it("handles plain text unchanged", () => {
     const text = "Just plain text with no markdown.";
 

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -24,7 +24,11 @@ export interface ProcessedLineMessage {
   text: string;
   /** Flex messages extracted from tables/code blocks */
   flexMessages: FlexMessage[];
+  /** Source-ordered delivery parts only when a table must fall back to plain text. */
+  segments?: Array<{ type: "text"; text: string } | { type: "flex"; message: FlexMessage }>;
 }
+
+type LineMessageSegment = NonNullable<ProcessedLineMessage["segments"]>[number];
 
 export interface MarkdownTable {
   headers: string[];
@@ -48,8 +52,9 @@ const LINE_MARKDOWN_OPTIONS = {
   preserveSourceBlockSpacing: true,
 } as const;
 const TRANSCRIPT_ROLE_PREFIX = "[assistant-authored transcript] ";
+const LINE_FLEX_BUBBLE_MAX_BYTES = 30_000;
 
-function parseLineMarkdown(text: string, tableMode: "block" | "off" = "block") {
+function parseLineMarkdown(text: string, tableMode: "block" | "bullets" | "off" = "block") {
   return markdownToIRWithMeta(text, { ...LINE_MARKDOWN_OPTIONS, tableMode });
 }
 
@@ -73,7 +78,9 @@ function toCodeBlock(ir: MarkdownIR, span: MarkdownStyleSpan): CodeBlock {
   };
 }
 
-type PlainTextInsertion = { position: number; text: string };
+type PlainTextInsertion =
+  | { position: number; text: string }
+  | { position: number; message: FlexMessage };
 
 function rangesOverlap(
   left: { start: number; end: number },
@@ -82,8 +89,13 @@ function rangesOverlap(
   return left.start < right.end && right.start < left.end;
 }
 
-function projectPlainText(ir: MarkdownIR, omitted: MarkdownStyleSpan[] = []): string {
-  const insertions: PlainTextInsertion[] = [];
+function projectPlainText(
+  ir: MarkdownIR,
+  omitted: MarkdownStyleSpan[] = [],
+  additionalInsertions: PlainTextInsertion[] = [],
+  onSegment?: (segment: LineMessageSegment) => void,
+): string {
+  const insertions: PlainTextInsertion[] = [...additionalInsertions];
   for (const link of ir.links) {
     if (omitted.some((range) => rangesOverlap(range, link))) {
       continue;
@@ -133,6 +145,7 @@ function projectPlainText(ir: MarkdownIR, omitted: MarkdownStyleSpan[] = []): st
   );
 
   let output = "";
+  let segmentStart = 0;
   let cursor = 0;
   let insertionIndex = 0;
   const appendRange = (end: number) => {
@@ -142,7 +155,17 @@ function projectPlainText(ir: MarkdownIR, omitted: MarkdownStyleSpan[] = []): st
         break;
       }
       if (insertion.position >= cursor) {
-        output += ir.text.slice(cursor, insertion.position) + insertion.text;
+        output += ir.text.slice(cursor, insertion.position);
+        if ("text" in insertion) {
+          output += insertion.text;
+        } else if (onSegment) {
+          const precedingText = output.slice(segmentStart).trim();
+          if (precedingText) {
+            onSegment({ type: "text", text: precedingText });
+          }
+          onSegment({ type: "flex", message: insertion.message });
+          segmentStart = output.length;
+        }
         cursor = insertion.position;
       }
       insertionIndex += 1;
@@ -162,7 +185,28 @@ function projectPlainText(ir: MarkdownIR, omitted: MarkdownStyleSpan[] = []): st
     }
   }
   appendRange(ir.text.length);
+  if (onSegment) {
+    const trailingText = output.slice(segmentStart).trim();
+    if (trailingText) {
+      onSegment({ type: "text", text: trailingText });
+    }
+  }
   return output.trim();
+}
+
+function formatOversizedTableAsBullets(table: MarkdownTableMeta): string {
+  const markdownCell = (cell: MarkdownTableCell) =>
+    projectPlainText(cell)
+      .replace(/[\\|`*_[\]~<>&]/gu, "\\$&")
+      .replace(/\r?\n/gu, " ");
+  const markdownRow = (cells: MarkdownTableCell[]) => `| ${cells.map(markdownCell).join(" | ")} |`;
+  const markdown = [
+    markdownRow(table.headerCells),
+    `| ${table.headerCells.map(() => "---").join(" | ")} |`,
+    ...table.rowCells.map(markdownRow),
+  ].join("\n");
+
+  return projectPlainText(parseLineMarkdown(markdown, "bullets").ir);
 }
 
 type RenderedCell = {
@@ -386,16 +430,43 @@ export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
 export function processLineMessage(text: string): ProcessedLineMessage {
   const { ir, tables } = parseLineMarkdown(text);
   const codeSpans = codeBlockSpans(ir);
+  const flexMessages: FlexMessage[] = [];
+  const plainTextInsertions: PlainTextInsertion[] = [];
+  let hasOversizedTable = false;
+
+  for (const table of tables) {
+    const bubble = convertTableToFlexBubble(toMarkdownTable(table));
+    // LINE rejects the whole push/reply when any bubble exceeds its 30 KB UTF-8 JSON limit.
+    if (Buffer.byteLength(JSON.stringify(bubble), "utf8") > LINE_FLEX_BUBBLE_MAX_BYTES) {
+      hasOversizedTable = true;
+      plainTextInsertions.push({
+        position: table.placeholderOffset,
+        text: `\n\n${formatOversizedTableAsBullets(table)}\n\n`,
+      });
+      continue;
+    }
+    const message = toFlexMessage("Table", bubble);
+    flexMessages.push(message);
+    plainTextInsertions.push({ position: table.placeholderOffset, message });
+  }
+
+  for (const span of codeSpans) {
+    const message = toFlexMessage("Code", convertCodeBlockToFlexBubble(toCodeBlock(ir, span)));
+    flexMessages.push(message);
+    plainTextInsertions.push({ position: span.start, message });
+  }
+
+  const segments: LineMessageSegment[] = [];
+  const processedText = projectPlainText(
+    ir,
+    codeSpans,
+    plainTextInsertions,
+    hasOversizedTable ? (segment) => segments.push(segment) : undefined,
+  );
   return {
-    text: projectPlainText(ir, codeSpans),
-    flexMessages: [
-      ...tables.map((table) =>
-        toFlexMessage("Table", convertTableToFlexBubble(toMarkdownTable(table))),
-      ),
-      ...codeSpans.map((span) =>
-        toFlexMessage("Code", convertCodeBlockToFlexBubble(toCodeBlock(ir, span))),
-      ),
-    ],
+    text: processedText,
+    flexMessages,
+    ...(hasOversizedTable ? { segments } : {}),
   };
 }
 

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -99,9 +99,18 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         fallbackLimit: 5000,
       }) ?? 5000;
 
-    const chunks = processed.text
-      ? runtime.channel.text.chunkMarkdownText(processed.text, chunkLimit)
-      : [];
+    const orderedMessages = processed.segments?.flatMap((segment) =>
+      segment.type === "flex"
+        ? [segment.message]
+        : runtime.channel.text
+            .chunkMarkdownText(segment.text, chunkLimit)
+            .map((text) => ({ type: "text" as const, text })),
+    );
+    const chunks = orderedMessages
+      ? orderedMessages.flatMap((message) => (message.type === "text" ? [message.text] : []))
+      : processed.text
+        ? runtime.channel.text.chunkMarkdownText(processed.text, chunkLimit)
+        : [];
     const mediaUrls = resolveOutboundMediaUrls(payload);
     const useLineSpecificMedia = hasLineSpecificMediaOptions(lineData);
     const mediaOptions = {
@@ -179,15 +188,16 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         );
       }
 
-      for (const flexMsg of processed.flexMessages) {
-        const flexContents = flexMsg.contents;
-        await recordResult(
-          sendFlex(to, flexMsg.altText, flexContents, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          }),
-        );
+      if (!orderedMessages) {
+        for (const flexMsg of processed.flexMessages) {
+          await recordResult(
+            sendFlex(to, flexMsg.altText, flexMsg.contents, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
+        }
       }
     }
 
@@ -196,7 +206,40 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       await sendMediaMessages();
     }
 
-    if (chunks.length > 0) {
+    if (orderedMessages) {
+      for (const [index, message] of orderedMessages.entries()) {
+        const isLast = index === orderedMessages.length - 1;
+        if (message.type === "flex") {
+          if (isLast && quickReply) {
+            await sendMessageBatch([{ ...message, quickReply }]);
+          } else {
+            await recordResult(
+              sendFlex(to, message.altText, message.contents, {
+                verbose: false,
+                cfg,
+                accountId: accountId ?? undefined,
+              }),
+            );
+          }
+        } else if (isLast && hasQuickReplies) {
+          await recordResult(
+            sendQuickReplies(to, message.text, quickReplies, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
+        } else {
+          await recordResult(
+            sendText(to, message.text, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
+        }
+      }
+    } else if (chunks.length > 0) {
       for (const [i, chunk] of chunks.entries()) {
         const isLast = i === chunks.length - 1;
         if (isLast && hasQuickReplies) {

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -100,7 +100,9 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         fallbackLimit: 5000,
       }) ?? 5000;
 
-    const orderedMessages = processed.segments?.flatMap<messagingApi.Message>((segment) =>
+    const orderedMessages = processed.segments?.flatMap<
+      messagingApi.FlexMessage | messagingApi.TextMessage
+    >((segment) =>
       segment.type === "flex"
         ? [segment.message]
         : runtime.channel.text

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -1,3 +1,4 @@
+import type { messagingApi } from "@line/bot-sdk";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Line plugin module implements outbound behavior.
 import {
@@ -99,7 +100,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         fallbackLimit: 5000,
       }) ?? 5000;
 
-    const orderedMessages = processed.segments?.flatMap((segment) =>
+    const orderedMessages = processed.segments?.flatMap<messagingApi.Message>((segment) =>
       segment.type === "flex"
         ? [segment.message]
         : runtime.channel.text


### PR DESCRIPTION
## What Problem This Solves

LINE rejects a complete push or reply when one Markdown table produces a Flex
bubble above its official 30 KB UTF-8 JSON limit. Merely moving that table into
plain text also breaks source order whenever valid table or code cards remain.

## Why This Change Was Made

Keep the existing exported `{ text, flexMessages }` contract and all ordinary
message behavior intact. Add optional ordered segments only for oversized-table
fallback, reuse the canonical Markdown bullet renderer, and have both existing
LINE delivery owners consume that same source order. Existing 5,000-character
chunking, five-message reply/push batching, quick-reply ownership, media policy,
receipts, and partial-delivery handling stay with their current owners.

Official provider contract: https://developers.line.biz/en/reference/messaging-api/nojs/#bubble

## User Impact

Oversized ASCII and multibyte Unicode tables arrive completely as readable
bullet text in the correct position between valid cards. Authored links and
code cards survive; quick replies remain attached only to the final visible
message, even when that message is a Flex card and delivery spans reply-token
and push-continuation batches.

## Evidence

- Test-first baseline: **5 failing regressions and 72 passing controls**.
- Frozen immutable commit: **79/79 focused tests** across the Markdown owner,
  outbound adapter, and inbound auto-reply owner.
- Actual installed `@line/bot-sdk@11.2.0`: **41 authenticated localhost HTTP
  requests** through both real production callers, covering ASCII, multibyte
  Unicode, ordered cards, reply-token overflow, push continuation, and final-only
  quick replies. This is an authenticated local provider-contract fixture, not a
  claim of external live LINE access.
- The final quick-reply Flex produces **12 observer callbacks for 12 physical
  outbound sends**; its returned receipt and final observer both identify
  `line-27`. Every provider request contains at most five messages.
- Scoped lint is clean; the two type-aware diagnostics reproduce unchanged on
  clean `main`. Four independent hostile whole-owner reviews are clean.
- Final genuine Codex Sol/high P0–P3 autoreview: **zero accepted/actionable
  findings**, confidence **0.99**; exact added content passes TruffleHog.
- Exact reviewed canonical main: **3edbe19fbd84ba58fdbf8e83042da9efd1d06f81**; conflict-free synthetic composition tree **88972983d816c4a95410f93d6afb084c62d8e7a0**; plugin owner, scoped guides, and pinned dependencies unchanged.
- Hosted exact-head CI remains pending until its actual gate completes.
