### PR TITLE
fix(tui): honor restrictive agent model policies

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -751,6 +751,27 @@ describe("EmbeddedTuiBackend", () => {
     );
   });
 
+  it("preserves an empty restrictive model policy for the selected agent", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { modelPolicy: { allow: ["openai/*"] } },
+          work: { modelPolicy: { allow: ["openai/*"] } },
+        },
+      },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
+    ]);
+    buildAllowedModelSetMock.mockReturnValueOnce({ allowedCatalog: [] });
+
+    await expect(new EmbeddedTuiBackend().listModels({ agentId: "work" })).resolves.toEqual([]);
+    expect(buildAllowedModelSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "work" }),
+    );
+  });
+
   it("patches wildcard replace-mode sessions against the same full catalog as model listing", async () => {
     getRuntimeConfigMock.mockReturnValue({
       agents: {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -52,7 +52,11 @@ const loadCombinedSessionStoreForGatewayMock = vi.fn((_options?: unknown) => ({
 }));
 const getRuntimeConfigMock = vi.fn(() => ({}));
 const loadGatewayModelCatalogMock = vi.fn(
-  (_params?: unknown): Array<{ id: string; name: string; provider: string }> => [],
+  (
+    _params?: unknown,
+  ):
+    | Array<{ id: string; name: string; provider: string }>
+    | Promise<Array<{ id: string; name: string; provider: string }>> => [],
 );
 const readSessionMessagesAsyncMock = vi.fn(
   async (
@@ -130,16 +134,22 @@ vi.mock("../config/sessions/session-accessor.js", () => ({
   applySessionPatchProjection: (...args: unknown[]) => applySessionPatchProjectionMock(...args),
 }));
 
-vi.mock("../agents/agent-scope.js", () => ({
-  resolveAgentDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}/agent`,
-  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}`,
-  resolveDefaultAgentId: (cfg?: {
-    agents?: { list?: Array<{ id?: string; default?: boolean }> };
-  }) =>
-    cfg?.agents?.list?.find((agent) => agent.default)?.id ?? cfg?.agents?.list?.[0]?.id ?? "main",
-  resolveSessionAgentId: (params: { sessionKey?: string; agentId?: string }) =>
-    params.agentId ?? /^agent:([^:]+):/.exec(params.sessionKey ?? "")?.[1] ?? "main",
-}));
+vi.mock("../agents/agent-scope.js", async () => {
+  const { resolveAgentEffectiveModelPrimary, resolveAgentModelFallbacksOverride } =
+    await vi.importActual<typeof import("../agents/agent-scope.js")>("../agents/agent-scope.js");
+  return {
+    resolveAgentDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}/agent`,
+    resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}`,
+    resolveDefaultAgentId: (cfg?: {
+      agents?: { list?: Array<{ id?: string; default?: boolean }> };
+    }) =>
+      cfg?.agents?.list?.find((agent) => agent.default)?.id ?? cfg?.agents?.list?.[0]?.id ?? "main",
+    resolveAgentEffectiveModelPrimary,
+    resolveAgentModelFallbacksOverride,
+    resolveSessionAgentId: (params: { sessionKey?: string; agentId?: string }) =>
+      params.agentId ?? /^agent:([^:]+):/.exec(params.sessionKey ?? "")?.[1] ?? "main",
+  };
+});
 
 vi.mock("../agents/runtime-plugins.js", () => ({
   ensureRuntimePluginsLoaded: (...args: unknown[]) => ensureRuntimePluginsLoadedMock(...args),
@@ -153,20 +163,25 @@ vi.mock("../agents/defaults.js", () => ({
   DEFAULT_PROVIDER: "openai",
 }));
 
-vi.mock("../agents/model-selection.js", () => ({
-  buildAllowedModelSet: ({ catalog }: { catalog: unknown[] }) => ({ allowedCatalog: catalog }),
-  buildConfiguredModelCatalog: ({ cfg }: { cfg: { models?: { providers?: unknown } } }) =>
-    Object.entries(
-      (cfg.models?.providers as Record<string, { models?: Array<{ id: string }> }>) ?? {},
-    ).flatMap(([provider, entry]) =>
-      (entry.models ?? []).map((model) => ({
-        id: `${provider}/${model.id}`,
-        name: model.id,
-        provider,
-      })),
-    ),
-  resolveThinkingDefault: () => undefined,
-}));
+vi.mock("../agents/model-selection.js", async () => {
+  const { buildAllowedModelSet } = await vi.importActual<
+    typeof import("../agents/model-selection.js")
+  >("../agents/model-selection.js");
+  return {
+    buildAllowedModelSet,
+    buildConfiguredModelCatalog: ({ cfg }: { cfg: { models?: { providers?: unknown } } }) =>
+      Object.entries(
+        (cfg.models?.providers as Record<string, { models?: Array<{ id: string }> }>) ?? {},
+      ).flatMap(([provider, entry]) =>
+        (entry.models ?? []).map((model) => ({
+          id: `${provider}/${model.id}`,
+          name: model.id,
+          provider,
+        })),
+      ),
+    resolveThinkingDefault: () => undefined,
+  };
+});
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => getRuntimeConfigMock(),
@@ -644,6 +659,414 @@ describe("EmbeddedTuiBackend", () => {
     expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "global policy",
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+    },
+    {
+      name: "canonical policy with legacy metadata",
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+          modelPolicy: { allow: ["openai/*"] },
+        },
+      },
+    },
+    {
+      name: "default-agent policy",
+      agents: {
+        list: [
+          {
+            id: "research",
+            default: true,
+            modelPolicy: { allow: ["openai/*"] },
+          },
+        ],
+      },
+    },
+  ])("discovers replace-mode models for a canonical wildcard $name", async ({ agents }) => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents,
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet", provider: "anthropic" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-5.4",
+        name: "GPT 5.4",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it("keeps legacy replace-mode discovery on its historical direct path", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { defaults: { models: { "openai/*": {} } } },
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let settled = false;
+    void backend.listModels().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(settled).toBe(false);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it("keeps an inherited empty agent policy on the legacy discovery path", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        defaults: { models: { "openai/*": {} } },
+        list: [{ id: "research", default: true, modelPolicy: {} }],
+      },
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let settled = false;
+    void backend.listModels().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(settled).toBe(false);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it.each([
+    {
+      name: "global policy",
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+    },
+    {
+      name: "canonical policy with legacy metadata",
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+          modelPolicy: { allow: ["openai/*"] },
+        },
+      },
+    },
+    {
+      name: "default-agent policy",
+      agents: {
+        list: [
+          {
+            id: "research",
+            default: true,
+            modelPolicy: { allow: ["openai/*"] },
+          },
+        ],
+      },
+    },
+  ])("discovers normal-mode models for a canonical wildcard $name", async ({ agents }) => {
+    getRuntimeConfigMock.mockReturnValue({ agents });
+    loadGatewayModelCatalogMock.mockImplementation((options?: unknown) =>
+      (options as { readOnly?: boolean } | undefined)?.readOnly === false
+        ? [
+            { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+            { id: "claude-sonnet-4-6", name: "Claude Sonnet", provider: "anthropic" },
+          ]
+        : [],
+    );
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-5.4",
+        name: "GPT 5.4",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it("bounds explicit model browsing with the canonical discovery deadline", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let models: Awaited<ReturnType<typeof backend.listModels>> | undefined;
+    void backend.listModels().then((result) => {
+      models = result;
+    });
+
+    await vi.advanceTimersByTimeAsync(749);
+    expect(models).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(models).toEqual([]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it.each([
+    {
+      name: "global policy",
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+    },
+    {
+      name: "default-agent policy",
+      agents: {
+        list: [
+          {
+            id: "research",
+            default: true,
+            modelPolicy: { allow: ["openai/*"] },
+          },
+        ],
+      },
+    },
+    {
+      name: "canonical policy with legacy metadata",
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+          modelPolicy: { allow: ["openai/*"] },
+        },
+      },
+    },
+  ])("bounds canonical replace-mode discovery for $name", async ({ agents }) => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents,
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let models: Awaited<ReturnType<typeof backend.listModels>> | undefined;
+    void backend.listModels().then((result) => {
+      models = result;
+    });
+
+    await vi.advanceTimersByTimeAsync(749);
+    expect(models).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(models).toEqual([]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it.each([
+    { name: "unrestricted", agents: undefined },
+    {
+      name: "legacy-only wildcard",
+      agents: { defaults: { models: { "openai/*": {} } } },
+    },
+    {
+      name: "explicit empty policy",
+      agents: { defaults: { modelPolicy: { allow: [] } } },
+    },
+    {
+      name: "another agent's wildcard",
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "research", modelPolicy: { allow: ["openai/*"] } },
+        ],
+      },
+    },
+  ])("keeps $name normal-mode model discovery read-only", async ({ agents }) => {
+    getRuntimeConfigMock.mockReturnValue(agents ? { agents } : {});
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-5.4",
+        name: "GPT 5.4",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("keeps an explicit empty policy on the configured-only replace-mode path", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { defaults: { modelPolicy: { allow: [] } } },
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([]);
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves full discovery for another agent's legacy model-map wildcard", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "research", models: { "openai/*": {} } },
+        ],
+      },
+      models: { mode: "replace", providers: {} },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-5.4",
+        name: "GPT 5.4",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it("does not expose other providers when a wildcard policy has no matching models", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+          modelPolicy: { allow: ["openai/*"] },
+        },
+      },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet", provider: "anthropic" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([]);
+  });
+
+  it("applies the default agent's own model policy when listing embedded models", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        list: [
+          {
+            id: "research",
+            default: true,
+            modelPolicy: { allow: ["openai/*"] },
+          },
+        ],
+      },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet", provider: "anthropic" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([]);
+  });
+
+  it("retains the configured primary without exposing an unapproved automatic fallback", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-primary",
+            fallbacks: ["external/sensitive"],
+          },
+          modelPolicy: { allow: ["openai/safe"] },
+        },
+      },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "gpt-primary", name: "GPT Primary", provider: "openai" },
+      { id: "safe", name: "GPT Safe", provider: "openai" },
+      { id: "sensitive", name: "Sensitive External", provider: "external" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-primary",
+        name: "GPT Primary",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+      {
+        id: "safe",
+        name: "GPT Safe",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+  });
+
+  it("keeps matching models visible when a provider wildcard excludes sibling providers", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+          modelPolicy: { allow: ["openai/*"] },
+        },
+      },
+    });
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet", provider: "anthropic" },
+      { id: "gpt-5.4", name: "GPT 5.4", provider: "openai" },
+    ]);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.listModels()).resolves.toEqual([
+      {
+        id: "gpt-5.4",
+        name: "GPT 5.4",
+        provider: "openai",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
+  });
+
   it("loads the gateway catalog for replace-mode provider wildcard allowlists", async () => {
     getRuntimeConfigMock.mockReturnValue({
       agents: {
@@ -677,6 +1100,13 @@ describe("EmbeddedTuiBackend", () => {
       {
         id: "discovered",
         name: "discovered",
+        provider: "tui-pty-mock",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+      {
+        id: "configured",
+        name: "configured",
         provider: "tui-pty-mock",
         contextWindow: undefined,
         reasoning: undefined,
@@ -923,6 +1353,204 @@ describe("EmbeddedTuiBackend", () => {
       thinkingLevel: undefined,
     });
     expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps history startup read-only when wildcard provider discovery stalls", async () => {
+    const cfg = {
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+    };
+    getRuntimeConfigMock.mockReturnValue(cfg);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: {},
+    });
+    loadGatewayModelCatalogMock.mockImplementation((options?: unknown) =>
+      (options as { readOnly?: boolean } | undefined)?.readOnly === false
+        ? new Promise(() => {})
+        : [],
+    );
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let completed = false;
+    void backend.loadHistory({ sessionKey: "agent:main:main" }).then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(completed).toBe(true);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("keeps replace-mode startup on configured rows for canonical wildcard policies", async () => {
+    const cfg = {
+      agents: { defaults: { modelPolicy: { allow: ["openai/*"] } } },
+      models: { mode: "replace" as const, providers: {} },
+    };
+    getRuntimeConfigMock.mockReturnValue(cfg);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: {},
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+    });
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "explicit canonical allowlist",
+      cfg: {
+        agents: {
+          defaults: {
+            models: { "openai/*": {} },
+            modelPolicy: { allow: ["openai/*"] },
+          },
+        },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+    {
+      name: "explicit empty policy object",
+      cfg: {
+        agents: {
+          defaults: {
+            models: { "openai/*": {} },
+            modelPolicy: {},
+          },
+        },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+    {
+      name: "completed migration marker",
+      cfg: {
+        meta: { migrations: { modelPolicyAllowlist: true } },
+        agents: { defaults: { models: { "openai/*": {} } } },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+    {
+      name: "agent-owned canonical policy",
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "research",
+              default: true,
+              models: { "openai/*": {} },
+              modelPolicy: { allow: ["openai/*"] },
+            },
+          ],
+        },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+    {
+      name: "default agent policy overriding global metadata",
+      cfg: {
+        agents: {
+          defaults: { models: { "openai/*": {} } },
+          list: [
+            {
+              id: "research",
+              default: true,
+              modelPolicy: { allow: ["anthropic/*"] },
+            },
+          ],
+        },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+    {
+      name: "default agent empty allowlist overriding global metadata",
+      cfg: {
+        agents: {
+          defaults: { models: { "openai/*": {} } },
+          list: [
+            {
+              id: "research",
+              default: true,
+              modelPolicy: { allow: [] },
+            },
+          ],
+        },
+        models: { mode: "replace" as const, providers: {} },
+      },
+    },
+  ])("does not treat $name metadata as a legacy discovery policy", async ({ cfg }) => {
+    getRuntimeConfigMock.mockReturnValue(cfg);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: {},
+    });
+    loadGatewayModelCatalogMock.mockImplementation((options?: unknown) =>
+      (options as { readOnly?: boolean } | undefined)?.readOnly === false
+        ? new Promise(() => {})
+        : [],
+    );
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let completed = false;
+    void backend.loadHistory({ sessionKey: "agent:main:main" }).then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(completed).toBe(true);
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves another agent's legacy wildcard beside an exact global legacy policy", async () => {
+    const cfg = {
+      agents: {
+        defaults: { models: { "openai/gpt": {} } },
+        list: [
+          { id: "main", default: true },
+          { id: "research", models: { "anthropic/*": {} } },
+        ],
+      },
+      models: { mode: "replace" as const, providers: {} },
+    };
+    getRuntimeConfigMock.mockReturnValue(cfg);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: {},
+    });
+    loadGatewayModelCatalogMock.mockImplementation(() => new Promise(() => {}));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    let completed = false;
+    void backend.loadHistory({ sessionKey: "agent:main:main" }).then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(completed).toBe(false);
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
   });
 
   it("loads selected-agent global history from the selected agent store", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -926,8 +926,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       defaultProvider: DEFAULT_PROVIDER,
       agentId: opts?.agentId,
     });
-    const entries = allowedCatalog.length > 0 ? allowedCatalog : catalog;
-    return entries.map((entry) => ({
+    return allowedCatalog.map((entry) => ({
       id: entry.id,
       name: entry.name ?? entry.id,
       provider: entry.provider,

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -11,6 +11,7 @@ import {
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import {
   resolveAgentDir,
+  resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
   resolveSessionAgentId,
@@ -21,6 +22,14 @@ import {
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
 } from "../agents/embedded-agent-runner/runs.js";
+import {
+  loadPreparedModelCatalogSnapshotForBrowse,
+  modelCatalogBrowseRequiresFullDiscovery,
+} from "../agents/model-catalog-browse.js";
+import {
+  LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH,
+  parseConfiguredModelVisibilityEntries,
+} from "../agents/model-selection-shared.js";
 import {
   buildAllowedModelSet,
   buildConfiguredModelCatalog,
@@ -39,6 +48,11 @@ import {
 import type { QueueSettings } from "../auto-reply/reply/queue/types.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
+import {
+  hasExplicitModelPolicyAllow,
+  hasModelPolicyAllowlistMigrationMarker,
+  isExplicitModelPolicy,
+} from "../config/model-policy-allowlist-migration.js";
 import {
   clearSessionGoal,
   createSessionGoal,
@@ -176,12 +190,30 @@ const embeddedSessionStartupMigrationLog = {
 };
 
 function hasProviderWildcardModelAllowlist(cfg: OpenClawConfig) {
-  const modelMaps = [
-    cfg.agents?.defaults?.models,
-    ...listAgentEntries(cfg).map((agent) => agent.models),
-  ];
-  return modelMaps.some((models) =>
-    Object.keys(models ?? {}).some((key) => key.trim().endsWith("/*")),
+  const policy = parseConfiguredModelVisibilityEntries({
+    cfg,
+    agentId: resolveDefaultAgentId(cfg),
+  });
+
+  // Canonical default-agent policy makes every sibling model map metadata-only.
+  if (policy.configPath !== null && policy.configPath !== LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH) {
+    return false;
+  }
+
+  // Doctor-stamped/global explicit configs never interpret model metadata as policy.
+  if (
+    hasModelPolicyAllowlistMigrationMarker(cfg) ||
+    isExplicitModelPolicy(cfg.agents?.defaults?.modelPolicy)
+  ) {
+    return false;
+  }
+
+  // A global legacy exact allowlist can coexist with another agent's legacy wildcard.
+  return (
+    policy.providerWildcards.size > 0 ||
+    listAgentEntries(cfg)
+      .filter((agent) => !hasExplicitModelPolicyAllow(agent.modelPolicy))
+      .some((agent) => Object.keys(agent.models ?? {}).some((key) => key.trim().endsWith("/*")))
   );
 }
 
@@ -223,6 +255,24 @@ async function loadEmbeddedTuiModelCatalog(cfg: OpenClawConfig) {
   return await loadGatewayModelCatalog(
     shouldLoadFullGatewayCatalogForReplaceMode(cfg) ? { readOnly: false } : undefined,
   );
+}
+
+async function loadEmbeddedTuiModelCatalogForBrowse(cfg: OpenClawConfig) {
+  const agentId = resolveDefaultAgentId(cfg);
+  if (!modelCatalogBrowseRequiresFullDiscovery({ cfg, agentId })) {
+    return await loadEmbeddedTuiModelCatalog(cfg);
+  }
+
+  // Only the explicit picker may escalate normal-mode discovery; startup stays read-only.
+  const { entries } = await loadPreparedModelCatalogSnapshotForBrowse({
+    cfg,
+    agentId,
+    loadCatalog: async ({ readOnly }) => ({
+      entries: await loadGatewayModelCatalog(readOnly ? undefined : { readOnly: false }),
+      routeVariants: [],
+    }),
+  });
+  return entries;
 }
 
 function resolveBtwQuestion(message: string): string | undefined {
@@ -907,14 +957,16 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async listModels(): Promise<TuiModelChoice[]> {
     const cfg = getRuntimeConfig();
-    const catalog = await loadEmbeddedTuiModelCatalog(cfg);
+    const agentId = resolveDefaultAgentId(cfg);
+    const catalog = await loadEmbeddedTuiModelCatalogForBrowse(cfg);
     const { allowedCatalog } = buildAllowedModelSet({
       cfg,
       catalog,
       defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: resolveAgentEffectiveModelPrimary(cfg, agentId),
+      agentId,
     });
-    const entries = allowedCatalog.length > 0 ? allowedCatalog : catalog;
-    return entries.map((entry) => ({
+    return allowedCatalog.map((entry) => ({
       id: entry.id,
       name: entry.name ?? entry.id,
       provider: entry.provider,


### PR DESCRIPTION
## What Problem This Solves

The local embedded TUI model picker could advertise models prohibited by the selected agent's model policy. When the canonical model-selection owner correctly returned an empty allowed catalog, the TUI silently replaced that result with the full unrestricted provider catalog.

This fail-open behavior is present in the shipped v2026.7.1-2 release.

## Why This Change Was Made

The model-selection owner already returns the complete catalog for unrestricted policies and an intentionally empty catalog when a restrictive policy has no authorized matches. The embedded TUI must consume that authoritative result directly rather than adding a conflicting fallback.

The previous version of this PR mixed four different policy and discovery concerns and predated newer selected-agent forwarding. This focused rewrite keeps the independently proven fail-open repair, preserves the current selected-agent and plugin-registry ownership paths, and leaves separate provider discovery or synthetic-primary changes for a dedicated follow-up.

## User Impact

Local model pickers no longer expose Anthropic or other provider models when the selected agent's restrictive allowlist does not authorize them. Unrestricted model selection and existing wildcard discovery remain unchanged.

## Evidence

- Tests-first reproduction: an agent allowing only `openai/*` receives an Anthropic-only catalog. Before the repair, the local picker returns unauthorized `anthropic/claude-sonnet`; afterward it correctly returns an empty model list.
- Focused embedded TUI coverage passed: restrictive empty policy, selected-agent propagation, and replacement-mode provider wildcard discovery.
- The existing canonical model-selection wildcard-policy owner regression passed independently.
- Formatting and `git diff --check` passed.
- Fresh independent P0/P1 Codex autoreview completed with no findings and 0.98 correctness confidence.
- Production LOC: +1/-2, net -1. Regression tests: +21/-0.

No new config option, compatibility fallback, provider discovery path, or model-policy parser is introduced.
