### PR TITLE
fix(agents): honor cancellation before accepting media generation

### DIFF
--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -915,6 +915,140 @@ describe("createImageGenerateTool", () => {
     expect(resultDetails(duplicateResult).duplicateGuard).toBe(true);
   });
 
+  it.each([
+    { mode: "inline", agentSessionKey: undefined },
+    { mode: "detached", agentSessionKey: "agent:main:discord:direct:123" },
+  ])(
+    "does not start $mode image generation when its caller aborts during preparation",
+    async ({ agentSessionKey }) => {
+      stubImageGenerationProviders();
+      vi.stubEnv("OPENAI_API_KEY", "openai-test");
+      const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+      taskRuntimeMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-image-aborted" });
+      const scheduleBackgroundWork = vi.fn();
+      const tool = requireImageGenerateTool(
+        createImageGenerateTool({
+          config: {
+            agents: { defaults: { imageGenerationModel: { primary: "openai/gpt-image-1" } } },
+          },
+          agentSessionKey,
+          requesterOrigin: { channel: "discord", to: "dm:123" },
+          scheduleBackgroundWork,
+        }),
+      );
+      const controller = new AbortController();
+      const abortReason = new Error("image requester cancelled");
+
+      const pending = tool.execute("call-image-aborted", { prompt: "an image" }, controller.signal);
+      controller.abort(abortReason);
+
+      await expect(pending).rejects.toBe(abortReason);
+      expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+      expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+      expect(generateImage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stops loading later image references when the caller aborts a pending reference", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("GEMINI_API_KEY", "google-test");
+    const generateImage = stubEditedImageFlow();
+    let releaseReference!: (value: Awaited<ReturnType<typeof webMedia.loadWebMedia>>) => void;
+    const firstReference = new Promise<Awaited<ReturnType<typeof webMedia.loadWebMedia>>>(
+      (resolve) => {
+        releaseReference = resolve;
+      },
+    );
+    vi.mocked(webMedia.loadWebMedia).mockImplementationOnce(() => firstReference);
+    taskRuntimeMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-image-references" });
+    const scheduleBackgroundWork = vi.fn();
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: { imageGenerationModel: { primary: "google/gemini-3-pro-image-preview" } },
+          },
+        },
+        workspaceDir: process.cwd(),
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "dm:123" },
+        scheduleBackgroundWork,
+      }),
+    );
+    const controller = new AbortController();
+    const abortReason = new Error("image requester cancelled while loading a reference");
+
+    const pending = tool.execute(
+      "call-image-references-aborted",
+      {
+        prompt: "an image with references",
+        images: ["https://example.test/first.png", "https://example.test/second.png"],
+      },
+      controller.signal,
+    );
+    await vi.waitFor(() => expect(webMedia.loadWebMedia).toHaveBeenCalledOnce());
+    controller.abort(abortReason);
+    releaseReference({
+      kind: "image",
+      buffer: Buffer.from("first-image"),
+      contentType: "image/png",
+    });
+
+    await expect(pending).rejects.toBe(abortReason);
+    expect(webMedia.loadWebMedia).toHaveBeenCalledOnce();
+    expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+    expect(generateImage).not.toHaveBeenCalled();
+    const loadOptions = vi.mocked(webMedia.loadWebMedia).mock.calls[0]?.[1] as
+      | { requestInit?: { signal?: AbortSignal } }
+      | undefined;
+    expect(loadOptions?.requestInit?.signal).toBe(controller.signal);
+  });
+
+  it("keeps an accepted detached image task running after its requester aborts", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [{ buffer: Buffer.from("image"), mimeType: "image/png", fileName: "image.png" }],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/accepted-image.png",
+      id: "accepted-image.png",
+      size: 5,
+      contentType: "image/png",
+    });
+    taskRuntimeMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-image-accepted" });
+    const controller = new AbortController();
+    const scheduled: Array<() => Promise<void>> = [];
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: { defaults: { imageGenerationModel: { primary: "openai/gpt-image-1" } } },
+        },
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "dm:123" },
+        scheduleBackgroundWork: (work) => scheduled.push(work),
+        onAsyncTaskStarted: () => controller.abort(new Error("requester ended after acceptance")),
+      }),
+    );
+
+    const result = await tool.execute(
+      "call-image-accepted",
+      { prompt: "an accepted image" },
+      controller.signal,
+    );
+
+    expect(resultDetails(result).status).toBe("started");
+    expect(scheduled).toHaveLength(1);
+    await scheduled[0]?.();
+    expect(generateImage).toHaveBeenCalledOnce();
+    expect(taskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledOnce();
+  });
+
   it("starts run-scoped cron image generation as a tracked async task", async () => {
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -594,6 +594,7 @@ async function loadReferenceImages(params: {
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<
   Array<{
     sourceImage: ImageGenerationSourceImage;
@@ -608,6 +609,7 @@ async function loadReferenceImages(params: {
   }> = [];
 
   for (const imageRawInput of params.imageInputs) {
+    params.signal?.throwIfAborted();
     const trimmed = imageRawInput.trim();
     const imageRaw = normalizeMediaReferenceSource(
       trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
@@ -642,6 +644,7 @@ async function loadReferenceImages(params: {
       workspaceDir: params.workspaceDir,
       sandbox: params.sandboxConfig,
     });
+    params.signal?.throwIfAborted();
 
     const media = isDataUrl
       ? decodeDataUrl(resolvedImage, { maxBytes: params.maxBytes })
@@ -650,13 +653,16 @@ async function loadReferenceImages(params: {
             maxBytes: params.maxBytes,
             sandboxValidated: true,
             readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
+            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
           })
         : await loadWebMedia(resolvedPath ?? resolvedImage, {
             maxBytes: params.maxBytes,
             localRoots,
             ssrfPolicy: params.ssrfPolicy,
             ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
+            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
           });
+    params.signal?.throwIfAborted();
     if (media.kind !== "image") {
       throw new ToolInputError(`Unsupported media type: ${media.kind}`);
     }
@@ -681,10 +687,13 @@ async function loadReferenceImages(params: {
 
 async function inferResolutionFromInputImages(
   images: ImageGenerationSourceImage[],
+  signal?: AbortSignal,
 ): Promise<ImageGenerationResolution> {
   let maxDimension = 0;
   for (const image of images) {
+    signal?.throwIfAborted();
     const meta = await getImageMetadata(image.buffer);
+    signal?.throwIfAborted();
     const dimension = Math.max(meta?.width ?? 0, meta?.height ?? 0);
     maxDimension = Math.max(maxDimension, dimension);
   }
@@ -929,7 +938,7 @@ export function createImageGenerateTool(options?: {
     description:
       'Create/edit images. Batch via count; aspectRatio and resolution up to 4K. Session chat runs background: call once/request, await completion, then visible reply with structured media attachment. Transparent: outputFormat png|webp + background="transparent"; OpenAI also openai.background, default gpt-image-1.5. action=list providers/models/readiness/auth; status active task.',
     parameters: ImageGenerateToolSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal) => {
       const params = args as Record<string, unknown>;
       const action = resolveAction(params);
       if (action === "list") {
@@ -1057,6 +1066,7 @@ export function createImageGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
+        signal,
       });
       const inputImages = loadedReferenceImages.map((entry) => entry.sourceImage);
       const modeCaps =
@@ -1067,7 +1077,7 @@ export function createImageGenerateTool(options?: {
         size || explicitResolution
           ? undefined
           : inputImages.length > 0
-            ? await inferResolutionFromInputImages(inputImages)
+            ? await inferResolutionFromInputImages(inputImages, signal)
             : undefined;
       const resolution =
         explicitResolution ??
@@ -1085,6 +1095,8 @@ export function createImageGenerateTool(options?: {
         resolution,
         explicitResolution: Boolean(explicitResolution),
       });
+      // Accepted tasks own their paid work independently; cancellation applies only before admission.
+      signal?.throwIfAborted();
       const taskHandle = createImageGenerationTaskRun({
         sessionKey: options?.agentSessionKey,
         requesterOrigin: options?.requesterOrigin,

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -187,6 +187,7 @@ function resetMusicGenerateMocks() {
   vi.spyOn(musicGenerationRuntime, "listRuntimeMusicGenerationProviders").mockReturnValue([]);
   musicGenerationRuntimeMocks.generateMusic.mockReset();
   mediaStoreMocks.saveMediaBuffer.mockReset();
+  vi.mocked(webMedia.loadWebMedia).mockReset();
   probeMediaFilesWithinBudgetMock.mockReset();
   probeMediaFilesWithinBudgetMock.mockImplementation(async (inputs: readonly unknown[]) =>
     inputs.map(() => ({})),
@@ -695,6 +696,153 @@ describe("createMusicGenerateTool", () => {
         sizeBytes: 11,
       },
     ]);
+  });
+
+  it.each([
+    { mode: "inline", agentSessionKey: undefined },
+    { mode: "detached", agentSessionKey: "agent:main:discord:direct:123" },
+  ])(
+    "does not start $mode music generation when its caller aborts during preparation",
+    async ({ agentSessionKey }) => {
+      taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-music-aborted" });
+      const generateMusic = vi.spyOn(musicGenerationRuntime, "generateMusic");
+      const scheduleBackgroundWork = vi.fn();
+      const tool = expectMusicGenerateTool(
+        createMusicGenerateTool({
+          config: asConfig({
+            agents: {
+              defaults: { musicGenerationModel: { primary: "google/lyria-3-clip-preview" } },
+            },
+          }),
+          agentSessionKey,
+          requesterOrigin: { channel: "discord", to: "channel:1" },
+          scheduleBackgroundWork,
+        }),
+      );
+      const controller = new AbortController();
+      const abortReason = new Error("music requester cancelled");
+
+      const pending = tool.execute("call-music-aborted", { prompt: "a song" }, controller.signal);
+      controller.abort(abortReason);
+
+      await expect(pending).rejects.toBe(abortReason);
+      expect(taskExecutorMocks.createRunningTaskRun).not.toHaveBeenCalled();
+      expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+      expect(generateMusic).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stops loading later music references when the caller aborts a pending reference", async () => {
+    vi.spyOn(musicGenerationRuntime, "listRuntimeMusicGenerationProviders").mockReturnValue([
+      {
+        id: "minimax",
+        defaultModel: "music-2.6",
+        models: ["music-2.6"],
+        capabilities: { edit: { enabled: true, maxInputImages: 2 } },
+        generateMusic: vi.fn(async () => {
+          throw new Error("not used");
+        }),
+      },
+    ]);
+    const generateMusic = vi.spyOn(musicGenerationRuntime, "generateMusic");
+    let releaseReference!: (value: Awaited<ReturnType<typeof webMedia.loadWebMedia>>) => void;
+    const firstReference = new Promise<Awaited<ReturnType<typeof webMedia.loadWebMedia>>>(
+      (resolve) => {
+        releaseReference = resolve;
+      },
+    );
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("second-image"),
+      contentType: "image/png",
+    });
+    loadWebMedia.mockImplementationOnce(() => firstReference);
+    taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-music-references" });
+    const scheduleBackgroundWork = vi.fn();
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: { defaults: { musicGenerationModel: { primary: "minimax/music-2.6" } } },
+        }),
+        workspaceDir: process.cwd(),
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "channel:1" },
+        scheduleBackgroundWork,
+      }),
+    );
+    const controller = new AbortController();
+    const abortReason = new Error("music requester cancelled while loading a reference");
+
+    const pending = tool.execute(
+      "call-music-references-aborted",
+      {
+        prompt: "a song with references",
+        images: ["https://example.test/first.png", "https://example.test/second.png"],
+      },
+      controller.signal,
+    );
+    await vi.waitFor(() => expect(loadWebMedia).toHaveBeenCalledOnce());
+    controller.abort(abortReason);
+    releaseReference({
+      kind: "image",
+      buffer: Buffer.from("first-image"),
+      contentType: "image/png",
+    });
+
+    await expect(pending).rejects.toBe(abortReason);
+    expect(loadWebMedia).toHaveBeenCalledOnce();
+    expect(taskExecutorMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+    expect(generateMusic).not.toHaveBeenCalled();
+    const loadOptions = loadWebMedia.mock.calls[0]?.[1] as
+      | { requestInit?: { signal?: AbortSignal } }
+      | undefined;
+    expect(loadOptions?.requestInit?.signal?.aborted).toBe(true);
+    expect(loadOptions?.requestInit?.signal?.reason).toBe(abortReason);
+  });
+
+  it("keeps an accepted detached music task running after its requester aborts", async () => {
+    taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-music-accepted" });
+    const generateMusic = vi.spyOn(musicGenerationRuntime, "generateMusic").mockResolvedValue({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      attempts: [],
+      ignoredOverrides: [],
+      tracks: [{ buffer: Buffer.from("music"), mimeType: "audio/mpeg", fileName: "music.mp3" }],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/accepted-music.mp3",
+      id: "accepted-music.mp3",
+      size: 5,
+      contentType: "audio/mpeg",
+    });
+    const controller = new AbortController();
+    const scheduled: Array<() => Promise<void>> = [];
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: { musicGenerationModel: { primary: "google/lyria-3-clip-preview" } },
+          },
+        }),
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "channel:1" },
+        scheduleBackgroundWork: (work) => scheduled.push(work),
+        onAsyncTaskStarted: () => controller.abort(new Error("requester ended after acceptance")),
+      }),
+    );
+
+    const result = await tool.execute(
+      "call-music-accepted",
+      { prompt: "an accepted song" },
+      controller.signal,
+    );
+
+    expect(detailsOf(result).status).toBe("started");
+    expect(scheduled).toHaveLength(1);
+    await scheduled[0]?.();
+    expect(generateMusic).toHaveBeenCalledOnce();
+    expect(taskExecutorMocks.completeTaskRunByRunId).toHaveBeenCalledOnce();
   });
 
   it("dedupes a recent default-model music request repeated with explicit or model-only override", async () => {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -300,6 +300,7 @@ async function loadReferenceImages(params: {
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<
   Array<{
     sourceImage: MusicGenerationSourceImage;
@@ -314,6 +315,7 @@ async function loadReferenceImages(params: {
   }> = [];
 
   for (const rawInput of params.inputs) {
+    params.signal?.throwIfAborted();
     const trimmed = rawInput.trim();
     const inputRaw = normalizeMediaReferenceSource(
       trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
@@ -343,12 +345,14 @@ async function loadReferenceImages(params: {
       workspaceDir: params.workspaceDir,
       sandbox: params.sandboxConfig,
     });
+    params.signal?.throwIfAborted();
     const media = isDataUrl
       ? decodeDataUrl(resolvedInput)
       : params.sandboxConfig
         ? await loadWebMedia(resolvedPath ?? resolvedInput, {
             sandboxValidated: true,
             readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
+            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
           })
         : await (async () => {
             const referenceTarget = resolvedPath ?? resolvedInput;
@@ -356,6 +360,7 @@ async function loadReferenceImages(params: {
             const { signal, cleanup } = buildTimeoutAbortSignal({
               timeoutMs: params.timeoutMs ?? DEFAULT_REFERENCE_FETCH_TIMEOUT_MS,
               operation: "music-generate.reference-fetch",
+              ...(params.signal ? { signal: params.signal } : {}),
               ...(isRemoteReference ? { url: referenceTarget } : {}),
             });
             try {
@@ -368,6 +373,7 @@ async function loadReferenceImages(params: {
               cleanup();
             }
           })();
+    params.signal?.throwIfAborted();
     if (media.kind !== "image") {
       throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);
     }
@@ -624,7 +630,7 @@ export function createMusicGenerateTool(options?: {
     description:
       "Create song/jingle/beat/loop/soundtrack/anthem/instrumental. Make/generate music => call; lyrics-only request => text only. prompt: style/genre/mood/tempo/instruments/purpose; lyrics: exact sung words; image/images condition on reference image(s). action=list discovers providers/models. Session chat background: call once/request, await, then visible reply + structured media. status checks active task.",
     parameters: MusicGenerateToolSchema,
-    execute: async (_toolCallId, rawArgs) => {
+    execute: async (_toolCallId, rawArgs, signal) => {
       const args = rawArgs as Record<string, unknown>;
       const action = resolveAction(args);
 
@@ -726,6 +732,7 @@ export function createMusicGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
+        signal,
       });
       validateMusicGenerationCapabilities({
         provider: selectedProvider,
@@ -736,6 +743,8 @@ export function createMusicGenerateTool(options?: {
         durationSeconds,
         format,
       });
+      // Accepted tasks own their paid work independently; cancellation applies only before admission.
+      signal?.throwIfAborted();
       const taskHandle = createMusicGenerationTaskRun({
         sessionKey: options?.agentSessionKey,
         requesterOrigin: options?.requesterOrigin,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -1007,6 +1007,133 @@ describe("createVideoGenerateTool", () => {
     expect(wake.result).not.toContain("MEDIA:");
   });
 
+  it.each([
+    { mode: "inline", agentSessionKey: undefined },
+    { mode: "detached", agentSessionKey: "agent:main:discord:direct:123" },
+  ])(
+    "does not start $mode video generation when its caller aborts during preparation",
+    async ({ agentSessionKey }) => {
+      taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-video-aborted" });
+      const generateVideo = vi.spyOn(videoGenerationRuntime, "generateVideo");
+      const scheduleBackgroundWork = vi.fn();
+      const tool = expectVideoGenerateTool(
+        createVideoGenerateTool({
+          config: asConfig({
+            agents: { defaults: { videoGenerationModel: { primary: "vydra/veo3" } } },
+          }),
+          agentSessionKey,
+          requesterOrigin: { channel: "discord", to: "channel:1" },
+          scheduleBackgroundWork,
+        }),
+      );
+      const controller = new AbortController();
+      const abortReason = new Error("video requester cancelled");
+
+      const pending = tool.execute("call-video-aborted", { prompt: "a video" }, controller.signal);
+      controller.abort(abortReason);
+
+      await expect(pending).rejects.toBe(abortReason);
+      expect(taskExecutorMocks.createRunningTaskRun).not.toHaveBeenCalled();
+      expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+      expect(generateVideo).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stops loading later video references when the caller aborts a pending reference", async () => {
+    mockVideoPluginProvider({ imageToVideo: { enabled: true, maxInputImages: 2 } });
+    const generateVideo = mockSavedVideoResult();
+    let releaseReference!: (value: Awaited<ReturnType<typeof webMedia.loadWebMedia>>) => void;
+    const firstReference = new Promise<Awaited<ReturnType<typeof webMedia.loadWebMedia>>>(
+      (resolve) => {
+        releaseReference = resolve;
+      },
+    );
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("second-image"),
+      contentType: "image/png",
+    });
+    loadWebMedia.mockImplementationOnce(() => firstReference);
+    taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-video-references" });
+    const scheduleBackgroundWork = vi.fn();
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: { defaults: { videoGenerationModel: { primary: "video-plugin/vid-v1" } } },
+        }),
+        workspaceDir: process.cwd(),
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "channel:1" },
+        scheduleBackgroundWork,
+      }),
+    );
+    const controller = new AbortController();
+    const abortReason = new Error("video requester cancelled while loading a reference");
+
+    const pending = tool.execute(
+      "call-video-references-aborted",
+      { prompt: "a video with references", images: ["./first.png", "./second.png"] },
+      controller.signal,
+    );
+    await vi.waitFor(() => expect(loadWebMedia).toHaveBeenCalledOnce());
+    controller.abort(abortReason);
+    releaseReference({
+      kind: "image",
+      buffer: Buffer.from("first-image"),
+      contentType: "image/png",
+    });
+
+    await expect(pending).rejects.toBe(abortReason);
+    expect(loadWebMedia).toHaveBeenCalledOnce();
+    expect(taskExecutorMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+    expect(generateVideo).not.toHaveBeenCalled();
+    const loadOptions = loadWebMedia.mock.calls[0]?.[1] as
+      | { requestInit?: { signal?: AbortSignal } }
+      | undefined;
+    expect(loadOptions?.requestInit?.signal).toBe(controller.signal);
+  });
+
+  it("keeps an accepted detached video task running after its requester aborts", async () => {
+    taskExecutorMocks.createRunningTaskRun.mockReturnValue({ taskId: "task-video-accepted" });
+    const generateVideo = vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
+      provider: "vydra",
+      model: "veo3",
+      attempts: [],
+      ignoredOverrides: [],
+      videos: [{ url: "https://example.com/accepted.mp4", mimeType: "video/mp4" }],
+    });
+    vi.spyOn(
+      videoGenerateBackground.videoGenerationTaskLifecycle,
+      "wakeTaskCompletion",
+    ).mockResolvedValue({ status: "delivered" });
+    const controller = new AbortController();
+    const scheduled: Array<() => Promise<void>> = [];
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: { defaults: { videoGenerationModel: { primary: "vydra/veo3" } } },
+        }),
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: { channel: "discord", to: "channel:1" },
+        scheduleBackgroundWork: (work) => scheduled.push(work),
+        onAsyncTaskStarted: () => controller.abort(new Error("requester ended after acceptance")),
+      }),
+    );
+
+    const result = await tool.execute(
+      "call-video-accepted",
+      { prompt: "an accepted video" },
+      controller.signal,
+    );
+
+    expect(resultDetails(result).status).toBe("started");
+    expect(scheduled).toHaveLength(1);
+    await scheduled[0]?.();
+    expect(generateVideo).toHaveBeenCalledOnce();
+    expect(taskExecutorMocks.completeTaskRunByRunId).toHaveBeenCalledOnce();
+  });
+
   it("surfaces provider generation failures inline when there is no detached session", async () => {
     vi.spyOn(videoGenerationRuntime, "generateVideo").mockRejectedValue(new Error("queue boom"));
 

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -556,6 +556,7 @@ async function loadReferenceAssets(params: {
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<
   Array<{
     sourceAsset: VideoGenerationSourceAsset;
@@ -570,6 +571,7 @@ async function loadReferenceAssets(params: {
   }> = [];
 
   for (const rawInput of params.inputs) {
+    params.signal?.throwIfAborted();
     const trimmed = rawInput.trim();
     const inputRaw = normalizeMediaReferenceSource(
       trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
@@ -614,6 +616,7 @@ async function loadReferenceAssets(params: {
       workspaceDir: params.workspaceDir,
       sandbox: params.sandboxConfig,
     });
+    params.signal?.throwIfAborted();
     const media = isDataUrl
       ? params.expectedKind === "image"
         ? decodeDataUrl(resolvedInput)
@@ -627,12 +630,15 @@ async function loadReferenceAssets(params: {
             maxBytes: params.maxBytes,
             sandboxValidated: true,
             readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
+            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
           })
         : await loadWebMedia(resolvedPath ?? resolvedInput, {
             maxBytes: params.maxBytes,
             localRoots,
             ssrfPolicy: params.ssrfPolicy,
+            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
           });
+    params.signal?.throwIfAborted();
     if (media.kind !== params.expectedKind) {
       throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);
     }
@@ -997,7 +1003,7 @@ export function createVideoGenerateTool(options?: {
       (includeAudioReferences ? "; audio refs condition sound" : "") +
       ". resolution up to 4K; audio/watermark toggles. action=list discovers providers/models. Session chat background: call once/request, await, then visible reply + structured media. status checks active task. Duration may round to provider value.",
     parameters: createVideoGenerateToolSchema({ includeAudioReferences }),
-    execute: async (_toolCallId, rawArgs) => {
+    execute: async (_toolCallId, rawArgs, signal) => {
       const args = rawArgs as Record<string, unknown>;
       const action = resolveAction(args);
 
@@ -1151,6 +1157,7 @@ export function createVideoGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
+        signal,
       });
       // Attach roles to the loaded image assets (positional, by index into images[]).
       for (let i = 0; i < loadedReferenceImages.length; i++) {
@@ -1166,6 +1173,7 @@ export function createVideoGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
+        signal,
       });
       for (let i = 0; i < loadedReferenceVideos.length; i++) {
         const role = videoRoles[i];
@@ -1180,6 +1188,7 @@ export function createVideoGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
+        signal,
       });
       for (let i = 0; i < loadedReferenceAudios.length; i++) {
         const role = audioRoles[i];
@@ -1202,6 +1211,8 @@ export function createVideoGenerateTool(options?: {
         audio,
         watermark,
       });
+      // Accepted tasks own their paid work independently; cancellation applies only before admission.
+      signal?.throwIfAborted();
       const taskHandle = createVideoGenerationTaskRun({
         sessionKey: options?.agentSessionKey,
         requesterOrigin: options?.requesterOrigin,


### PR DESCRIPTION
## What Problem This Solves

The image, video, and music generation tools ignored the native agent-tool cancellation signal while preparing references. A canceled caller could continue downloading subsequent references, create a durable background task, and start billable provider work. The same pre-acceptance ownership invariant was independently broken in all three sibling owners.

## Why This Change Was Made

Thread the native execute signal through the canonical image/video/music preparation owners. Check cancellation before and after asynchronous reference resolution and loading, before image metadata probes, and immediately before synchronous task admission. Pass caller cancellation into real media fetches and compose it with music's existing fetch timeout without changing timeout cleanup, SSRF policy, direct remote-video pass-through, or provider contracts.

Once the task has been accepted, it owns its work independently: never pass caller cancellation into scheduled generation, completion, or requester wake-up. Count this change as **one root cause**, with image, video, and music as three repaired sibling surfaces.

## User Impact

Canceling a run stops unnecessary image/video/music reference reads and prevents orphaned tasks or paid generation before acceptance. Legitimate detached image, video, and music jobs that were already accepted still finish and deliver their normal completion outcome, even when their requester stops afterward.

## Evidence

- Exact immutable commit: `b3a437d37eaae1c4c3ca3a9ac4fc25da77d89b7f`; tree `b8089d84cb6af1b19ea58707e06a3fb7765ca58a`; parent `8738fe1354613e32fdf130010313cbef1bb192e3`.
- Authentic first RED: each canceled default-path owner still returned a started image/video/music background task. Authentic second RED: each owner began loading a second reference after the caller canceled a blocked first reference.
- Exact-head focused proof: `PATH=/Users/steipete/.local/opt/node-v24.18.0-darwin-arm64/bin:$PATH OPENCLAW_VITEST_FS_MODULE_CACHE=0 TSX_DISABLE_CACHE=1 node scripts/run-vitest.mjs src/agents/tools/image-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts --no-file-parallelism --maxWorkers=1` — **123/123 passed**.
- Regressions exercise all three inline and detached pre-acceptance paths, blocked real reference-loader boundaries and suppressed second reads, composed music timeout/caller signals, isolated Vitest mock reset, and all three accepted detached provider/completion paths.
- Five independently fresh immutable hostile reviews: **zero P0–P3 findings**.
- Genuine native structured review: `gpt-5.6-sol`, reasoning `high`, maximum priority `P3`; `findings=[]`, correctness `patch is correct`, confidence **0.98**. Real TruffleHog **3.96.0: zero findings**.
- Targeted formatting, targeted warning-free lint, and `git diff --check`: passed. Production delta: **+32 lines** across the three canonical cancellation-owner boundaries. No provider network calls or paid generations were made during proof.
