### PR TITLE
refactor(board): remove duplicate in-memory store

### DIFF
--- a/src/boards/board-generated-identity.test.ts
+++ b/src/boards/board-generated-identity.test.ts
@@ -6,7 +6,8 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { InMemoryBoardStore, type BoardStore } from "./board-store.js";
+import type { BoardStore } from "./board-store.js";
+import { createTestBoardStore } from "./board-store.test-support.js";
 import { SqliteBoardStore } from "./sqlite-board-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -20,12 +21,7 @@ function seedSession(env: NodeJS.ProcessEnv, sessionKey: string): void {
 }
 
 function createSqliteStore(): BoardStore {
-  const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-identity-") };
-  seedSession(env, "agent:main:board");
-  return new SqliteBoardStore({
-    resolveSession: () => ({ agentId: "main", sessionKey: "agent:main:board" }),
-    env,
-  });
+  return createTestBoardStore();
 }
 
 function generatedIdentity(key: string, fallbackName: string) {
@@ -41,10 +37,8 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-describe.each([
-  ["memory", () => new InMemoryBoardStore()],
-  ["sqlite", createSqliteStore],
-] as const)("generated BoardStore identity: %s", (_kind, createStore) => {
+describe("generated BoardStore identity", () => {
+  const createStore = createSqliteStore;
   it("keeps colliding titles distinct and canonical spellings stable", () => {
     const store = createStore();
     const composed = store.putWidget({

--- a/src/boards/board-store.parity.test.ts
+++ b/src/boards/board-store.parity.test.ts
@@ -11,7 +11,8 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { InMemoryBoardStore, type BoardStore } from "./board-store.js";
+import type { BoardStore } from "./board-store.js";
+import { createTestBoardStore } from "./board-store.test-support.js";
 import { SqliteBoardStore } from "./sqlite-board-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -27,16 +28,7 @@ function seedSession(env: NodeJS.ProcessEnv, agentId: string, sessionKey: string
 }
 
 function createSqliteStore(): BoardStore {
-  const stateDir = tempDirs.make("openclaw-board-parity-");
-  const env = { OPENCLAW_STATE_DIR: stateDir };
-  seedSession(env, "main", "agent:main:board");
-  return new SqliteBoardStore({
-    resolveSession: (sessionKey) => ({
-      agentId: sessionKey.split(":")[1] ?? "main",
-      sessionKey,
-    }),
-    env,
-  });
+  return createTestBoardStore();
 }
 
 afterEach(() => {
@@ -73,10 +65,8 @@ it("does not select the HTML BLOB when preparing board view metadata", () => {
   prepare.mockRestore();
 });
 
-describe.each([
-  ["memory", () => new InMemoryBoardStore()],
-  ["sqlite", createSqliteStore],
-] as const)("BoardStore parity: %s", (_kind, createStore) => {
+describe("SqliteBoardStore behavior", () => {
+  const createStore = createSqliteStore;
   it("persists revisions, layout, bytes, and declared summaries", () => {
     const store = createStore();
     const first = store.putWidget({

--- a/src/boards/board-store.test-support.ts
+++ b/src/boards/board-store.test-support.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { onTestFinished } from "vitest";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.entry.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { SqliteBoardStore } from "./sqlite-board-store.js";
+
+export function createTestBoardStore(options: { stateDir?: string } = {}): SqliteBoardStore {
+  const ownsStateDir = options.stateDir === undefined;
+  const stateDir = options.stateDir ?? mkdtempSync(path.join(tmpdir(), "openclaw-board-store-"));
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const seededSessions = new Set<string>();
+
+  if (ownsStateDir) {
+    onTestFinished(() => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    });
+  }
+
+  return new SqliteBoardStore({
+    resolveSession: (sessionKey) => {
+      const parsed = parseAgentSessionKey(sessionKey);
+      const agentId = parsed?.agentId ?? "main";
+      // Mirror the Gateway resolver so shorthand keys exercise canonical persisted rows.
+      const canonicalSessionKey = parsed ? sessionKey : `agent:${agentId}:${sessionKey}`;
+      const identity = `${agentId}\0${canonicalSessionKey}`;
+      if (!seededSessions.has(identity)) {
+        const database = openOpenClawAgentDatabase({ agentId, env });
+        replaceSessionEntrySync(
+          { agentId, sessionKey: canonicalSessionKey, storePath: database.path },
+          { sessionId: `board-test-${seededSessions.size}`, updatedAt: Date.now() },
+        );
+        seededSessions.add(identity);
+      }
+      return { agentId, sessionKey: canonicalSessionKey };
+    },
+    env,
+  });
+}

--- a/src/boards/board-store.test.ts
+++ b/src/boards/board-store.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { BoardValidationError } from "./board-layout.js";
-import { InMemoryBoardStore } from "./board-store.js";
+import type { BoardStore } from "./board-store.js";
+import { createTestBoardStore } from "./board-store.test-support.js";
 
-function putHtml(store: InMemoryBoardStore, sessionKey: string, name: string, html = "<p>one</p>") {
+function putHtml(store: BoardStore, sessionKey: string, name: string, html = "<p>one</p>") {
   return store.putWidget({ sessionKey, name, content: { kind: "html", html } });
 }
 
-describe("in-memory board store", () => {
+describe("board store", () => {
   it("creates the implicit main tab and bumps board and widget revisions", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     const first = putHtml(store, "agent:main:main", "status");
     const second = putHtml(store, "agent:main:main", "status", "<p>two</p>");
     expect(first).toMatchObject({
@@ -21,15 +22,18 @@ describe("in-memory board store", () => {
   });
 
   it("returns immutable snapshots and lists only existing boards", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     putHtml(store, "session-b", "b");
     putHtml(store, "session-a", "a");
     const snapshot = store.getSnapshot("session-a");
     snapshot.tabs[0]!.title = "Changed";
     expect(store.getSnapshot("session-a").tabs[0]!.title).toBe("Main");
-    expect(store.listSessionsWithBoards()).toEqual(["session-a", "session-b"]);
+    expect(store.listSessionsWithBoards()).toEqual([
+      "agent:main:session-a",
+      "agent:main:session-b",
+    ]);
     expect(store.getSnapshot("missing")).toEqual({
-      sessionKey: "missing",
+      sessionKey: "agent:main:missing",
       revision: 0,
       tabs: [],
       widgets: [],
@@ -37,7 +41,7 @@ describe("in-memory board store", () => {
   });
 
   it("stores HTML bytes with digest and keeps MCP descriptors non-HTML", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     putHtml(store, "session", "html", "<main>ok</main>");
     store.putWidget({
       sessionKey: "session",
@@ -74,7 +78,7 @@ describe("in-memory board store", () => {
   });
 
   it("transitions declared widgets through pending grants", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     const pending = store.putWidget({
       sessionKey: "session",
       name: "networked",
@@ -92,14 +96,14 @@ describe("in-memory board store", () => {
   });
 
   it("survives reset/new boundaries", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     putHtml(store, "session", "status");
     // Session reset has no BoardStore call; the stable session key remains authoritative.
     expect(store.getSnapshot("session").widgets).toHaveLength(1);
   });
 
   it("rejects stale grant revisions and accepts the current revision", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     const pending = store.putWidget({
       sessionKey: "session",
       name: "networked",
@@ -123,7 +127,7 @@ describe("in-memory board store", () => {
   });
 
   it("enforces the board widget count and UTF-8 HTML byte limits", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     for (let index = 0; index < 48; index += 1) {
       putHtml(store, "session", `widget-${index}`, "ok");
     }
@@ -135,13 +139,13 @@ describe("in-memory board store", () => {
       expect(error).toMatchObject({ code: "invalid_operation" });
       expect((error as Error).message).toContain("more than 48 widgets");
     }
-    expect(() =>
-      putHtml(new InMemoryBoardStore(), "session", "large", "é".repeat(131_073)),
-    ).toThrow("262144 UTF-8 bytes");
+    expect(() => putHtml(createTestBoardStore(), "session", "large", "é".repeat(131_073))).toThrow(
+      "262144 UTF-8 bytes",
+    );
   });
 
   it("bumps once per applyOps transaction and removes widget bytes", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     putHtml(store, "session", "status");
     const snapshot = store.applyOps("session", [
       { kind: "widget_resize", name: "status", sizeW: 3, sizeH: 3 },
@@ -153,7 +157,7 @@ describe("in-memory board store", () => {
   });
 
   it("preserves position on content updates and honors explicit after placement", () => {
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore();
     putHtml(store, "session", "first");
     putHtml(store, "session", "second");
     putHtml(store, "session", "third");

--- a/src/boards/board-store.ts
+++ b/src/boards/board-store.ts
@@ -1,9 +1,8 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 import type {
   BoardMcpAppDescriptor,
   BoardOp,
   BoardSnapshot,
-  BoardWidgetMaterializedContent,
   BoardWidgetMaterializedPutParams,
   BoardWidgetDeclared,
   BoardWidgetGeneratedIdentity,
@@ -11,7 +10,6 @@ import type {
 } from "../../packages/gateway-protocol/src/index.js";
 import { boardDeclarationIsSubset, normalizeBoardWidgetDeclared } from "./board-capabilities.js";
 import {
-  applyBoardOps,
   BOARD_SIZE_PRESETS,
   BoardValidationError,
   insertBoardWidget,
@@ -59,12 +57,6 @@ export interface BoardStore {
   listSessionsWithBoards(): string[];
 }
 
-type StoredBoard = {
-  snapshot: BoardSnapshot;
-  documents: Map<string, BoardWidgetDocument>;
-  nameIdentities: Map<string, BoardWidgetNameIdentityMarker>;
-};
-
 const BOARD_MAX_WIDGETS = 48;
 const BOARD_MAX_WIDGET_HTML_BYTES = 256 * 1024;
 const BOARD_MAX_WIDGET_PLUGIN_PROPS_BYTES = 8 * 1024;
@@ -75,10 +67,6 @@ export type BoardWidgetNameIdentityMarker =
   | { kind: "explicit" }
   | BoardWidgetGeneratedIdentityMarker
   | { kind: "invalid" };
-
-function emptyBoardSnapshot(sessionKey: string): BoardSnapshot {
-  return { sessionKey, revision: 0, tabs: [], widgets: [] };
-}
 
 export function cloneBoardSnapshot(snapshot: BoardSnapshot): BoardSnapshot {
   return {
@@ -102,59 +90,6 @@ export function cloneBoardSnapshot(snapshot: BoardSnapshot): BoardSnapshot {
           }
         : {}),
     })),
-  };
-}
-
-function cloneBoardWidgetHtmlDocument(document: BoardWidgetHtmlDocument): BoardWidgetHtmlDocument {
-  return {
-    ...document,
-    ...(document.declared
-      ? {
-          declared: {
-            ...(document.declared.netOrigins
-              ? { netOrigins: [...document.declared.netOrigins] }
-              : {}),
-            ...(document.declared.tools ? { tools: [...document.declared.tools] } : {}),
-          },
-        }
-      : {}),
-  };
-}
-
-function cloneBoardWidgetHtmlViewMetadata(
-  document: BoardWidgetHtmlDocument,
-): BoardWidgetHtmlViewMetadata {
-  const { html: _html, ...metadata } = cloneBoardWidgetHtmlDocument(document);
-  return metadata;
-}
-
-function createBoardWidgetDocument(
-  content: BoardWidgetMaterializedContent,
-  revision: number,
-  grantState: BoardWidgetHtmlDocument["grantState"],
-  declared: BoardWidgetDeclared | undefined,
-  instanceId: string,
-): BoardWidgetDocument | undefined {
-  if (content.kind === "html") {
-    return {
-      html: content.html,
-      revision,
-      sha256: createHash("sha256").update(content.html).digest("hex"),
-      viewGeneration: instanceId,
-      grantState,
-      ...(declared ? { declared } : {}),
-    };
-  }
-  if (content.kind === "plugin") {
-    return undefined;
-  }
-  return {
-    descriptor: { ...content.descriptor },
-    revision,
-    instanceId,
-    grantState,
-    declaredTools: [...(declared?.tools ?? [])],
-    interactive: content.interactive,
   };
 }
 
@@ -236,33 +171,6 @@ export function createBoardWidgetPutResult(
   resolvedWidgetName: string,
 ): BoardWidgetPutResult {
   return { ...cloneBoardSnapshot(snapshot), resolvedWidgetName };
-}
-
-type BoardWidgetGrantScope =
-  | { kind: "html" }
-  | { kind: "mcp-app"; serverName: string }
-  | { kind: "plugin" };
-
-function grantScopeMatches(
-  previous: BoardWidgetDocument | undefined,
-  content: BoardWidgetMaterializedContent,
-) {
-  const prior: BoardWidgetGrantScope | undefined = previous
-    ? "html" in previous
-      ? { kind: "html" }
-      : { kind: "mcp-app", serverName: previous.descriptor.serverName }
-    : undefined;
-  const next: BoardWidgetGrantScope =
-    content.kind === "html"
-      ? { kind: "html" }
-      : content.kind === "mcp-app"
-        ? { kind: "mcp-app", serverName: content.descriptor.serverName }
-        : { kind: "plugin" };
-  return (
-    prior === undefined ||
-    (prior.kind === "html" && next.kind === "html") ||
-    (prior.kind === "mcp-app" && next.kind === "mcp-app" && prior.serverName === next.serverName)
-  );
 }
 
 function validatePluginContent(params: BoardWidgetMaterializedPutParams): void {
@@ -431,167 +339,4 @@ export function createBoardGrantSnapshot(
   snapshot.widgets.find((candidate) => candidate.name === name)!.grantState = decision;
   snapshot.revision += 1;
   return snapshot;
-}
-
-export class InMemoryBoardStore implements BoardStore {
-  private readonly boards = new Map<string, StoredBoard>();
-
-  getSnapshot(sessionKey: string): BoardSnapshot {
-    return cloneBoardSnapshot(
-      this.boards.get(sessionKey)?.snapshot ?? emptyBoardSnapshot(sessionKey),
-    );
-  }
-
-  getSnapshotWithHtmlViewMetadata(sessionKey: string): BoardSnapshotWithHtmlViewMetadata {
-    const stored = this.boards.get(sessionKey);
-    const htmlViewMetadata = new Map<string, BoardWidgetHtmlViewMetadata>();
-    for (const [name, document] of stored?.documents ?? []) {
-      if ("html" in document) {
-        htmlViewMetadata.set(name, cloneBoardWidgetHtmlViewMetadata(document));
-      }
-    }
-    return {
-      snapshot: cloneBoardSnapshot(stored?.snapshot ?? emptyBoardSnapshot(sessionKey)),
-      htmlViewMetadata,
-    };
-  }
-
-  applyOps(sessionKey: string, ops: readonly BoardOp[]): BoardSnapshot {
-    const current = this.boards.get(sessionKey);
-    const snapshot = current?.snapshot ?? emptyBoardSnapshot(sessionKey);
-    if (ops.length === 0) {
-      return cloneBoardSnapshot(snapshot);
-    }
-    const layout = applyBoardOps(snapshot, ops);
-    const next: BoardSnapshot = {
-      sessionKey,
-      revision: snapshot.revision + 1,
-      ...layout,
-    };
-    const removedNames = new Set(next.widgets.map((widget) => widget.name));
-    const documents = new Map(
-      [...(current?.documents ?? [])].filter(([name]) => removedNames.has(name)),
-    );
-    const nameIdentities = new Map(
-      [...(current?.nameIdentities ?? [])].filter(([name]) => removedNames.has(name)),
-    );
-    if (next.tabs.length === 0 && next.widgets.length === 0) {
-      this.boards.delete(sessionKey);
-    } else {
-      this.boards.set(sessionKey, { snapshot: next, documents, nameIdentities });
-    }
-    return cloneBoardSnapshot(next);
-  }
-
-  putWidget(params: BoardWidgetMaterializedPutParams): BoardWidgetPutResult {
-    let canonicalParams = normalizeBoardWidgetPutParams(params);
-    const declared = canonicalParams.declared;
-    const current = this.boards.get(canonicalParams.sessionKey);
-    const prior = current?.snapshot ?? emptyBoardSnapshot(canonicalParams.sessionKey);
-    canonicalParams = resolveBoardWidgetPutParams(
-      prior,
-      canonicalParams,
-      current?.nameIdentities ?? new Map(),
-    );
-    const existingDocument = current?.documents.get(canonicalParams.name);
-    const grantedSha256 =
-      existingDocument && "html" in existingDocument && existingDocument.grantState === "granted"
-        ? existingDocument.sha256
-        : undefined;
-    const instanceId = randomBytes(16).toString("hex");
-    const snapshot = createBoardWidgetPutSnapshot(prior, canonicalParams, {
-      grantScopeMatches: grantScopeMatches(existingDocument, canonicalParams.content),
-      grantedSha256,
-      instanceId,
-    });
-    const documents = new Map(current?.documents ?? []);
-    const widgetRevision = snapshot.widgets.find(
-      (widget) => widget.name === canonicalParams.name,
-    )!.revision;
-    const widget = snapshot.widgets.find((candidate) => candidate.name === canonicalParams.name)!;
-    const document = createBoardWidgetDocument(
-      canonicalParams.content,
-      widgetRevision,
-      widget.grantState,
-      declared,
-      instanceId,
-    );
-    if (document) {
-      documents.set(canonicalParams.name, document);
-    } else {
-      documents.delete(canonicalParams.name);
-    }
-    const nameIdentities = new Map(current?.nameIdentities ?? []);
-    if (canonicalParams.generatedIdentity) {
-      nameIdentities.set(canonicalParams.name, {
-        kind: "generated",
-        source: canonicalParams.generatedIdentity.source,
-        key: canonicalParams.generatedIdentity.key,
-      });
-    } else {
-      nameIdentities.set(canonicalParams.name, { kind: "explicit" });
-    }
-    this.boards.set(canonicalParams.sessionKey, {
-      snapshot,
-      documents,
-      nameIdentities,
-    });
-    return createBoardWidgetPutResult(snapshot, canonicalParams.name);
-  }
-
-  grant(
-    sessionKey: string,
-    name: string,
-    decision: "granted" | "rejected",
-    revision: number,
-    instanceId?: string,
-  ): BoardSnapshot {
-    const current = this.boards.get(sessionKey);
-    if (!current) {
-      throw new BoardValidationError("not_found", `board widget not found: ${name}`);
-    }
-    const snapshot = createBoardGrantSnapshot(
-      current.snapshot,
-      name,
-      decision,
-      revision,
-      instanceId,
-    );
-    const document = current.documents.get(name);
-    if (document) {
-      document.grantState = decision;
-    }
-    this.boards.set(sessionKey, {
-      snapshot,
-      documents: current.documents,
-      nameIdentities: current.nameIdentities,
-    });
-    return cloneBoardSnapshot(snapshot);
-  }
-
-  readWidgetHtml(sessionKey: string, name: string): BoardWidgetHtmlDocument | undefined {
-    const document = this.boards.get(sessionKey)?.documents.get(name);
-    if (!document) {
-      return undefined;
-    }
-    return "html" in document ? cloneBoardWidgetHtmlDocument(document) : undefined;
-  }
-
-  readWidgetMcpApp(sessionKey: string, name: string): BoardWidgetMcpAppDocument | undefined {
-    const document = this.boards.get(sessionKey)?.documents.get(name);
-    return document && !("html" in document)
-      ? {
-          ...document,
-          descriptor: { ...document.descriptor },
-          declaredTools: [...document.declaredTools],
-        }
-      : undefined;
-  }
-
-  listSessionsWithBoards(): string[] {
-    return [...this.boards]
-      .filter(([, board]) => board.snapshot.tabs.length > 0 || board.snapshot.widgets.length > 0)
-      .map(([sessionKey]) => sessionKey)
-      .toSorted();
-  }
 }

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -5,9 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
-import { InMemoryBoardStore } from "../boards/board-store.js";
+import { createTestBoardStore } from "../boards/board-store.test-support.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveCanvasDocumentsDir } from "./documents.js";
 import { createShowWidgetTool } from "./widget-tool.js";
 import { buildWidgetDocument } from "./wrap.js";
@@ -19,6 +21,8 @@ const tempDirs: string[] = [];
 
 afterEach(async () => {
   vi.useRealTimers();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -269,7 +273,7 @@ describe("show_widget", () => {
 
   it("lets the board domain wrap pinned source before storing and broadcasting", async () => {
     const stateDir = await createStateDir();
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore({ stateDir });
     const broadcast = vi.fn();
     const handlers = createBoardHandlers(store);
     const title = "Release Status ".repeat(8).trim();
@@ -331,7 +335,7 @@ describe("show_widget", () => {
 
   it("pins a granted-CSP document and declaration without networking in the inline preview", async () => {
     const stateDir = await createStateDir();
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore({ stateDir });
     const handlers = createBoardHandlers(store);
     const callGateway: InProcessGatewayCaller = async <T>(
       method: string,
@@ -460,7 +464,7 @@ describe("show_widget", () => {
 
   it("keeps colliding generated pins distinct and canonical spellings stable", async () => {
     const stateDir = await createStateDir();
-    const store = new InMemoryBoardStore();
+    const store = createTestBoardStore({ stateDir });
     const handlers = createBoardHandlers(store);
     const callGateway: InProcessGatewayCaller = async <T>(
       method: string,

--- a/src/gateway/board-http.test.ts
+++ b/src/gateway/board-http.test.ts
@@ -1,7 +1,12 @@
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { InMemoryBoardStore } from "../boards/board-store.js";
+import { createTestBoardStore } from "../boards/board-store.test-support.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { handleBoardHttpRequest } from "./board-http.js";
 import {
   BOARD_VIEW_TICKET_TTL_MS,
@@ -9,7 +14,8 @@ import {
   verifyBoardViewTicket,
 } from "./board-view-ticket.js";
 
-const store = new InMemoryBoardStore();
+const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-board-http-"));
+const store = createTestBoardStore({ stateDir });
 const nowMs = 1_800_000_000_000;
 let server: Server;
 let baseUrl: string;
@@ -91,6 +97,9 @@ afterAll(async () => {
       resolve();
     });
   });
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  rmSync(stateDir, { recursive: true, force: true });
 });
 
 function ticketFor(name: string, revision = 1, issuedAtMs = nowMs): string {

--- a/src/gateway/server-methods/board.test-support.ts
+++ b/src/gateway/server-methods/board.test-support.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
-import { InMemoryBoardStore, type BoardStore } from "../../boards/board-store.js";
+import type { BoardStore } from "../../boards/board-store.js";
+import { createTestBoardStore } from "../../boards/board-store.test-support.js";
 import { createBoardHandlers } from "./board.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -43,7 +44,7 @@ export function createMcpAppDependencies(): BoardMcpAppDependencies {
 export function createBoardHarness(
   readCanvasHtml?: Parameters<typeof createBoardHandlers>[2],
   dependencies: BoardHandlerDependencies = {},
-  store: BoardStore = new InMemoryBoardStore(),
+  store: BoardStore = createTestBoardStore(),
   contextOverrides: Partial<GatewayRequestContext> = {},
 ) {
   const defaults = createMcpAppDependencies();

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -28,21 +28,6 @@ vi.mock("./sessions.runtime.js", () => ({
   })),
 }));
 
-function normalizeBoardGetSnapshot(snapshot: BoardSnapshot): BoardSnapshot {
-  return {
-    ...snapshot,
-    widgets: snapshot.widgets.map(
-      ({ frameUrl, viewTicket, viewGeneration, instanceId, ...widget }) => ({
-        ...widget,
-        ...(frameUrl ? { frameUrl: frameUrl.replace(/bt=[^&]+/u, "bt=<ticket>") } : {}),
-        ...(viewTicket ? { viewTicket: "<ticket>" } : {}),
-        ...(viewGeneration ? { viewGeneration: "<generation>" } : {}),
-        ...(instanceId ? { instanceId: "<instance>" } : {}),
-      }),
-    ),
-  };
-}
-
 describe("board gateway methods", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -215,41 +200,6 @@ describe("board gateway methods", () => {
     expect(snapshot.widgets[0]).toMatchObject({ sandboxPort: 18790 });
   });
 
-  it("returns the same board.get wire structure from memory and SQLite stores", async () => {
-    const sessionKey = "agent:main:board-get-parity";
-    const stateDir = tempDirs.make("openclaw-board-get-parity-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const database = openOpenClawAgentDatabase({ agentId: "main", env });
-    replaceSessionEntrySync(
-      { agentId: "main", sessionKey, storePath: database.path },
-      { sessionId: "board-get-parity", updatedAt: Date.now() },
-    );
-    const sqliteStore = new SqliteBoardStore({
-      resolveSession: () => ({ agentId: "main", sessionKey }),
-      env,
-    });
-    const memory = createHarness();
-    const sqlite = createHarness(undefined, {}, sqliteStore);
-    for (const harness of [memory, sqlite]) {
-      await harness.invoke("board.widget.put", {
-        sessionKey,
-        name: "status",
-        title: "Status",
-        content: { kind: "html", html: "<p>ready</p>" },
-      });
-    }
-
-    const memoryResponse = await memory.invoke("board.get", { sessionKey });
-    const sqliteResponse = await sqlite.invoke("board.get", { sessionKey });
-    const memorySnapshot = memoryResponse.mock.calls[0]?.[1] as BoardSnapshot;
-    const sqliteSnapshot = sqliteResponse.mock.calls[0]?.[1] as BoardSnapshot;
-
-    expect(memorySnapshot.widgets[0]?.viewTicket).not.toBe(sqliteSnapshot.widgets[0]?.viewTicket);
-    expect(normalizeBoardGetSnapshot(sqliteSnapshot)).toEqual(
-      normalizeBoardGetSnapshot(memorySnapshot),
-    );
-  });
-
   it("prepares HTML view metadata with the snapshot instead of rereading the store", async () => {
     const { invoke, store } = createHarness();
     await invoke("board.widget.put", {
@@ -279,10 +229,10 @@ describe("board gateway methods", () => {
     });
     expect(response).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ sessionKey: "session", revision: 1 }),
+      expect.objectContaining({ sessionKey: "agent:main:session", revision: 1 }),
     );
     expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       revision: 1,
     });
   });
@@ -290,7 +240,7 @@ describe("board gateway methods", () => {
   it("puts widgets, emits iframe-specific changes, and grants declared capabilities", async () => {
     const { invoke, broadcast } = createHarness();
     const put = await invoke("board.widget.put", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       name: "weather",
       content: { kind: "html", html: "<p>weather</p>" },
       declared: { tools: ["weather.refresh"] },
@@ -308,14 +258,14 @@ describe("board gateway methods", () => {
       }),
     );
     expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       revision: 1,
       widget: "weather",
     });
 
     const snapshot = put.mock.calls[0]?.[1] as BoardSnapshot;
     const grant = await invoke("board.widget.grant", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       name: "weather",
       decision: "granted",
       revision: 1,
@@ -329,7 +279,7 @@ describe("board gateway methods", () => {
       }),
     );
     expect(broadcast).toHaveBeenLastCalledWith("board.changed", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       revision: 2,
     });
   });
@@ -647,7 +597,7 @@ describe("board gateway methods", () => {
       expect.objectContaining({ widgets: [expect.objectContaining({ name: "canvas-widget" })] }),
     );
     expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "session",
+      sessionKey: "agent:main:session",
       revision: 1,
       widget: "canvas-widget",
     });
@@ -842,7 +792,9 @@ describe("board gateway methods", () => {
     });
     expect(first.mock.calls[0]?.[1]).toEqual({ ok: true, appended: true });
     expect(duplicate.mock.calls[0]?.[1]).toEqual({ ok: true, appended: false });
-    expect(peekSystemEvents("session")).toEqual(['[dashboard] {"count":1} on widget counter']);
+    expect(peekSystemEvents("agent:main:session")).toEqual([
+      '[dashboard] {"count":1} on widget counter',
+    ]);
   });
 
   it("binds state.emit notices to the widget view ticket", async () => {
@@ -859,7 +811,9 @@ describe("board gateway methods", () => {
     const response = await invoke("board.event", { ticket, payload: { count: 2 } });
 
     expect(response.mock.calls[0]?.[1]).toEqual({ ok: true, appended: true });
-    expect(peekSystemEvents("session")).toEqual(['[dashboard] {"count":2} on widget counter']);
+    expect(peekSystemEvents("agent:main:session")).toEqual([
+      '[dashboard] {"count":2} on widget counter',
+    ]);
   });
 
   it("skips prompt confirmation only for an explicitly granted prompt tool", async () => {
@@ -1020,7 +974,7 @@ describe("board gateway methods", () => {
     // JSON's opening quote places the emoji across the legacy slice boundary.
     const payload = `${"x".repeat(clippedCodeUnits - 2)}😀tail`;
     await invoke("board.event", { sessionKey: "session", widget: "counter", payload });
-    const unicodeNotice = peekSystemEvents("session")[0] ?? "";
+    const unicodeNotice = peekSystemEvents("agent:main:session")[0] ?? "";
     expect(unicodeNotice.length).toBeLessThanOrEqual(500);
     expect(unicodeNotice).not.toContain(String.fromCharCode(0xd83d));
     expect(unicodeNotice).toMatch(/… on widget counter$/u);
@@ -1029,7 +983,7 @@ describe("board gateway methods", () => {
       widget: "counter",
       payload: "x".repeat(1_000),
     });
-    expect(peekSystemEvents("session")[1]).toHaveLength(500);
+    expect(peekSystemEvents("agent:main:session")[1]).toHaveLength(500);
     const oversized = await invoke("board.event", {
       sessionKey: "session",
       widget: "counter",


### PR DESCRIPTION
## What Problem This Solves

The board test suite maintained a second, in-memory implementation of the board storage contract even though the Gateway only ships the SQLite-backed store. That duplicate path had accumulated its own cloning, grant, document, and generated-identity logic, letting tests exercise storage behavior that production never uses.

## Why This Change Was Made

Remove the internal `InMemoryBoardStore` and its private helpers, then run every affected board, Gateway, HTTP, session-deletion, and canvas test against `SqliteBoardStore`. A test-only fixture seeds real session ownership rows and canonicalizes shorthand session keys the same way the tested Gateway path expects.

No public package/plugin-SDK export, database schema/version, configuration, or runtime behavior changes. Production code is +1/-256 (net -255); the complete patch is +116/-368 (net -252).

## User Impact

No intentional user-visible behavior change. Board tests now cover the actual durable runtime owner, including session-key canonicalization, persistence, restart behavior, concurrent generated-name collisions, and deletion. This removes a parallel implementation that could drift from shipped behavior.

## Evidence

- [100/100 focused board, Gateway, HTTP, canvas, persistence, and deletion tests passed on Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30695260030).
- [Remote `check:changed` passed](https://github.com/openclaw/openclaw/actions/runs/30695379812), including core/test typechecks, lint, formatting, dead-export scans, schema/database guards, and import-cycle checks.
- [Full package and Control UI build passed](https://github.com/openclaw/openclaw/actions/runs/30695380074).
- Fresh `gpt-5.6-sol` autoreview at `xhigh` returned clean with no actionable P0-P2 findings (correctness 0.88).
- `git diff --check` passed; `rg InMemoryBoardStore` returns no remaining references.
- Exact-head GitHub CI passed every board-relevant lane. Its sole failure is the unrelated [`checks-node-compact-small-2` TUI PTY no-output watchdog](https://github.com/openclaw/openclaw/actions/runs/30695903037/job/91358678214), which repeated on one failed-job rerun. The same false stall is red on [`main` at the PR base](https://github.com/openclaw/openclaw/actions/runs/30695582928/job/91357846946) and the next [`main` run](https://github.com/openclaw/openclaw/actions/runs/30695914674/job/91358851223); the latest preceding green `main` run passed that shard [here](https://github.com/openclaw/openclaw/actions/runs/30694578763/job/91355336015). Existing PR #114388 contains the independent reporter fix; this board patch does not touch TUI code.
- Moving-main disposition: the branch remains on its assigned base `aa743c9f818`. There is no touched-path overlap between this patch's nine files and `main` changes through locally observed `4e47c4cabf8`; an optional rebase was skipped to preserve the tested exact SHA. The landing owner can refresh the base if repository merge policy requires it.

### Real Gateway restart transcript

Run on exact head `ba8e29439207` in isolated Blacksmith Testbox `tbx_01kyyhqzmhw9cqn9vzh280f3k3`. The harness built the package, launched the real foreground Gateway with an ephemeral state directory/token, created a real session through `sessions.create`, wrote through `board.widget.put`, read through `board.get`, stopped and restarted the Gateway process against the same state directory, read again, and independently queried the SQLite row. The temporary harness and state directory were deleted after the run.

```text
$ OPENCLAW_STATE_DIR=<tmp>/state pnpm openclaw gateway run --allow-unconfigured --auth token --token <ephemeral-token> --bind loopback --port 19873
$ pnpm openclaw gateway call sessions.create --url ws://127.0.0.1:19873 --token <ephemeral-token> --params '{"agentId":"main","key":"agent:main:sqlite-proof"}' --json
$ pnpm openclaw gateway call board.widget.put --url ws://127.0.0.1:19873 --token <ephemeral-token> --params '{"sessionKey":"agent:main:sqlite-proof","name":"durable","title":"Durable proof","content":{"kind":"html","html":"<p>survives restart</p>"}}' --json
$ pnpm openclaw gateway call board.get --url ws://127.0.0.1:19873 --token <ephemeral-token> --params '{"sessionKey":"agent:main:sqlite-proof"}' --json
{"phase":"session-created","key":"agent:main:sqlite-proof","sessionIdPresent":true}
{"phase":"widget-written","sessionKey":"agent:main:sqlite-proof","revision":1,"resolvedWidgetName":"durable","widgetCount":1}
{"phase":"before-restart","sessionKey":"agent:main:sqlite-proof","revision":1,"widgets":[{"name":"durable","revision":1,"contentKind":"html"}]}
$ kill <gateway-pid>; OPENCLAW_STATE_DIR=<same-tmp>/state pnpm openclaw gateway run --allow-unconfigured --auth token --token <ephemeral-token> --bind loopback --port 19873
$ pnpm openclaw gateway call board.get --url ws://127.0.0.1:19873 --token <ephemeral-token> --params '{"sessionKey":"agent:main:sqlite-proof"}' --json
{"phase":"after-restart","sessionKey":"agent:main:sqlite-proof","revision":1,"widgets":[{"name":"durable","revision":1,"contentKind":"html"}]}
$ node --input-type=module -e '<read-only node:sqlite SELECT from board_widgets>' <tmp>/state/agents/main/agent/openclaw-agent.sqlite
{"phase":"sqlite-row","session_key":"agent:main:sqlite-proof","name":"durable","content_kind":"html","revision":1,"html_bytes":13026}
{"phase":"proof-result","restartStable":true,"duplicateWidgets":0}
```

AI-assisted; I reviewed the implementation and validation evidence.
