### PR TITLE
fix(google): enforce terminal video generation ownership

### DIFF
--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -1,4 +1,5 @@
 // Google tests cover video generation provider plugin behavior.
+import * as mediaRuntime from "openclaw/plugin-sdk/media-runtime";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -244,19 +245,22 @@ describe("google video generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    const videoBytes = Buffer.from("too-large").toString("base64");
     generateVideosMock.mockResolvedValue({
       done: true,
       response: {
         generatedVideos: [
           {
             video: {
-              videoBytes: Buffer.from("too-large").toString("base64"),
+              videoBytes,
               mimeType: "video/mp4",
             },
           },
         ],
       },
     });
+    const canonicalizeBase64 = vi.spyOn(mediaRuntime, "canonicalizeBase64");
+    const decodeBase64 = vi.spyOn(Buffer, "from");
 
     const provider = buildGoogleVideoGenerationProvider();
     await expect(
@@ -268,6 +272,39 @@ describe("google video generation provider", () => {
         durationSeconds: 3,
       }),
     ).rejects.toThrow("Google generated video download exceeds 1 bytes");
+    expect(canonicalizeBase64).not.toHaveBeenCalled();
+    expect(decodeBase64).not.toHaveBeenCalledWith(videoBytes, "base64");
+  });
+
+  it("accepts inline video bytes exactly at the configured media cap", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              videoBytes: Buffer.from("a").toString("base64"),
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await buildGoogleVideoGenerationProvider().generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "One-byte video fixture",
+      cfg: { agents: { defaults: { mediaMaxMb: 0.000001 } } },
+      durationSeconds: 4,
+    });
+
+    expect(result.videos[0]?.buffer).toEqual(Buffer.from("a"));
   });
 
   it.each([
@@ -597,6 +634,100 @@ describe("google video generation provider", () => {
       }),
     ).rejects.toThrow("Google generated video download exceeds 1 bytes");
     expect(downloadMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "an explicit safety-filter reason",
+      response: {
+        generatedVideos: [],
+        raiMediaFilteredCount: 1,
+        raiMediaFilteredReasons: ["SAFETY"],
+      },
+      error: "Google video generation response missing generated videos: safety filter (SAFETY)",
+    },
+    {
+      name: "a safety-filter count without a reason",
+      response: { generatedVideos: [], raiMediaFilteredCount: 2 },
+      error: "Google video generation response missing generated videos: safety filter (2 videos)",
+    },
+    {
+      name: "blank safety reasons and one filtered video",
+      response: {
+        generatedVideos: [],
+        raiMediaFilteredCount: 1,
+        raiMediaFilteredReasons: ["  "],
+      },
+      error: "Google video generation response missing generated videos: safety filter (1 video)",
+    },
+    {
+      name: "a safety reason after blank entries",
+      response: {
+        generatedVideos: [],
+        raiMediaFilteredReasons: ["  ", "  PERSON_GENERATION  "],
+      },
+      error:
+        "Google video generation response missing generated videos: safety filter (PERSON_GENERATION)",
+    },
+    {
+      name: "an otherwise empty completed response",
+      response: { generatedVideos: [] },
+      error: "Google video generation response missing generated videos",
+    },
+  ])("never starts a second paid generation after $name", async ({ response, error }) => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      name: "operations/completed-once",
+      response,
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            done: true,
+            response: {
+              generateVideoResponse: {
+                generatedSamples: [
+                  {
+                    video: {
+                      videoBytes: Buffer.from("unwanted-second-generation").toString("base64"),
+                      mimeType: "video/mp4",
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const outcome = await buildGoogleVideoGenerationProvider()
+      .generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "Do not repeat a completed paid video generation.",
+        cfg: {},
+        durationSeconds: 4,
+      })
+      .then(
+        () => ({ status: "fulfilled" as const }),
+        (cause: unknown) => ({
+          status: "rejected" as const,
+          message: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(generateVideosMock).toHaveBeenCalledTimes(1);
+    expect(getVideosOperationMock).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "rejected", message: error });
   });
 
   it("falls back to REST predictLongRunning when text-only SDK video generation returns 404", async () => {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -1,6 +1,6 @@
 // Google provider module implements model/runtime integration.
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
-import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "openclaw/plugin-sdk/media-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   createProviderOperationDeadline,
@@ -12,7 +12,6 @@ import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtim
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
-  GeneratedVideoAsset,
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
@@ -37,12 +36,6 @@ const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
   return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
-}
-
-function assertGeneratedVideoBufferWithinLimit(buffer: Buffer, maxBytes: number): void {
-  if (buffer.length > maxBytes) {
-    throw new Error(`Google generated video download exceeds ${maxBytes} bytes`);
-  }
 }
 
 function resolveGoogleVideoRestBaseUrl(configuredBaseUrl?: string): string {
@@ -219,7 +212,7 @@ async function downloadGeneratedVideoFromUri(params: {
   index: number;
   maxBytes: number;
   timeoutMs: number;
-}): Promise<GeneratedVideoAsset | undefined> {
+}) {
   const downloadUrl = resolveGoogleGeneratedVideoDownloadUrl({
     uri: params.uri,
     apiKey: params.apiKey,
@@ -540,25 +533,29 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
         }
         operation = sdkOperation;
       }
-      const finalOperation = operation as { error?: unknown; name?: string };
+      const finalOperation = operation as Awaited<
+        ReturnType<GoogleGenAIClient["models"]["generateVideos"]>
+      >;
       if (finalOperation.error) {
         throw new Error(JSON.stringify(finalOperation.error));
       }
-      let generatedVideos = extractGeneratedVideos(operation);
-      if (generatedVideos.length === 0 && !hasReferenceInputs && !usedRestFallback) {
-        operation = await generateGoogleVideoViaRest({
-          baseUrl: restBaseUrl,
-          headers: authHeaders,
-          deadline,
-          model,
-          prompt: req.prompt,
-          durationSeconds,
-          aspectRatio,
-          resolution,
-        });
-        generatedVideos = extractGeneratedVideos(operation);
-      }
+      const generatedVideos = extractGeneratedVideos(operation);
       if (generatedVideos.length === 0) {
+        const filteredReason = finalOperation.response?.raiMediaFilteredReasons
+          ?.map((reason) => normalizeOptionalString(reason))
+          .find((reason) => reason !== undefined);
+        const filteredCount = finalOperation.response?.raiMediaFilteredCount;
+        if (filteredReason) {
+          throw new Error(
+            `${GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE}: safety filter (${filteredReason})`,
+          );
+        }
+        if (typeof filteredCount === "number" && filteredCount > 0) {
+          const filteredLabel = filteredCount === 1 ? "video" : "videos";
+          throw new Error(
+            `${GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE}: safety filter (${filteredCount} ${filteredLabel})`,
+          );
+        }
         throw new Error(GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE);
       }
       const maxVideoBytes = resolveGeneratedMediaMaxBytes(req.cfg, "video");
@@ -568,12 +565,14 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
             | { videoBytes?: string; uri?: string; mimeType?: string }
             | undefined;
           if (inline?.videoBytes) {
+            if (estimateBase64DecodedBytes(inline.videoBytes) > maxVideoBytes) {
+              throw new Error(`Google generated video download exceeds ${maxVideoBytes} bytes`);
+            }
             const canonicalVideo = canonicalizeBase64(inline.videoBytes);
             if (!canonicalVideo) {
               throw new Error("Google video generation returned malformed base64 video data");
             }
             const buffer = Buffer.from(canonicalVideo, "base64");
-            assertGeneratedVideoBufferWithinLimit(buffer, maxVideoBytes);
             return {
               buffer,
               mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",


### PR DESCRIPTION
## What Problem This Solves

Google video generation had two independent defects in the same provider owner:

1. Inline provider-returned video was canonicalized and fully decoded into a `Buffer` before the configured generated-media byte limit was checked. A large response could therefore allocate both a cleaned base64 copy and the complete decoded video before eventually failing.
2. A successfully completed Google SDK operation with no generated videos triggered a new `predictLongRunning` creation request. Google's SDK explicitly represents valid terminal safety-filtered responses through `raiMediaFilteredCount` and `raiMediaFilteredReasons`, so those results incorrectly started a second paid generation and discarded the operator-visible filtering reason.

Both behaviors are present in shipped releases. The initial SDK `404` fallback is different: it happens before a generation operation is created and remains supported.

## Why This Change Was Made

The Google video provider owns both media allocation and the lifecycle of its generation operations. Its inline-media path now uses the existing allocation-free public base64-size estimator before canonicalization or decoding, retaining the exact configured limit and the existing malformed-base64 error.

A completed SDK operation is now treated as authoritative and terminal. Explicit safety reasons, blank-reason/count fallbacks, and singular/plural filtered counts are surfaced to the operator; an unexplained empty response retains its existing error. The obsolete second-creation fallback and its post-allocation size-check helper are deleted, while the legitimate pre-creation `404` fallback and bounded URI/file downloads remain unchanged.

The production refactor is net-negative by one line and adds no configuration, authentication, SDK, dependency, protocol, migration, or compatibility surface.

## User Impact

Google Veo users no longer allocate oversized generated videos before rejecting them, and a completed safety-filtered or empty generation no longer silently triggers another potentially billable request. Safety-filter explanations are visible, exact-size valid videos still succeed, and existing SDK-`404` recovery and media downloads continue to work.

## Evidence

- Installed official `@google/genai@2.13.0` SDK types define `done: true` as a completed operation and explicitly expose terminal `raiMediaFilteredCount` and `raiMediaFilteredReasons`; the installed MLDev and Vertex response transformers preserve those fields.
- Baseline reproduction produced **four genuine failures**: the oversized-media regression observed `canonicalizeBase64` running before rejection, and three terminal SDK outcomes each issued a production-path `POST` to `/v1beta/models/veo-3.1-fast-generate-preview:predictLongRunning`. Six existing compatibility cases passed.
- `node scripts/run-vitest.mjs extensions/google/video-generation-provider.test.ts` — **26 passed**.
- Regression coverage proves the canonicalizer and base64 decoder are never called for oversized media, validates exact-limit success and malformed input, and covers explicit, trimmed, blank, singular, plural, and absent safety-filter explanations with **zero second-generation fetches**.
- Existing owner tests still prove the supported initial SDK-`404` REST generation fallback, reference-input `404` rejection, bounded remote downloads, transient polling, and operation handling.
- Configured type-aware extensions lint, targeted formatting, and `git diff HEAD^ HEAD --check` all pass.
- A fresh immutable-commit hostile review reported no actionable P0–P3 findings; the campaign root tracks additional independent reviews.
- Genuine exclusive `gpt-5.6-sol` / `high` autoreview through P3 passed with **zero findings** and **0.98 confidence**; real TruffleHog **3.96.0** passed.
- The exact owner and test files are unchanged between the original candidate base and the latest verified canonical main; read-only merge analysis reports no conflicts.
- No live external Google API was contacted or claimed; the proof combines the installed authoritative SDK contract, allocation spies, and the actual production fetch path under an isolated test stub.
