### PR TITLE
fix(agents): preserve cancellation at tool execution boundary

### DIFF
--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -384,6 +384,8 @@ export function toToolDefinitions(
               }
               throw new Error(hookOutcome.reason);
             }
+            // Stop cancellation-ignoring hooks before the synchronous mutation boundary.
+            signal?.throwIfAborted();
             executeParams = finalizeBeforeToolCallExecutionParams({
               tool,
               preparedParams,
@@ -532,6 +534,8 @@ export function toClientToolDefinitions(
             }
             throw new Error(outcome.reason);
           }
+          // Stop cancellation-ignoring hooks before the synchronous mutation boundary.
+          signal?.throwIfAborted();
           const adjustedParams = outcome.params;
           const paramsRecord = coerceParamsRecord(adjustedParams, func.parameters);
           // Client-hosted tools have no tool-owned finalizer, so hook reconciliation
@@ -563,6 +567,9 @@ export function toClientToolDefinitions(
         } catch (err) {
           if (onClientToolCall && typeof onClientToolCall !== "function") {
             onClientToolCall.discard?.(toolCallId, func.name);
+          }
+          if (signal?.aborted) {
+            throw err;
           }
           if (err instanceof ToolInputError) {
             return buildToolExecutionErrorResult({

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -57,6 +57,7 @@ import { CODE_MODE_EXEC_TOOL_NAME, createCodeModeTools } from "./code-mode.js";
 import { splitSdkTools } from "./embedded-agent-runner/tool-split.js";
 import type { ExtensionContext } from "./sessions/index.js";
 import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
+import { ToolInputError } from "./tools/common.js";
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
 
@@ -1348,6 +1349,62 @@ describe("before_tool_call adapter and client tool integration", () => {
     };
   }
 
+  function installAbortIgnoringAllowedHook() {
+    let releaseHook: () => void = () => {};
+    const hookGate = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    let markStarted: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const rewrittenParams = { path: "/tmp/rewritten" };
+    installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => {
+        markStarted();
+        await hookGate;
+        return { params: rewrittenParams };
+      },
+    });
+    return { release: () => releaseHook(), rewrittenParams, started };
+  }
+
+  function createCancellationParityTool(pathKind: "wrapped" | "adapter" | "client") {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const recorder = { reserve: vi.fn(), complete: vi.fn(), discard: vi.fn() };
+    const runId = `run-late-cancellation-${pathKind}`;
+    const hookContext = { agentId: "main", runId };
+    if (pathKind === "client") {
+      const tool = expectDefined(
+        toClientToolDefinitions(
+          [
+            {
+              type: "function",
+              function: {
+                name: "client_tool",
+                description: "Client tool",
+                parameters: { type: "object", properties: { path: { type: "string" } } },
+              },
+            },
+          ],
+          recorder,
+          hookContext,
+        )[0],
+        "client cancellation parity tool",
+      );
+      return { execute, recorder, runId, tool, toolName: "client_tool" };
+    }
+
+    const sourceTool = asAgentTool({ name: "read", execute });
+    const hookedTool =
+      pathKind === "wrapped" ? wrapToolWithBeforeToolCallHook(sourceTool, hookContext) : sourceTool;
+    const tool = expectDefined(
+      toToolDefinitions([hookedTool], hookContext)[0],
+      `${pathKind} cancellation parity tool`,
+    );
+    return { execute, recorder, runId, tool, toolName: "read" };
+  }
+
   beforeEach(() => {
     resetGlobalHookRunner();
     resetDiagnosticSessionStateForTest();
@@ -1386,6 +1443,104 @@ describe("before_tool_call adapter and client tool integration", () => {
       expect(execute).not.toHaveBeenCalled();
     },
   );
+
+  it.each(["wrapped", "adapter", "client"] as const)(
+    "stops the %s mutation boundary when an allowed hook ignores cancellation",
+    async (pathKind) => {
+      const controller = new AbortController();
+      const abortReason = new Error("run cancelled before tool mutation");
+      const hook = installAbortIgnoringAllowedHook();
+      const { execute, recorder, runId, tool, toolName } = createCancellationParityTool(pathKind);
+      const toolCallId = `call-late-cancellation-${pathKind}`;
+      const execution = tool.execute(
+        toolCallId,
+        { path: "/tmp/input" },
+        controller.signal,
+        undefined,
+        {} as ExtensionContext,
+      );
+      await hook.started;
+      controller.abort(abortReason);
+      hook.release();
+
+      const failure = await execution.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toBe(abortReason.message);
+      if (pathKind === "wrapped") {
+        expect((failure as Error).cause).toBe(abortReason);
+      } else {
+        expect(failure).toBe(abortReason);
+      }
+      expect(execute).not.toHaveBeenCalled();
+      expect(consumeAdjustedParamsForToolCall(toolCallId, runId)).toBeUndefined();
+      if (pathKind === "client") {
+        expect(recorder.reserve).toHaveBeenCalledWith(toolCallId, toolName);
+        expect(recorder.discard).toHaveBeenCalledWith(toolCallId, toolName);
+        expect(recorder.complete).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["wrapped", "adapter", "client"] as const)(
+    "keeps allowed rewritten hook parameters on the non-cancelled %s path",
+    async (pathKind) => {
+      const controller = new AbortController();
+      const hook = installAbortIgnoringAllowedHook();
+      const { execute, recorder, runId, tool, toolName } = createCancellationParityTool(pathKind);
+      const toolCallId = `call-allowed-rewrite-${pathKind}`;
+      const execution = tool.execute(
+        toolCallId,
+        { path: "/tmp/input" },
+        controller.signal,
+        undefined,
+        {} as ExtensionContext,
+      );
+      await hook.started;
+      hook.release();
+
+      const result = await execution;
+      if (pathKind === "client") {
+        expect(result.terminate).toBe(true);
+        expect(recorder.reserve).toHaveBeenCalledWith(toolCallId, toolName);
+        expect(recorder.complete).toHaveBeenCalledWith(toolCallId, toolName, hook.rewrittenParams);
+        expect(recorder.discard).not.toHaveBeenCalled();
+      } else {
+        expect(execute).toHaveBeenCalledWith(
+          toolCallId,
+          hook.rewrittenParams,
+          controller.signal,
+          undefined,
+        );
+        expect(consumeAdjustedParamsForToolCall(toolCallId, runId)).toEqual(hook.rewrittenParams);
+      }
+    },
+  );
+
+  it("preserves input-error cancellation instead of converting it into a client tool result", async () => {
+    const controller = new AbortController();
+    const abortReason = new ToolInputError("run cancelled before client tool mutation");
+    const hook = installAbortIgnoringAllowedHook();
+    const { recorder, tool, toolName } = createCancellationParityTool("client");
+    const toolCallId = "call-client-input-error-cancellation";
+    const execution = tool.execute(
+      toolCallId,
+      { path: "/tmp/input" },
+      controller.signal,
+      undefined,
+      {} as ExtensionContext,
+    );
+    await hook.started;
+    controller.abort(abortReason);
+    hook.release();
+
+    await expect(execution).rejects.toBe(abortReason);
+    expect(recorder.reserve).toHaveBeenCalledWith(toolCallId, toolName);
+    expect(recorder.discard).toHaveBeenCalledWith(toolCallId, toolName);
+    expect(recorder.complete).not.toHaveBeenCalled();
+  });
 
   it("cancels client-tool hook work and releases its reservation", async () => {
     const controller = new AbortController();


### PR DESCRIPTION
## What Problem This Solves

When a before-tool-call plugin hook ignored cancellation and eventually allowed a call, the unwrapped local adapter could still execute a mutating tool and the client-hosted adapter could still dispatch it after the owning agent run had already been cancelled. A client cancellation whose original reason was ToolInputError was also incorrectly converted into a normal model-visible tool result.

## Why This Change Was Made

The canonical wrapped-tool owner already rechecks cancellation immediately after an allowed hook and before its synchronous mutation boundary. Mirror that existing invariant in the local and client adapters, before finalization, one-shot voice approval, adjusted-parameter recording, execution, or client completion. Release client reservations first, then propagate the original abort reason before ordinary input-error normalization. Existing hook vetoes, denied voice approval, non-cancelled parameter rewrites, and wrapped error causes retain their current contracts.

## User Impact

Cancelled agent runs no longer perform local side effects or send client-hosted tools after a slow cancellation-ignoring plugin hook finishes. Voice approvals and adjusted replay state remain untouched, client reservations are released, and cancellation is never silently transformed into an ordinary successful tool-error result. Normal allowed and intentionally vetoed calls continue behaving as before.

## Evidence

- **Two authentic test-first reproductions:** unchanged production failed both unsafe local/client paths (**39 passed, 2 failed**); a second hostile-review regression exposed the client ToolInputError cancellation swallow (**41 passed, 1 failed**) before its owner fix.
- **Fresh exact-source focused validation:** node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.integration.e2e.test.ts --no-file-parallelism --maxWorkers=1: **42/42 passed; exit 0; source caches disabled.**
- **Behavioral parity:** real wrapped, unwrapped-local, and client-hosted paths verify original abort identity or wrapped cause, no local execution, no adjusted replay, client reserve/discard without completion, unchanged allowed rewritten parameters, and unchanged cancellation-aware hook vetoes.
- **Four independent hostile owner-boundary reviews:** no P0–P3 findings; confidences **0.99, 0.993, 0.99, and 0.985**.
- **Genuine official structured autoreview:** gpt-5.6-sol, high reasoning, P0–P3, real TruffleHog, exact commit; **zero findings, “patch is correct,” confidence 0.93**.
- **Formatting and whitespace:** exact two-file oxfmt --check, oxlint, and git diff --check pass. Current authoritative main has zero touched-owner or caller drift and merges without conflicts. Hosted exact-head required CI remains to be verified before landing.

Head: cfd525fabfeb66e3c1f89f624a6a1565fb6bff70
Base: 3edbe19fbd84ba58fdbf8e83042da9efd1d06f81
Current compatible main: aa2a5c96f69a1be639c602649d4aa2e4de8da0a8
