### PR TITLE
fix(plugins): prevent ambiguous uninstall targets

### DIFF
--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -217,6 +217,98 @@ describe("plugins cli uninstall", () => {
     });
   });
 
+  it("uninstalls the exact plugin id when an earlier plugin uses it as a display name", async () => {
+    const baseConfig = {
+      plugins: {
+        entries: {
+          "unrelated-plugin": { enabled: true },
+          calendar: { enabled: true },
+        },
+        installs: {
+          "unrelated-plugin": { source: "npm", spec: "unrelated-plugin@1.0.0" },
+          calendar: { source: "npm", spec: "calendar@1.0.0" },
+        },
+      },
+    } as OpenClawConfig;
+    const nextConfig = {
+      plugins: {
+        entries: { "unrelated-plugin": { enabled: true } },
+        installs: {
+          "unrelated-plugin": { source: "npm", spec: "unrelated-plugin@1.0.0" },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(baseConfig);
+    setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [
+        { id: "unrelated-plugin", name: "calendar" },
+        { id: "calendar", name: "Real Calendar" },
+      ],
+      diagnostics: [],
+    });
+    planPluginUninstall.mockReturnValue({
+      ok: true,
+      config: nextConfig,
+      actions: {
+        entry: true,
+        install: true,
+        allowlist: false,
+        denylist: false,
+        loadPath: false,
+        memorySlot: false,
+        contextEngineSlot: false,
+        directory: false,
+      },
+      directoryRemoval: null,
+    });
+
+    await runPluginsCommand(["plugins", "uninstall", "calendar", "--force", "--keep-files"]);
+
+    expectLatestUninstallPlanParams({ pluginId: "calendar", deleteFiles: false });
+    expect(writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({
+      "unrelated-plugin": { source: "npm", spec: "unrelated-plugin@1.0.0" },
+    });
+  });
+
+  it("rejects an ambiguous display name before planning or mutating installed plugins", async () => {
+    const baseConfig = {
+      plugins: {
+        entries: {
+          "calendar-one": { enabled: true },
+          "calendar-two": { enabled: true },
+        },
+        installs: {
+          "calendar-one": { source: "npm", spec: "calendar-one@1.0.0" },
+          "calendar-two": { source: "npm", spec: "calendar-two@1.0.0" },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(baseConfig);
+    setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [
+        { id: "calendar-one", name: "calendar" },
+        { id: "calendar-two", name: "calendar" },
+      ],
+      diagnostics: [],
+    });
+
+    await expect(
+      runPluginsCommand(["plugins", "uninstall", "calendar", "--force"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors.at(-1)).toContain('Plugin uninstall target "calendar" is ambiguous');
+    expect(planPluginUninstall).not.toHaveBeenCalled();
+    expect(promptYesNo).not.toHaveBeenCalled();
+    expect(applyPluginUninstallDirectoryRemoval).not.toHaveBeenCalled();
+    expect(writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+  });
+
   it("warns but proceeds when a shared plugin has an uncertain Claw reference", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = tempDirs.make("openclaw-claw-plugin-ref-");

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -114,11 +114,17 @@ async function runPluginUninstallCommandUnlocked(
     runtime.log(theme.warn("`--keep-config` is deprecated, use `--keep-files`."));
   }
 
-  const { plugin, pluginId } = resolvePluginUninstallId({
+  const selection = resolvePluginUninstallId({
     rawId: id,
     config: cfg,
     plugins: report.plugins,
   });
+  if (!selection.ok) {
+    runtime.error(selection.error);
+    runtime.exit(1);
+    return;
+  }
+  const { plugin, pluginId } = selection.value;
   const channelIds = plugin?.status === "loaded" ? plugin.channelIds : undefined;
   const initialPlan = planPluginUninstall({
     config: cfg,

--- a/src/cli/plugins-uninstall-selection.test.ts
+++ b/src/cli/plugins-uninstall-selection.test.ts
@@ -4,6 +4,118 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginUninstallId } from "./plugins-uninstall-selection.js";
 
 describe("resolvePluginUninstallId", () => {
+  it("prefers an exact plugin id over an earlier plugin display name", () => {
+    const alias = { id: "unrelated-plugin", name: "calendar" };
+    const target = { id: "calendar", name: "Real Calendar" };
+
+    const result = resolvePluginUninstallId({
+      rawId: "calendar",
+      config: {},
+      plugins: [alias, target],
+    });
+
+    expect(result).toEqual({ ok: true, value: { pluginId: "calendar", plugin: target } });
+  });
+
+  it.each([
+    { label: "an installed plugin", plugins: { installs: { calendar: { source: "npm" } } } },
+    { label: "a stale plugin entry", plugins: { entries: { calendar: { enabled: true } } } },
+    { label: "an allowlist entry", plugins: { allow: ["calendar"] } },
+    { label: "a denylist entry", plugins: { deny: ["calendar"] } },
+    { label: "the memory slot", plugins: { slots: { memory: "calendar" } } },
+    { label: "the context-engine slot", plugins: { slots: { contextEngine: "calendar" } } },
+  ])("prefers the exact id recorded by $label over a display-name alias", ({ plugins }) => {
+    const alias = { id: "unrelated-plugin", name: "calendar" };
+
+    const result = resolvePluginUninstallId({
+      rawId: "calendar",
+      config: { plugins } as OpenClawConfig,
+      plugins: [alias],
+    });
+
+    expect(result).toEqual({ ok: true, value: { pluginId: "calendar" } });
+  });
+
+  it("rejects an ambiguous plugin display name", () => {
+    const result = resolvePluginUninstallId({
+      rawId: "calendar",
+      config: {},
+      plugins: [
+        { id: "calendar-one", name: "calendar" },
+        { id: "calendar-two", name: "calendar" },
+      ],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Plugin uninstall target "calendar" is ambiguous; matches: calendar-one, calendar-two. Use an exact plugin id.',
+    });
+  });
+
+  it("rejects a package alias shared by multiple installed plugins", () => {
+    const result = resolvePluginUninstallId({
+      rawId: "@scope/calendar",
+      config: {
+        plugins: {
+          installs: {
+            "calendar-one": { source: "npm", resolvedName: "@scope/calendar" },
+            "calendar-two": { source: "npm", resolvedName: "@scope/calendar" },
+          },
+        },
+      } as OpenClawConfig,
+      plugins: [],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Plugin uninstall target "@scope/calendar" is ambiguous; matches: calendar-one, calendar-two. Use an exact plugin id.',
+    });
+  });
+
+  it("rejects a ClawHub alias shared by multiple installed plugins", () => {
+    const result = resolvePluginUninstallId({
+      rawId: "clawhub:calendar",
+      config: {
+        plugins: {
+          installs: {
+            "calendar-one": { source: "npm", spec: "clawhub:calendar@1.0.0" },
+            "calendar-two": { source: "npm", clawhubPackage: "calendar" },
+          },
+        },
+      } as OpenClawConfig,
+      plugins: [],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Plugin uninstall target "clawhub:calendar" is ambiguous; matches: calendar-one, calendar-two. Use an exact plugin id.',
+    });
+  });
+
+  it("deduplicates display and package aliases owned by the same plugin", () => {
+    const plugin = { id: "calendar-owner", name: "calendar" };
+
+    const result = resolvePluginUninstallId({
+      rawId: "calendar",
+      config: {
+        plugins: {
+          installs: {
+            "calendar-owner": { source: "npm", resolvedName: "calendar" },
+          },
+        },
+      } as OpenClawConfig,
+      plugins: [plugin],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: { pluginId: "calendar-owner", plugin },
+    });
+  });
+
   it("accepts the recorded ClawHub spec as an uninstall target", () => {
     const plugin = {
       id: "linkmind-context",
@@ -29,8 +141,10 @@ describe("resolvePluginUninstallId", () => {
       plugins: [plugin],
     });
 
-    expect(result.pluginId).toBe("linkmind-context");
-    expect(result.plugin).toBe(plugin);
+    expect(result).toEqual({
+      ok: true,
+      value: { pluginId: "linkmind-context", plugin },
+    });
   });
 
   it("accepts a versionless ClawHub spec when the install was pinned", () => {
@@ -57,7 +171,9 @@ describe("resolvePluginUninstallId", () => {
       plugins: [plugin],
     });
 
-    expect(result.pluginId).toBe("linkmind-context");
-    expect(result.plugin).toBe(plugin);
+    expect(result).toEqual({
+      ok: true,
+      value: { pluginId: "linkmind-context", plugin },
+    });
   });
 });

--- a/src/cli/plugins-uninstall-selection.ts
+++ b/src/cli/plugins-uninstall-selection.ts
@@ -1,4 +1,5 @@
 // Plugin uninstall id resolver for registry ids, display names, npm specs, and ClawHub specs.
+import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import type { PluginRecord } from "../plugins/registry.js";
@@ -10,40 +11,63 @@ export function resolvePluginUninstallId<
   rawId: string;
   config: OpenClawConfig;
   plugins: TPlugin[];
-}): { pluginId: string; plugin?: TPlugin } {
+}): Result<{ pluginId: string; plugin?: TPlugin }, string> {
   const rawId = params.rawId.trim();
+  const pluginConfig = params.config.plugins;
+  const installs = pluginConfig?.installs ?? {};
   const resolveInstalledPlugin = (pluginId: string) => {
     const plugin = params.plugins.find((entry) => entry.id === pluginId);
     return plugin ? { pluginId, plugin } : { pluginId };
   };
-  const plugin = params.plugins.find((entry) => entry.id === rawId || entry.name === rawId);
-  if (plugin) {
-    return { pluginId: plugin.id, plugin };
+  const exactPlugin = params.plugins.find((entry) => entry.id === rawId);
+  if (exactPlugin) {
+    return ok({ pluginId: exactPlugin.id, plugin: exactPlugin });
+  }
+  // Config records and stale policy references are canonical ids, never display-name aliases.
+  if (
+    Object.hasOwn(installs, rawId) ||
+    Object.hasOwn(pluginConfig?.entries ?? {}, rawId) ||
+    pluginConfig?.allow?.includes(rawId) ||
+    pluginConfig?.deny?.includes(rawId) ||
+    pluginConfig?.slots?.memory === rawId ||
+    pluginConfig?.slots?.contextEngine === rawId
+  ) {
+    return ok(resolveInstalledPlugin(rawId));
   }
 
-  for (const [pluginId, install] of Object.entries(params.config.plugins?.installs ?? {})) {
+  const matchingPluginIds = new Set(
+    params.plugins.filter((plugin) => plugin.name === rawId).map((plugin) => plugin.id),
+  );
+  for (const [pluginId, install] of Object.entries(installs)) {
     if (
       install.spec === rawId ||
       install.resolvedSpec === rawId ||
       install.resolvedName === rawId ||
       install.marketplacePlugin === rawId
     ) {
-      return resolveInstalledPlugin(pluginId);
+      matchingPluginIds.add(pluginId);
     }
   }
 
   const requestedClawHub = parseClawHubPluginSpec(rawId);
   if (requestedClawHub) {
-    for (const [pluginId, install] of Object.entries(params.config.plugins?.installs ?? {})) {
+    for (const [pluginId, install] of Object.entries(installs)) {
       const installedClawHubName =
         install.clawhubPackage ??
         parseClawHubPluginSpec(install.spec ?? "")?.name ??
         parseClawHubPluginSpec(install.resolvedSpec ?? "")?.name;
       if (installedClawHubName === requestedClawHub.name) {
-        return resolveInstalledPlugin(pluginId);
+        matchingPluginIds.add(pluginId);
       }
     }
   }
 
-  return { pluginId: rawId };
+  if (matchingPluginIds.size > 1) {
+    const matches = [...matchingPluginIds].toSorted().join(", ");
+    return resultError(
+      `Plugin uninstall target "${rawId}" is ambiguous; matches: ${matches}. Use an exact plugin id.`,
+    );
+  }
+  const [matchedPluginId] = matchingPluginIds;
+  return ok(resolveInstalledPlugin(matchedPluginId ?? rawId));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users uninstalling a plugin by its exact ID could silently remove a different plugin when an earlier plugin used that ID as its display name. Duplicate display names or package, marketplace, and ClawHub aliases could likewise select and remove the first matching plugin without warning.

## Why This Change Was Made

The canonical uninstall selector now prioritizes authoritative plugin IDs from the registry, installed-plugin index, stale configuration entries, allow/deny lists, and memory/context-engine slots before considering aliases. It deduplicates all aliases by owner and returns an actionable failure for ambiguous matches; the sole uninstall caller stops before planning or mutation. Existing unique aliases, force/confirmation lease ordering, stale-reference cleanup, hooks, and ClawHub compatibility remain intact.

## User Impact

An exact plugin ID always targets that plugin, regardless of colliding display names. Ambiguous uninstall requests explain which IDs matched and make no configuration, installed-index, channel, or filesystem changes.

## Evidence

- **Genuine Commander RED:** `plugins uninstall calendar --force --keep-files` planned `unrelated-plugin` instead of `calendar`; a duplicate display-name request incorrectly succeeded.
- **Genuine Commander GREEN:** `node scripts/run-vitest.mjs src/cli/plugins-cli.uninstall.test.ts` — **14/14 passed**; collision and ambiguity regressions prove correct targeting and zero plan/prompt/config/index/files/refresh side effects.
- **Canonical selector GREEN:** `node scripts/run-vitest.mjs src/cli/plugins-uninstall-selection.test.ts` — **13/13 passed**, covering exact IDs, installed records, stale entries, allow/deny lists, slots, display/npm/ClawHub ambiguity, same-owner alias deduplication, and existing ClawHub aliases.
- **Hosted-rule type-aware lint:** actual installed oxlint with `--type-aware --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.core.json --report-unused-disable-directives-severity error` on all four files exited **0** with no findings. The repository wrapper separately encounters an unrelated, unchanged-main boundary-DTS preflight `packages/terminal-core/src/ansi.ts:194 TS2554` caused by stale hoisted string-width declarations; it is not reported as green.
- **Independent review:** five hostile source reviews clean; genuine `gpt-5.6-sol` / high / P3 autoreview, TruffleHog 3.96 clean, **zero findings**, confidence **0.97**. Immutable head: `e0fcb85f51cbcf6b519d9a14a32d45907073e270`.

### Authentic configured CLI proof — frozen head `e0fcb85f51cbcf6b519d9a14a32d45907073e270`

Executed on hosted Blacksmith Testbox `tbx_01kyys40m1dtrpvkj25sdsxkya` after a successful full production `pnpm build`; all commands used the actual built CLI and isolated real plugin manifests, config, linked files, and discovered shared SQLite state.

1. Real `pnpm openclaw plugins install --link ... --force` installed `unrelated-plugin` with display name `calendar`, followed by the actual plugin ID `calendar`. Real `pnpm openclaw plugins uninstall calendar --force` removed only plugin `calendar` and its config/install record; subsequent actual `pnpm openclaw plugins list --json` retained `unrelated-plugin`. Linked plugin file-tree hash remained `26ab4c610a54f7150ff86e3d4b26cf85f85b9c7cbb539c2789578c3e8c7ad27f`.
2. Installed real plugins `calendar-one` and `calendar-two`, both with display name `calendar`. Real `pnpm openclaw plugins uninstall calendar` failed with exit `1`: `Plugin uninstall target "calendar" is ambiguous; matches: calendar-one, calendar-two. Use an exact plugin id.` Both actual plugin IDs remained. Before and after hashes were byte-identical:
   - config: `94338a428d77ba6e7ebfbfd9a7121f4cc4c82455346ec8d45433dd47cc885c71`
   - SQLite `installed_plugin_index`: `2852636a4a5c9fc4627f9682622a450a15d31c3d6568260a5ac5d4dc78daa493`
   - both linked plugin file trees: `5d203c2bb4e0e27e89a27b953822eec51042f02c82c5c0e7fec79c3cafff964f`

Final authenticated hosted result: `RESULT AUTHENTIC CONFIGURED CLI PROOF PASS`, `CLI_PROOF_EXIT 0`; Blacksmith timing `commandMs=17967`, `totalMs=18003`, `exitCode=0`. Proof script SHA-256 `602ff195c54e2ec36cbe1bf25028a589f9c39869e1e273888a042002274d1861`; proof log SHA-256 `e9cbb9a23b113a3425c9e710b270d62dc6015b950b13b8fdc330c0941552acb4`.
