### PR TITLE
fix(testing): activate realtime relay live smoke

### DIFF
--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -973,7 +973,10 @@ try {
       },
     },
   );
-  await transport.start();
+  const startResult = await transport.start();
+  if (startResult !== "ready") {
+    throw new Error("Relay smoke transport did not become ready: " + startResult);
+  }
   transport.activate();
   emit({ event: "talk.event", payload: { relaySessionId: "relay-live-smoke", type: "ready" } });
   emit({

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -974,6 +974,7 @@ try {
     },
   );
   await transport.start();
+  transport.activate();
   emit({ event: "talk.event", payload: { relaySessionId: "relay-live-smoke", type: "ready" } });
   emit({
     event: "talk.event",


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Resolves a problem where the realtime voice live smoke reported the gateway relay adapter as failed after the relay transport adopted deferred activation.

## Why This Change Was Made

The smoke now verifies that relay startup reached `ready`, then activates the transport before emitting synthetic provider events. This matches the production `RealtimeTalkSession` lifecycle without changing runtime behavior.

## User Impact

No user-visible runtime change. Maintainers regain a trustworthy end-to-end realtime voice smoke across OpenAI, Google Live, and the gateway relay adapter.

## Evidence

- Exact head: `5bcaca64423fc3fcb611f6f652fd1816611e36f5`
- `test/scripts/dev-tooling-safety.test.ts`: 63/64 passed initially; the single unrelated Anthropic timeout test passed on its isolated retry
- `node scripts/check-changed.mjs -- scripts/dev/realtime-talk-live-smoke.ts`: passed on Testbox
- Changed-gate Testbox run: https://github.com/openclaw/openclaw/actions/runs/30695618441
- Exact-head live Testbox proof:
  - OpenAI backend bridge passed
  - OpenAI audio roundtrip returned `glacier` with zero late audio bytes
  - OpenAI WebRTC browser passed
  - Google Live browser WebSocket, video, describe-view, and function response passed
  - Gateway relay browser adapter passed with listening/thinking statuses, transcripts, audio append, tool call/result, and close
- Live Testbox run: https://github.com/openclaw/openclaw/actions/runs/30695801302
- Autoreview: clean, no P0/P1 findings
