### PR TITLE
fix(agents): bound project memory git remote lookup

### DIFF
--- a/src/agents/project-memory-scope.test.ts
+++ b/src/agents/project-memory-scope.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 import { resolveProjectKey } from "./project-memory-scope.js";
 
 const execFileAsync = promisify(execFile);
@@ -94,4 +95,34 @@ describe("project memory scope", () => {
       Promise.all([resolveProjectKey(repo), resolveProjectKey(worktree)]),
     ).resolves.toEqual(["github.com/OpenClaw/OpenClaw", "github.com/OpenClaw/OpenClaw"]);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "falls back to the path key when the git lookup hangs",
+    async () => {
+      const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-hang-"));
+      cleanup.push(parent);
+      const fakeBinDir = path.join(parent, "fake-bin");
+      await fs.mkdir(fakeBinDir);
+      const fakeGitPath = path.join(fakeBinDir, "git");
+      await fs.writeFile(
+        fakeGitPath,
+        `#!${process.execPath}\nsetInterval(() => {}, 1000);\n`,
+        "utf-8",
+      );
+      await fs.chmod(fakeGitPath, 0o755);
+      const repo = path.join(parent, "repo");
+      await fs.mkdir(repo);
+
+      const started = Date.now();
+      const key = await withEnvAsync(
+        { PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        () => resolveProjectKey(repo),
+      );
+      const elapsed = Date.now() - started;
+
+      expect(key).toBe(`path:${repo}`);
+      expect(elapsed).toBeLessThan(15_000);
+    },
+    20_000,
+  );
 });

--- a/src/agents/project-memory-scope.test.ts
+++ b/src/agents/project-memory-scope.test.ts
@@ -112,6 +112,8 @@ describe("project memory scope", () => {
       await fs.chmod(fakeGitPath, 0o755);
       const repo = path.join(parent, "repo");
       await fs.mkdir(repo);
+      await git(repo, "init");
+      await git(repo, "remote", "add", "origin", "https://github.com/OpenClaw/OpenClaw.git");
 
       const started = Date.now();
       const key = await withEnvAsync(

--- a/src/agents/project-memory-scope.ts
+++ b/src/agents/project-memory-scope.ts
@@ -1,10 +1,10 @@
-import { execFile } from "node:child_process";
 import path from "node:path";
-import { promisify } from "node:util";
+import { runCommandWithTimeout } from "../process/exec.js";
 import { parseGitUrl } from "./utils/git.js";
 
-const execFileAsync = promisify(execFile);
 const MAX_PROJECT_KEY_CACHE_ENTRIES = 128;
+// Cheap git reads elsewhere bound at 4s (see detectGitRoot in infra/update-check.ts).
+const GIT_CONFIG_TIMEOUT_MS = 4_000;
 
 const projectKeyByRepoRoot = new Map<string, Promise<string>>();
 
@@ -32,20 +32,21 @@ function setBounded<K, V>(map: Map<K, V>, key: K, value: V, limit: number): void
 
 async function resolveUncachedProjectKey(repoRoot: string): Promise<string> {
   try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["-C", repoRoot, "config", "--get", "remote.origin.url"],
-      { encoding: "utf8" },
+    const result = await runCommandWithTimeout(
+      ["git", "-C", repoRoot, "config", "--get", "remote.origin.url"],
+      { timeoutMs: GIT_CONFIG_TIMEOUT_MS },
     );
-    const source = parseGitUrl(`git:${stdout.trim()}`);
-    if (source) {
-      // Userinfo is deliberately folded out so SSH and HTTPS clones converge.
-      // This accepts a rare same-host, same-path collision across distinct SSH
-      // accounts; the tradeoff is relevance bleed within one operator's store.
-      // Preserve remote path case so case-sensitive hosts fail closed. Providers
-      // with case-insensitive slugs may miss boosts/digests across casing variants,
-      // but folding paths could cross-inject memory between distinct repositories.
-      return escapeProjectKeyForAnnotation(`${source.host.toLowerCase()}/${source.path}`);
+    if (result.code === 0) {
+      const source = parseGitUrl(`git:${result.stdout.trim()}`);
+      if (source) {
+        // Userinfo is deliberately folded out so SSH and HTTPS clones converge.
+        // This accepts a rare same-host, same-path collision across distinct SSH
+        // accounts; the tradeoff is relevance bleed within one operator's store.
+        // Preserve remote path case so case-sensitive hosts fail closed. Providers
+        // with case-insensitive slugs may miss boosts/digests across casing variants,
+        // but folding paths could cross-inject memory between distinct repositories.
+        return escapeProjectKeyForAnnotation(`${source.host.toLowerCase()}/${source.path}`);
+      }
     }
   } catch {
     // Repositories without an origin intentionally use their canonical local root.


### PR DESCRIPTION
## Summary

Bound the `git config --get remote.origin.url` lookup in `resolveProjectKey` with `runCommandWithTimeout` (4s), so killable user-space Git stalls and broken PATH shims no longer block every embedded agent run and compaction indefinitely.

## What Problem This Solves

`resolveProjectKey` (`src/agents/project-memory-scope.ts:35`) resolves a stable repository identity for project-scoped memory. It is awaited on two hot paths:

- `src/agents/embedded-agent-runner/run-orchestrator.ts:243` - every embedded agent run
- `src/agents/embedded-agent-runner/compact.ts:170` - every compaction

It spawned a **bare `execFile("git", ["-C", repoRoot, "config", "--get", "remote.origin.url"])` with no timeout**. If that Git process never settles, the promise never resolves and the whole agent run or compaction hangs with it. Active sibling agent Git paths already use `runCommandWithTimeout` (`infra/update-check.ts`, `agents/worktrees/git.ts`, `agents/workspace.ts`). A dormant footer data provider still contains separate unbounded probes; it is not constructed on this runtime path and is outside this PR's scope.

**Code evidence**: `src/agents/project-memory-scope.ts:35-39` awaited `promisify(execFile)("git", ...)` with only `{ encoding: "utf8" }` - no timeout or abort path.

## Root Cause

- Introduced by commit d41a56fca1f (2026-07-28, "feat(memory): isolate curated entries by project", #115438), which added the file with the unbounded `execFile`.
- Violated invariant: callers assume `resolveProjectKey` settles; `execFile` without `timeout` only settles when the child exits.
- Reproduced trigger: a malicious or broken `git` shim earlier in PATH that remains alive indefinitely.

The timeout requests termination after 4s and normally settles shortly afterward. It is not a hard wall-clock guarantee for an uninterruptible kernel I/O state, which cannot be made responsive by a userspace timeout.

## Why This Fix

- Switch to the repo-standard `runCommandWithTimeout` with a 4s bound - the same timeout `detectGitRoot` (`src/infra/update-check.ts:215`) uses for an equally cheap Git read.
- On timeout or any non-zero exit, the function falls back to the `path:<root>` key - exactly the fallback repositories without an origin already take.
- Alternative considered: passing `timeout` to `execFile` directly. That works for the basic case but bypasses the shared helper's normalized kill, output, Windows, and result handling.

## User Impact

- Affected operations: an embedded agent run or compaction whose project-key Git lookup stalls.
- Before: the run can hang indefinitely with no visible outcome.
- After: the helper requests termination at the 4s bound, falls back to the canonical local path key after process cleanup, and the run proceeds.

## Evidence

- **Before**: with a fake `git` that remains alive first in PATH, `resolveProjectKey` on a real repository never settles - still pending 12s later.
- **After**: the same fake Git receives timeout termination at the 4s bound and the call returns the `path:` fallback key in about 4s.

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
elapsed_ms=12010 settled=false
FAIL: resolveProjectKey never settled; the agent run hangs with the wedged git
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
elapsed_ms=4027 settled=true key=path:/tmp/proof-hang-repo-BDfeG8
PASS: hung git lookup timed out and fell back to the path key
```

## Tests and Validation

- `pnpm check` passed on the original head.
- Focused sanitized AWS proof on the repaired head: 9/9 `src/agents/project-memory-scope.test.ts` cases passed; the hanging-Git case settled in about 4.0s.
- `oxfmt --check src/agents/project-memory-scope.test.ts` passed.
- The regression test now initializes a real repository with an origin before PATH interception. If interception breaks and real Git runs, the test returns the remote key and fails instead of producing a false-positive path fallback.
