### PR TITLE
fix(cron): preserve authoritative run origin across delivery lifecycles

### DIFF
--- a/src/cron/active-jobs-manual-run.test.ts
+++ b/src/cron/active-jobs-manual-run.test.ts
@@ -35,6 +35,8 @@ import {
   setupCronServiceSuite,
   writeCronStoreSnapshot,
 } from "./service.test-harness.js";
+import { clearManualCronJobActive, markManualCronJobActive } from "./service/ops-shared.js";
+import { createCronServiceState } from "./service/state.js";
 import type { CronJob } from "./types.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -65,11 +67,15 @@ function createManualIsolatedJob(id: string): CronJob {
   };
 }
 
-async function createManualRunHarness(jobId: string) {
+async function createManualRunHarness(jobId: string, deliveryRequested = false) {
   const store = await makeStorePath();
+  const job = createManualIsolatedJob(jobId);
+  if (deliveryRequested) {
+    job.delivery = { mode: "announce", channel: "telegram", to: "123" };
+  }
   await writeCronStoreSnapshot({
     storePath: store.storePath,
-    jobs: [createManualIsolatedJob(jobId)],
+    jobs: [job],
   });
 
   const entered = createDeferred<void>();
@@ -97,26 +103,60 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
     vi.useRealTimers();
   });
 
-  it("marks the job active during a manual run and clears it on success", async () => {
-    const { cron, entered, release, store } = await createManualRunHarness("manual-isolated-ok");
+  it.each(["operator", "stream", "exit"] as const)(
+    "preserves the %s run origin only while its invocation is active",
+    async (executionOrigin) => {
+      const jobId = `manual-isolated-${executionOrigin}`;
+      const deliveryRequested = executionOrigin !== "operator";
+      const { cron, entered, release, store } = await createManualRunHarness(
+        jobId,
+        deliveryRequested,
+      );
+      const deliveryError =
+        "cron delivery skipped because execution began after its scheduled window";
 
-    try {
-      await cron.start();
+      try {
+        await cron.start();
 
-      const runPromise = cron.run("manual-isolated-ok", "force");
-      await entered.promise;
+        const runPromise =
+          executionOrigin === "operator"
+            ? cron.run(jobId, "force")
+            : cron.run(jobId, "force", { executionOrigin });
+        await entered.promise;
 
-      expect(isCronJobActive("manual-isolated-ok")).toBe(true);
+        expect(isCronJobActive(jobId)).toBe(true);
+        expect(cron.resolveRunExecution(jobId)).toMatchObject({
+          origin: executionOrigin,
+          reservationAt: expect.any(Number),
+        });
 
-      release.resolve({ status: "ok", summary: "ok" });
-      await runPromise;
+        release.resolve({
+          status: "ok",
+          summary: "ok",
+          ...(deliveryRequested
+            ? { delivered: false, deliveryAttempted: true, deliveryError }
+            : {}),
+        });
+        await runPromise;
 
-      expect(isCronJobActive("manual-isolated-ok")).toBe(false);
-    } finally {
-      cron.stop();
-      await store.cleanup();
-    }
-  });
+        expect(isCronJobActive(jobId)).toBe(false);
+        expect(cron.resolveRunExecution(jobId)).toEqual({ origin: "scheduled" });
+        if (deliveryRequested) {
+          expect(cron.getJob(jobId)?.state).toMatchObject({
+            lastRunStatus: "ok",
+            lastDeliveryStatus: "not-delivered",
+            lastDeliveryError: deliveryError,
+            lastFailureNotificationDeliveryStatus: "not-requested",
+            consecutiveErrors: 0,
+          });
+          expect(cron.getJob(jobId)?.state.lastFailureAlertAtMs).toBeUndefined();
+        }
+      } finally {
+        cron.stop();
+        await store.cleanup();
+      }
+    },
+  );
 
   it("does not let old restart-lifecycle finalizers clear new active markers", () => {
     const oldMarker = markCronJobActive("manual-generation-reuse");
@@ -144,6 +184,116 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
     clearCronJobActive("manual-token-reuse", freshMarker);
 
     expect(isCronJobActive("manual-token-reuse")).toBe(false);
+  });
+
+  it.each(["same-generation", "restart-generation"] as const)(
+    "keeps the replacement run origin when a %s finalizer retires an old marker",
+    (replacement) => {
+      const state = createCronServiceState({
+        storePath: "/unused/cron-origin-test.sqlite",
+        cronEnabled: false,
+        log: logger,
+        enqueueSystemEvent: () => {},
+        requestHeartbeat: () => {},
+        runIsolatedAgentJob: async () => ({ status: "ok" }),
+      });
+      const job = createManualIsolatedJob("manual-origin-replacement");
+      const oldReservationAt = Date.now();
+      const oldMarker = markManualCronJobActive(state, job, "operator", oldReservationAt);
+      if (replacement === "restart-generation") {
+        advanceCronActiveJobGeneration();
+      }
+      const freshReservationAt = oldReservationAt + 1;
+      const freshMarker = markManualCronJobActive(state, job, "stream", freshReservationAt);
+      state.manualSetupTimeoutNotified = true;
+
+      clearManualCronJobActive(state, job.id, oldMarker);
+
+      expect(state.activeRunOrigins.get(job.id)?.origin).toBe("stream");
+      expect(state.activeRunOrigins.get(job.id)?.reservationAt).toBe(freshReservationAt);
+      expect(state.manualSetupTimeoutNotified).toBe(true);
+      expect(isCronJobActive(job.id)).toBe(true);
+
+      clearManualCronJobActive(state, job.id, freshMarker);
+
+      expect(state.activeRunOrigins.has(job.id)).toBe(false);
+      expect(state.manualSetupTimeoutNotified).toBe(false);
+      expect(isCronJobActive(job.id)).toBe(false);
+    },
+  );
+
+  it.each(["generation advance", "global marker reset"] as const)(
+    "does not expose a retired isolated operator after %s before its finalizer runs",
+    async (retirement) => {
+      const jobId = "retired-manual-operator-origin";
+      const { cron, entered, release, store } = await createManualRunHarness(jobId);
+
+      try {
+        await cron.start();
+        const staleRun = cron.run(jobId, "force");
+        await entered.promise;
+        expect(cron.resolveRunExecution(jobId).origin).toBe("operator");
+
+        if (retirement === "generation advance") {
+          advanceCronActiveJobGeneration();
+        } else {
+          resetCronActiveJobs();
+        }
+
+        expect(cron.resolveRunExecution(jobId)).toEqual({ origin: "scheduled" });
+        release.resolve({ status: "ok", summary: "retired" });
+        await staleRun;
+      } finally {
+        cron.stop();
+        await store.cleanup();
+      }
+    },
+  );
+
+  it("preserves the real main-session operator invocation across generation advance", async () => {
+    const store = await makeStorePath();
+    const job = {
+      ...createManualIsolatedJob("preserved-main-operator-origin"),
+      sessionTarget: "main" as const,
+      wakeMode: "now" as const,
+      payload: { kind: "systemEvent" as const, text: "operator-owned wake" },
+    };
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [job] });
+    const heartbeatStarted = createDeferred();
+    const releaseHeartbeat = createDeferred();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeat: () => {},
+      runHeartbeatOnce: async () => {
+        heartbeatStarted.resolve();
+        await releaseHeartbeat.promise;
+        return { status: "ran", durationMs: 1 };
+      },
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+    });
+    let run: Promise<unknown> | undefined;
+
+    try {
+      await cron.start();
+      run = cron.run(job.id, "force");
+      await heartbeatStarted.promise;
+
+      advanceCronActiveJobGeneration();
+
+      expect(cron.resolveRunExecution(job.id)).toMatchObject({ origin: "operator" });
+      resetCronActiveJobs();
+      expect(cron.resolveRunExecution(job.id)).toEqual({ origin: "scheduled" });
+    } finally {
+      releaseHeartbeat.resolve();
+      if (run) {
+        await run;
+      }
+      cron.stop();
+      await store.cleanup();
+    }
   });
 
   it("retires preserved main-session markers at the lifecycle cutoff", () => {

--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -322,6 +322,80 @@ describe("runCronIsolatedAgentTurn core-channel direct delivery", () => {
     clearRuntimeConfigSnapshot();
   });
 
+  it("delivers freshly generated output for an operator-requested overdue automation", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const cfg = makeCfg(home, storePath);
+      const deps = createCliDeps();
+      const output = "Fresh operator-requested automation result";
+      mockAgentPayloads([{ text: output }]);
+
+      const result = await runCronIsolatedAgentTurn({
+        cfg,
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "generate a fresh report" }),
+          state: { nextRunAtMs: Date.now() - 4 * 60 * 60_000 },
+          delivery: { mode: "announce", channel: "slack", to: "channel:C12345" },
+        },
+        message: "generate a fresh report",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+        executionOrigin: "operator",
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.delivered).toBe(true);
+      expect(deps.sendMessageSlack).toHaveBeenCalledExactlyOnceWith(
+        "channel:C12345",
+        output,
+        expect.objectContaining({ cfg }),
+      );
+    });
+  });
+
+  it.each(["direct hook", "scheduled", "stream", "exit"] as const)(
+    "records overdue %s delivery suppression without sending stale output",
+    async (executionOrigin) => {
+      await withTempCronHome(async (home) => {
+        const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+        const cfg = makeCfg(home, storePath);
+        const deps = createCliDeps();
+        const deliveryError =
+          "cron delivery skipped because execution began after its scheduled window";
+        const reservationAt = Date.now() - 4 * 60 * 60_000;
+        const eventOwned = executionOrigin === "stream" || executionOrigin === "exit";
+        mockAgentPayloads([{ text: "Overdue automation output" }]);
+
+        const result = await runCronIsolatedAgentTurn({
+          cfg,
+          deps,
+          job: {
+            ...makeJob({ kind: "agentTurn", message: "generate a report" }),
+            state: eventOwned ? {} : { nextRunAtMs: reservationAt },
+            delivery: { mode: "announce", channel: "slack", to: "channel:C12345" },
+          },
+          message: "generate a report",
+          sessionKey: "cron:job-1",
+          lane: "cron",
+          ...(executionOrigin === "direct hook" ? {} : { executionOrigin }),
+          ...(eventOwned ? { executionReservedAtMs: reservationAt } : {}),
+        });
+
+        expect(result).toMatchObject({
+          status: "ok",
+          delivered: false,
+          deliveryAttempted: true,
+          deliveryError,
+        });
+        expect(result.diagnostics?.entries).toContainEqual(
+          expect.objectContaining({ source: "delivery", message: deliveryError }),
+        );
+        expect(deps.sendMessageSlack).not.toHaveBeenCalled();
+      });
+    },
+  );
+
   for (const testCase of CASES) {
     it(`routes ${testCase.name} text-only announce delivery through the outbound adapter`, async () => {
       await expectCoreChannelAnnounceDelivery({

--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -25,6 +25,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 import { createCronExecutionId } from "../run-id.js";
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";
+import type { CronRunOrigin } from "../service/state.js";
 import type { CronJob } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
@@ -154,23 +155,34 @@ export function logCronDeliveryErrorDeferred(message: string): void {
   });
 }
 
-export function resolveCronDeliveryScheduledAtMs(params: {
+type CronDeliveryExecutionTiming = {
   job: CronJob;
   runStartedAt: number;
-}): number {
+  executionOrigin?: CronRunOrigin;
+  executionReservedAtMs?: number;
+};
+
+export function resolveCronDeliveryScheduledAtMs(params: CronDeliveryExecutionTiming): number {
   const scheduledAt = params.job.state?.nextRunAtMs;
-  return hasScheduledNextRunAtMs(scheduledAt) ? scheduledAt : params.runStartedAt;
+  if (hasScheduledNextRunAtMs(scheduledAt)) {
+    return scheduledAt;
+  }
+  return params.executionOrigin === "stream" || params.executionOrigin === "exit"
+    ? (params.executionReservedAtMs ?? params.runStartedAt)
+    : params.runStartedAt;
 }
 
-export function resolveCronDeliveryStartDelayMs(params: {
-  job: CronJob;
-  runStartedAt: number;
-}): number {
+export function resolveCronDeliveryStartDelayMs(params: CronDeliveryExecutionTiming): number {
   return params.runStartedAt - resolveCronDeliveryScheduledAtMs(params);
 }
 
-export function isStaleCronDelivery(params: { job: CronJob; runStartedAt: number }): boolean {
-  return resolveCronDeliveryStartDelayMs(params) > STALE_CRON_DELIVERY_MAX_START_DELAY_MS;
+export function isStaleCronDelivery(
+  params: CronDeliveryExecutionTiming & { executionOrigin: CronRunOrigin },
+): boolean {
+  return (
+    params.executionOrigin !== "operator" &&
+    resolveCronDeliveryStartDelayMs(params) > STALE_CRON_DELIVERY_MAX_START_DELAY_MS
+  );
 }
 
 export async function maybeApplyTtsToCronPayloads(params: {

--- a/src/cron/isolated-agent/delivery-dispatch-types.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-types.ts
@@ -3,6 +3,7 @@ import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import type { SourceDeliveryOutcome } from "../../infra/outbound/source-delivery-plan.js";
+import type { CronRunOrigin } from "../service/state.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
@@ -23,6 +24,8 @@ export type DispatchCronDeliveryParams = {
   beforeSessionDelete?: () => void;
   runStartedAt: number;
   runEndedAt: number;
+  executionOrigin: CronRunOrigin;
+  executionReservedAtMs?: number;
   timeoutMs: number;
   resolvedDelivery: DeliveryTargetResolution;
   deliveryRequested: boolean;

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -215,6 +215,8 @@ function makeBaseParams(overrides: {
   sessionTarget?: string;
   deliveryBestEffort?: boolean;
   spawnOnlyHandoff?: boolean;
+  executionOrigin?: Parameters<typeof dispatchCronDelivery>[0]["executionOrigin"];
+  executionReservedAtMs?: number;
   runSessionKey?: string;
   resolvedDeliveryMode?: "explicit" | "implicit";
 }): Parameters<typeof dispatchCronDelivery>[0] {
@@ -242,6 +244,8 @@ function makeBaseParams(overrides: {
     sessionUpdatedAt: 1_000,
     runStartedAt,
     runEndedAt: runStartedAt,
+    executionOrigin: overrides.executionOrigin ?? "scheduled",
+    executionReservedAtMs: overrides.executionReservedAtMs,
     timeoutMs: 30_000,
     resolvedDelivery,
     deliveryRequested: overrides.deliveryRequested ?? true,
@@ -1176,6 +1180,48 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     },
   );
 
+  it.each(["operator", "scheduled", "stream", "exit"] as const)(
+    "applies %s stale-delivery policy after recovering accepted child output",
+    async (executionOrigin) => {
+      const childReply = "Freshly completed accepted child result.";
+      const reservationAt = Date.now() - 4 * 60 * 60_000;
+      const eventOwned = executionOrigin === "stream" || executionOrigin === "exit";
+      vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(childReply);
+      vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
+
+      const params = makeBaseParams({
+        executionOrigin,
+        ...(eventOwned ? { executionReservedAtMs: reservationAt } : {}),
+        spawnOnlyHandoff: true,
+        synthesizedText: "",
+      });
+      params.synthesizedText = undefined;
+      params.deliveryPayloads = [];
+      params.summary = undefined;
+      params.outputText = undefined;
+      (params.job as { state?: { nextRunAtMs?: number } }).state = eventOwned
+        ? {}
+        : { nextRunAtMs: reservationAt };
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(readDescendantSubagentFallbackReply).toHaveBeenCalledOnce();
+      expect(state.deliveryAttempted).toBe(true);
+      if (executionOrigin === "operator") {
+        expect(state.delivered).toBe(true);
+        expect(state.deliveryError).toBeUndefined();
+        expectDeliveryCall(0, { payloads: [{ text: childReply }] });
+      } else {
+        expectResultFields(state.result, {
+          status: "ok",
+          delivered: false,
+          deliveryError: "cron delivery skipped because execution began after its scheduled window",
+        });
+        expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("preserves a substantive parent synthesis after an accepted child has completed", async () => {
     const parentReply = "Combined parent summary already includes every child result.";
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
@@ -1769,23 +1815,80 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("skips stale cron deliveries while still suppressing fallback main summary", async () => {
+  it.each(["scheduled", "stream", "exit"] as const)(
+    "records stale %s delivery suppression without announcing a fallback summary",
+    async (executionOrigin) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
+
+      const params = makeBaseParams({
+        synthesizedText: "Yesterday's morning briefing.",
+        executionOrigin,
+        ...(executionOrigin === "scheduled"
+          ? {}
+          : { executionReservedAtMs: Date.now() - (3 * 60 * 60_000 + 1) }),
+      });
+      (params.job as { state?: { nextRunAtMs?: number } }).state =
+        executionOrigin === "scheduled" ? { nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1) } : {};
+
+      const state = await dispatchCronDelivery(params);
+
+      expectResultFields(state.result, {
+        status: "ok",
+        delivered: false,
+        deliveryAttempted: true,
+        deliveryError: "cron delivery skipped because execution began after its scheduled window",
+      });
+      expect(state.deliveryError).toBe(
+        "cron delivery skipped because execution began after its scheduled window",
+      );
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["stream", "exit"] as const)(
+    "delivers a promptly admitted %s event after a long agent execution",
+    async (executionOrigin) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
+      const reservationAt = Date.now();
+      vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
+      const params = makeBaseParams({
+        synthesizedText: "Fresh source event.",
+        executionOrigin,
+        runStartedAt: reservationAt,
+        executionReservedAtMs: reservationAt,
+      });
+      (params.job as { state?: { nextRunAtMs?: number } }).state = {};
+      vi.setSystemTime(reservationAt + 4 * 60 * 60_000);
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(state.delivered).toBe(true);
+      expect(state.deliveryError).toBeUndefined();
+      expect(deliverOutboundPayloads).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("delivers a fresh overdue operator-requested result exactly once", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
 
-    const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
+    const params = makeBaseParams({
+      synthesizedText: "Freshly requested automation result.",
+      executionOrigin: "operator",
+    });
     (params.job as { state?: { nextRunAtMs?: number } }).state = {
-      nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
+      nextRunAtMs: Date.now() - 4 * 60 * 60_000,
     };
 
     const state = await dispatchCronDelivery(params);
 
-    expectResultFields(state.result, {
-      status: "ok",
-      delivered: false,
-      deliveryAttempted: true,
-    });
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.deliveryError).toBeUndefined();
+    expect(deliverOutboundPayloads).toHaveBeenCalledOnce();
   });
 
   it("still delivers when the run started on time but finished more than three hours later", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -270,32 +270,28 @@ export async function dispatchCronDelivery(
           ...params.telemetry,
         });
       }
-      if (
-        params.deliveryRequested &&
-        isStaleCronDelivery({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
-        })
-      ) {
+      const executionTiming = {
+        job: params.job,
+        runStartedAt: params.runStartedAt,
+        executionOrigin: params.executionOrigin,
+        executionReservedAtMs: params.executionReservedAtMs,
+      };
+      if (params.deliveryRequested && isStaleCronDelivery(executionTiming)) {
         deliveryAttempted = true;
         const nowMs = Date.now();
-        const scheduledAtMs = resolveCronDeliveryScheduledAtMs({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
-        });
-        const startDelayMs = resolveCronDeliveryStartDelayMs({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
-        });
+        const scheduledAtMs = resolveCronDeliveryScheduledAtMs(executionTiming);
+        const startDelayMs = resolveCronDeliveryStartDelayMs(executionTiming);
         await logCronDeliveryWarn(
           `[cron:${params.job.id}] skipping stale delivery scheduled at ${new Date(scheduledAtMs).toISOString()}, started ${Math.round(startDelayMs / 60_000)}m late, current age ${Math.round((nowMs - scheduledAtMs) / 60_000)}m`,
         );
+        deliveryError = "cron delivery skipped because execution began after its scheduled window";
         return params.withRunSession({
           status: "ok",
           summary,
           outputText,
           deliveryAttempted,
           delivered: false,
+          deliveryError,
           ...params.telemetry,
         });
       }
@@ -739,16 +735,11 @@ export async function dispatchCronDelivery(
     const useDirectDelivery =
       params.deliveryPayloadHasStructuredContent ||
       (params.resolvedDelivery.threadId != null && !params.spawnOnlyHandoff);
-    if (useDirectDelivery) {
-      const directResult = await deliverViaDirectAndCleanup(params.resolvedDelivery);
-      if (directResult) {
-        return buildDeliveryState(directResult);
-      }
-    } else {
-      const finalizedTextResult = await finalizeTextDelivery(params.resolvedDelivery);
-      if (finalizedTextResult) {
-        return buildDeliveryState(finalizedTextResult);
-      }
+    const deliveryResult = useDirectDelivery
+      ? await deliverViaDirectAndCleanup(params.resolvedDelivery)
+      : await finalizeTextDelivery(params.resolvedDelivery);
+    if (deliveryResult) {
+      return buildDeliveryState(deliveryResult);
     }
   }
 

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -434,6 +434,8 @@ export async function finalizeCronRun(params: {
     beforeSessionDelete: params.beforeSessionDelete,
     runStartedAt: execution.runStartedAt,
     runEndedAt: execution.runEndedAt,
+    executionOrigin: prepared.input.executionOrigin ?? "scheduled",
+    executionReservedAtMs: prepared.input.executionReservedAtMs,
     timeoutMs: prepared.timeoutMs,
     resolvedDelivery: prepared.resolvedDelivery,
     deliveryRequested: prepared.deliveryRequested,

--- a/src/cron/isolated-agent/run-prepare-runtime.ts
+++ b/src/cron/isolated-agent/run-prepare-runtime.ts
@@ -5,6 +5,7 @@ import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { CronRunOrigin } from "../service/state.js";
 import type {
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
@@ -27,6 +28,8 @@ export type RunCronAgentTurnParams = {
   sessionKey: string;
   agentId?: string;
   lane?: string;
+  executionOrigin?: CronRunOrigin;
+  executionReservedAtMs?: number;
 };
 
 export function resolveCronAgentTurnMessage(input: RunCronAgentTurnParams): string {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,8 +1,6 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
-import type { CliDeps } from "../../cli/outbound-send-deps.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
@@ -21,12 +19,9 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { removeCronRunContinuationSessionIfIdle } from "../../tasks/cron-run-continuation-cleanup.js";
 import { createCronRunDiagnosticsFromError, mergeCronRunDiagnostics } from "../run-diagnostics.js";
 import { resolveCronAbortReasonText } from "../service/execution-errors.js";
-import type {
-  CronAgentExecutionPhaseUpdate,
-  CronAgentExecutionStarted,
-  CronJob,
-} from "../types.js";
+import type { CronAgentExecutionPhaseUpdate } from "../types.js";
 import { finalizeCronRun } from "./run-finalize.js";
+import type { RunCronAgentTurnParams } from "./run-prepare-runtime.js";
 import { prepareCronRunContext } from "./run-prepare.js";
 import { CronSessionLifecycleClaimError, type MutableCronSession } from "./run-session-state.js";
 import { logWarn } from "./run.runtime.js";
@@ -76,20 +71,9 @@ async function disposeCronRunContext(params: {
 }
 
 /** Runs one isolated cron agent turn, including setup, execution, delivery, and persistence. */
-export async function runCronIsolatedAgentTurn(params: {
-  cfg: OpenClawConfig;
-  deps: CliDeps;
-  job: CronJob;
-  message: string;
-  abortSignal?: AbortSignal;
-  signal?: AbortSignal;
-  onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
-  onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
-  onLaneWait?: (info?: { waiting?: boolean }) => void;
-  sessionKey: string;
-  agentId?: string;
-  lane?: string;
-}): Promise<RunCronAgentTurnResult> {
+export async function runCronIsolatedAgentTurn(
+  params: RunCronAgentTurnParams,
+): Promise<RunCronAgentTurnResult> {
   const admittedLifecycleGeneration = getAgentEventLifecycleGeneration();
   const upstreamAbortSignal = params.abortSignal ?? params.signal;
   const lifecycleAbortController = new AbortController();

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -260,7 +260,7 @@ export function createMockCronStateForJobs(params: {
     schedulingPaused: false,
     schedulerStarted: false,
     restartRecoveryPending: false,
-    activeManualRunJobIds: new Set<string>(),
+    activeRunOrigins: new Map(),
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map(),

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -1,4 +1,5 @@
 /** Stateful CronService facade around the locked service operation helpers. */
+import { isCronActiveJobMarkerCurrent } from "./active-jobs.js";
 import type {
   CronServiceContract,
   CronServiceRunOptions,
@@ -11,6 +12,7 @@ import * as readOps from "./service/ops-read.js";
 import * as runOps from "./service/ops-run.js";
 import {
   type CronAddOptions,
+  type CronRunOrigin,
   type CronServiceDeps,
   type CronUpdatePrecondition,
   type CronUpdateOptions,
@@ -141,7 +143,7 @@ export class CronService implements CronServiceContract {
   async run(
     id: string,
     mode?: "due" | "force",
-    opts?: CronServiceRunOptions,
+    opts?: CronServiceRunOptions & { executionOrigin?: "stream" | "exit" },
   ): Promise<CronServiceRunResult> {
     return await runOps.run(this.state, id, mode, opts);
   }
@@ -154,6 +156,14 @@ export class CronService implements CronServiceContract {
       throw new Error("cron enqueueRun returned unresolved runnable disposition");
     }
     return result;
+  }
+
+  /** Returns provenance from the exact invocation that currently owns this run. */
+  resolveRunExecution(id: string): { origin: CronRunOrigin; reservationAt?: number } {
+    const activeRun = this.state.activeRunOrigins.get(id);
+    return activeRun && isCronActiveJobMarkerCurrent(activeRun.marker)
+      ? { origin: activeRun.origin, reservationAt: activeRun.reservationAt }
+      : { origin: "scheduled" };
   }
 
   getJob(id: string): CronJob | undefined {

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -22,7 +22,7 @@ import {
   reserveQueuedCronRun,
   updateQueuedCronRunReservationMarker,
 } from "./run-admission.js";
-import type { CronEvent, CronServiceState } from "./state.js";
+import type { CronEvent, CronRunOrigin, CronServiceState } from "./state.js";
 import { emit } from "./state.js";
 import {
   ensureLoaded,
@@ -55,6 +55,7 @@ type PreparedManualRun =
       scheduleOwnershipAtMs: number;
       reservationIdentity: object;
       wasEnabled: boolean;
+      executionOrigin: Exclude<CronRunOrigin, "scheduled">;
       payload?: CronPayload;
       evaluateTrigger?: boolean;
       streamBatch?: string;
@@ -78,6 +79,7 @@ export type ManualRunOptions = {
   payload?: CronPayload;
   terminalTracker?: ManualRunTerminalTracker;
   owningCronLaneTaskMarker?: CommandLaneTaskMarker;
+  executionOrigin?: Exclude<CronRunOrigin, "scheduled">;
   evaluateTrigger?: boolean;
   streamBatch?: string;
   streamScheduleKey?: string;
@@ -385,6 +387,7 @@ export async function prepareManualRun(
       scheduleOwnershipAtMs: opts?.scheduleOwnershipAtMs ?? reservationAt,
       reservationIdentity,
       wasEnabled: isJobEnabled(job),
+      executionOrigin: opts?.executionOrigin ?? "operator",
       ...(opts?.payload ? { payload: structuredClone(opts.payload) } : {}),
       ...(opts?.evaluateTrigger ? { evaluateTrigger: true } : {}),
       ...(opts?.streamBatch !== undefined ? { streamBatch: opts.streamBatch } : {}),
@@ -500,7 +503,12 @@ export async function activatePreparedManualRun(
       startedAt,
       publicRunId: prepared.runId,
     });
-    const activeJobMarker = markManualCronJobActive(state, job);
+    const activeJobMarker = markManualCronJobActive(
+      state,
+      job,
+      prepared.executionOrigin,
+      prepared.reservationAt,
+    );
     // Execute against a snapshot so later reload/merge can preserve delivery
     // target writeback from disk without mutating the running object.
     const admittedJob = structuredClone(job);

--- a/src/cron/service/ops-shared.ts
+++ b/src/cron/service/ops-shared.ts
@@ -5,7 +5,7 @@ import { cronStreamScheduleKey } from "../stream-schedule.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRunsForMaintenance } from "./jobs.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
-import type { CronServiceState } from "./state.js";
+import type { CronRunOrigin, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 import {
   type IsolatedAgentSetupTimeoutSignal,
@@ -31,12 +31,17 @@ export function resolveEffectiveJobAgentId(
 export function markManualCronJobActive(
   state: CronServiceState,
   job: CronJob,
+  origin: Exclude<CronRunOrigin, "scheduled">,
+  reservationAt: number,
 ): CronActiveJobMarker | undefined {
   const jobId = job.id;
-  state.activeManualRunJobIds.add(jobId);
-  return markCronJobActive(jobId, {
+  const marker = markCronJobActive(jobId, {
     preserveAcrossGenerationAdvance: !runsDetachedFromMainSession(job),
   });
+  if (marker) {
+    state.activeRunOrigins.set(jobId, { origin, marker, reservationAt });
+  }
+  return marker;
 }
 
 export function clearManualCronJobActive(
@@ -44,9 +49,12 @@ export function clearManualCronJobActive(
   jobId: string,
   activeJobMarker?: CronActiveJobMarker,
 ): void {
-  state.activeManualRunJobIds.delete(jobId);
+  // Older finalizers must never erase a replacement invocation's provenance.
+  if (state.activeRunOrigins.get(jobId)?.marker === activeJobMarker) {
+    state.activeRunOrigins.delete(jobId);
+  }
   clearCronJobActive(jobId, activeJobMarker);
-  if (state.activeManualRunJobIds.size === 0) {
+  if (state.activeRunOrigins.size === 0) {
     state.manualSetupTimeoutNotified = false;
   }
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -58,6 +58,9 @@ export type Logger = {
   error: (obj: unknown, msg?: string) => void;
 };
 
+/** Authoritative execution source carried from cron admission into delivery. */
+export type CronRunOrigin = "operator" | "stream" | "exit" | "scheduled";
+
 export type CronSystemEventEnqueueResult =
   | boolean
   | void
@@ -260,7 +263,14 @@ export type CronServiceState = {
   schedulingPaused: boolean;
   schedulerStarted: boolean;
   restartRecoveryPending: boolean;
-  activeManualRunJobIds: Set<string>;
+  activeRunOrigins: Map<
+    string,
+    {
+      origin: Exclude<CronRunOrigin, "scheduled">;
+      marker: CronActiveJobMarker;
+      reservationAt: number;
+    }
+  >;
   manualSetupTimeoutNotified: boolean;
   /** Bounds scheduled, manual, and on-exit work with one shared cron limit. */
   runAdmission: CronRunAdmission;
@@ -295,7 +305,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     schedulingPaused: false,
     schedulerStarted: false,
     restartRecoveryPending: false,
-    activeManualRunJobIds: new Set<string>(),
+    activeRunOrigins: new Map(),
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map<string, QueuedCronRunReservation>(),

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentDeletionCommitUncertainError } from "../agents/agent-lifecycle-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -217,6 +218,7 @@ vi.mock("../cron/trigger-script.js", () => ({
   createCronScriptRuntime: createCronScriptRuntimeMock,
 }));
 
+import { advanceCronActiveJobGeneration } from "../cron/active-jobs.js";
 import {
   registerActiveCronTaskRun,
   trackActiveCronTaskRunSettlement,
@@ -657,6 +659,283 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
     }
   });
+
+  it.each(["stream", "exit"] as const)(
+    "preserves the real %s event reservation across delayed activation without a scheduled wake",
+    async (executionOrigin) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-18T12:00:00.000Z"));
+      const watcherExit = createDeferred<{
+        reason: "exit" | "manual-cancel";
+        exitCode: number | null;
+        exitSignal: null;
+        durationMs: number;
+        stdout: string;
+        stderr: string;
+        timedOut: false;
+        noOutputTimedOut: false;
+      }>();
+      const spawn = vi.fn(async () => ({
+        runId: `run-${executionOrigin}-delayed`,
+        startedAtMs: Date.now(),
+        cancel: vi.fn(() =>
+          watcherExit.resolve({
+            reason: "manual-cancel",
+            exitCode: null,
+            exitSignal: null,
+            durationMs: 1,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          }),
+        ),
+        detachOutput: vi.fn(),
+        wait: () => watcherExit.promise,
+      }));
+      getProcessSupervisorMock.mockReturnValue({ spawn, cancelScope: vi.fn() });
+      const cfg = createCronConfig(`server-cron-${executionOrigin}-delayed-reservation`);
+      if (executionOrigin === "stream") {
+        cfg.cron = { ...cfg.cron, triggers: { enabled: true } };
+      }
+      loadConfigMock.mockReturnValue(cfg);
+      const state = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      const blockerRelease = createDeferred();
+      const blockersStarted = createDeferred();
+      const blockerIds = new Set<string>();
+      const blockerRuns: Array<Promise<unknown>> = [];
+      let startedBlockers = 0;
+      runCronIsolatedAgentTurnMock.mockImplementation(async (params) => {
+        const runJob = requireRecord(requireRecord(params, "isolated run").job, "isolated job");
+        if (typeof runJob.id === "string" && blockerIds.has(runJob.id)) {
+          startedBlockers += 1;
+          if (startedBlockers === DEFAULT_CRON_MAX_CONCURRENT_RUNS) {
+            blockersStarted.resolve();
+          }
+          await blockerRelease.promise;
+        }
+        return { status: "ok", summary: "ok" };
+      });
+
+      try {
+        const eventJob = await state.cron.add({
+          name: `${executionOrigin} event`,
+          enabled: true,
+          schedule:
+            executionOrigin === "stream"
+              ? { kind: "stream", command: ["source"], batchMs: 1 }
+              : { kind: "on-exit", command: "source" },
+          payload: { kind: "agentTurn", message: "deliver event" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          delivery: { mode: "announce", channel: "slack", to: "channel:C12345" },
+        });
+        expect(eventJob.state.nextRunAtMs).toBeUndefined();
+        if (executionOrigin === "exit") {
+          await state.reconcileExitWatchers?.();
+        }
+        await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+        for (let index = 0; index < DEFAULT_CRON_MAX_CONCURRENT_RUNS; index += 1) {
+          const blocker = await state.cron.add({
+            name: `${executionOrigin} blocker ${index}`,
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+            payload: { kind: "agentTurn", message: "occupy cron admission" },
+            sessionTarget: "isolated",
+            wakeMode: "next-heartbeat",
+          });
+          blockerIds.add(blocker.id);
+          blockerRuns.push(state.cron.run(blocker.id, "force"));
+        }
+        await blockersStarted.promise;
+
+        if (executionOrigin === "stream") {
+          const watcherInput = requireRecord(
+            callArg(spawn, 0, 0, "stream source spawn"),
+            "stream source spawn",
+          );
+          const onStdout = watcherInput.onStdout;
+          if (typeof onStdout !== "function") {
+            throw new Error("stream watcher did not expose its actual stdout callback");
+          }
+          onStdout("fresh source event\n");
+          await vi.advanceTimersByTimeAsync(1);
+        } else {
+          watcherExit.resolve({
+            reason: "exit",
+            exitCode: 0,
+            exitSignal: null,
+            durationMs: 1,
+            stdout: "fresh source event",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          });
+        }
+
+        let reservationAt = 0;
+        await vi.waitFor(() => {
+          const reservedAt = state.cron.getJob(eventJob.id)?.state.queuedAtMs;
+          expect(reservedAt).toBeTypeOf("number");
+          reservationAt = reservedAt as number;
+        });
+        expect(state.cron.getJob(eventJob.id)?.state.nextRunAtMs).toBeUndefined();
+        vi.setSystemTime(reservationAt + 4 * 60 * 60_000);
+        blockerRelease.resolve();
+        await Promise.all(blockerRuns);
+        await vi.waitFor(() => {
+          const targetRun = runCronIsolatedAgentTurnMock.mock.calls.find(([params]) => {
+            const runJob = requireRecord(requireRecord(params, "isolated run").job, "isolated job");
+            return runJob.id === eventJob.id;
+          });
+          expect(targetRun).toBeDefined();
+          const options = requireRecord(targetRun?.[0], "event isolated run");
+          expect(options.executionOrigin).toBe(executionOrigin);
+          expect(
+            requireRecord(requireRecord(options.job, "event job").state, "event job state")
+              .nextRunAtMs,
+          ).toBeUndefined();
+          expect(options.executionReservedAtMs).toBe(reservationAt);
+        });
+      } finally {
+        blockerRelease.resolve();
+        watcherExit.resolve({
+          reason: "manual-cancel",
+          exitCode: null,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+        await Promise.allSettled(blockerRuns);
+        if (executionOrigin === "stream") {
+          await state.stopStreamWatchers?.();
+        }
+        state.cron.stop();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["timer", "startup catch-up"] as const)(
+    "does not transfer an interrupted operator origin to a real %s replacement",
+    async (replacementOwner) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-19T12:00:00.000Z"));
+      const cfg = createCronConfig(`server-cron-${replacementOwner}-replacement-origin`);
+      loadConfigMock.mockReturnValue(cfg);
+      const staleOperatorStarted = createDeferred();
+      const releaseStaleOperator = createDeferred();
+      let isolatedCalls = 0;
+      runCronIsolatedAgentTurnMock.mockImplementation(async () => {
+        isolatedCalls += 1;
+        if (isolatedCalls === 1) {
+          staleOperatorStarted.resolve();
+          await releaseStaleOperator.promise;
+        }
+        return { status: "ok", summary: "ok" };
+      });
+      let replacementJobId: string | undefined;
+      let observeReplacement = false;
+      const observedOrigins: string[] = [];
+      const state: ReturnType<typeof buildGatewayCronService> = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: (_event, payload) => {
+          const cronEvent = requireRecord(payload, "cron event");
+          if (
+            observeReplacement &&
+            cronEvent.action === "started" &&
+            cronEvent.jobId === replacementJobId
+          ) {
+            observedOrigins.push(state.cron.resolveRunExecution(replacementJobId).origin);
+          }
+        },
+      });
+      let staleOperatorRun: Promise<unknown> | undefined;
+      let restart: Promise<void> | undefined;
+
+      try {
+        await state.cron.start();
+        const originalAt = Date.now() + 60_000;
+        const job = await state.cron.add({
+          name: `${replacementOwner} replacement`,
+          enabled: true,
+          deleteAfterRun: false,
+          schedule: { kind: "at", at: new Date(originalAt).toISOString() },
+          payload: { kind: "agentTurn", message: "original operator work" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+        });
+        replacementJobId = job.id;
+        staleOperatorRun = state.cron.run(job.id, "force");
+        await staleOperatorStarted.promise;
+        expect(state.cron.resolveRunExecution(job.id).origin).toBe("operator");
+        const interruptedRunningAt = state.cron.getJob(job.id)?.state.runningAtMs;
+        expect(interruptedRunningAt).toBeTypeOf("number");
+
+        advanceCronActiveJobGeneration();
+        const replacementAt = Date.now() + 5;
+        await state.cron.update(job.id, {
+          schedule: { kind: "at", at: new Date(replacementAt).toISOString() },
+          ...(replacementOwner === "startup catch-up"
+            ? {
+                sessionTarget: "main" as const,
+                payload: { kind: "systemEvent" as const, text: "replacement event" },
+              }
+            : {}),
+        });
+        expect(state.cron.getJob(job.id)?.state.runningAtMs).toBe(interruptedRunningAt);
+        expect(state.cron.getJob(job.id)?.state.nextRunAtMs).toBe(replacementAt);
+        observeReplacement = true;
+        state.cron.stop();
+
+        if (replacementOwner === "startup catch-up") {
+          vi.setSystemTime(replacementAt + 1);
+        }
+        restart = state.cron.start();
+        if (replacementOwner === "timer") {
+          await restart;
+          expect(state.cron.getJob(job.id)?.state.runningAtMs).toBeUndefined();
+          expect(state.cron.getJob(job.id)?.state.nextRunAtMs).toBe(replacementAt);
+          await vi.advanceTimersByTimeAsync(5);
+        }
+        await vi.waitFor(() => expect(observedOrigins).toHaveLength(1));
+        expect(observedOrigins).toEqual(["scheduled"]);
+        if (replacementOwner === "timer") {
+          await vi.waitFor(() => expect(isolatedCalls).toBe(2));
+        } else {
+          await vi.waitFor(() =>
+            expect(
+              enqueueSystemEventMock.mock.calls.some(([text]) => text === "replacement event"),
+            ).toBe(true),
+          );
+        }
+        await restart;
+        await vi.waitFor(() => expect(state.cron.getJob(job.id)?.state.lastRunStatus).toBe("ok"));
+        releaseStaleOperator.resolve();
+        await staleOperatorRun;
+        expect(state.cron.getJob(job.id)?.state.lastRunStatus).toBe("ok");
+      } finally {
+        releaseStaleOperator.resolve();
+        if (staleOperatorRun) {
+          await staleOperatorRun;
+        }
+        if (restart) {
+          await restart;
+        }
+        state.cron.stop();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("aborts and drains active cron runs during shutdown", async () => {
     const controller = new AbortController();
@@ -2745,7 +3024,10 @@ describe("buildGatewayCronService", () => {
 
       await state.cron.run(job.id, "force");
 
-      const options = expectIsolatedRunFields({ sessionKey: `cron:${job.id}` });
+      const options = expectIsolatedRunFields({
+        sessionKey: `cron:${job.id}`,
+        executionOrigin: "operator",
+      });
       expect(requireRecord(options.job, "isolated job").id).toBe(job.id);
       const isolatedRunCalls = runCronIsolatedAgentTurnMock.mock.calls as Array<Array<unknown>>;
       expect(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -726,6 +726,7 @@ export function buildGatewayCronService(params: {
       onLaneWait,
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+      const execution = cron.resolveRunExecution(job.id);
       const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
       return await runCronIsolatedAgentTurn({
         cfg: runtimeConfig,
@@ -739,6 +740,8 @@ export function buildGatewayCronService(params: {
         agentId,
         sessionKey,
         lane: "cron",
+        executionOrigin: execution.origin,
+        executionReservedAtMs: execution.reservationAt,
       });
     },
     runCommandJob: async ({ job, abortSignal }) => {
@@ -1130,7 +1133,11 @@ export function buildGatewayCronService(params: {
     fireOnExit: async (job, exit) => {
       await runWithGatewayIndependentRootWorkAdmission(async () =>
         fireOnExitJob(job, exit, {
-          run: (jobId, payload) => cron.run(jobId, "force", payload ? { payload } : undefined),
+          run: (jobId, payload) =>
+            cron.run(jobId, "force", {
+              ...(payload ? { payload } : {}),
+              executionOrigin: "exit",
+            }),
         }),
       );
     },
@@ -1158,6 +1165,7 @@ export function buildGatewayCronService(params: {
         fireStreamJob(job, {
           run: async (jobId, onDisposition) => {
             const result = await cron.run(jobId, "force", {
+              executionOrigin: "stream",
               evaluateTrigger: true,
               streamBatch: batch,
               streamScheduleKey,


### PR DESCRIPTION
## What Problem This Solves

Fixes automations that report success while silently discarding an operator-requested fresh response, while preserving stale-event protection across genuine stream/exit queues and scheduler lifecycle replacement.

## Why This Change Was Made

Recurring force-runs preserve their original schedule, and stream/exit jobs have no scheduled time at all. Cron now carries the trusted execution origin, its actual pre-admission reservation timestamp, and the exact current lifecycle marker into the existing delivery policy; retired manual markers cannot contaminate a replacement scheduled run.

## User Impact

Fresh manually requested automation output is delivered. Stream and process-exit output that genuinely waited too long is suppressed with a visible recorded reason, while long-running work admitted promptly still sends normally. Startup recovery, retry/failure alerts, child-session handoff, plugin interfaces, configuration, protocol, and storage schemas are preserved.

## Evidence

- Real mocked Slack proof reproduced the original operator false-success bug before repair.
- Authentic stdout-stream and subprocess-exit watchers with no `nextRunAtMs` were each delayed four hours behind eight actual occupied cron admission slots.
- Lifecycle replacement regressions use only serializable public schedule updates and actual stop/start interruption repair: the normal timer invokes a real second isolated payload and startup catch-up emits a real main-session event.
- Final verification: 244 passing tests in five existing suites, including generation/reset/preserved-main controls, exact-marker fencing, timely long-running events, durable diagnostics without alerts, and current-main child handoff.
- Configured type-aware lint, formatting, and whitespace checks pass for the exact sixteen root-approved files. Current main has zero touched-path drift. Fresh independent review and root-granted genuine strict review remain pending; no landing is authorized.
