### PR TITLE
fix(agents): skip provider discovery when cache pruning is disabled

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -149,6 +149,61 @@ describe("installEmbeddedAttemptContextGuards", () => {
     expect(removeLoopHook).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { name: "attempt configuration is absent", config: undefined },
+    {
+      name: "context pruning is not configured",
+      config: { agents: { defaults: {} } },
+    },
+    {
+      name: "context pruning has no mode",
+      config: { agents: { defaults: { contextPruning: {} } } },
+    },
+    {
+      name: "context pruning is explicitly off",
+      config: { agents: { defaults: { contextPruning: { mode: "off" } } } },
+    },
+  ])("does not inspect providers when $name", ({ config }) => {
+    hoisted.isCacheTtlEligibleProvider.mockReturnValue(true);
+    const input = createInput();
+    input.attempt = { ...input.attempt, config: config as never };
+
+    const guards = installEmbeddedAttemptContextGuards(input as never);
+
+    expect(hoisted.isCacheTtlEligibleProvider).not.toHaveBeenCalled();
+    expect(hoisted.readLastCacheTtlTimestamp).not.toHaveBeenCalled();
+    guards.remove();
+  });
+
+  it("does not install cache-TTL pruning for an ineligible provider", async () => {
+    const input = createInput();
+    input.attempt = {
+      ...input.attempt,
+      config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } } as never,
+    };
+    const originalTransform = vi.fn(async (messages: AgentMessage[]) => messages);
+    input.activeSession.agent.transformContext = originalTransform;
+
+    const guards = installEmbeddedAttemptContextGuards(input as never);
+
+    expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
+      "provider-1",
+      "model-1",
+      "anthropic-messages",
+    );
+    expect(hoisted.readLastCacheTtlTimestamp).not.toHaveBeenCalled();
+    const messages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+    ];
+    expect(
+      await input.activeSession.agent.transformContext?.(messages, new AbortController().signal),
+    ).toBe(messages);
+    expect(originalTransform).toHaveBeenCalledOnce();
+
+    guards.remove();
+    expect(input.activeSession.agent.transformContext).toBe(originalTransform);
+  });
+
   it("projects expired cache-TTL history before context-engine assembly once per attempt", async () => {
     const now = Date.now();
     hoisted.isCacheTtlEligibleProvider.mockReturnValue(true);
@@ -193,6 +248,18 @@ describe("installEmbeddedAttemptContextGuards", () => {
     ] as AgentMessage[];
 
     const guards = installEmbeddedAttemptContextGuards(input as never);
+    expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
+      "anthropic",
+      "claude-sonnet-4-6",
+      "anthropic-messages",
+    );
+    expect(hoisted.readLastCacheTtlTimestamp).toHaveBeenCalledExactlyOnceWith(
+      input.sessionManager,
+      {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+      },
+    );
     await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
     const firstTool = engineMessages?.find((message) => message.role === "toolResult");
     expect(firstTool?.content[0]).toMatchObject({

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
@@ -86,13 +86,13 @@ export function installEmbeddedAttemptContextGuards(input: {
         }
       : {};
 
-  const cacheTtlSettings = isCacheTtlEligibleProvider(
-    attempt.provider,
-    attempt.modelId,
-    attempt.model.api,
-  )
-    ? resolveCacheTtlPruningSettings(attempt.config?.agents?.defaults?.contextPruning)
-    : undefined;
+  const contextPruning = attempt.config?.agents?.defaults?.contextPruning;
+  // Disabled pruning must not resolve provider hooks and cold-load plugin metadata.
+  const cacheTtlSettings =
+    contextPruning?.mode === "cache-ttl" &&
+    isCacheTtlEligibleProvider(attempt.provider, attempt.modelId, attempt.model.api)
+      ? resolveCacheTtlPruningSettings(contextPruning)
+      : undefined;
   const previousCacheTtlTransform = activeSession.agent.transformContext;
   let lastCacheTouchAt = cacheTtlSettings
     ? readLastCacheTtlTimestamp(input.sessionManager, {


### PR DESCRIPTION
## What Problem This Solves

The embedded-agent refactor in #117313 reversed the existing cache-TTL guard order. Every embedded agent attempt now resolves provider eligibility before checking whether cache-TTL pruning is enabled. Provider eligibility enters plugin/runtime discovery without the caller configuration, so default or explicitly disabled pruning can still cold-load installed plugin metadata, including when plugins are disabled. Real `openclaw tui --local` PTY scenarios consequently rose to approximately 83-85 seconds each and intermittently exhausted the CI silence watchdog.

## Why This Change Was Made

Restore the original producer-owned, configuration-first short circuit in `installEmbeddedAttemptContextGuards`: inspect `contextPruning.mode` first and invoke provider eligibility only for explicit `cache-ttl`. This matches the existing sibling cache-marker guard and preserves eligible/ineligible provider behavior, timestamps, prompt transforms, and cleanup. The production change is exactly 7 additions and 7 deletions: zero net production lines, no new configuration, no provider special cases, and no reporter/timeout workaround.

## User Impact

Default local TUI and embedded-agent launches no longer perform unnecessary cold plugin discovery. Real remote PTY subprocess measurements using the actual embedded runtime, with only the external model HTTP endpoint mocked:

- Normal local model response: 83 seconds before -> 11.76 seconds after, 7.06x faster.
- Same-turn local session steering: 83 seconds before -> 5.46 seconds after, 15.20x faster.
- Real local validation-loop abort diagnostics: 83 seconds before -> 5.31 seconds after, 15.62x faster.

Explicitly configured cache-TTL pruning continues to discover provider capabilities and project expired history exactly as before.

## Evidence

- Testbox proved the exact reviewed Git tree and both changed-file SHA-256 hashes, then independently verified conflict-free merging with the newer GitHub main head while preserving both reviewed source blobs.
- Four complete focused owner/sibling suites passed: 29 tests across embedded attempt context guards, provider cache-TTL eligibility, expired tool-result projection, and cache-TTL session markers.
- Three actual `tui --local` PTY subprocess and embedded-runtime scenarios passed: exactly 3 selected, 3 passed, 0 failed, 0 selected skips; wall-clock case times 11.76s, 5.46s, and 5.31s. Same-turn steering produced two real provider requests and rendered the completion. Thirteen unrelated gateway/unit cases were explicitly name-filtered, not reported as skips.
- New owner regressions prove provider discovery and timestamp reads never occur for absent configuration, absent pruning, missing mode, or explicit off; separate regressions preserve enabled/ineligible and enabled/eligible providers.
- Canonical two-file formatting and complete remote `pnpm check:changed --base origin/main -- <two changed files>` passed: core and test `tsgo`, targeted lint, SDK/API, provider/plugin boundaries, dead-code, database, webhook/pairing, and zero runtime-cycle guards.
- Fresh full-branch autoreview and TruffleHog passed with no accepted findings; correctness confidence 0.99.
- Production delta: +7/-7, net zero; focused regression tests: +67.
- Original single Testbox proof exited 0 after 6m04s; its lease was independently verified stopped.