### PR TITLE
fix(agents): avoid slow default embedded agent startup

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -77,6 +77,53 @@ describe("installEmbeddedAttemptContextGuards", () => {
     hoisted.readLastCacheTtlTimestamp.mockReturnValue(null);
   });
 
+  it.each([
+    { label: "configuration is missing", config: undefined },
+    { label: "pruning is omitted", config: { agents: { defaults: {} } } },
+    {
+      label: "pruning is disabled",
+      config: { agents: { defaults: { contextPruning: { mode: "off" } } } },
+    },
+  ])("skips provider discovery when cache-TTL $label", async ({ config }) => {
+    const input = createInput();
+    input.attempt = { ...input.attempt, config } as never;
+    const originalTransform = vi.fn(async (messages: AgentMessage[]) => messages);
+    input.activeSession.agent.transformContext = originalTransform;
+
+    const guards = installEmbeddedAttemptContextGuards(input as never);
+
+    expect(hoisted.isCacheTtlEligibleProvider).not.toHaveBeenCalled();
+    expect(hoisted.readLastCacheTtlTimestamp).not.toHaveBeenCalled();
+
+    const messages = [{ role: "user", content: "hello", timestamp: 1 }] as AgentMessage[];
+    await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
+    expect(originalTransform).toHaveBeenCalledOnce();
+
+    guards.remove();
+    expect(input.activeSession.agent.transformContext).toBe(originalTransform);
+  });
+
+  it("checks configured cache-TTL pruning without installing it for ineligible providers", () => {
+    const input = createInput();
+    input.attempt = {
+      ...input.attempt,
+      config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } },
+    } as never;
+    const originalTransform = input.activeSession.agent.transformContext;
+
+    const guards = installEmbeddedAttemptContextGuards(input as never);
+
+    expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
+      "provider-1",
+      "model-1",
+      "anthropic-messages",
+    );
+    expect(hoisted.readLastCacheTtlTimestamp).not.toHaveBeenCalled();
+
+    guards.remove();
+    expect(input.activeSession.agent.transformContext).toBe(originalTransform);
+  });
+
   it("tracks mid-turn requests and restores attempt-local transforms", async () => {
     const input = createInput();
     const originalTransform = input.activeSession.agent.transformContext;
@@ -193,6 +240,11 @@ describe("installEmbeddedAttemptContextGuards", () => {
     ] as AgentMessage[];
 
     const guards = installEmbeddedAttemptContextGuards(input as never);
+    expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
+      "anthropic",
+      "claude-sonnet-4-6",
+      "anthropic-messages",
+    );
     await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
     const firstTool = engineMessages?.find((message) => message.role === "toolResult");
     expect(firstTool?.content[0]).toMatchObject({

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
@@ -86,13 +86,15 @@ export function installEmbeddedAttemptContextGuards(input: {
         }
       : {};
 
-  const cacheTtlSettings = isCacheTtlEligibleProvider(
-    attempt.provider,
-    attempt.modelId,
-    attempt.model.api,
-  )
-    ? resolveCacheTtlPruningSettings(attempt.config?.agents?.defaults?.contextPruning)
-    : undefined;
+  const configuredCacheTtlSettings = resolveCacheTtlPruningSettings(
+    attempt.config?.agents?.defaults?.contextPruning,
+  );
+  // Provider eligibility can load plugin runtimes; never pay that cost for disabled pruning.
+  const cacheTtlSettings =
+    configuredCacheTtlSettings &&
+    isCacheTtlEligibleProvider(attempt.provider, attempt.modelId, attempt.model.api)
+      ? configuredCacheTtlSettings
+      : undefined;
   const previousCacheTtlTransform = activeSession.agent.transformContext;
   let lastCacheTouchAt = cacheTtlSettings
     ? readLastCacheTtlTimestamp(input.sessionManager, {


### PR DESCRIPTION
## What Problem This Solves

Normal embedded agent turns perform full provider-plugin discovery even when cache-TTL context pruning is not configured or is explicitly disabled. This regressed the default first-turn path after #117313: three real local terminal scenarios increased from 13.3 s / 5.8 s / 5.4 s to 83.8 s / 85.4 s / 85.8 s. The terminal CI shard repeatedly exceeded its five-minute no-output watchdog.

## Why This Change Was Made

The previous pruning owner checked the configured mode before asking whether the provider was eligible. Its replacement reversed that order, so every embedded attempt called the provider-runtime resolver before learning that the optional feature was disabled. The resolver receives no configuration in this path and can materialize provider plugins even for configurations that disable plugins.

The attempt-local prompt owner now resolves cache-TTL settings first and asks the provider about eligibility only when pruning is actually configured. This restores the same config-first invariant already used by the sibling cache-TTL marker owner. Enabled-provider behavior, invalid-duration fallback, transform composition, and reverse teardown remain unchanged.

## User Impact

Default local embedded turns avoid an unnecessary expensive provider-plugin load. Cache-TTL pruning remains unchanged for opted-in eligible providers and remains inactive for opted-in ineligible providers.

## Evidence

- Tests-first baseline: three genuine failures for missing configuration, omitted pruning, and explicitly disabled pruning; each proved an unwanted provider lookup. Three existing owner tests passed.
- Exact candidate: seven focused owner tests passed, including zero provider lookups and zero TTL-marker reads for all disabled cases, exactly one lookup for an opted-in ineligible provider, and exactly one lookup plus unchanged prompt projection for an opted-in eligible provider.
- The negative cases also verify the original context transform and reverse teardown are preserved.
- Both changed files pass the existing formatter check and `git diff --check`.
- Genuine structured pre-ship autoreview: Codex `gpt-5.6-sol`, high reasoning, P0-P3, zero actionable findings, confidence 0.96; genuine TruffleHog 3.96.0 scan clean.
- Four fresh, independently blind hostile reviews: all clean; two additional nonblind owner reviews also found no actionable issues.
- Before-regression real PTY shard: https://github.com/openclaw/openclaw/actions/runs/30693954308/job/91353616941
- First regressed real PTY shard: https://github.com/openclaw/openclaw/actions/runs/30694225440/job/91354251921
- A later nominally green shard still needed a five-minute watchdog kill and retry, with local scenarios taking 82.7 s / 82.3 s / 85.1 s: https://github.com/openclaw/openclaw/actions/runs/30697365473/job/91362467563
- Exact candidate hosted Blacksmith real local PTY: `src/tui/tui-pty-local.e2e.test.ts` passed the operator first-turn scenario in **12.253 s**, down from **83-85 s** on regressed main; final timing JSON reports `exitCode: 0` and `runStatus: succeeded`, and the one-shot lease was stopped: https://github.com/openclaw/openclaw/actions/runs/30698620922
