### PR TITLE
refactor(test): derive changed tooling routes

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -473,18 +473,6 @@ const PRECISE_SOURCE_TEST_TARGETS = new Map([
     ],
   ],
 ]);
-const PLUGIN_SDK_ENTRY_METADATA_TEST_TARGETS = [
-  "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
-  "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-  "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-  "src/plugins/contracts/extension-package-project-boundaries.test.ts",
-  "test/scripts/plugin-sdk-surface-report.test.ts",
-  "test/scripts/build-all.test.ts",
-  "test/release-check.test.ts",
-  "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-  "test/scripts/ts-topology.test.ts",
-  TOOLING_VITEST_CONFIG,
-];
 const RUNTIME_SIDECAR_BASELINE_OWNER_TEST_TARGETS = ["src/plugins/bundled-plugin-metadata.test.ts"];
 const RUNTIME_SIDECAR_PATH_CONSUMER_TEST_TARGETS = [
   ...RUNTIME_SIDECAR_BASELINE_OWNER_TEST_TARGETS,
@@ -492,1376 +480,7 @@ const RUNTIME_SIDECAR_PATH_CONSUMER_TEST_TARGETS = [
   "src/infra/update-runner.test.ts",
   "test/openclaw-npm-postpublish-verify.test.ts",
 ];
-const OFFICIAL_EXTERNAL_CATALOG_TEST_TARGETS = [
-  "src/plugins/official-external-plugin-catalog.test.ts",
-  "test/release-check.test.ts",
-];
-const RECOMMENDED_TOOL_INSTALLS_TEST_TARGETS = [
-  "src/plugins/recommended-tool-installs.test.ts",
-  "test/release-check.test.ts",
-];
-const DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS = [
-  "src/docker-build-cache.test.ts",
-  "src/docker-image-digests.test.ts",
-];
-const ROOT_DOCKERFILE_TEST_TARGETS = [
-  ...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS,
-  "src/dockerfile.test.ts",
-  "test/scripts/test-install-sh-docker.test.ts",
-];
-const INSTALL_DOCKERFILE_TEST_TARGETS = [
-  ...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS,
-  "test/scripts/test-install-sh-docker.test.ts",
-];
-const LIVE_MEDIA_RUNNER_IMAGE_TEST_TARGETS = ["test/scripts/package-acceptance-workflow.test.ts"];
 const GITHUB_YAML_PINNING_GUARD_TEST_TARGETS = ["test/scripts/ci-workflow-guards.test.ts"];
-
-function resolveToolingTestOwnerTargets(...owners) {
-  return owners.map((owner) => (owner.includes("/") ? owner : `test/scripts/${owner}.test.ts`));
-}
-
-/** @type {[string, string[]][]} */
-const GITHUB_WORKFLOW_TEST_OWNERS = [
-  ["ci-build-artifacts-testbox", ["install-trufflehog", "package-acceptance-workflow"]],
-  ["ci-check-arm-testbox", ["install-trufflehog", "package-acceptance-workflow"]],
-  ["ci-check-testbox", ["changed-lanes", "install-trufflehog", "package-acceptance-workflow"]],
-  [
-    "ci",
-    [
-      "changed-lanes",
-      "check-workflows",
-      "plugin-contract-test-plan",
-      "plugin-prerelease-test-plan",
-      "verify-pr-hosted-gates",
-    ],
-  ],
-  ["crabbox-hydrate", ["package-acceptance-workflow"]],
-  ["dependency-guard", ["dependency-guard-workflow"]],
-  ["docker-release", ["src/dockerfile.test.ts"]],
-  [
-    "full-release-validation",
-    ["src/dockerfile.test.ts", "package-acceptance-workflow", "plugin-prerelease-test-plan"],
-  ],
-  ["install-smoke", ["install-smoke-no-push-workflow", "test-install-sh-docker"]],
-  ["install-smoke-reusable", ["install-smoke-no-push-workflow", "test-install-sh-docker"]],
-  ["ios-periphery-comment", ["ios-periphery-comment-workflow"]],
-  ["ios-periphery", ["ios-periphery-comment-workflow", "periphery-scope-workflows"]],
-  ["macos-periphery", ["ios-periphery-comment-workflow", "periphery-scope-workflows"]],
-  ["shared-openclawkit-periphery", ["periphery-intersection", "periphery-scope-workflows"]],
-  ["live-media-runner-image", ["package-acceptance-workflow"]],
-  ["macos-release", ["package-acceptance-workflow"]],
-  ["mantis-scenario", ["mantis-telegram-desktop-proof-workflow"]],
-  [
-    "mantis-telegram-desktop-proof",
-    ["mantis-telegram-desktop-proof-workflow", "package-acceptance-workflow"],
-  ],
-  [
-    "mantis-web-ui-chat-proof",
-    ["mantis-web-ui-chat-proof-workflow", "package-acceptance-workflow"],
-  ],
-  ["mantis-discord-smoke", ["package-acceptance-workflow"]],
-  ["mantis-discord-status-reactions", ["package-acceptance-workflow"]],
-  ["mantis-discord-thread-attachment", ["package-acceptance-workflow"]],
-  ["mantis-slack-desktop-smoke", ["package-acceptance-workflow"]],
-  [
-    "mantis-telegram-live",
-    ["mantis-telegram-desktop-proof-workflow", "package-acceptance-workflow"],
-  ],
-  ["npm-telegram-beta-e2e", ["package-acceptance-workflow"]],
-  ["android-release", ["package-acceptance-workflow"]],
-  [
-    "openclaw-cross-os-release-checks-reusable",
-    [
-      "openclaw-cross-os-release-checks",
-      "openclaw-cross-os-release-workflow",
-      "package-acceptance-workflow",
-    ],
-  ],
-  [
-    "openclaw-live-and-e2e-checks-reusable",
-    ["package-acceptance-workflow", "release-workflow-matrix-plan", "test-install-sh-docker"],
-  ],
-  [
-    "openclaw-npm-release",
-    [
-      "test/openclaw-npm-postpublish-verify.test.ts",
-      "openclaw-npm-extended-stable-workflow",
-      "package-acceptance-workflow",
-    ],
-  ],
-  ["openclaw-performance", ["openclaw-performance-workflow"]],
-  [
-    "openclaw-release-checks",
-    [
-      "openclaw-cross-os-release-checks",
-      "package-acceptance-workflow",
-      "plugin-prerelease-test-plan",
-      "test-install-sh-docker",
-    ],
-  ],
-  ["openclaw-release-publish", ["package-acceptance-workflow"]],
-  ["openclaw-scheduled-live-checks", ["package-acceptance-workflow", "release-no-push-workflow"]],
-  ["openclaw-stable-main-closeout", ["package-acceptance-workflow"]],
-  ["package-acceptance", ["package-acceptance-workflow"]],
-  ["plugin-clawhub-new", ["package-acceptance-workflow", "plugin-clawhub-new-workflow"]],
-  ["plugin-clawhub-release", ["package-acceptance-workflow"]],
-  ["plugin-npm-release", ["package-acceptance-workflow", "plugin-npm-extended-stable-workflow"]],
-  ["plugin-prerelease", ["plugin-prerelease-test-plan"]],
-  ["qa-live-transports-convex", ["package-acceptance-workflow"]],
-  ["sandbox-common-smoke", ["sandbox-common-smoke-workflow"]],
-  ["security-sensitive-guard", ["security-sensitive-guard-workflow"]],
-  ["tui-pty", ["package-acceptance-workflow"]],
-  ["update-migration", ["package-acceptance-workflow"]],
-  ["website-installer-sync", ["website-installer-sync-workflow"]],
-  ["windows-node-release", ["package-acceptance-workflow"]],
-  ["windows-testbox-probe", ["check-workflows"]],
-];
-const GITHUB_WORKFLOW_OWNER_TEST_TARGETS = new Map(
-  GITHUB_WORKFLOW_TEST_OWNERS.map(([workflow, owners]) => [
-    `.github/workflows/${workflow}.yml`,
-    resolveToolingTestOwnerTargets(...owners),
-  ]),
-);
-const TOOLING_SOURCE_TEST_TARGETS = new Map([
-  ["Dockerfile", ROOT_DOCKERFILE_TEST_TARGETS],
-  [
-    ".agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs",
-    ["test/scripts/release-notes-ledger.test.ts", "test/scripts/verify-release-notes.test.ts"],
-  ],
-  [".crabbox.yaml", ["test/scripts/package-acceptance-workflow.test.ts"]],
-  [
-    ".github/actions/setup-node-env/action.yml",
-    resolveToolingTestOwnerTargets(
-      "install-trufflehog",
-      "package-acceptance-workflow",
-      "ci-workflow-guards",
-    ),
-  ],
-  [
-    ".github/actions/setup-node-env/dependency-fingerprint.mjs",
-    ["test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    ".github/actions/setup-node-env/sticky-importers.sh",
-    ["test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    ".github/actions/setup-node-env/verify-importers.mjs",
-    ["test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    ".github/actions/setup-pnpm-store-cache/action.yml",
-    ["test/scripts/package-acceptance-workflow.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    ".github/actions/setup-pnpm-store-cache/ensure-node.sh",
-    ["test/scripts/setup-pnpm-store-cache-ensure-node.test.ts"],
-  ],
-  [".github/images/live-media-runner/Dockerfile", LIVE_MEDIA_RUNNER_IMAGE_TEST_TARGETS],
-  [".github/workflows/ci.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
-  [
-    ".github/workflows/ci-check-testbox.yml",
-    ["test/scripts/ci-workflow-guards.test.ts", "test/scripts/package-acceptance-workflow.test.ts"],
-  ],
-  [
-    ".github/workflows/ci-check-arm-testbox.yml",
-    ["test/scripts/ci-workflow-guards.test.ts", "test/scripts/package-acceptance-workflow.test.ts"],
-  ],
-  [
-    ".github/workflows/crabbox-hydrate.yml",
-    ["test/scripts/ci-workflow-guards.test.ts", "test/scripts/package-acceptance-workflow.test.ts"],
-  ],
-  [
-    ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
-    ["test/scripts/package-acceptance-workflow.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    ".github/workflows/openclaw-release-checks.yml",
-    ["test/scripts/package-acceptance-workflow.test.ts"],
-  ],
-  ["scripts/clawtributors-map.json", ["test/scripts/update-clawtributors.test.ts"]],
-  ["scripts/tsconfig.json", ["test/scripts/oxlint-config.test.ts"]],
-  [
-    "tsconfig.scripts.json",
-    ["test/scripts/changed-lanes.test.ts", "test/scripts/test-projects.test.ts"],
-  ],
-  ["scripts/build-stamp.mjs", ["src/infra/build-stamp.test.ts"]],
-  ["scripts/crabbox-wrapper-providers.mjs", ["test/scripts/crabbox-wrapper.test.ts"]],
-  ["scripts/check-changed.mjs", ["test/scripts/changed-lanes.test.ts"]],
-  ["config/env-var-count-budget.txt", ["test/scripts/check-env-var-count.test.ts"]],
-  ["config/max-lines-baseline.txt", ["test/scripts/check-max-lines-ratchet.test.ts"]],
-  [".oxlintrc.json", ["test/scripts/oxlint-config.test.ts"]],
-  ["scripts/generate-prompt-snapshots.ts", ["test/scripts/prompt-snapshots.test.ts"]],
-  [
-    "scripts/generate-runtime-sidecar-paths-baseline.ts",
-    RUNTIME_SIDECAR_BASELINE_OWNER_TEST_TARGETS,
-  ],
-  [
-    "scripts/lib/config-boundary-guard.mjs",
-    [
-      "src/plugins/contracts/config-boundary-guard.test.ts",
-      "src/plugins/contracts/deprecated-internal-config-api.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/deprecated-config-api-guard.mjs",
-    ["src/plugins/contracts/deprecated-internal-config-api.test.ts"],
-  ],
-  [
-    "scripts/lib/extension-package-boundary.ts",
-    ["src/plugins/contracts/extension-package-project-boundaries.test.ts"],
-  ],
-  ["scripts/check-extension-plugin-sdk-boundary.mjs", ["test/extension-import-boundaries.test.ts"]],
-  [
-    "scripts/check-plugin-extension-import-boundary.mjs",
-    ["test/plugin-extension-import-boundary.test.ts"],
-  ],
-  [
-    "scripts/check-sdk-package-extension-import-boundary.mjs",
-    ["test/extension-import-boundaries.test.ts"],
-  ],
-  ["scripts/check-src-extension-import-boundary.mjs", ["test/extension-import-boundaries.test.ts"]],
-  [
-    "scripts/lib/guard-inventory-utils.mjs",
-    [
-      "test/extension-import-boundaries.test.ts",
-      "test/plugin-extension-import-boundary.test.ts",
-      "test/architecture-smells.test.ts",
-      "test/web-provider-boundary.test.ts",
-      "test/test-helper-extension-import-boundary.test.ts",
-      "test/scripts/extension-import-boundary-checker.test.ts",
-      "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-    ],
-  ],
-  [
-    "scripts/check-test-helper-extension-import-boundary.mjs",
-    ["test/test-helper-extension-import-boundary.test.ts"],
-  ],
-  [
-    "scripts/check-workflows.mjs",
-    resolveToolingTestOwnerTargets(
-      "check-composite-action-input-interpolation",
-      "check-no-conflict-markers",
-      "ci-workflow-guards",
-    ),
-  ],
-  [
-    "scripts/ci-changed-scope.mjs",
-    ["src/scripts/ci-changed-scope.test.ts", "test/scripts/control-ui-i18n.test.ts"],
-  ],
-  [
-    "scripts/native-app-i18n.ts",
-    ["test/scripts/native-app-i18n.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
-  ],
-  [
-    "scripts/copy-bundled-plugin-metadata.mjs",
-    ["src/plugins/copy-bundled-plugin-metadata.test.ts", "src/infra/run-node.test.ts"],
-  ],
-  [
-    "scripts/e2e/agent-bundle-mcp-tools-docker.sh",
-    [
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/scripts/plugin-prerelease-test-plan.test.ts",
-      "src/agents/agent-bundle-mcp-runtime.test.ts",
-      "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
-    ],
-  ],
-  [
-    "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts",
-    [
-      "src/agents/agent-bundle-mcp-runtime.test.ts",
-      "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/codex-media-path-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "codex-media-path-client",
-    ),
-  ],
-  [
-    "scripts/e2e/codex-npm-plugin-live-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/codex-on-demand-docker.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/docker-e2e-plan.test.ts"],
-  ],
-  [
-    "scripts/e2e/system-agent-first-run-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "docker-e2e-system-agent",
-    ),
-  ],
-  [
-    "test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts",
-    [
-      "test/scripts/docker-e2e-system-agent.test.ts",
-      "src/cli/program/register.onboard.test.ts",
-      "src/cli/run-main.test.ts",
-      "src/cli/run-main.exit.test.ts",
-      "src/commands/system-agent-with-inference.test.ts",
-      "src/system-agent/assistant.configured.test.ts",
-      "src/system-agent/assistant.test.ts",
-      "src/system-agent/system-agent.test.ts",
-      "src/system-agent/operations.test.ts",
-      "src/system-agent/overview.test.ts",
-      "src/system-agent/setup-inference.test.ts",
-      "src/system-agent/audit.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/system-agent-first-run-spec.json",
-    [
-      "test/scripts/docker-e2e-system-agent.test.ts",
-      "src/system-agent/operations.test.ts",
-      "src/system-agent/audit.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/system-agent-rescue-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "docker-e2e-system-agent",
-    ),
-  ],
-  [
-    "scripts/e2e/system-agent-rescue-docker-client.ts",
-    [
-      "test/scripts/docker-e2e-system-agent.test.ts",
-      "src/system-agent/rescue-policy.test.ts",
-      "src/system-agent/rescue-message.test.ts",
-      "src/system-agent/operations.test.ts",
-      "src/system-agent/audit.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/commitments-safety-docker-client.ts",
-    [
-      "test/scripts/docker-e2e-clients.test.ts",
-      "src/commitments/runtime.test.ts",
-      "src/commitments/store.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/commitments-safety-docker.sh",
-    [
-      "test/scripts/docker-e2e-clients.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "src/commitments/runtime.test.ts",
-      "src/commitments/store.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/session-runtime-context-docker-client.ts",
-    [
-      "test/scripts/docker-e2e-clients.test.ts",
-      "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
-      "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/session-runtime-context-docker.sh",
-    [
-      "test/scripts/docker-e2e-clients.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
-      "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/mcp-channels-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-observability",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-    ),
-  ],
-  [
-    "test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts",
-    ["test/scripts/docker-e2e-plan.test.ts", "test/scripts/plugin-prerelease-test-plan.test.ts"],
-  ],
-  [
-    "test/e2e/qa-lab/runtime/mcp-channels.fixture.ts",
-    [
-      "test/e2e/qa-lab/runtime/mcp-gateway-transport.e2e.test.ts",
-      "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
-    ],
-  ],
-  [
-    "test/e2e/qa-lab/runtime/mcp-client-temp-state.fixture.ts",
-    ["test/e2e/qa-lab/runtime/mcp-gateway-transport.e2e.test.ts"],
-  ],
-  ["scripts/e2e/mcp-channels-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-  ["scripts/e2e/docker-openai-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-  [
-    "scripts/e2e/mcp-code-mode-gateway-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-      "mcp-code-mode-gateway-client",
-      "session-log-mentions",
-    ),
-  ],
-  [
-    "scripts/e2e/mcp-code-mode-gateway-live-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-      "mcp-code-mode-gateway-client",
-      "session-log-mentions",
-    ),
-  ],
-  ["scripts/e2e/mcp-code-mode-gateway-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-  [
-    "scripts/e2e/lib/mcp-code-mode-probe-server.ts",
-    ["test/scripts/docker-e2e-seeds.test.ts", "test/scripts/mcp-code-mode-gateway-client.test.ts"],
-  ],
-  [
-    "scripts/e2e/cron-cli-docker.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/docker-e2e-observability.test.ts"],
-  ],
-  [
-    "scripts/e2e/cron-mcp-cleanup-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-observability",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-      "cron-mcp-cleanup-docker-client",
-      "docker-e2e-seeds",
-    ),
-  ],
-  [
-    "scripts/e2e/cron-mcp-cleanup-docker-client.ts",
-    [
-      "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
-      "src/gateway/server.cron.test.ts",
-      "src/gateway/server-methods/agent.test.ts",
-      "src/cron/isolated-agent/run.fast-mode.test.ts",
-      "src/cron/active-jobs-manual-run.test.ts",
-    ],
-  ],
-  [
-    "scripts/mcp-code-mode-gateway-e2e.ts",
-    resolveToolingTestOwnerTargets("mcp-code-mode-gateway-client", "session-log-mentions"),
-  ],
-  [
-    "scripts/github/dependency-guard.mjs",
-    resolveToolingTestOwnerTargets("dependency-guard-script", "dependency-guard-workflow"),
-  ],
-  [
-    "scripts/github/guard-shared.mjs",
-    resolveToolingTestOwnerTargets(
-      "dependency-guard-script",
-      "dependency-guard-workflow",
-      "security-sensitive-guard-script",
-      "security-sensitive-guard-workflow",
-    ),
-  ],
-  [
-    "scripts/github/run-openclaw-cross-os-release-checks.sh",
-    ["test/scripts/openclaw-cross-os-release-workflow.test.ts"],
-  ],
-  ["scripts/compare-release-evidence-zip.py", ["test/scripts/package-acceptance-workflow.test.ts"]],
-  ["scripts/android-release.sh", ["test/scripts/android-release-wrapper-args.test.ts"]],
-  ["scripts/android-release-upload.sh", ["test/scripts/android-release-wrapper-args.test.ts"]],
-  [
-    "apps/android/scripts/build-release-artifacts.ts",
-    ["test/scripts/android-release-artifacts.test.ts"],
-  ],
-  ["apps/android/fastlane/Fastfile", ["test/scripts/android-release-fastlane-gates.test.ts"]],
-  ["scripts/ios-release-archive.sh", ["test/scripts/ios-release-wrapper-args.test.ts"]],
-  ["scripts/ios-release-cut.sh", ["test/scripts/ios-release-plan.test.ts"]],
-  ["scripts/ios-release-cut.ts", ["test/scripts/ios-release-plan.test.ts"]],
-  [
-    "scripts/ios-release-prepare.sh",
-    ["test/scripts/ios-release-prepare.test.ts", "test/scripts/ios-release-wrapper-args.test.ts"],
-  ],
-  ["apps/ios/fastlane/Fastfile", ["test/scripts/ios-release-fastlane-gates.test.ts"]],
-  [
-    "scripts/ios-release-upload.sh",
-    resolveToolingTestOwnerTargets("ios-release-wrapper-args", "ios-release-fastlane-gates"),
-  ],
-  ["scripts/lib/restart-mac-gateway.sh", ["test/scripts/restart-mac.test.ts"]],
-  ["scripts/openclaw-release-clawhub-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  [
-    "scripts/plan-release-workflow-matrix.mjs",
-    ["test/scripts/release-workflow-matrix-plan.test.ts"],
-  ],
-  ["scripts/release-fast-pretag-check.sh", ["test/scripts/package-acceptance-workflow.test.ts"]],
-  ["scripts/plugin-clawhub-release-check.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  ["scripts/plugin-clawhub-release-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  ["scripts/plugin-npm-release-check.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  ["scripts/plugin-npm-release-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  ["scripts/release-verify-beta.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-  [
-    "scripts/github/security-sensitive-guard.mjs",
-    resolveToolingTestOwnerTargets(
-      "security-sensitive-guard-script",
-      "security-sensitive-guard-workflow",
-    ),
-  ],
-  [
-    "scripts/deadcode-unused-files.allowlist.mjs",
-    ["test/scripts/check-deadcode-unused-files.test.ts"],
-  ],
-  [
-    "scripts/lib/android-version.ts",
-    ["test/scripts/android-version.test.ts", "test/scripts/android-pin-version.test.ts"],
-  ],
-  [
-    "scripts/lib/bundled-plugin-build-entries.mjs",
-    ["test/scripts/bundled-plugin-build-entries.test.ts", "test/release-check.test.ts"],
-  ],
-  ["scripts/lib/bundled-runtime-sidecar-paths.json", RUNTIME_SIDECAR_PATH_CONSUMER_TEST_TARGETS],
-  ["scripts/lib/changed-extensions.mjs", ["test/scripts/test-extension.test.ts"]],
-  [
-    "scripts/lib/dependency-ownership.json",
-    ["test/scripts/dependency-ownership-surface-report.test.ts"],
-  ],
-  [
-    "scripts/lib/deprecated-plugin-sdk-usage.mjs",
-    ["test/scripts/check-deprecated-api-usage.test.ts"],
-  ],
-  [
-    "scripts/lib/plugin-sdk-deprecated-barrel-subpaths.json",
-    PLUGIN_SDK_ENTRY_METADATA_TEST_TARGETS,
-  ],
-  [
-    "scripts/lib/plugin-sdk-deprecated-public-subpaths.json",
-    [
-      "test/scripts/check-deprecated-api-usage.test.ts",
-      "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-      "test/scripts/plugin-sdk-surface-report.test.ts",
-      "test/scripts/build-all.test.ts",
-    ],
-  ],
-  ["scripts/lib/plugin-sdk-entrypoints.json", PLUGIN_SDK_ENTRY_METADATA_TEST_TARGETS],
-  ["scripts/lib/plugin-sdk-entries.mjs", PLUGIN_SDK_ENTRY_METADATA_TEST_TARGETS],
-  [
-    "scripts/lib/plugin-sdk-private-local-only-subpaths.json",
-    PLUGIN_SDK_ENTRY_METADATA_TEST_TARGETS,
-  ],
-  [
-    "scripts/lib/official-external-channel-catalog.json",
-    [...OFFICIAL_EXTERNAL_CATALOG_TEST_TARGETS, "test/official-channel-catalog.test.ts"],
-  ],
-  ["scripts/lib/official-external-plugin-catalog.json", OFFICIAL_EXTERNAL_CATALOG_TEST_TARGETS],
-  ["scripts/lib/official-external-provider-catalog.json", OFFICIAL_EXTERNAL_CATALOG_TEST_TARGETS],
-  ["scripts/lib/recommended-tool-installs.json", RECOMMENDED_TOOL_INSTALLS_TEST_TARGETS],
-  ["scripts/lib/direct-run.mjs", ["test/scripts/changed-lanes.test.ts"]],
-  ["scripts/prompt-snapshot-files.ts", ["test/scripts/prompt-snapshots.test.ts"]],
-  [
-    "scripts/docker/cleanup-smoke/Dockerfile",
-    [...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS, "test/scripts/docker-build-helper.test.ts"],
-  ],
-  ["scripts/docker/cleanup-smoke/run.sh", ["test/scripts/docker-build-helper.test.ts"]],
-  ["scripts/docker/install-sh-e2e/Dockerfile", INSTALL_DOCKERFILE_TEST_TARGETS],
-  [
-    "scripts/docker/install-sh-e2e/run.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  [
-    "scripts/docker/install-sh-common/cli-verify.sh",
-    ["test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  [
-    "scripts/docker/install-sh-common/version-parse.sh",
-    ["test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  ["scripts/docker/install-sh-nonroot/Dockerfile", INSTALL_DOCKERFILE_TEST_TARGETS],
-  ["scripts/docker/install-sh-nonroot/run.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-  ["scripts/docker/install-sh-smoke/Dockerfile", INSTALL_DOCKERFILE_TEST_TARGETS],
-  ["scripts/docker/install-sh-smoke/run.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-  [
-    "scripts/docker/sandbox/Dockerfile",
-    [...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS, "src/dockerfile.test.ts"],
-  ],
-  [
-    "scripts/docker/sandbox/Dockerfile.browser",
-    [...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS, "src/agents/sandbox/browser.create.test.ts"],
-  ],
-  ["scripts/docker/sandbox/Dockerfile.common", ["src/docker-build-cache.test.ts"]],
-  [
-    "scripts/e2e/Dockerfile",
-    [
-      ...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS,
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/Dockerfile.qr-import",
-    [...DOCKERFILE_CACHE_AND_DIGEST_TEST_TARGETS, "test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/plugin-binding-command-escape.Dockerfile",
-    [
-      "src/docker-image-digests.test.ts",
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-    ],
-  ],
-  ["scripts/lib/docker-e2e-container.sh", ["test/scripts/docker-build-helper.test.ts"]],
-  ["scripts/lib/docker-e2e-package.sh", ["test/scripts/docker-build-helper.test.ts"]],
-  [
-    "scripts/lib/docker-e2e-plan.mjs",
-    resolveToolingTestOwnerTargets(
-      "docker-e2e-plan",
-      "docker-all-scheduler",
-      "plugin-prerelease-test-plan",
-    ),
-  ],
-  ["scripts/lib/ios-fastlane.sh", ["test/scripts/ios-release-wrapper-args.test.ts"]],
-  ["scripts/live-docker-stage-private-sdk-exports.mjs", ["test/scripts/live-docker-stage.test.ts"]],
-  [
-    "scripts/lib/windows-taskkill.mjs",
-    ["test/scripts/managed-child-process.test.ts", "test/scripts/run-with-env.test.ts"],
-  ],
-  [
-    "scripts/lib/local-build-metadata.mjs",
-    [
-      "src/infra/build-stamp.test.ts",
-      "test/scripts/runtime-postbuild-stamp.test.ts",
-      "src/infra/run-node.test.ts",
-      "src/infra/package-dist-inventory.test.ts",
-      "test/release-check.test.ts",
-      "test/openclaw-npm-release-check.test.ts",
-      "test/scripts/check-gateway-watch-regression.test.ts",
-      "test/scripts/check-openclaw-package-tarball.test.ts",
-      "test/scripts/openclaw-cross-os-release-checks.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/local-build-metadata-paths.mjs",
-    [
-      "src/infra/build-stamp.test.ts",
-      "test/scripts/runtime-postbuild-stamp.test.ts",
-      "src/infra/run-node.test.ts",
-      "src/infra/package-dist-inventory.test.ts",
-      "test/release-check.test.ts",
-      "test/openclaw-npm-release-check.test.ts",
-      "test/scripts/check-gateway-watch-regression.test.ts",
-      "test/scripts/check-openclaw-package-tarball.test.ts",
-      "test/scripts/openclaw-cross-os-release-checks.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/workspace-bootstrap-smoke.mjs",
-    ["test/release-check.test.ts", "test/openclaw-npm-release-check.test.ts"],
-  ],
-  [
-    "scripts/lib/package-dist-imports.mjs",
-    [
-      "test/scripts/check-package-dist-imports.test.ts",
-      "test/scripts/check-openclaw-package-tarball.test.ts",
-      "test/scripts/postinstall-bundled-plugins.test.ts",
-      "test/release-check.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/build-metadata.sh",
-    [
-      "src/docker-setup.e2e.test.ts",
-      "test/scripts/apple-release-source-check.test.ts",
-      "test/scripts/ios-version.test.ts",
-      "test/scripts/package-mac-app.test.ts",
-      "test/scripts/test-install-sh-docker.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/plistbuddy.sh",
-    resolveToolingTestOwnerTargets("create-dmg", "package-mac-app", "package-mac-dist"),
-  ],
-  [
-    "scripts/lib/swift-toolchain.sh",
-    ["test/scripts/package-mac-app.test.ts", "test/scripts/package-mac-dist.test.ts"],
-  ],
-  [
-    "scripts/lib/plugin-npm-runtime-build.mjs",
-    ["test/scripts/plugin-npm-runtime-build-args.test.ts", "test/plugin-npm-runtime-build.test.ts"],
-  ],
-  [
-    "scripts/lib/npm-publish-plan.mjs",
-    [
-      "test/npm-publish-plan.test.ts",
-      "test/openclaw-npm-release-check.test.ts",
-      "test/openclaw-npm-postpublish-verify.test.ts",
-      "test/plugin-npm-release.test.ts",
-      "test/plugin-clawhub-release.test.ts",
-      "test/scripts/release-upgrade-baseline.test.ts",
-      "test/scripts/android-version.test.ts",
-      "test/scripts/ios-version.test.ts",
-      "test/scripts/upgrade-survivor-baselines.test.ts",
-      "test/scripts/upgrade-survivor-config-recipe.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/release-version.mjs",
-    [
-      "test/release-version.test.ts",
-      "test/npm-publish-plan.test.ts",
-      "test/openclaw-npm-release-check.test.ts",
-      "test/openclaw-npm-postpublish-verify.test.ts",
-      "test/plugin-npm-release.test.ts",
-      "test/plugin-clawhub-release.test.ts",
-      "test/scripts/android-version.test.ts",
-      "test/scripts/android-pin-version.test.ts",
-      "test/scripts/docker-release-policy.test.ts",
-      "test/scripts/ios-version.test.ts",
-      "test/scripts/openclaw-npm-extended-stable-release.test.ts",
-      "test/scripts/openclaw-npm-publish.test.ts",
-      "test/scripts/release-preflight.test.ts",
-      "test/scripts/release-prepare.test.ts",
-      "test/scripts/release-upgrade-baseline.test.ts",
-      "test/scripts/release-version.test.ts",
-      "test/scripts/upgrade-survivor-baselines.test.ts",
-      "test/scripts/upgrade-survivor-config-recipe.test.ts",
-    ],
-  ],
-  ["scripts/sync-codex-model-prompt-fixture.ts", ["test/scripts/prompt-snapshots.test.ts"]],
-  [
-    "scripts/lib/npm-pack-budget.mjs",
-    ["test/release-check.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  ["scripts/lib/openclaw-release-clawhub-plan.ts", ["test/plugin-clawhub-release.test.ts"]],
-  [
-    "scripts/lib/actions-artifact-archive.mjs",
-    ["test/scripts/plugin-publication-artifact.test.ts"],
-  ],
-  [
-    "scripts/lib/clawhub-bootstrap-artifact.mjs",
-    resolveToolingTestOwnerTargets(
-      "clawhub-bootstrap-artifact",
-      "verify-clawhub-published-artifact",
-    ),
-  ],
-  [
-    "scripts/materialize-clawhub-cli.sh",
-    resolveToolingTestOwnerTargets("package-acceptance-workflow", "plugin-clawhub-new-workflow"),
-  ],
-  [
-    ".github/release/clawhub-cli/package.json",
-    resolveToolingTestOwnerTargets("package-acceptance-workflow", "plugin-clawhub-new-workflow"),
-  ],
-  [
-    ".github/release/clawhub-cli/package-lock.json",
-    resolveToolingTestOwnerTargets("package-acceptance-workflow", "plugin-clawhub-new-workflow"),
-  ],
-  ["scripts/plugin-clawhub-publish.sh", ["test/plugin-clawhub-release.test.ts"]],
-  [
-    "scripts/lib/plugin-clawhub-release.ts",
-    ["test/plugin-clawhub-release.test.ts", "test/plugin-npm-release.test.ts"],
-  ],
-  [
-    "scripts/lib/plugin-npm-release.ts",
-    ["test/plugin-npm-release.test.ts", "test/plugin-clawhub-release.test.ts"],
-  ],
-  [
-    "scripts/lib/plugin-npm-package-manifest.mjs",
-    [
-      "test/scripts/plugin-npm-package-manifest-args.test.ts",
-      "test/plugin-npm-package-manifest.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/plugin-npm-runtime-assets.mjs",
-    ["test/scripts/plugin-npm-runtime-build-args.test.ts"],
-  ],
-  [
-    "scripts/lib/generated-text-asset.mjs",
-    [
-      "extensions/browser/scripts/build-copilot-runtime.test.ts",
-      "test/scripts/build-diffs-viewer-runtime.test.ts",
-      "test/scripts/bundled-plugin-assets.test.ts",
-    ],
-  ],
-  [
-    "scripts/lib/static-extension-assets.mjs",
-    [
-      "test/scripts/bundled-plugin-assets.test.ts",
-      "test/scripts/runtime-postbuild.test.ts",
-      "src/infra/run-node.test.ts",
-      "test/scripts/plugin-npm-runtime-build-args.test.ts",
-    ],
-  ],
-  ["scripts/lib/stable-release-closeout.mjs", ["test/stable-release-closeout.test.ts"]],
-  [
-    "scripts/lib/extension-source-classifier.mjs",
-    [
-      "test/scripts/extension-source-classifier.test.ts",
-      "src/channels/plugins/contracts/channel-import-guardrails.test.ts",
-    ],
-  ],
-  ["scripts/lib/ts-topology/analyze.ts", ["test/scripts/ts-topology.test.ts"]],
-  ["scripts/lib/ts-topology/reports.ts", ["test/scripts/ts-topology.test.ts"]],
-  ["scripts/lib/ts-topology/scope.ts", ["test/scripts/ts-topology.test.ts"]],
-  [
-    "scripts/lib/tsgo-sparse-guard.mjs",
-    ["test/scripts/run-tsgo.test.ts", "test/scripts/changed-lanes.test.ts"],
-  ],
-  [
-    "scripts/mantis/build-web-ui-chat-evidence.mjs",
-    ["test/scripts/mantis-web-ui-chat-evidence.test.ts"],
-  ],
-  ["scripts/qa-coverage-report.ts", ["test/scripts/qa-report-cli.test.ts"]],
-  ["scripts/qa-parity-report.ts", ["test/scripts/qa-report-cli.test.ts"]],
-  [
-    "scripts/run-vitest.mjs",
-    resolveToolingTestOwnerTargets("run-vitest", "test-projects", "vitest-local-scheduling"),
-  ],
-  ["scripts/run-oxlint-shards.mjs", ["test/scripts/run-oxlint.test.ts"]],
-  ["scripts/run-lint.mjs", ["test/scripts/run-oxlint.test.ts"]],
-  ["scripts/run-node.mjs", ["src/infra/run-node.test.ts"]],
-  ["scripts/codespell-dictionary.txt", ["test/scripts/docs-spellcheck.test.ts"]],
-  ["scripts/codespell-ignore.txt", ["test/scripts/docs-spellcheck.test.ts"]],
-  ["scripts/mobile-reauth.sh", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/committer", ["test/scripts/committer.test.ts"]],
-  ["scripts/gh-read", ["test/scripts/gh-read.test.ts"]],
-  ["scripts/pr", resolveToolingTestOwnerTargets("pr-merge", "pr-operation-lock", "pr-wrappers")],
-  ["scripts/pr-lib/merge.sh", ["test/scripts/pr-merge.test.ts"]],
-  ["scripts/pr-lib/operation-lock.sh", ["test/scripts/pr-operation-lock.test.ts"]],
-  ["scripts/pr-lib/process-group-runner.mjs", ["test/scripts/pr-operation-lock.test.ts"]],
-  ["scripts/pr-merge", ["test/scripts/pr-wrappers.test.ts"]],
-  ["scripts/pr-prepare", ["test/scripts/pr-wrappers.test.ts"]],
-  ["scripts/pr-review", ["test/scripts/pr-wrappers.test.ts"]],
-  ["scripts/setup-auth-system.sh", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/systemd/openclaw-auth-monitor.service", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/systemd/openclaw-auth-monitor.timer", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/termux-auth-widget.sh", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/termux-quick-auth.sh", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/termux-sync-widget.sh", ["test/scripts/auth-monitor.test.ts"]],
-  ["scripts/docker-e2e.mjs", ["test/scripts/docker-e2e-helper-cli.test.ts"]],
-  ["scripts/docker-e2e-rerun.mjs", ["test/scripts/docker-e2e-helper-cli.test.ts"]],
-  ["scripts/docker-e2e-timings.mjs", ["test/scripts/docker-e2e-helper-cli.test.ts"]],
-  ["scripts/e2e/bun-global-install-smoke.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-  [
-    "scripts/install.sh",
-    [
-      "test/scripts/install-sh.test.ts",
-      "test/scripts/test-install-sh-docker.test.ts",
-      "test/scripts/website-installer-sync-workflow.test.ts",
-      "test/scripts/openclaw-cross-os-release-checks.test.ts",
-      "src/scripts/ci-changed-scope.test.ts",
-    ],
-  ],
-  [
-    "scripts/install.ps1",
-    [
-      "test/scripts/install-ps1.test.ts",
-      "test/scripts/website-installer-sync-workflow.test.ts",
-      "test/scripts/openclaw-cross-os-release-checks.test.ts",
-      "src/scripts/ci-changed-scope.test.ts",
-    ],
-  ],
-  ["scripts/podman/openclaw.container.in", ["test/scripts/test-install-sh-docker.test.ts"]],
-  ["scripts/ios-write-version-xcconfig.sh", ["test/scripts/ios-version.test.ts"]],
-  ["scripts/make_appcast.sh", ["test/scripts/make-appcast.test.ts"]],
-  ["scripts/openclaw-npm-prepublish-verify.ts", ["test/openclaw-npm-prepublish-verify.test.ts"]],
-  ["scripts/openclaw-npm-postpublish-verify.ts", ["test/openclaw-npm-postpublish-verify.test.ts"]],
-  ["scripts/openclaw-npm-release-check.ts", ["test/openclaw-npm-release-check.test.ts"]],
-  ["scripts/openclaw-prepack.ts", ["test/openclaw-prepack.test.ts"]],
-  [
-    "scripts/check-plugin-npm-runtime-builds.mjs",
-    ["test/scripts/plugin-npm-runtime-build-args.test.ts"],
-  ],
-  [
-    "scripts/sparkle-build.ts",
-    [
-      "test/appcast.test.ts",
-      "test/release-check.test.ts",
-      "test/scripts/package-mac-app.test.ts",
-      "test/scripts/package-mac-dist.test.ts",
-    ],
-  ],
-  [
-    "scripts/package-openclaw-for-docker.mjs",
-    ["test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts"],
-  ],
-  ["scripts/test-extension-batch.mjs", ["test/scripts/test-extension.test.ts"]],
-  [
-    "scripts/test-install-sh-e2e-docker.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  [
-    "scripts/write-plugin-sdk-entry-dts.ts",
-    resolveToolingTestOwnerTargets("build-all", "prepare-extension-package-boundary-artifacts"),
-  ],
-  ["scripts/fixtures/packed-plugin-sdk-type-smoke.ts", ["test/release-check.test.ts"]],
-  ["scripts/lib/extension-test-plan.mjs", ["test/scripts/test-extension.test.ts"]],
-  ["scripts/lib/extension-vitest-paths.mjs", ["test/scripts/test-extension.test.ts"]],
-  ["scripts/lib/vitest-batch-runner.mjs", ["test/scripts/test-extension.test.ts"]],
-  [
-    "scripts/lib/docker-e2e-scenarios.mjs",
-    ["test/scripts/docker-e2e-plan.test.ts", "test/scripts/plugin-prerelease-test-plan.test.ts"],
-  ],
-  [
-    "scripts/e2e/kitchen-sink-plugin-docker.sh",
-    resolveToolingTestOwnerTargets("docker-build-helper", "plugin-prerelease-test-plan"),
-  ],
-  [
-    "scripts/e2e/kitchen-sink-rpc-docker.sh",
-    resolveToolingTestOwnerTargets("docker-build-helper", "plugin-prerelease-test-plan"),
-  ],
-  [
-    "scripts/e2e/kitchen-sink-rpc-walk.mjs",
-    resolveToolingTestOwnerTargets("kitchen-sink-rpc-walk", "plugin-prerelease-test-plan"),
-  ],
-  ["scripts/e2e/telegram-user-credential-io.ts", ["test/scripts/telegram-user-credential.test.ts"]],
-  [
-    "scripts/e2e/telegram-user-credential-paths.ts",
-    ["test/scripts/telegram-user-credential.test.ts"],
-  ],
-  [
-    "scripts/e2e/onboard-docker.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/openclaw-test-state.test.ts"],
-  ],
-  [
-    "scripts/e2e/agents-delete-shared-workspace-docker.sh",
-    [
-      "test/scripts/docker-e2e-plan.test.ts",
-      "src/scripts/ci-changed-scope.test.ts",
-      "src/commands/agents.delete.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/browser-cdp-snapshot-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "browser-cdp-snapshot",
-      "e2e-helper-env-limits",
-    ),
-  ],
-  [
-    "scripts/e2e/config-reload-source-docker.sh",
-    [
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/scripts/package-acceptance-workflow.test.ts",
-      "test/scripts/fixture-config.test.ts",
-      "test/scripts/e2e-mock-config-limits.test.ts",
-      "src/gateway/config-reload.test.ts",
-    ],
-  ],
-  ["scripts/e2e/lib/env-limits.mjs", ["test/scripts/e2e-helper-env-limits.test.ts"]],
-  ["scripts/e2e/mock-openai-server.mjs", ["test/scripts/e2e-mock-config-limits.test.ts"]],
-  [
-    "scripts/e2e/gateway-network-docker.sh",
-    [
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/scripts/package-acceptance-workflow.test.ts",
-      "test/scripts/gateway-network-client.test.ts",
-      "src/scripts/ci-changed-scope.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/npm-onboard-channel-agent-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-      "npm-onboard-channel-agent-assertions",
-      "plugin-prerelease-test-plan",
-    ),
-  ],
-  ["scripts/e2e/npm-telegram-live-docker.sh", ["test/scripts/npm-telegram-live.test.ts"]],
-  ["scripts/e2e/npm-telegram-live-runner.ts", ["test/scripts/npm-telegram-live.test.ts"]],
-  [
-    "scripts/e2e/multi-node-update-docker.sh",
-    ["test/scripts/docker-build-helper.test.ts", "test/scripts/docker-e2e-plan.test.ts"],
-  ],
-  [
-    "scripts/e2e/doctor-install-switch-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/update-channel-switch-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/skill-install-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-      "e2e-shell-tempfiles",
-    ),
-  ],
-  [
-    "scripts/e2e/upgrade-survivor-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-      "upgrade-survivor-probe-gateway",
-      "upgrade-survivor-assertions",
-      "openclaw-test-state",
-    ),
-  ],
-  ["scripts/e2e/plugin-lifecycle-matrix-docker.sh", ["test/scripts/docker-build-helper.test.ts"]],
-  [
-    "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-      "bundled-plugin-install-uninstall-probe",
-    ),
-  ],
-  [
-    "scripts/e2e/lib/plugin-lifecycle-matrix/measure.mjs",
-    ["test/scripts/plugin-lifecycle-measure.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/bun-global-install/assertions.mjs",
-    ["test/scripts/test-install-sh-docker.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/auth-profile-store-assertions.mjs",
-    resolveToolingTestOwnerTargets(
-      "release-scenarios-assertions",
-      "npm-onboard-channel-agent-assertions",
-    ),
-  ],
-  [
-    "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs",
-    ["test/scripts/codex-install-assertions.test.ts", "test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  ["scripts/e2e/lib/codex-install-utils.mjs", ["test/scripts/codex-install-assertions.test.ts"]],
-  [
-    "scripts/e2e/lib/codex-on-demand/assertions.mjs",
-    ["test/scripts/codex-install-assertions.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/clawhub-fixture-server.cjs",
-    resolveToolingTestOwnerTargets("clawhub-fixture-server", "plugin-prerelease-test-plan"),
-  ],
-  ["scripts/e2e/lib/config-reload/assert-log.mjs", ["test/scripts/e2e-mock-config-limits.test.ts"]],
-  [
-    "scripts/e2e/lib/docker-stats/assert-resource-ceiling.mjs",
-    ["test/scripts/docker-stats-resource-ceiling.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/doctor-install-switch/scenario.sh",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/doctor-install-switch/write-wrapper.mjs",
-    ["test/scripts/doctor-install-switch-wrapper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/doctor-install-switch/shims/loginctl",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/doctor-install-switch/shims/systemctl",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/fixture.mjs",
-    resolveToolingTestOwnerTargets(
-      "fixture-config",
-      "fixtures-workspace",
-      "fixture-plugin-commands",
-    ),
-  ],
-  ["scripts/e2e/lib/fixtures/config.mjs", ["test/scripts/fixture-config.test.ts"]],
-  ["scripts/e2e/lib/fixtures/common.mjs", ["test/scripts/fixture-common.test.ts"]],
-  ["scripts/e2e/lib/fixtures/plugins.mjs", ["test/scripts/fixture-plugin-commands.test.ts"]],
-  [
-    "scripts/e2e/lib/codex-app-server-fixture.mjs",
-    [
-      "test/scripts/codex-media-path-client.test.ts",
-      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs",
-    [
-      "test/scripts/codex-media-path-client.test.ts",
-      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/incremental-line-reader.mjs",
-    [
-      "test/scripts/incremental-line-reader.test.ts",
-      "test/scripts/config-reload-log-scanner.test.ts",
-      "test/scripts/codex-media-path-client.test.ts",
-      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/mcp-code-mode-validation.ts",
-    ["test/scripts/mcp-code-mode-gateway-client.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/onboard/scenario.sh",
-    ["test/scripts/e2e-shell-tempfiles.test.ts", "test/scripts/openclaw-test-state.test.ts"],
-  ],
-  ["scripts/e2e/lib/onboard/assert-config.mjs", ["test/scripts/onboard-config-fixtures.test.ts"]],
-  ["scripts/e2e/lib/onboard/write-config.mjs", ["test/scripts/onboard-config-fixtures.test.ts"]],
-  ["scripts/e2e/lib/package-compat.mjs", ["test/scripts/docker-build-helper.test.ts"]],
-  [
-    "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
-    ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/plugin-update/probe.mjs",
-    ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/plugin-update/registry-server.mjs",
-    ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/plugin-update/unchanged-scenario.sh",
-    ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-  ],
-  [
-    "scripts/e2e/plugin-update-unchanged-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "plugin-prerelease-test-plan",
-      "plugin-update-unchanged-docker",
-    ),
-  ],
-  [
-    "scripts/e2e/update-corrupt-plugin-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-      "plugin-update-unchanged-docker",
-    ),
-  ],
-  [
-    "scripts/e2e/plugins-docker.sh",
-    resolveToolingTestOwnerTargets("docker-build-helper", "docker-e2e-plan", "plugins-assertions"),
-  ],
-  [
-    "scripts/e2e/lib/release-plugin-marketplace/scenario.sh",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/release-typed-onboarding/scenario.sh",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/release-upgrade-user-journey/scenario.sh",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/release-plugin-marketplace-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/release-typed-onboarding-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/release-upgrade-user-journey-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  [
-    "scripts/e2e/release-user-journey-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-      "release-user-journey-assertions",
-    ),
-  ],
-  [
-    "scripts/e2e/lib/release-assertion-files.mjs",
-    resolveToolingTestOwnerTargets(
-      "release-scenarios-assertions",
-      "release-user-journey-assertions",
-    ),
-  ],
-  ["scripts/e2e/lib/skills/clawhub-install-proof.sh", ["test/scripts/e2e-shell-tempfiles.test.ts"]],
-  [
-    "scripts/e2e/lib/update-channel-switch/assertions.mjs",
-    ["test/scripts/docker-build-helper.test.ts"],
-  ],
-  [
-    "scripts/e2e/live-plugin-tool-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "live-plugin-tool-assertions",
-    ),
-  ],
-  [
-    "scripts/e2e/openai-image-auth-docker.sh",
-    [
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/scripts/openai-image-auth-docker-client.test.ts",
-      "extensions/openai/image-generation-provider.test.ts",
-    ],
-  ],
-  [
-    "test/e2e/qa-lab/runtime/openai-image-auth-docker-client.ts",
-    [
-      "test/scripts/openai-image-auth-docker-client.test.ts",
-      "extensions/openai/image-generation-provider.test.ts",
-      "src/image-generation/openai-compatible-image-provider.test.ts",
-    ],
-  ],
-  [
-    "test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs",
-    ["test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/openai-chat-tools/client.mjs",
-    ["test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/openai-chat-tools/scenario.sh",
-    ["test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/openai-chat-tools/write-config.mjs",
-    ["test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/openai-chat-tools-docker.sh",
-    [
-      "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/openai-web-search-minimal/assertions.mjs",
-    ["test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/openai-web-search-minimal/client.mjs",
-    ["test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/lib/openai-web-search-minimal/mock-server.mjs",
-    [
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/openai-web-search-minimal/scenario.sh",
-    [
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/openai-web-search-minimal-docker.sh",
-    [
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
-      "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
-    ],
-  ],
-  [
-    "scripts/e2e/lib/openwebui/http-probe.mjs",
-    ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"],
-  ],
-  [
-    "scripts/e2e/openwebui-docker.sh",
-    [
-      "test/scripts/docker-build-helper.test.ts",
-      "test/scripts/docker-e2e-plan.test.ts",
-      "test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts",
-      "test/scripts/fixture-config.test.ts",
-    ],
-  ],
-  ["scripts/e2e/openwebui-probe.mjs", ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"]],
-  [
-    "scripts/e2e/plugin-binding-command-escape-docker.sh",
-    resolveToolingTestOwnerTargets(
-      "docker-build-helper",
-      "docker-e2e-plan",
-      "package-acceptance-workflow",
-    ),
-  ],
-  ["scripts/e2e/qr-import-docker.sh", ["test/scripts/docker-build-helper.test.ts"]],
-  [
-    "scripts/e2e/release-media-memory-docker.sh",
-    ["test/scripts/docker-e2e-plan.test.ts", "test/scripts/release-media-memory-scenario.test.ts"],
-  ],
-  [
-    "scripts/plugin-prerelease-liveish-matrix.mjs",
-    ["test/scripts/plugin-prerelease-test-plan.test.ts"],
-  ],
-  ["scripts/test-projects.test-support.mjs", ["test/scripts/test-projects.test.ts"]],
-  [
-    "test/vitest/vitest.contracts-paths.mjs",
-    [
-      "test/scripts/test-projects.test.ts",
-      CONTRACTS_CHANNEL_SURFACE_VITEST_CONFIG,
-      CONTRACTS_CHANNEL_CONFIG_VITEST_CONFIG,
-      CONTRACTS_CHANNEL_REGISTRY_VITEST_CONFIG,
-      CONTRACTS_CHANNEL_SESSION_VITEST_CONFIG,
-    ],
-  ],
-  ["scripts/dev/gateway-smoke.ts", ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"]],
-  [
-    "test/e2e/qa-lab/media/hosted-media-provider-live.ts",
-    ["test/e2e/qa-lab/media/hosted-media-provider-live.test.ts"],
-  ],
-  ["scripts/write-package-dist-inventory.ts", ["test/scripts/test-install-sh-docker.test.ts"]],
-  ["scripts/e2e/cron-mcp-cleanup-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-  ["scripts/bundle-a2ui.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
-  ["scripts/build-discord-activity-sdk.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
-  ["scripts/run-node-watch-paths.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
-  [
-    "extensions/browser/scripts/build-copilot-runtime.mjs",
-    ["extensions/browser/scripts/build-copilot-runtime.test.ts"],
-  ],
-  ["extensions/canvas/scripts/bundle-a2ui.mjs", ["extensions/canvas/scripts/bundle-a2ui.test.ts"]],
-  ["extensions/canvas/scripts/copy-a2ui.mjs", ["extensions/canvas/scripts/copy-a2ui.test.ts"]],
-]);
-
 const GROUP_VISIBLE_REPLY_TEST_TARGETS = [
   "src/auto-reply/reply/dispatch-acp.test.ts",
   "src/auto-reply/reply/dispatch-from-config.test.ts",
@@ -2061,6 +680,17 @@ const SOURCE_ROOTS_FOR_IMPORT_GRAPH = [
 const IMPORTABLE_FILE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
 const IMPORT_GRAPH_GREP_PATHS = SOURCE_ROOTS_FOR_IMPORT_GRAPH.flatMap((root) =>
   IMPORTABLE_FILE_EXTENSIONS.map((ext) => `:(glob)${root}/**/*${ext}`),
+);
+const TOOLING_IMPORT_GRAPH_ROOTS = [...SOURCE_ROOTS_FOR_IMPORT_GRAPH, "scripts"];
+const TOOLING_IMPORTABLE_FILE_EXTENSIONS = [
+  ...IMPORTABLE_FILE_EXTENSIONS,
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+const TOOLING_IMPORT_GRAPH_GREP_PATHS = TOOLING_IMPORT_GRAPH_ROOTS.flatMap((root) =>
+  TOOLING_IMPORTABLE_FILE_EXTENSIONS.map((ext) => `:(glob)${root}/**/*${ext}`),
 );
 const IMPORT_SPECIFIER_PATTERN =
   /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu;
@@ -2685,7 +1315,7 @@ function isSkippedImportGraphDirectory(name) {
   return name === ".git" || name === "dist" || name === "node_modules" || name === "vendor";
 }
 
-function listImportGraphFiles(cwd, directory, files = []) {
+function listImportGraphFiles(cwd, directory, files = [], extensions = IMPORTABLE_FILE_EXTENSIONS) {
   let entries;
   try {
     entries = fs.readdirSync(path.join(cwd, directory), { withFileTypes: true });
@@ -2697,18 +1327,23 @@ function listImportGraphFiles(cwd, directory, files = []) {
     const relative = normalizePathPattern(path.posix.join(directory, entry.name));
     if (entry.isDirectory()) {
       if (!isSkippedImportGraphDirectory(entry.name)) {
-        listImportGraphFiles(cwd, relative, files);
+        listImportGraphFiles(cwd, relative, files, extensions);
       }
       continue;
     }
-    if (entry.isFile() && IMPORTABLE_FILE_EXTENSIONS.some((ext) => relative.endsWith(ext))) {
+    if (entry.isFile() && extensions.some((ext) => relative.endsWith(ext))) {
       files.push(relative);
     }
   }
   return files;
 }
 
-function resolveImportSpecifier(importer, specifier, fileSet) {
+function resolveImportSpecifier(
+  importer,
+  specifier,
+  fileSet,
+  extensions = IMPORTABLE_FILE_EXTENSIONS,
+) {
   if (!specifier.startsWith(".")) {
     return null;
   }
@@ -2721,14 +1356,12 @@ function resolveImportSpecifier(importer, specifier, fileSet) {
     candidates.push(base);
     if ([".js", ".jsx", ".mjs", ".cjs"].includes(ext)) {
       const withoutExt = base.slice(0, -ext.length);
-      candidates.push(
-        ...IMPORTABLE_FILE_EXTENSIONS.map((candidateExt) => `${withoutExt}${candidateExt}`),
-      );
+      candidates.push(...extensions.map((candidateExt) => `${withoutExt}${candidateExt}`));
     }
   } else {
     candidates.push(
-      ...IMPORTABLE_FILE_EXTENSIONS.map((candidateExt) => `${base}${candidateExt}`),
-      ...IMPORTABLE_FILE_EXTENSIONS.map((candidateExt) => `${base}/index${candidateExt}`),
+      ...extensions.map((candidateExt) => `${base}${candidateExt}`),
+      ...extensions.map((candidateExt) => `${base}/index${candidateExt}`),
     );
   }
 
@@ -2737,8 +1370,7 @@ function resolveImportSpecifier(importer, specifier, fileSet) {
 
 let cachedImportGraph = null;
 let cachedImportGraphCwd = null;
-let cachedImportGraphFiles = null;
-let cachedImportGraphFilesCwd = null;
+const cachedImportGraphFiles = new Map();
 const cachedImportGraphGrepMatches = new Map();
 const cachedDirectImporters = new Map();
 
@@ -2746,8 +1378,8 @@ function isImportableGraphFile(relative) {
   return IMPORTABLE_FILE_EXTENSIONS.some((ext) => relative.endsWith(ext));
 }
 
-function listImportGraphFilesFromGit(cwd) {
-  const result = spawnSync("git", ["ls-files", "--", ...SOURCE_ROOTS_FOR_IMPORT_GRAPH], {
+function listImportGraphFilesFromGit(cwd, roots, extensions) {
+  const result = spawnSync("git", ["ls-files", "--", ...roots], {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -2758,23 +1390,26 @@ function listImportGraphFilesFromGit(cwd) {
   return result.stdout
     .split("\n")
     .map((line) => normalizePathPattern(line.trim()))
-    .filter((line) => line.length > 0 && isImportableGraphFile(line));
+    .filter((line) => line.length > 0 && extensions.some((ext) => line.endsWith(ext)));
 }
 
-function listImportGraphFilesForCwd(cwd) {
-  if (cachedImportGraphFiles && cachedImportGraphFilesCwd === cwd) {
-    return cachedImportGraphFiles;
+function listImportGraphFilesForCwd(cwd, options = {}) {
+  const tooling = options.tooling === true;
+  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}`;
+  if (cachedImportGraphFiles.has(cacheKey)) {
+    return cachedImportGraphFiles.get(cacheKey);
   }
-
-  cachedImportGraphFiles =
-    listImportGraphFilesFromGit(cwd) ??
-    SOURCE_ROOTS_FOR_IMPORT_GRAPH.flatMap((root) => listImportGraphFiles(cwd, root));
-  cachedImportGraphFilesCwd = cwd;
-  return cachedImportGraphFiles;
+  const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  const files =
+    listImportGraphFilesFromGit(cwd, roots, extensions) ??
+    roots.flatMap((root) => listImportGraphFiles(cwd, root, [], extensions));
+  cachedImportGraphFiles.set(cacheKey, files);
+  return files;
 }
 
-function stripImportableGraphExtension(relative) {
-  for (const ext of IMPORTABLE_FILE_EXTENSIONS) {
+function stripImportableGraphExtension(relative, extensions = IMPORTABLE_FILE_EXTENSIONS) {
+  for (const ext of extensions) {
     if (relative.endsWith(ext)) {
       return relative.slice(0, -ext.length);
     }
@@ -2782,9 +1417,9 @@ function stripImportableGraphExtension(relative) {
   return relative;
 }
 
-function resolveImportGraphSearchTerms(relative) {
-  const withoutExtension = stripImportableGraphExtension(relative);
-  const basename = path.posix.basename(stripImportableGraphExtension(relative));
+function resolveImportGraphSearchTerms(relative, extensions = IMPORTABLE_FILE_EXTENSIONS) {
+  const withoutExtension = stripImportableGraphExtension(relative, extensions);
+  const basename = path.posix.basename(stripImportableGraphExtension(relative, extensions));
   if (basename === "index" || basename.length < 3) {
     return [];
   }
@@ -2800,15 +1435,23 @@ function resolveImportGraphSearchTerms(relative) {
   return [...new Set(terms)];
 }
 
-function listImportGraphGrepMatches(cwd, term) {
-  const cacheKey = `${cwd}\0${term}`;
+function listImportGraphGrepMatches(cwd, term, options = {}) {
+  const tooling = options.tooling === true;
+  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}\0${term}`;
   if (cachedImportGraphGrepMatches.has(cacheKey)) {
     return cachedImportGraphGrepMatches.get(cacheKey);
   }
 
   const result = spawnSync(
     "git",
-    ["grep", "-l", "--fixed-strings", term, "--", ...IMPORT_GRAPH_GREP_PATHS],
+    [
+      "grep",
+      "-l",
+      "--fixed-strings",
+      term,
+      "--",
+      ...(tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS),
+    ],
     {
       cwd,
       encoding: "utf8",
@@ -2826,18 +1469,26 @@ function listImportGraphGrepMatches(cwd, term) {
   const matches = result.stdout
     .split("\n")
     .map((line) => normalizePathPattern(line.trim()))
-    .filter((line) => line.length > 0 && isImportableGraphFile(line));
+    .filter(
+      (line) =>
+        line.length > 0 &&
+        (tooling
+          ? TOOLING_IMPORTABLE_FILE_EXTENSIONS.some((ext) => line.endsWith(ext))
+          : isImportableGraphFile(line)),
+    );
   cachedImportGraphGrepMatches.set(cacheKey, matches);
   return matches;
 }
 
-function findDirectImportersWithGitGrep(cwd, importedFile, fileSet) {
-  const cacheKey = `${cwd}\0${importedFile}`;
+function findDirectImportersWithGitGrep(cwd, importedFile, fileSet, options = {}) {
+  const tooling = options.tooling === true;
+  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}\0${importedFile}`;
   if (cachedDirectImporters.has(cacheKey)) {
     return cachedDirectImporters.get(cacheKey);
   }
 
-  const terms = resolveImportGraphSearchTerms(importedFile);
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  const terms = resolveImportGraphSearchTerms(importedFile, extensions);
   if (terms.length === 0) {
     cachedDirectImporters.set(cacheKey, null);
     return null;
@@ -2846,7 +1497,7 @@ function findDirectImportersWithGitGrep(cwd, importedFile, fileSet) {
   let skippedBroadTerm = false;
   const importers = [];
   for (const term of terms) {
-    const candidates = listImportGraphGrepMatches(cwd, term);
+    const candidates = listImportGraphGrepMatches(cwd, term, { tooling });
     if (!candidates) {
       cachedDirectImporters.set(cacheKey, null);
       return null;
@@ -2866,7 +1517,12 @@ function findDirectImportersWithGitGrep(cwd, importedFile, fileSet) {
         continue;
       }
       for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
-        const imported = resolveImportSpecifier(file, match[1] ?? match[2] ?? "", fileSet);
+        const imported = resolveImportSpecifier(
+          file,
+          match[1] ?? match[2] ?? "",
+          fileSet,
+          extensions,
+        );
         if (imported === importedFile) {
           importers.push(file);
           break;
@@ -2885,9 +1541,10 @@ function findDirectImportersWithGitGrep(cwd, importedFile, fileSet) {
   return result;
 }
 
-function resolveAffectedTestsFromTargetedImportScan(changedPath, cwd) {
+function resolveAffectedTestsFromTargetedImportScan(changedPath, cwd, options = {}) {
   const normalized = normalizePathPattern(changedPath);
-  const files = listImportGraphFilesForCwd(cwd);
+  const tooling = options.tooling === true;
+  const files = listImportGraphFilesForCwd(cwd, { tooling });
   const fileSet = new Set(files);
   if (!fileSet.has(normalized)) {
     return [];
@@ -2901,7 +1558,7 @@ function resolveAffectedTestsFromTargetedImportScan(changedPath, cwd) {
   const targets = [];
 
   for (const current of queue) {
-    const importers = findDirectImportersWithGitGrep(cwd, current, fileSet);
+    const importers = findDirectImportersWithGitGrep(cwd, current, fileSet, { tooling });
     if (importers === null) {
       return null;
     }
@@ -2914,7 +1571,9 @@ function resolveAffectedTestsFromTargetedImportScan(changedPath, cwd) {
         targets.push(importer);
         continue;
       }
-      queue.push(importer);
+      if (options.direct !== true) {
+        queue.push(importer);
+      }
     }
   }
 
@@ -3115,7 +1774,8 @@ function shouldKeepBroadChangedRun(changedPaths) {
 function resolveToolingChangedTestTargets(changedPaths, cwd = process.cwd()) {
   const targets = [];
   for (const changedPath of changedPaths) {
-    const testTargets = resolveToolingTestTargets(changedPath, cwd);
+    const testTargets =
+      SOURCE_TEST_TARGETS.get(changedPath) ?? resolveToolingTestTargets(changedPath, cwd);
     if (!testTargets) {
       return null;
     }
@@ -3222,6 +1882,847 @@ function resolveParallelsToolingTestTargets(changedPath) {
   return targets;
 }
 
+function resolveToolingTestOwnerTargets(...owners) {
+  return owners.map((owner) => (owner.includes("/") ? owner : `test/scripts/${owner}.test.ts`));
+}
+
+const packageAcceptance = "package-acceptance-workflow";
+const dockerBuild = "docker-build-helper";
+const dockerE2e = "docker-e2e-plan";
+const workflowGuards = "ci-workflow-guards";
+const pluginPrerelease = "plugin-prerelease-test-plan";
+const releaseCheck = "test/release-check.test.ts";
+const installDocker = "test-install-sh-docker";
+const changedScope = "src/scripts/ci-changed-scope.test.ts";
+const dockerCache = "src/docker-build-cache.test.ts";
+const dockerDigests = "src/docker-image-digests.test.ts";
+const openaiChatToolsE2e = "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts";
+const npmPostpublish = "test/openclaw-npm-postpublish-verify.test.ts";
+const crossOsReleaseChecks = "openclaw-cross-os-release-checks";
+const runNode = "src/infra/run-node.test.ts";
+const pluginSdkEntryOwners = [
+  "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
+  "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+  "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+  "src/plugins/contracts/extension-package-project-boundaries.test.ts",
+  "plugin-sdk-surface-report",
+  "build-all",
+  releaseCheck,
+  "prepare-extension-package-boundary-artifacts",
+  "ts-topology",
+  "test/vitest/vitest.tooling.config.ts",
+];
+
+// Keep only genuinely ambiguous paths explicit; conventional discovery owns
+// unambiguous scripts and direct imports without a second inventory.
+const EXACT_TOOLING_TARGETS = new Map([
+  [
+    ".github/workflows/mantis-telegram-live.yml",
+    ["mantis-telegram-desktop-proof-workflow", packageAcceptance, workflowGuards],
+  ],
+  [
+    ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
+    [packageAcceptance, workflowGuards, "release-workflow-matrix-plan", installDocker],
+  ],
+  [
+    ".github/workflows/plugin-npm-release.yml",
+    [packageAcceptance, "plugin-npm-extended-stable-workflow", workflowGuards],
+  ],
+  [".github/workflows/qa-live-transports-convex.yml", [packageAcceptance, workflowGuards]],
+  [".github/workflows/update-migration.yml", [packageAcceptance, workflowGuards]],
+  [
+    ".github/actions/setup-node-env/action.yml",
+    ["install-trufflehog", packageAcceptance, workflowGuards],
+  ],
+  [".github/actions/setup-node-env/dependency-fingerprint.mjs", [workflowGuards]],
+  [".github/actions/setup-pnpm-store-cache/action.yml", [packageAcceptance, workflowGuards]],
+  [".github/actions/setup-pnpm-store-cache/ensure-node.sh", ["setup-pnpm-store-cache-ensure-node"]],
+  ["test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts", [dockerE2e, pluginPrerelease]],
+  [
+    "scripts/e2e/lib/mcp-code-mode-probe-server.ts",
+    ["docker-e2e-seeds", "mcp-code-mode-gateway-client"],
+  ],
+  ["scripts/e2e/cron-cli-docker.sh", [dockerBuild, "docker-e2e-observability"]],
+  ["scripts/ios-release-upload.sh", ["ios-release-wrapper-args", "ios-release-fastlane-gates"]],
+  ["scripts/release-verify-beta.ts", ["release-wrapper-scripts"]],
+  ["scripts/lib/bundled-plugin-build-entries.mjs", ["bundled-plugin-build-entries", releaseCheck]],
+  ["scripts/lib/docker-e2e-package.sh", [dockerBuild]],
+  [
+    "scripts/lib/release-version.mjs",
+    [
+      "test/release-version.test.ts",
+      "test/npm-publish-plan.test.ts",
+      "test/openclaw-npm-release-check.test.ts",
+      npmPostpublish,
+      "test/plugin-npm-release.test.ts",
+      "test/plugin-clawhub-release.test.ts",
+      "android-version",
+      "android-pin-version",
+      "docker-release-policy",
+      "ios-version",
+      "openclaw-npm-extended-stable-release",
+      "openclaw-npm-publish",
+      "release-preflight",
+      "release-prepare",
+      "release-upgrade-baseline",
+      "release-version",
+      "upgrade-survivor-baselines",
+      "upgrade-survivor-config-recipe",
+    ],
+  ],
+  [
+    "scripts/lib/clawhub-bootstrap-artifact.mjs",
+    ["clawhub-bootstrap-artifact", "verify-clawhub-published-artifact"],
+  ],
+  [
+    "scripts/lib/plugin-npm-release.ts",
+    ["test/plugin-npm-release.test.ts", "test/plugin-clawhub-release.test.ts"],
+  ],
+  [
+    "scripts/lib/extension-source-classifier.mjs",
+    [
+      "extension-source-classifier",
+      "src/channels/plugins/contracts/channel-import-guardrails.test.ts",
+    ],
+  ],
+  ["scripts/run-vitest.mjs", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
+  ["scripts/docker-e2e-rerun.mjs", ["docker-e2e-helper-cli"]],
+  ["scripts/openclaw-postpack.mjs", [TOOLING_VITEST_CONFIG]],
+  ["scripts/openclaw-npm-prepublish-verify.ts", ["test/openclaw-npm-prepublish-verify.test.ts"]],
+  ["scripts/lib/docker-e2e-scenarios.mjs", [dockerE2e, pluginPrerelease]],
+  ["scripts/e2e/kitchen-sink-rpc-walk.mjs", ["kitchen-sink-rpc-walk", pluginPrerelease]],
+  [
+    "scripts/e2e/agents-delete-shared-workspace-docker.sh",
+    [dockerE2e, changedScope, "src/commands/agents.delete.test.ts"],
+  ],
+  [
+    "scripts/e2e/browser-cdp-snapshot-docker.sh",
+    [dockerBuild, "browser-cdp-snapshot", "e2e-helper-env-limits"],
+  ],
+  [
+    "scripts/e2e/config-reload-source-docker.sh",
+    [
+      dockerE2e,
+      packageAcceptance,
+      "fixture-config",
+      "e2e-mock-config-limits",
+      "src/gateway/config-reload.test.ts",
+    ],
+  ],
+  [
+    "scripts/e2e/gateway-network-docker.sh",
+    [dockerBuild, dockerE2e, packageAcceptance, "gateway-network-client", changedScope],
+  ],
+  ["scripts/e2e/npm-telegram-live-runner.ts", ["npm-telegram-live"]],
+  [
+    "scripts/e2e/upgrade-survivor-docker.sh",
+    [
+      dockerBuild,
+      dockerE2e,
+      packageAcceptance,
+      "upgrade-survivor-probe-gateway",
+      "upgrade-survivor-assertions",
+      "openclaw-test-state",
+    ],
+  ],
+  [
+    "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
+    [dockerBuild, dockerE2e, pluginPrerelease, "bundled-plugin-install-uninstall-probe"],
+  ],
+  ["scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh", ["plugin-update-unchanged-docker"]],
+  ["scripts/e2e/lib/plugin-update/probe.mjs", ["plugin-update-unchanged-docker"]],
+  ["scripts/e2e/lib/plugin-update/unchanged-scenario.sh", ["plugin-update-unchanged-docker"]],
+  [
+    "scripts/e2e/update-corrupt-plugin-docker.sh",
+    [dockerBuild, dockerE2e, packageAcceptance, "plugin-update-unchanged-docker"],
+  ],
+  ["scripts/e2e/plugins-docker.sh", [dockerBuild, dockerE2e, "plugins-assertions"]],
+  [
+    "scripts/e2e/release-user-journey-docker.sh",
+    [dockerBuild, dockerE2e, packageAcceptance, "release-user-journey-assertions"],
+  ],
+  [
+    "scripts/e2e/openai-image-auth-docker.sh",
+    [
+      dockerBuild,
+      dockerE2e,
+      "openai-image-auth-docker-client",
+      "extensions/openai/image-generation-provider.test.ts",
+    ],
+  ],
+  ["scripts/e2e/lib/openai-chat-tools/client.mjs", [openaiChatToolsE2e]],
+  [
+    "scripts/e2e/lib/openai-web-search-minimal/client.mjs",
+    ["test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts"],
+  ],
+  ["scripts/e2e/qr-import-docker.sh", [dockerBuild]],
+  ["scripts/bundle-a2ui.mjs", ["bundled-plugin-assets"]],
+]);
+
+const SEMANTIC_TOOLING_TARGET_PATTERNS = [
+  [/^scripts\/pr$/u, ["pr-merge", "pr-operation-lock", "pr-wrappers"]],
+  [/^scripts\/lib\/windows-taskkill\.mjs$/u, ["managed-child-process", "run-with-env"]],
+  [
+    /^scripts\/lib\/config-boundary-guard\.mjs$/u,
+    [
+      "src/plugins/contracts/config-boundary-guard.test.ts",
+      "src/plugins/contracts/deprecated-internal-config-api.test.ts",
+    ],
+  ],
+  [
+    /^\.github\/workflows\/ci\.yml$/u,
+    [
+      workflowGuards,
+      "changed-lanes",
+      "check-workflows",
+      "plugin-contract-test-plan",
+      pluginPrerelease,
+      "verify-pr-hosted-gates",
+    ],
+  ],
+  [
+    /^\.github\/workflows\/ci-check-testbox\.yml$/u,
+    [workflowGuards, packageAcceptance, "changed-lanes", "install-trufflehog"],
+  ],
+  [
+    /^\.github\/workflows\/ci-check-arm-testbox\.yml$/u,
+    [workflowGuards, packageAcceptance, "install-trufflehog"],
+  ],
+  [/^\.github\/workflows\/crabbox-hydrate\.yml$/u, [workflowGuards, packageAcceptance]],
+  [
+    /^\.github\/workflows\/ci-build-artifacts-testbox\.yml$/u,
+    ["install-trufflehog", packageAcceptance, workflowGuards],
+  ],
+  [
+    /^\.github\/workflows\/full-release-validation\.yml$/u,
+    ["src/dockerfile.test.ts", packageAcceptance, pluginPrerelease],
+  ],
+  [
+    /^\.github\/workflows\/openclaw-release-checks\.yml$/u,
+    [packageAcceptance, crossOsReleaseChecks, pluginPrerelease, installDocker],
+  ],
+  [/^\.github\/workflows\/docker-release\.yml$/u, ["src/dockerfile.test.ts"]],
+  [/^\.github\/workflows\/install-smoke\.yml$/u, ["install-smoke-no-push-workflow", installDocker]],
+  [/^\.github\/workflows\/openclaw-performance\.yml$/u, ["openclaw-performance-workflow"]],
+  [/^\.github\/workflows\/plugin-prerelease\.yml$/u, [pluginPrerelease]],
+  [/^\.github\/workflows\/tui-pty\.yml$/u, [packageAcceptance]],
+  [
+    /^\.github\/workflows\/openclaw-cross-os-release-checks-reusable\.yml$/u,
+    [crossOsReleaseChecks, "openclaw-cross-os-release-workflow", packageAcceptance],
+  ],
+  [
+    /^\.github\/workflows\/(?:openclaw-release-publish|package-acceptance)\.yml$/u,
+    [packageAcceptance],
+  ],
+  [
+    /^\.github\/workflows\/plugin-clawhub-new\.yml$/u,
+    [packageAcceptance, "plugin-clawhub-new-workflow"],
+  ],
+  [
+    /^\.github\/workflows\/openclaw-npm-release\.yml$/u,
+    [npmPostpublish, "openclaw-npm-extended-stable-workflow", packageAcceptance],
+  ],
+  [
+    new RegExp(
+      [
+        "^\\.github\\/workflows\\/(?:auto-response|clawsweeper-dispatch|labeler|",
+        "real-behavior-proof|stale)\\.yml$",
+      ].join(""),
+      "u",
+    ),
+    [workflowGuards],
+  ],
+  [
+    new RegExp(
+      [
+        "^\\.github\\/workflows\\/mantis-(?:discord-(?:smoke|status-reactions|",
+        "thread-attachment)|slack-desktop-smoke)\\.yml$",
+      ].join(""),
+      "u",
+    ),
+    [packageAcceptance, workflowGuards],
+  ],
+  [
+    /^\.github\/workflows\/mantis-telegram-desktop-proof\.yml$/u,
+    ["mantis-telegram-desktop-proof-workflow", packageAcceptance, workflowGuards],
+  ],
+  [
+    /^\.github\/workflows\/mantis-web-ui-chat-proof\.yml$/u,
+    ["mantis-web-ui-chat-proof-workflow", packageAcceptance, workflowGuards],
+  ],
+  [/^\.github\/workflows\/android-release\.yml$/u, [packageAcceptance, workflowGuards]],
+  [/^\.github\/actions\/setup-node-env\/verify-importers\.mjs$/u, [workflowGuards]],
+  [/^\.github\/actions\/ensure-base-commit\/action\.yml$/u, [workflowGuards]],
+  [/^tsconfig\.scripts\.json$/u, ["changed-lanes", "test-projects"]],
+  [/^scripts\/test-projects\.test-support\.mjs$/u, ["test-projects"]],
+  [/^scripts\/ci-changed-scope\.mjs$/u, [changedScope, "control-ui-i18n"]],
+  [/^scripts\/check-changed\.mjs$/u, ["changed-lanes"]],
+  [
+    new RegExp(
+      [
+        "^scripts\\/(?:generate-prompt-snapshots|prompt-snapshot-files|",
+        "sync-codex-model-prompt-fixture)\\.ts$",
+      ].join(""),
+      "u",
+    ),
+    ["prompt-snapshots"],
+  ],
+  [/^scripts\/e2e\/npm-telegram-live-docker\.sh$/u, ["npm-telegram-live"]],
+  [
+    /^scripts\/package-openclaw-for-docker\.mjs$/u,
+    ["test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts"],
+  ],
+  [/^scripts\/run-node\.mjs$/u, [runNode]],
+  [/^scripts\/pr-lib\/merge\.sh$/u, ["pr-merge"]],
+  [/^scripts\/plugin-clawhub-publish\.sh$/u, ["test/plugin-clawhub-release.test.ts"]],
+  [/^scripts\/openclaw-npm-postpublish-verify\.ts$/u, [npmPostpublish]],
+  [
+    /^scripts\/install\.ps1$/u,
+    ["install-ps1", "website-installer-sync-workflow", crossOsReleaseChecks, changedScope],
+  ],
+  [/^scripts\/crabbox-wrapper(?:-providers)?\.mjs$/u, ["crabbox-wrapper"]],
+  [
+    /^scripts\/copy-bundled-plugin-metadata\.mjs$/u,
+    ["src/plugins/copy-bundled-plugin-metadata.test.ts", runNode],
+  ],
+  [
+    /^scripts\/github\/run-openclaw-cross-os-release-checks\.sh$/u,
+    ["openclaw-cross-os-release-workflow"],
+  ],
+  [
+    /^scripts\/write-plugin-sdk-entry-dts\.ts$/u,
+    ["build-all", "prepare-extension-package-boundary-artifacts"],
+  ],
+  [/^scripts\/pr-lib\/worktree\.sh$/u, ["test/vitest/vitest.tooling.config.ts"]],
+  [/^scripts\/dev\/gateway-smoke\.ts$/u, ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"]],
+  [/^scripts\/e2e\/mock-openai-server\.mjs$/u, ["e2e-mock-config-limits"]],
+  [/^apps\/android\/scripts\/build-release-artifacts\.ts$/u, ["android-release-artifacts"]],
+  [
+    new RegExp(
+      [
+        "^scripts\\/(?:auth-monitor|mobile-reauth|setup-auth-system|",
+        "termux-(?:auth-widget|quick-auth|sync-widget))\\.sh$|",
+        "^scripts\\/systemd\\/openclaw-auth-monitor\\.(?:service|timer)$",
+      ].join(""),
+      "u",
+    ),
+    ["auth-monitor"],
+  ],
+  [/^scripts\/native-app-i18n\.ts$/u, ["native-app-i18n", workflowGuards]],
+  [
+    /^scripts\/github\/(?:dependency-guard|guard-shared)\.mjs$/u,
+    ["dependency-guard-script", "dependency-guard-workflow"],
+  ],
+  [
+    /^scripts\/github\/(?:security-sensitive-guard|guard-shared)\.mjs$/u,
+    ["security-sensitive-guard-script", "security-sensitive-guard-workflow"],
+  ],
+  [/^scripts\/plugin-clawhub-release-check\.ts$/u, ["release-wrapper-scripts"]],
+  [
+    /^scripts\/generate-runtime-sidecar-paths-baseline\.ts$/u,
+    ["src/plugins/bundled-plugin-metadata.test.ts"],
+  ],
+  [
+    /^scripts\/lib\/guard-inventory-utils\.mjs$/u,
+    [
+      "test/extension-import-boundaries.test.ts",
+      "test/plugin-extension-import-boundary.test.ts",
+      "test/architecture-smells.test.ts",
+      "test/web-provider-boundary.test.ts",
+      "test/test-helper-extension-import-boundary.test.ts",
+      "extension-import-boundary-checker",
+      "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/check-workflows\.mjs$/u,
+    ["check-composite-action-input-interpolation", "check-no-conflict-markers", workflowGuards],
+  ],
+  [/^apps\/android\/fastlane\/Fastfile$/u, ["android-release-fastlane-gates"]],
+  [/^apps\/ios\/fastlane\/Fastfile$/u, ["ios-release-fastlane-gates"]],
+  [/^scripts\/ios-release-cut\.(?:sh|ts)$/u, ["ios-release-plan"]],
+  [/^scripts\/ios-release-prepare\.sh$/u, ["ios-release-prepare", "ios-release-wrapper-args"]],
+  [
+    /^scripts\/lib\/bundled-runtime-sidecar-paths\.json$/u,
+    [
+      "src/plugins/bundled-plugin-metadata.test.ts",
+      "src/infra/update-global.test.ts",
+      "src/infra/update-runner.test.ts",
+      npmPostpublish,
+    ],
+  ],
+  [/^scripts\/lib\/android-version\.ts$/u, ["android-version", "android-pin-version"]],
+  [/^scripts\/lib\/docker-e2e-plan\.mjs$/u, [dockerE2e, "docker-all-scheduler", pluginPrerelease]],
+  [
+    new RegExp(
+      [
+        "^scripts\\/lib\\/plugin-sdk-(?:deprecated-barrel-subpaths|entrypoints|",
+        "private-local-only-subpaths)\\.json$",
+      ].join(""),
+      "u",
+    ),
+    pluginSdkEntryOwners,
+  ],
+  [
+    /^scripts\/lib\/plugin-sdk-deprecated-public-subpaths\.json$/u,
+    [
+      "check-deprecated-api-usage",
+      "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+      "plugin-sdk-surface-report",
+      "build-all",
+    ],
+  ],
+  [/^scripts\/lib\/plugin-sdk-entries\.mjs$/u, pluginSdkEntryOwners],
+  [
+    /^scripts\/lib\/official-external-channel-catalog\.json$/u,
+    [
+      "src/plugins/official-external-plugin-catalog.test.ts",
+      releaseCheck,
+      "test/official-channel-catalog.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/lib\/official-external-provider-catalog\.json$/u,
+    ["src/plugins/official-external-plugin-catalog.test.ts", releaseCheck],
+  ],
+  [
+    /^scripts\/lib\/official-external-plugin-catalog\.json$/u,
+    ["src/plugins/official-external-plugin-catalog.test.ts", releaseCheck],
+  ],
+  [
+    /^scripts\/lib\/workspace-bootstrap-smoke\.mjs$/u,
+    [releaseCheck, "test/openclaw-npm-release-check.test.ts"],
+  ],
+  [/^scripts\/lib\/extension-test-plan\.mjs$/u, ["test-extension"]],
+  [
+    /^scripts\/lib\/recommended-tool-installs\.json$/u,
+    ["src/plugins/recommended-tool-installs.test.ts", releaseCheck],
+  ],
+  [/^scripts\/docker\/install-sh-common\/version-parse\.sh$/u, [installDocker]],
+  [
+    /^scripts\/lib\/local-build-metadata(?:-paths)?\.mjs$/u,
+    [
+      "src/infra/build-stamp.test.ts",
+      "runtime-postbuild-stamp",
+      runNode,
+      "src/infra/package-dist-inventory.test.ts",
+      releaseCheck,
+      "test/openclaw-npm-release-check.test.ts",
+      "check-gateway-watch-regression",
+      "check-openclaw-package-tarball",
+      crossOsReleaseChecks,
+    ],
+  ],
+  [
+    /^scripts\/lib\/package-dist-imports\.mjs$/u,
+    [
+      "check-package-dist-imports",
+      "check-openclaw-package-tarball",
+      "postinstall-bundled-plugins",
+      releaseCheck,
+    ],
+  ],
+  [
+    /^scripts\/lib\/build-metadata\.sh$/u,
+    [
+      "src/docker-setup.e2e.test.ts",
+      "apple-release-source-check",
+      "ios-version",
+      "package-mac-app",
+      installDocker,
+    ],
+  ],
+  [/^scripts\/lib\/plistbuddy\.sh$/u, ["create-dmg", "package-mac-app", "package-mac-dist"]],
+  [/^scripts\/lib\/swift-toolchain\.sh$/u, ["package-mac-app", "package-mac-dist"]],
+  [
+    /^scripts\/lib\/npm-publish-plan\.mjs$/u,
+    [
+      "test/npm-publish-plan.test.ts",
+      "test/openclaw-npm-release-check.test.ts",
+      npmPostpublish,
+      "test/plugin-npm-release.test.ts",
+      "test/plugin-clawhub-release.test.ts",
+      "release-upgrade-baseline",
+      "android-version",
+      "ios-version",
+      "upgrade-survivor-baselines",
+      "upgrade-survivor-config-recipe",
+    ],
+  ],
+  [/^scripts\/lib\/npm-pack-budget\.mjs$/u, [releaseCheck, installDocker]],
+  [/^scripts\/lib\/actions-artifact-archive\.mjs$/u, ["plugin-publication-artifact"]],
+  [
+    /^scripts\/lib\/static-extension-assets\.mjs$/u,
+    ["bundled-plugin-assets", "runtime-postbuild", runNode, "plugin-npm-runtime-build-args"],
+  ],
+  [
+    /^scripts\/lib\/plugin-npm-runtime-build\.mjs$/u,
+    ["plugin-npm-runtime-build-args", "test/plugin-npm-runtime-build.test.ts"],
+  ],
+  [/^scripts\/lib\/run-node\.mjs$/u, [runNode]],
+  [
+    /^\.agents\/skills\/openclaw-changelog-update\/scripts\/verify-release-notes\.mjs$/u,
+    ["release-notes-ledger", "verify-release-notes"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/docker-stats\/assert-resource-ceiling\.mjs$/u,
+    ["docker-stats-resource-ceiling"],
+  ],
+  [
+    /^scripts\/e2e\/mcp-channels-docker\.sh$/u,
+    [dockerBuild, "docker-e2e-observability", dockerE2e, pluginPrerelease],
+  ],
+  [
+    /^scripts\/e2e\/cron-mcp-cleanup-docker\.sh$/u,
+    [dockerBuild, "docker-e2e-observability", dockerE2e, pluginPrerelease],
+  ],
+  [
+    /^scripts\/e2e\/mcp-code-mode-gateway-(?:live-)?docker\.sh$/u,
+    [
+      dockerBuild,
+      dockerE2e,
+      pluginPrerelease,
+      "mcp-code-mode-gateway-client",
+      "session-log-mentions",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/agent-bundle-mcp-tools-docker\.sh$/u,
+    [
+      dockerBuild,
+      dockerE2e,
+      pluginPrerelease,
+      "src/agents/agent-bundle-mcp-runtime.test.ts",
+      "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
+    ],
+  ],
+  [/^scripts\/lib\/tsgo-sparse-guard\.mjs$/u, ["run-tsgo", "changed-lanes"]],
+  [
+    new RegExp(
+      [
+        "^(?:scripts\\/materialize-clawhub-cli\\.sh|",
+        "\\.github\\/release\\/clawhub-cli\\/package(?:-lock)?\\.json)$",
+      ].join(""),
+      "u",
+    ),
+    [packageAcceptance, "plugin-clawhub-new-workflow"],
+  ],
+  [
+    /^scripts\/lib\/generated-text-asset\.mjs$/u,
+    [
+      "extensions/browser/scripts/build-copilot-runtime.test.ts",
+      "build-diffs-viewer-runtime",
+      "bundled-plugin-assets",
+    ],
+  ],
+  [/^scripts\/check-plugin-npm-runtime-builds\.mjs$/u, ["plugin-npm-runtime-build-args"]],
+  [
+    /^scripts\/install\.sh$/u,
+    [
+      "install-sh",
+      installDocker,
+      "website-installer-sync-workflow",
+      crossOsReleaseChecks,
+      changedScope,
+    ],
+  ],
+  [
+    /^scripts\/sparkle-build\.ts$/u,
+    ["test/appcast.test.ts", releaseCheck, "package-mac-app", "package-mac-dist"],
+  ],
+  [
+    /^test\/vitest\/vitest\.contracts-paths\.mjs$/u,
+    [
+      "test-projects",
+      "test/vitest/vitest.contracts-channel-surface.config.ts",
+      "test/vitest/vitest.contracts-channel-config.config.ts",
+      "test/vitest/vitest.contracts-channel-registry.config.ts",
+      "test/vitest/vitest.contracts-channel-session.config.ts",
+    ],
+  ],
+  [/^scripts\/e2e\/openai-chat-tools-docker\.sh$/u, [openaiChatToolsE2e, dockerE2e]],
+  [
+    /^scripts\/e2e\/session-runtime-context-docker\.sh$/u,
+    [
+      "docker-e2e-clients",
+      dockerE2e,
+      "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
+      "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
+    ],
+  ],
+  [
+    new RegExp(
+      [
+        "^scripts\\/e2e\\/(?!(?:commitments-safety|config-reload-source|",
+        "kitchen-sink-(?:plugin|rpc)|npm-telegram-live|onboard|openai-chat-tools|",
+        "plugin-lifecycle-matrix|release-media-memory|session-runtime-context|",
+        "update-corrupt-plugin)-docker\\.sh$).+-docker\\.sh$",
+      ].join(""),
+      "u",
+    ),
+    [dockerBuild, dockerE2e],
+  ],
+  [/^scripts\/e2e\/kitchen-sink-rpc-docker\.sh$/u, [dockerBuild, pluginPrerelease]],
+  [/^scripts\/e2e\/kitchen-sink-plugin-docker\.sh$/u, [dockerBuild, pluginPrerelease]],
+  [/^scripts\/e2e\/plugin-lifecycle-matrix-docker\.sh$/u, [dockerBuild]],
+  [
+    /^scripts\/e2e\/release-media-memory-docker\.sh$/u,
+    [dockerE2e, "release-media-memory-scenario"],
+  ],
+  [/^scripts\/e2e\/codex-media-path-docker\.sh$/u, ["codex-media-path-client"]],
+  [/^scripts\/e2e\/live-plugin-tool-docker\.sh$/u, ["live-plugin-tool-assertions"]],
+  [
+    /^scripts\/e2e\/commitments-safety-docker\.sh$/u,
+    [
+      "docker-e2e-clients",
+      dockerE2e,
+      "src/commitments/runtime.test.ts",
+      "src/commitments/store.test.ts",
+    ],
+  ],
+  [/^scripts\/e2e\/onboard-docker\.sh$/u, [dockerBuild, "openclaw-test-state"]],
+  [
+    new RegExp(
+      [
+        "^scripts\\/e2e\\/(?:codex-npm-plugin-live|config-reload-source|",
+        "gateway-network|npm-onboard-channel-agent|doctor-install-switch|",
+        "update-channel-switch|skill-install|upgrade-survivor|",
+        "update-corrupt-plugin|release-(?:plugin-marketplace|typed-onboarding|",
+        "upgrade-user-journey|user-journey)|plugin-binding-command-escape)-docker",
+        "\\.sh$",
+      ].join(""),
+      "u",
+    ),
+    [packageAcceptance],
+  ],
+  [
+    /^scripts\/e2e\/npm-onboard-channel-agent-docker\.sh$/u,
+    ["npm-onboard-channel-agent-assertions"],
+  ],
+  [/^scripts\/docker\/cleanup-smoke\/Dockerfile$/u, [dockerCache, dockerDigests, dockerBuild]],
+  [
+    /^scripts\/docker\/install-sh-(?:e2e|nonroot|smoke)\/Dockerfile$/u,
+    [dockerCache, dockerDigests, installDocker],
+  ],
+  [
+    /^scripts\/docker\/sandbox\/Dockerfile$/u,
+    [dockerCache, dockerDigests, "src/dockerfile.test.ts"],
+  ],
+  [
+    /^scripts\/docker\/sandbox\/Dockerfile\.browser$/u,
+    [dockerCache, dockerDigests, "src/agents/sandbox/browser.create.test.ts"],
+  ],
+  [/^scripts\/docker\/sandbox\/Dockerfile\.common$/u, [dockerCache]],
+  [/^scripts\/e2e\/Dockerfile$/u, [dockerCache, dockerDigests, dockerBuild, dockerE2e]],
+  [/^scripts\/e2e\/Dockerfile\.qr-import$/u, [dockerCache, dockerDigests, dockerBuild]],
+  [
+    /^scripts\/e2e\/plugin-binding-command-escape\.Dockerfile$/u,
+    [dockerDigests, dockerBuild, dockerE2e],
+  ],
+  [
+    new RegExp(
+      [
+        "^(?:scripts\\/e2e|test\\/e2e\\/qa-lab\\/runtime)\\/agent-bundle-mcp-tools-doc",
+        "ker(?:-client)?\\.(?:sh|ts)$",
+      ].join(""),
+      "u",
+    ),
+    [
+      "src/agents/agent-bundle-mcp-runtime.test.ts",
+      "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
+    ],
+  ],
+  [/^scripts\/e2e\/system-agent-(?:first-run|rescue)-docker\.sh$/u, ["docker-e2e-system-agent"]],
+  [
+    /^test\/e2e\/qa-lab\/runtime\/system-agent-first-run-docker-client\.ts$/u,
+    [
+      "docker-e2e-system-agent",
+      "src/cli/program/register.onboard.test.ts",
+      "src/cli/run-main.test.ts",
+      "src/cli/run-main.exit.test.ts",
+      "src/commands/system-agent-with-inference.test.ts",
+      "src/system-agent/assistant.configured.test.ts",
+      "src/system-agent/assistant.test.ts",
+      "src/system-agent/system-agent.test.ts",
+      "src/system-agent/operations.test.ts",
+      "src/system-agent/overview.test.ts",
+      "src/system-agent/setup-inference.test.ts",
+      "src/system-agent/audit.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/system-agent-first-run-spec\.json$/u,
+    [
+      "docker-e2e-system-agent",
+      "src/system-agent/operations.test.ts",
+      "src/system-agent/audit.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/system-agent-rescue-docker-client\.ts$/u,
+    [
+      "docker-e2e-system-agent",
+      "src/system-agent/rescue-policy.test.ts",
+      "src/system-agent/rescue-message.test.ts",
+      "src/system-agent/operations.test.ts",
+      "src/system-agent/audit.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/commitments-safety-docker(?:-client)?\.(?:sh|ts)$/u,
+    ["docker-e2e-clients", "src/commitments/runtime.test.ts", "src/commitments/store.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/session-runtime-context-docker(?:-client)?\.(?:sh|ts)$/u,
+    [
+      "docker-e2e-clients",
+      "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
+      "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
+    ],
+  ],
+  [
+    new RegExp(
+      [
+        "^(?:scripts\\/e2e\\/(?!(?:cron-mcp-cleanup-docker-client\\.ts)$)(?:agent-bu",
+        "ndle-mcp-tools|mcp-[^/]+-docker|cron-mcp-cleanup-docker|",
+        "bundled-plugin-install-uninstall|plugin-update-unchanged).+|",
+        "test\\/e2e\\/qa-lab\\/runtime\\/mcp-channels-docker-client\\.ts)$",
+      ].join(""),
+      "u",
+    ),
+    [pluginPrerelease, dockerE2e],
+  ],
+  [
+    new RegExp(
+      [
+        "^(?:scripts\\/e2e\\/mcp-code-mode-gateway-(?:docker|live-docker|",
+        "docker-client).+|scripts\\/mcp-code-mode-gateway-e2e\\.ts)$",
+      ].join(""),
+      "u",
+    ),
+    ["mcp-code-mode-gateway-client", "session-log-mentions"],
+  ],
+  [
+    /^(?:scripts\/e2e\/(?:mcp-channels|mcp-code-mode-gateway|cron-mcp-cleanup)-seed\.ts)$/u,
+    ["docker-e2e-seeds"],
+  ],
+  [
+    /^scripts\/e2e\/(?:mcp-channels|cron-cli|cron-mcp-cleanup)-docker\.sh$/u,
+    ["docker-e2e-observability"],
+  ],
+  [
+    /^scripts\/e2e\/cron-mcp-cleanup-docker-client\.ts$/u,
+    [
+      "cron-mcp-cleanup-docker-client",
+      "src/gateway/server.cron.test.ts",
+      "src/gateway/server-methods/agent.test.ts",
+      "src/cron/isolated-agent/run.fast-mode.test.ts",
+      "src/cron/active-jobs-manual-run.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/cron-mcp-cleanup-docker\.sh$/u,
+    ["cron-mcp-cleanup-docker-client", "docker-e2e-seeds"],
+  ],
+  [
+    /^test\/e2e\/qa-lab\/runtime\/mcp-channels\.fixture\.ts$/u,
+    ["test/e2e/qa-lab/runtime/mcp-gateway-transport.e2e.test.ts", "cron-mcp-cleanup-docker-client"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/auth-profile-store-assertions\.mjs$/u,
+    ["release-scenarios-assertions", "npm-onboard-channel-agent-assertions"],
+  ],
+  [
+    /^scripts\/lib\/plugin-npm-package-manifest\.mjs$/u,
+    ["plugin-npm-package-manifest-args", "test/plugin-npm-package-manifest.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/release-assertion-files\.mjs$/u,
+    ["release-scenarios-assertions", "release-user-journey-assertions"],
+  ],
+  [/^scripts\/e2e\/lib\/fixtures\/config\.mjs$/u, ["fixture-config"]],
+  [/^scripts\/e2e\/lib\/fixtures\/plugins\.mjs$/u, ["fixture-plugin-commands"]],
+  [
+    /^scripts\/e2e\/lib\/codex-app-server-fixture\.mjs$/u,
+    ["codex-media-path-client", "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/incremental-line-reader\.mjs$/u,
+    [
+      "incremental-line-reader",
+      "config-reload-log-scanner",
+      "codex-media-path-client",
+      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/lib\/fixture\.mjs$/u,
+    ["fixture-config", "fixtures-workspace", "fixture-plugin-commands"],
+  ],
+  [
+    /^test\/e2e\/qa-lab\/runtime\/openai-image-auth-docker-client\.ts$/u,
+    [
+      "openai-image-auth-docker-client",
+      "extensions/openai/image-generation-provider.test.ts",
+      "src/image-generation/openai-compatible-image-provider.test.ts",
+    ],
+  ],
+  [
+    /^test\/e2e\/qa-lab\/runtime\/codex-auth-app-server\.fixture\.mjs$/u,
+    ["test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/openai-web-search-minimal\/(?:mock-server\.mjs|scenario\.sh)$/u,
+    [
+      "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
+      "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/lib\/openwebui\/http-probe\.mjs$/u,
+    ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/(?:browser-cdp-snapshot-docker\.sh|lib\/env-limits\.mjs)$/u,
+    ["e2e-helper-env-limits"],
+  ],
+  [/^scripts\/e2e\/skill-install-docker\.sh$/u, ["e2e-shell-tempfiles"]],
+  [/^scripts\/e2e\/npm-onboard-channel-agent-docker\.sh$/u, [pluginPrerelease]],
+  [
+    /^scripts\/e2e\/lib\/clawhub-fixture-server\.cjs$/u,
+    ["clawhub-fixture-server", pluginPrerelease],
+  ],
+  [
+    /^scripts\/e2e\/lib\/codex-media-path\/jsonl-request-tail\.mjs$/u,
+    ["codex-media-path-client", "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts"],
+  ],
+  [
+    /^scripts\/e2e\/lib\/codex-npm-plugin-live\/assertions\.mjs$/u,
+    ["codex-install-assertions", dockerBuild],
+  ],
+  [
+    /^scripts\/e2e\/(?:lib\/openai-chat-tools\/scenario\.sh|openai-chat-tools-docker\.sh)$/u,
+    [openaiChatToolsE2e],
+  ],
+  [/^scripts\/e2e\/lib\/openai-chat-tools\/write-config\.mjs$/u, [openaiChatToolsE2e]],
+  [
+    /^scripts\/e2e\/openai-web-search-minimal-docker\.sh$/u,
+    [
+      "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
+      "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
+    ],
+  ],
+  [
+    /^scripts\/e2e\/openwebui-docker\.sh$/u,
+    ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts", "fixture-config"],
+  ],
+];
+function resolveSemanticToolingTargets(changedPath) {
+  return SEMANTIC_TOOLING_TARGET_PATTERNS.flatMap(([pattern, owners]) =>
+    pattern.test(changedPath) ? resolveToolingTestOwnerTargets(...owners) : [],
+  );
+}
+
 function resolveGithubYamlGuardTargets(changedPath) {
   if (/^\.github\/workflows\/[^/]+\.ya?ml$/u.test(changedPath)) {
     return GITHUB_YAML_PINNING_GUARD_TEST_TARGETS;
@@ -3232,46 +2733,108 @@ function resolveGithubYamlGuardTargets(changedPath) {
   return null;
 }
 
-function resolveGithubWorkflowOwnerTargets(changedPath) {
-  return GITHUB_WORKFLOW_OWNER_TEST_TARGETS.get(changedPath) ?? null;
+function resolveDirectToolingReferenceTests(changedPath, cwd) {
+  const normalized = normalizePathPattern(changedPath);
+  return (listImportGraphGrepMatches(cwd, normalized, { tooling: true }) ?? []).filter(
+    (file) =>
+      file !== "test/scripts/test-projects.test.ts" &&
+      !file.endsWith(".live.test.ts") &&
+      isTestFileTarget(file) &&
+      fs
+        .readFileSync(path.join(cwd, file), "utf8")
+        .match(/[A-Za-z0-9_.@+/-]{4,}/gu)
+        ?.includes(normalized),
+  );
 }
 
 function resolveToolingTestTargets(changedPath, cwd = process.cwd()) {
   if (changedPath.startsWith("test/scripts/") && isTestFileTarget(changedPath)) {
     return [changedPath];
   }
+  if (BROAD_CHANGED_FALLBACK_PATTERNS.some((pattern) => pattern.test(changedPath))) {
+    return null;
+  }
   // Declarations and implementations share the same owner; deriving the
   // sibling also covers newly added script declarations without an inventory.
   const implementationPath = changedPath.endsWith(".d.mts")
     ? changedPath.replace(/\.d\.mts$/u, ".mjs")
     : changedPath;
+  const exactOwners = EXACT_TOOLING_TARGETS.get(implementationPath);
+  if (exactOwners) {
+    return resolveToolingTestOwnerTargets(...exactOwners);
+  }
+  const semanticTargets = resolveSemanticToolingTargets(implementationPath);
+  const facts = getChangedPathFacts(changedPath);
+  const hasToolingOwner =
+    semanticTargets.length > 0 ||
+    facts.surface === "rootTooling" ||
+    changedPath === "Dockerfile" ||
+    changedPath === ".crabbox.yaml" ||
+    changedPath.startsWith(".agents/") ||
+    isToolingScriptPath(implementationPath) ||
+    (facts.surface === "app" && /\/(?:fastlane|scripts)\//u.test(changedPath)) ||
+    (facts.surface === "extension" && /\/(?:scripts\/|package\.json$)/u.test(changedPath)) ||
+    (facts.surface === "rootTest" && changedPath.startsWith("test/e2e/qa-lab/"));
+  if (!hasToolingOwner) {
+    return null;
+  }
   const crossOsReleaseTargets =
     implementationPath === "scripts/openclaw-cross-os-release-checks.ts" ||
     implementationPath.startsWith("scripts/lib/cross-os-release-checks/")
       ? ["test/scripts/openclaw-cross-os-release-checks.test.ts"]
       : null;
   const explicitTargets =
-    TOOLING_SOURCE_TEST_TARGETS.get(changedPath) ??
-    TOOLING_SOURCE_TEST_TARGETS.get(implementationPath) ??
+    (changedPath === "Dockerfile"
+      ? [
+          "src/docker-build-cache.test.ts",
+          "src/docker-image-digests.test.ts",
+          "src/dockerfile.test.ts",
+          "test/scripts/test-install-sh-docker.test.ts",
+        ]
+      : changedPath === ".crabbox.yaml"
+        ? ["test/scripts/package-acceptance-workflow.test.ts"]
+        : null) ??
     crossOsReleaseTargets ??
-    resolveUpgradeSurvivorConfigRecipeTargets(changedPath) ??
-    resolveDocsI18nBehaviorTargets(changedPath) ??
-    resolveDocsI18nGoTargets(changedPath) ??
-    resolveK8sManifestTargets(changedPath) ??
-    resolveParallelsToolingTestTargets(changedPath);
-  const githubWorkflowOwnerTargets = resolveGithubWorkflowOwnerTargets(changedPath);
-  const githubYamlGuardTargets = resolveGithubYamlGuardTargets(changedPath);
+    resolveUpgradeSurvivorConfigRecipeTargets(implementationPath) ??
+    resolveDocsI18nBehaviorTargets(implementationPath) ??
+    resolveDocsI18nGoTargets(implementationPath) ??
+    resolveK8sManifestTargets(implementationPath) ??
+    resolveParallelsToolingTestTargets(implementationPath);
+  const githubYamlGuardTargets = resolveGithubYamlGuardTargets(implementationPath);
   const conventionalTargets = resolveConventionalToolingTestTargets(implementationPath, cwd);
+  const hasDirectOwner = Boolean(
+    explicitTargets?.length ||
+    githubYamlGuardTargets?.length ||
+    semanticTargets.length ||
+    conventionalTargets?.length,
+  );
+  const importGraphResult =
+    !hasDirectOwner &&
+    TOOLING_IMPORTABLE_FILE_EXTENSIONS.some((ext) => implementationPath.endsWith(ext))
+      ? resolveAffectedTestsFromTargetedImportScan(implementationPath, cwd, {
+          tooling: true,
+          direct: true,
+        })
+      : [];
+  const importGraphTargets = importGraphResult ?? [];
+  const referenceTargets =
+    semanticTargets.length === 0 && (githubYamlGuardTargets || !hasDirectOwner)
+      ? resolveDirectToolingReferenceTests(implementationPath, cwd)
+      : [];
   const targets = [
     ...(explicitTargets ?? []),
-    ...(githubWorkflowOwnerTargets ?? []),
-    ...(githubYamlGuardTargets ?? []),
+    ...semanticTargets,
     ...(conventionalTargets ?? []),
+    ...importGraphTargets,
+    ...referenceTargets,
+    ...(githubYamlGuardTargets ?? []),
   ];
   if (targets.length > 0) {
     return uniqueOrdered(targets);
   }
-  return isToolingScriptPath(changedPath) ? [TOOLING_VITEST_CONFIG] : null;
+  return isToolingScriptPath(implementationPath) || facts.surface === "rootTooling"
+    ? [TOOLING_VITEST_CONFIG]
+    : null;
 }
 
 function shouldUseBroadChangedTargets(env = process.env) {
@@ -3326,8 +2889,8 @@ function resolveAppcastTargets(changedPath) {
 function resolvePreciseChangedTestTargets(changedPath, options) {
   const cwd = options.cwd ?? process.cwd();
   const mappedTargets =
-    resolveToolingTestTargets(changedPath) ??
     SOURCE_TEST_TARGETS.get(changedPath) ??
+    resolveToolingTestTargets(changedPath, cwd) ??
     resolveAppcastTargets(changedPath) ??
     resolvePromptSnapshotFixtureTargets(changedPath);
   if (mappedTargets) {


### PR DESCRIPTION
## Summary

- replace the duplicated workflow/tooling source ownership inventories with conventional test-name discovery, direct import discovery, and targeted path-reference discovery
- retain readable semantic/exact exceptions only for ambiguous multi-owner paths, with shared named owner families
- preserve precise ordinary-source routing and the existing changed-test target order
- preserve the full-tooling owner for packaging lifecycle hooks that cannot be safely narrowed
- remove 437 genuine tooling LOC (`1,136` additions, `1,573` deletions); no packed tables or newly introduced lines over 120 characters

## Why

The changed-test router encoded the same ownership facts in large hand-maintained maps even when test names and direct imports already described those relationships. That made new scripts and workflows require manual routing entries and let the inventory drift away from the code it represented.

This keeps one discovery path for conventional ownership while preserving readable explicit exceptions where filenames or shared helpers cannot identify a single safe owner. Repeated owner names and the shared plugin SDK contract family are factored once instead of compressing data onto oversized physical lines.

## Impact

Changed-file CI remains equally selective for all existing routes, while new conventionally named scripts and direct tooling imports can resolve without growing the ownership matrix.

## Validation

- `node --check scripts/test-projects.test-support.mjs`
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts --reporter=dot` — 260 passed ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/30705275482))
- exhaustive old/new ownership comparison against current `main` — 411 paths, zero missing or reordered routes, 967 selected targets before and after; includes newly landed docs/package scripts, declarations, workflows, and full-tooling postpack coverage
- `node scripts/check-changed.mjs -- scripts/test-projects.test-support.mjs` — passed ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/30705407603))
- autoreview (`gpt-5.6-sol`, xhigh) — clean, no accepted/actionable findings
