### PR TITLE
fix(plugins): reject duplicate marketplace plugin identities

### DIFF
--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -305,6 +305,107 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it.each(["frontend-design", " frontend-design "])(
+    "rejects duplicate normalized marketplace plugin names when listing (%j)",
+    async (duplicateName) => {
+      await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
+        const manifestPath = await writeMarketplaceManifest(rootDir, {
+          plugins: [
+            { name: "frontend-design", source: "./plugins/shadow" },
+            { name: duplicateName, source: "./plugins/intended" },
+          ],
+        });
+
+        await expect(listMarketplacePlugins({ marketplace: rootDir })).resolves.toEqual({
+          ok: false,
+          error: `invalid marketplace entry "frontend-design" in ${manifestPath}: duplicate plugin name`,
+        });
+        expect(installPluginFromPathMock).not.toHaveBeenCalled();
+        expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+        expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("rejects ambiguous marketplace plugin installs before resolving either source", async () => {
+    await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
+      const shadowDir = path.join(rootDir, "plugins", "shadow");
+      const manifestPath = await writeLocalMarketplaceFixture({
+        rootDir,
+        pluginDir: shadowDir,
+        manifest: {
+          plugins: [
+            { name: "frontend-design", source: "./plugins/shadow" },
+            { name: " frontend-design ", source: "./plugins/intended" },
+          ],
+        },
+      });
+      installPluginFromPathMock.mockResolvedValue({
+        ok: true,
+        pluginId: "frontend-design",
+        targetDir: "/tmp/frontend-design",
+        extensions: ["index.ts"],
+      });
+
+      await expect(
+        installPluginFromMarketplace({ marketplace: manifestPath, plugin: "frontend-design" }),
+      ).resolves.toEqual({
+        ok: false,
+        error: `invalid marketplace entry "frontend-design" in ${manifestPath}: duplicate plugin name`,
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves distinct case-sensitive marketplace plugin names", async () => {
+    await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
+      await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          { name: "Calendar", source: "./plugins/upper" },
+          { name: "calendar", source: "./plugins/lower" },
+        ],
+      });
+
+      const result = await listMarketplacePlugins({ marketplace: rootDir });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.manifest.plugins.map((plugin) => plugin.name)).toEqual([
+          "Calendar",
+          "calendar",
+        ]);
+      }
+    });
+  });
+
+  it("rejects duplicate remote marketplace names before resolving plugin sources", async () => {
+    mockRemoteMarketplaceClone({
+      pluginDir: path.join("plugins", "shadow"),
+      manifest: {
+        plugins: [
+          { name: "frontend-design", source: "./plugins/shadow" },
+          { name: " frontend-design ", source: "./plugins/intended" },
+        ],
+      },
+    });
+
+    const result = await installPluginFromMarketplace({
+      marketplace: "owner/repo",
+      plugin: "frontend-design",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('invalid marketplace entry "frontend-design"');
+      expect(result.error).toContain("duplicate plugin name");
+    }
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    expect(installPluginFromPathMock).not.toHaveBeenCalled();
+  });
+
   it("rejects oversized local marketplace manifests", async () => {
     await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
       const manifestPath = path.join(rootDir, ".claude-plugin", "marketplace.json");

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -376,6 +376,7 @@ function parseMarketplaceManifest(
   }
 
   const plugins: MarketplacePluginEntry[] = [];
+  const pluginNames = new Set<string>();
   for (const entry of rec.plugins) {
     if (!entry || typeof entry !== "object") {
       return { ok: false, error: `invalid marketplace entry in ${sourceLabel}: expected object` };
@@ -385,6 +386,14 @@ function parseMarketplaceManifest(
     if (!name) {
       return { ok: false, error: `invalid marketplace entry in ${sourceLabel}: missing name` };
     }
+    // Marketplace names select install sources; duplicates would silently run the first entry.
+    if (pluginNames.has(name)) {
+      return {
+        ok: false,
+        error: `invalid marketplace entry "${name}" in ${sourceLabel}: duplicate plugin name`,
+      };
+    }
+    pluginNames.add(name);
     const normalizedSource = normalizeEntrySource(plugin.source);
     if (!normalizedSource.ok) {
       return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a named plugin from a marketplace could silently install the wrong plugin source when the marketplace contained multiple entries with the same normalized plugin name. Listing also presented those conflicting entries as indistinguishable plugin identities.

## Why This Change Was Made

Marketplace names are the authoritative install selectors. The canonical marketplace manifest parser now rejects repeated exact-case names after existing whitespace normalization and before either entry's source is resolved, so the same identity rule protects local and remote listing and installation without changing source trust, remote-path restrictions, or case-sensitive names.

## User Impact

Operators receive an actionable duplicate-name error instead of installing whichever conflicting plugin appears first. Normal marketplaces continue working, including distinct case-sensitive plugin names and existing local, remote, archive, SSRF, and installation-policy behavior.

## Evidence

- Tests-first baseline: four focused regressions failed against unchanged production code, including successful wrong-source installation and whitespace-normalized duplicate listings.
- Full existing marketplace owner suite: 36/36 passing after the canonical parser fix, including remote cleanup, source restrictions, SSRF protection, and case-sensitive identities.
- Actual source-blind proof imported the real marketplace implementation without module mocks; both listing and installation rejected duplicates before missing local/Git source resolution, left the manifest unchanged, and preserved `Calendar` plus `calendar`.
- Formatting, `git diff --check`, and the configured type-aware oxlint policy passed for both changed files.
- Four independent hostile P0–P3 reviews were clean: plugin-discovery reviewer .997, plugin-facade reviewer .995, independent Bedrock/OpenRouter reviewer HIGH, and parent reviewer .989.
- A genuine official `gpt-5.6-sol` high-reasoning autoreview with `--max-priority P3` and real TruffleHog 3.96.0 found no actionable issues; structured confidence was .97.
