### PR TITLE
fix(agent): reuse validated config during startup

### DIFF
--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -5,7 +5,10 @@ import {
   getScopedChannelsCommandSecretTargets,
 } from "../cli/command-secret-targets.js";
 import { getRuntimeConfig, readConfigFileSnapshotForWrite } from "../config/io.js";
-import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import {
+  getPreparedRuntimeConfigSnapshot,
+  setPreparedRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef } from "../config/types.secrets.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -27,7 +30,8 @@ export async function resolveAgentRuntimeConfig(
   cfg: OpenClawConfig;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
 }> {
-  const loadedRaw = getRuntimeConfig();
+  const preparedRuntimeConfig = getPreparedRuntimeConfigSnapshot();
+  const loadedRaw = preparedRuntimeConfig?.runtimeConfig ?? getRuntimeConfig();
   const includeChannelTargets = params?.runtimeTargetsChannelSecrets === true;
   const channelSecretScope = params?.runtimeChannelSecretScope;
   const hasRuntimeSecretRefs = hasAgentRuntimeSecretRefs({
@@ -35,20 +39,23 @@ export async function resolveAgentRuntimeConfig(
     includeChannelTargets,
     channel: channelSecretScope?.channel,
   });
-  let pluginMetadataSnapshot: PluginMetadataSnapshot | undefined;
-  const sourceConfig = await (async () => {
-    try {
-      const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
-      if (snapshot.valid) {
-        pluginMetadataSnapshot = writeOptions.basePluginMetadataSnapshot;
-        return snapshot.resolved;
+  let sourceConfig = preparedRuntimeConfig?.sourceConfig;
+  let pluginMetadataSnapshot = preparedRuntimeConfig?.pluginMetadataSnapshot;
+  if (!sourceConfig) {
+    sourceConfig = await (async () => {
+      try {
+        const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+        if (snapshot.valid) {
+          pluginMetadataSnapshot = writeOptions.basePluginMetadataSnapshot;
+          return snapshot.resolved;
+        }
+      } catch {
+        // Direct callers may not have a readable source snapshot.
       }
-    } catch {
-      // Fall back to runtime-loaded config when source snapshot is unavailable.
-    }
-    pluginMetadataSnapshot = resolvePluginMetadataSnapshot({ config: loadedRaw });
-    return loadedRaw;
-  })();
+      pluginMetadataSnapshot = resolvePluginMetadataSnapshot({ config: loadedRaw });
+      return loadedRaw;
+    })();
+  }
   const cfg = hasRuntimeSecretRefs
     ? await (async () => {
         const runtimeSecretTargets = resolveAgentRuntimeSecretTargets({
@@ -76,7 +83,11 @@ export async function resolveAgentRuntimeConfig(
     : loadedRaw;
   const secretsRuntime = await import("../secrets/runtime.js");
   if (secretsRuntime.getActiveSecretsRuntimeSnapshot()) {
-    setRuntimeConfigSnapshot(cfg, sourceConfig);
+    setPreparedRuntimeConfigSnapshot({
+      runtimeConfig: cfg,
+      sourceConfig,
+      ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
+    });
   } else {
     // Standalone local agent commands have no Gateway-owned snapshot. Materialize
     // auth-profile refs too; resolving only config refs leaves selected credentials unusable.

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -16,7 +16,8 @@ const pluginPackagingRecoveryHint = [
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
-const setRuntimeConfigSnapshotMock = vi.hoisted(() => vi.fn());
+const readConfigFileSnapshotWithPluginMetadataMock = vi.hoisted(() => vi.fn());
+const setPreparedRuntimeConfigSnapshotMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../commands/doctor-config-preflight.js", () => ({
   runDoctorConfigPreflight: loadAndMaybeMigrateDoctorConfigMock,
@@ -24,7 +25,8 @@ vi.mock("../../commands/doctor-config-preflight.js", () => ({
 
 vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
-  setRuntimeConfigSnapshot: setRuntimeConfigSnapshotMock,
+  readConfigFileSnapshotWithPluginMetadata: readConfigFileSnapshotWithPluginMetadataMock,
+  setPreparedRuntimeConfigSnapshot: setPreparedRuntimeConfigSnapshotMock,
 }));
 
 type ConfigIssue = { path: string; message: string };
@@ -143,6 +145,9 @@ describe("ensureConfigReady", () => {
     }
     useTempOpenClawHome();
     readConfigFileSnapshotMock.mockResolvedValue(makeSnapshot());
+    readConfigFileSnapshotWithPluginMetadataMock.mockImplementation(async (options) => ({
+      snapshot: await readConfigFileSnapshotMock(options),
+    }));
     loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => ({
       snapshot: makeSnapshot(),
       baseConfig: {},
@@ -377,10 +382,10 @@ describe("ensureConfigReady", () => {
       migrateLegacyConfig: false,
       invalidConfigNote: false,
     });
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
-      migratedSnapshot.runtimeConfig,
-      migratedSnapshot.sourceConfig,
-    );
+    expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+      runtimeConfig: migratedSnapshot.runtimeConfig,
+      sourceConfig: migratedSnapshot.sourceConfig,
+    });
   });
 
   it("preserves plugin listing migrations when the shared state database exists", async () => {
@@ -488,20 +493,25 @@ describe("ensureConfigReady", () => {
   );
 
   it("pins a valid preflight snapshot for command code reuse", async () => {
+    const pluginMetadataSnapshot = { plugins: [] };
     const snapshot = {
       ...makeSnapshot(),
       config: { runtime: true },
       runtimeConfig: { runtime: true, materialized: true },
       sourceConfig: { source: true },
     };
-    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    readConfigFileSnapshotWithPluginMetadataMock.mockResolvedValue({
+      snapshot,
+      pluginMetadataSnapshot,
+    });
 
     await runEnsureConfigReady(["health"]);
 
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
-      snapshot.runtimeConfig,
-      snapshot.sourceConfig,
-    );
+    expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+      runtimeConfig: snapshot.runtimeConfig,
+      sourceConfig: snapshot.sourceConfig,
+      pluginMetadataSnapshot,
+    });
   });
 
   it("pins plugin listing config without loading state migration runtime", async () => {
@@ -516,10 +526,10 @@ describe("ensureConfigReady", () => {
     await runEnsureConfigReady(["plugins", "list"]);
 
     expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
-      snapshot.runtimeConfig,
-      snapshot.sourceConfig,
-    );
+    expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+      runtimeConfig: snapshot.runtimeConfig,
+      sourceConfig: snapshot.sourceConfig,
+    });
   });
 
   it("retries the cached config snapshot after a read rejection", async () => {
@@ -544,7 +554,10 @@ describe("ensureConfigReady", () => {
     }
 
     expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(undefined, undefined);
+    expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+      runtimeConfig: undefined,
+      sourceConfig: undefined,
+    });
   });
 
   it("exits for invalid config on non-allowlisted commands", async () => {
@@ -597,10 +610,10 @@ describe("ensureConfigReady", () => {
       invalidConfigNote: false,
     });
     expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
-      validSnapshot.config,
-      validSnapshot.sourceConfig,
-    );
+    expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+      runtimeConfig: validSnapshot.config,
+      sourceConfig: validSnapshot.sourceConfig,
+    });
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { withSuppressedNotes } from "../../../packages/terminal-core/src/note.js";
-import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
+import {
+  readConfigFileSnapshot,
+  readConfigFileSnapshotWithPluginMetadata,
+  setPreparedRuntimeConfigSnapshot,
+} from "../../config/config.js";
 import { createInvalidConfigError } from "../../config/io.invalid-config.js";
 import {
   resolveIsNixMode,
@@ -34,8 +38,8 @@ const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
 ]);
 const ALLOWED_INVALID_TASK_SUBCOMMANDS = new Set(["list", "audit"]);
 let didRunDoctorConfigFlow = false;
-let configSnapshotPromise: Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>> | null =
-  null;
+type BootstrapConfigSnapshot = Awaited<ReturnType<typeof readConfigFileSnapshotWithPluginMetadata>>;
+let configSnapshotPromise: Promise<BootstrapConfigSnapshot> | null = null;
 
 function resetConfigGuardStateForTests() {
   didRunDoctorConfigFlow = false;
@@ -190,15 +194,21 @@ function isGatewayStartupCommand(commandPath: string[]): boolean {
 }
 
 async function getConfigSnapshot(options?: { observe: false; skipPluginValidation?: true }) {
+  const readSnapshot = async (): Promise<BootstrapConfigSnapshot> => {
+    if (options?.skipPluginValidation) {
+      return { snapshot: await readConfigFileSnapshot(options) };
+    }
+    return await readConfigFileSnapshotWithPluginMetadata(options);
+  };
   if (options?.observe === false) {
-    return readConfigFileSnapshot(options);
+    return await readSnapshot();
   }
   // Tests often mutate config fixtures; caching can make those flaky.
   if (process.env.VITEST === "true") {
-    return readConfigFileSnapshot();
+    return await readSnapshot();
   }
   if (!configSnapshotPromise) {
-    const pendingSnapshot = readConfigFileSnapshot();
+    const pendingSnapshot = readSnapshot();
     configSnapshotPromise = pendingSnapshot;
     pendingSnapshot.catch(() => {
       if (configSnapshotPromise === pendingSnapshot) {
@@ -224,7 +234,7 @@ export async function ensureConfigReady(
   const commandPath = params.commandPath ?? [];
   const commandName = commandPath[0];
   const subcommandName = commandPath[1];
-  let preflightSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | null = null;
+  let preflightSnapshot: BootstrapConfigSnapshot | null = null;
   const shouldConsiderStateMigration = shouldMigrateStateFromPath(commandPath);
   const requiresLegacyStateInput = shouldRunStateMigrationOnlyWithLegacyInputs(commandPath);
   const runStateMigrationPreflight = async () => {
@@ -250,8 +260,8 @@ export async function ensureConfigReady(
       });
     try {
       return !params.suppressDoctorStdout
-        ? (await runDoctorConfigPreflight()).snapshot
-        : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+        ? await runDoctorConfigPreflight()
+        : await withSuppressedNotes(runDoctorConfigPreflight);
     } catch (error) {
       if (error instanceof ExitError) {
         // The migration owner has unwound its lease and heartbeat before this handoff.
@@ -276,7 +286,8 @@ export async function ensureConfigReady(
       : commandName === "status" || (commandName === "gateway" && subcommandName === "call")
         ? ({ observe: false } as const)
         : undefined;
-  let snapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));
+  let preparedSnapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));
+  let snapshot = preparedSnapshot.snapshot;
   if (
     !preflightSnapshot &&
     !didRunDoctorConfigFlow &&
@@ -286,7 +297,8 @@ export async function ensureConfigReady(
     snapshotHasConfiguredSessionStore(snapshot)
   ) {
     preflightSnapshot = await runStateMigrationPreflight();
-    snapshot = preflightSnapshot;
+    preparedSnapshot = preflightSnapshot;
+    snapshot = preparedSnapshot.snapshot;
   }
   const isBareGatewayForegroundRun =
     commandName === "gateway" && (subcommandName === undefined || subcommandName.trim() === "");
@@ -312,7 +324,13 @@ export async function ensureConfigReady(
 
   const invalid = snapshot.exists && !snapshot.valid;
   if (!invalid) {
-    setRuntimeConfigSnapshot(snapshot.runtimeConfig ?? snapshot.config, snapshot.sourceConfig);
+    setPreparedRuntimeConfigSnapshot({
+      runtimeConfig: snapshot.runtimeConfig ?? snapshot.config,
+      sourceConfig: snapshot.sourceConfig,
+      ...(preparedSnapshot.pluginMetadataSnapshot
+        ? { pluginMetadataSnapshot: preparedSnapshot.pluginMetadataSnapshot }
+        : {}),
+    });
   }
   if (!invalid) {
     return;
@@ -387,14 +405,13 @@ export async function ensureConfigReady(
         configSnapshotPromise = null;
         const { runDoctorConfigPreflight } =
           await import("../../commands/doctor-config-preflight.js");
-        const retrySnapshot = (
-          await runDoctorConfigPreflight({
-            migrateState: false,
-            migrateLegacyConfig: false,
-            invalidConfigNote: false,
-            ...configSnapshotOptions,
-          })
-        ).snapshot;
+        const retryPreparedSnapshot = await runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+          ...configSnapshotOptions,
+        });
+        const retrySnapshot = retryPreparedSnapshot.snapshot;
         if (retrySnapshot.exists && !retrySnapshot.valid) {
           const retryIssues = formatConfigIssueLines(retrySnapshot.issues, "-", {
             normalizeRoot: true,
@@ -404,10 +421,13 @@ export async function ensureConfigReady(
             retryIssues.join("\n") || "Unknown validation issue.",
           );
         }
-        setRuntimeConfigSnapshot(
-          retrySnapshot.runtimeConfig ?? retrySnapshot.config,
-          retrySnapshot.sourceConfig,
-        );
+        setPreparedRuntimeConfigSnapshot({
+          runtimeConfig: retrySnapshot.runtimeConfig ?? retrySnapshot.config,
+          sourceConfig: retrySnapshot.sourceConfig,
+          ...(retryPreparedSnapshot.pluginMetadataSnapshot
+            ? { pluginMetadataSnapshot: retryPreparedSnapshot.pluginMetadataSnapshot }
+            : {}),
+        });
       },
     });
     if (recovery.status === "recovered") {

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -5,12 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentRuntimeConfig } from "../agents/agent-runtime-config.js";
 import { resolveSession } from "../agents/command/session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createThrowingTestRuntime } from "./test-runtime-config-helpers.js";
 
 type ConfigSnapshotForWrite = {
   snapshot: { valid: boolean; resolved: OpenClawConfig };
-  writeOptions: Record<string, never>;
+  writeOptions: { basePluginMetadataSnapshot?: PluginMetadataSnapshot };
 };
 
 type ResolveCommandConfigParams = {
@@ -84,11 +85,34 @@ vi.mock("../secrets/target-registry.js", () => ({
   },
 }));
 
-const setRuntimeConfigSnapshotMock = vi.hoisted(() =>
-  vi.fn<(cfg: OpenClawConfig, sourceConfig: OpenClawConfig) => void>(),
+const getPreparedRuntimeConfigSnapshotMock = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      runtimeConfig: OpenClawConfig;
+      sourceConfig: OpenClawConfig;
+      pluginMetadataSnapshot?: PluginMetadataSnapshot;
+    } | null
+  >(),
+);
+const setPreparedRuntimeConfigSnapshotMock = vi.hoisted(() =>
+  vi.fn<
+    (snapshot: {
+      runtimeConfig: OpenClawConfig;
+      sourceConfig: OpenClawConfig;
+      pluginMetadataSnapshot?: PluginMetadataSnapshot;
+    }) => void
+  >(),
 );
 vi.mock("../config/runtime-snapshot.js", () => ({
-  setRuntimeConfigSnapshot: setRuntimeConfigSnapshotMock,
+  getPreparedRuntimeConfigSnapshot: getPreparedRuntimeConfigSnapshotMock,
+  setPreparedRuntimeConfigSnapshot: setPreparedRuntimeConfigSnapshotMock,
+}));
+
+const resolvePluginMetadataSnapshotMock = vi.hoisted(() =>
+  vi.fn<() => PluginMetadataSnapshot | undefined>(),
+);
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: resolvePluginMetadataSnapshotMock,
 }));
 
 const getActiveSecretsRuntimeSnapshotMock = vi.hoisted(() => vi.fn<() => object | null>());
@@ -154,6 +178,7 @@ function mockConfig(home: string, storePath: string): OpenClawConfig {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getPreparedRuntimeConfigSnapshotMock.mockReturnValue(null);
   getActiveSecretsRuntimeSnapshotMock.mockReturnValue({});
   readConfigFileSnapshotForWriteMock.mockResolvedValue({
     snapshot: { valid: false, resolved: {} as OpenClawConfig },
@@ -183,11 +208,12 @@ describe("agentCommand runtime config", () => {
       expect(activateSecretsRuntimeSnapshotMock).toHaveBeenCalledWith(
         expect.objectContaining({ sourceConfig, config: loadedConfig }),
       );
-      expect(setRuntimeConfigSnapshotMock).not.toHaveBeenCalled();
+      expect(readConfigFileSnapshotForWriteMock).toHaveBeenCalledOnce();
+      expect(setPreparedRuntimeConfigSnapshotMock).not.toHaveBeenCalled();
     });
   });
 
-  it("sets runtime snapshots from source config before embedded agent run", async () => {
+  it("uses prepared source config and metadata while materializing SecretRefs", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       const loadedConfig = {
@@ -233,11 +259,13 @@ describe("agentCommand runtime config", () => {
           },
         },
       } as unknown as OpenClawConfig;
+      const pluginMetadataSnapshot = { plugins: [] } as unknown as PluginMetadataSnapshot;
 
       loadConfigMock.mockReturnValue(loadedConfig);
-      readConfigFileSnapshotForWriteMock.mockResolvedValue({
-        snapshot: { valid: true, resolved: sourceConfig },
-        writeOptions: {},
+      getPreparedRuntimeConfigSnapshotMock.mockReturnValue({
+        runtimeConfig: loadedConfig,
+        sourceConfig,
+        pluginMetadataSnapshot,
       });
       resolveCommandConfigWithSecretsMock.mockResolvedValueOnce({
         resolvedConfig,
@@ -257,8 +285,37 @@ describe("agentCommand runtime config", () => {
       const targetIds = requireResolveCommandConfigParams().targetIds;
       expect(targetIds.has("models.providers.*.apiKey")).toBe(true);
       expect(targetIds.has("channels.telegram.botToken")).toBe(false);
-      expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
+      expect(readConfigFileSnapshotForWriteMock).not.toHaveBeenCalled();
+      expect(resolvePluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+        runtimeConfig: resolvedConfig,
+        sourceConfig,
+        pluginMetadataSnapshot,
+      });
       expect(prepared.cfg).toBe(resolvedConfig);
+      expect(prepared.sourceConfig).toBe(sourceConfig);
+      expect(prepared.pluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
+    });
+  });
+
+  it("reuses prepared config and metadata without a write snapshot read or metadata rescan", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const loadedConfig = mockConfig(home, store);
+      const sourceConfig = { ...loadedConfig, logging: { level: "info" } } as OpenClawConfig;
+      const pluginMetadataSnapshot = { plugins: [] } as unknown as PluginMetadataSnapshot;
+      getPreparedRuntimeConfigSnapshotMock.mockReturnValue({
+        runtimeConfig: loadedConfig,
+        sourceConfig,
+        pluginMetadataSnapshot,
+      });
+
+      const prepared = await resolveAgentRuntimeConfig(runtime);
+
+      expect(readConfigFileSnapshotForWriteMock).not.toHaveBeenCalled();
+      expect(resolvePluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(prepared.sourceConfig).toBe(sourceConfig);
+      expect(prepared.pluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
     });
   });
 
@@ -409,7 +466,10 @@ describe("agentCommand runtime config", () => {
 
       expect(readConfigFileSnapshotForWriteMock).toHaveBeenCalledTimes(1);
       expect(resolveCommandConfigWithSecretsMock).not.toHaveBeenCalled();
-      expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(loadedConfig, loadedConfig);
+      expect(setPreparedRuntimeConfigSnapshotMock).toHaveBeenCalledWith({
+        runtimeConfig: loadedConfig,
+        sourceConfig: loadedConfig,
+      });
       expect(prepared.cfg).toBe(loadedConfig);
     });
   });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -7,7 +7,7 @@ import { cloneEnvWithPlatformSemantics } from "../config/env-vars.js";
 import {
   parseConfigJson5,
   preserveConfigSnapshotAsClobbered,
-  readConfigFileSnapshot,
+  readConfigFileSnapshotWithPluginMetadata,
   recoverConfigFromJsonRootSuffix,
   recoverConfigFromLastKnownGood,
 } from "../config/io.js";
@@ -18,6 +18,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { StartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   buildDegradedPluginsFromVerificationFailures,
   formatPluginVerificationDiagnostic,
@@ -118,13 +119,14 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
 }
 
 export type DoctorConfigPreflightResult = {
-  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshotWithPluginMetadata>>["snapshot"];
   baseConfig: OpenClawConfig;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
   cronCodexRuntimePolicyTargets?: CronCodexRuntimePolicyTarget[];
 };
 
 function collectDoctorLegacyIssues(
-  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+  snapshot: DoctorConfigPreflightResult["snapshot"],
 ): LegacyConfigIssue[] {
   if (!snapshot.exists) {
     return [];
@@ -135,8 +137,8 @@ function collectDoctorLegacyIssues(
 }
 
 function addDoctorLegacyIssues(
-  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
-): Awaited<ReturnType<typeof readConfigFileSnapshot>> {
+  snapshot: DoctorConfigPreflightResult["snapshot"],
+): DoctorConfigPreflightResult["snapshot"] {
   const legacyIssues = collectDoctorLegacyIssues(snapshot);
   if (legacyIssues.length === 0) {
     return snapshot;
@@ -512,18 +514,20 @@ export async function runDoctorConfigPreflight(
       ...(options.observe === false ? { observe: false } : {}),
       skipPluginValidation: shouldSkipPluginValidationForDoctorConfigPreflight(),
     };
-    let snapshot = addDoctorLegacyIssues(
-      await measureStartupPreflightStep("config-snapshot", () =>
-        readConfigFileSnapshot(readOptions),
-      ),
+    let snapshotRead = await measureStartupPreflightStep("config-snapshot", () =>
+      readConfigFileSnapshotWithPluginMetadata(readOptions),
     );
+    let snapshot = addDoctorLegacyIssues(snapshotRead.snapshot);
+    let pluginMetadataSnapshot = snapshotRead.pluginMetadataSnapshot;
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
       if (await recoverConfigFromJsonRootSuffix(snapshot)) {
         note(
           "Removed non-JSON prefix from openclaw.json; original saved as .clobbered.*.",
           "Config",
         );
-        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions));
+        snapshotRead = await readConfigFileSnapshotWithPluginMetadata(readOptions);
+        snapshot = addDoctorLegacyIssues(snapshotRead.snapshot);
+        pluginMetadataSnapshot = snapshotRead.pluginMetadataSnapshot;
       } else if (
         await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" })
       ) {
@@ -531,7 +535,9 @@ export async function runDoctorConfigPreflight(
           "Restored openclaw.json from last-known-good; original saved as .clobbered.*.",
           "Config",
         );
-        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions));
+        snapshotRead = await readConfigFileSnapshotWithPluginMetadata(readOptions);
+        snapshot = addDoctorLegacyIssues(snapshotRead.snapshot);
+        pluginMetadataSnapshot = snapshotRead.pluginMetadataSnapshot;
       }
       if (
         !snapshot.valid &&
@@ -714,6 +720,7 @@ export async function runDoctorConfigPreflight(
     return {
       snapshot,
       baseConfig,
+      ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
       ...(cronCodexRuntimePolicyTargets.length > 0 ? { cronCodexRuntimePolicyTargets } : {}),
     };
   } finally {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,6 +5,7 @@ export {
   clearRuntimeConfigSnapshot,
   registerConfigWriteListener,
   createConfigIO,
+  getPreparedRuntimeConfigSnapshot,
   getRuntimeConfig,
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSnapshot,
@@ -27,6 +28,7 @@ export {
   resolveConfigSnapshotHash,
   resolveRuntimeConfigCacheKey,
   selectApplicableRuntimeConfig,
+  setPreparedRuntimeConfigSnapshot,
   setRuntimeConfigSnapshotRefreshHandler,
   setRuntimeConfigSnapshot,
   writeConfigFile,
@@ -42,6 +44,7 @@ export {
 export type {
   ConfigWriteAfterWrite,
   ConfigWriteFollowUp,
+  PreparedRuntimeConfigSnapshot,
   RuntimeConfigSnapshotMetadata,
 } from "./runtime-snapshot.js";
 export type {

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -157,6 +157,7 @@ export async function readConfigFileSnapshotWithPluginMetadata(
     | "measure"
     | "observe"
     | "recoverSuspicious"
+    | "skipPluginValidation"
   >,
 ): Promise<ReadConfigFileSnapshotWithPluginMetadataResult> {
   return await createConfigIO({
@@ -164,6 +165,7 @@ export async function readConfigFileSnapshotWithPluginMetadata(
     ...(options?.observe === false ? { observe: false } : {}),
     ...(options?.isolateEnv ? { env: cloneEnvWithPlatformSemantics(process.env) } : {}),
     ...(options?.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
+    ...(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}),
   }).readConfigFileSnapshotWithPluginMetadata({
     recoverSuspicious: options?.recoverSuspicious === true,
     allowSuspiciousRecovery: options?.allowSuspiciousRecovery,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -43,6 +43,7 @@ export {
 export { projectConfigOntoRuntimeSourceSnapshot } from "./runtime-source-projection.js";
 export {
   clearRuntimeConfigSnapshot,
+  getPreparedRuntimeConfigSnapshot,
   getRuntimeConfigSnapshot,
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSourceSnapshot,
@@ -51,6 +52,7 @@ export {
   resolveRuntimeConfigCacheKey,
   selectApplicableRuntimeConfig,
   setAppliedRuntimeConfigSnapshot,
+  setPreparedRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
   setRuntimeConfigSnapshotRefreshHandler,
 } from "./runtime-snapshot.js";

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   finalizeRuntimeSnapshotWrite,
+  getPreparedRuntimeConfigSnapshot,
   getRuntimeConfigAppliedHash,
   hashRuntimeConfigValue,
   hasManagedRuntimeConfigWriteOwner,
@@ -16,6 +17,7 @@ import {
   resetConfigRuntimeState,
   resolveRuntimeConfigCacheKey,
   selectApplicableRuntimeConfig,
+  setPreparedRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
   setRuntimeConfigAppliedHash,
   setRuntimeConfigSnapshotRefreshHandler,
@@ -78,6 +80,27 @@ describe("runtime snapshot state", () => {
 
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     expect(getRuntimeConfigSourceSnapshot()).toEqual(sourceConfig);
+  });
+
+  it("keeps validation-owned config and plugin metadata in one prepared handoff", () => {
+    const runtimeConfig: OpenClawConfig = { gateway: { port: 18789 } };
+    const sourceConfig: OpenClawConfig = { gateway: { mode: "local" } };
+    const pluginMetadataSnapshot = { plugins: [] } as never;
+
+    setPreparedRuntimeConfigSnapshot({
+      runtimeConfig,
+      sourceConfig,
+      pluginMetadataSnapshot,
+    });
+
+    expect(getPreparedRuntimeConfigSnapshot()).toEqual({
+      runtimeConfig,
+      sourceConfig,
+      pluginMetadataSnapshot,
+    });
+
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    expect(getPreparedRuntimeConfigSnapshot()).toBeNull();
   });
 
   it("tracks snapshot metadata and cache keys across runtime refreshes", () => {
@@ -170,6 +193,7 @@ describe("runtime snapshot state", () => {
     resetRuntimeConfigState();
     expect(getRuntimeConfigSnapshot()).toBeNull();
     expect(getRuntimeConfigSourceSnapshot()).toBeNull();
+    expect(getPreparedRuntimeConfigSnapshot()).toBeNull();
     expect(getRuntimeConfigSnapshotMetadata()).toBeNull();
   });
 

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -1,6 +1,7 @@
 // Produces redacted runtime config snapshots for diagnostics and UI surfaces.
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { clearExecutablePathCache } from "../infra/executable-path.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   resetPublishedConfigRuntimeEnv,
   type PreparedConfigRuntimeEnv,
@@ -104,8 +105,15 @@ export type RuntimeConfigSnapshotMetadata = {
   updatedAtMs: number;
 };
 
+export type PreparedRuntimeConfigSnapshot = {
+  runtimeConfig: OpenClawConfig;
+  sourceConfig: OpenClawConfig;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
+};
+
 let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
+let preparedRuntimeConfigSnapshot: PreparedRuntimeConfigSnapshot | null = null;
 let runtimeConfigSnapshotMetadata: RuntimeConfigSnapshotMetadata | null = null;
 let runtimeConfigAppliedHash: string | null = null;
 let runtimeConfigSnapshotRevision = 0;
@@ -169,7 +177,14 @@ export function setRuntimeConfigSnapshot(
   clearExecutablePathCache();
   runtimeConfigSnapshot = config;
   runtimeConfigSourceSnapshot = sourceConfig ?? null;
+  preparedRuntimeConfigSnapshot = null;
   runtimeConfigSnapshotMetadata = createRuntimeConfigSnapshotMetadata(config, sourceConfig);
+}
+
+/** Publish one validation-owned runtime/source/metadata handoff for command preparation. */
+export function setPreparedRuntimeConfigSnapshot(snapshot: PreparedRuntimeConfigSnapshot): void {
+  setRuntimeConfigSnapshot(snapshot.runtimeConfig, snapshot.sourceConfig);
+  preparedRuntimeConfigSnapshot = snapshot;
 }
 
 export function setAppliedRuntimeConfigSnapshot(
@@ -200,6 +215,7 @@ export function resetConfigRuntimeState(): void {
   clearExecutablePathCache();
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;
+  preparedRuntimeConfigSnapshot = null;
   runtimeConfigSnapshotMetadata = null;
   runtimeConfigAppliedHash = null;
   runtimeConfigSnapshotRevision = 0;
@@ -216,6 +232,10 @@ export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
 
 export function getRuntimeConfigSourceSnapshot(): OpenClawConfig | null {
   return runtimeConfigSourceSnapshot;
+}
+
+export function getPreparedRuntimeConfigSnapshot(): PreparedRuntimeConfigSnapshot | null {
+  return preparedRuntimeConfigSnapshot;
 }
 
 export function getRuntimeConfigSnapshotMetadata(): RuntimeConfigSnapshotMetadata | null {


### PR DESCRIPTION
Related: #117323

## What Problem This Solves

Fixes an issue where `openclaw agent` startup validated the configuration and discovered plugin metadata in the CLI guard, then immediately reread the config through the write path and rescanned plugin metadata during agent preparation.

## Why This Change Was Made

The validation-owned runtime snapshot now carries the runtime config, source config, and plugin metadata as one prepared handoff. Agent preparation consumes that handoff directly. Standalone callers without CLI bootstrap still perform one fallback read, ordinary runtime snapshot updates invalidate the prepared handoff, and SecretRef materialization continues to use the source config.

## User Impact

Agent commands avoid one redundant config read and plugin metadata discovery during startup without changing configuration, provider, or SecretRef behavior.

## Exact-Head Evidence

- Reviewed head: `0c2ff9a668ca1a6916dff24d6336a19ee830d459`
- Current `origin/main`: `133a8a6274296133eeb625ff37811bdb857a3374`
- Clean merge tree: `e0c123d24776e6b786fcac62b4e73d52df2869bc`
- 85 focused tests passed across:
  - `src/config/runtime-snapshot.test.ts`
  - `src/cli/program/config-guard.test.ts`
  - `src/commands/agent.runtime-config.test.ts`
- Regression coverage proves prepared startup performs no write-snapshot reread or metadata rescan, standalone fallback reads once, ordinary snapshot updates invalidate the handoff, and SecretRefs retain source-backed materialization.
- Targeted `oxfmt`, direct targeted `oxlint`, and `git diff --check` are clean.
- This is an in-process ephemeral handoff only. It adds no persistent state, migration, or SQLite schema change.

## Remaining Hosted Proof

Exact-head GitHub CI, Kova startup evidence, and the fresh durable ClawSweeper review must complete before this PR leaves draft or merges.
