### PR TITLE
fix(cli): show live probe failures in health output

### DIFF
--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import type { HealthSummary } from "../gateway/health/types.js";
+import { formatHealthChannelLines } from "./health-format.js";
+
+const createHealthSummary = (
+  params: Pick<HealthSummary, "channels" | "channelOrder" | "channelLabels">,
+): HealthSummary => ({
+  ok: true,
+  ts: 0,
+  durationMs: 0,
+  heartbeatSeconds: 60,
+  defaultAgentId: "main",
+  agents: [],
+  sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+  ...params,
+});
+
+describe("formatHealthChannelLines", () => {
+  it("formats per-account probe timings", () => {
+    const summary = createHealthSummary({
+      channels: {
+        telegram: {
+          accountId: "main",
+          configured: true,
+          probe: { ok: true, elapsedMs: 196, bot: { username: "pinguini_ugi_bot" } },
+          accounts: {
+            main: {
+              accountId: "main",
+              configured: true,
+              probe: { ok: true, elapsedMs: 196, bot: { username: "pinguini_ugi_bot" } },
+            },
+            flurry: {
+              accountId: "flurry",
+              configured: true,
+              probe: { ok: true, elapsedMs: 190, bot: { username: "flurry_ugi_bot" } },
+            },
+            poe: {
+              accountId: "poe",
+              configured: true,
+              probe: { ok: true, elapsedMs: 188, bot: { username: "poe_ugi_bot" } },
+            },
+          },
+        },
+      },
+      channelOrder: ["telegram"],
+      channelLabels: { telegram: "Telegram" },
+    });
+
+    expect(formatHealthChannelLines(summary, { accountMode: "all" })).toStrictEqual([
+      "Telegram: ok (@pinguini_ugi_bot:main:196ms, @flurry_ugi_bot:flurry:190ms, @poe_ugi_bot:poe:188ms)",
+    ]);
+  });
+
+  it("formats statusState without inferring from linked", () => {
+    const summary = createHealthSummary({
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          statusState: "unstable",
+          configured: true,
+        },
+      },
+      channelOrder: ["whatsapp"],
+      channelLabels: { whatsapp: "WhatsApp" },
+    });
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual(["WhatsApp: auth stabilizing"]);
+  });
+
+  it.each([
+    [
+      "fresh probe failure over passive healthy state",
+      { healthState: "healthy", probe: { ok: false, error: "sync rejected" } },
+      "failed (unknown) - sync rejected",
+    ],
+    [
+      "fresh probe success over passive healthy state",
+      { healthState: "healthy", probe: { ok: true, elapsedMs: 12 } },
+      "ok (12ms)",
+    ],
+    [
+      "blocked lifecycle over a failed probe",
+      { linked: true, healthState: "blocked", probe: { ok: false, error: "sync rejected" } },
+      "blocked",
+    ],
+    [
+      "unknown degraded lifecycle over a successful probe",
+      { healthState: "degraded", probe: { ok: true, elapsedMs: 12 } },
+      "degraded",
+    ],
+    [
+      "unstable authentication over passive healthy state and a failed probe",
+      {
+        healthState: "healthy",
+        statusState: "unstable",
+        probe: { ok: false, error: "sync rejected" },
+      },
+      "auth stabilizing",
+    ],
+    [
+      "disabled status over stale passive healthy state",
+      { healthState: "healthy", statusState: "disabled" },
+      "disabled",
+    ],
+    [
+      "unconfigured account over stale lifecycle and authentication state",
+      { configured: false, healthState: "blocked", statusState: "unstable" },
+      "not configured",
+    ],
+    [
+      "fresh probe failure over configured status",
+      { statusState: "configured", probe: { ok: false, error: "credentials rejected" } },
+      "failed (unknown) - credentials rejected",
+    ],
+    [
+      "fresh probe failure over affirmative linked state",
+      { linked: true, probe: { ok: false, error: "session rejected" } },
+      "failed (unknown) - session rejected",
+    ],
+    [
+      "negative linked state over a failed probe",
+      { linked: false, probe: { ok: false, error: "session rejected" } },
+      "not linked",
+    ],
+    ["passive healthy state without a probe", { healthState: "healthy" }, "healthy"],
+  ])("formats %s", (_name, account, expected) => {
+    const summary = createHealthSummary({
+      channels: {
+        test: {
+          accountId: "default",
+          configured: true,
+          ...account,
+        },
+      },
+      channelOrder: ["test"],
+      channelLabels: { test: "Test" },
+    });
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([`Test: ${expected}`]);
+  });
+
+  it("surfaces a failed sibling probe over the selected account's passive healthy state", () => {
+    const summary = createHealthSummary({
+      channels: {
+        matrix: {
+          accountId: "main",
+          configured: true,
+          healthState: "healthy",
+          probe: { ok: true, elapsedMs: 12 },
+          accounts: {
+            main: {
+              accountId: "main",
+              configured: true,
+              healthState: "healthy",
+              probe: { ok: true, elapsedMs: 12 },
+            },
+            alerts: {
+              accountId: "alerts",
+              configured: true,
+              healthState: "healthy",
+              probe: { ok: false, error: "sync rejected" },
+            },
+          },
+        },
+      },
+      channelOrder: ["matrix"],
+      channelLabels: { matrix: "Matrix" },
+    });
+
+    expect(formatHealthChannelLines(summary, { accountMode: "all" })).toStrictEqual([
+      "Matrix: failed (unknown) - sync rejected",
+    ]);
+  });
+
+  it("formats iMessage probe failures as failed health lines", () => {
+    const summary = createHealthSummary({
+      channels: {
+        imessage: {
+          accountId: "default",
+          configured: true,
+          probe: {
+            ok: false,
+            error:
+              "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
+          },
+        },
+      },
+      channelOrder: ["imessage"],
+      channelLabels: { imessage: "iMessage" },
+    });
+
+    expect(formatHealthChannelLines(summary)).toContain(
+      "iMessage: failed (unknown) - imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
+    );
+  });
+});

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -186,40 +186,32 @@ export const formatHealthChannelLines = (
       : [];
     const statusState =
       typeof selectedSummary.statusState === "string" ? selectedSummary.statusState : null;
-    const healthState = selectedSummary.healthState;
-    if (typeof healthState === "string" && healthState) {
-      lines.push(`${label}: ${healthState}`);
-      continue;
-    }
-    if (statusState) {
-      if (statusState === "linked") {
-        const authAgeMs =
-          typeof selectedSummary.authAgeMs === "number" ? selectedSummary.authAgeMs : null;
-        const authLabel = authAgeMs != null ? ` (auth age ${Math.round(authAgeMs / 60000)}m)` : "";
-        lines.push(`${label}: ${formatChannelStatusState(statusState)}${authLabel}`);
-      } else {
-        lines.push(`${label}: ${formatChannelStatusState(statusState)}`);
-      }
-      continue;
-    }
-
+    const healthState =
+      typeof selectedSummary.healthState === "string" && selectedSummary.healthState
+        ? selectedSummary.healthState
+        : null;
     const linked = typeof selectedSummary.linked === "boolean" ? selectedSummary.linked : null;
-    if (linked !== null) {
-      if (linked) {
-        const authAgeMs =
-          typeof selectedSummary.authAgeMs === "number" ? selectedSummary.authAgeMs : null;
-        const authLabel = authAgeMs != null ? ` (auth age ${Math.round(authAgeMs / 60000)}m)` : "";
-        lines.push(`${label}: linked${authLabel}`);
-      } else {
-        lines.push(`${label}: not linked`);
-      }
-      continue;
-    }
-
     const configured =
       typeof selectedSummary.configured === "boolean" ? selectedSummary.configured : null;
-    if (configured === false) {
-      lines.push(`${label}: not configured`);
+    const inactiveState =
+      statusState === "disabled" || statusState === "unconfigured"
+        ? formatChannelStatusState(statusState)
+        : configured === false
+          ? "not configured"
+          : null;
+    // Explicit inactive/degraded facts outrank probes; passive success waits until after them.
+    // Otherwise a live probe can be hidden behind stale "healthy", "linked", or "configured".
+    const preProbeState = inactiveState
+      ? inactiveState
+      : healthState && healthState !== "healthy"
+        ? healthState
+        : statusState && statusState !== "linked" && statusState !== "configured"
+          ? formatChannelStatusState(statusState)
+          : linked === false
+            ? "not linked"
+            : null;
+    if (preProbeState) {
+      lines.push(`${label}: ${preProbeState}`);
       continue;
     }
 
@@ -251,11 +243,19 @@ export const formatHealthChannelLines = (
       continue;
     }
 
-    if (configured === true) {
-      lines.push(`${label}: configured`);
-      continue;
-    }
-    lines.push(`${label}: unknown`);
+    const authAgeMs =
+      typeof selectedSummary.authAgeMs === "number" ? selectedSummary.authAgeMs : null;
+    const authLabel = authAgeMs != null ? ` (auth age ${Math.round(authAgeMs / 60000)}m)` : "";
+    const passiveState = healthState
+      ? healthState
+      : statusState
+        ? `${formatChannelStatusState(statusState)}${statusState === "linked" ? authLabel : ""}`
+        : linked === true
+          ? `linked${authLabel}`
+          : configured === true
+            ? "configured"
+            : "unknown";
+    lines.push(`${label}: ${passiveState}`);
   }
   return lines;
 };

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -12,7 +12,6 @@ import {
   formatConfigReloadHealthLine,
   formatContextEngineHealthLine,
   formatDeliveryQueueHealthLine,
-  formatHealthChannelLines,
   healthCommand,
 } from "./health.js";
 
@@ -504,100 +503,6 @@ describe("healthCommand", () => {
       [GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE],
     ]);
     expect(runtime.error).not.toHaveBeenCalled();
-  });
-
-  it("formats per-account probe timings", () => {
-    const summary = createHealthSummary({
-      channels: {
-        telegram: {
-          accountId: "main",
-          configured: true,
-          probe: { ok: true, elapsedMs: 196, bot: { username: "pinguini_ugi_bot" } },
-          accounts: {
-            main: {
-              accountId: "main",
-              configured: true,
-              probe: { ok: true, elapsedMs: 196, bot: { username: "pinguini_ugi_bot" } },
-            },
-            flurry: {
-              accountId: "flurry",
-              configured: true,
-              probe: { ok: true, elapsedMs: 190, bot: { username: "flurry_ugi_bot" } },
-            },
-            poe: {
-              accountId: "poe",
-              configured: true,
-              probe: { ok: true, elapsedMs: 188, bot: { username: "poe_ugi_bot" } },
-            },
-          },
-        },
-      },
-      channelOrder: ["telegram"],
-      channelLabels: { telegram: "Telegram" },
-    });
-
-    const lines = formatHealthChannelLines(summary, { accountMode: "all" });
-    expect(lines).toStrictEqual([
-      "Telegram: ok (@pinguini_ugi_bot:main:196ms, @flurry_ugi_bot:flurry:190ms, @poe_ugi_bot:poe:188ms)",
-    ]);
-  });
-
-  it("formats statusState without inferring from linked", () => {
-    const summary = createHealthSummary({
-      channels: {
-        whatsapp: {
-          accountId: "default",
-          statusState: "unstable",
-          configured: true,
-        },
-      },
-      channelOrder: ["whatsapp"],
-      channelLabels: { whatsapp: "WhatsApp" },
-    });
-
-    const lines = formatHealthChannelLines(summary, { accountMode: "default" });
-    expect(lines).toStrictEqual(["WhatsApp: auth stabilizing"]);
-  });
-
-  it("formats derived channel health before linked state", () => {
-    const summary = createHealthSummary({
-      channels: {
-        slack: {
-          accountId: "default",
-          configured: true,
-          linked: true,
-          lifecycle: "blocked",
-          healthState: "blocked",
-        },
-      },
-      channelOrder: ["slack"],
-      channelLabels: { slack: "Slack" },
-    });
-
-    expect(formatHealthChannelLines(summary)).toStrictEqual(["Slack: blocked"]);
-  });
-
-  it("formats iMessage probe failures as failed health lines", () => {
-    const summary = createHealthSummary({
-      channels: {
-        imessage: {
-          accountId: "default",
-          configured: true,
-          probe: {
-            ok: false,
-            error:
-              "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
-          },
-        },
-      },
-      channelOrder: ["imessage"],
-      channelLabels: { imessage: "iMessage" },
-    });
-
-    const lines = formatHealthChannelLines(summary, { accountMode: "default" });
-    expect(lines).toContain(
-      "iMessage: failed (unknown) - imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
-    );
   });
 });
 


### PR DESCRIPTION
Closes #117409

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where operators running `openclaw health --verbose` or `openclaw status --deep` could see a channel reported as healthy, configured, or linked even though the fresh active probe in the same Gateway snapshot failed. The same precedence bug hid a failed sibling account behind the selected account's passive healthy state.

Matrix exposes the regression directly: its sync monitor records `healthState: "healthy"` independently from its account probe. SMS and Zalouser exposed the older sibling cases through `statusState: "configured"` and `linked: true`.

## Why This Change Was Made

The shared health-text formatter now orders facts by meaning instead of field position:

1. Explicitly inactive, unconfigured, degraded, blocked, unlinked, or unstable-auth facts remain authoritative.
2. Fresh probe failures and successes outrank only passive affirmative states.
3. Healthy, linked, and configured values remain fallbacks when no live probe result exists.

Raw health JSON still records lifecycle and probe facts independently. This does not change probe execution, caching, protocol, configuration, persistence, or Plugin SDK contracts. Formatter tests moved into a dedicated module, shrinking the broader health-command test file from 743 to 648 lines.

## User Impact

Verbose health and deep status now show the actionable live probe result instead of a stale/passive success label. Channel-specific failure states such as `blocked`, `logged-out`, `conflict`, and `auth stabilizing` remain visible, and ordinary non-probed output remains unchanged.

## Evidence

- Current-main reproduction: 7 new precedence cases failed while 32 controls passed. Observed examples were `Matrix: healthy`, `SMS: configured`, and `Zalo User: linked` instead of their distinct fresh probe errors.
- Focused and sibling tests: 65/65 passed locally and 65/65 passed on Blacksmith Testbox `tbx_01kyynm65xf29bsg18s28xmm03` ([run 30700284352](https://github.com/openclaw/openclaw/actions/runs/30700284352)).
- Scoped changed gate: fully green on the same Testbox, including core production/test types, changed-file lint/format, import cycles, dead-code scans, API/boundary/dependency guards, and database-first checks.
- Full `pnpm build`: green on the same Testbox.
- Built CLI black-box proof: `dist/entry.js health --verbose` sent `{"probe":true}`, exited 0 with empty stderr, and rendered five fixture-sensitive outcomes:

  ```text
  Matrix: failed (unknown) - sync rejected
  SMS: failed (unknown) - credentials rejected
  Zalo User: failed (unknown) - session rejected
  Slack: blocked
  WhatsApp: auth stabilizing
  ```

- Source-blind behavior validation: all five contract clauses and the varied-fixture anti-cheat check passed.
- Fresh Codex autoreview: clean, no P0/P1 findings, overall patch-correct confidence 0.96.
- Production delta: line-neutral (`+36/-36`); total PR delta `+232/-131` across three files.

Regression provenance: #117300 added the unconditional `healthState` early return while preserving authored lifecycle facts. This repair keeps that ownership decision and corrects only the text projection precedence.
