### PR TITLE
feat(ui): make reasoning blocks collapsible

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -152,9 +152,10 @@ describeControlUiE2e("Control UI chat message actions", () => {
         {
           role: "assistant",
           content: [
+            { type: "thinking", thinking: privateThinking },
             {
               type: "text",
-              text: `<thinking>${privateThinking}</thinking>${visibleThinkingAnswer}`,
+              text: visibleThinkingAnswer,
             },
           ],
           timestamp: Date.now() + 2,
@@ -219,6 +220,22 @@ describeControlUiE2e("Control UI chat message actions", () => {
       const thinkingGroup = page
         .locator(".chat-group.assistant")
         .filter({ hasText: visibleThinkingAnswer });
+      const reasoningDisclosure = thinkingGroup.locator(".chat-thinking-disclosure");
+      const reasoningSummary = reasoningDisclosure.getByText("Reasoning", { exact: true });
+      await reasoningSummary.waitFor({ state: "visible" });
+      expect(await reasoningDisclosure.getAttribute("open")).toBeNull();
+      await expect.poll(() => thinkingGroup.getByText(privateThinking).isVisible()).toBe(false);
+      await screenshot(page, "01-reasoning-collapsed.png");
+
+      await reasoningSummary.press("Enter");
+      await expect.poll(() => reasoningDisclosure.getAttribute("open")).not.toBeNull();
+      await thinkingGroup.getByText(privateThinking).waitFor({ state: "visible" });
+      await screenshot(page, "02-reasoning-expanded.png");
+
+      await reasoningSummary.press("Space");
+      await expect.poll(() => reasoningDisclosure.getAttribute("open")).toBeNull();
+      await expect.poll(() => thinkingGroup.getByText(privateThinking).isVisible()).toBe(false);
+
       await thinkingGroup.hover();
       await thinkingGroup.getByRole("button", { name: "Reply to message" }).click();
       const thinkingReplyPreview = page.locator(".chat-reply-preview");

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -136,6 +136,23 @@ describeControlUiE2e("Control UI chat message actions", () => {
     const privateThinking = "private reply reasoning";
     const visibleThinkingAnswer = "Visible reply context only.";
     await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+          path: "",
+          sessions: [
+            {
+              key: "main",
+              kind: "direct",
+              label: "Main",
+              reasoningLevel: "medium",
+              updatedAt: Date.now(),
+            },
+          ],
+          ts: Date.now(),
+        },
+      },
       historyMessages: [
         {
           role: "assistant",
@@ -227,12 +244,12 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await expect.poll(() => thinkingGroup.getByText(privateThinking).isVisible()).toBe(false);
       await screenshot(page, "01-reasoning-collapsed.png");
 
-      await reasoningSummary.press("Enter");
+      await reasoningSummary.click();
       await expect.poll(() => reasoningDisclosure.getAttribute("open")).not.toBeNull();
       await thinkingGroup.getByText(privateThinking).waitFor({ state: "visible" });
       await screenshot(page, "02-reasoning-expanded.png");
 
-      await reasoningSummary.press("Space");
+      await reasoningSummary.click();
       await expect.poll(() => reasoningDisclosure.getAttribute("open")).toBeNull();
       await expect.poll(() => thinkingGroup.getByText(privateThinking).isVisible()).toBe(false);
 

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -152,6 +152,21 @@ function renderPairingQrExpiryNotices(notices: PairingQrExpiryNotice[]) {
   `;
 }
 
+function renderReasoningDisclosure(reasoningMarkdown: string | null) {
+  if (!reasoningMarkdown) {
+    return nothing;
+  }
+  return html`
+    <details class="chat-thinking-disclosure">
+      <summary class="chat-thinking-summary">
+        <span class="chat-thinking-summary__icon" aria-hidden="true">${icons.chevronRight}</span>
+        <span>${t("chat.view.reasoning")}</span>
+      </summary>
+      <div class="chat-thinking">${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}</div>
+    </details>
+  `;
+}
+
 export function renderGroupedMessage(
   message: unknown,
   messageKey: string,
@@ -254,6 +269,7 @@ export function renderGroupedMessage(
   const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
   if (
     !markdown &&
+    !reasoningMarkdown &&
     !visibleToolCards &&
     !hasImages &&
     !hasPairingQrExpiryNotices &&
@@ -424,12 +440,7 @@ export function renderGroupedMessage(
                         opts.onOpenImage,
                         opts.resolveArtifactDownload,
                       )}
-                      ${assistantViewContent}
-                      ${reasoningMarkdown
-                        ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                          </div>`
-                        : nothing}
+                      ${assistantViewContent} ${renderReasoningDisclosure(reasoningMarkdown)}
                       ${jsonResult
                         ? html`<details
                             class="chat-json-collapse"
@@ -491,12 +502,7 @@ export function renderGroupedMessage(
               opts.onOpenImage,
               opts.resolveArtifactDownload,
             )}
-            ${reasoningMarkdown
-              ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                </div>`
-              : nothing}
-            ${assistantViewContent}
+            ${renderReasoningDisclosure(reasoningMarkdown)} ${assistantViewContent}
             ${jsonResult
               ? html`<details class="chat-json-collapse">
                   <summary class="chat-json-summary">

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -787,6 +787,48 @@ describe("grouped chat rendering", () => {
     expect(order).toEqual(["Reply to message", "Hide message", "Rewind", "name", "time"]);
   });
 
+  it("collapses assistant reasoning by default and keeps the answer visible", () => {
+    const container = document.createElement("div");
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private reasoning details" },
+        { type: "text", text: "Visible answer." },
+      ],
+      timestamp: 1000,
+    };
+
+    renderAssistantMessage(container, message);
+
+    const disclosure = expectElement(container, ".chat-thinking-disclosure", HTMLDetailsElement);
+    const summary = expectElement(disclosure, ".chat-thinking-summary", HTMLElement);
+    expect(disclosure.open).toBe(false);
+    expect(summary.textContent).toContain("Reasoning");
+    expect(disclosure.textContent).toContain("private reasoning details");
+    expect(container.textContent).toContain("Visible answer.");
+
+    summary.click();
+    expect(disclosure.open).toBe(true);
+    summary.click();
+    expect(disclosure.open).toBe(false);
+
+    renderAssistantMessage(container, message, { showReasoning: false });
+    expect(container.querySelector(".chat-thinking-disclosure")).toBeNull();
+    expect(container.textContent).toContain("Visible answer.");
+  });
+
+  it("renders reasoning-only messages without exposing reply actions", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "private reasoning only" }],
+      timestamp: 1000,
+    });
+
+    expect(container.querySelector(".chat-thinking-disclosure")).not.toBeNull();
+    expect(container.querySelector('[aria-label="Reply to message"]')).toBeNull();
+  });
+
   it("keeps hidden assistant thinking out of inline reply context", () => {
     const container = document.createElement("div");
     const onReply = vi.fn();

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -2,8 +2,60 @@
    CHAT TEXT STYLING
    ============================================= */
 
-.chat-thinking {
+.chat-thinking-disclosure {
   margin-bottom: 10px;
+}
+
+.chat-thinking-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chat-thinking-summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-thinking-summary::marker {
+  content: "";
+}
+
+.chat-thinking-summary:hover {
+  background: color-mix(in srgb, var(--secondary) 72%, transparent);
+  color: var(--text);
+}
+
+.chat-thinking-summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.chat-thinking-summary__icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  transition: transform 140ms ease;
+}
+
+.chat-thinking-summary__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-thinking-disclosure[open] .chat-thinking-summary__icon {
+  transform: rotate(90deg);
+}
+
+.chat-thinking {
+  margin-top: 6px;
   padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px dashed rgba(255, 255, 255, 0.18);
@@ -16,6 +68,12 @@
 :root[data-theme-mode="light"] .chat-thinking {
   border-color: rgba(16, 24, 40, 0.25);
   background: rgba(16, 24, 40, 0.04);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-thinking-summary__icon {
+    transition: none;
+  }
 }
 
 .chat-text {


### PR DESCRIPTION
## What Problem This Solves

Resolves a Control UI problem where assistant reasoning is always expanded inline with the final answer. Long reasoning traces dominate the conversation, make the final response difficult to find, and can leave reasoning-only messages without a useful visual container.

## Why This Change Was Made

Reasoning is rendered in a native collapsed `<details>` disclosure with a clear `Reasoning` summary and chevron. The final answer remains visible outside the disclosure.

Using the native disclosure element preserves keyboard behavior and accessibility semantics without introducing new state management. The change also handles reasoning-only messages and keeps reply actions limited to messages with replyable answer content.

## Product Decision

Collapsed-by-default reasoning is intentional. The operator requested a ChatGPT-like transcript, verified the deployed Control UI behavior, and confirmed this as the desired default. A persisted preference is intentionally outside this focused presentation change.

## User Impact

Control UI conversations read more like ChatGPT: answers stay prominent, while reasoning can be expanded on demand with mouse or keyboard. Existing reasoning content is preserved; only its default presentation changes.

## Evidence

- 152 focused component tests passed in `ui/src/pages/chat/components/chat-message.test.ts`.
- Added coverage for collapsed-by-default rendering, expansion, reasoning-only messages, final-answer visibility, and reply-action behavior.
- Added browser E2E assertions for disclosure expansion and answer visibility in `ui/src/e2e/chat-message-actions.e2e.test.ts`.
- GitHub CI passed the Control UI checks, type checks, lint, and three of four browser E2E shards. The remaining E2E shard and `checks-node-compact-small-2` were terminated in an unrelated shared TUI/PTY test group; the same infrastructure failure occurred on both independent PRs.
- Full Docker/Control UI build completed successfully.
- Live Gateway verification confirmed the served Control UI asset changed and the operator confirmed the deployed behavior works as intended.
- Inspectable browser-proof request and product decision: https://github.com/openclaw/openclaw/pull/117365#issuecomment-5151269055
- `git diff --check` passes against current `origin/main`.

## Inspectable Browser Proof

The focused Playwright test passed against the built Control UI with `OPENCLAW_CAPTURE_UI_PROOF=1` (1 file, 1 test). It explicitly enables reasoning for the fixture, verifies the disclosure is closed initially, opens it through the native summary, confirms the private reasoning becomes visible, and verifies the final answer remains outside the disclosure.

- [Collapsed reasoning](https://raw.githubusercontent.com/chernoff-code/openclaw/codex/pr-117365-ui-proof/proof/pr-117365/01-reasoning-collapsed.png)
- [Expanded reasoning](https://raw.githubusercontent.com/chernoff-code/openclaw/codex/pr-117365-ui-proof/proof/pr-117365/02-reasoning-expanded.png)

The proof files live on a separate fork branch so the official PR diff remains source-only.