### PR TITLE
fix(cron): preserve structured timeout task outcomes

### DIFF
--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import type { CronEvent } from "./service.js";
 import { CronService } from "./service.js";
 import { createDeferred, setupCronServiceSuite } from "./service.test-harness.js";
@@ -203,6 +204,17 @@ describe("cron trigger evaluation", () => {
         status: "error",
         error: expect.stringContaining("deadline exceeded"),
       });
+      expect(
+        listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+          runtime: "cron",
+          sourceId: job.id,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          status: "timed_out",
+          detail: expect.objectContaining({ errorReason: "timeout" }),
+        }),
+      ]);
       expect(harness.events.map((event) => event.action)).toEqual([
         "started",
         "finished",
@@ -214,6 +226,64 @@ describe("cron trigger evaluation", () => {
         nextRunAtMs: persisted?.state.nextRunAtMs,
         job: { state: { nextRunAtMs: persisted?.state.nextRunAtMs } },
       });
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it("persists classified script payload timeouts as timed-out tasks", async () => {
+    const runScriptJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "cron script payload failed (timeout): deadline exceeded",
+      errorClassification: { kind: "reason" as const, reason: "timeout" as const },
+    }));
+    const harness = await createHarness({ runScriptJob });
+    try {
+      const job = await harness.cron.add(
+        watcher({
+          trigger: undefined,
+          payload: { kind: "script", script: "return {}" },
+        }),
+      );
+
+      await runWhenDue(harness.cron, job.id);
+
+      expect(runScriptJob).toHaveBeenCalledOnce();
+      expect(
+        listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+          runtime: "cron",
+          sourceId: job.id,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          status: "timed_out",
+          detail: expect.objectContaining({ errorReason: "timeout" }),
+        }),
+      ]);
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it("keeps ordinary trigger failures failed despite inferred provider timeout text", async () => {
+    const evaluateCronTrigger = vi.fn(async () => ({
+      kind: "error" as const,
+      code: "internal_error" as const,
+      error: "ordinary trigger failure",
+    }));
+    const harness = await createHarness({ evaluateCronTrigger });
+    try {
+      const job = await harness.cron.add(watcher());
+
+      await runWhenDue(harness.cron, job.id);
+
+      expect(evaluateCronTrigger).toHaveBeenCalledOnce();
+      expect(
+        listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+          runtime: "cron",
+          sourceId: job.id,
+        }),
+      ).toEqual([expect.objectContaining({ status: "failed" })]);
     } finally {
       harness.cron.stop();
     }

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -132,6 +132,7 @@ async function finishPreparedManualRun(
         taskRunId,
         status: coreResult.status,
         error: coreResult.error,
+        errorClassification: coreResult.errorClassification,
         endedAt,
         summary: coreResult.summary,
         childSessionKey: coreResult.sessionKey,

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -7,7 +7,6 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
-import { isCronTimeoutErrorText } from "../execution-error-constants.js";
 
 function requireCronAgentId(agentId: string | undefined): string {
   if (!agentId?.trim()) {
@@ -284,6 +283,7 @@ export function tryFinishCronTaskRunWithoutHistory(
     taskRunId?: string;
     status: "ok" | "error" | "skipped";
     error?: unknown;
+    errorClassification?: CronRunErrorClassification;
     endedAt: number;
     summary?: string;
     childSessionKey?: string;
@@ -297,12 +297,13 @@ export function tryFinishCronTaskRunWithoutHistory(
     finalizeTaskRunByRunId({
       runId: result.taskRunId,
       runtime: "cron",
-      status:
-        result.status === "ok" || result.status === "skipped"
-          ? "succeeded"
-          : isCronTimeoutErrorText(error)
-            ? "timed_out"
-            : "failed",
+      status: cronRunStatusToTaskStatus(
+        {
+          status: result.status,
+          error,
+        },
+        result.errorClassification,
+      ),
       endedAt: result.endedAt,
       lastEventAt: result.endedAt,
       error,
@@ -365,7 +366,7 @@ export function tryFinishCronTaskRun(
       status: Extract<
         TaskStatus,
         "succeeded" | "failed" | "timed_out" | "cancelled"
-      > = cronRunStatusToTaskStatus(entry),
+      > = cronRunStatusToTaskStatus(entry, result.errorClassification),
     ) =>
       finalizeTaskRunByRunId({
         runId,
@@ -397,7 +398,7 @@ export function tryFinishCronTaskRun(
         // Startup recovery replaces them with the durable interrupted outcome.
         const recovered = finalizeTaskRunById({
           taskId: existing.taskId,
-          status: cronRunStatusToTaskStatus(entry),
+          status: cronRunStatusToTaskStatus(entry, result.errorClassification),
           childSessionKey: entry.sessionKey ?? null,
           endedAt: entry.ts,
           lastEventAt: entry.ts,

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -125,6 +125,9 @@ export async function executeJobCore(
       return {
         status: "error",
         error: `cron trigger evaluation failed (${evaluation.code}): ${evaluation.error}`,
+        ...(evaluation.code === "timeout"
+          ? { errorClassification: { kind: "reason" as const, reason: "timeout" as const } }
+          : {}),
         triggerEval: { fired: false, stateChanged: false },
       };
     }

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -255,7 +255,7 @@ export function cronTaskRecordToScriptRunResult(
 
 /** Maps the cron outcome vocabulary onto generic task terminal states. */
 export function cronRunStatusToTaskStatus(
-  entry: Pick<CronRunLogEntry, "status" | "error">,
+  entry: Pick<CronRunLogEntry, "status" | "error"> & Partial<CronRunLogEntry>,
   errorClassification?: CronRunErrorClassification,
 ): Extract<TaskStatus, "succeeded" | "failed" | "timed_out"> {
   if (entry.status === "ok" || entry.status === "skipped") {

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -11,6 +11,7 @@ type TaskRecord = import("../tasks/task-registry.types.js").TaskRecord;
 type TaskStatus = import("../tasks/task-registry.types.js").TaskStatus;
 type CronRunLogEntry = import("./run-log-types.js").CronRunLogEntry;
 type CronDeliveryStatus = import("./types.js").CronDeliveryStatus;
+type CronRunErrorClassification = import("./types.js").CronRunErrorClassification;
 type CronRunStatus = import("./types.js").CronRunStatus;
 
 const CRON_TASK_DETAIL_KIND = "cron-run";
@@ -254,12 +255,18 @@ export function cronTaskRecordToScriptRunResult(
 
 /** Maps the cron outcome vocabulary onto generic task terminal states. */
 export function cronRunStatusToTaskStatus(
-  entry: CronRunLogEntry,
+  entry: Pick<CronRunLogEntry, "status" | "error">,
+  errorClassification?: CronRunErrorClassification,
 ): Extract<TaskStatus, "succeeded" | "failed" | "timed_out"> {
   if (entry.status === "ok" || entry.status === "skipped") {
     return "succeeded";
   }
-  return isCronTimeoutErrorText(entry.error) ? "timed_out" : "failed";
+  // History error reasons can be inferred from provider-like local error text;
+  // only producer-owned classification or the stable watchdog contract is authoritative.
+  return (errorClassification?.kind === "reason" && errorClassification.reason === "timeout") ||
+    isCronTimeoutErrorText(entry.error)
+    ? "timed_out"
+    : "failed";
 }
 
 /** Reconstructs the unchanged CronRunLogEntry wire shape from a cron task row. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators inspecting scheduled automation tasks would see trigger-evaluation or script-payload timeouts incorrectly reported as ordinary failures, even though the underlying cron run had an explicit timeout reason.

## Why This Change Was Made

The cron execution owner now carries its existing structured timeout classification through one canonical task-status projector for scheduled runs, manual early finalization, normal run history, and interrupted-task recovery. Provider-style text inferred into historical diagnostics is not treated as authoritative terminal state.

## User Impact

Timed-out trigger evaluations and script payloads now appear correctly as timed-out automation tasks. Ordinary failures remain failed, existing watchdog timeouts remain timed out, and operator-cancelled tasks stay cancelled when their final run history is attached.

## Evidence

- Regression-first proof against actual `CronService` and the real SQLite task ledger reproduced both trigger and script timeouts persisting as `failed` before the fix.
- Cache-disabled production-path matrix after the fix verified five actual SQLite outcomes: trigger timeout `timed_out`, structured script timeout `timed_out`, ordinary local failure `failed`, legacy watchdog timeout `timed_out`, and operator cancellation `cancelled` after actual cron completion.
- Existing focused cron suite: 20 tests passed with cache disabled (`node scripts/run-vitest.mjs src/cron/service.trigger-eval.test.ts --no-cache`).
- Five independent hostile read-only reviews reported no P0–P3 issues. Genuine TruffleHog 3.96.0 scanning was clean, and `gpt-5.6-sol` with high reasoning reported zero actionable findings (confidence 0.90).
- Exact immutable reviewed commit: `35f011be903801507a2b8c27a1195bf2fcb849b4`. All five owner paths are unchanged on current main `aa2a5c96f69a1be639c602649d4aa2e4de8da0a8`, and the synthetic merge is clean. Remote CI has not been run.
