### PR TITLE
fix: prevent streaming errors from hanging behind response clones

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1382,6 +1382,77 @@ describe("buildGuardedModelFetch", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    {
+      name: "JSON-to-SSE synthesis",
+      contentType: "application/json",
+      expectedError: /exceeded.*bytes while synthesizing SSE/i,
+    },
+    {
+      name: "SSE sanitization",
+      contentType: "text/event-stream",
+      expectedError: /exceeded max buffer size/i,
+    },
+  ])("surfaces $name errors without waiting for an unread response clone", async (testCase) => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
+        },
+      }),
+      { headers: { "content-type": testCase.contentType } },
+    );
+    const unreadClone = upstream.clone();
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: upstream,
+      finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+      release,
+    });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.4", stream: true }),
+      },
+    );
+    const reading = response
+      .body!.getReader()
+      .read()
+      .then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const result = await Promise.race([
+        reading,
+        new Promise<{ status: "timeout" }>((resolve) => {
+          timeout = setTimeout(() => resolve({ status: "timeout" }), 750);
+        }),
+      ]);
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.error).toEqual(
+          expect.objectContaining({ message: expect.stringMatching(testCase.expectedError) }),
+        );
+      }
+      await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1), { timeout: 250 });
+    } finally {
+      clearTimeout(timeout);
+      void unreadClone.body?.cancel().catch(() => undefined);
+      await reading;
+    }
+  });
+
   it("does not re-prefix SSE bodies mislabeled as JSON by streaming gateways", async () => {
     const source = openResponseStreamText(
       'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n' +

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -97,13 +97,13 @@ function findSseEventBoundary(buffer: string): { index: number; length: number }
   return best;
 }
 
-async function cancelReaderBestEffort(
+function cancelReaderBestEffort(
   reader: ReadableStreamDefaultReader<Uint8Array> | undefined,
   reason?: unknown,
-): Promise<void> {
-  // Reader cancellation is cleanup. An upstream cancel failure must not replace
-  // the wrapper's authoritative stream error or downstream cancellation.
-  await reader?.cancel(reason).catch(() => undefined);
+): void {
+  // A cloned response keeps tee cancellation pending while its sibling is open.
+  // Cleanup must not block the wrapper's stream error or downstream cancellation.
+  void reader?.cancel(reason).catch(() => undefined);
 }
 
 function capNonOkResponseBodyLazily(response: Response, maxBytes: number): Response {
@@ -133,18 +133,18 @@ function capNonOkResponseBodyLazily(response: Response, maxBytes: number): Respo
           }
           total = maxBytes;
           controller.close();
-          void cancelReaderBestEffort(reader);
+          cancelReaderBestEffort(reader);
           return;
         }
         total += chunk.value.byteLength;
         controller.enqueue(chunk.value);
       } catch (error) {
         controller.error(error);
-        void cancelReaderBestEffort(reader, error);
+        cancelReaderBestEffort(reader, error);
       }
     },
-    async cancel(reason) {
-      await cancelReaderBestEffort(reader, reason);
+    cancel(reason) {
+      cancelReaderBestEffort(reader, reason);
     },
   });
   return new Response(capped, response);
@@ -199,12 +199,12 @@ function sanitizeOpenAISdkSseResponse(
             buffer += decoder.decode(chunk.value, { stream: true });
           }
         } catch (error) {
-          await cancelReaderBestEffort(reader, error);
+          cancelReaderBestEffort(reader, error);
           controller.error(error);
         }
       },
-      async cancel(reason) {
-        await cancelReaderBestEffort(reader, reason);
+      cancel(reason) {
+        cancelReaderBestEffort(reader, reason);
       },
     });
     const headers = new Headers(response.headers);
@@ -287,12 +287,12 @@ function sanitizeOpenAISdkSseResponse(
           }
         }
       } catch (error) {
-        await cancelReaderBestEffort(reader, error);
+        cancelReaderBestEffort(reader, error);
         controller.error(error);
       }
     },
-    async cancel(reason) {
-      await cancelReaderBestEffort(reader, reason);
+    cancel(reason) {
+      cancelReaderBestEffort(reader, reason);
     },
   });
 
@@ -371,7 +371,7 @@ async function classifyOpenAISdkStreamBody(response: Response): Promise<OpenAISd
     text += decoder.decode();
     return classifyOpenAISdkStreamBodyPrefix(text);
   } finally {
-    void cancelReaderBestEffort(reader);
+    cancelReaderBestEffort(reader);
   }
 }
 

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -145,6 +145,54 @@ describe("readResponseWithLimit", () => {
     });
   });
 
+  it.each([
+    {
+      name: "overflow",
+      chunks: [new Uint8Array([1, 2, 3, 4, 5])],
+      maxBytes: 4,
+      options: undefined,
+      expectedError: /Content too large: 5 bytes \(limit: 4 bytes\)/,
+    },
+    {
+      name: "an expired lazy deadline",
+      chunks: [],
+      maxBytes: 1024,
+      options: {
+        timeoutMs: () => {
+          throw new Error("deadline expired");
+        },
+      },
+      expectedError: /deadline expired/,
+    },
+  ])("surfaces $name without waiting for an unread response clone", async (testCase) => {
+    const response = new Response(makeStallingStream(testCase.chunks));
+    const unreadClone = response.clone();
+    const reading = readResponseWithLimit(response, testCase.maxBytes, testCase.options).then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const result = await Promise.race([
+        reading,
+        new Promise<{ status: "timeout" }>((resolve) => {
+          timeout = setTimeout(() => resolve({ status: "timeout" }), 250);
+        }),
+      ]);
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.error).toEqual(
+          expect.objectContaining({ message: expect.stringMatching(testCase.expectedError) }),
+        );
+      }
+    } finally {
+      clearTimeout(timeout);
+      void unreadClone.body?.cancel().catch(() => undefined);
+      await reading;
+    }
+  });
+
   it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
     "rejects invalid maxBytes before reading: %s",
     async (maxBytes) => {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -186,7 +186,9 @@ async function readResponsePrefixFromReader(
         size = nextTotal;
         truncated = true;
         try {
-          await reader.cancel();
+          // A response clone keeps tee cancellation pending until its sibling closes.
+          // Cleanup must not delay the authoritative overflow or prefix result.
+          void reader.cancel().catch(() => undefined);
         } catch {}
         break;
       }
@@ -220,7 +222,7 @@ async function readResponsePrefix(
   try {
     timeoutMs = typeof options?.timeoutMs === "function" ? options.timeoutMs() : options?.timeoutMs;
   } catch (error) {
-    await response.body?.cancel(error).catch(() => undefined);
+    void response.body?.cancel(error).catch(() => undefined);
     throw error;
   }
   const body = response.body;

--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -16,6 +16,25 @@ describe("wrapGuardedBodyStream", () => {
     expect(source.locked).toBe(false);
   });
 
+  it("releases guarded resources without waiting for an unread response clone", async () => {
+    const response = new Response(new ReadableStream<Uint8Array>());
+    const unreadClone = response.clone();
+    const cleanup = vi.fn();
+    const wrapped = wrapGuardedBodyStream({ body: response.body!, cleanup });
+    const cancellation = wrapped.cancel("consumer stopped").then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+
+    try {
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce(), { timeout: 250 });
+      expect(response.body!.locked).toBe(false);
+    } finally {
+      void unreadClone.body?.cancel().catch(() => undefined);
+      await expect(cancellation).resolves.toEqual({ status: "resolved" });
+    }
+  });
+
   it("propagates downstream cancellation failure after releasing resources", async () => {
     const expected = new Error("source cancellation failed");
     const cleanup = vi.fn();

--- a/src/infra/net/guarded-body-stream.ts
+++ b/src/infra/net/guarded-body-stream.ts
@@ -35,8 +35,12 @@ export function wrapGuardedBodyStream(params: {
     }
     finalized = true;
     guardedBodyCleanupRegistry.unregister(cleanupRegistrationToken);
+    let cancellation: Promise<void> | undefined;
     try {
-      await cancelReader();
+      cancellation = cancelReader();
+      // Tee cancellation can remain pending while an unread response clone is
+      // alive; release guarded resources before awaiting its eventual outcome.
+      void cancellation.catch(() => undefined);
     } finally {
       try {
         reader?.releaseLock();
@@ -48,6 +52,7 @@ export function wrapGuardedBodyStream(params: {
         }
       }
     }
+    await cancellation;
   };
   const wrappedBody = new ReadableStream<Uint8Array>({
     start() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users streaming model-provider responses or using MCP-backed tools could see an oversized response, expired deadline, or failed JSON/SSE stream hang indefinitely when another response clone remained open. The same response lifecycle could retain guarded dispatcher resources and local-service leases even after a visible stream failure.

## Why This Change Was Made

Native `Response.clone()` tees resolve a branch's cancellation promise only after both branches cancel. Refactor the existing HTTP, provider-stream, and shared guarded-body lifecycle owners so terminal errors are delivered without waiting for sibling cancellation, while guarded reader locks and dispatcher/service resources are released exactly once before awaiting the original cancellation outcome. Preserve the existing downstream source-cancellation failure contract and the shared MCP transport.

## User Impact

Users receive the original response overflow, expired-deadline, or provider-stream error promptly. Model streaming and MCP consumers release their dispatcher resources and local-service leases even while another response clone remains open; successful streams and intentional cancellation behavior remain unchanged.

## Evidence

- Exact immutable commit: `5844bccaf2739da7091bc0411b77e2a6b441d53e`; direct base: `4e47c4cabf8f2901ec781b59d059999211398813`.
- Native `Response.clone()` RED-to-GREEN coverage proves HTTP overflow/deadline errors, JSON-to-SSE/SSE sanitizer terminal errors, and guarded cleanup/reader unlocking occur before the unread sibling is canceled.
- A previously withdrawn candidate exposed a real managed-release leak; strengthened provider tests now assert dispatcher release **before** closing the held clone, and the canonical owner regression separately proves prompt cleanup and reader unlocking.
- Focused suites: **145 passed** across HTTP/guarded lifecycle (**30**), provider transport (**98**), and shared MCP transport (**17**); the existing source-cancellation rejection regression also remains green.
- Configured type-aware `oxlint --type-aware --tsconfig config/tsconfig/oxlint.json` passed on all six changed files; targeted formatting and whitespace checks passed.
- Five fresh independent hostile source reviews reported no actionable P0–P3 findings, including both reviewers who found the withdrawn candidate's leak.
- Genuine `gpt-5.6-sol` autoreview with high reasoning and P3 coverage reported **zero findings**, **0.94 confidence**; real TruffleHog **3.96.0** secret scanning passed.
