### PR TITLE
fix(plugins): surface actionable doctor diagnostics

### DIFF
--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -100,6 +100,55 @@ describe("plugins cli list", () => {
     expect(runtimeLogs).toContain(cleanDoctorMessage);
   });
 
+  it.each([
+    {
+      description: "a required plugin is missing",
+      diagnostic: {
+        level: "warn" as const,
+        pluginId: "calendar",
+        message: 'plugin "calendar" requires plugin "contacts"; install "contacts" to use it',
+      },
+      expected: 'calendar: plugin "calendar" requires plugin "contacts"',
+    },
+    {
+      description: "discovery cannot read an extensions directory",
+      diagnostic: {
+        level: "warn" as const,
+        message: "failed to read extensions dir: /tmp/plugins (permission denied)",
+      },
+      expected: "failed to read extensions dir: /tmp/plugins (permission denied)",
+    },
+  ])(
+    "reports actionable discovery warnings when $description",
+    async ({ diagnostic, expected }) => {
+      buildPluginDiagnosticsReport.mockReturnValue({ plugins: [], diagnostics: [diagnostic] });
+
+      await runPluginsCommand(["plugins", "doctor"]);
+
+      const output = runtimeLogs.join("\n");
+      expect(output).toContain("Diagnostics:");
+      expect(output).toContain(expected);
+      expect(output).not.toContain(cleanDoctorMessage);
+    },
+  );
+
+  it("keeps actionable discovery warnings alongside existing errors", async () => {
+    buildPluginDiagnosticsReport.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        { level: "error", pluginId: "broken", message: "plugin manifest invalid" },
+        { level: "warn", pluginId: "calendar", message: "required plugin contacts is missing" },
+      ],
+    });
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain("broken: plugin manifest invalid");
+    expect(output).toContain("calendar: required plugin contacts is missing");
+    expect(output).not.toContain(cleanDoctorMessage);
+  });
+
   it("reports stale plugin config in doctor output without claiming full plugin health", async () => {
     const sourceConfig = {
       plugins: {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -375,7 +375,7 @@ export async function runPluginsDoctorCommand(): Promise<void> {
     | undefined;
   const report = buildPluginDiagnosticsReport({ config: cfg, effectiveOnly: true });
   const errors = report.plugins.filter((p) => p.status === "error");
-  const diags = report.diagnostics.filter((d) => d.level === "error");
+  const diags = report.diagnostics.filter((entry) => !isConfigSelectedShadowDiagnostic(entry));
   const shadowed = report.diagnostics.filter((entry) =>
     isErroredConfigSelectedShadowDiagnostic({ entry, plugins: report.plugins }),
   );


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins doctor` claimed plugin discovery, loading, compatibility, and configuration checks passed while real discovery and manifest problems already existed. Missing required plugins, unreadable plugin roots, incompatible plugin hosts, and other actionable warnings disappeared entirely; reports containing both errors and warnings also silently dropped the warnings.

## Why This Change Was Made

The canonical doctor renderer threw away every diagnostic except errors. Existing producers intentionally model many real discovery and compatibility failures as warnings, so that severity filter broke the doctor's existing promise. Select every actionable diagnostic at the doctor owner and exclude only deliberately handled, config-selected duplicate-shadow diagnostics; their dedicated failure section remains authoritative.

## User Impact

- Actionable discovery and manifest warnings are visible with or without an associated plugin id; warnings and errors appear together instead of producing false healthy output.
- Healthy intentional duplicate-source selection remains quiet; broken selected sources keep their specialized shadowing details without duplicate messages.
- Clean doctor runs, existing error/config/compatibility rendering, exit status, and zero configuration-write behavior are preserved.

## Evidence

- Authentic immutable production-baseline regression: **3 failed / 20 passed** before the production change.
- Frozen candidate: **23/23** existing Commander/doctor owner tests in one cache-disabled single-worker run.
- A source-blind harness independently loads immutable baseline/candidate production owners, runs **6 real Commander/defaultRuntime subprocess cases each**, and passes **6 baseline RED + 7 candidate GREEN** stdout/stderr/exit/no-write assertions.
- Four fresh independent hostile P0-P3 audits are clean; the sole official full strict autoreview with real TruffleHog is clean at **0.91 confidence**.
- Exact root-approved two existing files; production **+1/-1, net 0**. No discovery, config, manifest schema, SDK, SQLite, auth, security policy, severity, or doctor exit-contract changes.
- Current `main` `dabba0ce108f556a498c206a690436f9e6279776` retains all **15** reviewed owner/caller/docs/root blobs unchanged; synthetic merge is clean.
