### PR TITLE
fix(qa): Telegram live evidence never starts polling

### DIFF
--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
@@ -105,6 +105,7 @@ describe("telegram bot token runtime evidence", () => {
       env: {
         OPENCLAW_SKIP_CHANNELS: undefined,
         OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
       },
     });
     const log = await fs.readFile(

--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
@@ -234,6 +234,7 @@ export async function runTelegramBotTokenRuntime(
       env: {
         OPENCLAW_SKIP_CHANNELS: undefined,
         OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         TELEGRAM_BOT_TOKEN: "qa-invalid-precedence-decoy",
       },
       startTimeoutMs: options.startupTimeoutMs,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Telegram bot-token maturity scenario would acquire a real credential but never start polling because its Gateway inherited the shared minimal-plugin test mode.

## Why This Change Was Made

The bot-token runtime now opts out of the test helper's minimal Gateway mode at the live-product startup boundary. The shared helper keeps its fast minimal default for isolated tests; only the caller that requires the bundled Telegram plugin enables product plugin loading.

## User Impact

Operators can collect real Telegram bot-token evidence instead of timing out before the channel starts.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/30693345330/job/91352128376
- Focused Telegram bot-token runtime suite: 6 tests passed.
- Blacksmith Testbox changed-file gate: wrapper exit 0, `runStatus=succeeded` (the backing one-shot job may show cancelled when its completed lease is stopped): https://github.com/openclaw/openclaw/actions/runs/30698449339
- Autoreview: clean; no actionable findings.
- `git diff --check` passed.

Production delta: none; this changes only the live QA runtime and its test.

AI-assisted: yes. Agent transcript omitted unless requested.
