### PR TITLE
fix(diagnostics): report provider HTTP status in timelines

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -6,6 +6,7 @@ import { getAiTransportHost } from "../host.js";
 import { resolveAzureDeploymentNameFromMap } from "../providers/azure-deployment-map.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../providers/azure-openai-responses-client-compat.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
+import { headersToRecord } from "../utils/headers.js";
 import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
@@ -125,7 +126,9 @@ type ResponsesTransportExecutorOptions = {
     options: OpenAIResponsesOptions | undefined,
     metadata?: Record<string, string>,
   ) => ReturnType<typeof buildOpenAIResponsesParams>;
-  createResponseStream: (params: ResponsesStreamParams) => Promise<AsyncIterable<unknown>>;
+  createResponseStream: (
+    params: ResponsesStreamParams,
+  ) => Promise<{ stream: AsyncIterable<unknown>; response: Response }>;
   pricingOptions?: (options: OpenAIResponsesOptions | undefined) => ResponsesPricingOptions;
 };
 
@@ -203,12 +206,16 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             `baseUrl=${formatModelTransportDebugBaseUrl(model.baseUrl)} timeoutMs=${safeDebugValue(requestOptions?.timeout)} ` +
             `apiKey=${apiKey ? "present" : "missing"} ${summarizeResponsesPayload(params)}`,
         );
-        const responseStream = await config.createResponseStream({
+        const { stream: responseStream, response } = await config.createResponseStream({
           client,
           request: params,
           requestOptions,
           model,
         });
+        await options?.onResponse?.(
+          { status: response.status, headers: headersToRecord(response.headers) },
+          model,
+        );
         emitModelTransportDebug(
           log,
           `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
@@ -283,11 +290,12 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         resolveAzureDeploymentName(model),
         metadata,
       ),
-    createResponseStream: async ({ client, request, requestOptions }) =>
-      (await client.responses.create(
-        request as never,
-        requestOptions,
-      )) as unknown as AsyncIterable<unknown>,
+    createResponseStream: async ({ client, request, requestOptions }) => {
+      const { data, response } = await client.responses
+        .create(request as never, requestOptions)
+        .withResponse();
+      return { stream: data as unknown as AsyncIterable<unknown>, response };
+    },
   });
 }
 

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -221,12 +221,12 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
   request: OpenAIResponsesRequestParams;
   requestOptions: unknown;
   model: Model;
-}): Promise<AsyncIterable<unknown>> {
+}): Promise<{ stream: AsyncIterable<unknown>; response: Response }> {
   try {
-    return (await params.client.responses.create(
-      params.request as never,
-      params.requestOptions as never,
-    )) as unknown as AsyncIterable<unknown>;
+    const { data, response } = await params.client.responses
+      .create(params.request as never, params.requestOptions as never)
+      .withResponse();
+    return { stream: data as unknown as AsyncIterable<unknown>, response };
   } catch (error) {
     const retryRequest = stripResponsesRequestEncryptedContent(params.request);
     if (!isInvalidEncryptedContentError(error) || retryRequest === params.request) {
@@ -236,10 +236,10 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
       `[responses] retrying without encrypted reasoning content provider=${params.model.provider} ` +
         `api=${params.model.api} model=${params.model.id}`,
     );
-    return (await params.client.responses.create(
-      retryRequest as never,
-      params.requestOptions as never,
-    )) as unknown as AsyncIterable<unknown>;
+    const { data, response } = await params.client.responses
+      .create(retryRequest as never, params.requestOptions as never)
+      .withResponse();
+    return { stream: data as unknown as AsyncIterable<unknown>, response };
   }
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -406,13 +406,8 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
 
   it("records a non-2xx provider response on a failed model call", async () => {
     const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-      ((
-        model: Parameters<StreamFn>[0],
-        _context: Parameters<StreamFn>[1],
-        options: Parameters<StreamFn>[2],
-      ) => {
-        void options?.onResponse?.({ status: 429, headers: {} }, model);
-        throw new Error("rate limited");
+      (() => {
+        throw Object.assign(new Error("rate limited"), { status: 429 });
       }) as unknown as StreamFn,
       {
         runId: "run-timeline-http-error",
@@ -434,6 +429,39 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
       type: "provider.request",
       ok: false,
       status: 429,
+    });
+  });
+
+  it("keeps an observed response status when the terminal error has another status", async () => {
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      ((
+        model: Parameters<StreamFn>[0],
+        _context: Parameters<StreamFn>[1],
+        options: Parameters<StreamFn>[2],
+      ) => {
+        void options?.onResponse?.({ status: 503, headers: {} }, model);
+        throw Object.assign(new Error("retry failed"), { status: 429 });
+      }) as unknown as StreamFn,
+      {
+        runId: "run-timeline-observed-http-error",
+        provider: "openai",
+        model: "gpt-5.6",
+        api: "openai-responses",
+        transport: "http",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-timeline-observed-http-error",
+      },
+    );
+
+    const events = await collectProviderTimelineEvents(async () => {
+      expect(() => wrapped({} as never, {} as never, {} as never)).toThrow("retry failed");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "provider.request",
+      ok: false,
+      status: 503,
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -284,6 +284,50 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
         transport: "http",
       },
     });
+    expect(events[0]?.status).toBeUndefined();
+  });
+
+  it("records provider response status and preserves the original response callback", async () => {
+    const originalOnResponse = vi.fn(async () => undefined);
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      ((
+        model: Parameters<StreamFn>[0],
+        _context: Parameters<StreamFn>[1],
+        options: Parameters<StreamFn>[2],
+      ) => {
+        return options?.onResponse?.({ status: 200, headers: { "x-request-id": "req-1" } }, model);
+      }) as unknown as StreamFn,
+      {
+        runId: "run-timeline-status",
+        provider: "openai",
+        model: "gpt-5.6",
+        api: "openai-responses",
+        transport: "http",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-timeline-status",
+      },
+    );
+
+    const events = await collectProviderTimelineEvents(async () => {
+      await wrapped(
+        { id: "gpt-5.6" } as never,
+        {} as never,
+        {
+          onResponse: originalOnResponse,
+        } as never,
+      );
+    });
+
+    expect(originalOnResponse).toHaveBeenCalledWith(
+      { status: 200, headers: { "x-request-id": "req-1" } },
+      { id: "gpt-5.6" },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "provider.request",
+      ok: true,
+      status: 200,
+    });
   });
 
   it("writes Unicode-safe bounded attributes to the provider timeline JSONL", async () => {
@@ -357,6 +401,39 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
         model: "claude-sonnet-4-6",
         transport: "sse",
       },
+    });
+  });
+
+  it("records a non-2xx provider response on a failed model call", async () => {
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      ((
+        model: Parameters<StreamFn>[0],
+        _context: Parameters<StreamFn>[1],
+        options: Parameters<StreamFn>[2],
+      ) => {
+        void options?.onResponse?.({ status: 429, headers: {} }, model);
+        throw new Error("rate limited");
+      }) as unknown as StreamFn,
+      {
+        runId: "run-timeline-http-error",
+        provider: "openai",
+        model: "gpt-5.6",
+        api: "openai-responses",
+        transport: "http",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-timeline-http-error",
+      },
+    );
+
+    const events = await collectProviderTimelineEvents(async () => {
+      expect(() => wrapped({} as never, {} as never, {} as never)).toThrow("rate limited");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "provider.request",
+      ok: false,
+      status: 429,
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -88,6 +88,7 @@ type ModelCallUsage = NonNullable<
 >;
 type ModelCallObservationState = {
   requestPayloadBytes?: number;
+  responseStatus?: number;
   responseStreamBytes: number;
   timeToFirstByteMs?: number;
   modelContent?: DiagnosticModelCallContent;
@@ -432,6 +433,7 @@ function emitProviderRequestTimelineEvent(
   startedAt: number,
   durationMs: number,
   ok: boolean,
+  responseStatus: number | undefined,
 ): void {
   const provider = boundedTimelineAttribute(eventBase.provider);
   const model = boundedTimelineAttribute(eventBase.model);
@@ -447,6 +449,7 @@ function emitProviderRequestTimelineEvent(
     provider,
     operation: api ?? transport ?? "model.call",
     ok,
+    ...(responseStatus !== undefined ? { status: responseStatus } : {}),
     attributes: {
       ...(model ? { model } : {}),
       ...(api ? { api } : {}),
@@ -578,7 +581,7 @@ function emitModelCallCompleted(
   state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = modelCallSizeTimingFields(state);
-  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, true);
+  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, true, state.responseStatus);
   emitTrustedDiagnosticEventWithPrivateData(
     {
       type: "model.call.completed",
@@ -610,7 +613,7 @@ function emitModelCallError(
   state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = modelCallSizeTimingFields(state);
-  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, false);
+  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, false, state.responseStatus);
   emitTrustedDiagnosticEventWithPrivateData(
     {
       type: "model.call.error",
@@ -640,6 +643,7 @@ function withDiagnosticRequestContext(
 ): ModelCallStreamOptions {
   const traceparent = formatDiagnosticTraceparent(trace);
   const originalOnPayload = options?.onPayload;
+  const originalOnResponse = options?.onResponse;
   const onPayload: NonNullable<ModelCallStreamOptions>["onPayload"] = (payload, model) => {
     if (!originalOnPayload) {
       assignRequestPayloadBytes(state, payload);
@@ -655,12 +659,19 @@ function withDiagnosticRequestContext(
     assignRequestPayloadBytes(state, result ?? payload);
     return result;
   };
+  const onResponse: NonNullable<ModelCallStreamOptions>["onResponse"] = (response, model) => {
+    // Retrying providers can expose several responses; the terminal request status
+    // is the latest response observed before the model call completes or fails.
+    state.responseStatus = response.status;
+    return originalOnResponse?.(response, model);
+  };
 
   if (!traceparent) {
     return {
       ...options,
       requestId: callId,
       onPayload,
+      onResponse,
     };
   }
 
@@ -677,6 +688,7 @@ function withDiagnosticRequestContext(
     requestId: callId,
     headers,
     onPayload,
+    onResponse,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -7,6 +7,7 @@ import { fireAndForgetBoundedHook } from "../../../hooks/fire-and-forget.js";
 import {
   diagnosticErrorCategory,
   diagnosticErrorFailureKind,
+  diagnosticHttpStatusCode,
   diagnosticProviderRequestIdHash,
 } from "../../../infra/diagnostic-error-metadata.js";
 import {
@@ -605,7 +606,7 @@ function emitModelCallError(
   eventBase: ModelCallEventBase,
   startedAt: number,
   state: ModelCallObservationState,
-  fields: ModelCallErrorFields,
+  err: unknown,
 ): void {
   if (state.terminalEventEmitted) {
     return;
@@ -613,7 +614,11 @@ function emitModelCallError(
   state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = modelCallSizeTimingFields(state);
-  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, false, state.responseStatus);
+  const fields = modelCallErrorFields(err);
+  const errorStatus = diagnosticHttpStatusCode(err);
+  const responseStatus =
+    state.responseStatus ?? (errorStatus === undefined ? undefined : Number(errorStatus));
+  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, false, responseStatus);
   emitTrustedDiagnosticEventWithPrivateData(
     {
       type: "model.call.error",
@@ -750,7 +755,7 @@ async function* observeModelCallIterator<T>(
     emitModelCallCompleted(eventBase, startedAt, state);
   } catch (err) {
     iteratorSettled = true;
-    emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+    emitModelCallError(eventBase, startedAt, state, err);
     throw err;
   } finally {
     if (!iteratorSettled) {
@@ -793,14 +798,14 @@ function createObservedResultFunction(
         return result.then(
           (resolved) => observeModelCallFinalResult(resolved, eventBase, startedAt, state),
           (err: unknown) => {
-            emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+            emitModelCallError(eventBase, startedAt, state, err);
             throw err;
           },
         );
       }
       return observeModelCallFinalResult(result, eventBase, startedAt, state);
     } catch (err) {
-      emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+      emitModelCallError(eventBase, startedAt, state, err);
       throw err;
     }
   };
@@ -903,14 +908,14 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
         return result.then(
           (resolved) => observeModelCallResult(resolved, eventBase, startedAt, state),
           (err: unknown) => {
-            emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+            emitModelCallError(eventBase, startedAt, state, err);
             throw err;
           },
         );
       }
       return observeModelCallResult(result, eventBase, startedAt, state);
     } catch (err) {
-      emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+      emitModelCallError(eventBase, startedAt, state, err);
       throw err;
     }
   }) as StreamFn;

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -811,22 +811,31 @@ describe("openai transport stream", () => {
       ],
     };
     const recoveredStream = streamChunks([]);
+    const recoveredResponse = new Response(null, { status: 200 });
     const create = vi
       .fn()
-      .mockRejectedValueOnce(
-        new OpenAI.BadRequestError(
-          400,
-          {
-            code: "thinking_signature_invalid",
-            message:
-              "The encrypted content for item rs_prior could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
-            type: "invalid_request_error",
-          },
-          undefined,
-          new Headers(),
+      .mockReturnValueOnce({
+        withResponse: vi.fn().mockRejectedValue(
+          new OpenAI.BadRequestError(
+            400,
+            {
+              code: "thinking_signature_invalid",
+              message:
+                "The encrypted content for item rs_prior could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+              type: "invalid_request_error",
+            },
+            undefined,
+            new Headers(),
+          ),
         ),
-      )
-      .mockResolvedValueOnce(recoveredStream);
+      })
+      .mockReturnValueOnce({
+        withResponse: vi.fn().mockResolvedValue({
+          data: recoveredStream,
+          response: recoveredResponse,
+          request_id: null,
+        }),
+      });
 
     await expect(
       testing.createResponsesStreamWithEncryptedContentRetry({
@@ -846,7 +855,7 @@ describe("openai transport stream", () => {
           maxTokens: 8192,
         },
       }),
-    ).resolves.toBe(recoveredStream);
+    ).resolves.toEqual({ stream: recoveredStream, response: recoveredResponse });
 
     expect(create).toHaveBeenCalledTimes(2);
     expect(create.mock.calls[0]?.[0]).toBe(request);
@@ -862,6 +871,47 @@ describe("openai transport stream", () => {
         request.input[2],
       ],
     });
+  });
+
+  it("preserves HTTP status when a managed Responses request rejects", async () => {
+    const failure = new OpenAI.RateLimitError(
+      429,
+      {
+        code: "rate_limit_exceeded",
+        message: "rate limited",
+        type: "rate_limit_error",
+      },
+      undefined,
+      new Headers(),
+    );
+    const withResponse = vi.fn().mockRejectedValue(failure);
+
+    await expect(
+      testing.createResponsesStreamWithEncryptedContentRetry({
+        client: {
+          responses: {
+            create: vi.fn().mockReturnValue({ withResponse }),
+          },
+        } as never,
+        request: { model: "gpt-5.5", stream: true, input: [] } as never,
+        requestOptions: undefined,
+        model: {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8192,
+        },
+      }),
+    ).rejects.toBe(failure);
+
+    expect(failure.status).toBe(429);
+    expect(withResponse).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -273,6 +273,72 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("reports the managed Responses HTTP status before streaming events", async () => {
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(202, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "x-provider-test": "managed-response",
+        });
+        res.end(
+          `data: ${JSON.stringify({
+            type: "response.completed",
+            response: { id: "resp_status", status: "completed", output: [] },
+          })}\n\n`,
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const onResponse = vi.fn();
+      const model = {
+        id: "gpt-status",
+        name: "GPT Status",
+        api: "openai-responses",
+        provider: "custom-openai",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+      } satisfies Model<"openai-responses">;
+
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        model,
+        {
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+          tools: [],
+        },
+        { apiKey: "test-key", onResponse },
+      );
+      for await (const event of stream) {
+        // Drain the stream so the terminal event and hook complete.
+        void event;
+      }
+
+      expect(onResponse).toHaveBeenCalledWith(
+        {
+          status: 202,
+          headers: expect.objectContaining({ "x-provider-test": "managed-response" }),
+        },
+        model,
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it.each(["reasoning_content", "reasoning"] as const)(
     "keeps hidden local %s streams alive beyond the model idle timeout",
     async (reasoningField) => {

--- a/src/infra/diagnostics-timeline.test.ts
+++ b/src/infra/diagnostics-timeline.test.ts
@@ -156,6 +156,31 @@ describe("diagnostics timeline", () => {
     expect(attributes.ignored).toBeUndefined();
   });
 
+  it("writes provider response status as a top-level field", async () => {
+    const { env, path } = await createTimelineEnv();
+
+    emitDiagnosticsTimelineEvent(
+      {
+        type: "provider.request",
+        name: "provider.request",
+        provider: "openai",
+        operation: "openai-responses",
+        ok: true,
+        status: 200,
+      },
+      { env },
+    );
+
+    const [event] = await readTimeline(path);
+    expect(event).toMatchObject({
+      type: "provider.request",
+      provider: "openai",
+      operation: "openai-responses",
+      ok: true,
+      status: 200,
+    });
+  });
+
   it("routes timeline write failures through the captured console boundary once", async () => {
     const { env, path } = await createTimelineEnv();
     await mkdir(dirname(path), { recursive: true });

--- a/src/infra/diagnostics-timeline.ts
+++ b/src/infra/diagnostics-timeline.ts
@@ -44,6 +44,7 @@ type DiagnosticsTimelineEvent = {
   provider?: string;
   operation?: string;
   ok?: boolean;
+  status?: number;
   command?: string;
   exitCode?: number | null;
   signal?: string | null;
@@ -160,6 +161,7 @@ function serializeTimelineEvent(event: DiagnosticsTimelineEvent, env: NodeJS.Pro
     ...(event.provider ? { provider: event.provider } : {}),
     ...(event.operation ? { operation: event.operation } : {}),
     ...(typeof event.ok === "boolean" ? { ok: event.ok } : {}),
+    ...(typeof event.status === "number" ? { status: normalizeNumber(event.status) } : {}),
     ...(event.command ? { command: event.command } : {}),
     ...(event.exitCode !== undefined ? { exitCode: event.exitCode } : {}),
     ...(event.signal !== undefined ? { signal: event.signal } : {}),


### PR DESCRIPTION
Related: #117323

## What Problem This Solves

Fixes an issue where live provider diagnostics could report successful model turns without the HTTP response status, causing evidence consumers such as Kova to reject otherwise complete provider proof.

## Why This Change Was Made

The model-call diagnostic wrapper now composes the existing provider `onResponse` callback, records the latest authoritative HTTP status across retries, and writes it as a top-level `provider.request` timeline field. Transports that do not expose a response status remain unchanged; no status is inferred from the model-call outcome.

## User Impact

Operators and release tooling can distinguish successful and failed provider HTTP responses from real transport evidence instead of receiving an ambiguous `unknown` status.

## Exact-Head Evidence

- Reviewed head: `eaed7effe3e9e20253162275aae2453c23142d53`
- Current `origin/main`: `9e43844264a736b234e32af5b018da1e4a058c87`
- Clean merge tree: `29ce99abb43ccc027c1e06d5f62138466097b083`
- Reproduction: the live OpenAI lane completed both cold and warm turns with `KOVA_AGENT_OK`, but lacked `provider.request.status` and failed `invariant:agent-cli-provider-proof`: https://github.com/openclaw/openclaw/actions/runs/30699421710
- 133 focused tests passed across:
  - `src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts`
  - `src/agents/openai-transport-stream.replay-and-tools.test.ts`
  - `src/agents/openai-transport-stream.streaming.test.ts`
  - `src/infra/diagnostics-timeline.test.ts`
- Coverage includes successful `200` propagation, non-2xx `429` status on failure, preservation of the original async `onResponse` callback, retries, streaming/replay transport behavior, and no fabricated status when the transport exposes none.
- Direct dependency inspection against pinned `openai@6.49.0`:
  - `node_modules/openai/src/core/api-promise.ts:44-74` confirms `withResponse()` returns the parsed data with the raw authoritative `Response`.
  - `node_modules/openai/src/core/error.ts:8-28,60-105` exposes the numeric `APIError.status` and constructs terminal HTTP errors from that status.
  - `node_modules/openai/src/client.ts:851-948` retries eligible non-2xx responses, then constructs the terminal error from `response.status`; successful calls return the same raw `Response`.
- Targeted `oxfmt`, direct targeted `oxlint`, and `git diff --check` are clean.
- Exact-head Kova run https://github.com/openclaw/openclaw/actions/runs/30704075746 passed the live OpenAI, mock-provider, source-performance, and deep-profile lanes.
- The live artifact records two canonical `provider.request` events with `status: 200`, model `gpt-5.6-luna`, and operation `openai-responses`.
- Release-note context is recorded in this PR body; `CHANGELOG.md` is release-owned and is not changed by this normal PR.
- No persistent state or SQLite schema changes.

## Hosted Proof

Exact-head GitHub CI run https://github.com/openclaw/openclaw/actions/runs/30704033502 completed successfully, including the required `openclaw/ci-gate`. Exact-head Kova run https://github.com/openclaw/openclaw/actions/runs/30704075746 passed its live OpenAI, mock-provider, source-performance, and deep-profile lanes and records canonical `provider.request.status: 200` events for `gpt-5.6-luna`. Fresh exact-head CI is running at https://github.com/openclaw/openclaw/actions/runs/30705578597 after restoring the release-policy-compliant head. Merge remains gated on that required CI and a durable exact-head ClawSweeper review with no unresolved technical, security, owner-decision, or merge-risk item.
