### PR TITLE
fix(ui): bound stalled widget content fetches in the sandbox host

### DIFF
--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -118,7 +118,7 @@ describe("BoardWidgetSandboxHost", () => {
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     expect(fetchMock).toHaveBeenCalledWith(
       "https://gateway.example/__openclaw__/board/weather?bt=ticket",
-      { cache: "no-store" },
+      { cache: "no-store", signal: expect.any(AbortSignal) },
     );
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -118,7 +118,7 @@ describe("BoardWidgetSandboxHost", () => {
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     expect(fetchMock).toHaveBeenCalledWith(
       "https://gateway.example/__openclaw__/board/weather?bt=ticket",
-      { cache: "no-store" },
+      { cache: "no-store", signal: expect.any(AbortSignal) },
     );
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -857,5 +857,164 @@ describe("BoardWidgetSandboxHost", () => {
     host.dispose();
     await vi.advanceTimersByTimeAsync(20_000);
     expect(onReadyTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it("times out stalled widget content fetch through onLoadFailed", async () => {
+    vi.useFakeTimers();
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation timed out.", "TimeoutError"));
+          });
+        });
+      }),
+    );
+
+    const onLoadFailed = vi.fn();
+    const host = new BoardWidgetSandboxHost({
+      frame,
+      widget: widget(),
+      sandboxOrigin: "https://sandbox.example",
+      sandboxUrl: SANDBOX_URL,
+      sourceOrigin: "https://gateway.example",
+      client: { request: vi.fn(async () => ({ ok: true })) },
+      resolveFrameUrl: () => "/__openclaw__/board/weather?bt=ticket",
+      confirmPrompt: () => true,
+      onFrameUrl: vi.fn(),
+      onLoadFailed,
+      onUnauthorized: vi.fn(),
+      onReadyTimeout: vi.fn(),
+      onLoaded: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    host.handleMessage(
+      new MessageEvent("message", {
+        source: frame.contentWindow,
+        origin: "https://sandbox.example",
+        data: {
+          method: "ui/notifications/sandbox-proxy-ready",
+          params: { sandboxUrl: SANDBOX_URL },
+        },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onLoadFailed).toHaveBeenCalledWith(widget());
+    expect(onLoadFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out stalled widget content body reads through onLoadFailed", async () => {
+    vi.useFakeTimers();
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("<html>"));
+              init.signal?.addEventListener("abort", () => {
+                controller.error(new DOMException("The operation timed out.", "TimeoutError"));
+              });
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/html" } },
+        );
+      }),
+    );
+
+    const onLoadFailed = vi.fn();
+    const onLoaded = vi.fn();
+    const host = new BoardWidgetSandboxHost({
+      frame,
+      widget: widget(),
+      sandboxOrigin: "https://sandbox.example",
+      sandboxUrl: SANDBOX_URL,
+      sourceOrigin: "https://gateway.example",
+      client: { request: vi.fn(async () => ({ ok: true })) },
+      resolveFrameUrl: () => "/__openclaw__/board/weather?bt=ticket",
+      confirmPrompt: () => true,
+      onFrameUrl: vi.fn(),
+      onLoadFailed,
+      onUnauthorized: vi.fn(),
+      onReadyTimeout: vi.fn(),
+      onLoaded,
+      onError: vi.fn(),
+    });
+
+    host.handleMessage(
+      new MessageEvent("message", {
+        source: frame.contentWindow,
+        origin: "https://sandbox.example",
+        data: {
+          method: "ui/notifications/sandbox-proxy-ready",
+          params: { sandboxUrl: SANDBOX_URL },
+        },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onLoadFailed).toHaveBeenCalledWith(widget());
+    expect(onLoadFailed).toHaveBeenCalledTimes(1);
+    expect(onLoaded).not.toHaveBeenCalled();
+  });
+
+  it("aborts in-flight content fetch on reset without triggering onLoadFailed", async () => {
+    vi.useFakeTimers();
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation timed out.", "TimeoutError"));
+          });
+        });
+      }),
+    );
+
+    const onLoadFailed = vi.fn();
+    const host = new BoardWidgetSandboxHost({
+      frame,
+      widget: widget(),
+      sandboxOrigin: "https://sandbox.example",
+      sandboxUrl: SANDBOX_URL,
+      sourceOrigin: "https://gateway.example",
+      client: { request: vi.fn(async () => ({ ok: true })) },
+      resolveFrameUrl: () => "/__openclaw__/board/weather?bt=ticket",
+      confirmPrompt: () => true,
+      onFrameUrl: vi.fn(),
+      onLoadFailed,
+      onUnauthorized: vi.fn(),
+      onReadyTimeout: vi.fn(),
+      onLoaded: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    host.handleMessage(
+      new MessageEvent("message", {
+        source: frame.contentWindow,
+        origin: "https://sandbox.example",
+        data: {
+          method: "ui/notifications/sandbox-proxy-ready",
+          params: { sandboxUrl: SANDBOX_URL },
+        },
+      }),
+    );
+
+    await Promise.resolve();
+    host.reset();
+    await Promise.resolve();
+    expect(onLoadFailed).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BoardWidget } from "./types.ts";
+import { BoardWidgetSandboxHost } from "./widget-sandbox-host.ts";
+
+const SANDBOX_URL = "https://sandbox.example/mcp-app-sandbox";
+
+function widget(viewGeneration = "a".repeat(32)): BoardWidget {
+  return {
+    name: "weather",
+    tabId: "main",
+    contentKind: "html",
+    sizeW: 6,
+    sizeH: 4,
+    position: 0,
+    grantState: "granted",
+    revision: 2,
+    viewTicket: "ticket",
+    viewGeneration,
+  };
+}
+
+function createHost() {
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const onLoadFailed = vi.fn();
+  const onLoaded = vi.fn();
+  const options = {
+    frame,
+    widget: widget(),
+    sandboxOrigin: "https://sandbox.example",
+    sandboxUrl: SANDBOX_URL,
+    sourceOrigin: "https://gateway.example",
+    resolveFrameUrl: () => "/widget?generation=first",
+    confirmPrompt: () => true,
+    onFrameUrl: vi.fn(),
+    onLoadFailed,
+    onUnauthorized: vi.fn(),
+    onReadyTimeout: vi.fn(),
+    onLoaded,
+    onError: vi.fn(),
+  };
+  const host = new BoardWidgetSandboxHost(options);
+  host.handleMessage(
+    new MessageEvent("message", {
+      source: frame.contentWindow,
+      origin: "https://sandbox.example",
+      data: {
+        method: "ui/notifications/sandbox-proxy-ready",
+        params: { sandboxUrl: SANDBOX_URL },
+      },
+    }),
+  );
+  return { host, onLoadFailed, onLoaded, options };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe("BoardWidgetSandboxHost document timeout", () => {
+  it.each(["headers", "body"] as const)("times out stalled %s delivery", async (phase) => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal;
+        if (phase === "headers") {
+          return new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("request aborted")));
+          });
+        }
+        return Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("<!doctype html>"));
+                signal?.addEventListener("abort", () =>
+                  controller.error(new Error("body aborted")),
+                );
+              },
+            }),
+          ),
+        );
+      }),
+    );
+    const { host, onLoadFailed, onLoaded } = createHost();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onLoadFailed).toHaveBeenCalledWith(widget());
+    expect(onLoadFailed).toHaveBeenCalledOnce();
+    expect(onLoaded).not.toHaveBeenCalled();
+    host.dispose();
+  });
+
+  it("keeps a replacement document after cancelling a stalled load", async () => {
+    vi.useFakeTimers();
+    let firstSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      if (fetchMock.mock.calls.length === 1) {
+        firstSignal = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          firstSignal?.addEventListener("abort", () => reject(new Error("request aborted")));
+        });
+      }
+      return Promise.resolve(new Response("<!doctype html><p>replacement</p>"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { host, onLoadFailed, onLoaded, options } = createHost();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    host.update({
+      ...options,
+      widget: widget("b".repeat(32)),
+      resolveFrameUrl: () => "/widget?generation=replacement",
+    });
+    await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(firstSignal?.aborted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onLoadFailed).not.toHaveBeenCalled();
+    expect(onLoaded).toHaveBeenCalledOnce();
+    host.dispose();
+  });
+});

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -7,7 +7,7 @@ import {
   isBoardWidgetBridgeRequest,
 } from "./widget-bridge.ts";
 
-const SANDBOX_READY_TIMEOUT_MS = 10_000;
+const WIDGET_LOAD_TIMEOUT_MS = 10_000;
 
 type BoardWidgetSandboxHostOptions = {
   frame: HTMLIFrameElement;
@@ -39,8 +39,11 @@ export class BoardWidgetSandboxHost {
   private ready = false;
   private readyTimer: number | null = null;
   private loadedDocumentKey = "";
-  private loadingDocumentKey = "";
-  private loadGeneration = 0;
+  private activeDocumentLoad: {
+    controller: AbortController;
+    key: string;
+    timeout: number;
+  } | null = null;
   private requestGeneration = 0;
   private readonly pendingRequests = new Map<string, number>();
 
@@ -60,8 +63,7 @@ export class BoardWidgetSandboxHost {
     this.active = active;
     if (!active) {
       this.clearReadyTimeout();
-      this.loadGeneration += 1;
-      this.loadingDocumentKey = "";
+      this.cancelDocumentLoad();
       this.cancelPendingRequests("Widget inactive");
       this.requestGeneration += 1;
       return;
@@ -116,11 +118,10 @@ export class BoardWidgetSandboxHost {
   }
 
   reset(): void {
-    this.loadGeneration += 1;
+    this.cancelDocumentLoad();
     this.requestGeneration += 1;
     this.pendingRequests.clear();
     this.loadedDocumentKey = "";
-    this.loadingDocumentKey = "";
     this.bridgePort?.close();
     this.bridgePort = null;
     this.adoptedTicket = "";
@@ -292,6 +293,18 @@ export class BoardWidgetSandboxHost {
     }
   }
 
+  private cancelDocumentLoad(): void {
+    const load = this.activeDocumentLoad;
+    // Clear ownership before aborting so the rejection is stale and cannot
+    // spend the retry budget or clear a replacement load.
+    this.activeDocumentLoad = null;
+    if (!load) {
+      return;
+    }
+    window.clearTimeout(load.timeout);
+    load.controller.abort();
+  }
+
   private scheduleReadyTimeout(): void {
     if (!this.active || this.ready || this.readyTimer !== null) {
       return;
@@ -304,7 +317,7 @@ export class BoardWidgetSandboxHost {
       // Browsers do not expose iframe HTTP failures through `error`. Bound the
       // proxy handshake so an unavailable adjacent listener cannot stay blank.
       this.retrySandboxFrame();
-    }, SANDBOX_READY_TIMEOUT_MS);
+    }, WIDGET_LOAD_TIMEOUT_MS);
   }
 
   private retrySandboxFrame(): void {
@@ -379,16 +392,25 @@ export class BoardWidgetSandboxHost {
       return;
     }
     const documentKey = this.documentKey();
-    if (documentKey === this.loadedDocumentKey || documentKey === this.loadingDocumentKey) {
+    if (documentKey === this.loadedDocumentKey || documentKey === this.activeDocumentLoad?.key) {
       return;
     }
-    this.loadingDocumentKey = documentKey;
+    this.cancelDocumentLoad();
     const sourceHref = sourceUrl.href;
     this.options.onFrameUrl(sourceHref);
-    const generation = ++this.loadGeneration;
+    const controller = new AbortController();
+    const load = {
+      controller,
+      key: documentKey,
+      timeout: window.setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        WIDGET_LOAD_TIMEOUT_MS,
+      ),
+    };
+    this.activeDocumentLoad = load;
     try {
-      const response = await fetch(sourceHref, { cache: "no-store" });
-      if (!this.active || generation !== this.loadGeneration || !frame.isConnected) {
+      const response = await fetch(sourceHref, { cache: "no-store", signal: controller.signal });
+      if (!this.active || this.activeDocumentLoad !== load || !frame.isConnected) {
         return;
       }
       if (response.status === 401) {
@@ -399,7 +421,7 @@ export class BoardWidgetSandboxHost {
         throw new Error(`widget content request failed (${response.status})`);
       }
       const documentHtml = await response.text();
-      if (!this.active || generation !== this.loadGeneration || !frame.isConnected) {
+      if (!this.active || this.activeDocumentLoad !== load || !frame.isConnected) {
         return;
       }
       frame.contentWindow?.postMessage(
@@ -416,12 +438,13 @@ export class BoardWidgetSandboxHost {
       // pending. Complete the handshake once these exact bytes become current.
       this.postHostInit();
     } catch {
-      if (generation === this.loadGeneration) {
+      if (this.activeDocumentLoad === load) {
         this.options.onLoadFailed(widget);
       }
     } finally {
-      if (generation === this.loadGeneration) {
-        this.loadingDocumentKey = "";
+      window.clearTimeout(load.timeout);
+      if (this.activeDocumentLoad === load) {
+        this.activeDocumentLoad = null;
       }
     }
   }

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -6,6 +6,7 @@ import {
 } from "./widget-bridge.ts";
 
 const SANDBOX_READY_TIMEOUT_MS = 10_000;
+const WIDGET_CONTENT_FETCH_TIMEOUT_MS = 10_000;
 
 type BoardWidgetSandboxHostOptions = {
   frame: HTMLIFrameElement;
@@ -36,6 +37,7 @@ export class BoardWidgetSandboxHost {
   private readyTimer: number | null = null;
   private loadedDocumentKey = "";
   private loadGeneration = 0;
+  private contentFetchController: AbortController | null = null;
   private requestGeneration = 0;
   private readonly pendingRequests = new Map<string, number>();
 
@@ -91,6 +93,8 @@ export class BoardWidgetSandboxHost {
   reset(): void {
     this.loadGeneration += 1;
     this.requestGeneration += 1;
+    this.contentFetchController?.abort();
+    this.contentFetchController = null;
     this.pendingRequests.clear();
     this.loadedDocumentKey = "";
     this.bridgePort?.close();
@@ -338,8 +342,18 @@ export class BoardWidgetSandboxHost {
     const sourceHref = sourceUrl.href;
     this.options.onFrameUrl(sourceHref);
     const generation = ++this.loadGeneration;
+    this.contentFetchController?.abort();
+    const controller = new AbortController();
+    this.contentFetchController = controller;
+    const timeout = window.setTimeout(
+      () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+      WIDGET_CONTENT_FETCH_TIMEOUT_MS,
+    );
     try {
-      const response = await fetch(sourceHref, { cache: "no-store" });
+      const response = await fetch(sourceHref, {
+        cache: "no-store",
+        signal: controller.signal,
+      });
       if (generation !== this.loadGeneration || !frame.isConnected) {
         return;
       }
@@ -370,6 +384,11 @@ export class BoardWidgetSandboxHost {
     } catch {
       if (generation === this.loadGeneration) {
         this.options.onLoadFailed(widget);
+      }
+    } finally {
+      window.clearTimeout(timeout);
+      if (this.contentFetchController === controller) {
+        this.contentFetchController = null;
       }
     }
   }


### PR DESCRIPTION
## What problem this solves

A dashboard HTML widget could stay blank forever when its Gateway document route accepted the request but never completed the response.

## Root cause

The sandbox host bounded the proxy handshake, but it did not bound the later document fetch or body read. The existing retry and visible error path only ran after those operations rejected.

## Fix

The active document load now owns one abort controller and one 10-second deadline across response acquisition and body delivery. Reset, inactivity, and document replacement cancel that same load. Object identity rejects stale results and prevents old cleanup from changing a replacement widget.

No configuration, fallback, or second fetch path was added.

## Evidence

- **Before:** Chromium loaded a real dashboard widget against an isolated Gateway document route. With response headers withheld, and again with a partial body that never completed, the widget was still blank after 12 seconds with no retry or visible error.
- **After:** The same browser flow stopped each stalled request at about 10 seconds. The third attempt reached the existing visible “This widget could not load” state at about 30 seconds.
- **Success control:** A complete document rendered its unique content in the nested widget frame.
- **Lifecycle control:** Replacing a stalled widget closed the old request in about 0.1 seconds, rendered the replacement, and showed no stale error after the old deadline.

Focused regression support: `node scripts/run-vitest.mjs ui/src/lib/board/widget-sandbox-host.test.ts` passed all 18 tests. The live Control UI proof passed all 4 Chromium scenarios on the final file content.

This pull request keeps the original contributor as the commit author.
