### PR TITLE
fix(doctor): diagnose inaccessible Claude CLI workspace paths

### DIFF
--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -55,6 +55,29 @@ function noteTitle(noteFn: ReturnType<typeof vi.fn>): string {
   return value;
 }
 
+function noteHealthyClaudeCliDirectories(params: {
+  homeDir: string;
+  workspaceDir: string;
+}): ReturnType<typeof vi.fn> {
+  const noteFn = vi.fn();
+  noteClaudeCliHealth(
+    {
+      agents: {
+        defaults: { model: { primary: "claude-cli/claude-sonnet-4-6" } },
+        entries: { main: { default: true } },
+      },
+    },
+    {
+      ...params,
+      noteFn,
+      store: createStore(),
+      readClaudeCliCredentials: () => ({ type: "api_key_helper" }),
+      resolveCommandPath: () => "/opt/homebrew/bin/claude",
+    },
+  );
+  return noteFn;
+}
+
 describe("resolveClaudeCliProjectDirForWorkspace", () => {
   it("matches Claude's sanitized workspace project dir shape", () => {
     expect(
@@ -283,6 +306,357 @@ describe("noteClaudeCliHealth", () => {
       );
 
       expect(noteFn).not.toHaveBeenCalled();
+    });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reports an inaccessible Claude project directory instead of silently treating it as missing",
+    async () => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        fs.mkdirSync(projectDir, { recursive: true });
+        const projectsDir = path.dirname(projectDir);
+        fs.chmodSync(projectsDir, 0o000);
+
+        try {
+          expect(() => fs.statSync(projectDir)).toThrow(
+            expect.objectContaining({ code: "EACCES" }),
+          );
+
+          const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+          expect(noteFn).toHaveBeenCalledOnce();
+          expect(noteBody(noteFn)).toContain("Claude project dir:");
+          expect(noteBody(noteFn)).toContain("is not readable by this user.");
+          expect(noteBody(noteFn)).toContain("- Fix: make the Claude project dir readable");
+        } finally {
+          fs.chmodSync(projectsDir, 0o755);
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "provides actionable repair guidance for a read-only Claude project directory",
+    async () => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.chmodSync(projectDir, 0o555);
+
+        try {
+          const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+          expect(noteFn).toHaveBeenCalledOnce();
+          expect(noteBody(noteFn)).toContain("is not writable by this user.");
+          expect(noteBody(noteFn)).toContain("- Fix: make the Claude project dir writable");
+        } finally {
+          fs.chmodSync(projectDir, 0o755);
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reports a non-directory Claude project ancestor instead of silently treating it as missing",
+    async () => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const projectsDir = path.dirname(projectDir);
+        fs.mkdirSync(path.dirname(projectsDir), { recursive: true });
+        fs.writeFileSync(projectsDir, "not a directory");
+
+        expect(() => fs.statSync(projectDir)).toThrow(expect.objectContaining({ code: "ENOTDIR" }));
+
+        const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+        expect(noteFn).toHaveBeenCalledOnce();
+        expect(noteBody(noteFn)).toContain("Claude project dir:");
+        expect(noteBody(noteFn)).toContain("exists but is not a directory.");
+        expect(noteBody(noteFn)).toContain("- Fix: make the Claude project dir readable");
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "reports a dangling %s directory symlink instead of silently treating it as missing",
+    async (location) => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const linkPath = location === "project" ? projectDir : workspaceDir;
+        if (location === "project") {
+          fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+        } else {
+          fs.rmdirSync(linkPath);
+        }
+        fs.symlinkSync(path.join(path.dirname(linkPath), "missing-claude-directory"), linkPath);
+
+        expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+        expect(() => fs.statSync(linkPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+
+        const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+        expect(noteFn).toHaveBeenCalledOnce();
+        expect(noteBody(noteFn)).toContain(
+          location === "project" ? "Claude project dir:" : "Workspace:",
+        );
+        expect(noteBody(noteFn)).toContain("exists but is not a directory.");
+        expect(noteBody(noteFn)).toContain("- Fix:");
+        if (location === "project") {
+          expect(noteBody(noteFn)).toContain("remove the broken path");
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "reports a dangling %s directory ancestor symlink instead of silently treating it as missing",
+    async (location) => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const ancestorPath =
+          location === "project"
+            ? path.dirname(projectDir)
+            : path.join(path.dirname(workspaceDir), "workspace-parent");
+        fs.mkdirSync(path.dirname(ancestorPath), { recursive: true });
+        fs.symlinkSync(path.join(homeDir, `missing-${location}-parent-target`), ancestorPath);
+        const checkedPath =
+          location === "project" ? projectDir : path.join(ancestorPath, "workspace");
+
+        expect(fs.lstatSync(ancestorPath).isSymbolicLink()).toBe(true);
+        expect(() => fs.lstatSync(checkedPath)).toThrow(
+          expect.objectContaining({ code: "ENOENT" }),
+        );
+
+        const noteFn = noteHealthyClaudeCliDirectories({
+          homeDir,
+          workspaceDir: location === "project" ? workspaceDir : checkedPath,
+        });
+        expect(noteFn).toHaveBeenCalledOnce();
+        expect(noteBody(noteFn)).toContain(
+          location === "project" ? "Claude project dir:" : "Workspace:",
+        );
+        expect(noteBody(noteFn)).toContain("exists but is not a directory.");
+        expect(noteBody(noteFn)).toContain("- Fix:");
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "preserves a healthy %s directory symlink",
+    async (location) => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const linkPath = location === "project" ? projectDir : workspaceDir;
+        if (location === "project") {
+          fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+        } else {
+          fs.rmdirSync(linkPath);
+        }
+        const targetPath = path.join(homeDir, `healthy-${location}-target`);
+        fs.mkdirSync(targetPath, { recursive: true });
+        fs.symlinkSync(targetPath, linkPath);
+
+        expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+        expect(noteHealthyClaudeCliDirectories({ homeDir, workspaceDir })).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "preserves a healthy %s directory ancestor symlink",
+    async (location) => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const ancestorPath =
+          location === "project"
+            ? path.dirname(projectDir)
+            : path.join(path.dirname(workspaceDir), "workspace-parent");
+        fs.mkdirSync(path.dirname(ancestorPath), { recursive: true });
+        const targetPath = path.join(homeDir, `healthy-${location}-parent-target`);
+        fs.mkdirSync(targetPath, { recursive: true });
+        fs.symlinkSync(targetPath, ancestorPath);
+        const checkedPath =
+          location === "project" ? projectDir : path.join(ancestorPath, "workspace");
+        expect(fs.lstatSync(ancestorPath).isSymbolicLink()).toBe(true);
+        expect(
+          noteHealthyClaudeCliDirectories({
+            homeDir,
+            workspaceDir: location === "project" ? workspaceDir : checkedPath,
+          }),
+        ).not.toHaveBeenCalled();
+
+        fs.mkdirSync(checkedPath, { recursive: true });
+        expect(
+          noteHealthyClaudeCliDirectories({
+            homeDir,
+            workspaceDir: location === "project" ? workspaceDir : checkedPath,
+          }),
+        ).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "reports an unsearchable %s directory even when it is readable and writable",
+    async (location) => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const dirPath = location === "project" ? projectDir : workspaceDir;
+        fs.mkdirSync(dirPath, { recursive: true });
+        fs.chmodSync(dirPath, 0o666);
+
+        try {
+          expect(() => fs.accessSync(dirPath, fs.constants.R_OK)).not.toThrow();
+          expect(() => fs.accessSync(dirPath, fs.constants.W_OK)).not.toThrow();
+          expect(() => fs.accessSync(dirPath, fs.constants.X_OK)).toThrow(
+            expect.objectContaining({ code: "EACCES" }),
+          );
+
+          const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+          expect(noteFn).toHaveBeenCalledOnce();
+          expect(noteBody(noteFn)).toContain(
+            location === "project" ? "Claude project dir:" : "Workspace:",
+          );
+          expect(noteBody(noteFn)).toContain("is not readable by this user.");
+          expect(noteBody(noteFn)).toContain("- Fix:");
+        } finally {
+          fs.chmodSync(dirPath, 0o755);
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each([
+    { location: "project", parentKind: "direct" },
+    { location: "project", parentKind: "symlinked" },
+    { location: "workspace", parentKind: "direct" },
+    { location: "workspace", parentKind: "symlinked" },
+  ] as const)(
+    "reports a missing $location directory under a $parentKind read-only parent",
+    async ({ location, parentKind }) => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const parentPath =
+          location === "project"
+            ? path.dirname(projectDir)
+            : path.join(path.dirname(workspaceDir), "read-only-workspace-parent");
+        fs.mkdirSync(path.dirname(parentPath), { recursive: true });
+        const parentTarget =
+          parentKind === "symlinked"
+            ? path.join(homeDir, `read-only-${location}-parent-target`)
+            : parentPath;
+        fs.mkdirSync(parentTarget, { recursive: true });
+        if (parentKind === "symlinked") {
+          fs.symlinkSync(parentTarget, parentPath);
+        }
+        const checkedPath =
+          location === "project" ? projectDir : path.join(parentPath, "workspace");
+        fs.chmodSync(parentTarget, 0o555);
+
+        try {
+          expect(() => fs.statSync(checkedPath)).toThrow(
+            expect.objectContaining({ code: "ENOENT" }),
+          );
+          expect(() => fs.mkdirSync(checkedPath)).toThrow(
+            expect.objectContaining({ code: "EACCES" }),
+          );
+
+          const noteFn = noteHealthyClaudeCliDirectories({
+            homeDir,
+            workspaceDir: location === "project" ? workspaceDir : checkedPath,
+          });
+          expect(noteFn).toHaveBeenCalledOnce();
+          expect(noteBody(noteFn)).toContain(
+            location === "project" ? "Claude project dir:" : "Workspace:",
+          );
+          expect(noteBody(noteFn)).toContain("is not writable by this user.");
+          expect(noteBody(noteFn)).toContain("- Fix:");
+        } finally {
+          fs.chmodSync(parentTarget, 0o755);
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["project", "workspace"] as const)(
+    "keeps a missing %s directory quiet when its parent is writable and searchable but unreadable",
+    async (location) => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+        const parentPath =
+          location === "project"
+            ? path.dirname(projectDir)
+            : path.join(path.dirname(workspaceDir), "write-only-workspace-parent");
+        fs.mkdirSync(parentPath, { recursive: true });
+        const checkedPath =
+          location === "project" ? projectDir : path.join(parentPath, "workspace");
+        fs.chmodSync(parentPath, 0o300);
+
+        try {
+          expect(() => fs.accessSync(parentPath, fs.constants.R_OK)).toThrow(
+            expect.objectContaining({ code: "EACCES" }),
+          );
+          expect(() =>
+            fs.accessSync(parentPath, fs.constants.W_OK | fs.constants.X_OK),
+          ).not.toThrow();
+          expect(
+            noteHealthyClaudeCliDirectories({
+              homeDir,
+              workspaceDir: location === "project" ? workspaceDir : checkedPath,
+            }),
+          ).not.toHaveBeenCalled();
+          expect(() => fs.mkdirSync(checkedPath)).not.toThrow();
+        } finally {
+          fs.chmodSync(parentPath, 0o755);
+        }
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves actionable repair guidance for a read-only workspace",
+    async () => {
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        fs.chmodSync(workspaceDir, 0o555);
+
+        try {
+          const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+          expect(noteBody(noteFn)).toContain("Workspace:");
+          expect(noteBody(noteFn)).toContain("is not writable by this user.");
+          expect(noteBody(noteFn)).toContain(
+            "- Fix: make the workspace a readable, writable directory for the gateway user.",
+          );
+        } finally {
+          fs.chmodSync(workspaceDir, 0o755);
+        }
+      });
+    },
+  );
+
+  it("preserves actionable repair guidance for a non-directory Claude project path", async () => {
+    await withTempHome(({ homeDir, workspaceDir }) => {
+      const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir });
+      fs.mkdirSync(path.dirname(projectDir), { recursive: true });
+      fs.writeFileSync(projectDir, "not a directory");
+
+      const noteFn = noteHealthyClaudeCliDirectories({ homeDir, workspaceDir });
+      expect(noteBody(noteFn)).toContain("exists but is not a directory.");
+      expect(noteBody(noteFn)).toContain("- Fix: make the Claude project dir readable");
     });
   });
 

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -1,5 +1,6 @@
 /** Doctor health note for Claude CLI binary, auth, and workspace/project directories. */
 import fs from "node:fs";
+import path from "node:path";
 import {
   normalizeOptionalLowercaseString,
   resolvePrimaryStringValue,
@@ -24,6 +25,7 @@ import { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isErrno } from "../infra/errors.js";
 import { resolveExecutablePath } from "../infra/executable-path.js";
 import { shortenHomePath } from "../utils.js";
 
@@ -53,56 +55,59 @@ function resolveClaudeCliCommand(cfg: OpenClawConfig): string {
 }
 
 function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {
-  try {
-    const stat = fs.statSync(dirPath);
-    if (!stat.isDirectory()) {
-      return "not_directory";
+  let candidate = dirPath; // A missing leaf can conceal a broken ancestor symlink.
+  while (true) {
+    let isSymlink = false;
+    try {
+      const entry = fs.lstatSync(candidate);
+      isSymlink = entry.isSymbolicLink();
+      const stat = isSymlink ? fs.statSync(candidate) : entry;
+      if (!stat.isDirectory()) {
+        return "not_directory";
+      }
+      break;
+    } catch (error) {
+      if (isErrno(error) && error.code === "ENOENT") {
+        if (isSymlink) {
+          return "not_directory";
+        }
+        const parent = path.dirname(candidate);
+        if (parent === candidate) {
+          return "missing";
+        }
+        candidate = parent;
+        continue;
+      }
+      return isErrno(error) && error.code === "ENOTDIR" ? "not_directory" : "unreadable";
     }
-  } catch {
-    return "missing";
   }
   try {
-    fs.accessSync(dirPath, fs.constants.R_OK);
+    // Missing children need parent search/write; existing directories also need read access.
+    // X_OK has no effect on Windows.
+    const readableAccess =
+      (candidate === dirPath ? fs.constants.R_OK : fs.constants.F_OK) |
+      (process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
+    fs.accessSync(candidate, readableAccess);
   } catch {
     return "unreadable";
   }
   try {
-    fs.accessSync(dirPath, fs.constants.W_OK);
+    fs.accessSync(candidate, fs.constants.W_OK);
   } catch {
     return "readonly";
   }
-  return "present";
+  return candidate === dirPath ? "present" : "missing";
 }
 
-function formatWorkspaceProblemLine(
-  workspaceDir: string,
+function formatDirectoryProblemLine(
+  dirPath: string,
   health: ClaudeCliDirHealth,
-  agentId?: string,
+  label: string,
 ): string | null {
-  const label = agentId ? `Agent ${agentId} workspace` : "Workspace";
-  const display = shortenHomePath(workspaceDir);
   if (health === "present" || health === "missing") {
     return null;
   }
-  if (health === "not_directory") {
-    return `- ${label}: ${display} exists but is not a directory.`;
-  }
-  if (health === "unreadable") {
-    return `- ${label}: ${display} is not readable by this user.`;
-  }
-  return `- ${label}: ${display} is not writable by this user.`;
-}
-
-function formatProjectDirProblemLine(
-  projectDir: string,
-  health: ClaudeCliDirHealth,
-  agentId?: string,
-): string | null {
-  const label = agentId ? `Agent ${agentId} Claude project dir` : "Claude project dir";
-  const display = shortenHomePath(projectDir);
-  if (health === "present" || health === "missing") {
-    return null;
-  }
+  const display = shortenHomePath(dirPath);
   if (health === "not_directory") {
     return `- ${label}: ${display} exists but is not a directory.`;
   }
@@ -257,19 +262,13 @@ export function noteClaudeCliHealth(
 
   for (const target of workspaceTargets) {
     const agentLabel = showAgentLabels ? target.agentId : undefined;
-    const workspaceProblem = formatWorkspaceProblemLine(
+    const workspaceProblem = formatDirectoryProblemLine(
       target.workspaceDir,
       target.workspaceHealth,
-      agentLabel,
+      agentLabel ? `Agent ${agentLabel} workspace` : "Workspace",
     );
     if (workspaceProblem) {
       lines.push(workspaceProblem);
-    }
-    if (
-      target.workspaceHealth === "readonly" ||
-      target.workspaceHealth === "unreadable" ||
-      target.workspaceHealth === "not_directory"
-    ) {
       fixHints.push(
         `- Fix: make ${
           agentLabel ? `agent ${agentLabel}'s workspace` : "the workspace"
@@ -277,19 +276,18 @@ export function noteClaudeCliHealth(
       );
     }
 
-    const projectDirProblem = formatProjectDirProblemLine(
+    const projectDirProblem = formatDirectoryProblemLine(
       target.projectDir,
       target.projectDirHealth,
-      agentLabel,
+      agentLabel ? `Agent ${agentLabel} Claude project dir` : "Claude project dir",
     );
     if (projectDirProblem) {
       lines.push(projectDirProblem);
-    }
-    if (target.projectDirHealth === "unreadable" || target.projectDirHealth === "not_directory") {
+      const requiredAccess = target.projectDirHealth === "readonly" ? "writable" : "readable";
       fixHints.push(
         `- Fix: make ${
           agentLabel ? `agent ${agentLabel}'s Claude project dir` : "the Claude project dir"
-        } readable, or remove the broken path and let Claude recreate it.`,
+        } ${requiredAccess}, or remove the broken path and let Claude recreate it.`,
       );
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Claude CLI doctor silently treated inaccessible, malformed, dangling, non-searchable, and uncreatable workspace/project directories as harmless missing paths. Existing read-only project warnings also lacked actionable repair guidance.

## Why This Change Was Made

Keep directory classification at its existing owner, inspect the nearest real ancestor before accepting absence, distinguish existing-directory permissions from missing-child creation permissions, and consolidate duplicated directory diagnostics without changing authentication, configuration, persistence, or platform contracts.

## User Impact

Operators now see actionable Claude workspace/project diagnostics for permission failures, broken links, malformed ancestors, uncreatable missing directories, and read-only project paths. Genuinely missing creatable directories, healthy relocated symlinks, valid write-only/searchable parents, Windows behavior, and healthy multi-agent setups remain unchanged.

## Evidence

- Frozen candidate: bb652ee3f385b15e43796ca25f5940a0f225342d; production delta: +44/-46, net -2.
- Real filesystem red-to-green evidence covers EACCES, ENOTDIR, dangling leaf and ancestor symlinks, non-searchable directories, direct and relocated read-only parents, and missing project repair guidance.
- Positive real filesystem evidence preserves healthy leaf/ancestor symlinks, creatable missing paths, and writable/searchable-but-unreadable parents.
- Exact existing owner suite: 30 passed, 0 failed; formatting and whitespace gates pass.
- Four fresh independent hostile reviews of this exact commit found no P0-P3 findings.
- Genuine Codex gpt-5.6-sol/high/P3 autoreview: clean; 0 findings; confidence 0.94; real TruffleHog preflight passed.
- Exact owner paths are unchanged on current main 4e47c4cabf8f2901ec781b59d059999211398813; a read-only synthetic patch application against that exact clean head succeeds.
