### PR TITLE
fix(qa): validate Slack run artifacts and approval identities

### DIFF
--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -39,18 +39,22 @@ function phaseStatus(
 async function writeApprovalCheckpointArtifacts(outputDir: string, scenarioIds: readonly string[]) {
   const checkpointDir = path.join(outputDir, "approval-checkpoints");
   await fs.mkdir(checkpointDir, { recursive: true });
-  for (const scenarioId of scenarioIds) {
+  for (const [index, scenarioId] of scenarioIds.entries()) {
+    const approvalKind = scenarioId === "slack-approval-exec-native" ? "exec" : "plugin";
     for (const state of ["pending", "resolved"] as const) {
       await fs.writeFile(
         path.join(checkpointDir, `${scenarioId}.${state}.json`),
         `${JSON.stringify({
           version: 1,
           scenarioId,
-          approvalKind: scenarioId.includes("plugin") ? "plugin" : "exec",
+          approvalKind,
           state,
-          approvalId: scenarioId.includes("plugin") ? "plugin:abc" : "exec-abc",
-          channelId: "C123456789",
-          messageTs: "1.000000",
+          approvalId: `${scenarioId}:approval`,
+          channelId:
+            process.env.OPENCLAW_MANTIS_SLACK_CHANNEL_ID ??
+            process.env.OPENCLAW_QA_SLACK_CHANNEL_ID ??
+            "C0AUXUC5AGN",
+          messageTs: `${index + 1}.000000`,
           threadTs: null,
           decision: state === "resolved" ? "allow-once" : null,
           observedAt: "2026-05-04T13:00:29.000Z",
@@ -104,6 +108,175 @@ describe("mantis Slack desktop smoke runtime", () => {
   afterEach(async () => {
     vi.unstubAllGlobals();
     await fs.rm(repoRoot, { force: true, recursive: true });
+  });
+
+  function createFreshnessRunner(copy: (outputDir: string, run: number) => Promise<void>) {
+    let runs = 0;
+    return vi.fn(async (command: string, args: readonly string[]) => {
+      if (command === "/tmp/crabbox" && args[0] === "warmup") {
+        return { stdout: "ready lease cbx_abc123\n", stderr: "" };
+      }
+      if (command === "/tmp/crabbox" && args[0] === "inspect") {
+        return {
+          stdout: `${JSON.stringify({
+            host: "203.0.113.10",
+            id: "cbx_abc123",
+            provider: "hetzner",
+            sshKey: "/tmp/key",
+            sshPort: "2222",
+            sshUser: "crabbox",
+          })}\n`,
+          stderr: "",
+        };
+      }
+      if (command === "rsync") {
+        const outputDir = args.at(-1) as string;
+        await fs.mkdir(outputDir, { recursive: true });
+        if (!outputDir.endsWith("slack-qa/")) {
+          await copy(outputDir, ++runs);
+        }
+      }
+      return { stdout: "", stderr: "" };
+    });
+  }
+
+  it("invalidates only selected prior-run evidence and allocates a fresh remote namespace", async () => {
+    const selected = "slack-approval-plugin-native";
+    const unselected = "slack-approval-exec-native";
+    const runner = createFreshnessRunner(async (outputDir, run) => {
+      await fs.writeFile(path.join(outputDir, "slack-desktop-smoke.png"), `image ${run}`);
+      if (run === 1) {
+        await fs.writeFile(path.join(outputDir, "slack-desktop-smoke.mp4"), "old video");
+        await fs.writeFile(path.join(outputDir, "remote-metadata.json"), '{"qaExitCode":0}');
+        await writeApprovalCheckpointArtifacts(outputDir, [selected, unselected]);
+      }
+    });
+    const options = {
+      approvalCheckpoints: true,
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_abc123",
+      now: () => new Date("2026-05-04T13:00:00.000Z"),
+      outputDir: ".artifacts/reused-freshness",
+      repoRoot,
+      scenarioIds: [selected],
+    };
+    const first = await runMantisSlackDesktopSmoke(options);
+    const firstSummary = JSON.parse(await fs.readFile(first.summaryPath, "utf8"));
+    await fs.writeFile(path.join(first.outputDir, "unrelated.log"), "keep diagnostics");
+
+    const second = await runMantisSlackDesktopSmoke(options);
+    const secondSummary = JSON.parse(await fs.readFile(second.summaryPath, "utf8"));
+
+    expect(first.status).toBe("pass");
+    expect(second.status).toBe("fail");
+    expect(firstSummary.remoteOutputDir).not.toBe(secondSummary.remoteOutputDir);
+    await expect(fs.readFile(path.join(second.outputDir, "unrelated.log"), "utf8")).resolves.toBe(
+      "keep diagnostics",
+    );
+    for (const stale of [
+      "slack-desktop-smoke.mp4",
+      "remote-metadata.json",
+      `approval-checkpoints/${selected}.pending.json`,
+    ]) {
+      await expect(fs.lstat(path.join(second.outputDir, stale))).rejects.toThrow();
+    }
+    await expect(
+      fs.lstat(path.join(second.outputDir, "approval-checkpoints", `${unselected}.pending.json`)),
+    ).resolves.toBeDefined();
+  });
+
+  it.each([
+    { state: "pending", field: "decision", value: "allow-once" },
+    { state: "resolved", field: "decision", value: null },
+    { state: "pending", field: "approvalKind", value: "exec" },
+    { state: "pending", field: "channelId", value: "CWRONG" },
+    { state: "resolved", field: "approvalId", value: "other-approval" },
+    { state: "resolved", field: "messageTs", value: "99.000000" },
+    { state: "resolved", field: "threadTs", value: "99.000000" },
+  ])("rejects a mismatched $state $field approval interaction", async ({ state, field, value }) => {
+    const scenarioId = "slack-approval-plugin-native";
+    const runner = createFreshnessRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "slack-desktop-smoke.png"), "fresh image");
+      await fs.writeFile(path.join(outputDir, "remote-metadata.json"), '{"qaExitCode":0}');
+      await writeApprovalCheckpointArtifacts(outputDir, [scenarioId]);
+      const checkpointPath = path.join(
+        outputDir,
+        "approval-checkpoints",
+        `${scenarioId}.${state}.json`,
+      );
+      const checkpoint = JSON.parse(await fs.readFile(checkpointPath, "utf8"));
+      await fs.writeFile(checkpointPath, JSON.stringify({ ...checkpoint, [field]: value }));
+    });
+
+    const result = await runMantisSlackDesktopSmoke({
+      approvalCheckpoints: true,
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_abc123",
+      outputDir: `.artifacts/approval-identity-${state}-${field}`,
+      repoRoot,
+      scenarioIds: [scenarioId],
+    });
+
+    expect(result.status).toBe("fail");
+  });
+
+  it("rejects a Slack approval interaction reused by different selected scenarios", async () => {
+    const scenarioIds = ["slack-approval-exec-native", "slack-approval-plugin-native"];
+    const runner = createFreshnessRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "slack-desktop-smoke.png"), "fresh image");
+      await fs.writeFile(path.join(outputDir, "remote-metadata.json"), '{"qaExitCode":0}');
+      await writeApprovalCheckpointArtifacts(outputDir, scenarioIds);
+      for (const state of ["pending", "resolved"]) {
+        const checkpointPath = path.join(
+          outputDir,
+          "approval-checkpoints",
+          `${scenarioIds[1]}.${state}.json`,
+        );
+        const checkpoint = JSON.parse(await fs.readFile(checkpointPath, "utf8"));
+        await fs.writeFile(
+          checkpointPath,
+          JSON.stringify({
+            ...checkpoint,
+            approvalId: `${scenarioIds[0]}:approval`,
+            messageTs: "1.000000",
+          }),
+        );
+      }
+    });
+
+    const result = await runMantisSlackDesktopSmoke({
+      approvalCheckpoints: true,
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_abc123",
+      outputDir: ".artifacts/reused-approval-interaction",
+      repoRoot,
+      scenarioIds,
+    });
+
+    expect(result.status).toBe("fail");
+  });
+
+  it("does not authenticate Slack success with external symlinked metadata", async () => {
+    const externalMetadata = path.join(repoRoot, "outside-metadata.json");
+    await fs.writeFile(externalMetadata, '{"qaExitCode":0}');
+    const runner = createFreshnessRunner(async (outputDir) => {
+      await fs.writeFile(path.join(outputDir, "slack-desktop-smoke.png"), "fresh image");
+      await fs.symlink(externalMetadata, path.join(outputDir, "remote-metadata.json"));
+    });
+
+    const result = await runMantisSlackDesktopSmoke({
+      commandRunner: runner,
+      crabboxBin: "/tmp/crabbox",
+      leaseId: "cbx_abc123",
+      outputDir: ".artifacts/symlinked-slack-metadata",
+      repoRoot,
+    });
+
+    expect(result.status).toBe("fail");
+    await expect(fs.readFile(externalMetadata, "utf8")).resolves.toBe('{"qaExitCode":0}');
   });
 
   it("leases a desktop box, runs Slack QA inside it, copies artifacts, and stops on pass", async () => {
@@ -267,11 +440,15 @@ describe("mantis Slack desktop smoke runtime", () => {
       .filter((entry) => entry.command === "rsync")
       .flatMap((entry) => entry.args);
     expect(rsyncArgs).not.toContain("--delete");
-    expect(rsyncArgs).toContain(
-      "crabbox@203.0.113.10:/tmp/openclaw-mantis-slack-desktop-2026-05-04T13-00-00-000Z/",
-    );
-    expect(rsyncArgs).toContain(
-      "crabbox@203.0.113.10:/tmp/openclaw-mantis-slack-desktop-2026-05-04T13-00-00-000Z/slack-qa/",
+    expect(rsyncArgs).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^crabbox@203\.0\.113\.10:\/tmp\/openclaw-mantis-slack-desktop-2026-05-04T13-00-00-000Z-[0-9a-f-]{36}\/$/u,
+        ),
+        expect.stringMatching(
+          /^crabbox@203\.0\.113\.10:\/tmp\/openclaw-mantis-slack-desktop-2026-05-04T13-00-00-000Z-[0-9a-f-]{36}\/slack-qa\/$/u,
+        ),
+      ]),
     );
     await expect(fs.readFile(result.screenshotPath ?? "", "utf8")).resolves.toBe("png");
     await expect(fs.readFile(result.videoPath ?? "", "utf8")).resolves.toBe("mp4");
@@ -396,14 +573,42 @@ describe("mantis Slack desktop smoke runtime", () => {
   });
 
   it("rejects non-approval scenarios in approval checkpoint mode", async () => {
+    const outputDir = path.join(repoRoot, ".artifacts", "invalid-scenario-preserves-evidence");
+    await fs.mkdir(outputDir, { recursive: true });
+    const previousSummary = path.join(outputDir, "mantis-slack-desktop-smoke-summary.json");
+    await fs.writeFile(previousSummary, "preserve the prior valid run");
     await expect(
       runMantisSlackDesktopSmoke({
         approvalCheckpoints: true,
         crabboxBin: "/tmp/crabbox",
+        outputDir: path.relative(repoRoot, outputDir),
         repoRoot,
         scenarioIds: ["slack-canary"],
       }),
     ).rejects.toThrow("--approval-checkpoints only supports approval checkpoint scenarios");
+    await expect(fs.readFile(previousSummary, "utf8")).resolves.toBe(
+      "preserve the prior valid run",
+    );
+  });
+
+  it("preserves the previous smoke evidence when hydration options are invalid", async () => {
+    const outputDir = path.join(repoRoot, ".artifacts", "invalid-hydrate-preserves-evidence");
+    await fs.mkdir(outputDir, { recursive: true });
+    const previousSummary = path.join(outputDir, "mantis-slack-desktop-smoke-summary.json");
+    await fs.writeFile(previousSummary, "preserve the prior valid run");
+
+    await expect(
+      runMantisSlackDesktopSmoke({
+        crabboxBin: "/tmp/crabbox",
+        hydrateMode: "invalid" as "source",
+        outputDir: path.relative(repoRoot, outputDir),
+        repoRoot,
+      }),
+    ).rejects.toThrow("Unsupported Mantis Slack desktop hydrate mode");
+
+    await expect(fs.readFile(previousSummary, "utf8")).resolves.toBe(
+      "preserve the prior valid run",
+    );
   });
 
   it.each([

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -1,8 +1,9 @@
 // Qa Lab plugin module implements slack desktop smoke behavior.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
+import { pathExists, root } from "openclaw/plugin-sdk/security-runtime";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "../cli-paths.js";
 import {
   acquireQaCredentialLease,
@@ -115,6 +116,12 @@ type SlackDesktopRemoteMetadata = {
 };
 
 type MantisApprovalCheckpointState = "pending" | "resolved";
+type SlackArtifactOwner = Awaited<ReturnType<typeof root>>;
+type MantisApprovalCheckpointIdentity = {
+  approvalId: string;
+  messageTs: string;
+  threadTs: string | null;
+};
 
 type MantisApprovalCheckpointScreenshot = {
   ackPath: string;
@@ -221,30 +228,61 @@ function resolveScenarioIds(params: {
   return scenarioIds;
 }
 
-async function assertNonEmptyFile(filePath: string, label: string) {
-  let stats;
+async function assertNonEmptyFile(owner: SlackArtifactOwner, relativePath: string, label: string) {
+  let opened;
   try {
-    stats = await fs.stat(filePath);
+    opened = await owner.open(relativePath);
   } catch (error) {
-    throw new Error(`${label} is missing: ${filePath}`, { cause: error });
+    throw new Error(`${label} is missing: ${relativePath}`, { cause: error });
   }
-  if (!stats.isFile() || stats.size <= 0) {
-    throw new Error(`${label} is empty: ${filePath}`);
+  try {
+    if (opened.stat.size <= 0) {
+      throw new Error(`${label} is empty: ${relativePath}`);
+    }
+  } finally {
+    await opened.handle.close();
   }
 }
 
-async function readJsonObject(filePath: string, label: string): Promise<Record<string, unknown>> {
-  await assertNonEmptyFile(filePath, label);
+async function readJsonObject(
+  owner: SlackArtifactOwner,
+  relativePath: string,
+  label: string,
+): Promise<Record<string, unknown>> {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    parsed = JSON.parse(await owner.readText(relativePath));
   } catch (error) {
-    throw new Error(`${label} is not valid JSON: ${filePath}`, { cause: error });
+    throw new Error(`${label} is not valid JSON: ${relativePath}`, { cause: error });
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`${label} must be a JSON object: ${filePath}`);
+    throw new Error(`${label} must be a JSON object: ${relativePath}`);
   }
   return parsed as Record<string, unknown>;
+}
+
+async function clearSlackArtifacts(owner: SlackArtifactOwner, artifactPaths: readonly string[]) {
+  await Promise.all(
+    [...new Set(artifactPaths)].map(async (artifactPath) => {
+      if (await owner.exists(artifactPath)) {
+        await owner.remove(artifactPath);
+      }
+    }),
+  );
+}
+
+async function finalizeSlackRunActions(actions: readonly (() => Promise<void>)[]) {
+  let firstFailure: unknown;
+  for (const action of actions) {
+    try {
+      await action();
+    } catch (error) {
+      firstFailure ??= error;
+    }
+  }
+  if (firstFailure !== undefined) {
+    throw firstFailure;
+  }
 }
 
 function assertApprovalCheckpointBaseJson(params: {
@@ -266,13 +304,43 @@ function assertApprovalCheckpointBaseJson(params: {
 }
 
 function assertApprovalCheckpointJson(params: {
+  channelId: string;
   filePath: string;
+  identity?: MantisApprovalCheckpointIdentity;
   label: string;
   record: Record<string, unknown>;
   scenarioId: string;
   state: MantisApprovalCheckpointState;
-}) {
+}): MantisApprovalCheckpointIdentity {
   assertApprovalCheckpointBaseJson(params);
+  const expectedKind = params.scenarioId === "slack-approval-exec-native" ? "exec" : "plugin";
+  if (params.record.approvalKind !== expectedKind || params.record.channelId !== params.channelId) {
+    throw new Error(`${params.label} has unexpected approval kind or Slack channel.`);
+  }
+  const approvalId = params.record.approvalId;
+  const messageTs = params.record.messageTs;
+  const threadTs = params.record.threadTs;
+  if (
+    typeof approvalId !== "string" ||
+    !approvalId.trim() ||
+    typeof messageTs !== "string" ||
+    !messageTs.trim() ||
+    (threadTs !== null && (typeof threadTs !== "string" || !threadTs.trim()))
+  ) {
+    throw new Error(`${params.label} is missing its Slack approval interaction identity.`);
+  }
+  const identity = { approvalId, messageTs, threadTs };
+  if (
+    params.identity &&
+    (identity.approvalId !== params.identity.approvalId ||
+      identity.messageTs !== params.identity.messageTs ||
+      identity.threadTs !== params.identity.threadTs)
+  ) {
+    throw new Error(`${params.label} does not match its pending approval interaction.`);
+  }
+  if (params.record.decision !== (params.state === "pending" ? null : "allow-once")) {
+    throw new Error(`${params.label} has an unexpected approval decision.`);
+  }
   const message = params.record.message;
   if (!message || typeof message !== "object" || Array.isArray(message)) {
     throw new Error(`${params.label} is missing Slack message evidence in ${params.filePath}`);
@@ -300,11 +368,15 @@ function assertApprovalCheckpointJson(params: {
       `${params.label} message evidence is missing hasNativeActions in ${params.filePath}`,
     );
   }
-  if (params.state === "pending" && candidate.actionLabels.length === 0) {
-    throw new Error(
-      `${params.label} pending message evidence has no native action labels in ${params.filePath}`,
-    );
+  if (
+    (params.state === "pending" &&
+      (!candidate.hasNativeActions || !candidate.actionLabels.includes("Allow Once"))) ||
+    (params.state === "resolved" &&
+      (candidate.hasNativeActions || candidate.actionLabels.length > 0))
+  ) {
+    throw new Error(`${params.label} has unexpected native approval actions in ${params.filePath}`);
   }
+  return identity;
 }
 
 function assertApprovalCheckpointAckJson(params: {
@@ -325,6 +397,8 @@ function assertApprovalCheckpointAckJson(params: {
 }
 
 async function collectApprovalCheckpointArtifacts(params: {
+  artifactOwner: SlackArtifactOwner;
+  channelId: string;
   enabled: boolean;
   outputDir: string;
   scenarioIds: readonly string[];
@@ -333,31 +407,57 @@ async function collectApprovalCheckpointArtifacts(params: {
     return undefined;
   }
   const directoryPath = path.join(params.outputDir, "approval-checkpoints");
+  const seenApprovalIds = new Set<string>();
+  const seenSlackMessages = new Set<string>();
   const screenshots: MantisApprovalCheckpointScreenshot[] = [];
   for (const scenarioId of params.scenarioIds) {
+    let identity: MantisApprovalCheckpointIdentity | undefined;
     for (const state of ["pending", "resolved"] as const) {
       const checkpointPath = path.join(directoryPath, `${scenarioId}.${state}.json`);
       const ackPath = path.join(directoryPath, `${scenarioId}.${state}.ack.json`);
       const screenshotPath = path.join(directoryPath, `${scenarioId}-${state}.png`);
       const checkpointLabel = `Approval checkpoint ${scenarioId}.${state}`;
       const ackLabel = `Approval checkpoint ack ${scenarioId}.${state}`;
-      assertApprovalCheckpointJson({
+      identity = assertApprovalCheckpointJson({
+        channelId: params.channelId,
         filePath: checkpointPath,
+        identity,
         label: checkpointLabel,
-        record: await readJsonObject(checkpointPath, checkpointLabel),
+        record: await readJsonObject(
+          params.artifactOwner,
+          path.relative(params.outputDir, checkpointPath),
+          checkpointLabel,
+        ),
         scenarioId,
         state,
       });
+      if (state === "pending") {
+        const slackMessage = JSON.stringify([
+          params.channelId,
+          identity.messageTs,
+          identity.threadTs,
+        ]);
+        if (seenApprovalIds.has(identity.approvalId) || seenSlackMessages.has(slackMessage)) {
+          throw new Error(`${checkpointLabel} reuses another scenario's approval interaction.`);
+        }
+        seenApprovalIds.add(identity.approvalId);
+        seenSlackMessages.add(slackMessage);
+      }
       assertApprovalCheckpointAckJson({
         filePath: ackPath,
         label: ackLabel,
-        record: await readJsonObject(ackPath, ackLabel),
+        record: await readJsonObject(
+          params.artifactOwner,
+          path.relative(params.outputDir, ackPath),
+          ackLabel,
+        ),
         scenarioId,
         screenshotPath,
         state,
       });
       await assertNonEmptyFile(
-        screenshotPath,
+        params.artifactOwner,
+        path.relative(params.outputDir, screenshotPath),
         `Approval checkpoint screenshot ${scenarioId}.${state}`,
       );
       screenshots.push({
@@ -376,14 +476,13 @@ async function collectApprovalCheckpointArtifacts(params: {
 }
 
 async function readRemoteMetadata(
-  outputDir: string,
+  owner: SlackArtifactOwner,
 ): Promise<SlackDesktopRemoteMetadata | undefined> {
-  const metadataPath = path.join(outputDir, "remote-metadata.json");
-  if (!(await pathExists(metadataPath))) {
+  if (!(await owner.exists("remote-metadata.json"))) {
     return undefined;
   }
   try {
-    const parsed = JSON.parse(await fs.readFile(metadataPath, "utf8")) as unknown;
+    const parsed = JSON.parse(await owner.readText("remote-metadata.json")) as unknown;
     if (!parsed || typeof parsed !== "object") {
       return undefined;
     }
@@ -1287,8 +1386,37 @@ export async function runMantisSlackDesktopSmoke(
     "Mantis Slack desktop smoke output directory",
     { mode: 0o755 },
   );
+  const gatewaySetup = opts.gatewaySetup ?? false;
+  const approvalCheckpoints = opts.approvalCheckpoints ?? false;
+  if (approvalCheckpoints && gatewaySetup) {
+    throw new Error("--approval-checkpoints cannot be used with --gateway-setup.");
+  }
+  const scenarioIds = resolveScenarioIds({
+    approvalCheckpoints,
+    scenarioIds: opts.scenarioIds,
+  });
+  const hydrateMode =
+    normalizeHydrateMode(opts.hydrateMode) ??
+    normalizeHydrateMode(env[HYDRATE_MODE_ENV]) ??
+    DEFAULT_HYDRATE_MODE;
+  const artifactOwner = await root(outputDir, { symlinks: "reject" });
   const summaryPath = path.join(outputDir, "mantis-slack-desktop-smoke-summary.json");
   const reportPath = path.join(outputDir, "mantis-slack-desktop-smoke-report.md");
+  await clearSlackArtifacts(artifactOwner, [
+    path.basename(summaryPath),
+    path.basename(reportPath),
+    "error.txt",
+    "slack-desktop-smoke.png",
+    "slack-desktop-smoke.mp4",
+    "remote-metadata.json",
+    ...(approvalCheckpoints ? scenarioIds : []).flatMap((scenarioId) =>
+      (["pending", "resolved"] as const).flatMap((state) => [
+        `approval-checkpoints/${scenarioId}.${state}.json`,
+        `approval-checkpoints/${scenarioId}.${state}.ack.json`,
+        `approval-checkpoints/${scenarioId}-${state}.png`,
+      ]),
+    ),
+  ]);
   const crabboxBin = await resolveCrabboxBin({
     env,
     envName: CRABBOX_BIN_ENV,
@@ -1312,19 +1440,6 @@ export async function runMantisSlackDesktopSmoke(
   const alternateModel = trimToValue(opts.alternateModel) ?? primaryModel;
   const fastMode = opts.fastMode ?? true;
   const freshPr = trimToValue(opts.freshPr);
-  const hydrateMode =
-    normalizeHydrateMode(opts.hydrateMode) ??
-    normalizeHydrateMode(env[HYDRATE_MODE_ENV]) ??
-    DEFAULT_HYDRATE_MODE;
-  const gatewaySetup = opts.gatewaySetup ?? false;
-  const approvalCheckpoints = opts.approvalCheckpoints ?? false;
-  if (approvalCheckpoints && gatewaySetup) {
-    throw new Error("--approval-checkpoints cannot be used with --gateway-setup.");
-  }
-  const scenarioIds = resolveScenarioIds({
-    approvalCheckpoints,
-    scenarioIds: opts.scenarioIds,
-  });
   const slackChannelId =
     trimToValue(opts.slackChannelId) ??
     trimToValue(env[SLACK_CHANNEL_ID_ENV]) ??
@@ -1337,7 +1452,7 @@ export async function runMantisSlackDesktopSmoke(
   const createdLease = explicitLeaseId === undefined;
   const remoteOutputDir = `/tmp/openclaw-mantis-slack-desktop-${startedAt
     .toISOString()
-    .replace(/[^0-9A-Za-z]/gu, "-")}`;
+    .replace(/[^0-9A-Za-z]/gu, "-")}-${randomUUID()}`;
   let credentialLease: SlackGatewayCredentialLease | undefined;
   let leaseHeartbeat: SlackGatewayCredentialHeartbeat | undefined;
   let leaseId = explicitLeaseId;
@@ -1446,14 +1561,19 @@ export async function runMantisSlackDesktopSmoke(
         runner,
       }),
     );
+    await clearSlackArtifacts(artifactOwner, [
+      "error.txt",
+      path.basename(summaryPath),
+      path.basename(reportPath),
+    ]);
     screenshotPath = path.join(outputDir, "slack-desktop-smoke.png");
     videoPath = path.join(outputDir, "slack-desktop-smoke.mp4");
     if (!(await pathExists(videoPath))) {
       videoPath = undefined;
     }
-    remoteMetadata = await readRemoteMetadata(outputDir);
+    remoteMetadata = await readRemoteMetadata(artifactOwner);
     slackQaDir = path.join(outputDir, "slack-qa");
-    await assertNonEmptyFile(screenshotPath, "Slack desktop screenshot");
+    await assertNonEmptyFile(artifactOwner, "slack-desktop-smoke.png", "Slack desktop screenshot");
     const gatewaySetupCompleted =
       gatewaySetup && remoteMetadata?.qaExitCode === 0 && remoteMetadata.gatewayAlive === true;
     const slackQaCompleted = !gatewaySetup && remoteMetadata?.qaExitCode === 0;
@@ -1477,6 +1597,8 @@ export async function runMantisSlackDesktopSmoke(
       throw new Error(`${detail} See slack-desktop-command.log for details.`);
     }
     approvalCheckpointArtifacts = await collectApprovalCheckpointArtifacts({
+      artifactOwner,
+      channelId: slackChannelId,
       enabled: approvalCheckpoints,
       outputDir,
       scenarioIds,
@@ -1548,7 +1670,7 @@ export async function runMantisSlackDesktopSmoke(
       status: "fail",
       timings: timer.snapshot(),
     };
-    await fs.writeFile(path.join(outputDir, "error.txt"), `${summary.error}\n`, "utf8");
+    await artifactOwner.create("error.txt", `${summary.error}\n`);
     return {
       outputDir,
       reportPath,
@@ -1558,25 +1680,35 @@ export async function runMantisSlackDesktopSmoke(
       videoPath,
     };
   } finally {
-    if (summary) {
-      summary.finishedAt = new Date().toISOString();
-      summary.timings = timer.snapshot();
-      await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
-      await fs.writeFile(reportPath, renderReport(summary), "utf8");
-    }
-    if (createdLease && leaseId && !keepLease) {
-      await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
-    }
-    if (leaseHeartbeat) {
-      await leaseHeartbeat.stop().catch((error: unknown) => {
-        console.warn(`Slack credential heartbeat cleanup failed: ${formatErrorMessage(error)}`);
-      });
-    }
-    if (credentialLease) {
-      await credentialLease.release().catch((error: unknown) => {
-        console.warn(`Slack credential release failed: ${formatErrorMessage(error)}`);
-      });
-    }
+    await finalizeSlackRunActions([
+      async () => {
+        if (summary) {
+          summary.finishedAt = new Date().toISOString();
+          summary.timings = timer.snapshot();
+          await artifactOwner.create(path.basename(reportPath), renderReport(summary));
+          await artifactOwner.createJson(path.basename(summaryPath), summary, { space: 2 });
+        }
+      },
+      async () => {
+        if (createdLease && leaseId && !keepLease) {
+          await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
+        }
+      },
+      async () => {
+        if (leaseHeartbeat) {
+          await leaseHeartbeat.stop().catch((error: unknown) => {
+            console.warn(`Slack credential heartbeat cleanup failed: ${formatErrorMessage(error)}`);
+          });
+        }
+      },
+      async () => {
+        if (credentialLease) {
+          await credentialLease.release().catch((error: unknown) => {
+            console.warn(`Slack credential release failed: ${formatErrorMessage(error)}`);
+          });
+        }
+      },
+    ]);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running Slack Desktop QA could receive a false success when artifacts from a previous run survived, or when fresh approval artifacts represented a different or replayed Slack/Codex approval interaction.

## Why This Change Was Made

The existing QA artifact owner now invalidates only current-run-owned artifacts, creates a unique remote evidence namespace, and consumes evidence through the existing pinned filesystem-root API. Approval kind, opaque identity, message/thread identity, action availability, and pending-to-resolved transitions are checked against the actual Slack and Codex producers; reports publish before summaries, and resource cleanup remains independent.

## User Impact

Stale, external, malformed, or replayed evidence can no longer turn an incomplete Slack Desktop or approval-checkpoint run into a passing result. Native and Codex command/file approvals stay covered, unrelated diagnostics and unselected scenarios remain intact, and existing lease, heartbeat, and credential cleanup behavior is preserved.

## Evidence

- Two independently reproduced root causes: prior-run/external artifact authentication and approval-identity replay with otherwise fresh current-run evidence.
- Focused deterministic owner proof: `OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts` — **29 passed**.
- Four independent whole-owner hostile reviews: zero P0, P1, P2, or P3 findings.
- Genuine strict Codex AutoReview (`gpt-5.6-sol`, high reasoning, P3 threshold): zero findings; real TruffleHog secret scan clean.
- Clean read-only recursive synthetic merge, patch application, and `git diff --check` against current main `aa2a5c96f69a1be639c602649d4aa2e4de8da0a8`.
- Existing runtime delta: **+132 production lines**; existing adjacent tests: **+205 lines**.
- This proof is focused and deterministic; it does not claim a fresh live Slack/Crabbox run or hosted CI result.
