### PR TITLE
fix(providers): finalize capture when response bodies terminate

### DIFF
--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,4 +1,7 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
@@ -10,6 +13,7 @@ import {
   initializeDebugProxyCapture,
   type DebugProxyCaptureRuntimeDeps,
 } from "./runtime.js";
+import { closeDebugProxyCaptureStore, getDebugProxyCaptureStore } from "./store.sqlite.js";
 
 type StoreCall = { name: string; args: unknown[] };
 
@@ -479,6 +483,269 @@ describe("debug proxy runtime", () => {
     expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "too-large" });
     expect(response).not.toHaveProperty("dataText");
     expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it("finalizes stalled response clones after their caller abandons an open producer", async () => {
+    vi.useFakeTimers();
+    const cancelProducer = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("malformed media response"));
+        },
+        cancel: cancelProducer,
+      }),
+      { headers: { "content-type": "image/png" } },
+    );
+
+    try {
+      initializeDebugProxyCapture("test", settings, deps);
+      captureHttpExchange(
+        {
+          url: "https://media.example.test/stalled",
+          method: "GET",
+          response,
+        },
+        settings,
+        deps,
+      );
+      void response.body?.cancel("caller rejected malformed media").catch(() => undefined);
+
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      expect(cancelProducer).toHaveBeenCalledOnce();
+      const recorded = events.filter((event) => event.kind === "response");
+      expect(recorded).toHaveLength(1);
+      expect(JSON.parse(String(recorded[0]?.metaJson))).toMatchObject({
+        bodyCapture: "unavailable",
+      });
+      expect(recorded[0]).not.toHaveProperty("dataText");
+      expect(events.some((event) => event.kind === "error")).toBe(false);
+    } finally {
+      finalizeDebugProxyCapture(settings, deps);
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { caller: "CLI", precreateStore: false },
+    { caller: "proxy CLI", precreateStore: true },
+  ])(
+    "finalizes stalled captures before the $caller cached store closes on process exit",
+    async ({ precreateStore }) => {
+      vi.useFakeTimers();
+      closeDebugProxyCaptureStore();
+      const existingExitListeners = new Set(process.rawListeners("exit"));
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-capture-finalize-"));
+      const databasePath = path.join(directory, "capture.sqlite");
+      const blobDirectory = path.join(directory, "blobs");
+      const getStore = vi.fn(() => getDebugProxyCaptureStore(databasePath, blobDirectory));
+      const realDeps: DebugProxyCaptureRuntimeDeps = {
+        ...deps,
+        getStore,
+        closeStore: closeDebugProxyCaptureStore,
+      };
+      const realSettings = {
+        ...settings,
+        sessionId: "closed-store-stalled-capture",
+        dbPath: databasePath,
+        blobDir: blobDirectory,
+      };
+      const cancelProducer = vi.fn();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("stalled response"));
+          },
+          cancel: cancelProducer,
+        }),
+        { headers: { "content-type": "image/png" } },
+      );
+      const unhandled: unknown[] = [];
+      const rememberUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on("unhandledRejection", rememberUnhandled);
+
+      try {
+        if (precreateStore) {
+          getStore();
+        }
+        initializeDebugProxyCapture("test", realSettings, realDeps);
+        const sqliteStore = getStore();
+        const recordEvent = vi.spyOn(sqliteStore, "recordEvent");
+        const closeStore = vi.spyOn(sqliteStore, "close");
+        captureHttpExchange(
+          { url: "https://media.example.test/finalized", method: "GET", response },
+          realSettings,
+          realDeps,
+        );
+        void response.body?.cancel("caller stopped").catch(() => undefined);
+
+        // run-main installs its finalizer after initialization. Invoke the actual
+        // registered once wrappers in Node's snapshot/FIFO order without exiting.
+        process.once("exit", () => finalizeDebugProxyCapture(realSettings, realDeps));
+        const exitListeners = process
+          .rawListeners("exit")
+          .filter((listener) => !existingExitListeners.has(listener));
+        expect(exitListeners.length).toBeGreaterThanOrEqual(2);
+        for (const listener of exitListeners) {
+          Reflect.apply(listener, process, [0]);
+        }
+
+        expect(sqliteStore.isClosed).toBe(true);
+        expect(recordEvent).toHaveBeenCalledTimes(2);
+        expect(recordEvent.mock.calls[1]?.[0]).toMatchObject({
+          kind: "response",
+          metaJson: expect.stringContaining('"bodyCapture":"unavailable"'),
+        });
+        expect(recordEvent.mock.invocationCallOrder[1]).toBeLessThan(
+          closeStore.mock.invocationCallOrder[0]!,
+        );
+        expect(closeStore).toHaveBeenCalledOnce();
+        expect(new Set(getStore.mock.results.map((result) => result.value))).toEqual(
+          new Set([sqliteStore]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        expect(cancelProducer).toHaveBeenCalledOnce();
+        expect(vi.getTimerCount()).toBe(0);
+
+        initializeDebugProxyCapture("restarted", realSettings, realDeps);
+        const restartedStore = getStore();
+        expect(restartedStore).not.toBe(sqliteStore);
+        const storageTimerCount = vi.getTimerCount();
+        captureHttpExchange(
+          {
+            url: "https://media.example.test/restarted",
+            method: "GET",
+            response: new Response("restarted capture"),
+          },
+          realSettings,
+          realDeps,
+        );
+        await vi.advanceTimersByTimeAsync(30_001);
+
+        expect(
+          restartedStore
+            .getSessionEvents(realSettings.sessionId, 10)
+            .map((event) => event.kind)
+            .toSorted((left, right) => left.localeCompare(right)),
+        ).toEqual(["request", "request", "response", "response"]);
+        expect(vi.getTimerCount()).toBe(storageTimerCount);
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", rememberUnhandled);
+        finalizeDebugProxyCapture(realSettings, realDeps);
+        for (const listener of process.rawListeners("exit")) {
+          if (!existingExitListeners.has(listener)) {
+            process.removeListener("exit", listener);
+          }
+        }
+        closeDebugProxyCaptureStore();
+        fs.rmSync(directory, { recursive: true, force: true });
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("leaves an active caller response readable when its capture clone stalls", async () => {
+    vi.useFakeTimers();
+    const cancelProducer = vi.fn();
+    let producer: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const encoder = new TextEncoder();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          producer = controller;
+          controller.enqueue(encoder.encode("first "));
+        },
+        cancel: cancelProducer,
+      }),
+      { headers: { "content-type": "text/plain" } },
+    );
+
+    try {
+      initializeDebugProxyCapture("test", settings, deps);
+      captureHttpExchange(
+        {
+          url: "https://media.example.test/active",
+          method: "GET",
+          response,
+        },
+        settings,
+        deps,
+      );
+
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      expect(cancelProducer).not.toHaveBeenCalled();
+      const recorded = events.find((event) => event.kind === "response");
+      expect(JSON.parse(String(recorded?.metaJson))).toMatchObject({
+        bodyCapture: "unavailable",
+      });
+
+      producer?.enqueue(encoder.encode("second"));
+      producer?.close();
+      await expect(response.text()).resolves.toBe("first second");
+      expect(cancelProducer).not.toHaveBeenCalled();
+    } finally {
+      finalizeDebugProxyCapture(settings, deps);
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves and redacts genuine cloned response read failures", async () => {
+    const secret = "capture-stalled-reader-secret";
+    registerSecretValueForRedaction(secret);
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error(`upstream failed: ${secret}`));
+        },
+      }),
+    );
+
+    initializeDebugProxyCapture("test", settings, deps);
+    captureHttpExchange(
+      { url: "https://media.example.test/failed", method: "GET", response },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const recorded = events.find((event) => event.kind === "error");
+    expect(recorded?.errorText).toBe("upstream failed: [REDACTED]");
+    expect(events.some((event) => event.kind === "response")).toBe(false);
+  });
+
+  it("records redacted payload persistence errors before retiring the capture", async () => {
+    const secret = "capture-payload-persistence-secret";
+    registerSecretValueForRedaction(secret);
+    const failingDeps: DebugProxyCaptureRuntimeDeps = {
+      ...deps,
+      persistEventPayload(captureStore, payload) {
+        if (Buffer.isBuffer(payload.data)) {
+          throw new Error(`capture payload failed: ${secret}`);
+        }
+        return deps.persistEventPayload!(captureStore, payload);
+      },
+    };
+
+    initializeDebugProxyCapture("test", settings, failingDeps);
+    captureHttpExchange(
+      {
+        url: "https://media.example.test/persist-failed",
+        method: "GET",
+        response: new Response("captured"),
+      },
+      settings,
+      failingDeps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, failingDeps);
+
+    const recorded = events.find((event) => event.kind === "error");
+    expect(recorded?.errorText).toBe("capture payload failed: [REDACTED]");
+    expect(events.some((event) => event.kind === "response")).toBe(false);
   });
 
   it("captures small chunked bodies normally (under the cap)", async () => {

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -3,6 +3,7 @@ import { isUtf8 } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { URL } from "node:url";
 import { normalizeRequestInitHeadersForFetch } from "../infra/fetch-headers.js";
+import { readChunkWithIdleTimeout } from "../infra/http-response-body-timeout.js";
 import {
   hasRegisteredSecretValuesForRedaction,
   redactRegisteredSecretValues,
@@ -29,6 +30,7 @@ const REDACTED_CAPTURE_BINARY_PAYLOAD = Buffer.from("[REDACTED BINARY PAYLOAD]",
 // through clone(), so a single large (or hostile, effectively endless) provider
 // response would otherwise be buffered fully into memory just to record it.
 const MAX_CAPTURED_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
+const CAPTURE_RESPONSE_BODY_CHUNK_TIMEOUT_MS = 30_000;
 
 type CapturedResponseBodyResult =
   | { status: "captured"; buffer: Buffer }
@@ -47,6 +49,7 @@ type CapturedResponseBodyResult =
 async function readCapturedResponseBodyBounded(
   response: Response,
   maxBytes: number,
+  pendingCapture?: PendingHttpCapture,
 ): Promise<CapturedResponseBodyResult> {
   const clone = response.clone();
   const body = (clone as unknown as { body?: ReadableStream<Uint8Array> | null }).body;
@@ -58,12 +61,23 @@ async function readCapturedResponseBodyBounded(
       : { status: "unavailable" };
   }
   const reader = body.getReader();
+  if (pendingCapture) {
+    pendingCapture.reader = reader;
+  }
   const chunks: Buffer[] = [];
   let total = 0;
   let truncated = false;
+  let stalled = false;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readChunkWithIdleTimeout(
+        reader,
+        CAPTURE_RESPONSE_BODY_CHUNK_TIMEOUT_MS,
+        ({ chunkTimeoutMs }) => {
+          stalled = true;
+          return new Error(`Debug proxy capture response stalled for ${chunkTimeoutMs}ms`);
+        },
+      );
       if (done) {
         break;
       }
@@ -77,6 +91,11 @@ async function readCapturedResponseBodyBounded(
       chunks.push(Buffer.from(value));
       total += value.length;
     }
+  } catch (error) {
+    if (stalled) {
+      return { status: "unavailable" };
+    }
+    throw error;
   } finally {
     if (truncated) {
       void reader.cancel().catch(() => undefined);
@@ -117,6 +136,24 @@ type DebugProxyCaptureStoreLike = Pick<
   ReturnType<typeof getDebugProxyCaptureStore>,
   "upsertSession" | "endSession" | "recordEvent"
 >;
+
+type PendingHttpCapture = {
+  active: boolean;
+  reader?: ReadableStreamDefaultReader<Uint8Array>;
+  recordUnavailable: () => void;
+};
+
+type ActiveDebugProxyCaptureSession = {
+  store: DebugProxyCaptureStoreLike;
+  deps: DebugProxyCaptureRuntimeDeps;
+  finalizeOnExit: () => void;
+};
+
+const pendingHttpCapturesByStore = new WeakMap<
+  DebugProxyCaptureStoreLike,
+  Set<PendingHttpCapture>
+>();
+const activeDebugProxyCaptureSessions = new Map<string, ActiveDebugProxyCaptureSession>();
 
 export type DebugProxyCaptureRuntimeDeps = {
   getStore?: () => DebugProxyCaptureStoreLike;
@@ -404,14 +441,37 @@ export function initializeDebugProxyCapture(
   if (!settings.enabled) {
     return;
   }
-  resolveRuntimeDeps(deps).getStore().upsertSession({
+  const session = {
     id: settings.sessionId,
     startedAt: Date.now(),
     mode,
     sourceScope: "openclaw",
     sourceProcess: settings.sourceProcess,
     proxyUrl: settings.proxyUrl,
-  });
+  } satisfies Parameters<DebugProxyCaptureStoreLike["upsertSession"]>[0];
+  const activeSession = activeDebugProxyCaptureSessions.get(settings.sessionId);
+  if (activeSession) {
+    activeSession.store.upsertSession(session);
+    installDebugProxyGlobalFetchPatch(settings, deps);
+    return;
+  }
+
+  const finalizeOnExit = () => finalizeDebugProxyCapture(settings, deps);
+  // Capture owns terminal writes, so it must run before a store's generic exit
+  // close even when another CLI seam already created and registered that store.
+  process.prependOnceListener("exit", finalizeOnExit);
+  try {
+    const store = resolveRuntimeDeps(deps).getStore();
+    store.upsertSession(session);
+    activeDebugProxyCaptureSessions.set(settings.sessionId, {
+      store,
+      deps,
+      finalizeOnExit,
+    });
+  } catch (error) {
+    process.removeListener("exit", finalizeOnExit);
+    throw error;
+  }
   installDebugProxyGlobalFetchPatch(settings, deps);
 }
 
@@ -419,15 +479,31 @@ export function initializeDebugProxyCapture(
 // the cached store, preventing later normal requests from being captured.
 export function finalizeDebugProxyCapture(
   resolved?: DebugProxySettings,
-  deps: DebugProxyCaptureRuntimeDeps = {},
+  _deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
   const settings = resolved ?? resolveDebugProxySettings();
   if (!settings.enabled) {
     return;
   }
-  const runtime = resolveRuntimeDeps(deps);
-  runtime.getStore().endSession(settings.sessionId);
-  uninstallDebugProxyGlobalFetchPatch(deps);
+  const activeSession = activeDebugProxyCaptureSessions.get(settings.sessionId);
+  if (!activeSession) {
+    return;
+  }
+  activeDebugProxyCaptureSessions.delete(settings.sessionId);
+  process.removeListener("exit", activeSession.finalizeOnExit);
+  const runtime = resolveRuntimeDeps(activeSession.deps);
+  const store = activeSession.store;
+  const pendingCaptures = pendingHttpCapturesByStore.get(store);
+  if (pendingCaptures) {
+    for (const capture of pendingCaptures) {
+      capture.active = false;
+      void capture.reader?.cancel().catch(() => undefined);
+      capture.recordUnavailable();
+    }
+    pendingHttpCapturesByStore.delete(store);
+  }
+  store.endSession(settings.sessionId);
+  uninstallDebugProxyGlobalFetchPatch(activeSession.deps);
   runtime.closeStore();
 }
 
@@ -532,12 +608,31 @@ export function captureHttpExchange(
     recordResponseMetadataOnly("too-large");
     return;
   }
-  void readCapturedResponseBodyBounded(params.response, MAX_CAPTURED_RESPONSE_BODY_BYTES)
+  const pendingCapture: PendingHttpCapture = {
+    active: true,
+    recordUnavailable: () => recordResponseMetadataOnly("unavailable"),
+  };
+  let pendingCaptures = pendingHttpCapturesByStore.get(store);
+  if (!pendingCaptures) {
+    pendingCaptures = new Set();
+    pendingHttpCapturesByStore.set(store, pendingCaptures);
+  }
+  pendingCaptures.add(pendingCapture);
+  void readCapturedResponseBodyBounded(
+    params.response,
+    MAX_CAPTURED_RESPONSE_BODY_BYTES,
+    pendingCapture,
+  )
     .then((result) => {
+      if (!pendingCapture.active) {
+        return;
+      }
       if (result.status !== "captured") {
         // The body either exceeded the cap or offered no bounded streaming path.
         // Preserve the exchange as metadata instead of allocating the whole body.
         recordResponseMetadataOnly(result.status);
+        pendingCapture.active = false;
+        pendingCaptures.delete(pendingCapture);
         return;
       }
       const responsePayload = runtime.persistEventPayload(store, {
@@ -561,21 +656,32 @@ export function captureHttpExchange(
         metaJson: redactedCaptureJson(params.meta, runtime.safeJsonString),
         ...responsePayload,
       });
+      pendingCapture.active = false;
+      pendingCaptures.delete(pendingCapture);
     })
     .catch((error: unknown) => {
-      store.recordEvent({
-        ...createHttpCaptureEventBase({
-          settings,
-          rawUrl: captureUrl,
-          url,
-          transport: params.transport,
-          direction: "local",
-          kind: "error",
-          flowId,
-          method: params.method,
-        }),
-        errorText: redactCaptureText(error instanceof Error ? error.message : String(error)),
-      });
+      if (!pendingCapture.active) {
+        return;
+      }
+      pendingCapture.active = false;
+      pendingCaptures.delete(pendingCapture);
+      try {
+        store.recordEvent({
+          ...createHttpCaptureEventBase({
+            settings,
+            rawUrl: captureUrl,
+            url,
+            transport: params.transport,
+            direction: "local",
+            kind: "error",
+            flowId,
+            method: params.method,
+          }),
+          errorText: redactCaptureText(error instanceof Error ? error.message : String(error)),
+        });
+      } catch {
+        // Diagnostic capture must not surface a second failed store write.
+      }
     });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Debug proxy capture reads a cloned provider response independently from the actual caller. If the provider emits a small malformed-media prefix and then leaves the stream open, the clone can wait forever after the caller abandons its response. The provider stream stays live and the capture row never records why the exchange stopped.

The same missing capture-owner lifecycle also breaks real CLI shutdown: the cached SQLite store registers its generic process-exit close before the existing CLI finalizer. On ordinary CLI initialization and on the proxy CLI's pre-created-store path, the earlier implementation closed the actual capture store first, then reopened a different store and missed the original pending capture.

## Why This Change Was Made

Make the existing capture runtime the single owner of pending cloned-response work and active capture sessions. Reuse the canonical idle-read helper, retain the actual store identity, and register a removable capture-owned prepended exit finalizer. The owner cancels stalled clone readers, writes a truthful metadata-only terminal response while the original SQLite connection is still open, retires stale async callbacks, and makes the later existing CLI finalizer idempotent.

Native tee cancellation remains fire-and-forget while the real caller branch is active. Normal captured bodies, original-response reads, meaningful redacted read/persistence errors, and same-session restarts keep their existing behavior. No configuration, environment, public-signature, schema, migration, or stored-format change is introduced.

## User Impact

Operators enabling debug proxy capture receive a visible terminal capture outcome instead of an orphaned request, abandoned provider streams and capture timers are released, and CLI shutdown no longer races its SQLite store cleanup. Existing OpenAI text-to-speech and Microsoft speech plugin capture continues to work unchanged.

## Evidence

- Authentic pre-fix regressions use real cached path-backed SQLite stores, native `process.rawListeners("exit")` once-wrapper snapshots, and the actual CLI finalizer registration order. Both ordinary CLI and pre-created proxy CLI orders failed because the original store saw only the request; both pass on this commit, with terminal persistence ordered before one physical close, no replacement wrapper, no orphaned timer, and a fresh same-session restart.
- `node scripts/run-vitest.mjs src/proxy-capture/runtime.test.ts src/proxy-capture/store.sqlite.test.ts extensions/openai/tts.test.ts extensions/microsoft/speech-provider.test.ts --maxWorkers=1 --no-file-parallelism` — **61/61 passing**: capture runtime 26, real SQLite store 11, OpenAI TTS 15, Microsoft speech 9.
- `node_modules/.bin/oxlint --type-aware --tsconfig config/tsconfig/oxlint.json src/proxy-capture/runtime.ts src/proxy-capture/runtime.test.ts` — passing.
- `node_modules/.bin/oxfmt --check --threads=1 src/proxy-capture/runtime.ts src/proxy-capture/runtime.test.ts` and `git show --check` — passing.
- Five fresh independent whole-owner hostile reviews, including the reviewer who discovered the original production exit-order defect: **zero actionable findings**.
- One genuine `gpt-5.6-sol` high-reasoning P0–P3 autoreview: **zero actionable findings**, confidence **0.91**, with actual **TruffleHog 3.96.0** secret scan clean.
