### PR TITLE
fix(plugins): fail blocked enable commands

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -129,11 +129,13 @@ describe("plugins cli policy mutations", () => {
     });
     mockPluginRegistry(["alpha"]);
 
-    await runPluginsCommand(["plugins", "enable", "alpha"]);
+    await expect(runPluginsCommand(["plugins", "enable", "alpha"])).rejects.toThrow("__exit__:1");
 
     expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(replaceConfigFile).not.toHaveBeenCalled();
     expect(refreshPluginRegistry).not.toHaveBeenCalled();
-    expect(runtimeLogs).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
+    expect(runtimeErrors).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
+    expect(runtimeLogs).not.toContain(`Plugin "alpha" could not be enabled (${reason}).`);
   });
 
   it("refuses plugin enablement in Nix mode before config mutation", async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -205,12 +205,10 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   });
   // A blocked request must not displace the active slot or rewrite persisted state.
   if (!enableResult.enabled) {
-    defaultRuntime.log(
-      theme.warn(
-        `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
-      ),
+    defaultRuntime.error(
+      `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
     );
-    return;
+    return defaultRuntime.exit(1);
   }
 
   const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw plugins enable <id>` would receive a successful exit status even when global plugin disablement, a denylist, or an allowlist prevented the requested plugin from being enabled.

## Why This Change Was Made

Blocked plugin enablement now follows the existing failed-command contract: report the actionable reason on stderr and exit nonzero before loading slot helpers, writing configuration, or refreshing the plugin registry.

## User Impact

Shell scripts and operators can reliably detect denied plugin enablement. Successful enablement, unknown-plugin errors, configuration ownership, and marketplace JSON output keep their existing behavior.

## Evidence

- TDD: the existing three-policy regression matrix failed 3/13 tests before the implementation and passes 13/13 after it.
- Five real Commander/defaultRuntime subprocesses verified global disablement, denylist, allowlist, missing-plugin control, and successful-enable control using isolated temporary config/state.
- All blocked cases produced exit 1, empty stdout, the exact actionable stderr reason, and byte-identical configuration; the successful control preserved exit 0 and its existing stdout.
- Production change removes two lines; no slot/config/registry mutation occurs on failed requests.
