### PR TITLE
fix(qa): staged QA Lab cannot load Matrix

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -8,7 +8,6 @@
     "@copilotkit/aimock": "1.37.4",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@openclaw/crabline": "0.1.11",
-    "@openclaw/matrix": "workspace:*",
     "p-limit": "7.3.1",
     "p-map": "7.0.6",
     "playwright-core": "1.62.0",
@@ -20,6 +19,7 @@
   },
   "devDependencies": {
     "@openclaw/discord": "workspace:*",
+    "@openclaw/matrix": "workspace:*",
     "@openclaw/plugin-sdk": "workspace:*",
     "@openclaw/slack": "workspace:*",
     "@openclaw/whatsapp": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1598,9 +1598,6 @@ importers:
       '@openclaw/crabline':
         specifier: 0.1.11
         version: 0.1.11
-      '@openclaw/matrix':
-        specifier: workspace:*
-        version: link:../matrix
       p-limit:
         specifier: 7.3.1
         version: 7.3.1
@@ -1629,6 +1626,9 @@ importers:
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord
+      '@openclaw/matrix':
+        specifier: workspace:*
+        version: link:../matrix
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where staged OpenClaw projected QA Lab as unhealthy before any scenario ran because QA Lab declared the external Matrix plugin as a required runtime dependency.

## Why This Change Was Made

Every direct QA Lab import from `@openclaw/matrix/test-api.js` is type-only and erased at build time. Runtime access already goes through the host-owned `loadQaRunnerBundledPluginTestApi("matrix")` facade, which loads Matrix's built test artifact from the active OpenClaw host.

Moving `@openclaw/matrix` back to `devDependencies` therefore records its real role: source typechecking and tests. It prevents generic plugin dependency-health discovery from requiring a separately installed Matrix package in staged OpenClaw without adding a special case or bundling a second plugin runtime.

## User Impact

Maintainers can stage and validate QA Lab channel scenarios without a false missing-runtime-dependency failure before the scenario starts.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/30693345330/job/91352128376
- Focused package and staging contract suite: 454 tests passed.
- Blacksmith Testbox changed-file gate: wrapper exit 0, `runStatus=succeeded`: https://github.com/openclaw/openclaw/actions/runs/30698449370
- All relevant package, dependency, type, lint, and QA Smoke CI lanes passed.
- `git diff --check` passed.

Production delta: zero lines; package metadata only.

Landing note: dependency guard intentionally requires a repository admin or `@openclaw/openclaw-secops` member to comment `/allow-dependencies-change <reason>` for the current head SHA.

AI-assisted: yes. Agent transcript omitted unless requested.
