### PR TITLE
fix(xai): classify run-out-of-credits and Grok-subscription 403s as billing

### DIFF
--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -527,6 +527,16 @@ describe("xai provider plugin", () => {
     ).toBe("billing");
     expect(
       provider.classifyFailoverReason?.({
+        errorMessage: "You have run out of credits",
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "You need a Grok subscription to access this model",
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
         errorMessage:
           '429 {"code":"Some resource has been exhausted","error":"Rate limit exceeded"}',
       }),

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -57,7 +57,7 @@ import {
 const PROVIDER_ID = "xai";
 
 const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
-  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
+  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit|run out of credits|need(?:s|ed)? a grok subscription)\b/i;
 const XAI_RATE_LIMIT_RE = /\b(?:rate limit exceeded|too many requests)\b/i;
 
 const loadCodeExecutionModule = createLazyRuntimeModule(() => import("./code-execution.js"));


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/openclaw/issues/115853

When the xAI provider returns an HTTP 403 whose message says the account has exhausted its credits ("You have run out of credits") or needs a Grok subscription ("You need a Grok subscription to access this model"), OpenClaw classifies the failure as `auth` instead of `billing`. The xAI profile then only receives the normal auth cooldown, so later requests can call xAI again and repeat the same failing transport before falling back to the configured fallback provider.

## Why This Change Was Made

The xAI provider plugin owns a credit/subscription failover matcher (`XAI_CREDIT_OR_SPENDING_LIMIT_RE` in `extensions/xai/index.ts`) that already recognized phrases like "used all available credits", "monthly spending limit", "purchase more credits", and "raise your spending limit". The two observed phrases from the issue ("run out of credits", "need a Grok subscription") were not in that matcher, so those 403s fell through to the generic auth classification.

This extends the xAI plugin's own owner-scoped matcher — the correct owner boundary — rather than touching the shared core billing matcher, so other providers' classification semantics are unaffected.

## User Impact

- xAI accounts with exhausted credits or an expired Grok subscription now get classified as `billing`, applying the billing disabled window.
- While that window is active, model selection skips the unavailable xAI profile and goes directly to the configured fallback provider.
- Generic classifications are unchanged: `403 Forbidden` → `auth`, `429 Too Many Requests` → `rate_limit`.

## Evidence

### Unit tests (xAI plugin suite, 369 passed)

`extensions/xai/index.test.ts` adds coverage for both new phrases through the real registered provider plugin hook:

```ts
// "You have run out of credits" → billing
// "You need a Grok subscription to access this model" → billing
```

Verified locally: `node scripts/run-vitest.mjs extensions/xai/` → **25 test files, 369 tests passed**.

### Regression coverage (core failover classifiers, 264 passed)

`node scripts/run-vitest.mjs src/agents/embedded-agent-helpers` → **13 test files, 264 tests passed**. Confirms generic 403 → auth and 429 → rate_limit classifications are unchanged.

### Full combined suite

`node scripts/run-vitest.mjs extensions/xai src/agents/embedded-agent-helpers` → **38 test files, 633 tests passed**.

### Real-process verification (before vs after, same real process + same inputs)

A real Node process loaded the actual xAI plugin entry (`extensions/xai/index.ts` → `defineSingleProviderPluginEntry`), registered it via the real plugin runtime, and invoked the registered provider's `classifyFailoverReason` on the issue's error messages. Both runs used the identical script; only the plugin source differed (pre-fix commit `aa2a5c96f69` vs this branch).

**Before the fix (commit `aa2a5c96f69`, real process output):**

```json
{"msg":"You have run out of credits", "reason": undefined}
{"msg":"You need a Grok subscription to access this model", "reason": undefined}
```

Both new phrases returned `undefined` → the 403 fell through to generic `auth` classification (the bug).

**After the fix (this branch, real process output):**

```json
{"msg":"You have run out of credits", "reason": "billing"}
{"msg":"You need a Grok subscription to access this model", "reason": "billing"}
```

Both phrases now classify as `billing`. Control messages are stable across both runs: the pre-existing "used all available credits / monthly spending limit" phrasing → `billing`, and `429 Rate limit exceeded` → `rate_limit`.

