### PR TITLE
fix: image messages lose attachments across reply execution

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -108,6 +108,88 @@ describe("prepareCliPromptImagePayload prompt references", () => {
     }
   });
 
+  it("hydrates managed structured media outside the active agent workspace", async () => {
+    const managedMediaDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-managed-media-"),
+    );
+    const workspaceDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-agent-workspace-"),
+    );
+    const imagePath = path.join(managedMediaDir, "photo.png");
+    await fs.writeFile(imagePath, createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 }));
+
+    try {
+      const result = await prepareCliPromptImagePayload({
+        backend: { command: "codex" },
+        prompt: "describe the attachment",
+        workspaceDir,
+        media: [
+          {
+            path: imagePath,
+            contentType: "image/png",
+            workspaceDir: managedMediaDir,
+          },
+        ],
+        imageOrder: ["offloaded"],
+      });
+
+      expect(result.imagePaths).toHaveLength(1);
+    } finally {
+      await fs.rm(managedMediaDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates structured media inside a non-default agent workspace root", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(process.cwd(), ".openclaw-cli-nondefault-workspace-"),
+    );
+    const imagePath = path.join(workspaceDir, "photo.png");
+    await fs.writeFile(imagePath, createSolidPngBuffer(1, 1, { r: 12, g: 34, b: 56 }));
+
+    try {
+      const result = await prepareCliPromptImagePayload({
+        backend: { command: "codex" },
+        prompt: "describe the attachment",
+        workspaceDir,
+        media: [{ path: imagePath, contentType: "image/png" }],
+        imageOrder: ["offloaded"],
+      });
+
+      expect(result.imagePaths).toHaveLength(1);
+      await result.cleanupImages?.();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects structured media outside default and active agent workspace roots", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(process.cwd(), ".openclaw-cli-bounded-workspace-"),
+    );
+    const outsideDir = await fs.mkdtemp(
+      path.join(process.cwd(), ".openclaw-cli-outside-workspace-"),
+    );
+    const imagePath = path.join(outsideDir, "photo.png");
+    await fs.writeFile(imagePath, createSolidPngBuffer(1, 1, { r: 56, g: 34, b: 12 }));
+
+    try {
+      await expect(
+        prepareCliPromptImagePayload({
+          backend: { command: "codex" },
+          prompt: "describe the attachment",
+          workspaceDir,
+          media: [{ path: imagePath, contentType: "image/png" }],
+          imageOrder: ["offloaded"],
+        }),
+      ).rejects.toThrow("failed to hydrate 1 structured image attachment");
+      await expect(fs.stat(path.join(workspaceDir, ".openclaw-cli-images"))).rejects.toThrow();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("dedupes repeated refs and skips failed loads before sanitizing", async () => {
     const workspaceDir = await fs.mkdtemp(
       path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-ref-dedupe-"),

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -190,6 +190,7 @@ export async function executePreparedCliRun(
         workspaceDir: context.workspaceDir,
         images: params.images,
         imageOrder: params.imageOrder,
+        imageFactIndexes: params.imageFactIndexes,
         media: params.media,
       });
   prompt = imagePayload.prompt;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -23,6 +23,7 @@ import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import type { ImageContent } from "../../llm/types.js";
+import { getDefaultMediaLocalRoots } from "../../media/local-roots.js";
 import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
@@ -418,6 +419,7 @@ export async function prepareCliPromptImagePayload(params: {
   workspaceDir: string;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  imageFactIndexes?: readonly (number | null)[];
   media?: MediaFact[];
 }): Promise<{
   prompt: string;
@@ -437,8 +439,12 @@ export async function prepareCliPromptImagePayload(params: {
         workspaceDir: params.workspaceDir,
         model: { input: ["text", "image"] },
         existingImages: params.images,
+        existingImageFactIndexes: params.imageFactIndexes,
         imageOrder: params.imageOrder,
         maxBytes: MAX_IMAGE_BYTES,
+        // Structured CLI media may live in managed inbound, sandbox, remote-cache, or agent
+        // workspace roots. Never use caller-supplied fact roots as the allowlist.
+        localRoots: [...getDefaultMediaLocalRoots(), params.workspaceDir],
       })
     : undefined;
   if (imageResult?.failedMediaCount) {

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -174,6 +174,8 @@ export type RunCliAgentParams = {
   bootstrapContextRunKind?: BootstrapContextRunKind;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  /** Media fact identity for each inline image, aligned with `images`. */
+  imageFactIndexes?: readonly (number | null)[];
   /** Ordered facts represented by attachment text in the current prompt. */
   media?: MediaFact[];
   skillsSnapshot?: SkillSnapshot;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { finalizeRuntimePromptImages } from "../../../media/runtime-prompt-image-provenance.js";
 
 const hoisted = vi.hoisted(() => ({
   canAdvanceSessionEntryCache: vi.fn(() => true),
@@ -300,6 +301,87 @@ describe("prepareEmbeddedAttemptPromptExecution", () => {
           suppressedFactIndexes: [],
         },
       }),
+    );
+  });
+
+  it("passes runner-hydrated fact ownership into embedded prompt hydration", async () => {
+    const base = createInput();
+    const image = { type: "image" as const, data: "managed", mimeType: "image/png" };
+    const images = finalizeRuntimePromptImages([{ image, factIndex: 0 }], "inbound-media").images;
+    const persistedMessage = {
+      role: "user" as const,
+      content: "inspect",
+      __openclaw: {
+        media: [{ path: "/managed/inbound.png", contentType: "image/png" }],
+        mediaImageLayout: { slots: [{ kind: "offloaded" as const, factIndex: 0 }] },
+      },
+    };
+    const input = createInput({
+      attempt: {
+        ...base.attempt,
+        images,
+        imageOrder: ["inline"],
+        userTurnTranscriptRecorder: {
+          message: persistedMessage,
+          resolveMessage: vi.fn(async () => persistedMessage),
+        } as unknown as NonNullable<PromptExecutionInput["attempt"]["userTurnTranscriptRecorder"]>,
+      },
+    });
+
+    await prepareEmbeddedAttemptPromptExecution(input);
+
+    expect(hoisted.detectAndLoadPromptImages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        existingImages: images,
+        existingImageFactIndexes: [0],
+        mediaImageLayout: {
+          slots: [{ kind: "offloaded", factIndex: 0 }],
+          suppressedFactIndexes: [],
+        },
+      }),
+    );
+  });
+
+  it("does not apply collected run-media ownership to persisted inbound media", async () => {
+    const base = createInput();
+    const image = { type: "image" as const, data: "managed", mimeType: "image/png" };
+    const images = finalizeRuntimePromptImages([{ image, factIndex: 0 }], "run-media").images;
+    const persistedMessage = {
+      role: "user" as const,
+      content: "inspect",
+      __openclaw: {
+        media: [
+          { path: "/managed/voice.m4a", contentType: "audio/mp4", transcribed: true },
+          { path: "/managed/inbound.png", contentType: "image/png" },
+        ],
+      },
+    };
+    const input = createInput({
+      attempt: {
+        ...base.attempt,
+        images,
+        imageOrder: ["inline"],
+        userTurnTranscriptRecorder: {
+          message: persistedMessage,
+          resolveMessage: vi.fn(async () => persistedMessage),
+        } as unknown as NonNullable<PromptExecutionInput["attempt"]["userTurnTranscriptRecorder"]>,
+      },
+    });
+
+    await prepareEmbeddedAttemptPromptExecution(input);
+
+    expect(hoisted.detectAndLoadPromptImages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        existingImages: images,
+        imageOrder: ["inline"],
+        media: [
+          expect.objectContaining({ path: "/managed/voice.m4a", transcribed: true }),
+          expect.objectContaining({ path: "/managed/inbound.png" }),
+        ],
+      }),
+    );
+    expect(hoisted.detectAndLoadPromptImages).toHaveBeenCalledWith(
+      expect.not.objectContaining({ existingImageFactIndexes: expect.anything() }),
     );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
@@ -2,6 +2,7 @@
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { OwnedSessionTranscriptCacheSnapshot } from "../../../config/sessions/transcript-write-context.js";
 import { readPersistedMediaFacts } from "../../../media/media-facts.js";
+import { readRuntimePromptImageProvenance } from "../../../media/runtime-prompt-image-provenance.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { SandboxContext } from "../../sandbox/types.js";
 import type { AgentSession } from "../../sessions/index.js";
@@ -72,12 +73,21 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     attempt.userTurnTranscriptRecorder?.message ??
     (await attempt.userTurnTranscriptRecorder?.resolveMessage());
   const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
+  const imageProvenance = readRuntimePromptImageProvenance(attempt.images);
+  // A collected run indexes its compact runtime media projection, while the recorder persists the
+  // original inbound facts (for example, transcribed audio before an image). Never apply run-media
+  // indexes to that persisted array; omission lets canonical layout/attachment inference recover.
+  const existingImageFactIndexes =
+    persistedMedia.length > 0 && imageProvenance?.space === "run-media"
+      ? undefined
+      : imageProvenance?.factIndexes;
 
   return await detectAndLoadPromptImages({
     prompt: input.prompt,
     workspaceDir: input.effectiveWorkspace,
     model: attempt.model,
     existingImages: attempt.images,
+    ...(existingImageFactIndexes ? { existingImageFactIndexes } : {}),
     imageOrder: attempt.imageOrder,
     media: persistedMedia.length > 0 ? persistedMedia : attempt.media,
     mediaImageLayout: persistedMessage

--- a/src/agents/embedded-agent-runner/run/images.replay.test.ts
+++ b/src/agents/embedded-agent-runner/run/images.replay.test.ts
@@ -36,6 +36,67 @@ describe("structured prompt media replay", () => {
     expect(readRuntimePromptImageFactIndexes(images)).toEqual([0, 1]);
   });
 
+  it("rebinds a collected image after transcribed audio to persisted fact ownership", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-collect-replay-"));
+    const imagePath = path.join(workspaceDir, "photo.png");
+    const imageData = Buffer.from(TINY_PNG_BASE64, "base64");
+    await fs.writeFile(imagePath, imageData);
+    const runtimeImages = finalizeRuntimePromptImages(
+      [
+        {
+          image: { type: "image" as const, data: TINY_PNG_BASE64, mimeType: "image/png" },
+          factIndex: 0,
+        },
+      ],
+      "run-media",
+    ).images;
+    const persistedMedia = [
+      { path: path.join(workspaceDir, "voice.m4a"), contentType: "audio/mp4", transcribed: true },
+      { path: imagePath, contentType: "image/png" },
+    ];
+
+    try {
+      const embeddedHydration = await detectAndLoadPromptImages({
+        prompt: "inspect",
+        media: persistedMedia,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        existingImages: runtimeImages,
+        imageOrder: ["inline"],
+        workspaceOnly: true,
+      });
+      expect(embeddedHydration.images).toHaveLength(1);
+      expect(embeddedHydration.imageFactIndexes).toEqual([1]);
+      expect(embeddedHydration.loadedCount).toBe(0);
+
+      const persistedMessage = {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "inspect" }, ...embeddedHydration.images],
+        timestamp: Date.now(),
+        __openclaw: {
+          media: persistedMedia,
+          mediaImageBlockFactIndexes: embeddedHydration.imageFactIndexes,
+        },
+      } as unknown as AgentMessage;
+      const replay = await hydratePromptMediaMessages([persistedMessage], {
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+      });
+      const replayContent = (replay[0] as { content?: unknown } | undefined)?.content;
+      expect(
+        Array.isArray(replayContent) ? replayContent.filter((block) => block.type === "image") : [],
+      ).toHaveLength(1);
+      expect(
+        (replay[0] as unknown as { __openclaw?: { mediaImageBlockFactIndexes?: unknown } })[
+          "__openclaw"
+        ]?.mediaImageBlockFactIndexes,
+      ).toEqual([1]);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("retains the runtime fact carrier when queued hydration fails", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-failure-"));
     const media = [{ path: path.join(workspaceDir, "missing.png"), contentType: "image/png" }];

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -110,7 +110,10 @@ export type GetReplyOptions = {
   images?: ImageContent[];
   /** Original inline/offloaded attachment order for inbound images. */
   imageOrder?: PromptImageOrderEntry[];
-  /** Ordered media facts whose model-facing text projection is already present in the prompt. */
+  /**
+   * Ordered media facts whose model-facing text projection is already present in the prompt.
+   * `workspaceDir` is ignored here: public reply options cannot add local filesystem roots.
+   */
   media?: MediaFact[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -175,22 +175,34 @@ describe("buildInboundMediaNote", () => {
   });
 
   it("strips audio attachments when transcription succeeded via MediaUnderstanding", () => {
-    const note = buildInboundMediaNote({
-      MediaPaths: ["/tmp/voice.ogg", "/tmp/image.png"],
-      MediaUrls: ["https://example.com/voice.ogg", "https://example.com/image.png"],
-      MediaTypes: ["audio/ogg", "image/png"],
+    const ctx = {
+      media: [
+        {
+          path: "/tmp/voice.ogg",
+          url: "https://example.com/voice.ogg",
+          contentType: "audio/ogg",
+        },
+        {
+          path: "/tmp/image.png",
+          url: "https://example.com/image.png",
+          contentType: "image/png",
+        },
+      ],
       MediaUnderstanding: [
         {
-          kind: "audio.transcription",
+          kind: "audio.transcription" as const,
           attachmentIndex: 0,
           text: "Hello world",
           provider: "whisper",
         },
       ],
-    });
+    };
+    const note = buildInboundMediaNote(ctx);
     expect(note).toBe(
       "[media attached: /tmp/image.png (image/png) | https://example.com/image.png]",
     );
+    const projection = buildInboundMediaNoteProjection(ctx);
+    expect(projection.mediaSourceIndexes).toEqual([1]);
   });
 
   it("strips audio attachments when transcription succeeded via decisions", () => {
@@ -400,7 +412,7 @@ describe("buildInboundMediaNote", () => {
       ],
     });
 
-    expect(projection).toEqual({ media: [] });
+    expect(projection).toEqual({ media: [], mediaSourceIndexes: [] });
   });
 
   it("keeps audio attachments when no transcription is available", () => {
@@ -469,6 +481,7 @@ describe("buildInboundMediaNote", () => {
           messageId: undefined,
         },
       ],
+      mediaSourceIndexes: [0],
     });
 
     const multi = buildInboundMediaNoteProjection({
@@ -494,5 +507,6 @@ describe("buildInboundMediaNote", () => {
       { path: "/tmp/a.png", contentType: "image/png", kind: "image" },
       { path: "/tmp/b.pdf", contentType: "application/pdf", kind: "document" },
     ]);
+    expect(multi.mediaSourceIndexes).toEqual([0, 1]);
   });
 });

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -127,6 +127,8 @@ function collectDescribedImageAttachmentIndices(ctx: MsgContext): Set<number> {
 type InboundMediaNoteProjection = {
   text?: string;
   media: MediaFact[];
+  /** Original ctx.media index aligned one-to-one with each projected media fact. */
+  mediaSourceIndexes: number[];
 };
 
 /** Formats prompt-visible attachment text and retains facts that still need native hydration. */
@@ -147,7 +149,7 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
       : [];
   });
   if (entries.length === 0) {
-    return { media: [] };
+    return { media: [], mediaSourceIndexes: [] };
   }
 
   const transcribedAudioIndices = collectTranscribedAudioAttachmentIndices(ctx, facts.length);
@@ -175,13 +177,14 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
     return true;
   });
   if (visibleEntries.length === 0) {
-    return { media: [] };
+    return { media: [], mediaSourceIndexes: [] };
   }
   const describedImageIndices = collectDescribedImageAttachmentIndices(ctx);
   const media = visibleEntries.map((entry) => ({
     ...entry.fact,
     ...(describedImageIndices.has(entry.index) ? { hydrationSuppressed: true } : {}),
   }));
+  const mediaSourceIndexes = visibleEntries.map((entry) => entry.index);
   if (visibleEntries.length === 1) {
     return {
       text: formatMediaAttachedLine({
@@ -190,6 +193,7 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
         url: visibleEntries[0]?.url,
       }),
       media,
+      mediaSourceIndexes,
     };
   }
 
@@ -206,5 +210,5 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
       }),
     );
   }
-  return { text: lines.join("\n"), media };
+  return { text: lines.join("\n"), media, mediaSourceIndexes };
 }

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -13,6 +13,11 @@ import {
 } from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logError } from "../../logger.js";
+import {
+  resolveInlineImageFactIndexes,
+  resolveProjectedImageSourceIndexes,
+} from "../../media/image-source-indexes.js";
 import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
@@ -84,6 +89,27 @@ export async function runCliFallbackCandidate(params: {
   bootstrapPromptWarningSignaturesSeen: string[];
 }> {
   const turn = params.turn;
+  // Unlike embedded execution, CLI must use the pre-persistence runtime projection: collect merges
+  // several recorders without merging their mediaImageLayout slots, and the mapping also drives
+  // the second hydration before a recorder layout is guaranteed to be materialized.
+  const cliSourceResult = resolveProjectedImageSourceIndexes({
+    imageSourceMapping: params.currentTurnImages.imageSourceIndexes
+      ? {
+          indexes: params.currentTurnImages.imageSourceIndexes,
+          space: turn.sessionMediaSourceSpace,
+        }
+      : undefined,
+    imageOrderLength: params.currentTurnImages.imageOrder?.length ?? 0,
+    projectedMediaSourceIndexes: turn.followupRun.mediaSourceIndexes,
+    projectedMediaLength: turn.followupRun.media?.length ?? 0,
+  });
+  if (cliSourceResult.kind === "invalid") {
+    logError(
+      `CLI image source projection is invalid; falling back to positional inference: ${cliSourceResult.reason}`,
+    );
+  }
+  const cliImageSourceIndexes =
+    cliSourceResult.kind === "mapped" ? cliSourceResult.indexes : undefined;
   const cliSessionBinding = getCliSessionBinding(
     turn.getActiveSessionEntry(),
     params.cliExecutionProvider,
@@ -378,6 +404,10 @@ export async function runCliFallbackCandidate(params: {
               ],
             images: params.currentTurnImages.images,
             imageOrder: params.currentTurnImages.imageOrder,
+            imageFactIndexes: resolveInlineImageFactIndexes({
+              imageOrder: params.currentTurnImages.imageOrder,
+              imageSourceIndexes: cliImageSourceIndexes,
+            }),
             skillsSnapshot: turn.followupRun.run.skillsSnapshot,
             messageChannel: turn.followupRun.originatingChannel ?? undefined,
             messageProvider: hookMessageProvider,

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -239,6 +239,8 @@ export async function runEmbeddedFallbackCandidate(params: {
         forceHeartbeatTool: turn.opts?.forceHeartbeatTool,
         bootstrapContextMode: turn.opts?.bootstrapContextMode,
         bootstrapContextRunKind: params.bootstrapContextRunKind,
+        // Embedded execution reads persisted media ownership. Runtime images retain their source
+        // space so collect projections cannot be mistaken for persisted inbound-media indexes.
         images: params.currentTurnImages.images,
         imageOrder: params.currentTurnImages.imageOrder,
         abortSignal: params.runAbortSignal,

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -364,6 +364,7 @@ export async function executePreparedReplyAgentRun(
           transcriptCommandBody,
           followupRun,
           sessionCtx,
+          sessionMediaSourceSpace: "inbound-media",
           replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
           replyOperation,
           opts,

--- a/src/auto-reply/reply/agent-runner-execution-contract.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import {
+  createFollowupRun,
   createMinimalRunAgentTurnParams,
   createMockReplyOperation,
   setupAgentRunnerExecutionTestState,
@@ -10,6 +11,70 @@ const state = setupAgentRunnerExecutionTestState();
 const { executeAgentTurn } = await import("./agent-runner-execution.js");
 
 describe("executeAgentTurn contract", () => {
+  it("drops mismatched-space ownership and continues with inference", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: { durationMs: 1 },
+    });
+    const followupRun = {
+      ...createFollowupRun(),
+      images: [{ type: "image" as const, data: "image", mimeType: "image/png" }],
+      imageOrder: ["inline" as const],
+      imageSourceMapping: { indexes: [0], space: "inbound-media" as const },
+    };
+
+    await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "whatsapp",
+          MessageSid: "msg",
+          media: [{ path: "/tmp/photo.png", contentType: "image/png" }],
+        },
+        sessionMediaSourceSpace: "run-media",
+      }),
+    );
+
+    expect(state.resolveCurrentTurnImagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageSourceIndexes: undefined,
+        sourceMappingInvalid: true,
+        invalidSourceMappingPolicy: "infer-inline",
+      }),
+    );
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+  });
+
+  it("passes run-media image indexes through the execution boundary", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: { durationMs: 1 },
+    });
+    const followupRun = {
+      ...createFollowupRun(),
+      images: [{ type: "image" as const, data: "image", mimeType: "image/png" }],
+      imageOrder: ["inline" as const],
+      imageSourceMapping: { indexes: [0], space: "run-media" as const },
+      media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" as const }],
+    };
+
+    await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "whatsapp",
+          MessageSid: "msg",
+          media: followupRun.media,
+        },
+        sessionMediaSourceSpace: "run-media",
+      }),
+    );
+
+    expect(state.resolveCurrentTurnImagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ imageSourceIndexes: [0] }),
+    );
+  });
+
   it("returns one closed settled result with winner and fallback facts", async () => {
     state.runEmbeddedAgentMock.mockResolvedValue({
       payloads: [{ text: "done" }],

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -513,6 +513,64 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     });
   });
 
+  it("projects direct inbound image identities into CLI prompt media space", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("codex-cli", "gpt-5.4"),
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const inlineImage = {
+      type: "image" as const,
+      data: Buffer.from("inline").toString("base64"),
+      mimeType: "image/png",
+    };
+    state.resolveCurrentTurnImagesMock.mockResolvedValueOnce({
+      images: [inlineImage],
+      imageOrder: ["inline", "offloaded"],
+      imageSourceIndexes: [1, 2],
+    });
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.4";
+    followupRun.images = [inlineImage];
+    followupRun.imageOrder = ["inline", "offloaded"];
+    followupRun.imageSourceMapping = { indexes: [1, 2], space: "inbound-media" };
+    followupRun.media = [
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "/tmp/b.png", contentType: "image/png" },
+    ];
+    followupRun.mediaSourceIndexes = [1, 2];
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionMediaSourceSpace: "inbound-media",
+        sessionCtx: {
+          Provider: "whatsapp",
+          MessageSid: "msg",
+          media: [
+            { path: "/tmp/transcribed.ogg", contentType: "audio/ogg", transcribed: true },
+            ...followupRun.media,
+          ],
+        },
+      }),
+    );
+
+    expect(state.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      images: [inlineImage],
+      imageOrder: ["inline", "offloaded"],
+      imageFactIndexes: [0],
+      media: followupRun.media,
+    });
+  });
+
   it("consumes pending MCP App context when a CLI process receives the turn", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -13,6 +13,7 @@ import {
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import type { FollowupRun } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import type { TypingSignaler } from "./typing-mode.js";
@@ -275,8 +276,14 @@ vi.mock("./reply-media-paths.runtime.js", () => ({
 
 export async function getExecuteAgentTurnForTest() {
   const execute = (await import("./agent-runner-execution.js")).executeAgentTurn;
-  return async (...args: Parameters<typeof execute>) => {
-    const execution = await execute(...args);
+  return async (
+    params: Omit<AgentTurnParams, "sessionMediaSourceSpace"> &
+      Partial<Pick<AgentTurnParams, "sessionMediaSourceSpace">>,
+  ) => {
+    const execution = await execute({
+      ...params,
+      sessionMediaSourceSpace: params.sessionMediaSourceSpace ?? "inbound-media",
+    });
     const outcome = execution.outcome;
     if (outcome.kind === "settled") {
       return {
@@ -564,6 +571,7 @@ export function createMinimalRunAgentTurnParams(overrides?: {
   opts?: GetReplyOptions & ReplyOptionsWithHeartbeatRunScope;
   replyOperation?: ReplyOperation;
   sessionCtx?: TemplateContext;
+  sessionMediaSourceSpace?: "inbound-media" | "run-media";
   typingSignals?: TypingSignaler;
 }) {
   return {
@@ -575,6 +583,7 @@ export function createMinimalRunAgentTurnParams(overrides?: {
         Provider: "whatsapp",
         MessageSid: "msg",
       } as unknown as TemplateContext),
+    sessionMediaSourceSpace: overrides?.sessionMediaSourceSpace ?? "inbound-media",
     opts: overrides?.opts ?? ({} satisfies GetReplyOptions),
     replyOperation: overrides?.replyOperation,
     typingSignals: overrides?.typingSignals ?? createMockTypingSignaler(),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -30,6 +30,7 @@ import {
 import { emitAgentRunStatusEvent } from "../../infra/agent-run-status-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { logError } from "../../logger.js";
 import { logSessionTurnCreated } from "../../logging/diagnostic.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { ReplyPayload } from "../types.js";
@@ -198,12 +199,35 @@ async function executeAgentTurnInternalWithRetryState(
           requesterSenderE164: params.followupRun.run.senderE164,
         }),
       );
+    const imageSourceMapping = params.followupRun.imageSourceMapping;
+    const hasFollowupImageLayout =
+      params.followupRun.images !== undefined ||
+      params.followupRun.imageOrder !== undefined ||
+      imageSourceMapping !== undefined;
+    let imageSourceIndexes = hasFollowupImageLayout ? imageSourceMapping?.indexes : undefined;
+    let sourceMappingInvalid = params.followupRun.imageSourceMappingInvalid === true;
+    // Direct runs declare inbound-media; queued runs normalize to run-media. Never trust a
+    // wrong-space index, but degrade to ownership inference so an internal contract bug does not
+    // turn an otherwise recoverable user message into a terminal failure.
+    if (imageSourceMapping && imageSourceMapping.space !== params.sessionMediaSourceSpace) {
+      logError(
+        `Image source space ${imageSourceMapping.space} does not match session media space ${params.sessionMediaSourceSpace}`,
+      );
+      imageSourceIndexes = undefined;
+      sourceMappingInvalid = true;
+    }
     currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
       resolveCurrentTurnImages({
         ctx: params.sessionCtx,
         cfg: runtimeConfig,
-        images: params.followupRun.images ?? params.opts?.images,
-        imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
+        images: hasFollowupImageLayout ? params.followupRun.images : params.opts?.images,
+        imageOrder: hasFollowupImageLayout
+          ? params.followupRun.imageOrder
+          : params.opts?.imageOrder,
+        imageSourceIndexes,
+        sourceMappingInvalid,
+        invalidSourceMappingPolicy: "infer-inline",
+        imageFactIndexSpace: params.sessionMediaSourceSpace,
       }),
     );
   } catch (error) {

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -77,6 +77,8 @@ export type AgentTurnParams = {
   transcriptCommandBody?: string;
   followupRun: FollowupRun;
   sessionCtx: TemplateContext;
+  /** Declares which media index space sessionCtx.media represents when image sources are mapped. */
+  sessionMediaSourceSpace: "inbound-media" | "run-media";
   replyThreading?: TemplateContext["ReplyThreading"];
   replyOperation?: ReplyOperation;
   opts?: InternalGetReplyOptions;

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -659,6 +659,7 @@ describe("runReplyAgent media path normalization", () => {
         },
       }),
       sessionCtx,
+      sessionMediaSourceSpace: "inbound-media",
       typingSignals: {
         mode: "instant",
         shouldStartImmediately: true,
@@ -725,6 +726,7 @@ describe("runReplyAgent media path normalization", () => {
         AccountId: "default",
         MessageSid: "msg-1",
       } as unknown as TemplateContext,
+      sessionMediaSourceSpace: "inbound-media",
       typingSignals: {
         mode: "instant",
         shouldStartImmediately: true,

--- a/src/auto-reply/reply/agent-turn-attachments.ts
+++ b/src/auto-reply/reply/agent-turn-attachments.ts
@@ -64,8 +64,11 @@ export async function resolveAgentTurnAttachments(params: {
     return { attachments: [], recentHistoryImages: [] };
   }
   const runtime = params.runtime ?? (await loadAgentTurnMediaRuntime());
-  const currentAttachments = runtime
-    .normalizeAttachments(params.ctx)
+  const normalizedCurrentAttachments = runtime.normalizeAttachments(params.ctx);
+  const currentAttachments = normalizedCurrentAttachments
+    // Persisted or queued facts can retain this proof even when callers bypass current-turn image
+    // collection; keep the lower-level attachment loader safe as a replay boundary.
+    .filter((attachment) => attachment.hydrationSuppressed !== true)
     .map((attachment) =>
       normalizeOptionalString(attachment.path)
         ? Object.assign({}, attachment, { url: undefined })
@@ -75,7 +78,7 @@ export async function resolveAgentTurnAttachments(params: {
     ? resolveRecentInboundHistoryImages({ ctx: params.ctx })
     : [];
   const firstHistoryAttachmentIndex =
-    currentAttachments.reduce(
+    normalizedCurrentAttachments.reduce(
       (maxIndex, attachment) =>
         Number.isFinite(attachment.index) ? Math.max(maxIndex, attachment.index) : maxIndex,
       -1,

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -3,8 +3,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveProjectedImageSourceIndexes } from "../../media/image-source-indexes.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
+import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { MsgContext } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
 
@@ -54,6 +56,7 @@ describe("resolveCurrentTurnImages", () => {
           },
         ],
         imageOrder: ["inline"],
+        imageSourceIndexes: [0],
       });
     });
   });
@@ -92,14 +95,11 @@ describe("resolveCurrentTurnImages", () => {
       await fs.writeFile(imagePath, imageBytes);
       const sharedContext = {
         Body: "caption",
-        media: [{ path: imagePath, contentType: "image/png" }],
+        media: [{ path: imagePath, contentType: "image/png", workspaceDir: stagingRoot }],
       } satisfies MsgContext;
 
       const prepared = await resolveCurrentTurnImages({
-        ctx: {
-          ...sharedContext,
-          media: [{ path: imagePath, contentType: "image/png", workspaceDir: stagingRoot }],
-        },
+        ctx: sharedContext,
         cfg: {} as OpenClawConfig,
       });
       const runner = await resolveCurrentTurnImages({
@@ -107,11 +107,161 @@ describe("resolveCurrentTurnImages", () => {
         cfg: {} as OpenClawConfig,
         images: prepared.images,
         imageOrder: prepared.imageOrder,
+        imageSourceIndexes: prepared.imageSourceIndexes,
       });
 
       expect(prepared.images).toHaveLength(1);
       expect(Buffer.from(prepared.images?.[0]?.data ?? "", "base64")).toEqual(imageBytes);
       expect(runner.images).toEqual(prepared.images);
+      expect(runner.imageOrder).toEqual(["inline"]);
+      expect(runner.imageSourceIndexes).toEqual([0]);
+    });
+  });
+
+  it("keeps direct-run image indexes in the original ctx media space", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-projected-media-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      const imageBytes = Buffer.from("projected-image");
+      await fs.writeFile(imagePath, imageBytes);
+      const ctx = {
+        Body: "caption",
+        media: [
+          {
+            path: path.join(base, "voice.ogg"),
+            contentType: "audio/ogg",
+            kind: "audio" as const,
+            transcribed: true,
+            workspaceDir: base,
+          },
+          { path: imagePath, contentType: "image/png", workspaceDir: base },
+        ],
+      } satisfies MsgContext;
+
+      const prepared = await resolveCurrentTurnImages({
+        ctx,
+        cfg: {} as OpenClawConfig,
+      });
+      const projection = buildInboundMediaNoteProjection(ctx);
+      const runner = await resolveCurrentTurnImages({
+        ctx,
+        cfg: {} as OpenClawConfig,
+        images: prepared.images,
+        imageOrder: prepared.imageOrder,
+        imageSourceIndexes: prepared.imageSourceIndexes,
+      });
+
+      expect(prepared.imageSourceIndexes).toEqual([1]);
+      expect(projection.mediaSourceIndexes).toEqual([1]);
+      expect(runner.images).toEqual(prepared.images);
+      expect(runner.imageOrder).toEqual(["inline"]);
+      expect(runner.imageSourceIndexes).toEqual([1]);
+    });
+  });
+
+  it("dedupes a second hydration in projected run-media space", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-run-media-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "run-media-image");
+      const inboundCtx = {
+        Body: "caption",
+        media: [
+          {
+            path: path.join(base, "voice.ogg"),
+            contentType: "audio/ogg",
+            kind: "audio" as const,
+            transcribed: true,
+            workspaceDir: base,
+          },
+          { path: imagePath, contentType: "image/png", workspaceDir: base },
+        ],
+      } satisfies MsgContext;
+
+      const prepared = await resolveCurrentTurnImages({
+        ctx: inboundCtx,
+        cfg: {} as OpenClawConfig,
+      });
+      const projection = buildInboundMediaNoteProjection(inboundCtx);
+      const projectedResult = resolveProjectedImageSourceIndexes({
+        imageSourceMapping: prepared.imageSourceIndexes
+          ? { indexes: prepared.imageSourceIndexes, space: "inbound-media" }
+          : undefined,
+        imageOrderLength: prepared.imageOrder?.length ?? 0,
+        projectedMediaSourceIndexes: projection.mediaSourceIndexes,
+        projectedMediaLength: projection.media.length,
+      });
+      expect(projectedResult.kind).toBe("mapped");
+      const projectedIndexes =
+        projectedResult.kind === "mapped" ? projectedResult.indexes : undefined;
+      const runner = await resolveCurrentTurnImages({
+        ctx: { ...inboundCtx, media: projection.media },
+        cfg: {} as OpenClawConfig,
+        images: prepared.images,
+        imageOrder: prepared.imageOrder,
+        imageSourceIndexes: projectedIndexes,
+      });
+
+      expect(projectedIndexes).toEqual([0]);
+      expect(runner.images).toEqual(prepared.images);
+      expect(runner.images).toHaveLength(1);
+      expect(runner.imageOrder).toEqual(["inline"]);
+      expect(runner.imageSourceIndexes).toEqual([0]);
+    });
+  });
+
+  it("dedupes all images after collect merges them into run-media space", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-collect-media-" }, async (base) => {
+      const firstPath = path.join(base, "first.png");
+      const secondPath = path.join(base, "second.png");
+      await fs.writeFile(firstPath, "first-image");
+      await fs.writeFile(secondPath, "second-image");
+      const collectCtx = {
+        Body: "compare",
+        media: [
+          { path: firstPath, contentType: "image/png", workspaceDir: base },
+          { path: secondPath, contentType: "image/png", workspaceDir: base },
+        ],
+      } satisfies MsgContext;
+
+      const prepared = await resolveCurrentTurnImages({
+        ctx: collectCtx,
+        cfg: {} as OpenClawConfig,
+      });
+      const runner = await resolveCurrentTurnImages({
+        ctx: collectCtx,
+        cfg: {} as OpenClawConfig,
+        images: prepared.images,
+        imageOrder: prepared.imageOrder,
+        imageSourceIndexes: [0, 1],
+      });
+
+      expect(runner.images).toEqual(prepared.images);
+      expect(runner.images).toHaveLength(2);
+      expect(runner.imageOrder).toEqual(["inline", "inline"]);
+      expect(runner.imageSourceIndexes).toEqual([0, 1]);
+    });
+  });
+
+  it("does not hydrate image facts explicitly suppressed by media understanding", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-suppressed-image-" }, async (base) => {
+      const imagePath = path.join(base, "described.png");
+      await fs.writeFile(imagePath, "already-described-image");
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          media: [
+            {
+              path: imagePath,
+              contentType: "image/png",
+              workspaceDir: base,
+              hydrationSuppressed: true,
+            },
+          ],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result).toEqual({});
     });
   });
 
@@ -184,6 +334,212 @@ describe("resolveCurrentTurnImages", () => {
     expect(result).toEqual({
       images: inlineImages,
       imageOrder: ["inline", "offloaded", "inline"],
+    });
+  });
+
+  it("normalizes inconsistent image slot layouts without retry loops", async () => {
+    const image = {
+      type: "image" as const,
+      data: Buffer.from("inline").toString("base64"),
+      mimeType: "image/png",
+    };
+
+    await expect(
+      resolveCurrentTurnImages({
+        ctx: { Body: "compare" } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        images: [image],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [0, 1],
+      }),
+    ).resolves.toEqual({
+      images: [image],
+      imageOrder: ["inline"],
+      imageSourceMappingInvalid: true,
+    });
+    await expect(
+      resolveCurrentTurnImages({
+        ctx: { Body: "compare" } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        images: [image],
+        imageOrder: ["offloaded"],
+      }),
+    ).resolves.toEqual({ images: [image], imageOrder: ["offloaded", "inline"] });
+  });
+
+  it("can assume invalid image sources were represented during second hydration", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-invalid-source-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "source-image");
+
+      const prepared = {
+        type: "image" as const,
+        data: Buffer.from("prepared").toString("base64"),
+        mimeType: "image/png",
+      };
+      await expect(
+        resolveCurrentTurnImages({
+          ctx: {
+            Body: "caption",
+            media: [{ path: imagePath, contentType: "image/png", workspaceDir: base }],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+          images: [prepared],
+          imageOrder: ["inline"],
+          imageSourceIndexes: [1],
+          invalidSourceMappingPolicy: "infer-inline",
+        }),
+      ).resolves.toEqual({
+        images: [prepared],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [0],
+        imageSourceMappingInvalid: true,
+      });
+    });
+  });
+
+  it("hydrates available media during first hydration when source mapping is invalid", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-invalid-source-hydrate-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "source-image");
+      const prepared = {
+        type: "image" as const,
+        data: Buffer.from("prepared").toString("base64"),
+        mimeType: "image/png",
+      };
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          media: [{ path: imagePath, contentType: "image/png", workspaceDir: base }],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        images: [prepared],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [1],
+        invalidSourceMappingPolicy: "hydrate",
+      });
+
+      expect(result.images).toHaveLength(2);
+      expect(result.imageOrder).toEqual(["inline", "inline"]);
+      expect(result.imageSourceIndexes).toEqual([undefined, 0]);
+      expect(result.imageSourceMappingInvalid).toBe(true);
+    });
+  });
+
+  it("does not infer invalid inline ownership from an already described attachment", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-invalid-described-" }, async (base) => {
+      const describedPath = path.join(base, "described.png");
+      const undescribedPath = path.join(base, "undescribed.png");
+      await fs.writeFile(describedPath, "described-image");
+      await fs.writeFile(undescribedPath, "undescribed-image");
+      const prepared = {
+        type: "image" as const,
+        data: Buffer.from("prepared").toString("base64"),
+        mimeType: "image/png",
+      };
+
+      await expect(
+        resolveCurrentTurnImages({
+          ctx: {
+            Body: "caption",
+            media: [
+              { path: describedPath, contentType: "image/png", workspaceDir: base },
+              { path: undescribedPath, contentType: "image/png", workspaceDir: base },
+            ],
+            MediaUnderstanding: [
+              {
+                kind: "image.description",
+                attachmentIndex: 0,
+                provider: "openai",
+                model: "test-vision",
+                text: "already described",
+              },
+            ],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+          images: [prepared],
+          imageOrder: ["inline"],
+          sourceMappingInvalid: true,
+          invalidSourceMappingPolicy: "infer-inline",
+        }),
+      ).resolves.toEqual({
+        images: [prepared],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [1],
+        imageSourceMappingInvalid: true,
+      });
+    });
+  });
+
+  it("accepts a valid high source index after an empty media slot", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-empty-slot-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "source-image");
+      const prepared = {
+        type: "image" as const,
+        data: Buffer.from("prepared").toString("base64"),
+        mimeType: "image/png",
+      };
+
+      await expect(
+        resolveCurrentTurnImages({
+          ctx: {
+            Body: "caption",
+            media: [{}, { path: imagePath, contentType: "image/png", workspaceDir: base }],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+          images: [prepared],
+          imageOrder: ["inline"],
+          imageSourceIndexes: [1],
+        }),
+      ).resolves.toEqual({
+        images: [prepared],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [1],
+      });
+    });
+  });
+
+  it("keeps unsourced slots stable while ordering source-backed images", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-mixed-sources-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "current-image");
+      const supplied = {
+        type: "image" as const,
+        data: Buffer.from("supplied-image").toString("base64"),
+        mimeType: "image/png",
+      };
+      const extracted = {
+        type: "image" as const,
+        data: Buffer.from("extracted-image").toString("base64"),
+        mimeType: "image/png",
+        attachmentIndex: 1,
+      };
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "compare",
+          media: [
+            { path: imagePath, contentType: "image/png", workspaceDir: base },
+            {
+              path: path.join(base, "scan.pdf"),
+              contentType: "application/pdf",
+              workspaceDir: base,
+            },
+          ],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        images: [supplied],
+        extractedFileImages: [extracted],
+      });
+
+      expect(result.images?.map((image) => Buffer.from(image.data, "base64").toString())).toEqual([
+        "supplied-image",
+        "current-image",
+        "extracted-image",
+      ]);
+      expect(result.imageSourceIndexes).toEqual([undefined, 0, 1]);
     });
   });
 

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -5,12 +5,17 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ImageContent } from "../../llm/types.js";
+import { logError } from "../../logger.js";
 import { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
 import {
   stripExtractedFileImageMetadata,
   type ExtractedFileImage,
 } from "../../media-understanding/extracted-file-images.js";
+import { orderSourceIndexedEntries } from "../../media/image-source-indexes.js";
+import { normalizeMediaFacts } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import { finalizeRuntimePromptImages } from "../../media/runtime-prompt-image-provenance.js";
+import type { RuntimePromptImageFactSpace } from "../../media/runtime-prompt-image-provenance.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
 import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
 
@@ -28,6 +33,11 @@ type OrderedTurnImage = {
   sequence: number;
 };
 
+type OrderedImageSlot = {
+  kind: PromptImageOrderEntry;
+  sourceIndex?: number;
+};
+
 function isGenericMediaType(mediaType: string | undefined): boolean {
   if (!mediaType) {
     return true;
@@ -36,8 +46,7 @@ function isGenericMediaType(mediaType: string | undefined): boolean {
   return normalized === "application/octet-stream" || normalized === "binary/octet-stream";
 }
 
-/** Resolves image media types from current-turn attachment metadata or filenames. */
-function resolveCurrentImageMediaType(pathValue: unknown, mediaType?: unknown): string | undefined {
+function resolveNativeImageMediaType(pathValue: unknown, mediaType?: unknown): string | undefined {
   const mediaPath = normalizeOptionalString(pathValue);
   if (!mediaPath) {
     return undefined;
@@ -53,10 +62,15 @@ function resolveCurrentImageMediaType(pathValue: unknown, mediaType?: unknown): 
   return inferredType?.startsWith("image/") ? inferredType : undefined;
 }
 
-function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment[] {
-  return normalizeAttachments(ctx).flatMap((attachment) => {
+function collectCurrentImageAttachments(
+  attachments: ReturnType<typeof normalizeAttachments>,
+): CurrentImageAttachment[] {
+  return attachments.flatMap((attachment) => {
+    if (attachment.hydrationSuppressed === true) {
+      return [];
+    }
     const mediaPath = normalizeOptionalString(attachment.path);
-    const mediaType = resolveCurrentImageMediaType(attachment.path, attachment.mime);
+    const mediaType = resolveNativeImageMediaType(attachment.path, attachment.mime);
     if (mediaPath && mediaType) {
       return [
         {
@@ -94,70 +108,104 @@ function createUndescribedImageContext(
   };
 }
 
+function normalizeOrderedImageSlots(params: {
+  images: ImageContent[] | undefined;
+  imageOrder?: PromptImageOrderEntry[];
+  imageSourceIndexes?: readonly (number | undefined)[];
+}): { slots: OrderedImageSlot[]; sourceMappingInvalid: boolean } {
+  const images = params.images ?? [];
+  const imageOrder = params.imageOrder ?? images.map(() => "inline" as const);
+  let slots = imageOrder.map((kind, index) => ({
+    kind,
+    sourceIndex: params.imageSourceIndexes?.[index],
+  }));
+  let sourceMappingInvalid = false;
+  if (params.imageSourceIndexes && params.imageSourceIndexes.length !== imageOrder.length) {
+    logError(
+      `Image source slot count ${params.imageSourceIndexes.length} does not match image order count ${imageOrder.length}`,
+    );
+    sourceMappingInvalid = true;
+  }
+  const inlineSlotCount = imageOrder.filter((entry) => entry === "inline").length;
+  if (inlineSlotCount !== images.length) {
+    const mismatchMessage = `Inline image count ${images.length} does not match image order slot count ${inlineSlotCount}`;
+    if (images.length === 0) {
+      logVerbose(`${mismatchMessage}; leaving fact-owned slots to runner hydration`);
+    } else if (params.imageSourceIndexes) {
+      logError(mismatchMessage);
+    } else {
+      logVerbose(mismatchMessage);
+    }
+    sourceMappingInvalid ||= params.imageSourceIndexes !== undefined;
+    let remainingInlineSlots = images.length;
+    slots = slots.filter((slot) => {
+      if (slot.kind === "offloaded") {
+        return true;
+      }
+      if (remainingInlineSlots === 0) {
+        return false;
+      }
+      remainingInlineSlots -= 1;
+      return true;
+    });
+    slots.push(
+      ...Array.from({ length: remainingInlineSlots }, () => ({
+        kind: "inline" as const,
+        sourceIndex: undefined,
+      })),
+    );
+  }
+  return { slots, sourceMappingInvalid };
+}
+
 function appendOrderedImages(params: {
   entries: OrderedTurnImage[];
   images: ImageContent[] | undefined;
-  imageOrder?: PromptImageOrderEntry[];
+  slots?: readonly OrderedImageSlot[];
   sourceIndex?: number;
-}) {
+}): void {
   const images = params.images ?? [];
-  if (!params.imageOrder || params.imageOrder.length === 0) {
-    for (const image of images) {
-      params.entries.push({
-        image,
-        imageOrder: "inline",
-        sourceIndex: params.sourceIndex,
-        sequence: params.entries.length,
-      });
-    }
-    return;
-  }
-
+  const slots: readonly OrderedImageSlot[] =
+    params.slots ?? images.map(() => ({ kind: "inline" as const }));
   let inlineIndex = 0;
-  for (const imageOrder of params.imageOrder) {
+  for (const slot of slots) {
+    const mappedSourceIndex = slot.sourceIndex;
     params.entries.push({
-      image: imageOrder === "inline" ? images[inlineIndex++] : undefined,
-      imageOrder,
-      sourceIndex: params.sourceIndex,
-      sequence: params.entries.length,
-    });
-  }
-  while (inlineIndex < images.length) {
-    params.entries.push({
-      image: images[inlineIndex++],
-      imageOrder: "inline",
-      sourceIndex: params.sourceIndex,
+      image: slot.kind === "inline" ? images[inlineIndex++] : undefined,
+      imageOrder: slot.kind,
+      sourceIndex: mappedSourceIndex ?? params.sourceIndex,
       sequence: params.entries.length,
     });
   }
 }
 
-function resolveMergedTurnImages(entries: OrderedTurnImage[]): {
+function resolveMergedTurnImages(
+  entries: OrderedTurnImage[],
+  sourceMappingInvalid: boolean,
+  imageFactIndexSpace?: RuntimePromptImageFactSpace,
+): {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
   imageSourceIndexes?: Array<number | undefined>;
+  imageSourceMappingInvalid?: true;
 } {
   if (entries.length === 0) {
-    return {};
+    return sourceMappingInvalid ? { imageSourceMappingInvalid: true } : {};
   }
-  const merged = entries.toSorted((left, right) => {
-    if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
-      return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
-    }
-    if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
-      return left.sequence - right.sequence;
-    }
-    return left.sequence - right.sequence;
-  });
-  const images = merged.flatMap((entry) => (entry.image ? [entry.image] : []));
-  const result = {
+  const merged = orderSourceIndexedEntries(entries);
+  const images = finalizeRuntimePromptImages(
+    merged.flatMap((entry) =>
+      entry.image ? [{ image: entry.image, factIndex: entry.sourceIndex ?? null }] : [],
+    ),
+    imageFactIndexSpace,
+  ).images;
+  const imageSourceIndexes = merged.map((entry) => entry.sourceIndex);
+  return {
     ...(images.length > 0 ? { images } : {}),
     imageOrder: merged.map((entry) => entry.imageOrder),
+    ...(imageSourceIndexes.some((index) => index !== undefined) ? { imageSourceIndexes } : {}),
+    ...(sourceMappingInvalid ? { imageSourceMappingInvalid: true as const } : {}),
   };
-  Object.defineProperty(result, "imageSourceIndexes", {
-    value: merged.map((entry) => entry.sourceIndex),
-  });
-  return result;
 }
 
 /** Resolves current-turn image attachments that were not already described by media understanding. */
@@ -166,18 +214,27 @@ export async function resolveCurrentTurnImages(params: {
   cfg: OpenClawConfig;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  imageSourceIndexes?: readonly (number | undefined)[];
+  sourceMediaCount?: number;
+  sourceMappingInvalid?: boolean;
+  invalidSourceMappingPolicy?: "hydrate" | "infer-inline";
   extractedFileImages?: ExtractedFileImage[];
+  imageFactIndexSpace?: RuntimePromptImageFactSpace;
 }): Promise<{
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
   imageSourceIndexes?: Array<number | undefined>;
+  imageSourceMappingInvalid?: true;
 }> {
   const entries: OrderedTurnImage[] = [];
-  appendOrderedImages({
-    entries,
+  const initialSlots = normalizeOrderedImageSlots({
     images: params.images,
     imageOrder: params.imageOrder,
+    imageSourceIndexes: params.imageSourceIndexes,
   });
+  appendOrderedImages({ entries, images: params.images, slots: initialSlots.slots });
+  let sourceMappingInvalid =
+    initialSlots.sourceMappingInvalid || params.sourceMappingInvalid === true;
   for (const image of params.extractedFileImages ?? []) {
     appendOrderedImages({
       entries,
@@ -186,16 +243,56 @@ export async function resolveCurrentTurnImages(params: {
     });
   }
 
-  const currentImageAttachments = collectCurrentImageAttachments(params.ctx);
+  const normalizedAttachments = normalizeAttachments(params.ctx);
+  const sourceMediaCount = params.sourceMediaCount ?? normalizeMediaFacts(params.ctx.media).length;
+  for (const entry of entries) {
+    const sourceIndex = entry.sourceIndex;
+    if (sourceIndex !== undefined && (sourceIndex < 0 || sourceIndex >= sourceMediaCount)) {
+      logError(
+        `Image source index ${sourceIndex} does not exist in the current session media space`,
+      );
+      sourceMappingInvalid = true;
+      entry.sourceIndex = undefined;
+    }
+  }
+  const currentImageAttachments = collectCurrentImageAttachments(normalizedAttachments);
   if (currentImageAttachments.length === 0) {
-    return resolveMergedTurnImages(entries);
+    return resolveMergedTurnImages(entries, sourceMappingInvalid, params.imageFactIndexSpace);
   }
   const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
+  // The hydrate policy leaves unsourced facts eligible for the native hydration path below.
+  const inferInlineOwnership =
+    sourceMappingInvalid && params.invalidSourceMappingPolicy === "infer-inline";
+  if (inferInlineOwnership) {
+    const claimedIndexes = new Set(
+      entries.flatMap((entry) => (entry.sourceIndex === undefined ? [] : [entry.sourceIndex])),
+    );
+    const unclaimedAttachments = currentImageAttachments.filter(
+      (attachment) =>
+        !claimedIndexes.has(attachment.index) && !describedImageIndexes.has(attachment.index),
+    );
+    let unclaimedIndex = 0;
+    for (const entry of entries) {
+      if (!entry.image || entry.sourceIndex !== undefined) {
+        continue;
+      }
+      const attachment = unclaimedAttachments[unclaimedIndex++];
+      if (!attachment) {
+        break;
+      }
+      entry.sourceIndex = attachment.index;
+    }
+  }
+  const representedImageIndexes = new Set(
+    entries.flatMap((entry) => (entry.sourceIndex === undefined ? [] : [entry.sourceIndex])),
+  );
   const undescribedImageAttachments = currentImageAttachments.filter(
-    (attachment) => !describedImageIndexes.has(attachment.index),
+    (attachment) =>
+      !describedImageIndexes.has(attachment.index) &&
+      !representedImageIndexes.has(attachment.index),
   );
   if (undescribedImageAttachments.length === 0) {
-    return resolveMergedTurnImages(entries);
+    return resolveMergedTurnImages(entries, sourceMappingInvalid, params.imageFactIndexSpace);
   }
 
   try {
@@ -216,7 +313,7 @@ export async function resolveCurrentTurnImages(params: {
       logVerbose(
         `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
       );
-      return resolveMergedTurnImages(entries);
+      return resolveMergedTurnImages(entries, sourceMappingInvalid, params.imageFactIndexSpace);
     }
     for (const [index, image] of images.entries()) {
       appendOrderedImages({
@@ -225,11 +322,11 @@ export async function resolveCurrentTurnImages(params: {
         sourceIndex: undescribedImageAttachments[index]?.index,
       });
     }
-    return resolveMergedTurnImages(entries);
+    return resolveMergedTurnImages(entries, sourceMappingInvalid, params.imageFactIndexSpace);
   } catch (error) {
     logVerbose(
       `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    return resolveMergedTurnImages(entries);
+    return resolveMergedTurnImages(entries, sourceMappingInvalid, params.imageFactIndexSpace);
   }
 }

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -1364,6 +1364,46 @@ describe("tryDispatchAcpReply", () => {
     expect(normalizeAttachments).not.toHaveBeenCalled();
   });
 
+  it("does not hydrate attachments explicitly suppressed by an earlier image slot", async () => {
+    const getBuffer = vi.fn(async () => {
+      throw new Error("suppressed attachment must not be read");
+    });
+    const result = await resolveAgentTurnAttachments({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        media: [
+          {
+            path: "/tmp/already-represented.png",
+            contentType: "image/png",
+            hydrationSuppressed: true,
+          },
+        ],
+      }),
+      runtime: {
+        MediaAttachmentCache: class {
+          getBuffer = getBuffer;
+        } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
+        isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
+          false,
+        normalizeAttachments: () => [
+          {
+            path: "/tmp/already-represented.png",
+            mime: "image/png",
+            index: 0,
+            hydrationSuppressed: true,
+          },
+        ],
+        resolveMediaAttachmentLocalRoots: () => ["/tmp"],
+      },
+      includeRecentHistoryImages: false,
+    });
+
+    expect(result).toEqual({ attachments: [], recentHistoryImages: [] });
+    expect(getBuffer).not.toHaveBeenCalled();
+  });
+
   it("does not inject recent history images when the current turn already has an image", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dispatch-acp-current-"));
     const currentPath = path.join(tempDir, "current.png");
@@ -1701,6 +1741,95 @@ describe("tryDispatchAcpReply", () => {
         mediaType: "image/png",
         data: pdfPage.data,
       },
+    ]);
+  });
+
+  it("orders ACP extracted attachments by their media source indexes", async () => {
+    setReadyAcpResolution();
+    const currentPath = "/tmp/openclaw-current-ordered-image.png";
+    const current = Buffer.from("current");
+    acpAttachmentBuffers.set(currentPath, current);
+    const extractedSecond = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("second").toString("base64"),
+      attachmentIndex: 2,
+    };
+    const extractedFirst = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("first").toString("base64"),
+      attachmentIndex: 1,
+    };
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValueOnce({
+      outputs: [],
+      decisions: [],
+      extractedFileImages: [extractedSecond, extractedFirst],
+      appliedImage: false,
+      appliedAudio: false,
+      appliedVideo: false,
+      appliedFile: true,
+    });
+
+    await runDispatch({
+      bodyForAgent: "compare pages",
+      ctxOverrides: { media: [{ path: currentPath, contentType: "image/png" }] },
+    });
+
+    const attachments = runTurnCall().attachments as
+      | Array<{ data: string; mimeType: string }>
+      | undefined;
+    expect(attachments?.map((attachment) => attachment.data)).toEqual([
+      current.toString("base64"),
+      extractedFirst.data,
+      extractedSecond.data,
+    ]);
+  });
+
+  it("keeps unsourced inline ACP attachments stable while sorting extracted sources", async () => {
+    setReadyAcpResolution();
+    const inline = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("inline").toString("base64"),
+    };
+    const extractedSecond = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("second").toString("base64"),
+      attachmentIndex: 2,
+    };
+    const extractedFirst = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("first").toString("base64"),
+      attachmentIndex: 1,
+    };
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValueOnce({
+      outputs: [],
+      decisions: [],
+      extractedFileImages: [extractedSecond, extractedFirst],
+      appliedImage: false,
+      appliedAudio: false,
+      appliedVideo: false,
+      appliedFile: true,
+    });
+
+    await runDispatch({
+      bodyForAgent: "compare",
+      images: [inline],
+      ctxOverrides: {
+        media: [{ path: "/tmp/report.pdf", contentType: "application/pdf" }],
+      },
+    });
+
+    const attachments = runTurnCall().attachments as
+      | Array<{ data: string; mimeType: string }>
+      | undefined;
+    expect(attachments?.map((attachment) => attachment.data)).toEqual([
+      inline.data,
+      extractedFirst.data,
+      extractedSecond.data,
     ]);
   });
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -27,6 +27,7 @@ import {
   stripExtractedFileImageMetadata,
   type ExtractedFileImage,
 } from "../../media-understanding/extracted-file-images.js";
+import { orderSourceIndexedEntries } from "../../media/image-source-indexes.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { classifySessionStateActor } from "../../sessions/session-state-events.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -77,17 +78,7 @@ function appendOrderedAcpAttachments(params: {
 }
 
 function resolveMergedAcpAttachments(entries: OrderedAcpAttachment[]): AcpTurnAttachment[] {
-  return entries
-    .toSorted((left, right) => {
-      if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
-        return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
-      }
-      if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
-        return left.sequence - right.sequence;
-      }
-      return left.sequence - right.sequence;
-    })
-    .map((entry) => entry.attachment);
+  return orderSourceIndexedEntries(entries).map((entry) => entry.attachment);
 }
 const dispatchAcpSessionRuntimeLoader = createLazyImportLoader(
   () => import("./dispatch-acp-session.runtime.js"),

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
+import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
 
 const state = vi.hoisted(() => ({
@@ -114,6 +115,7 @@ describe("executeFollowupTurn", () => {
     });
 
     const call = state.execute.mock.calls[0]?.[0] as AgentTurnParams;
+    expect(call.followupRun).toBe(turn.queued);
     expect(call).toMatchObject({
       commandBody: "queued prompt",
       transcriptCommandBody: "queued transcript",
@@ -136,6 +138,107 @@ describe("executeFollowupTurn", () => {
     expect(call.sessionCtx.media).toEqual([{ kind: "audio", contentType: "audio/ogg" }]);
     expect(onExecutionStarted).toHaveBeenCalledOnce();
     expect(onAgentRunStart).toHaveBeenCalledWith("run-1");
+  });
+
+  it("preserves probe-rechecked run writeback on the admitted queued turn", async () => {
+    const turn = createTurn();
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      params.followupRun.run = {
+        ...params.followupRun.run,
+        provider: "openai",
+        model: "rechecked-model",
+      };
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+
+    expect(turn.queued.run.provider).toBe("openai");
+    expect(turn.queued.run.model).toBe("rechecked-model");
+  });
+
+  it("remaps original image indexes to the queued media projection", async () => {
+    const base = createTurn();
+    const image = { type: "image" as const, data: "image", mimeType: "image/png" };
+    const turn = createTurn({
+      queued: {
+        ...base.queued,
+        images: [image],
+        imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [1], space: "inbound-media" },
+        media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" }],
+        mediaSourceIndexes: [1],
+      },
+    });
+
+    await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+
+    const call = state.execute.mock.calls[0]?.[0] as AgentTurnParams;
+    expect(call.sessionCtx.media).toEqual(turn.queued.media);
+    expect(call.followupRun.imageSourceMapping).toEqual({ indexes: [0], space: "run-media" });
+  });
+
+  it("drops invalid queued source ownership without suppressing visible hydration", async () => {
+    const base = createTurn();
+    const turn = createTurn({
+      queued: {
+        ...base.queued,
+        images: [{ type: "image", data: "image", mimeType: "image/png" }],
+        imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [0], space: "inbound-media" },
+        media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" }],
+      },
+    });
+
+    await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+
+    const call = state.execute.mock.calls[0]?.[0] as AgentTurnParams;
+    expect(call.followupRun.imageSourceMapping).toEqual({
+      indexes: [undefined],
+      space: "run-media",
+    });
+    expect(call.followupRun.imageSourceMappingInvalid).toBe(true);
+    expect(call.sessionCtx.media?.map((fact) => fact.path)).toEqual(["/tmp/photo.png"]);
+    expect(call.sessionCtx.media?.[0]?.hydrationSuppressed).toBeUndefined();
+
+    const secondHydration = await resolveCurrentTurnImages({
+      ctx: call.sessionCtx,
+      cfg: {} as never,
+      images: call.followupRun.images,
+      imageOrder: call.followupRun.imageOrder,
+      imageSourceIndexes: call.followupRun.imageSourceMapping?.indexes,
+      sourceMappingInvalid: call.followupRun.imageSourceMappingInvalid,
+      invalidSourceMappingPolicy: "infer-inline",
+    });
+    expect(secondHydration.images).toHaveLength(1);
+    expect(secondHydration.imageOrder).toEqual(["inline"]);
   });
 
   it("ignores verbosity loaded from a replacement session generation", async () => {

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -1,5 +1,7 @@
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { logError } from "../../logger.js";
+import { resolveProjectedImageSourceIndexes } from "../../media/image-source-indexes.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
@@ -277,11 +279,40 @@ export async function executeFollowupTurn(params: {
     };
   } else {
     try {
+      const sourceMapping = turn.queued.imageSourceMapping;
+      const imageOrderLength = turn.queued.imageOrder?.length ?? turn.queued.images?.length ?? 0;
+      const sourceResult = resolveProjectedImageSourceIndexes({
+        imageSourceMapping: sourceMapping,
+        imageOrderLength,
+        projectedMediaSourceIndexes: turn.queued.mediaSourceIndexes,
+        projectedMediaLength: turn.queued.media?.length ?? 0,
+      });
+      const sourceMappingInvalid =
+        turn.queued.imageSourceMappingInvalid === true || sourceResult.kind === "invalid";
+      if (sourceResult.kind === "invalid") {
+        logError(
+          `followup image source mapping is invalid; continuing without positional ownership: ${sourceResult.reason}`,
+        );
+      }
+      const queuedImageSourceIndexes =
+        sourceResult.kind === "none" ? undefined : sourceResult.indexes;
+      if (sourceMappingInvalid) {
+        turn.queued.imageSourceMappingInvalid = true;
+      }
+      if (queuedImageSourceIndexes) {
+        turn.queued.imageSourceMapping = {
+          indexes: queuedImageSourceIndexes,
+          space: "run-media",
+        };
+      }
       execution = await executeAgentTurn({
         commandBody: turn.queued.prompt,
         transcriptCommandBody: turn.queued.transcriptPrompt,
+        // Preserve queued object identity: executeAgentTurn deliberately writes a probe-rechecked
+        // runnable run back through followupRun.run for later accounting and delivery.
         followupRun: turn.queued,
         sessionCtx,
+        sessionMediaSourceSpace: "run-media",
         replyOperation: turn.operation,
         opts: progressOpts,
         typingSignals,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -198,6 +198,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     transcriptBody,
     transcriptCommandBody,
     media: promptMedia,
+    mediaSourceIndexes: promptMediaSourceIndexes,
     currentInboundContext,
   } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
   const isRoomEvent = inboundEventKind === "room_event";
@@ -548,6 +549,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
           transcriptBody,
           transcriptCommandBody,
           media: promptMedia,
+          mediaSourceIndexes: promptMediaSourceIndexes,
           currentInboundContext,
         } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));
       },
@@ -571,6 +573,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     transcriptBody,
     transcriptCommandBody,
     promptMedia,
+    promptMediaSourceIndexes,
     currentInboundContext,
     isRoomEvent,
     providedReplyOperation,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -7,6 +7,8 @@ import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { conversationIdentityFromMsgContext } from "../../config/sessions/conversation-identity.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
+import { logError } from "../../logger.js";
+import { buildSuppliedImageSourceIndexes } from "../../media/image-source-indexes.js";
 import { normalizeMediaFacts } from "../../media/media-facts.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import {
@@ -46,6 +48,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     transcriptBody,
     transcriptCommandBody,
     promptMedia,
+    promptMediaSourceIndexes,
     currentInboundContext,
     isRoomEvent,
     providedReplyOperation,
@@ -133,13 +136,33 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     runHasSessionModelOverride &&
     hasSessionAutoModelFallbackProvenance(preparedSessionState.sessionEntry);
   const originatingThreadId = resolveRoutedDeliveryThreadId({ ctx, sessionKey });
+  const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
+  const suppliedMediaForPersistence = normalizeMediaFacts(opts?.media);
+  const userTurnMediaForPersistence = [...ctxMediaForPersistence, ...suppliedMediaForPersistence];
+  const suppliedSourceResult = buildSuppliedImageSourceIndexes({
+    imageOrder: opts?.imageOrder,
+    suppliedMedia: suppliedMediaForPersistence,
+    sourceOffset: ctxMediaForPersistence.length,
+  });
+  if (suppliedSourceResult.kind === "invalid") {
+    logError(
+      `supplied image source mapping is invalid; continuing without positional ownership: ${suppliedSourceResult.reason}`,
+    );
+  }
+  const suppliedImageSourceIndexes =
+    suppliedSourceResult.kind === "none" ? undefined : suppliedSourceResult.indexes;
   const currentTurnImages = await traceRunPhase("reply.resolve_current_turn_images", () =>
     resolveCurrentTurnImages({
       ctx,
       cfg,
       images: opts?.images,
       imageOrder: opts?.imageOrder,
+      imageSourceIndexes: suppliedImageSourceIndexes,
+      sourceMediaCount: userTurnMediaForPersistence.length,
+      sourceMappingInvalid: suppliedSourceResult.kind === "invalid",
+      invalidSourceMappingPolicy: "hydrate",
       extractedFileImages: opts?.extractedFileImages,
+      imageFactIndexSpace: "inbound-media",
     }),
   );
   // Abort-signal attachment for queued followups:
@@ -188,9 +211,18 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
         })
       : undefined);
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
+  const agentSessionCtx =
+    userTurnMediaForPersistence.length > 0
+      ? {
+          ...sessionCtx,
+          // Preserve the exact slot order so `inbound-media` indexes address
+          // `[ctx.media, supplied images]`. stage-sandbox-media keeps ctx.media and
+          // sessionCtx.media aligned; public supplied roots were stripped at runPreparedReply.
+          // Snapshot only after all current-turn symbol metadata has been written to sessionCtx.
+          media: userTurnMediaForPersistence,
+        }
+      : sessionCtx;
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
-  const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
-  const userTurnMediaForPersistence = [...ctxMediaForPersistence, ...(opts?.media ?? [])];
   const mediaImageLayout = buildPersistedMediaImageLayout({
     ctx,
     media: userTurnMediaForPersistence,
@@ -302,6 +334,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     transcriptPrompt: transcriptCommandBody,
     ...(userTurnTranscriptRecorder ? { userTurnTranscriptRecorder } : {}),
     currentInboundEventKind: inboundEventKind,
+    // GetReplyOptions supplied media is image-only; keep audio semantics on the inbound context.
     currentInboundAudio: hasInboundAudio(sessionCtx),
     currentInboundContext,
     ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
@@ -313,6 +346,18 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     enqueuedAt: Date.now(),
     images: currentTurnImages.images,
     imageOrder: currentTurnImages.imageOrder,
+    ...(currentTurnImages.imageSourceIndexes
+      ? {
+          imageSourceMapping: {
+            indexes: currentTurnImages.imageSourceIndexes,
+            space: "inbound-media" as const,
+          },
+        }
+      : {}),
+    ...(currentTurnImages.imageSourceMappingInvalid
+      ? { imageSourceMappingInvalid: true as const }
+      : {}),
+    mediaSourceIndexes: promptMediaSourceIndexes,
     media: promptMedia,
     // Originating channel for reply routing.
     originatingChannel: replyRoute.channel,
@@ -436,7 +481,6 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     isBareSessionReset && sessionCtx.ReplyThreading?.implicitCurrentMessage !== "deny"
       ? { ...sessionCtx.ReplyThreading, implicitCurrentMessage: "deny" as const }
       : undefined;
-
   return runReplyAgent({
     commandBody: prefixedCommandBody,
     transcriptCommandBody,
@@ -471,7 +515,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     blockStreamingEnabled,
     blockReplyChunking,
     resolvedBlockStreamingBreak,
-    sessionCtx,
+    sessionCtx: agentSessionCtx,
     shouldInjectGroupIntro,
     typingMode,
     resetTriggered: effectiveResetTriggered,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1,19 +1,27 @@
 // Tests media-only get-reply runs and sandboxed media attachment handling.
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { detectAndLoadPromptImages } from "../../agents/embedded-agent-runner/run/images.js";
+import { readPersistedMediaImageLayout } from "../../agents/embedded-agent-runner/run/prompt-image-metadata.js";
 import {
   clearActiveEmbeddedRun,
   setActiveEmbeddedRun,
 } from "../../agents/embedded-agent-runner/runs.js";
+import { resolveStateDir } from "../../config/paths.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { logVerbose } from "../../globals.js";
 import { HEARTBEAT_RUN_SCOPE } from "../../infra/heartbeat-run-scope.js";
+import { resolveInlineImageFactIndexes } from "../../media/image-source-indexes.js";
+import { getDefaultMediaLocalRoots } from "../../media/local-roots.js";
+import { readRuntimePromptImageFactIndexes } from "../../media/runtime-prompt-image-provenance.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
 import { applySessionHints } from "./body.js";
+import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import {
   loadAgentRunnerRuntime,
   loadEmbeddedAgentRuntime,
@@ -30,7 +38,7 @@ import { createReplyOperation, getActiveReplyRunCount } from "./reply-run-regist
 import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
 import { routeReply } from "./route-reply.runtime.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
-import { buildChannelSourceTurnId } from "./source-turn-id.js";
+import { buildChannelSourceTurnId, readChannelSourceTurnId } from "./source-turn-id.js";
 import { resolveTypingMode } from "./typing-mode.js";
 
 vi.mock("../../agents/auth-profiles/session-override.js", () => ({
@@ -1192,6 +1200,15 @@ describe("runPreparedReply media-only handling", () => {
           ChatType: "group",
           media: [{ path: imagePath, workspaceDir: tmpDir }],
         },
+        opts: {
+          images: [
+            {
+              type: "image",
+              data: Buffer.from("supplied-image").toString("base64"),
+              mimeType: "image/png",
+            },
+          ] as never,
+        },
       }),
     );
 
@@ -1199,6 +1216,11 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
     const call = requireRunReplyAgentCall();
     expect(call.followupRun.images).toEqual([
+      {
+        type: "image",
+        data: Buffer.from("supplied-image").toString("base64"),
+        mimeType: "image/png",
+      },
       {
         type: "image",
         data: expect.any(String),
@@ -1212,8 +1234,330 @@ describe("runPreparedReply media-only handling", () => {
         media: [expect.objectContaining({ path: imagePath, contentType: "image/png" })],
       },
     });
-    expect(call.followupRun.images?.[0]?.data).toHaveLength(92);
-    expect(call.followupRun.imageOrder).toEqual(["inline"]);
+    expect(call.followupRun.images?.[1]?.data).toHaveLength(92);
+    expect(call.followupRun.imageOrder).toEqual(["inline", "inline"]);
+    expect(call.followupRun.imageSourceMapping).toEqual({
+      indexes: [undefined, 0],
+      space: "inbound-media",
+    });
+    expect(call.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+      __openclaw: {
+        mediaImageLayout: {
+          slots: [{ kind: "inline" }, { kind: "inline", factIndex: 0 }],
+        },
+      },
+    });
+  });
+
+  it("preserves a newly minted source-turn id on media-augmented session context", async () => {
+    const expectedSourceTurnId = buildChannelSourceTurnId({
+      provider: "telegram",
+      conversationId: "chat-42",
+      messageId: "message-7",
+    });
+
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          ...createInboundBody("inspect image"),
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-42",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          ...createSessionBody("inspect image"),
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-42",
+          ChatType: "direct",
+          MessageSid: "message-7",
+        },
+        opts: {
+          media: [{ path: "/tmp/source-turn-image.png", contentType: "image/png" }],
+          imageOrder: ["offloaded"],
+        },
+      }),
+    );
+
+    expect(readChannelSourceTurnId(requireRunReplyAgentCall().sessionCtx)).toBe(
+      expectedSourceTurnId,
+    );
+  });
+
+  it("strips supplied workspace roots across direct, transcript, and queued media", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-queued-offloaded-"));
+    const imagePath = path.join(tmpDir, "chat-send-offloaded.png");
+    const imageData = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64",
+    );
+    await writeFile(imagePath, imageData);
+    const offloaded = {
+      path: imagePath,
+      contentType: "image/png",
+      workspaceDir: tmpDir,
+    };
+    const params = baseParams({
+      ctx: {
+        ...createInboundBody("inspect offloaded image"),
+        OriginatingChannel: "webchat",
+        OriginatingTo: "webchat:local",
+        ChatType: "direct",
+      },
+      sessionCtx: {
+        ...createSessionBody("inspect offloaded image"),
+        Provider: "webchat",
+        OriginatingChannel: "webchat",
+        OriginatingTo: "webchat:local",
+        ChatType: "direct",
+      },
+      opts: { media: [offloaded], imageOrder: ["offloaded"] },
+    });
+
+    try {
+      await runPreparedReply(params);
+
+      const call = requireRunReplyAgentCall();
+      expect(offloaded.workspaceDir).toBe(tmpDir);
+      expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
+        "Ignoring 1 supplied media workspace root(s) at the public reply ingress",
+      );
+      expect(call.followupRun.imageSourceMapping).toEqual({
+        indexes: [0],
+        space: "inbound-media",
+      });
+      expect(call.followupRun.mediaSourceIndexes).toEqual([0]);
+      expect(call.followupRun.media).toEqual([
+        expect.objectContaining({ path: imagePath, contentType: "image/png" }),
+      ]);
+      expect(call.followupRun.media?.[0]).not.toHaveProperty("workspaceDir");
+      expect(call.sessionCtx.media).toEqual([
+        expect.objectContaining({ path: imagePath, contentType: "image/png" }),
+      ]);
+      expect(call.sessionCtx.media?.[0]).not.toHaveProperty("workspaceDir");
+      expect(call.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+        __openclaw: {
+          media: [expect.not.objectContaining({ workspaceDir: tmpDir })],
+        },
+      });
+
+      const queuedHydration = await resolveCurrentTurnImages({
+        ctx: call.sessionCtx,
+        cfg: params.cfg,
+        images: call.followupRun.images,
+        imageOrder: call.followupRun.imageOrder,
+        imageSourceIndexes: call.followupRun.imageSourceMapping?.indexes,
+      });
+      expect(queuedHydration).toEqual({
+        imageOrder: ["offloaded"],
+        imageSourceIndexes: [0],
+      });
+
+      const candidateImages = await detectAndLoadPromptImages({
+        prompt: call.commandBody,
+        media: call.followupRun.media,
+        workspaceDir: tmpDir,
+        model: { input: ["text", "image"] },
+        existingImages: queuedHydration.images,
+        existingImageFactIndexes: resolveInlineImageFactIndexes({
+          imageOrder: queuedHydration.imageOrder,
+          imageSourceIndexes: queuedHydration.imageSourceIndexes,
+        }),
+        imageOrder: queuedHydration.imageOrder,
+        localRoots: [...getDefaultMediaLocalRoots(), tmpDir],
+      });
+      expect(candidateImages.images).toEqual([
+        { type: "image", data: imageData.toString("base64"), mimeType: "image/png" },
+      ]);
+      expect(candidateImages.failedMediaCount).toBe(0);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates an unlayouted supplied image once at the trusted CLI boundary", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-supplied-native-image-"));
+    const imagePath = path.join(tmpDir, "supplied.png");
+    const imageData = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64",
+    );
+    await writeFile(imagePath, imageData);
+    const params = baseParams({
+      workspaceDir: tmpDir,
+      ctx: createInboundBody("inspect supplied image"),
+      sessionCtx: createSessionBody("inspect supplied image"),
+      opts: { media: [{ path: imagePath, contentType: "image/png", workspaceDir: tmpDir }] },
+    });
+
+    try {
+      await runPreparedReply(params);
+
+      const call = requireRunReplyAgentCall();
+      expect(call.followupRun.images).toBeUndefined();
+      expect(call.followupRun.imageOrder).toBeUndefined();
+      expect(call.followupRun.imageSourceMapping).toBeUndefined();
+      expect(call.followupRun.media?.[0]).not.toHaveProperty("workspaceDir");
+
+      const runnerHydration = await resolveCurrentTurnImages({
+        ctx: call.sessionCtx,
+        cfg: params.cfg,
+        images: call.followupRun.images,
+        imageOrder: call.followupRun.imageOrder,
+        imageSourceIndexes: call.followupRun.imageSourceMapping?.indexes,
+        invalidSourceMappingPolicy: "infer-inline",
+      });
+      expect(runnerHydration).toEqual({});
+
+      const candidateImages = await detectAndLoadPromptImages({
+        prompt: call.commandBody,
+        media: call.followupRun.media,
+        workspaceDir: tmpDir,
+        model: { input: ["text", "image"] },
+        existingImages: runnerHydration.images,
+        existingImageFactIndexes: resolveInlineImageFactIndexes({
+          imageOrder: runnerHydration.imageOrder,
+          imageSourceIndexes: runnerHydration.imageSourceIndexes,
+        }),
+        imageOrder: runnerHydration.imageOrder,
+        localRoots: [...getDefaultMediaLocalRoots(), tmpDir],
+      });
+      expect(candidateImages.images).toHaveLength(1);
+      expect(candidateImages.images[0]?.data).toBe(imageData.toString("base64"));
+      expect(candidateImages.failedMediaCount).toBe(0);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates an unlayouted managed supplied image exactly once for embedded and CLI", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-managed-supplied-"));
+    const imagePath = path.join(
+      resolveStateDir(),
+      "media",
+      "inbound",
+      `supplied-${process.pid}-${Date.now()}.png`,
+    );
+    const imageData = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64",
+    );
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await writeFile(imagePath, imageData);
+    const params = baseParams({
+      workspaceDir,
+      ctx: createInboundBody("inspect managed supplied image"),
+      sessionCtx: createSessionBody("inspect managed supplied image"),
+      opts: { media: [{ path: imagePath, contentType: "image/png" }] },
+    });
+
+    try {
+      await runPreparedReply(params);
+
+      const call = requireRunReplyAgentCall();
+      const runnerHydration = await resolveCurrentTurnImages({
+        ctx: call.sessionCtx,
+        cfg: params.cfg,
+        images: call.followupRun.images,
+        imageOrder: call.followupRun.imageOrder,
+        imageSourceIndexes: call.followupRun.imageSourceMapping?.indexes,
+        invalidSourceMappingPolicy: "infer-inline",
+      });
+      expect(runnerHydration.images).toHaveLength(1);
+      expect(runnerHydration.imageOrder).toEqual(["inline"]);
+      expect(runnerHydration.imageSourceIndexes).toEqual([0]);
+      expect(readRuntimePromptImageFactIndexes(runnerHydration.images)).toEqual([0]);
+
+      const persistedMessage = call.followupRun.userTurnTranscriptRecorder?.message;
+      expect(persistedMessage).toBeDefined();
+      const mediaImageLayout = readPersistedMediaImageLayout(persistedMessage!);
+      expect(mediaImageLayout).toEqual({
+        slots: [{ kind: "offloaded", factIndex: 0 }],
+        suppressedFactIndexes: [],
+      });
+
+      const embeddedImages = await detectAndLoadPromptImages({
+        prompt: call.commandBody,
+        media: call.followupRun.media,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        existingImages: runnerHydration.images,
+        existingImageFactIndexes: readRuntimePromptImageFactIndexes(runnerHydration.images),
+        imageOrder: runnerHydration.imageOrder,
+        mediaImageLayout,
+      });
+      expect(embeddedImages.images).toHaveLength(1);
+      expect(embeddedImages.images[0]?.data).toBe(imageData.toString("base64"));
+      expect(embeddedImages.loadedCount).toBe(0);
+
+      const cliImages = await detectAndLoadPromptImages({
+        prompt: call.commandBody,
+        media: call.followupRun.media,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        existingImages: runnerHydration.images,
+        existingImageFactIndexes: resolveInlineImageFactIndexes({
+          imageOrder: runnerHydration.imageOrder,
+          imageSourceIndexes: runnerHydration.imageSourceIndexes,
+        }),
+        imageOrder: runnerHydration.imageOrder,
+        localRoots: [...getDefaultMediaLocalRoots(), workspaceDir],
+      });
+      expect(cliImages.images).toHaveLength(1);
+      expect(cliImages.images[0]?.data).toBe(imageData.toString("base64"));
+      expect(cliImages.loadedCount).toBe(0);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+      await rm(imagePath, { force: true });
+    }
+  });
+
+  it("propagates malformed direct-run ownership without a second native hydration", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-invalid-direct-source-"));
+    const imagePath = path.join(tmpDir, "one.png");
+    await writeFile(imagePath, "source-image");
+    const inline = {
+      type: "image" as const,
+      data: Buffer.from("inline-image").toString("base64"),
+      mimeType: "image/png",
+    };
+    const params = baseParams({
+      ctx: createInboundBody("inspect malformed offload"),
+      sessionCtx: createSessionBody("inspect malformed offload"),
+      opts: {
+        images: [inline],
+        media: [{ path: imagePath, contentType: "image/png" }],
+        imageOrder: ["inline", "offloaded", "offloaded"],
+      },
+    });
+
+    try {
+      const result = await runPreparedReply(params);
+
+      expect(result).toEqual({ text: "ok" });
+      const call = requireRunReplyAgentCall();
+      expect(call.followupRun.imageSourceMapping).toEqual({
+        indexes: [undefined, 0, undefined],
+        space: "inbound-media",
+      });
+      expect(call.followupRun.imageSourceMappingInvalid).toBe(true);
+
+      const secondHydration = await resolveCurrentTurnImages({
+        ctx: call.sessionCtx,
+        cfg: params.cfg,
+        images: call.followupRun.images,
+        imageOrder: call.followupRun.imageOrder,
+        imageSourceIndexes: call.followupRun.imageSourceMapping?.indexes,
+        sourceMappingInvalid: call.followupRun.imageSourceMappingInvalid,
+        invalidSourceMappingPolicy: "infer-inline",
+      });
+      expect(secondHydration.images).toEqual([inline]);
+      expect(secondHydration.imageOrder).toEqual(["inline", "offloaded", "offloaded"]);
+      expect(secondHydration.imageSourceMappingInvalid).toBe(true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("does not copy prior session media onto text-only followups", async () => {
@@ -1469,6 +1813,10 @@ describe("runPreparedReply media-only handling", () => {
       },
     });
     expect(call.followupRun.imageOrder).toEqual(["inline"]);
+    expect(call.followupRun.imageSourceMapping).toEqual({
+      indexes: [1],
+      space: "inbound-media",
+    });
     expect(call.followupRun.prompt).toContain("a tiny dot image");
   });
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,15 +1,43 @@
 /** Prepares and runs auto-reply agent turns, including prompt context and session policy. */
+import { logVerbose } from "../../globals.js";
 import type { ReplyPayload } from "../types.js";
 import { prepareReplyRunAdmission } from "./get-reply-run-admission.js";
 import { prepareReplyRunContext } from "./get-reply-run-context.js";
 import { executePreparedReplyRun } from "./get-reply-run-execute.js";
 import type { RunPreparedReplyParams } from "./get-reply-run.types.js";
 
+function stripUntrustedMediaWorkspaceRoots(params: RunPreparedReplyParams): RunPreparedReplyParams {
+  if (!params.opts?.media) {
+    return params;
+  }
+  const strippedRootCount = params.opts.media.filter((fact) => fact.workspaceDir).length;
+  if (strippedRootCount === 0) {
+    return params;
+  }
+  logVerbose(
+    `Ignoring ${strippedRootCount} supplied media workspace root(s) at the public reply ingress`,
+  );
+  return {
+    ...params,
+    opts: {
+      ...params.opts,
+      // GetReplyOptions is a public ingress. A supplied fact may identify a file, but it must not
+      // add filesystem roots used by native hydration on either direct or queued execution paths.
+      media: params.opts.media.map((fact) => {
+        const sanitized = { ...fact };
+        delete sanitized.workspaceDir;
+        return sanitized;
+      }),
+    },
+  };
+}
+
 /** Runs a prepared reply turn after session, prompt, queue, and policy state are resolved. */
 export async function runPreparedReply(
   params: RunPreparedReplyParams,
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
-  const context = await prepareReplyRunContext(params);
+  const sanitizedParams = stripUntrustedMediaWorkspaceRoots(params);
+  const context = await prepareReplyRunContext(sanitizedParams);
   if (context.kind === "reply") {
     return context.reply;
   }

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -36,6 +36,8 @@ function buildReplyPromptBodies(params: {
   mediaNote?: string;
   mediaReplyHint?: string;
   media?: MediaFact[];
+  /** Index in the combined inbound list `[ctx.media, supplied media]` for each prompt fact. */
+  mediaSourceIndexes?: Array<number | undefined>;
   prefixedCommandBody: string;
   queuedBody: string;
   transcriptCommandBody: string;
@@ -55,7 +57,13 @@ function buildReplyPromptBodies(params: {
   const queueBodyBase = [params.threadContextNote, bodyWithEvents].filter(Boolean).join("\n\n");
   const generatedMedia = buildInboundMediaNoteProjection(params.ctx);
   const mediaNote = generatedMedia.text;
-  const media = [...generatedMedia.media, ...normalizeMediaFacts(params.media)];
+  const suppliedMedia = normalizeMediaFacts(params.media);
+  const media = [...generatedMedia.media, ...suppliedMedia];
+  const suppliedSourceOffset = normalizeMediaFacts(params.ctx.media).length;
+  const mediaSourceIndexes = [
+    ...generatedMedia.mediaSourceIndexes,
+    ...suppliedMedia.map((_, index) => suppliedSourceOffset + index),
+  ];
   const mediaReplyHint = mediaNote ? REPLY_MEDIA_HINT : undefined;
   const queuedBodyRaw = mediaNote
     ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
@@ -75,7 +83,7 @@ function buildReplyPromptBodies(params: {
   return {
     mediaNote,
     mediaReplyHint,
-    ...(media.length > 0 ? { media } : {}),
+    ...(media.length > 0 ? { media, mediaSourceIndexes } : {}),
     prefixedCommandBody: annotateInterSessionPromptText(
       prefixedCommandBodyRaw,
       params.sessionCtx.InputProvenance,

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -1911,6 +1911,9 @@ describe("followup queue collect routing", () => {
         }),
         images: [firstImage],
         imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [0], space: "inbound-media" },
+        media: [{ path: "/tmp/first.png", contentType: "image/png", kind: "image" }],
+        mediaSourceIndexes: [0],
       },
       settings,
     );
@@ -1924,6 +1927,9 @@ describe("followup queue collect routing", () => {
         }),
         images: [secondImage],
         imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [0], space: "inbound-media" },
+        media: [{ path: "/tmp/second.png", contentType: "image/png", kind: "image" }],
+        mediaSourceIndexes: [0],
       },
       settings,
     );
@@ -1933,6 +1939,147 @@ describe("followup queue collect routing", () => {
 
     expect(calls[0]?.images).toEqual([firstImage, secondImage]);
     expect(calls[0]?.imageOrder).toEqual(["inline", "inline"]);
+    expect(calls[0]?.imageSourceMapping).toEqual({
+      indexes: [0, 1],
+      space: "run-media",
+    });
+    expect(calls[0]?.mediaSourceIndexes).toBeUndefined();
+    expect(calls[0]?.media?.map((fact) => fact.path)).toEqual([
+      "/tmp/first.png",
+      "/tmp/second.png",
+    ]);
+  });
+
+  it("offsets collected image sources across preceding media-only runs", async () => {
+    const key = `test-collect-media-offset-${Date.now()}`;
+    const { calls, done, runFollowup } = createDrainRecorder();
+    const settings = createQueueSettings();
+    const image = { type: "image" as const, data: "image", mimeType: "image/png" };
+
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({
+          prompt: "document first",
+          originatingChannel: "slack",
+          originatingTo: "channel:A",
+        }),
+        media: [{ path: "/tmp/context.pdf", contentType: "application/pdf", kind: "document" }],
+        mediaSourceIndexes: [0],
+      },
+      settings,
+    );
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({
+          prompt: "image second",
+          originatingChannel: "slack",
+          originatingTo: "channel:A",
+        }),
+        images: [image],
+        imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [1], space: "inbound-media" },
+        media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" }],
+        mediaSourceIndexes: [1],
+      },
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls[0]?.imageSourceMapping).toEqual({ indexes: [1], space: "run-media" });
+    expect(calls[0]?.media?.map((fact) => fact.path)).toEqual([
+      "/tmp/context.pdf",
+      "/tmp/photo.png",
+    ]);
+  });
+
+  it("drops a misaligned collected source mapping instead of retrying the batch", async () => {
+    const key = `test-collect-invalid-image-source-mapping-${Date.now()}`;
+    const { calls, done, runFollowup } = createDrainRecorder();
+    const settings = createQueueSettings();
+
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({
+          prompt: "invalid image mapping",
+          originatingChannel: "slack",
+          originatingTo: "channel:A",
+        }),
+        images: [{ type: "image", data: "image", mimeType: "image/png" }],
+        imageOrder: ["inline"],
+        imageSourceMapping: { indexes: [0, 1], space: "run-media" },
+        media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" }],
+      },
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.imageSourceMapping).toEqual({ indexes: [0], space: "run-media" });
+    expect(calls[0]?.imageSourceMappingInvalid).toBe(true);
+    expect(calls[0]?.media?.map((fact) => fact.path)).toEqual(["/tmp/photo.png"]);
+    expect(calls[0]?.media?.[0]?.hydrationSuppressed).toBeUndefined();
+  });
+
+  it("preserves media hydration when collected source mapping has no image layout", async () => {
+    const key = `test-collect-missing-image-layout-${Date.now()}`;
+    const { calls, done, runFollowup } = createDrainRecorder();
+    const settings = createQueueSettings();
+
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({
+          prompt: "missing image layout",
+          originatingChannel: "slack",
+          originatingTo: "channel:A",
+        }),
+        imageSourceMapping: { indexes: [0], space: "run-media" },
+        media: [{ path: "/tmp/photo.png", contentType: "image/png", kind: "image" }],
+      },
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.imageSourceMapping).toBeUndefined();
+    expect(calls[0]?.imageSourceMappingInvalid).toBe(true);
+    expect(calls[0]?.media?.map((fact) => fact.path)).toEqual(["/tmp/photo.png"]);
+    expect(calls[0]?.media?.[0]?.hydrationSuppressed).toBeUndefined();
+  });
+
+  it("synthesizes inline slots for collected images without an image order", async () => {
+    const key = `test-collect-images-without-order-${Date.now()}`;
+    const { calls, done, runFollowup } = createDrainRecorder();
+    const settings = createQueueSettings();
+
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({
+          prompt: "legacy image",
+          originatingChannel: "slack",
+          originatingTo: "channel:A",
+        }),
+        images: [{ type: "image", data: "image", mimeType: "image/png" }],
+      },
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.images).toHaveLength(1);
+    expect(calls[0]?.imageOrder).toEqual(["inline"]);
   });
 
   it("splits collect batches when sender authorization changes", async () => {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -6,6 +6,7 @@ import { stableStringify } from "../../../agents/stable-stringify.js";
 import { normalizeChatType } from "../../../channels/chat-type.js";
 import { resolveStorePath } from "../../../config/sessions.js";
 import { loadSessionEntryReadOnly } from "../../../config/sessions/session-accessor.js";
+import { resolveProjectedImageSourceIndexes } from "../../../media/image-source-indexes.js";
 // Drains queued follow-up runs while preserving route and session identity.
 import {
   channelRouteCompactKey,
@@ -290,24 +291,62 @@ function renderCollectItemPrompt(item: FollowupRun, idx: number, prompt: string)
 
 function collectQueuedPromptMedia(
   items: FollowupRun[],
-): Pick<FollowupRun, "images" | "imageOrder" | "media"> {
+): Pick<
+  FollowupRun,
+  "images" | "imageOrder" | "imageSourceMapping" | "imageSourceMappingInvalid" | "media"
+> {
   const images: NonNullable<FollowupRun["images"]> = [];
   const imageOrder: NonNullable<FollowupRun["imageOrder"]> = [];
+  const imageSourceIndexes: NonNullable<FollowupRun["imageSourceMapping"]>["indexes"] = [];
   const media: NonNullable<FollowupRun["media"]> = [];
+  let imageSourceMappingInvalid = false;
+  let mediaOffset = 0;
   for (const item of items) {
+    const itemImageOrder = item.imageOrder ?? item.images?.map(() => "inline" as const);
     if (item.images) {
       images.push(...item.images);
     }
-    if (item.imageOrder) {
-      imageOrder.push(...item.imageOrder);
+    if (item.imageSourceMapping && !itemImageOrder) {
+      defaultRuntime.error?.(
+        "collect queue image source mapping has no image layout; continuing without positional ownership",
+      );
+      imageSourceMappingInvalid = true;
+    }
+    imageSourceMappingInvalid ||= item.imageSourceMappingInvalid === true;
+    if (itemImageOrder) {
+      imageOrder.push(...itemImageOrder);
+      const sourceResult = resolveProjectedImageSourceIndexes({
+        imageSourceMapping: item.imageSourceMapping,
+        imageOrderLength: itemImageOrder.length,
+        projectedMediaSourceIndexes: item.mediaSourceIndexes,
+        projectedMediaLength: item.media?.length ?? 0,
+      });
+      if (sourceResult.kind === "invalid") {
+        defaultRuntime.error?.(
+          `collect queue image source mapping is invalid; continuing without positional ownership: ${sourceResult.reason}`,
+        );
+        imageSourceMappingInvalid = true;
+      }
+      const projectedIndexes = sourceResult.kind === "none" ? undefined : sourceResult.indexes;
+      imageSourceIndexes.push(
+        ...itemImageOrder.map((_, index) => {
+          const sourceIndex = projectedIndexes?.[index];
+          return sourceIndex === undefined ? undefined : sourceIndex + mediaOffset;
+        }),
+      );
     }
     if (item.media) {
       media.push(...item.media);
     }
+    mediaOffset += item.media?.length ?? 0;
   }
   return {
     ...(images.length > 0 ? { images } : {}),
     ...(imageOrder.length > 0 ? { imageOrder } : {}),
+    ...(imageSourceIndexes.some((index) => index !== undefined)
+      ? { imageSourceMapping: { indexes: imageSourceIndexes, space: "run-media" as const } }
+      : {}),
+    ...(imageSourceMappingInvalid ? { imageSourceMappingInvalid: true as const } : {}),
     ...(media.length > 0 ? { media } : {}),
   };
 }

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -101,8 +101,24 @@ export type FollowupRun = {
   enqueuedAt: number;
   images?: Array<{ type: "image"; data: string; mimeType: string }>;
   imageOrder?: PromptImageOrderEntry[];
+  /**
+   * Runtime-only mapping from imageOrder slots to a declared media index space.
+   * Direct execution uses `inbound-media`; queued execution normalizes to `run-media`, whose
+   * indexes address the sessionCtx.media delivered with that run. This exists before the
+   * transcript recorder materializes and survives collect batching; persisted mediaImageLayout
+   * remains the durable first-hydration transcript snapshot, not the execution-time projection
+   * carrier (later native hydration can therefore refine runtime ownership without rewriting it).
+   */
+  imageSourceMapping?: {
+    indexes: Array<number | undefined>;
+    space: "inbound-media" | "run-media";
+  };
+  /** Mapping existed but failed validation; partial indexes remain safe ownership evidence. */
+  imageSourceMappingInvalid?: true;
   /** Ordered facts represented by attachment text in this prompt. */
   media?: MediaFact[];
+  /** Combined inbound index (`ctx.media` then supplied media) for each prompt fact. */
+  mediaSourceIndexes?: Array<number | undefined>;
   /**
    * Originating channel for reply routing.
    * When set, replies should be routed back to this provider

--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -8,7 +9,10 @@ import {
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { createSolidPngBuffer } from "../../../test/helpers/image-fixtures.js";
 import { pruneProcessedHistoryImages } from "../../agents/embedded-agent-runner/run/history-image-prune.js";
-import { hydratePromptMediaMessages } from "../../agents/embedded-agent-runner/run/images.js";
+import {
+  detectAndLoadPromptImages,
+  hydratePromptMediaMessages,
+} from "../../agents/embedded-agent-runner/run/images.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveStateDir } from "../../config/paths.js";
@@ -271,6 +275,71 @@ describe("prepareChatSendUserTurn", () => {
     await expect(readInput()).resolves.toMatchObject({
       mediaImageLayout: { slots: [{ kind: "offloaded", factIndex: 0 }] },
     });
+  });
+
+  it("keeps chat.send offloaded images hydratable for CLI backends", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-send-offloaded-cli-"));
+    const id = `chat-send-offloaded-${process.pid}-${Date.now()}.png`;
+    const imagePath = path.join(resolveStateDir(), "media", "inbound", id);
+    const imageBuffer = createSolidPngBuffer(1, 1, { r: 12, g: 34, b: 56 });
+    await fs.mkdir(path.dirname(imagePath), { recursive: true });
+    await fs.writeFile(imagePath, imageBuffer);
+    try {
+      const { controller } = createUserTurnInputController();
+      const mediaRef = `media://inbound/${id}`;
+      const prepared = prepareChatSendUserTurn({
+        request: {
+          clientInfo: createClientInfo(),
+          normalizedAttachments: [{}],
+          suppressCommandInterpretation: false,
+          systemInputProvenance: undefined,
+          systemProvenanceReceipt: undefined,
+        },
+        session: {
+          agentId: "main",
+          clientRunId: "run-cli-image",
+          sessionKey: "agent:main:main",
+        },
+        admission: {
+          originatingRoute: { originatingChannel: "webchat", explicitDeliverRoute: false },
+        },
+        attachments: createAttachments({
+          imageOrder: ["offloaded"],
+          offloadedRefs: [
+            {
+              mediaRef,
+              id: "large.png",
+              path: imagePath,
+              kind: "image",
+              mimeType: "image/png",
+              label: "large.png",
+              sizeBytes: imageBuffer.length,
+            },
+          ],
+          parsedMessage: `inspect\n[media attached: ${mediaRef}]`,
+        }),
+        client: null,
+        logGateway: { warn: vi.fn() } as never,
+        userTurn: controller,
+      });
+
+      const hydrated = await detectAndLoadPromptImages({
+        prompt: prepared.ctx.Body ?? "",
+        media: prepared.replyOptionMedia,
+        workspaceDir: root,
+        model: { input: ["text", "image"] },
+        imageOrder: ["offloaded"],
+        localRoots: [resolveStateDir()],
+      });
+
+      expect(hydrated.images).toEqual([
+        { type: "image", data: imageBuffer.toString("base64"), mimeType: "image/png" },
+      ]);
+      expect(hydrated.failedMediaCount).toBe(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+      await fs.rm(imagePath, { force: true });
+    }
   });
 
   it.each([

--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -86,4 +86,24 @@ describe("normalizeAttachments", () => {
       }),
     ]);
   });
+
+  it("preserves explicit hydration suppression on normalized attachments", () => {
+    expect(
+      normalizeAttachments({
+        media: [
+          {
+            path: "/tmp/described.png",
+            contentType: "image/png",
+            hydrationSuppressed: true,
+          },
+        ],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        path: "/tmp/described.png",
+        index: 0,
+        hydrationSuppressed: true,
+      }),
+    ]);
+  });
 });

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -32,14 +32,20 @@ export function normalizeAttachmentPath(raw?: string | null): string | undefined
 /** Converts ordered media facts into indexed attachment records. */
 export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
   return normalizeMediaFacts(ctx.media)
-    .map((fact, index) => ({
-      path: normalizeOptionalString(fact.path),
-      url: normalizeOptionalString(fact.url),
-      mime: normalizeOptionalString(fact.contentType) ?? fact.kind,
-      workspaceDir: normalizeOptionalString(fact.workspaceDir),
-      index,
-      alreadyTranscribed: fact.transcribed === true,
-    }))
+    .map((fact, index) => {
+      const attachment: MediaAttachment = {
+        path: normalizeOptionalString(fact.path),
+        url: normalizeOptionalString(fact.url),
+        mime: normalizeOptionalString(fact.contentType) ?? fact.kind,
+        workspaceDir: normalizeOptionalString(fact.workspaceDir),
+        index,
+        alreadyTranscribed: fact.transcribed === true,
+      };
+      if (fact.hydrationSuppressed === true) {
+        attachment.hydrationSuppressed = true;
+      }
+      return attachment;
+    })
     .filter((entry) => Boolean(entry.path ?? entry.url));
 }
 

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -30,6 +30,7 @@ export type MediaAttachment = {
   workspaceDir?: string;
   index: number;
   alreadyTranscribed?: boolean;
+  hydrationSuppressed?: boolean;
 };
 
 export type MediaUnderstandingOutput = {

--- a/src/media/image-source-indexes.test.ts
+++ b/src/media/image-source-indexes.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSuppliedImageSourceIndexes,
+  orderSourceIndexedEntries,
+  resolveInlineImageFactIndexes,
+  resolveProjectedImageSourceIndexes,
+} from "./image-source-indexes.js";
+
+describe("resolveProjectedImageSourceIndexes", () => {
+  it("maps source slots into projected media order", () => {
+    expect(
+      resolveProjectedImageSourceIndexes({
+        imageSourceMapping: { indexes: [2, undefined, 0], space: "inbound-media" },
+        imageOrderLength: 3,
+        projectedMediaSourceIndexes: [0, 2],
+        projectedMediaLength: 2,
+      }),
+    ).toEqual({ kind: "mapped", indexes: [1, undefined, 0] });
+  });
+
+  it("rejects source indexes absent from the projection", () => {
+    expect(
+      resolveProjectedImageSourceIndexes({
+        imageSourceMapping: { indexes: [1], space: "inbound-media" },
+        imageOrderLength: 1,
+        projectedMediaSourceIndexes: [0, 2],
+        projectedMediaLength: 2,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      reason: "Image source index 1 is absent from the media projection",
+      indexes: [undefined],
+    });
+  });
+
+  it("rejects missing or misaligned projection metadata", () => {
+    expect(
+      resolveProjectedImageSourceIndexes({
+        imageSourceMapping: { indexes: [0, 1], space: "inbound-media" },
+        imageOrderLength: 1,
+        projectedMediaLength: 1,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      reason:
+        "Queued image source slots and image order must remain aligned; Cannot remap image sources without a declared media projection",
+      indexes: [undefined],
+    });
+    expect(
+      resolveProjectedImageSourceIndexes({
+        imageSourceMapping: { indexes: [0], space: "inbound-media" },
+        imageOrderLength: 1,
+        projectedMediaSourceIndexes: [0],
+        projectedMediaLength: 2,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      reason: "Media projection facts and source indexes must remain aligned",
+      indexes: [undefined],
+    });
+  });
+
+  it("rejects run-media indexes outside the projected media list", () => {
+    expect(
+      resolveProjectedImageSourceIndexes({
+        imageSourceMapping: { indexes: [1], space: "run-media" },
+        imageOrderLength: 1,
+        projectedMediaLength: 1,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      reason: "Run-media image source index 1 is outside the media projection",
+      indexes: [undefined],
+    });
+  });
+});
+
+describe("buildSuppliedImageSourceIndexes", () => {
+  it("maps offloaded slots into the combined inbound media space", () => {
+    expect(
+      buildSuppliedImageSourceIndexes({
+        imageOrder: ["inline", "offloaded"],
+        suppliedMedia: [
+          { path: "/tmp/report.pdf", contentType: "application/pdf" },
+          { path: "/tmp/photo.png", contentType: "image/png" },
+        ],
+        sourceOffset: 3,
+      }),
+    ).toEqual({ kind: "mapped", indexes: [undefined, 4] });
+  });
+
+  it("returns an invalid result when offloaded slots and supplied image facts diverge", () => {
+    expect(
+      buildSuppliedImageSourceIndexes({
+        imageOrder: ["offloaded", "offloaded"],
+        suppliedMedia: [{ path: "/tmp/photo.png", contentType: "image/png" }],
+        sourceOffset: 0,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      reason: "Offloaded image slot count 2 does not match supplied image fact count 1",
+      indexes: [0, undefined],
+    });
+  });
+});
+
+describe("resolveInlineImageFactIndexes", () => {
+  it("selects only inline identities in image payload order", () => {
+    expect(
+      resolveInlineImageFactIndexes({
+        imageOrder: ["offloaded", "inline", "inline"],
+        imageSourceIndexes: [2, 0, undefined],
+      }),
+    ).toEqual([0, null]);
+  });
+});
+
+describe("orderSourceIndexedEntries", () => {
+  it("orders sourced entries without moving unsourced slots", () => {
+    const entries = [
+      { id: "supplied", sequence: 0 },
+      { id: "second-source", sourceIndex: 2, sequence: 1 },
+      { id: "first-source", sourceIndex: 0, sequence: 2 },
+      { id: "other-supplied", sequence: 3 },
+    ];
+
+    expect(orderSourceIndexedEntries(entries).map((entry) => entry.id)).toEqual([
+      "supplied",
+      "first-source",
+      "second-source",
+      "other-supplied",
+    ]);
+  });
+});

--- a/src/media/image-source-indexes.ts
+++ b/src/media/image-source-indexes.ts
@@ -1,0 +1,159 @@
+import { isImageMediaFact, type MediaFact } from "./media-facts.js";
+import type { PromptImageOrderEntry } from "./prompt-image-order.js";
+
+// Runtime image ownership must be available before transcript mediaImageLayout materializes and
+// must survive collect batching, where several recorders are merged into one projected media list.
+
+type ImageSourceIndexesResult =
+  | { kind: "none" }
+  | { kind: "mapped"; indexes: Array<number | undefined> }
+  | { kind: "invalid"; reason: string; indexes: Array<number | undefined> };
+
+type ImageSourceMappingInput = {
+  indexes: readonly (number | undefined)[];
+  space: "inbound-media" | "run-media";
+};
+
+/** Normalizes image slots into the media space used by an executing run. */
+export function resolveProjectedImageSourceIndexes(params: {
+  imageSourceMapping?: ImageSourceMappingInput;
+  imageOrderLength: number;
+  projectedMediaSourceIndexes?: readonly (number | undefined)[];
+  projectedMediaLength: number;
+}): ImageSourceIndexesResult {
+  const mapping = params.imageSourceMapping;
+  if (!mapping) {
+    return { kind: "none" };
+  }
+  const reasons: string[] = [];
+  if (mapping.indexes.length !== params.imageOrderLength) {
+    reasons.push("Queued image source slots and image order must remain aligned");
+  }
+  const sourceIndexes = Array.from(
+    { length: params.imageOrderLength },
+    (_, index) => mapping.indexes[index],
+  );
+  if (mapping.space === "run-media") {
+    const indexes = sourceIndexes.map((sourceIndex) => {
+      if (
+        sourceIndex !== undefined &&
+        (!Number.isInteger(sourceIndex) ||
+          sourceIndex < 0 ||
+          sourceIndex >= params.projectedMediaLength)
+      ) {
+        reasons.push(`Run-media image source index ${sourceIndex} is outside the media projection`);
+        return undefined;
+      }
+      return sourceIndex;
+    });
+    if (reasons.length > 0) {
+      return { kind: "invalid", reason: reasons.join("; "), indexes };
+    }
+    return { kind: "mapped", indexes };
+  }
+  if (!params.projectedMediaSourceIndexes) {
+    return {
+      kind: "invalid",
+      reason: [...reasons, "Cannot remap image sources without a declared media projection"].join(
+        "; ",
+      ),
+      indexes: sourceIndexes.map(() => undefined),
+    };
+  }
+  if (params.projectedMediaSourceIndexes.length !== params.projectedMediaLength) {
+    return {
+      kind: "invalid",
+      reason: [...reasons, "Media projection facts and source indexes must remain aligned"].join(
+        "; ",
+      ),
+      indexes: sourceIndexes.map(() => undefined),
+    };
+  }
+  const projectedIndexBySource = new Map<number, number>();
+  for (const [projectedIndex, sourceIndex] of params.projectedMediaSourceIndexes.entries()) {
+    if (sourceIndex !== undefined) {
+      projectedIndexBySource.set(sourceIndex, projectedIndex);
+    }
+  }
+  const indexes: Array<number | undefined> = [];
+  for (const sourceIndex of sourceIndexes) {
+    if (sourceIndex === undefined) {
+      indexes.push(undefined);
+      continue;
+    }
+    const projectedIndex = projectedIndexBySource.get(sourceIndex);
+    if (projectedIndex === undefined) {
+      reasons.push(`Image source index ${sourceIndex} is absent from the media projection`);
+      indexes.push(undefined);
+      continue;
+    }
+    indexes.push(projectedIndex);
+  }
+  if (reasons.length > 0) {
+    return { kind: "invalid", reason: reasons.join("; "), indexes };
+  }
+  return { kind: "mapped", indexes };
+}
+
+/** Maps offloaded image slots to their facts in the combined inbound media list. */
+export function buildSuppliedImageSourceIndexes(params: {
+  imageOrder?: readonly PromptImageOrderEntry[];
+  suppliedMedia: readonly MediaFact[];
+  sourceOffset: number;
+}): ImageSourceIndexesResult {
+  if (!params.imageOrder?.length) {
+    return { kind: "none" };
+  }
+  const suppliedImageIndexes = params.suppliedMedia.flatMap((fact, index) =>
+    isImageMediaFact(fact) ? [params.sourceOffset + index] : [],
+  );
+  const offloadedCount = params.imageOrder.filter((entry) => entry === "offloaded").length;
+  if (offloadedCount !== suppliedImageIndexes.length) {
+    let suppliedImageIndex = 0;
+    return {
+      kind: "invalid",
+      reason: `Offloaded image slot count ${offloadedCount} does not match supplied image fact count ${suppliedImageIndexes.length}`,
+      indexes: params.imageOrder.map((entry) =>
+        entry === "offloaded" ? suppliedImageIndexes[suppliedImageIndex++] : undefined,
+      ),
+    };
+  }
+  let offloadedIndex = 0;
+  const indexes = params.imageOrder.map((entry) =>
+    entry === "offloaded" ? suppliedImageIndexes[offloadedIndex++] : undefined,
+  );
+  return indexes.some((index) => index !== undefined)
+    ? { kind: "mapped", indexes }
+    : { kind: "none" };
+}
+
+/** Selects fact identities for inline payloads, aligned one-to-one with the image array. */
+export function resolveInlineImageFactIndexes(params: {
+  imageOrder?: readonly PromptImageOrderEntry[];
+  imageSourceIndexes?: readonly (number | undefined)[];
+}): Array<number | null> | undefined {
+  if (!params.imageSourceIndexes) {
+    return undefined;
+  }
+  return params.imageOrder?.flatMap((entry, index) =>
+    entry === "inline" ? [params.imageSourceIndexes?.[index] ?? null] : [],
+  );
+}
+
+/**
+ * Orders source-backed entries by source position without moving unsourced entries.
+ * Unsourced entries do not share the media index space, so their append positions stay fixed.
+ */
+export function orderSourceIndexedEntries<T extends { sourceIndex?: number; sequence: number }>(
+  entries: readonly T[],
+): T[] {
+  const sourced = entries
+    .filter((entry): entry is T & { sourceIndex: number } => entry.sourceIndex !== undefined)
+    .toSorted(
+      (left, right) => left.sourceIndex - right.sourceIndex || left.sequence - right.sequence,
+    );
+  let sourcedIndex = 0;
+  return entries
+    .toSorted((left, right) => left.sequence - right.sequence)
+    .map((entry) => (entry.sourceIndex === undefined ? entry : sourced[sourcedIndex++]!));
+}

--- a/src/media/runtime-prompt-image-provenance.ts
+++ b/src/media/runtime-prompt-image-provenance.ts
@@ -1,13 +1,20 @@
 const RUNTIME_PROMPT_IMAGE_FACT_INDEXES = Symbol.for("openclaw.runtimePromptImageFactIndexes");
 
 type RuntimePromptImageFactIndex = number | null;
+export type RuntimePromptImageFactSpace = "inbound-media" | "run-media";
+
+type RuntimePromptImageProvenance = {
+  factIndexes: RuntimePromptImageFactIndex[];
+  space?: RuntimePromptImageFactSpace;
+};
 
 export function finalizeRuntimePromptImages<TImage extends object>(
   entries: readonly { image: TImage; factIndex: RuntimePromptImageFactIndex }[],
+  space?: RuntimePromptImageFactSpace,
 ): { images: TImage[]; imageFactIndexes: RuntimePromptImageFactIndex[] } {
   const images = entries.map((entry) => entry.image);
   const imageFactIndexes = entries.map((entry) => entry.factIndex);
-  attachRuntimePromptImageFactIndexes(images, imageFactIndexes);
+  attachRuntimePromptImageFactIndexes(images, imageFactIndexes, space);
   return { images, imageFactIndexes };
 }
 
@@ -15,31 +22,66 @@ export function finalizeRuntimePromptImages<TImage extends object>(
 function attachRuntimePromptImageFactIndexes(
   images: readonly object[],
   factIndexes: readonly RuntimePromptImageFactIndex[],
+  space?: RuntimePromptImageFactSpace,
 ): void {
   if (images.length !== factIndexes.length) {
     return;
   }
   Object.defineProperty(images, RUNTIME_PROMPT_IMAGE_FACT_INDEXES, {
     configurable: true,
-    value: [...factIndexes],
+    value: {
+      factIndexes: [...factIndexes],
+      ...(space ? { space } : {}),
+    } satisfies RuntimePromptImageProvenance,
   });
+}
+
+function isRuntimePromptImageFactIndexes(
+  value: unknown,
+  imageCount: number,
+): value is RuntimePromptImageFactIndex[] {
+  return (
+    Array.isArray(value) &&
+    value.length === imageCount &&
+    value.every(
+      (entry) =>
+        entry === null || (typeof entry === "number" && Number.isSafeInteger(entry) && entry >= 0),
+    )
+  );
+}
+
+export function readRuntimePromptImageProvenance(
+  images: readonly object[] | null | undefined,
+): RuntimePromptImageProvenance | undefined {
+  if (!images?.length) {
+    return undefined;
+  }
+  const value = (images as unknown as Record<PropertyKey, unknown>)[
+    RUNTIME_PROMPT_IMAGE_FACT_INDEXES
+  ];
+  // Accept the pre-space carrier while queued turns from an older process drain during upgrade.
+  if (isRuntimePromptImageFactIndexes(value, images.length)) {
+    return { factIndexes: value };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (!isRuntimePromptImageFactIndexes(candidate.factIndexes, images.length)) {
+    return undefined;
+  }
+  const space = candidate.space;
+  if (space !== undefined && space !== "inbound-media" && space !== "run-media") {
+    return undefined;
+  }
+  return {
+    factIndexes: candidate.factIndexes,
+    ...(space ? { space } : {}),
+  };
 }
 
 export function readRuntimePromptImageFactIndexes(
   images: readonly object[] | null | undefined,
 ): RuntimePromptImageFactIndex[] | undefined {
-  if (!images?.length) {
-    return undefined;
-  }
-  const factIndexes = (images as unknown as Record<PropertyKey, unknown>)[
-    RUNTIME_PROMPT_IMAGE_FACT_INDEXES
-  ];
-  return Array.isArray(factIndexes) &&
-    factIndexes.length === images.length &&
-    factIndexes.every(
-      (entry) =>
-        entry === null || (typeof entry === "number" && Number.isSafeInteger(entry) && entry >= 0),
-    )
-    ? (factIndexes as RuntimePromptImageFactIndex[])
-    : undefined;
+  return readRuntimePromptImageProvenance(images)?.factIndexes;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending images through reply, queued, collected, CLI, or persisted-replay paths could have the same image hydrated twice, lose its source identity, or receive no reply when media indexes were interpreted in the wrong space.

## Why This Change Was Made

The change carries explicit image-source provenance through every execution path, distinguishes inbound-media indexes from run-media indexes, and safely re-infers image ownership when a mapping is absent or invalid. It also keeps CLI workspace media readable without expanding access outside the active workspace and standard media roots.

## User Impact

Image messages now reach native multimodal models once, in stable order, across direct replies, queued/collected turns, CLI execution, and persisted replay. Mixed audio-and-image turns no longer attach a run-media index to the wrong persisted fact, and callers cannot broaden filesystem access by supplying an arbitrary workspace root.

## Evidence

- Targeted main suite: 20 files / 587 tests passed.
- Targeted beta.5 suite: 18 files / 534 tests passed.
- Core and core-test type checks passed on both heads.
- Gateway tests: 7/7 passed on the beta.5 backport.
- Exact-head `check-changed` passed on main and exact beta.5 base.
- Exact-head TruffleHog and Codex `$autoreview` reported no actionable findings on both heads.
- Fresh Claude Opus 5 iterative reviews reached `建议合入` with no P0/P1 findings.
