### PR TITLE
refactor(tui): consolidate runtime ownership

### DIFF
--- a/src/auto-reply/reply/commands-goal.test.ts
+++ b/src/auto-reply/reply/commands-goal.test.ts
@@ -7,11 +7,7 @@ import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/ses
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { takeCommandSessionMetadataChanges } from "./command-session-metadata.js";
-import {
-  formatGoalContinuationPrompt,
-  handleGoalCommand,
-  parseGoalCommand,
-} from "./commands-goal.js";
+import { handleGoalCommand, parseGoalCommand } from "./commands-goal.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { parseInlineDirectives } from "./directive-handling.parse.js";
 
@@ -106,18 +102,6 @@ describe("goal commands", () => {
       action: "edit",
       text: "ship the fix and docs",
     });
-  });
-
-  it("formats command-looking continuation prompts so inline directives leave them intact", () => {
-    const prompt = formatGoalContinuationPrompt("ship /fast off");
-    expect(prompt).toBe(
-      `Pursue this goal exactly as written from this JSON string: "ship \\/fast off"`,
-    );
-
-    const directives = parseInlineDirectives(prompt);
-
-    expect(directives.cleaned).toBe(prompt);
-    expect(directives.hasFastDirective).toBe(false);
   });
 
   it("starts a goal from Codex-style bare /goal objective text", async () => {

--- a/src/auto-reply/reply/commands-goal.ts
+++ b/src/auto-reply/reply/commands-goal.ts
@@ -12,6 +12,7 @@ import {
   updateSessionGoalStatus,
 } from "../../config/sessions.js";
 import { loadSessionEntry as getSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
 import { commandReply as goalReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
@@ -84,16 +85,14 @@ function encodeGoalJsonString(trimmed: string): string {
   return JSON.stringify(trimmed).replaceAll("/", "\\/");
 }
 
-/** Formats the model prompt used to continue a newly started goal. */
-export function formatGoalContinuationPrompt(objective: string): string {
+function formatGoalContinuationPrompt(objective: string): string {
   const trimmed = objective.trim();
   return hasCommandLikeGoalText(trimmed)
     ? `${GOAL_CONTINUATION_PROMPT_PREFIX} ${encodeGoalJsonString(trimmed)}`
     : trimmed;
 }
 
-/** Formats the model prompt used when resuming a paused goal. */
-export function formatGoalResumeContinuationPrompt(note: string): string {
+function formatGoalResumeContinuationPrompt(note: string): string {
   const trimmed = note.trim();
   if (!trimmed) {
     return "Continue pursuing the current goal.";
@@ -121,135 +120,130 @@ function goalErrorReply(error: unknown): CommandHandlerResult {
   return goalReply(`Goal error: ${message}`);
 }
 
+type ParsedGoalCommand = NonNullable<ReturnType<typeof parseGoalCommand>>;
+
+type SessionGoalCommandResult = {
+  text: string;
+  continuationPrompt?: string;
+  changed: boolean;
+};
+
+/** Execute goal storage policy once for auto-reply, Gateway, and embedded callers. */
+export async function executeSessionGoalCommand(params: {
+  parsed: ParsedGoalCommand;
+  sessionKey: string;
+  storePath?: string;
+  fallbackEntry?: SessionEntry;
+  agentId?: string;
+  readOnlyStatus?: boolean;
+}): Promise<SessionGoalCommandResult> {
+  const common = {
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    actor: { type: "human" as const },
+    agentId: params.agentId,
+  };
+  const note = params.parsed.text ? { note: params.parsed.text } : {};
+
+  switch (params.parsed.action) {
+    case "status": {
+      const snapshot = await getSessionGoal({
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        ...(params.readOnlyStatus ? { fallbackEntry: params.fallbackEntry, persist: false } : {}),
+      });
+      return { text: formatSessionGoalStatus(snapshot.goal), changed: false };
+    }
+    case "start":
+    case "set":
+    case "create": {
+      const objective = normalizeOptionalString(params.parsed.text);
+      if (!objective) {
+        return { text: "Usage: /goal start <objective>", changed: false };
+      }
+      const goal = await createSessionGoal({
+        ...common,
+        objective,
+        fallbackEntry: params.fallbackEntry,
+      });
+      return {
+        text: `Goal started: ${goal.objective}`,
+        continuationPrompt: formatGoalContinuationPrompt(goal.objective),
+        changed: true,
+      };
+    }
+    case "edit": {
+      const objective = normalizeOptionalString(params.parsed.text);
+      if (!objective) {
+        return { text: "Usage: /goal edit <objective>", changed: false };
+      }
+      const goal = await updateSessionGoalObjective({ ...common, objective });
+      return { text: `Goal updated: ${goal.objective}`, changed: true };
+    }
+    case "pause": {
+      const goal = await updateSessionGoalStatus({ ...common, status: "paused", ...note });
+      return { text: `Goal paused: ${goal.objective}`, changed: true };
+    }
+    case "resume": {
+      const goal = await updateSessionGoalStatus({ ...common, status: "active", ...note });
+      return {
+        text: `Goal resumed: ${goal.objective}`,
+        continuationPrompt: formatGoalResumeContinuationPrompt(params.parsed.text),
+        changed: true,
+      };
+    }
+    case "complete":
+    case "done": {
+      const goal = await updateSessionGoalStatus({ ...common, status: "complete", ...note });
+      return {
+        text: `Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}`,
+        changed: true,
+      };
+    }
+    case "block":
+    case "blocked": {
+      const goal = await updateSessionGoalStatus({ ...common, status: "blocked", ...note });
+      return { text: `Goal blocked: ${goal.objective}`, changed: true };
+    }
+    case "clear": {
+      const removed = await clearSessionGoal(common);
+      return {
+        text: removed ? "Goal cleared." : "No goal to clear.",
+        changed: removed,
+      };
+    }
+    default:
+      return {
+        text: "Usage: /goal <objective> | /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear",
+        changed: false,
+      };
+  }
+}
+
 /** Command handler for /goal lifecycle commands. */
 export const handleGoalCommand: CommandHandler = defineAuthorizedTextCommand(
   { label: "/goal", match: parseGoalCommand },
   async (params, parsed) => {
-    const actor = { type: "human" as const };
-    const goalAgentId = params.agentId;
-
     try {
-      switch (parsed.action) {
-        case "status": {
-          const snapshot = await getSessionGoal({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            fallbackEntry: params.sessionEntry,
-            persist: false,
-          });
-          syncGoalSessionEntry(params);
-          return goalReply(formatSessionGoalStatus(snapshot.goal));
-        }
-        case "start":
-        case "set":
-        case "create": {
-          const objective = normalizeOptionalString(parsed.text);
-          if (!objective) {
-            return goalReply("Usage: /goal start <objective>");
-          }
-          const goal = await createSessionGoal({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            objective,
-            fallbackEntry: params.sessionEntry,
-            actor,
-            agentId: goalAgentId,
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          applyCommandTextToParams(params, formatGoalContinuationPrompt(goal.objective));
-          return goalContinuation();
-        }
-        case "edit": {
-          const objective = normalizeOptionalString(parsed.text);
-          if (!objective) {
-            return goalReply("Usage: /goal edit <objective>");
-          }
-          const goal = await updateSessionGoalObjective({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            objective,
-            actor,
-            agentId: goalAgentId,
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          return goalReply(`Goal updated: ${goal.objective}`);
-        }
-        case "pause": {
-          const goal = await updateSessionGoalStatus({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            status: "paused",
-            actor,
-            agentId: goalAgentId,
-            ...(parsed.text ? { note: parsed.text } : {}),
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          return goalReply(`Goal paused: ${goal.objective}`);
-        }
-        case "resume": {
-          await updateSessionGoalStatus({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            status: "active",
-            actor,
-            agentId: goalAgentId,
-            ...(parsed.text ? { note: parsed.text } : {}),
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          const message = formatGoalResumeContinuationPrompt(parsed.text);
-          applyCommandTextToParams(params, message);
-          return goalContinuation();
-        }
-        case "complete":
-        case "done": {
-          const goal = await updateSessionGoalStatus({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            status: "complete",
-            actor,
-            agentId: goalAgentId,
-            ...(parsed.text ? { note: parsed.text } : {}),
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          return goalReply(`Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}`);
-        }
-        case "block":
-        case "blocked": {
-          const goal = await updateSessionGoalStatus({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            status: "blocked",
-            actor,
-            agentId: goalAgentId,
-            ...(parsed.text ? { note: parsed.text } : {}),
-          });
-          syncGoalSessionEntry(params);
-          markCommandSessionMetadataChanged(params);
-          return goalReply(`Goal blocked: ${goal.objective}`);
-        }
-        case "clear": {
-          const removed = await clearSessionGoal({
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            actor,
-            agentId: goalAgentId,
-          });
-          syncGoalSessionEntry(params);
-          if (removed) {
-            markCommandSessionMetadataChanged(params);
-          }
-          return goalReply(removed ? "Goal cleared." : "No goal to clear.");
-        }
-        default:
-          return goalReply(
-            "Usage: /goal <objective> | /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear",
-          );
+      const result = await executeSessionGoalCommand({
+        parsed,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        fallbackEntry: params.sessionEntry,
+        agentId: params.agentId,
+        readOnlyStatus: true,
+      });
+      if (result.changed || parsed.action === "status" || parsed.action === "clear") {
+        syncGoalSessionEntry(params);
       }
+      if (result.changed) {
+        markCommandSessionMetadataChanged(params);
+      }
+      if (result.continuationPrompt) {
+        applyCommandTextToParams(params, result.continuationPrompt);
+        return goalContinuation();
+      }
+      return goalReply(result.text);
     } catch (error) {
       return goalErrorReply(error);
     }

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -24,6 +24,7 @@ const projectSessionsPatchEntryMock = vi.fn();
 const createSessionGoalMock = vi.fn();
 const clearSessionGoalMock = vi.fn();
 const getSessionGoalMock = vi.fn();
+const updateSessionGoalObjectiveMock = vi.fn();
 const updateSessionGoalStatusMock = vi.fn();
 const ensureRuntimePluginsLoadedMock = vi.fn();
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
@@ -54,13 +55,10 @@ const getRuntimeConfigMock = vi.fn(() => ({}));
 const loadGatewayModelCatalogMock = vi.fn(
   (_params?: unknown): Array<{ id: string; name: string; provider: string }> => [],
 );
-const readSessionMessagesAsyncMock = vi.fn(
-  async (
-    _sessionId?: string,
-    _storePath?: string,
-    _sessionFile?: string,
-    _opts?: unknown,
-  ): Promise<unknown[]> => [],
+const readChatHistoryPageMock = vi.fn(
+  async (_params?: unknown): Promise<{ messages: unknown[] }> => ({
+    messages: [],
+  }),
 );
 type LoadSessionEntryMockResult = {
   cfg: Record<string, unknown>;
@@ -122,6 +120,7 @@ vi.mock("../config/sessions.js", () => ({
   getSessionGoal: (...args: unknown[]) => getSessionGoalMock(...args),
   resolveAgentMainSessionKey: () => "agent:main:main",
   resolveStorePath: () => "/tmp/openclaw-sessions.json",
+  updateSessionGoalObjective: (...args: unknown[]) => updateSessionGoalObjectiveMock(...args),
   updateSessionGoalStatus: (...args: unknown[]) => updateSessionGoalStatusMock(...args),
   updateSessionStore: (...args: unknown[]) => updateSessionStoreMock(...args),
 }));
@@ -178,11 +177,6 @@ vi.mock("../config/sessions/startup-migration.js", () => ({
     runSessionStartupMigrationMock(...args),
 }));
 
-vi.mock("../gateway/cli-session-history.js", () => ({
-  augmentChatHistoryWithCliSessionImports: ({ localMessages }: { localMessages?: unknown[] }) =>
-    localMessages ?? [],
-}));
-
 vi.mock("../gateway/chat-display-projection.js", () => ({
   projectChatDisplayMessages: (messages: unknown[]) => messages,
   projectRecentChatDisplayMessages: (messages: unknown[]) => messages,
@@ -198,6 +192,11 @@ vi.mock("../gateway/server-methods/chat.js", () => ({
   augmentChatHistoryWithCanvasBlocks: (messages: unknown[]) => messages,
   enforceChatHistoryFinalBudget: ({ messages }: { messages: unknown[] }) => ({ messages }),
   replaceOversizedChatHistoryMessages: ({ messages }: { messages: unknown[] }) => ({ messages }),
+}));
+
+vi.mock("../gateway/server-methods/chat-history-pages.js", () => ({
+  enrichChatHistoryCompactionMarkers: (messages: unknown[]) => messages,
+  readChatHistoryPage: (params: unknown) => readChatHistoryPageMock(params),
 }));
 
 vi.mock("../gateway/session-utils.js", () => ({
@@ -242,8 +241,6 @@ vi.mock("../gateway/session-reset-service.js", () => ({
 
 vi.mock("../gateway/session-transcript-readers.js", () => ({
   capArrayByJsonBytes: (items: unknown[]) => ({ items }),
-  readSessionMessagesAsync: (...args: Parameters<typeof readSessionMessagesAsyncMock>) =>
-    readSessionMessagesAsyncMock(...args),
 }));
 
 vi.mock("../gateway/sessions-patch.js", () => ({
@@ -309,6 +306,7 @@ describe("EmbeddedTuiBackend", () => {
     clearSessionGoalMock.mockResolvedValue(false);
     getSessionGoalMock.mockReset();
     getSessionGoalMock.mockResolvedValue({ status: "missing" });
+    updateSessionGoalObjectiveMock.mockReset();
     updateSessionGoalStatusMock.mockReset();
     updateSessionGoalStatusMock.mockImplementation(async ({ status }: { status: string }) => ({
       objective: "ship",
@@ -355,8 +353,8 @@ describe("EmbeddedTuiBackend", () => {
     getRuntimeConfigMock.mockReturnValue({});
     loadGatewayModelCatalogMock.mockReset();
     loadGatewayModelCatalogMock.mockReturnValue([]);
-    readSessionMessagesAsyncMock.mockReset();
-    readSessionMessagesAsyncMock.mockResolvedValue([]);
+    readChatHistoryPageMock.mockReset();
+    readChatHistoryPageMock.mockResolvedValue({ messages: [] });
     loadSessionEntryMock.mockReset();
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
       cfg: {},
@@ -859,7 +857,10 @@ describe("EmbeddedTuiBackend", () => {
         sessionKey: "agent:main:main",
         command: "/GOAL start Ship Goal",
       }),
-    ).resolves.toEqual({ text: "Goal started: Ship Goal" });
+    ).resolves.toEqual({
+      text: "Goal started: Ship Goal",
+      continuationPrompt: "Ship Goal",
+    });
     expect(createSessionGoalMock).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
@@ -1001,7 +1002,7 @@ describe("EmbeddedTuiBackend", () => {
     await backend.stop();
   });
 
-  it("uses reset-archive fallback for embedded TUI history reads", async () => {
+  it("uses the canonical gateway projector for embedded TUI history reads", async () => {
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
       canonicalKey: "agent:main:main",
@@ -1014,21 +1015,19 @@ describe("EmbeddedTuiBackend", () => {
 
     await backend.loadHistory({ sessionKey: "agent:main:main" });
 
-    expect(readSessionMessagesAsyncMock).toHaveBeenCalledWith(
-      {
-        agentId: "main",
-        sessionEntry: { sessionId: "sess-main" },
-        sessionId: "sess-main",
-        sessionKey: "agent:main:main",
-        storePath: "/tmp/openclaw-sessions.json",
-      },
-      {
-        mode: "recent",
-        maxMessages: 200,
-        maxBytes: 1024 * 1024,
-        allowResetArchiveFallback: true,
-      },
-    );
+    expect(readChatHistoryPageMock).toHaveBeenCalledWith({
+      entry: { sessionId: "sess-main" },
+      provider: "openai",
+      sessionId: "sess-main",
+      storePath: "/tmp/openclaw-sessions.json",
+      sessionAgentId: "main",
+      canonicalKey: "agent:main:main",
+      max: 200,
+      maxHistoryBytes: 100_000,
+      effectiveMaxChars: 100_000,
+      offset: undefined,
+      messageId: undefined,
+    });
   });
 
   it("loads runtime plugins for the send-path workspace before returning embedded history", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -29,7 +29,7 @@ import {
 import { ensureRuntimePluginsLoaded } from "../agents/runtime-plugins.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { resolveTextCommand } from "../auto-reply/commands-registry.js";
-import { parseGoalCommand } from "../auto-reply/reply/commands-goal.js";
+import { executeSessionGoalCommand, parseGoalCommand } from "../auto-reply/reply/commands-goal.js";
 import { resolveQueueSettings } from "../auto-reply/reply/queue/settings.js";
 import {
   DEFAULT_QUEUE_CAP,
@@ -39,22 +39,10 @@ import {
 import type { QueueSettings } from "../auto-reply/reply/queue/types.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
-import {
-  clearSessionGoal,
-  createSessionGoal,
-  formatSessionGoalStatus,
-  getSessionGoal,
-  updateSessionGoalObjective,
-  updateSessionGoalStatus,
-} from "../config/sessions.js";
 import { applySessionPatchProjection } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
-import {
-  projectRecentChatDisplayMessages,
-  resolveEffectiveChatHistoryMaxChars,
-} from "../gateway/chat-display-projection.js";
-import { augmentChatHistoryWithCliSessionImports } from "../gateway/cli-session-history.js";
+import { resolveEffectiveChatHistoryMaxChars } from "../gateway/chat-display-projection.js";
 import {
   normalizeLiveAssistantBufferedText,
   projectLiveAssistantBufferedText,
@@ -64,7 +52,10 @@ import {
 } from "../gateway/live-chat-projector.js";
 import { getMaxChatHistoryMessagesBytes } from "../gateway/server-constants.js";
 import {
-  augmentChatHistoryWithCanvasBlocks,
+  enrichChatHistoryCompactionMarkers,
+  readChatHistoryPage,
+} from "../gateway/server-methods/chat-history-pages.js";
+import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
   enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
@@ -72,10 +63,7 @@ import {
 import { loadGatewayModelCatalog } from "../gateway/server-model-catalog.js";
 import { createGatewaySession } from "../gateway/session-create-service.js";
 import { performGatewaySessionReset } from "../gateway/session-reset-service.js";
-import {
-  capArrayByJsonBytes,
-  readSessionMessagesAsync,
-} from "../gateway/session-transcript-readers.js";
+import { capArrayByJsonBytes } from "../gateway/session-transcript-readers.js";
 import {
   buildGatewaySessionInfo,
   getSessionDefaults,
@@ -626,36 +614,21 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const max = Math.min(1000, typeof opts.limit === "number" ? opts.limit : 200);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
-    const localMessages =
-      sessionId && storePath
-        ? await readSessionMessagesAsync(
-            {
-              agentId: sessionAgentId,
-              sessionEntry: entry,
-              sessionId,
-              sessionKey: canonicalKey,
-              storePath,
-            },
-            {
-              mode: "recent",
-              maxMessages: max,
-              maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
-              allowResetArchiveFallback: true,
-            },
-          )
-        : [];
-    const rawMessages = augmentChatHistoryWithCliSessionImports({
+    const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg);
+    const historyPage = await readChatHistoryPage({
       entry,
       provider: resolvedSessionModel.provider,
-      localMessages,
+      sessionId,
+      storePath,
+      sessionAgentId,
+      canonicalKey,
+      max,
+      maxHistoryBytes,
+      effectiveMaxChars,
+      offset: undefined,
+      messageId: undefined,
     });
-    const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg);
-    const normalized = augmentChatHistoryWithCanvasBlocks(
-      projectRecentChatDisplayMessages(rawMessages, {
-        maxChars: effectiveMaxChars,
-        maxMessages: max,
-      }),
-    );
+    const normalized = enrichChatHistoryCompactionMarkers(historyPage.messages, entry);
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
     const replaced = replaceOversizedChatHistoryMessages({
       messages: normalized,
@@ -933,103 +906,16 @@ export class EmbeddedTuiBackend implements TuiBackend {
       throw new Error("invalid goal command");
     }
 
-    switch (parsed.action) {
-      case "status": {
-        const snapshot = await getSessionGoal({ sessionKey, storePath });
-        return { text: formatSessionGoalStatus(snapshot.goal) };
-      }
-      case "start":
-      case "set":
-      case "create": {
-        const objective = parsed.text.trim();
-        if (!objective) {
-          return { text: "Usage: /goal start <objective>" };
-        }
-        const fallbackEntry = entry ?? { sessionId: randomUUID(), updatedAt: Date.now() };
-        const goal = await createSessionGoal({
-          sessionKey,
-          storePath,
-          objective,
-          fallbackEntry,
-          actor: { type: "human" },
-          agentId: opts.agentId,
-        });
-        return { text: `Goal started: ${goal.objective}` };
-      }
-      case "edit": {
-        const objective = parsed.text.trim();
-        if (!objective) {
-          return { text: "Usage: /goal edit <objective>" };
-        }
-        const goal = await updateSessionGoalObjective({
-          sessionKey,
-          storePath,
-          objective,
-          actor: { type: "human" },
-          agentId: opts.agentId,
-        });
-        return { text: `Goal updated: ${goal.objective}` };
-      }
-      case "pause": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey,
-          storePath,
-          status: "paused",
-          actor: { type: "human" },
-          agentId: opts.agentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        return { text: `Goal paused: ${goal.objective}` };
-      }
-      case "resume": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey,
-          storePath,
-          status: "active",
-          actor: { type: "human" },
-          agentId: opts.agentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        return { text: `Goal resumed: ${goal.objective}` };
-      }
-      case "complete":
-      case "done": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey,
-          storePath,
-          status: "complete",
-          actor: { type: "human" },
-          agentId: opts.agentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        return { text: `Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}` };
-      }
-      case "block":
-      case "blocked": {
-        const goal = await updateSessionGoalStatus({
-          sessionKey,
-          storePath,
-          status: "blocked",
-          actor: { type: "human" },
-          agentId: opts.agentId,
-          ...(parsed.text ? { note: parsed.text } : {}),
-        });
-        return { text: `Goal blocked: ${goal.objective}` };
-      }
-      case "clear": {
-        const removed = await clearSessionGoal({
-          sessionKey,
-          storePath,
-          actor: { type: "human" },
-          agentId: opts.agentId,
-        });
-        return { text: removed ? "Goal cleared." : "No goal to clear." };
-      }
-      default:
-        return {
-          text: "Usage: /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear",
-        };
-    }
+    const result = await executeSessionGoalCommand({
+      parsed,
+      sessionKey,
+      storePath,
+      fallbackEntry: entry ?? { sessionId: randomUUID(), updatedAt: Date.now() },
+      agentId: opts.agentId,
+    });
+    return result.continuationPrompt
+      ? { text: result.text, continuationPrompt: result.continuationPrompt }
+      : { text: result.text };
   }
 
   private enqueuePendingLocalMessage(params: {

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -213,5 +213,7 @@ export type TuiBackend = {
   listTaskSuggestions?: () => Promise<TaskSuggestion[]>;
   acceptTaskSuggestion?: (taskId: string) => Promise<TaskSuggestionsAcceptResult>;
   dismissTaskSuggestion?: (taskId: string) => Promise<{ taskId: string; dismissed: boolean }>;
-  runGoalCommand?: (opts: TuiGoalCommandOptions) => Promise<{ text: string }>;
+  runGoalCommand?: (
+    opts: TuiGoalCommandOptions,
+  ) => Promise<{ text: string; continuationPrompt?: string }>;
 };

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -589,7 +589,9 @@ describe("tui command handlers", () => {
   });
 
   it("starts local goals and sends the objective to the model", async () => {
-    const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started: ship" });
+    const runGoalCommand = vi
+      .fn()
+      .mockResolvedValue({ text: "Goal started: ship", continuationPrompt: "ship" });
     const { handleCommand, sendChat, addSystem, refreshSessionInfo, addPendingUser } =
       createHarness({
         opts: { local: true },
@@ -613,28 +615,32 @@ describe("tui command handlers", () => {
   });
 
   it("wraps command-prefixed local goal objectives before sending", async () => {
-    const slashRunGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started" });
+    const slashPrompt = `Pursue this goal exactly as written from this JSON string: "\\/status"`;
+    const slashRunGoalCommand = vi
+      .fn()
+      .mockResolvedValue({ text: "Goal started", continuationPrompt: slashPrompt });
     const slashHarness = createHarness({
       opts: { local: true },
       runGoalCommand: slashRunGoalCommand,
     });
 
     await slashHarness.handleCommand("/goal start /status");
-    const slashPrompt = `Pursue this goal exactly as written from this JSON string: "\\/status"`;
     expectSendChatFields(slashHarness.sendChat, {
       sessionKey: "agent:main:main",
       message: slashPrompt,
     });
     expect(slashHarness.addPendingUser).toHaveBeenCalledWith(expect.any(String), slashPrompt);
 
-    const bangRunGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started" });
+    const bangPrompt = `Pursue this goal exactly as written from this JSON string: "!npm test"`;
+    const bangRunGoalCommand = vi
+      .fn()
+      .mockResolvedValue({ text: "Goal started", continuationPrompt: bangPrompt });
     const bangHarness = createHarness({
       opts: { local: true },
       runGoalCommand: bangRunGoalCommand,
     });
 
     await bangHarness.handleCommand("/goal start !npm test");
-    const bangPrompt = `Pursue this goal exactly as written from this JSON string: "!npm test"`;
     expectSendChatFields(bangHarness.sendChat, {
       sessionKey: "agent:main:main",
       message: bangPrompt,
@@ -656,7 +662,10 @@ describe("tui command handlers", () => {
   });
 
   it("wraps command-prefixed local goal resume notes before sending", async () => {
-    const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal resumed: ship" });
+    const prompt = `Continue pursuing the current goal. Interpret this JSON string as the resume note: "\\/fast off"`;
+    const runGoalCommand = vi
+      .fn()
+      .mockResolvedValue({ text: "Goal resumed: ship", continuationPrompt: prompt });
     const { handleCommand, sendChat, addPendingUser } = createHarness({
       opts: { local: true },
       runGoalCommand,
@@ -664,7 +673,6 @@ describe("tui command handlers", () => {
 
     await handleCommand("/goal resume /fast off");
 
-    const prompt = `Continue pursuing the current goal. Interpret this JSON string as the resume note: "\\/fast off"`;
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       message: prompt,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -7,11 +7,6 @@ import { modelKey } from "../agents/model-ref-shared.js";
 import { shouldForwardModelCommandToServer } from "../auto-reply/commands-registry.shared.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
-  formatGoalContinuationPrompt,
-  formatGoalResumeContinuationPrompt,
-  parseGoalCommand,
-} from "../auto-reply/reply/commands-goal.js";
-import {
   formatThinkingLevels,
   isSessionDefaultDirectiveValue,
   normalizeUsageDisplay,
@@ -124,21 +119,6 @@ function isTerminalChatSendAckSuccess(status: unknown): boolean {
 }
 
 const TERMINAL_CHAT_SEND_FAILURE_MESSAGE = "Chat failed before the run started; try again.";
-
-function goalContinuationPrompt(text: string): string | null {
-  const parsed = parseGoalCommand(text);
-  if (!parsed) {
-    return null;
-  }
-  const action = parsed.action;
-  if (action === "start" || action === "set" || action === "create") {
-    return formatGoalContinuationPrompt(parsed.text) || null;
-  }
-  if (action === "resume") {
-    return formatGoalResumeContinuationPrompt(parsed.text);
-  }
-  return null;
-}
 
 export function createCommandHandlers(context: CommandHandlerContext) {
   const {
@@ -294,6 +274,29 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     }
   };
 
+  const applySessionSetting = async (
+    patch: Omit<Parameters<TuiBackend["patchSession"]>[0], "key" | "agentId">,
+    success: string | ((result: SessionsPatchResult) => string),
+    failure: string,
+    after?: (result: SessionsPatchResult) => void | Promise<void>,
+  ) => {
+    try {
+      const result = await patchCurrentSession(patch);
+      if (!result) {
+        return;
+      }
+      chatLog.addSystem(typeof success === "function" ? success(result) : success);
+      applySessionInfoFromPatch(result);
+      if (after) {
+        await after(result);
+      } else {
+        await refreshSessionInfo();
+      }
+    } catch (err) {
+      chatLog.addSystem(`${failure}: ${formatTuiErrorMessage(err)}`);
+    }
+  };
+
   const openSelector = (
     selector: {
       onSelect?: (item: SelectItem) => void;
@@ -336,17 +339,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       });
       const selector = createSearchableSelectList(items, 9);
       openSelector(selector, async (value) => {
-        try {
-          const result = await patchCurrentSession({ model: value });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`model set to ${value}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`model set failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting({ model: value }, `model set to ${value}`, "model set failed");
       });
     } catch (err) {
       if (!isCurrentSessionSelection(selection)) {
@@ -608,9 +601,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             });
             chatLog.addSystem(result.text);
             await refreshSessionInfo();
-            const continuation = goalContinuationPrompt(raw);
-            if (continuation) {
-              await sendMessage(continuation);
+            if (result.continuationPrompt) {
+              await sendMessage(result.continuationPrompt);
             }
           } catch (err) {
             chatLog.addSystem(`goal failed: ${formatTuiErrorMessage(err)}`);
@@ -654,24 +646,20 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         } else if (!args) {
           await openModelSelector();
         } else {
-          try {
-            const result = await patchCurrentSession({ model: args });
-            if (!result) {
-              return;
-            }
-            const resolvedModel = result.resolved?.model;
-            const resolvedProvider = result.resolved?.modelProvider;
-            const resolvedModelRef = resolvedModel
-              ? resolvedProvider
-                ? modelKey(resolvedProvider, resolvedModel)
-                : resolvedModel
-              : args;
-            chatLog.addSystem(`model set to ${resolvedModelRef}`);
-            applySessionInfoFromPatch(result);
-            await refreshSessionInfo();
-          } catch (err) {
-            chatLog.addSystem(`model set failed: ${formatTuiErrorMessage(err)}`);
-          }
+          await applySessionSetting(
+            { model: args },
+            (result) => {
+              const resolvedModel = result.resolved?.model;
+              const resolvedProvider = result.resolved?.modelProvider;
+              const resolvedModelRef = resolvedModel
+                ? resolvedProvider
+                  ? modelKey(resolvedProvider, resolvedModel)
+                  : resolvedModel
+                : args;
+              return `model set to ${resolvedModelRef}`;
+            },
+            "model set failed",
+          );
         }
         break;
       case "models":
@@ -691,56 +679,37 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem(`usage: /think <${levels}>`);
           break;
         }
-        try {
-          const result = await patchCurrentSession({ thinkingLevel: args });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`thinking set to ${args}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`think failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { thinkingLevel: args },
+          `thinking set to ${args}`,
+          "think failed",
+        );
         break;
       case "verbose":
         if (!args) {
           chatLog.addSystem(`usage: ${formatTuiLevelCommandUsage("verbose")}`);
           break;
         }
-        try {
-          const result = await patchCurrentSession({ verboseLevel: args });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`verbose set to ${args}`);
-          applySessionInfoFromPatch(result);
-          if (args === "off") {
-            chatLog.clearTools();
-            await refreshSessionInfo();
-          } else {
-            await loadHistory();
-          }
-        } catch (err) {
-          chatLog.addSystem(`verbose failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { verboseLevel: args },
+          `verbose set to ${args}`,
+          "verbose failed",
+          async () => {
+            if (args === "off") {
+              chatLog.clearTools();
+              await refreshSessionInfo();
+            } else {
+              await loadHistory();
+            }
+          },
+        );
         break;
       case "trace":
         if (!args) {
           chatLog.addSystem("usage: /trace <on|off>");
           break;
         }
-        try {
-          const result = await patchCurrentSession({ traceLevel: args });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`trace set to ${args}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`trace failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting({ traceLevel: args }, `trace set to ${args}`, "trace failed");
         break;
       case "fast":
         if (!args || args === "status") {
@@ -751,36 +720,22 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem("usage: /fast <status|auto|on|off>");
           break;
         }
-        try {
-          const result = await patchCurrentSession({
-            fastMode: args === "auto" ? "auto" : args === "on",
-          });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`fast mode set to ${args}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`fast failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { fastMode: args === "auto" ? "auto" : args === "on" },
+          `fast mode set to ${args}`,
+          "fast failed",
+        );
         break;
       case "reasoning":
         if (!args) {
           chatLog.addSystem(`usage: ${formatTuiLevelCommandUsage("reasoning")}`);
           break;
         }
-        try {
-          const result = await patchCurrentSession({ reasoningLevel: args });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`reasoning set to ${args}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`reasoning failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { reasoningLevel: args },
+          `reasoning set to ${args}`,
+          "reasoning failed",
+        );
         break;
       case "usage": {
         const isReset = args ? isSessionDefaultDirectiveValue(args) : false;
@@ -790,19 +745,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         if (isReset) {
-          try {
-            const result = await patchCurrentSession({ responseUsage: null });
-            if (!result) {
-              return;
-            }
-            chatLog.addSystem("usage footer: reset to default");
-            applySessionInfoFromPatch(result);
-            delete state.sessionInfo.responseUsage;
-            delete state.sessionInfo.effectiveResponseUsage;
-            await refreshSessionInfo();
-          } catch (err) {
-            chatLog.addSystem(`usage failed: ${formatTuiErrorMessage(err)}`);
-          }
+          await applySessionSetting(
+            { responseUsage: null },
+            "usage footer: reset to default",
+            "usage failed",
+            async () => {
+              delete state.sessionInfo.responseUsage;
+              delete state.sessionInfo.effectiveResponseUsage;
+              await refreshSessionInfo();
+            },
+          );
           break;
         }
         const current =
@@ -810,17 +762,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           resolveResponseUsageMode(state.sessionInfo.responseUsage);
         const next =
           normalized ?? (current === "off" ? "tokens" : current === "tokens" ? "full" : "off");
-        try {
-          const result = await patchCurrentSession({ responseUsage: next });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`usage footer: ${next}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`usage failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting({ responseUsage: next }, `usage footer: ${next}`, "usage failed");
         break;
       }
       case "elevated":
@@ -832,17 +774,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem("usage: /elevated <on|off|ask|full>");
           break;
         }
-        try {
-          const result = await patchCurrentSession({ elevatedLevel: args });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`elevated set to ${args}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`elevated failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { elevatedLevel: args },
+          `elevated set to ${args}`,
+          "elevated failed",
+        );
         break;
       case "activation": {
         if (!args) {
@@ -854,17 +790,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem("usage: /activation <mention|always>");
           break;
         }
-        try {
-          const result = await patchCurrentSession({ groupActivation: activation });
-          if (!result) {
-            return;
-          }
-          chatLog.addSystem(`activation set to ${activation}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`activation failed: ${formatTuiErrorMessage(err)}`);
-        }
+        await applySessionSetting(
+          { groupActivation: activation },
+          `activation set to ${activation}`,
+          "activation failed",
+        );
         break;
       }
       case "new": {

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -1,6 +1,6 @@
 // Covers bounded TUI run ownership and transcript persistence coordination.
 import { describe, expect, it, vi } from "vitest";
-import { TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
+import { createTuiRunIdTracker, TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
 import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
 
 function makeState(overrides?: Partial<TuiStateAccess>): TuiStateAccess {
@@ -64,6 +64,24 @@ function createCoordinator(overrides?: {
     requestRender,
   };
 }
+
+describe("createTuiRunIdTracker", () => {
+  it("bounds FIFO membership and supports explicit cleanup", () => {
+    const tracker = createTuiRunIdTracker();
+    tracker.note("");
+    for (let index = 0; index <= 200; index += 1) {
+      tracker.note(`run-${index}`);
+    }
+
+    expect(tracker.has("")).toBe(false);
+    expect(tracker.has("run-0")).toBe(false);
+    expect(tracker.has("run-200")).toBe(true);
+    tracker.forget("run-200");
+    expect(tracker.has("run-200")).toBe(false);
+    tracker.clear();
+    expect(tracker.has("run-100")).toBe(false);
+  });
+});
 
 describe("TuiSessionRunCoordinator", () => {
   it("keeps the active session run while pruning hundreds of abandoned runs", () => {

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -11,6 +11,24 @@ const HISTORY_RELOAD_OWNED = 1 << 1;
 const HISTORY_RELOAD_DISPLAYED = 1 << 2;
 const HISTORY_RELOAD_GAP_RECOVERY = 1 << 3;
 
+/** A small FIFO membership tracker for run IDs that need no lifecycle metadata. */
+export function createTuiRunIdTracker() {
+  const runIds = new Set<string>();
+  return {
+    note: (runId: string) => {
+      if (runId) {
+        runIds.add(runId);
+      }
+      if (runIds.size > MAX_TRACKED_RUNS) {
+        runIds.delete(runIds.values().next().value as string);
+      }
+    },
+    forget: (runId: string) => void runIds.delete(runId),
+    has: (runId: string) => runIds.has(runId),
+    clear: () => runIds.clear(),
+  };
+}
+
 type HistoryOwnedRun = {
   runId: string;
   result: TuiHistoryLoadResult;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -61,7 +61,7 @@ import { createOverlayHandlers } from "./tui-overlays.js";
 import { createTuiPluginApprovalController } from "./tui-plugin-approvals.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
-import type { TuiPendingSubmit } from "./tui-submit-state.js";
+import { createTuiRunIdTracker } from "./tui-session-run-coordinator.js";
 import {
   createEditorSubmitHandler,
   createSubmitBurstCoalescer,
@@ -70,7 +70,6 @@ import {
 } from "./tui-submit.js";
 import { createTuiTaskSuggestionController } from "./tui-task-suggestions.js";
 import type {
-  AgentSummary,
   SessionInfo,
   SessionScope,
   TuiOptions,
@@ -609,54 +608,40 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const resolveUsableCwd = () => tryProcessCwd() ?? fallbackCwd;
   const emptySessionInfoDefaults = resolveEmptySessionInfoDefaults(config);
   const initialSessionInput = (opts.session ?? "").trim();
-  let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
-  let sessionMainKey = normalizeMainKey(config.session?.mainKey);
-  let agentDefaultId = resolveDefaultAgentId(config);
+  const sessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
+  const sessionMainKey = normalizeMainKey(config.session?.mainKey);
+  const agentDefaultId = resolveDefaultAgentId(config);
   let currentAgentId = resolveInitialTuiAgentId({
     cfg: config,
     fallbackAgentId: agentDefaultId,
     initialSessionInput,
   });
-  let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
   let currentSessionKey = "";
-  let initialSessionApplied = false;
   let rememberedSessionApplied = false;
   let currentSessionId: string | null = null;
   const sessionGenerations = new Map<string, number>();
   const sessionIds = new Map<string, string>();
-  let activeChatRunId: string | null = null;
-  let pendingSubmit: TuiPendingSubmit | null = null;
-  let historyLoaded = false;
-  let isConnected = false;
   let connectionGeneration = 0;
   let wasDisconnected = false;
-  let toolsExpanded = false;
-  let showThinking = false;
   let pairingHintShown = false;
-  const localRunIds = new Set<string>();
-  const localBtwRunIds = new Set<string>();
+  const localRunIds = createTuiRunIdTracker();
+  const localBtwRunIds = createTuiRunIdTracker();
 
   const deliverDefault = opts.deliver ?? false;
   const autoMessage = opts.message?.trim();
   const thinkingLevelOverride = normalizeThinkLevel(opts.thinking);
-  let autoMessageSent = false;
-  let sessionInfo: SessionInfo = { ...emptySessionInfoDefaults };
   let dynamicSlashCommands: CommandEntry[] = [];
   let dynamicSlashCommandsKey: string | null = null;
   let dynamicSlashCommandsInFlightKey: string | null = null;
   let dynamicSlashCommandsRequestId = 0;
   let dynamicSlashCommandsReady = false;
   let dynamicSlashCommandsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-  let lastCtrlCAt = 0;
   let exitRequested = false;
   let exitResult: TuiResult = { exitReason: "exit" };
-  let activityStatus = "idle";
-  let connectionStatus = isLocalMode ? "starting local runtime" : "connecting";
-  let statusTimeout: NodeJS.Timeout | null = null;
   let statusTimer: NodeJS.Timeout | null = null;
   let statusStartedAt: number | null = null;
-  let lastActivityStatus = activityStatus;
+  let lastActivityStatus = "idle";
   let invalidateSessionRunOwnership: () => void = () => undefined;
   let retireHistoryAbsentRun: (_runId: string) => void = () => undefined;
 
@@ -669,30 +654,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   const state: TuiStateAccess = {
-    get agentDefaultId() {
-      return agentDefaultId;
-    },
-    set agentDefaultId(value) {
-      agentDefaultId = value;
-    },
-    get sessionMainKey() {
-      return sessionMainKey;
-    },
-    set sessionMainKey(value) {
-      sessionMainKey = value;
-    },
-    get sessionScope() {
-      return sessionScope;
-    },
-    set sessionScope(value) {
-      sessionScope = value;
-    },
-    get agents() {
-      return agents;
-    },
-    set agents(value) {
-      agents = value;
-    },
+    agentDefaultId,
+    sessionMainKey,
+    sessionScope,
+    agents: [],
     get currentAgentId() {
       return currentAgentId;
     },
@@ -734,130 +699,19 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     set sessionGeneration(value) {
       writeCurrentSessionGeneration(Math.max(readCurrentSessionGeneration(), value));
     },
-    get activeChatRunId() {
-      return activeChatRunId;
-    },
-    set activeChatRunId(value) {
-      activeChatRunId = value;
-    },
-    get pendingSubmit() {
-      return pendingSubmit;
-    },
-    set pendingSubmit(value) {
-      pendingSubmit = value;
-    },
-    get historyLoaded() {
-      return historyLoaded;
-    },
-    set historyLoaded(value) {
-      historyLoaded = value;
-    },
-    get sessionInfo() {
-      return sessionInfo;
-    },
-    set sessionInfo(value) {
-      sessionInfo = value;
-    },
-    get initialSessionApplied() {
-      return initialSessionApplied;
-    },
-    set initialSessionApplied(value) {
-      initialSessionApplied = value;
-    },
-    get isConnected() {
-      return isConnected;
-    },
-    set isConnected(value) {
-      isConnected = value;
-    },
-    get autoMessageSent() {
-      return autoMessageSent;
-    },
-    set autoMessageSent(value) {
-      autoMessageSent = value;
-    },
-    get toolsExpanded() {
-      return toolsExpanded;
-    },
-    set toolsExpanded(value) {
-      toolsExpanded = value;
-    },
-    get showThinking() {
-      return showThinking;
-    },
-    set showThinking(value) {
-      showThinking = value;
-    },
-    get connectionStatus() {
-      return connectionStatus;
-    },
-    set connectionStatus(value) {
-      connectionStatus = value;
-    },
-    get activityStatus() {
-      return activityStatus;
-    },
-    set activityStatus(value) {
-      activityStatus = value;
-    },
-    get statusTimeout() {
-      return statusTimeout;
-    },
-    set statusTimeout(value) {
-      statusTimeout = value;
-    },
-    get lastCtrlCAt() {
-      return lastCtrlCAt;
-    },
-    set lastCtrlCAt(value) {
-      lastCtrlCAt = value;
-    },
-  };
-
-  const noteLocalRunId = (runId: string) => {
-    if (!runId) {
-      return;
-    }
-    localRunIds.add(runId);
-    if (localRunIds.size > 200) {
-      const [first] = localRunIds;
-      if (first) {
-        localRunIds.delete(first);
-      }
-    }
-  };
-
-  const forgetLocalRunId = (runId: string) => {
-    localRunIds.delete(runId);
-  };
-
-  const isLocalRunId = (runId: string) => localRunIds.has(runId);
-
-  const clearLocalRunIds = () => {
-    localRunIds.clear();
-  };
-
-  const noteLocalBtwRunId = (runId: string) => {
-    if (!runId) {
-      return;
-    }
-    localBtwRunIds.add(runId);
-    if (localBtwRunIds.size > 200) {
-      const [first] = localBtwRunIds;
-      if (first) {
-        localBtwRunIds.delete(first);
-      }
-    }
-  };
-
-  const forgetLocalBtwRunId = (runId: string) => {
-    localBtwRunIds.delete(runId);
-  };
-
-  const isLocalBtwRunId = (runId: string) => localBtwRunIds.has(runId);
-
-  const clearLocalBtwRunIds = () => {
-    localBtwRunIds.clear();
+    activeChatRunId: null,
+    pendingSubmit: null,
+    historyLoaded: false,
+    sessionInfo: { ...emptySessionInfoDefaults },
+    initialSessionApplied: false,
+    isConnected: false,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: isLocalMode ? "starting local runtime" : "connecting",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
   };
 
   let client: TuiBackend;
@@ -920,17 +774,17 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   root.addChild(footer);
   root.addChild(editor);
 
-  const resolveDynamicSlashCommandsKey = () => currentAgentId;
+  const resolveDynamicSlashCommandsKey = () => state.currentAgentId;
 
   const applyAutocompleteProvider = () => {
     const dynamicKey = resolveDynamicSlashCommandsKey();
     const slashCommands = getSlashCommands({
       cfg: config,
       local: isLocalMode,
-      provider: sessionInfo.modelProvider,
-      model: sessionInfo.model,
-      agentRuntime: sessionInfo.agentRuntime?.id,
-      thinkingLevels: sessionInfo.thinkingLevels,
+      provider: state.sessionInfo.modelProvider,
+      model: state.sessionInfo.model,
+      agentRuntime: state.sessionInfo.agentRuntime?.id,
+      thinkingLevels: state.sessionInfo.thinkingLevels,
       dynamicCommands: dynamicSlashCommandsKey === dynamicKey ? dynamicSlashCommands : [],
     });
     editor.shouldSubmitAutocomplete = (text) =>
@@ -953,7 +807,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     const key = resolveDynamicSlashCommandsKey();
     if (
       !dynamicSlashCommandsReady ||
-      !isConnected ||
+      !state.isConnected ||
       !client.listCommands ||
       dynamicSlashCommandsKey === key ||
       dynamicSlashCommandsInFlightKey === key
@@ -962,7 +816,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     }
     dynamicSlashCommandsInFlightKey = key;
     const requestId = ++dynamicSlashCommandsRequestId;
-    const agentId = currentAgentId;
+    const agentId = state.currentAgentId;
     void client
       .listCommands({
         agentId,
@@ -1024,9 +878,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const resolveSessionKey = (raw?: string) => {
     return resolveTuiSessionKey({
       raw,
-      sessionScope,
-      currentAgentId,
-      sessionMainKey,
+      sessionScope: state.sessionScope,
+      currentAgentId: state.currentAgentId,
+      sessionMainKey: state.sessionMainKey,
     });
   };
 
@@ -1036,8 +890,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     const parsed = parseAgentSessionKey(sessionKey);
     return buildTuiLastSessionScopeKey({
       connectionUrl: client.connection.url,
-      agentId: parsed?.agentId ?? currentAgentId,
-      sessionScope,
+      agentId: parsed?.agentId ?? state.currentAgentId,
+      sessionScope: state.sessionScope,
     });
   };
 
@@ -1059,7 +913,11 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     const remembered = await readTuiLastSessionKey({
       scopeKey: buildLastSessionScopeKeyFor(),
     });
-    if (expectedConnectionGeneration !== connectionGeneration || !isConnected || exitRequested) {
+    if (
+      expectedConnectionGeneration !== connectionGeneration ||
+      !state.isConnected ||
+      exitRequested
+    ) {
       return;
     }
     const rememberedKey = remembered ? resolveSessionKey(remembered) : null;
@@ -1068,7 +926,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     const rememberedAgent = parseAgentSessionKey(rememberedKey)?.agentId;
-    if (rememberedAgent && normalizeAgentId(rememberedAgent) !== currentAgentId) {
+    if (rememberedAgent && normalizeAgentId(rememberedAgent) !== state.currentAgentId) {
       rememberedSessionApplied = true;
       return;
     }
@@ -1078,13 +936,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         search: rememberedKey,
         includeGlobal: false,
         includeUnknown: false,
-        agentId: currentAgentId,
+        agentId: state.currentAgentId,
       })
       .catch(() => null);
     if (
       !sessions ||
       expectedConnectionGeneration !== connectionGeneration ||
-      !isConnected ||
+      !state.isConnected ||
       exitRequested
     ) {
       return;
@@ -1093,7 +951,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     rememberedSessionApplied = true;
     const restored = resolveRememberedTuiSessionKey({
       rememberedKey,
-      currentAgentId,
+      currentAgentId: state.currentAgentId,
       sessions: sessions.sessions,
     });
     if (!restored || restored === currentSessionKey) {
@@ -1106,7 +964,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
 
   const updateHeader = () => {
     const sessionLabel = formatSessionKey(currentSessionKey);
-    const agentLabel = formatAgentLabel(currentAgentId);
+    const agentLabel = formatAgentLabel(state.currentAgentId);
     const title = opts.title ?? "openclaw tui";
     header.setText(
       theme.header(
@@ -1164,21 +1022,21 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     }
     const elapsed = formatElapsed(statusStartedAt);
 
-    if (activityStatus === "waiting") {
+    if (state.activityStatus === "waiting") {
       waitingTick++;
       statusLoader.setMessage(
         buildWaitingStatusMessage({
           theme,
           tick: waitingTick,
           elapsed,
-          connectionStatus,
+          connectionStatus: state.connectionStatus,
           phrases: waitingPhrase ? [waitingPhrase] : undefined,
         }),
       );
       return;
     }
 
-    statusLoader.setMessage(`${activityStatus} • ${elapsed} | ${connectionStatus}`);
+    statusLoader.setMessage(`${state.activityStatus} • ${elapsed} | ${state.connectionStatus}`);
   };
 
   const startStatusTimer = () => {
@@ -1186,7 +1044,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     statusTimer = setInterval(() => {
-      if (!isTuiBusyActivityStatus(activityStatus)) {
+      if (!isTuiBusyActivityStatus(state.activityStatus)) {
         return;
       }
       updateBusyStatusMessage();
@@ -1202,11 +1060,11 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   const stopStatusTimeout = () => {
-    if (!statusTimeout) {
+    if (!state.statusTimeout) {
       return;
     }
-    clearTimeout(statusTimeout);
-    statusTimeout = null;
+    clearTimeout(state.statusTimeout);
+    state.statusTimeout = null;
   };
 
   const startWaitingTimer = () => {
@@ -1223,7 +1081,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     waitingTick = 0;
 
     waitingTimer = setInterval(() => {
-      if (activityStatus !== "waiting") {
+      if (state.activityStatus !== "waiting") {
         return;
       }
       updateBusyStatusMessage();
@@ -1250,13 +1108,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   const renderStatus = () => {
-    const isBusy = isTuiBusyActivityStatus(activityStatus);
+    const isBusy = isTuiBusyActivityStatus(state.activityStatus);
     if (isBusy) {
-      if (!statusStartedAt || lastActivityStatus !== activityStatus) {
+      if (!statusStartedAt || lastActivityStatus !== state.activityStatus) {
         statusStartedAt = Date.now();
       }
       ensureStatusLoader();
-      if (activityStatus === "waiting") {
+      if (state.activityStatus === "waiting") {
         stopStatusTimer();
         startWaitingTimer();
       } else {
@@ -1271,21 +1129,23 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       statusLoader?.stop();
       statusLoader = null;
       ensureStatusText();
-      const text = activityStatus ? `${connectionStatus} | ${activityStatus}` : connectionStatus;
+      const text = state.activityStatus
+        ? `${state.connectionStatus} | ${state.activityStatus}`
+        : state.connectionStatus;
       statusText?.setText(theme.dim(text));
     }
-    lastActivityStatus = activityStatus;
+    lastActivityStatus = state.activityStatus;
   };
 
   const setConnectionStatus = (text: string, ttlMs?: number) => {
-    connectionStatus = text;
+    state.connectionStatus = text;
     renderStatus();
-    if (statusTimeout) {
+    if (state.statusTimeout) {
       stopStatusTimeout();
     }
     if (ttlMs && ttlMs > 0) {
-      statusTimeout = setTimeout(() => {
-        connectionStatus = isConnected
+      state.statusTimeout = setTimeout(() => {
+        state.connectionStatus = state.isConnected
           ? isLocalMode
             ? "local ready"
             : "connected"
@@ -1298,7 +1158,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   const setActivityStatus = (text: string) => {
-    activityStatus = text;
+    state.activityStatus = text;
     renderStatus();
   };
 
@@ -1329,7 +1189,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
           // Codex owns its auth store; delegate when the CLI is available.
           const codexBin =
             provider === OPENAI_CODEX_PROVIDER ||
-            (!provider && sessionInfo.modelProvider === OPENAI_CODEX_PROVIDER)
+            (!provider && state.sessionInfo.modelProvider === OPENAI_CODEX_PROVIDER)
               ? await resolveCodexCliBin()
               : null;
 
@@ -1365,26 +1225,33 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
 
   const updateFooter = () => {
     const sessionKeyLabel = formatSessionKey(currentSessionKey);
-    const sessionLabel = sessionInfo.displayName
-      ? `${sessionKeyLabel} (${sessionInfo.displayName})`
+    const sessionLabel = state.sessionInfo.displayName
+      ? `${sessionKeyLabel} (${state.sessionInfo.displayName})`
       : sessionKeyLabel;
-    const agentLabel = formatAgentLabel(currentAgentId);
+    const agentLabel = formatAgentLabel(state.currentAgentId);
     const modelLabel = formatModelFooter({
-      model: sessionInfo.model,
-      thinkingLevel: thinkingLevelOverride ?? sessionInfo.thinkingLevel,
+      model: state.sessionInfo.model,
+      thinkingLevel: thinkingLevelOverride ?? state.sessionInfo.thinkingLevel,
     });
-    const tokens = formatTokens(sessionInfo.totalTokens ?? null, sessionInfo.contextTokens ?? null);
+    const tokens = formatTokens(
+      state.sessionInfo.totalTokens ?? null,
+      state.sessionInfo.contextTokens ?? null,
+    );
     const fastLabel =
-      sessionInfo.fastMode === "auto" ? "fast:auto" : sessionInfo.fastMode === true ? "fast" : null;
-    const verbose = sessionInfo.verboseLevel ?? "off";
-    const reasoning = sessionInfo.reasoningLevel ?? "off";
+      state.sessionInfo.fastMode === "auto"
+        ? "fast:auto"
+        : state.sessionInfo.fastMode === true
+          ? "fast"
+          : null;
+    const verbose = state.sessionInfo.verboseLevel ?? "off";
+    const reasoning = state.sessionInfo.reasoningLevel ?? "off";
     const reasoningLabel =
       reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
     const footerParts = [
       `agent ${agentLabel}`,
       `session ${sessionLabel}`,
       modelLabel,
-      formatGoalFooter(sessionInfo.goal),
+      formatGoalFooter(state.sessionInfo.goal),
       fastLabel,
       verbose !== "off" ? `verbose ${verbose}` : null,
       reasoningLabel,
@@ -1397,7 +1264,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const pluginApprovals = createTuiPluginApprovalController({
     client,
     chatLog,
-    getAgentId: () => currentAgentId,
+    getAgentId: () => state.currentAgentId,
     getSessionKey: () => currentSessionKey,
     openOverlay,
     closeOverlay,
@@ -1435,7 +1302,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     updateFooter,
     updateAutocompleteProvider,
     setActivityStatus,
-    clearLocalRunIds,
+    clearLocalRunIds: localRunIds.clear,
     rememberSessionKey: rememberCurrentSessionKey,
   });
   const {
@@ -1497,13 +1364,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     setActivityStatus,
     refreshSessionInfo,
     loadHistory,
-    noteLocalRunId,
-    isLocalRunId,
-    forgetLocalRunId,
-    clearLocalRunIds,
-    isLocalBtwRunId,
-    forgetLocalBtwRunId,
-    clearLocalBtwRunIds,
+    noteLocalRunId: localRunIds.note,
+    isLocalRunId: localRunIds.has,
+    forgetLocalRunId: localRunIds.forget,
+    clearLocalRunIds: localRunIds.clear,
+    isLocalBtwRunId: localBtwRunIds.has,
+    forgetLocalBtwRunId: localBtwRunIds.forget,
+    clearLocalBtwRunIds: localBtwRunIds.clear,
   });
   retireHistoryAbsentRun = () => reconnectStreamingWatchdog(null);
   invalidateSessionRunOwnership = () => {
@@ -1586,10 +1453,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     abortActive,
     setActivityStatus,
     formatSessionKey,
-    noteLocalRunId,
-    noteLocalBtwRunId,
-    forgetLocalRunId,
-    forgetLocalBtwRunId,
+    noteLocalRunId: localRunIds.note,
+    noteLocalBtwRunId: localBtwRunIds.note,
+    forgetLocalRunId: localRunIds.forget,
+    forgetLocalBtwRunId: localBtwRunIds.forget,
     consumeCompletedRunForPendingSend,
     isRunObserved,
     flushPendingHistoryRefreshIfIdle,
@@ -1639,7 +1506,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     const decision = resolveTuiCtrlCAction({
       hasInput: editor.getText().length > 0,
       now,
-      lastCtrlCAt,
+      lastCtrlCAt: state.lastCtrlCAt,
       exitRequested,
       wasDisconnected,
       exitWindowMs: opts.ctrlCExitWindowMs,
@@ -1648,7 +1515,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       forceExit();
       return;
     }
-    lastCtrlCAt = decision.nextLastCtrlCAt;
+    state.lastCtrlCAt = decision.nextLastCtrlCAt;
     if (decision.action === "clear") {
       editor.setText("");
       setActivityStatus("cleared input; press ctrl+c again to exit");
@@ -1669,14 +1536,14 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     requestExit();
   };
   editor.onCtrlO = () => {
-    toolsExpanded = !toolsExpanded;
-    chatLog.setToolsExpanded(toolsExpanded);
+    state.toolsExpanded = !state.toolsExpanded;
+    chatLog.setToolsExpanded(state.toolsExpanded);
     // Ctrl+O is presentation-only; preserve busy activity so the status loader
     // does not disappear before the run lifecycle ends.
     setActivityStatus(
       resolveTuiToolsToggleActivityStatus({
-        currentStatus: activityStatus,
-        toolsExpanded,
+        currentStatus: state.activityStatus,
+        toolsExpanded: state.toolsExpanded,
       }),
     );
     tui.requestRender();
@@ -1691,7 +1558,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     void openSessionSelector();
   };
   editor.onCtrlT = () => {
-    showThinking = !showThinking;
+    state.showThinking = !state.showThinking;
     void loadHistory();
   };
 
@@ -1740,8 +1607,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     }
     const connectedGeneration = ++connectionGeneration;
     const ownsConnection = () =>
-      connectedGeneration === connectionGeneration && isConnected && !exitRequested;
-    isConnected = true;
+      connectedGeneration === connectionGeneration && state.isConnected && !exitRequested;
+    state.isConnected = true;
     pairingHintShown = false;
     const reconnected = wasDisconnected;
     wasDisconnected = false;
@@ -1751,7 +1618,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     setConnectionStatus(isLocalMode ? "local ready" : "connected");
     // A reconnect may already have restored a live run's busy status. Only
     // claim the status line when startup owns it, then release that exact state.
-    if (!isTuiBusyActivityStatus(activityStatus)) {
+    if (!isTuiBusyActivityStatus(state.activityStatus)) {
       setActivityStatus("starting up");
     }
     void (async () => {
@@ -1765,7 +1632,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
           }
           if (attempt + 1 === SESSION_SUBSCRIPTION_MAX_ATTEMPTS) {
             chatLog.addSystem(`session event subscribe failed: ${formatTuiErrorMessage(err)}`);
-            if (activityStatus === "starting up") {
+            if (state.activityStatus === "starting up") {
               setActivityStatus("idle");
             }
             setConnectionStatus("session event subscription failed");
@@ -1819,7 +1686,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (!ownsConnection()) {
         return;
       }
-      if (activityStatus === "starting up") {
+      if (state.activityStatus === "starting up") {
         setActivityStatus("idle");
       }
       if (reconnected) {
@@ -1832,8 +1699,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       tui.requestRender();
       dynamicSlashCommandsReady = true;
       scheduleDynamicSlashCommandsRefresh();
-      if (!autoMessageSent && autoMessage) {
-        autoMessageSent = true;
+      if (!state.autoMessageSent && autoMessage) {
+        state.autoMessageSent = true;
         await sendMessage(autoMessage);
         if (!ownsConnection()) {
           return;
@@ -1846,7 +1713,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         return;
       }
       chatLog.addSystem(`startup failed: ${formatTuiErrorMessage(err)}`);
-      if (activityStatus === "starting up") {
+      if (state.activityStatus === "starting up") {
         setActivityStatus("idle");
       }
       setConnectionStatus("startup failed", 5000);
@@ -1859,9 +1726,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     connectionGeneration += 1;
-    isConnected = false;
+    state.isConnected = false;
     wasDisconnected = true;
-    historyLoaded = false;
+    state.historyLoaded = false;
     dynamicSlashCommands = [];
     dynamicSlashCommandsKey = null;
     dynamicSlashCommandsInFlightKey = null;
@@ -1892,7 +1759,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   client.onDisconnected = handleBackendDisconnected;
 
   client.onGap = (info) => {
-    if (exitRequested || !isConnected) {
+    if (exitRequested || !state.isConnected) {
       return;
     }
     setConnectionStatus(`event gap: expected ${info.expected}, got ${info.received}`, 5000);


### PR DESCRIPTION
## Summary

- make the auto-reply goal command executor the canonical owner for both auto-reply and embedded TUI goal behavior
- route embedded history through the gateway history owner instead of duplicating transcript reads, CLI merge, compaction enrichment, and display projection
- collapse TUI session-setting updates behind one transaction helper and ordinary mutable TUI state behind the canonical state object
- share bounded run-id tracking through the session run coordinator

## Root cause and owner boundary

The embedded TUI had accumulated parallel implementations of behavior already owned elsewhere: goal command execution in auto-reply, chat history projection in the gateway, repeated session-setting transactions in command handlers, and bounded run tracking in the run coordinator. The duplicate paths could drift while making the same state transitions harder to reason about.

This change keeps one canonical owner for each invariant and removes the connected shadow logic. TUI-specific selection invalidation and notification accessors remain in `tui.ts`, because they own UI lifecycle behavior rather than ordinary storage.

## Removed paths

- embedded goal parsing, status mutation, prompt reconstruction, and continuation formatting
- embedded direct transcript/CLI history merging and local display-message projection
- repeated model/think/verbose/trace/fast/reasoning/usage/elevated/activation mutation scaffolding
- ordinary TUI shadow locals plus getter/setter forwarding facade
- duplicate local and BTW bounded run-id set implementations

## LOC

- production: +376 / -679 = **-303 LOC**
- tests: +67 / -58 = **+9 LOC**
- total: +443 / -737 = **-294 LOC**

## Behavior and sibling coverage

- goal start/resume/edit/status/clear behavior remains covered through the canonical command handler and embedded-backend delegation
- embedded history preserves runtime prewarm, selected-agent scoping, in-flight run projection, thinking defaults, compaction markers, hard history budgets, and session metadata
- session-setting error text, stale-selection suppression, refresh hooks, and per-setting projections remain unchanged
- TUI selection-generation accessors still own run invalidation and approval/suggestion notifications
- run trackers preserve FIFO eviction at 200 entries, forget, clear, and local/BTW independence

## Proof

- focused unit tests: **327 passed** across TUI and goal command suites
- final focused regression run after parity adjustments: **239 passed**
- real Linux PTY suite with local embedded backend and real Gateway WebSocket: **65 passed** across 3 files
  - `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- full changed gate on Blacksmith Testbox: passed, exit 0
- `git diff --check`: passed
- formatter: passed using the prepared normal checkout dependency install
- fresh xhigh autoreview on the final diff: clean, 0.98 correctness confidence, no actionable findings

No protocol, config, schema, dependency, or user-visible TUI contract changes.


## Current-main integration disposition

- PR head: `39ed6db7d18328a372b44da03e0b62e263368468`
- merge base: `afe024e8c7990e9ced295f544c3cc5502c7136d4`
- audited `origin/main`: `b5a59e0a7d948a8b9021b97ab5c66248f12303d2`
- current main changed 200 paths since the merge base; exactly one intersects the 10 paths changed by this PR: `src/tui/tui.ts`
- `git merge-file -p` for that overlap exited 0, and `git merge-tree --write-tree origin/main HEAD` produced clean merged tree `701f35ce6f9048ee6e6ae7b8426f659abf3d3693`
- inspection of the merged file preserves both this PR’s canonical `createTuiRunIdTracker` owner cleanup and main’s `disposeSubmitBurst` shutdown behavior from `cd4bd7c6c0ca860babbcbf0b68a066f3627ad547`
- exact synthetic merged-result Testbox proof: `src/tui/tui.submit-handler.test.ts` passed 25/25, including pending/future submission disposal coverage

No branch rebase or push is needed: the overlap composes cleanly, and the native SHA-pinned squash landing against a fresh base will preserve both sides. Maintainers should still inspect the native generated result before landing.
