### PR TITLE
fix(gateway): bound initial terminal node heartbeat

### DIFF
--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -140,6 +140,10 @@ export class NodeInvokeStreamController {
       params.pending.idleTimeoutMs = params.idleTimeoutMs;
     }
     this.options.pendingInvokes.set(params.requestId, params.pending);
+    if (params.timeoutMs === 0) {
+      // Unbounded duplex invokes need a first-heartbeat deadline; bounded runs may await approval.
+      this.resetIdleTimer(params.requestId, params.pending);
+    }
     if (params.signal) {
       const onAbort = () => {
         if (this.options.pendingInvokes.get(params.requestId) !== params.pending) {

--- a/src/gateway/terminal/node-relay.test.ts
+++ b/src/gateway/terminal/node-relay.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS } from "../../infra/node-commands.js";
 import { type NodeInvokeResult, NodeRegistry } from "../node-registry.js";
 import { createNodeRelayBackend } from "./node-relay.js";
+import { TerminalSessionManager } from "./session-manager.js";
+import { baseOpenRequest } from "./session-manager.test-helpers.js";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -10,6 +13,35 @@ function deferred<T>() {
     resolve = next;
   });
   return { promise, resolve };
+}
+
+function registerNodeRelayClient(params: {
+  registry: NodeRegistry;
+  frames: string[];
+  nodeId: string;
+  connId: string;
+  pairingGeneration: string;
+}) {
+  params.registry.register(
+    {
+      connId: params.connId,
+      usesSharedGatewayAuth: false,
+      socket: {
+        readyState: WebSocket.OPEN,
+        send(frame: unknown) {
+          if (typeof frame === "string") {
+            params.frames.push(frame);
+          }
+        },
+      },
+      connect: {
+        client: { id: "openclaw-node-host", mode: "node" },
+        device: { id: params.nodeId },
+        commands: ["codex.terminal.resume.v1"],
+      },
+    } as never,
+    { pairingIdentity: "identity-a", pairingGeneration: params.pairingGeneration },
+  );
 }
 
 describe("createNodeRelayBackend", () => {
@@ -20,26 +52,13 @@ describe("createNodeRelayBackend", () => {
     const registry = new NodeRegistry({
       resolveCurrentPairingState,
     });
-    registry.register(
-      {
-        connId: "conn-validated",
-        usesSharedGatewayAuth: false,
-        socket: {
-          readyState: WebSocket.OPEN,
-          send(frame: unknown) {
-            if (typeof frame === "string") {
-              frames.push(frame);
-            }
-          },
-        },
-        connect: {
-          client: { id: "openclaw-node-host", mode: "node" },
-          device: { id: "node-validated" },
-          commands: ["codex.terminal.resume.v1"],
-        },
-      } as never,
-      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
-    );
+    registerNodeRelayClient({
+      registry,
+      frames,
+      nodeId: "node-validated",
+      connId: "conn-validated",
+      pairingGeneration: "generation-a",
+    });
 
     const opening = createNodeRelayBackend({
       registry,
@@ -70,6 +89,71 @@ describe("createNodeRelayBackend", () => {
     });
     backend.kill();
     registry.unregister("conn-validated");
+  });
+
+  it("times out a silent node terminal before its first progress heartbeat", async () => {
+    vi.useFakeTimers();
+    const registry = new NodeRegistry();
+    const frames: string[] = [];
+    registerNodeRelayClient({
+      registry,
+      frames,
+      nodeId: "node-silent",
+      connId: "conn-silent",
+      pairingGeneration: "generation-silent",
+    });
+
+    try {
+      const emit = vi.fn();
+      const manager = new TerminalSessionManager({ emit });
+      const opened = await manager.open(
+        baseOpenRequest({
+          owner: { kind: "conn", connId: "operator-silent" },
+          createBackend: async () =>
+            await createNodeRelayBackend({
+              registry,
+              nodeId: "node-silent",
+              expectedConnId: "conn-silent",
+              expectedPairingGeneration: "generation-silent",
+              command: "codex.terminal.resume.v1",
+              params: {},
+            }),
+        }),
+      );
+      if (!opened.ok) {
+        throw new Error(`failed to open node terminal: ${opened.message}`);
+      }
+      expect(manager.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS - 1);
+      expect(emit).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(emit).toHaveBeenCalledExactlyOnceWith("operator-silent", "terminal.exit", {
+        sessionId: opened.sessionId,
+        exitCode: null,
+        signal: null,
+        reason: "error",
+        error: "IDLE_TIMEOUT: node invoke produced no progress",
+      });
+      expect(manager.size).toBe(0);
+
+      const events = frames.map((frame) => JSON.parse(frame) as { event?: string });
+      expect(events.filter((event) => event.event === "node.invoke.cancel")).toHaveLength(1);
+      const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+      expect(
+        registry.handleInvokeProgress({
+          invokeId: request.payload?.id ?? "",
+          nodeId: "node-silent",
+          connId: "conn-silent",
+          seq: 0,
+          chunk: "late",
+        }),
+      ).toBe(false);
+    } finally {
+      registry.unregister("conn-silent");
+      vi.useRealTimers();
+    }
   });
 
   it("relays progress, input, resize, cancellation, and the node exit result", async () => {


### PR DESCRIPTION
## What Problem This Solves

A paired-node terminal can stay open forever when the node accepts its invocation but never produces its first heartbeat. Duplex terminals intentionally have no hard execution timeout, and the existing inactivity watchdog was started only after progress had already arrived. Until that first frame, no timer could cancel the remote invocation, remove the Gateway session, or explain the failure to the operator. The defect is present in shipped `v2026.7.2-beta.1` through `v2026.7.2-beta.6`.

## Why This Change Was Made

The canonical streamed-invocation owner now arms its existing inactivity watchdog immediately after registering an invocation only when its hard timeout is exactly zero. The existing watchdog is reused; normal heartbeat frames reset it, and existing abort, disconnect, result, and cancellation owners clean it up. Finite-timeout, approval-gated agent runs still start their inactivity window only after their first progress frame, while ordinary unbounded invocations without an inactivity timeout remain unbounded. No protocol, configuration, compatibility option, timer constant, or provider surface changes.

## User Impact

An unresponsive paired-node terminal now fails visibly after the existing 30-second heartbeat budget with `terminal.exit` and `IDLE_TIMEOUT: node invoke produced no progress`. The Gateway cancels the remote invocation exactly once, removes its terminal session, and rejects late progress instead of leaving a blank, permanently stuck terminal. Approval flows can still wait longer than their output-idle budget before execution begins.

## Evidence

- Immutable `b179d466002945d0a5a21e26d9965d3da6bfff18`, tree `dc1a8d1d53048cf85abdbbc648c75d83c3582dd2`, direct parent `aa2a5c96f69a1be639c602649d4aa2e4de8da0a8`; exactly two existing files, four production lines, no configuration or dependency changes.
- Authentic baseline regression: the real `NodeRegistry`, real node relay, and real `TerminalSessionManager` emitted zero `terminal.exit` events after 30 seconds; the new focused test failed while the other six tests passed. The identical regression passes after the fix and verifies no early exit at 29,999 ms, one visible terminal error at 30,000 ms, one remote cancellation, session cleanup, and rejected late progress.
- Focused final proof: **7/7 passed**, exit 0: `PNPM_CONFIG_MODULES_DIR=/Users/steipete/Projects/openclaw/node_modules OPENCLAW_VITEST_FS_MODULE_CACHE=0 TSX_DISABLE_CACHE=1 /Users/steipete/.local/bin/node scripts/run-vitest.mjs src/gateway/terminal/node-relay.test.ts`.
- Existing approval-delay and ordinary unbounded-invocation contracts: **6 passed, 279 skipped**, exit 0: the same environment and runner with `src/gateway/node-registry.test.ts -t 'resets streamed invoke idle timeout on progress|keeps zero-timeout invokes pending until the node responds'`.
- Exact-path formatter, linter, and `git diff --check` passed; independent hostile source reviews and genuine strict full P0–P3 autoreview, TruffleHog, hosted exact-head gates, and maintainer approval are required before landing.
