### PR TITLE
fix(tts): reject non-audio speech synthesis responses

### DIFF
--- a/extensions/azure-speech/tts.test.ts
+++ b/extensions/azure-speech/tts.test.ts
@@ -226,4 +226,29 @@ describe("azure speech tts", () => {
       },
     ]);
   });
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty audio", contentType: "audio/mpeg", body: "" },
+  ])("rejects a successful $name response as synthesized audio", async ({ contentType, body }) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(body, { status: 200, headers: { "content-type": contentType } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      azureSpeechTTS({
+        text: "hello",
+        apiKey: "fixture-value",
+        region: "eastus",
+        voice: "en-US-JennyNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
+  });
 });

--- a/extensions/azure-speech/tts.test.ts
+++ b/extensions/azure-speech/tts.test.ts
@@ -1,4 +1,6 @@
 // Azure Speech tests cover tts plugin behavior.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-media-understanding";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -250,5 +252,49 @@ describe("azure speech tts", () => {
         timeoutMs: 5_000,
       }),
     ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
+  });
+
+  it("closes the upstream socket for a never-ending malformed response over a real connection", async () => {
+    let notifySocketClosed: ((closed: boolean) => void) | undefined;
+    const socketClosed = new Promise<boolean>((resolve) => {
+      notifySocketClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => notifySocketClosed?.(true));
+      response.writeHead(200, { "content-type": "application/json" });
+      // Headers land, then the body never ends: only an explicit cancel closes this.
+      response.write('{"error":"still streaming');
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      await expect(
+        azureSpeechTTS({
+          text: "hello",
+          apiKey: "fixture-value",
+          endpoint: `http://127.0.0.1:${port}`,
+          voice: "en-US-JennyNeural",
+          lang: "en-US",
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
+
+      await expect(
+        Promise.race([
+          socketClosed,
+          new Promise<boolean>((resolve) => {
+            setTimeout(() => resolve(false), 250);
+          }),
+        ]),
+      ).resolves.toBe(true);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 });

--- a/extensions/azure-speech/tts.ts
+++ b/extensions/azure-speech/tts.ts
@@ -4,6 +4,7 @@
  */
 import {
   assertOkOrThrowProviderError,
+  assertProviderBinaryResponseContent,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -221,7 +222,15 @@ export async function azureSpeechTTS(params: {
 
   try {
     await assertOkOrThrowProviderError(response, "Azure Speech TTS API error");
-    return await readResponseWithLimit(
+    try {
+      assertProviderBinaryResponseContent(response, "Azure Speech TTS API error", "audio");
+    } catch (error) {
+      // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+      // before the rejected response and its dispatcher can be released.
+      void response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
+    const audio = await readResponseWithLimit(
       response,
       params.maxBytes ?? DEFAULT_AZURE_SPEECH_MAX_BYTES,
       {
@@ -229,6 +238,10 @@ export async function azureSpeechTTS(params: {
           new Error(`Azure Speech TTS audio response exceeds ${maxBytes} bytes`),
       },
     );
+    if (audio.byteLength === 0) {
+      throw new Error("Azure Speech TTS API error: malformed audio response");
+    }
+    return audio;
   } finally {
     await release();
   }

--- a/extensions/gradium/tts.test.ts
+++ b/extensions/gradium/tts.test.ts
@@ -226,4 +226,28 @@ describe("gradium tts diagnostics", () => {
 
     expect(streamed.getReadCount()).toBeLessThan(20);
   });
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty audio", contentType: "audio/mpeg", body: "" },
+  ])("rejects a successful $name response as synthesized audio", async ({ contentType, body }) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(body, { status: 200, headers: { "content-type": contentType } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      gradiumTTS({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: "https://api.gradium.ai",
+        voiceId: "YTpq7expH9539ERJ",
+        outputFormat: "wav",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium API error: malformed audio response");
+  });
 });

--- a/extensions/gradium/tts.ts
+++ b/extensions/gradium/tts.ts
@@ -1,5 +1,8 @@
 // Gradium plugin module implements tts behavior.
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  assertProviderBinaryResponseContent,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { GRADIUM_API_HOSTNAME, normalizeGradiumBaseUrl } from "./shared.js";
@@ -54,10 +57,22 @@ export async function gradiumTTS(params: {
   try {
     await assertOkOrThrowProviderError(response, "Gradium API error");
 
-    return await readResponseWithLimit(response, maxBytes, {
+    try {
+      assertProviderBinaryResponseContent(response, "Gradium API error", "audio");
+    } catch (error) {
+      // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+      // before the rejected response and its dispatcher can be released.
+      void response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
+    const audio = await readResponseWithLimit(response, maxBytes, {
       onOverflow: ({ maxBytes: maxBytesLocal }) =>
         new Error(`Gradium TTS audio response exceeds ${maxBytesLocal} bytes`),
     });
+    if (audio.byteLength === 0) {
+      throw new Error("Gradium API error: malformed audio response");
+    }
+    return audio;
   } finally {
     await release();
   }

--- a/extensions/openai/tts.test.ts
+++ b/extensions/openai/tts.test.ts
@@ -306,6 +306,60 @@ describe("openai tts", () => {
       ).rejects.toThrow("OpenAI TTS API error (503): temporary upstream outage");
     });
 
+    it.each([
+      { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+      { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+      { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+      { name: "empty audio", contentType: "audio/mpeg", body: "" },
+    ])(
+      "rejects a successful $name response as synthesized audio",
+      async ({ contentType, body }) => {
+        globalThis.fetch = vi
+          .fn()
+          .mockResolvedValue(
+            new Response(body, { status: 200, headers: { "content-type": contentType } }),
+          ) as unknown as typeof fetch;
+
+        await expect(
+          openaiTTS({
+            text: "hello",
+            apiKey: "test-key",
+            baseUrl: "https://api.openai.com/v1",
+            model: "gpt-4o-mini-tts",
+            voice: "alloy",
+            responseFormat: "mp3",
+            timeoutMs: 5_000,
+          }),
+        ).rejects.toThrow("OpenAI TTS API error: malformed audio response");
+      },
+    );
+
+    it.each([
+      { name: "audio content type", contentType: "audio/mpeg" },
+      { name: "generic binary content type", contentType: "application/octet-stream" },
+      { name: "missing content type", contentType: undefined },
+    ])("preserves nonempty $name speech responses", async ({ contentType }) => {
+      const audio = Buffer.from("audio-bytes");
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(audio, {
+          status: 200,
+          ...(contentType ? { headers: { "content-type": contentType } } : {}),
+        }),
+      ) as unknown as typeof fetch;
+
+      await expect(
+        openaiTTS({
+          text: "hello",
+          apiKey: "test-key",
+          baseUrl: "https://api.openai.com/v1",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+          responseFormat: "mp3",
+          timeoutMs: 5_000,
+        }),
+      ).resolves.toEqual(audio);
+    });
+
     it("caps streamed audio responses instead of buffering oversized TTS output", async () => {
       const streamed = createStreamingErrorResponse({
         status: 200,

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -1,6 +1,7 @@
 // Openai plugin module implements tts behavior.
 import {
   assertOkOrThrowProviderError,
+  assertProviderBinaryResponseContent,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -182,10 +183,22 @@ export async function openaiTTS(params: {
 
     await assertOkOrThrowProviderError(response, "OpenAI TTS API error");
 
-    return await readResponseWithLimit(response, maxBytes, {
+    try {
+      assertProviderBinaryResponseContent(response, "OpenAI TTS API error", "audio");
+    } catch (error) {
+      // Capture may clone and tee this response; awaiting cancellation would
+      // deadlock before the rejected response and dispatcher can be released.
+      void response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
+    const audio = await readResponseWithLimit(response, maxBytes, {
       onOverflow: ({ maxBytes: maxBytesLocal }) =>
         new Error(`OpenAI TTS audio response exceeds ${maxBytesLocal} bytes`),
     });
+    if (audio.byteLength === 0) {
+      throw new Error("OpenAI TTS API error: malformed audio response");
+    }
+    return audio;
   } finally {
     await release();
   }

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -644,4 +644,29 @@ describe("xai tts", () => {
       ).rejects.toThrow("xAI TTS API error (503): temporary upstream outage");
     });
   });
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty audio", contentType: "audio/mpeg", body: "" },
+  ])("rejects a successful $name response as synthesized audio", async ({ contentType, body }) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(body, { status: 200, headers: { "content-type": contentType } }),
+      );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      xaiTTS({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        language: "en",
+        responseFormat: "mp3",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("xAI TTS API error: malformed audio response");
+  });
 });

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -2,6 +2,7 @@
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
+  assertProviderBinaryResponseContent,
   postJsonRequest,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
@@ -505,10 +506,22 @@ export async function xaiTTS(params: {
   try {
     await assertOkOrThrowProviderError(response, "xAI TTS API error");
 
-    return await readResponseWithLimit(response, maxBytes, {
+    try {
+      assertProviderBinaryResponseContent(response, "xAI TTS API error", "audio");
+    } catch (error) {
+      // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+      // before the rejected response and its dispatcher can be released.
+      void response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
+    const audio = await readResponseWithLimit(response, maxBytes, {
       onOverflow: ({ maxBytes: maxBytesLocal }) =>
         new Error(`xAI TTS audio response exceeds ${maxBytesLocal} bytes`),
     });
+    if (audio.byteLength === 0) {
+      throw new Error("xAI TTS API error: malformed audio response");
+    }
+    return audio;
   } finally {
     await release();
   }


### PR DESCRIPTION
Related: #117339
Related: #117227

AI-assisted (Claude Code). I ran every measurement below myself; the mutation runs are reproducible with the commands shown.

## What Problem This Solves

Fixes an issue where users generating speech through xAI, Gradium, Azure Speech, or OpenAI would receive a corrupt audio attachment instead of an error when the provider answered with HTTP 200 but a non-audio body.

A successful-status JSON error, an HTML sign-in or captcha page, or a zero-byte response was read straight into the buffer and delivered as playable audio. The user gets a file that will not play, and the provider's actual error message is discarded.

## Why This Change Was Made

The repository already owns this contract, and one speech path already uses it: `src/tts/openai-compatible-speech-provider.ts:399` reads its audio through `readProviderBinaryResponse(..., "audio")`. The four affected bundled raw-binary synthesizers were never migrated, so whether a malformed 200 was caught depended on which provider a user routed through — OpenAI-compatible speech was guarded, while native xAI, Gradium, Azure Speech, and OpenAI were not.

This applies the split form (`assertProviderBinaryResponseContent` + `readResponseWithLimit`) rather than `readProviderBinaryResponse`, because the combined helper hardcodes its own `onOverflow` after spreading caller options and would therefore change each provider's existing byte-cap message. Keeping the split form preserves `<Provider> TTS audio response exceeds N bytes` exactly as it is today. The same reasoning is why `extensions/byteplus` and `extensions/runway` use the split form on the video side.

Cancellation uses `void ... .catch(() => undefined)` rather than `await`, matching `extensions/google/video-generation-provider.ts:241-243` and `src/infra/net/fetch-guard.ts`: under debug-proxy capture the body is one branch of a `Response.clone()` tee, and per `src/proxy-capture/runtime.ts:41-46` cancelling such a branch never settles while its sibling is live.

`extensions/openai/tts.ts` carried the same defect and is now included in a separately attributed maintainer follow-up commit. #117227 changes only the OpenAI video-generation provider and its test, so its file ownership does not overlap the OpenAI TTS owner or test here.

## User Impact

A malformed synthesis response now fails with `<Provider> TTS API error: malformed audio response` instead of producing an unplayable file, and the upstream socket is closed rather than left open until GC.

## Evidence

Original contributor validation at historical head `1450696a8f1`:

```
node scripts/run-vitest.mjs \
  extensions/xai/tts.test.ts \
  extensions/gradium/tts.test.ts \
  extensions/azure-speech/tts.test.ts

Tests  31 passed (31)
Tests  23 passed (23)
```

**The added tests are load-bearing, verified by mutation.** Reverting only the production files to `main` turns exactly the new cases red, in two runs (vitest splits these across projects, so they are measured separately):

```
git stash push -- extensions/xai/tts.ts
→ Tests  4 failed | 27 passed (31)
  × rejects a successful 'JSON error' response as synthesized audio
  × rejects a successful 'problem JSON' response as synthesized audio
  × rejects a successful 'HTML' response as synthesized audio
  × rejects a successful 'empty audio' response as synthesized audio

git stash push -- extensions/gradium/tts.ts extensions/azure-speech/tts.ts
→ Tests  8 failed | 15 passed (23)
  (the same four cases, once for gradium and once for azure-speech)
```

`npx oxlint` is clean on all six changed files.

### Real behavior proof: a real socket, a real never-ending response, no mocks

Added in `91b601ff667` after the review asked for evidence beyond mocked transports.

`extensions/azure-speech/tts.test.ts` starts a real `node:http` server on `127.0.0.1` that answers
`200` with `content-type: application/json` and then **never ends the body**, then calls the real
`azureSpeechTTS` against it through `endpoint` — real global `fetch`, real SSRF guard, real socket,
no `vi.stubGlobal`, no provider account. Only the guard differs between the two runs:

| source | result | wall clock |
|---|---|---|
| guard removed (current `main` behaviour) | `request timed out` — synthesis hangs to its deadline with the socket still open | **5029 ms** |
| this branch | `Azure Speech TTS API error: malformed audio response`, and the server observes its socket close | **120 ms** |

The close is asserted on the server side (`request.socket.once("close", ...)` raced against a 250 ms
deadline), so the pass is the operating system reporting the connection gone, not the client claiming
it cancelled.

The same control run also shows the defect's other half in its rawest form. With the guard removed,
the three mocked malformed cases stop throwing and instead resolve:

```
AssertionError: promise resolved "Buffer[ 123, 34, 101, 114, 114, ... ]" instead of rejecting
AssertionError: promise resolved "Buffer[ 123, 34, 116, 105, 116, ... ]" instead of rejecting
AssertionError: promise resolved "Buffer[ 60, 104, 116, 109, 108, ... ]" instead of rejecting
```

`123, 34, 101, 114, 114` is `{"err` and `60, 104, 116, 109, 108` is `<html` — the provider's JSON error
and its HTML sign-in page, handed back as the audio buffer that a channel then delivers as a voice
message.

Command: `node scripts/run-vitest.mjs run extensions/azure-speech/tts.test.ts --reporter=verbose`

**Proof boundary:** xAI and Gradium remain covered through their focused provider-owner tests because their provider network/hostname policies intentionally reject loopback. Azure Speech and OpenAI are each covered end to end with real localhost HTTP, real global `fetch`, their real SSRF guards, and synthetic credentials as detailed below. No hosted provider account was used.

### Maintainer complete-owner verification (exact head `97b84c2c8e95b4be937274631708f5d095219c07`)

Preserved both original @Yigtwxx commits `1450696a8f1bcc94289c72fea351bf308e4bbca6` and `91b601ff667a6e6beaa8f476451ca09edc34c297` with their exact original author/date; one separately Peter-authored commit adds only `extensions/openai/tts.ts` and its existing focused test.

Audited **all eight bundled TTS owners**: ElevenLabs and Fish Audio already use the canonical binary-response contract; Inworld and Volcengine intentionally consume JSON/base64-framed audio rather than raw audio; Azure Speech, Gradium, xAI, and OpenAI are the complete four-owner raw-binary gap fixed here.

Drove actual Azure Speech **and** OpenAI production owner functions separately against a real `node:http` localhost server using real global `fetch`, their actual SSRF guards, actual synthetic credential transmission, and real TCP connections—14 real authenticated HTTP requests per run, no mocked fetch/time/transport. Untouched current `main` accepted all eight malformed successful responses as supposed audio: JSON, `application/problem+json`, HTML, and zero-byte audio for each owner. Exact PR head rejects all eight with the owner-specific visible `malformed audio response` error. Both owners preserve a genuine 204-byte RIFF/WAVE response with `audio/wav`, the OpenAI SDK's explicitly supported `application/octet-stream`, and an absent `Content-Type`; all real sockets are released.

```text
provider        JSON       problem+json  HTML       empty      WAV      octet-stream  missing type
main Azure      accepted   accepted      accepted   accepted   204 B    204 B         204 B
head Azure      rejected   rejected      rejected   rejected   204 B    204 B         204 B
main OpenAI     accepted   accepted      accepted   accepted   204 B    204 B         204 B
head OpenAI     rejected   rejected      rejected   rejected   204 B    204 B         204 B
```

Focused exact-owner test command:

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-117345-tts node scripts/run-vitest.mjs extensions/azure-speech/tts.test.ts extensions/gradium/tts.test.ts extensions/xai/tts.test.ts extensions/openai/tts.test.ts
4 files passed; 77 tests passed (OpenAI 22, xAI 31, Azure/Gradium 24)
```

The existing Azure never-ending-body test also proves operating-system-observed real upstream socket closure. Existing focused cases preserve provider-specific exact overflow messages, non-2xx HTTP diagnostics, OpenAI debug capture, bounded body reads, and dispatcher release. Cancellation remains fire-and-forget because awaiting one branch of a debug-capture `Response.clone()` tee can deadlock.

Direct installed official OpenAI SDK `openai/src/resources/audio/speech.ts` sends `Accept: application/octet-stream`, marks `__binaryResponse: true`, and documents MP3/Opus/AAC/FLAC/WAV/PCM; official API contract: https://platform.openai.com/docs/api-reference/audio/createSpeech . Fresh full four-provider Codex Sol xhigh structured review: **clean (0.99)**. Exact-head Workflow Sanity **30722198801: success**; full CI attachment tracked separately.
