### PR TITLE
fix(ui): take session owner chip initials by code point

### DIFF
--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import type { SessionCreatedActor as ProtocolSessionCreatedActor } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { t } from "../i18n/index.ts";
+import { takeGraphemes } from "../lib/graphemes.ts";
 import { resolveAvatar } from "../lib/identity-avatar.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import "./viewer-facepile.ts";
@@ -66,8 +67,11 @@ function ownerInitials(createdActor: SessionCreatedActor): string {
     .replace(/@.*$/u, "")
     .split(/[\s._-]+/u)
     .filter(Boolean);
-  const initials = ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase();
-  return initials || source[0]!.toUpperCase();
+  // Grapheme clusters, not UTF-16 units or bare code points: emoji display names
+  // must render their complete visible initial (no lone surrogates or split ZWJ sequences).
+  const firstChar = (value: string | undefined): string => (value ? takeGraphemes(value, 1) : "");
+  const initials = (firstChar(parts[0]) + firstChar(parts[1])).toUpperCase();
+  return initials || firstChar(source).toUpperCase();
 }
 
 // Deterministic hue per identity so a person keeps one color everywhere.

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -130,6 +130,38 @@ describe("AppSidebar session ownership", () => {
     expect(carolChip?.textContent?.trim()).toBe("C");
   });
 
+  it("keeps emoji display-name initials as whole grapheme clusters", async () => {
+    for (const { label, expected } of [
+      { label: "🦞小明", expected: "🦞" },
+      { label: "👨‍👩‍👧‍👦Family", expected: "👨‍👩‍👧‍👦" },
+    ]) {
+      const gateway = createGateway({} as GatewayBrowserClient);
+      const harness = createSessionsHarness("main", ["agent:main:main", "agent:main:lobster"]);
+      const result = harness.sessions.state.result;
+      if (!result) {
+        throw new Error("expected session list");
+      }
+      const lobster = result.sessions.find((row) => row.key.endsWith(":lobster"));
+      if (!lobster) {
+        throw new Error("expected creator row");
+      }
+      lobster.createdActor = { type: "human", id: "profile-lobster", label };
+      result.creators = [
+        { id: "profile-lobster", label },
+        { id: "profile-ada", label: "Ada" },
+      ];
+
+      const { sidebar } = await mountSidebar(gateway, harness.sessions);
+      harness.publishList({ result, agentId: "main" });
+      await sidebar.updateComplete;
+
+      const chip = sidebar.querySelector(
+        '[data-session-key="agent:main:lobster"] .session-owner-chip',
+      );
+      expect(chip?.textContent?.trim()).toBe(expected);
+    }
+  });
+
   it("uses the complete facet and requests unloaded creators from the Gateway", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:main", "agent:main:ada"]);


### PR DESCRIPTION
## Summary

Take session owner-chip initials by grapheme cluster (the Control UI's canonical `takeGraphemes` helper) instead of UTF-16 code-unit indexing, so emoji display names no longer render a lone surrogate (tofu) in the sessions list, and ZWJ emoji sequences render as the complete visible initial.

## What Problem This Solves

The session owner chip (`ui/src/components/session-owner-chip.ts`) shows one- or two-character initials derived from the creator's display name. `ownerInitials` took those "characters" with `parts[0]?.[0]` and `source[0]` — UTF-16 **code-unit** indexing. Any display name starting with an astral character (emoji such as 🦞, 🚀, or CJK ext-B) yields the lone **high surrogate**, which renders as tofu/invalid glyph in the chip on every sessions list row.

The same bug class was already fixed for identity avatars in #104912 (`ui/src/lib/identity-avatar.ts:209` now uses `Array.from(word)[0]`); this chip is the remaining display-name initial extraction that still indexes code units. Sibling audit: every other `charAt(0)`/`[0]` initial site in `ui/src` either capitalizes internal ASCII constants while keeping the rest of the string (surrogate pairs stay intact) or handles non-user text — this file is the only user-controlled display name affected.

**Code evidence**: `session-owner-chip.ts:69-70` built initials via `(parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")` and fell back to `source[0]` — all code-unit indexing.

## Root Cause

- Introduced by commit cf2f5911610 (2026-07-22, "feat(sessions): permanent creator attribution, owner avatars, person filter", #112658), which added `ownerInitials` with code-unit indexing.
- Violated invariant: the chip treats `string[0]` as "the first visible character", which only holds for BMP text; astral characters occupy two UTF-16 units, so `[0]` returns half a character.
- Trigger: set a profile/session display name whose first letter is an emoji (e.g. "🦞小明"), then open the sessions list — the owner chip shows tofu instead of 🦞.

## Why This Fix

- Use the repo's canonical grapheme helper `takeGraphemes(value, 1)` (`ui/src/lib/graphemes.ts`) — `Intl.Segmenter` when available, `Array.from` as fallback. This is the established Control UI contract for Unicode-safe initials (`ui/src/lib/avatar.ts:58`, `provider-icon.ts:143`): it keeps astral characters whole **and** keeps multi-code-point grapheme clusters (ZWJ family emoji, flags, skin-tone sequences) as one visible initial.
- An earlier revision of this PR used `Array.from(value)[0]` (code points only). Review feedback correctly flagged that this still splits ZWJ sequences — `👨‍👩‍👧‍👦Family` would render only `👨` — so the fix now routes through `takeGraphemes`, matching the sibling avatar initializer that already tests complete ZWJ clusters.
- Kept the surrounding logic (delimiter split, `@`-strip, two-part initials, uppercase) untouched; the helper only changes how a "first character" is read.

## User Impact

- Affected operations: Control UI sessions list / thread header owner chips for any creator whose display name starts with an emoji or other astral character.
- Before: chip shows a replacement/tofu glyph.
- After: chip shows the actual first visible character, including complete ZWJ emoji clusters (e.g. 🦞, 👨‍👩‍👧‍👦).

## Evidence

- **Before**: rendering the real `openclaw-session-owner-chip` component with display name "🦞小明" produces chip text `\ud83e` — a lone high surrogate → FAIL; "👨‍👩‍👧‍👦Family" likewise produces `\ud83d` → FAIL
- **After**: the same renders produce `🦞` as one whole code point → PASS, and `👨‍👩‍👧‍👦` as the complete ZWJ grapheme cluster → PASS

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
displayName="🦞小明" chip_text="\ud83e" codepoints=[U+d83e]
FAIL: emoji display name renders a lone UTF-16 surrogate (tofu) in the owner chip
displayName="👨‍👩‍👧‍👦Family" chip_text="\ud83d" codepoints=[U+d83d]
FAIL: emoji display name renders a lone UTF-16 surrogate (tofu) in the owner chip
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
displayName="🦞小明" chip_text="🦞" codepoints=[U+1f99e]
PASS: owner chip renders the complete visible initial "🦞"
displayName="👨‍👩‍👧‍👦Family" chip_text="👨‍👩‍👧‍👦" codepoints=[U+1f468 U+200d U+1f469 U+200d U+1f467 U+200d U+1f466]
PASS: owner chip renders the complete visible initial "👨‍👩‍👧‍👦"
```

## Tests and Validation

- `pnpm check` passed
- Extended regression coverage in `ui/src/test-helpers/app-sidebar-cases/session-ownership.ts`: creators labeled "🦞小明" and "👨‍👩‍👧‍👦Family" must render chip text exactly "🦞" and "👨‍👩‍👧‍👦" through the full sidebar render path; all 226 app-sidebar cases pass
- Proof above renders the real `openclaw-session-owner-chip` custom element and reads the DOM text users see; no external services involved

## Maintainer Exact-Head Real Browser Verification

Original contributor @zenglingbiao, original Git author/email, and original first authored timestamp are preserved. Refreshed exact head `17ebd51c8d9a56c8e355aa48d9da515f781ca1c4` changes only the two original owner/sidebar-regression files, for +4 net production lines. There is no linked issue, config, storage, migration, protocol, or dependency change.

The actual Vite-served production `openclaw-session-owner-chip` custom element was mounted in real **Google Chrome 150** and its visible `.session-owner-chip` DOM text was read for seven Unicode/BMP cases.

Before, current main:

```json
{
  "browser": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36",
  "intlSegmenter": true,
  "results": [
    {
      "case": "lobster",
      "label": "🦞小明",
      "visible": "\ud83e",
      "expected": "🦞",
      "codePoints": [
        "U+d83e"
      ],
      "pass": false
    },
    {
      "case": "family-zwj",
      "label": "👨‍👩‍👧‍👦Family",
      "visible": "\ud83d",
      "expected": "👨‍👩‍👧‍👦",
      "codePoints": [
        "U+d83d"
      ],
      "pass": false
    },
    {
      "case": "flag",
      "label": "🇺🇸Flag",
      "visible": "\ud83c",
      "expected": "🇺🇸",
      "codePoints": [
        "U+d83c"
      ],
      "pass": false
    },
    {
      "case": "skin-tone",
      "label": "👍🏽Thumbs",
      "visible": "\ud83d",
      "expected": "👍🏽",
      "codePoints": [
        "U+d83d"
      ],
      "pass": false
    },
    {
      "case": "astral-cjk",
      "label": "𠀀Creator",
      "visible": "\ud840",
      "expected": "𠀀",
      "codePoints": [
        "U+d840"
      ],
      "pass": false
    },
    {
      "case": "combining-accent",
      "label": "éclair",
      "visible": "E",
      "expected": "É",
      "codePoints": [
        "U+45"
      ],
      "pass": false
    },
    {
      "case": "ascii-two-part",
      "label": "Ada Lovelace",
      "visible": "AL",
      "expected": "AL",
      "codePoints": [
        "U+41",
        "U+4c"
      ],
      "pass": true
    }
  ]
}
```

After, exact refreshed original-contributor head:

```json
{
  "browser": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36",
  "intlSegmenter": true,
  "results": [
    {
      "case": "lobster",
      "label": "🦞小明",
      "visible": "🦞",
      "expected": "🦞",
      "codePoints": [
        "U+1f99e"
      ],
      "pass": true
    },
    {
      "case": "family-zwj",
      "label": "👨‍👩‍👧‍👦Family",
      "visible": "👨‍👩‍👧‍👦",
      "expected": "👨‍👩‍👧‍👦",
      "codePoints": [
        "U+1f468",
        "U+200d",
        "U+1f469",
        "U+200d",
        "U+1f467",
        "U+200d",
        "U+1f466"
      ],
      "pass": true
    },
    {
      "case": "flag",
      "label": "🇺🇸Flag",
      "visible": "🇺🇸",
      "expected": "🇺🇸",
      "codePoints": [
        "U+1f1fa",
        "U+1f1f8"
      ],
      "pass": true
    },
    {
      "case": "skin-tone",
      "label": "👍🏽Thumbs",
      "visible": "👍🏽",
      "expected": "👍🏽",
      "codePoints": [
        "U+1f44d",
        "U+1f3fd"
      ],
      "pass": true
    },
    {
      "case": "astral-cjk",
      "label": "𠀀Creator",
      "visible": "𠀀",
      "expected": "𠀀",
      "codePoints": [
        "U+20000"
      ],
      "pass": true
    },
    {
      "case": "combining-accent",
      "label": "éclair",
      "visible": "É",
      "expected": "É",
      "codePoints": [
        "U+45",
        "U+301"
      ],
      "pass": true
    },
    {
      "case": "ascii-two-part",
      "label": "Ada Lovelace",
      "visible": "AL",
      "expected": "AL",
      "codePoints": [
        "U+41",
        "U+4c"
      ],
      "pass": true
    }
  ]
}
```

Lobster emoji, a complete family ZWJ sequence, a flag, skin-tone emoji, astral CJK, and combining-accent graphemes are now all intact; ordinary two-word ASCII initials remain `AL`. Existing `Intl.Segmenter` ownership remains in the canonical shared Control UI helper.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-117350-ui node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/lib/avatar.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --thinking xhigh
```

Both focused suites pass: **231 tests**. Targeted formatter and `git diff --check` pass; fresh Codex Sol xhigh structured autoreview is clean. The old unrelated failing CI baseline was removed by refreshing current main; exact-head hosted CI must finish green before landing.