### PR TITLE
fix: prevent durable SQLite user turns from orphan cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+- **SQLite session turn reconciliation:** wait for pending user-turn persistence before orphan cleanup so restart and queued-turn timing cannot remove an already-durable current user message and fail the agent run. (#117384) Thanks @RomneyDa.
 
 ## 2026.7.1
 

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -309,4 +309,25 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
       fixture.trajectoryRecorder,
     );
   });
+
+  it("settles pending user-turn persistence before reconciling the session boundary", async () => {
+    const fixture = createFixture();
+    let releasePersistence: (() => void) | undefined;
+    const pendingPersistence = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    const waitForRuntimePersistence = vi.fn(async () => await pendingPersistence);
+    fixture.input.attempt.userTurnTranscriptRecorder = {
+      waitForRuntimePersistence,
+    } as PrepareInput["attempt"]["userTurnTranscriptRecorder"];
+
+    const preparing = prepareEmbeddedAttemptSessionRuntime(fixture.input);
+    await vi.waitFor(() => expect(waitForRuntimePersistence).toHaveBeenCalledOnce());
+    expect(mocks.prepareSessionBoundary).not.toHaveBeenCalled();
+
+    releasePersistence?.();
+    await preparing;
+
+    expect(mocks.prepareSessionBoundary).toHaveBeenCalledOnce();
+  });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -133,6 +133,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     sessionManager,
   });
   const { activeSession, setActiveSessionSystemPrompt, settingsManager } = preparedAgentSession;
+  await attempt.userTurnTranscriptRecorder?.waitForRuntimePersistence();
   const boundary = prepareEmbeddedAttemptSessionBoundary({
     activeSession,
     attempt,


### PR DESCRIPTION
Related: #116894
Follow-up to #116924

## What Problem This Solves

Fixes an intermittent failure where a SQLite-backed agent turn could remove its already-durable current user message as an orphan after restart or queue timing delayed the recorder's persistence lifecycle. The resulting prompt append then failed with `Session transcript parent entry was not persisted`.

This is separate from #116859; that PR's auth-fixture changes do not touch the session persistence path.

## Why This Change Was Made

The SQLite row can be committed before the recorder's runtime-persistence barrier settles. Session retry normalization already waits for that barrier, but first-attempt session-boundary reconciliation did not. The boundary could therefore read the durable keyed user leaf while `hasPersisted()` was not yet authoritative, remove it, clear suppression, and then collide with the durable idempotency row.

The fix awaits the recorder's existing persistence barrier immediately before orphan reconciliation. It keeps #116924's recorder-confirmed exact-key invariant and does not add retries, timeouts, config, compatibility paths, or schema changes.

## User Impact

SQLite-backed sessions no longer intermittently fail an otherwise valid agent turn during restart, queued-turn, plugin-SDK consumer, or concurrent session lifecycle timing.

## Evidence

- Original GitHub failure: https://github.com/openclaw/openclaw/actions/runs/30685646626/job/91330835271
- Untouched baseline, original proof order on Blacksmith: 2 failures / 36 runs (5.6%).
- Two-CPU baseline reproduction: failed on iteration 2; failure occurred after the durable run-keyed user row existed and immediately after orphan removal.
- Focused ordering regression: `attempt-session-runtime-prepare.test.ts`, 3/3 passed.
- Runtime build: all 11 build invocations passed.
- Fixed two-CPU original-order stress: 20/20 passed; warm proof time 38.6–39.0s.
- AutoReview: clean, no actionable findings (0.99 confidence).
- Diff: production +1 LOC; tests +21 LOC; no schema/config changes.

