### PR TITLE
fix(openrouter): apply configured image request transport

### DIFF
--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -150,6 +150,7 @@ describe("openrouter image generation provider", () => {
         "HTTP-Referer": "https://openclaw.ai",
         "X-OpenRouter-Title": "OpenClaw",
       },
+      request: undefined,
       provider: "openrouter",
       capability: "image",
       transport: "http",
@@ -189,6 +190,84 @@ describe("openrouter image generation provider", () => {
     const image = requireGeneratedImage(result, 0);
     expect(image.buffer.toString()).toBe("png-one");
     expect(image.mimeType).toBe("image/png");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("applies configured image request transport without weakening private-network policy", async () => {
+    const requestPolicy = {
+      allowPrivateNetwork: true,
+      headers: { "X-OpenRouter-Trace": "image-trace" },
+      auth: { mode: "authorization-bearer" as const, token: "override-image-token" },
+      proxy: { mode: "explicit-proxy" as const, url: "http://proxy.example.test:8443" },
+      tls: { ca: "synthetic-provider-ca", serverName: "provider.example.test" },
+    };
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: requestPolicy.proxy.url,
+    };
+    resolveProviderHttpRequestConfigMock.mockImplementationOnce((params) => {
+      const headers = new Headers(params.defaultHeaders);
+      for (const [name, value] of Object.entries(params.request?.headers ?? {})) {
+        headers.set(name, value);
+      }
+      if (params.request?.auth?.mode === "authorization-bearer") {
+        headers.set("Authorization", `Bearer ${params.request.auth.token}`);
+      }
+      return {
+        baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+        allowPrivateNetwork:
+          (params.allowPrivateNetwork ?? params.request?.allowPrivateNetwork) === true,
+        headers,
+        dispatcherPolicy,
+      };
+    });
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: Response.json({
+        choices: [
+          {
+            message: {
+              images: [{ image_url: { url: "data:image/png;base64,cG5n" } }],
+            },
+          },
+        ],
+      }),
+      release,
+    });
+
+    const result = await buildOpenRouterImageGenerationProvider().generateImage({
+      provider: "openrouter",
+      model: "google/gemini-3.1-flash-image-preview",
+      prompt: "draw through the configured transport",
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://custom.openrouter.test/api/v1",
+              request: requestPolicy,
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(requireOpenRouterConfigRequest()).toMatchObject({
+      baseUrl: "https://custom.openrouter.test/api/v1",
+      provider: "openrouter",
+      capability: "image",
+      allowPrivateNetwork: false,
+      request: requestPolicy,
+    });
+    const request = requireOpenRouterPostRequest();
+    const headers = requireHeaders(request.headers);
+    expect(headers.get("authorization")).toBe("Bearer override-image-token");
+    expect(headers.get("x-openrouter-trace")).toBe("image-trace");
+    expect(request).toMatchObject({
+      allowPrivateNetwork: false,
+      dispatcherPolicy,
+    });
+    expect(requireGeneratedImage(result, 0).buffer.toString()).toBe("png");
     expect(release).toHaveBeenCalledOnce();
   });
 

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -18,6 +18,7 @@ import {
   postJsonRequest,
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
@@ -265,6 +266,9 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
             "HTTP-Referer": "https://openclaw.ai",
             "X-OpenRouter-Title": "OpenClaw",
           },
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.openrouter?.request,
+          ),
           provider: "openrouter",
           capability: "image",
           transport: "http",


### PR DESCRIPTION
## What Problem This Solves

OpenRouter image generation silently ignored `models.providers.openrouter.request`. Configured bearer authentication, request headers, proxy routing, and TLS policy were applied to OpenRouter video and music but disappeared from image requests, causing authentication failures and bypassing operator-selected network transport.

## Why This Change Was Made

Pass the existing sanitized provider request policy through the existing image-provider owner, matching the canonical OpenRouter video and music paths. Keep the explicit image-provider private-network restriction unchanged; configured `allowPrivateNetwork: true` cannot override it.

## User Impact

OpenRouter image requests now honor configured bearer overrides, custom headers, explicit proxies, and TLS settings. Existing provider authentication, attribution headers, response limits, request timeouts, SSRF policy, and image parsing are unchanged. No configuration, authentication, SDK, or compatibility surface is added.

## Evidence

- Immutable commit `83d24d0bd8ae8ffc202c0dba6b61328f68676c6a`, tree `c38741b7209bf3acbe889cf5e0e540675c58b66e`, parent `03698f98881f7abdff9f168cd4d26d27c42a6dfa`.
- Exact scope: the existing OpenRouter image provider and its existing test; four production lines added.
- Authentic regression: 7 existing tests passed and the new configured-transport test failed before the fix; all 8 focused tests pass after the fix.
- Real secretless HTTPS proof used an ephemeral trusted local CA and a real HTTP CONNECT proxy. Before the fix: zero proxy connections, no configured bearer or custom header, and HTTP 401. After the fix: one CONNECT tunnel, correct configured bearer and custom header, and successfully returned PNG bytes.
- Focused regression verifies explicit `allowPrivateNetwork: false` still wins over configured `allowPrivateNetwork: true`, alongside auth, headers, proxy, and TLS forwarding.
- Targeted formatter, full scoped oxlint, and `git diff --check` pass.
- Four fresh independent hostile reviews report zero P0–P3 findings.
- Genuine `gpt-5.6-sol` high-thinking, P0–P3 exact-commit autoreview: clean, confidence 0.94; real TruffleHog scan clean.
- Hosted exact-head CI remains mandatory and has not been claimed complete.
