### PR TITLE
fix(feishu): page directory lookups without dropping provider results

### DIFF
--- a/extensions/feishu/src/directory.test.ts
+++ b/extensions/feishu/src/directory.test.ts
@@ -1,4 +1,5 @@
 // Feishu tests cover directory plugin behavior.
+import * as Lark from "@larksuiteoapi/node-sdk";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -48,6 +49,52 @@ function makeConfiguredCfg(): ClawdbotConfig {
       },
     },
   } as ClawdbotConfig;
+}
+
+type FeishuSdkDirectoryResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    items?: Array<{ open_id?: string; chat_id?: string; name: string }>;
+    has_more?: boolean;
+    page_token?: string;
+  };
+};
+
+function createSdkDirectoryClient(responses: Array<FeishuSdkDirectoryResponse | Error>) {
+  const request = vi.fn(async (options: Lark.HttpRequestOptions<unknown>) => {
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Feishu SDK request: ${String(options.url)}`);
+    }
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  });
+  const post = vi.fn(async () => {
+    throw new Error("Unexpected Feishu SDK authentication request");
+  });
+  const httpInstance = Object.assign(Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance, {
+    request,
+    post,
+  });
+  const client = new Lark.Client({
+    appId: "directory-test-app",
+    appSecret: "directory-test-placeholder", // pragma: allowlist secret
+    disableTokenCache: true,
+    loggerLevel: Lark.LoggerLevel.error,
+    logger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    },
+    httpInstance,
+  });
+  createFeishuClientMock.mockReturnValueOnce(client);
+  return { request, post };
 }
 
 describe("feishu directory (config-backed)", () => {
@@ -170,6 +217,288 @@ describe("feishu directory (config-backed)", () => {
       { kind: "user", id: "alice" },
       { kind: "user", id: "carla" },
     ]);
+  });
+
+  it("finds matching live peers beyond the first provider page", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ open_id: "ou_other", name: "Other" }, { name: "Missing provider identity" }],
+          has_more: true,
+          page_token: "page-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ open_id: "ou_alice", name: "Alice" }],
+          has_more: false,
+        },
+      });
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    await expect(
+      listFeishuDirectoryPeersLive({
+        cfg: makeConfiguredCfg(),
+        query: "alice",
+        limit: 1,
+        fallbackToStatic: false,
+      }),
+    ).resolves.toEqual([{ kind: "user", id: "ou_alice", name: "Alice" }]);
+    expect(list).toHaveBeenNthCalledWith(2, {
+      params: { page_size: 1, page_token: "page-2" },
+    });
+  });
+
+  it("honors peer limits above the provider's 50-user page size", async () => {
+    const users = Array.from({ length: 60 }, (_, index) => ({
+      open_id: `ou_${index + 1}`,
+      name: `User ${index + 1}`,
+    }));
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: users.slice(0, 50), has_more: true, page_token: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: users.slice(50), has_more: false },
+      });
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    const peers = await listFeishuDirectoryPeersLive({
+      cfg: makeConfiguredCfg(),
+      limit: 60,
+      fallbackToStatic: false,
+    });
+
+    expect(peers).toHaveLength(60);
+    expect(peers.at(-1)).toEqual({ kind: "user", id: "ou_60", name: "User 60" });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      params: { page_size: 50, page_token: "page-2" },
+    });
+  });
+
+  it("paginates live peers through the installed Lark SDK HTTP boundary", async () => {
+    const { request, post } = createSdkDirectoryClient([
+      {
+        code: 0,
+        data: {
+          items: [{ open_id: "ou_other", name: "Other" }],
+          has_more: true,
+          page_token: "page-2",
+        },
+      },
+      {
+        code: 0,
+        data: { items: [{ open_id: "ou_alice", name: "Alice" }], has_more: false },
+      },
+    ]);
+
+    await expect(
+      listFeishuDirectoryPeersLive({
+        cfg: makeConfiguredCfg(),
+        query: "alice",
+        limit: 1,
+        fallbackToStatic: false,
+      }),
+    ).resolves.toEqual([{ kind: "user", id: "ou_alice", name: "Alice" }]);
+    expect(request.mock.calls.map(([options]) => options)).toEqual([
+      expect.objectContaining({
+        method: "GET",
+        url: "https://open.feishu.cn/open-apis/contact/v3/users",
+        params: { page_size: 1 },
+      }),
+      expect.objectContaining({
+        method: "GET",
+        url: "https://open.feishu.cn/open-apis/contact/v3/users",
+        params: { page_size: 1, page_token: "page-2" },
+      }),
+    ]);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { kind: "peer", limit: 0 },
+    { kind: "peer", limit: -1 },
+    { kind: "group", limit: 0 },
+    { kind: "group", limit: -1 },
+  ] as const)("treats a nonpositive $kind limit $limit as unlimited", async ({ kind, limit }) => {
+    const first =
+      kind === "peer"
+        ? { open_id: "ou_first", name: "First" }
+        : { chat_id: "chat-first", name: "First" };
+    const second =
+      kind === "peer"
+        ? { open_id: "ou_second", name: "Second" }
+        : { chat_id: "chat-second", name: "Second" };
+    const { request, post } = createSdkDirectoryClient([
+      { code: 0, data: { items: [first], has_more: true, page_token: "page-2" } },
+      { code: 0, data: { items: [second], has_more: false } },
+    ]);
+    const directory =
+      kind === "peer" ? listFeishuDirectoryPeersLive : listFeishuDirectoryGroupsLive;
+
+    await expect(
+      directory({ cfg: makeConfiguredCfg(), limit, fallbackToStatic: false }),
+    ).resolves.toHaveLength(2);
+    const pageSize = kind === "peer" ? 50 : 100;
+    const path = kind === "peer" ? "/open-apis/contact/v3/users" : "/open-apis/im/v1/chats";
+    expect(request.mock.calls.map(([options]) => options)).toEqual([
+      expect.objectContaining({
+        method: "GET",
+        url: `https://open.feishu.cn${path}`,
+        params: { page_size: pageSize },
+      }),
+      expect.objectContaining({
+        method: "GET",
+        url: `https://open.feishu.cn${path}`,
+        params: { page_size: pageSize, page_token: "page-2" },
+      }),
+    ]);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("propagates later-page transport errors through the installed Lark SDK", async () => {
+    const { request, post } = createSdkDirectoryClient([
+      { code: 0, data: { items: [], has_more: true, page_token: "page-2" } },
+      new Error("SDK page two refused"),
+    ]);
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+    ).rejects.toThrow("SDK page two refused");
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("rejects repeated continuation tokens through the installed Lark SDK", async () => {
+    const page = {
+      code: 0,
+      data: { items: [], has_more: true, page_token: "repeated" },
+    };
+    const { request, post } = createSdkDirectoryClient([page, page]);
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+    ).rejects.toThrow("Feishu live peer directory returned a repeated page token");
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "returned", response: { code: 999, msg: "page two forbidden" } },
+    { label: "thrown", error: new Error("page two forbidden") },
+  ])("surfaces $label later-page peer failures when fallback is disabled", async (failure) => {
+    const list = vi.fn().mockResolvedValueOnce({
+      code: 0,
+      data: { items: [], has_more: true, page_token: "page-2" },
+    });
+    if ("error" in failure) {
+      list.mockRejectedValueOnce(failure.error);
+    } else {
+      list.mockResolvedValueOnce(failure.response);
+    }
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+    ).rejects.toThrow("page two forbidden");
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves static peer fallback when a later provider page fails", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [], has_more: true, page_token: "page-2" },
+      })
+      .mockRejectedValueOnce(new Error("page two forbidden"));
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), query: "a" }),
+    ).resolves.toEqual([
+      { kind: "user", id: "alice" },
+      { kind: "user", id: "carla" },
+    ]);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["peer", "group"] as const)(
+    "stops the %s directory before inspecting an unused continuation",
+    async (kind) => {
+      const item =
+        kind === "peer"
+          ? { open_id: "ou_alice", name: "Alice" }
+          : { chat_id: "chat-allowed", name: "Allowed" };
+      const list = vi.fn().mockResolvedValue({
+        code: 0,
+        data: { items: [item], has_more: true },
+      });
+      if (kind === "peer") {
+        createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+      } else {
+        createFeishuClientMock.mockReturnValueOnce({ im: { chat: { list } } });
+      }
+      const directory =
+        kind === "peer" ? listFeishuDirectoryPeersLive : listFeishuDirectoryGroupsLive;
+
+      await expect(
+        directory({ cfg: makeConfiguredCfg(), limit: 1, fallbackToStatic: false }),
+      ).resolves.toHaveLength(1);
+      expect(list).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["peer", "group"] as const)(
+    "rejects missing %s directory continuation tokens",
+    async (kind) => {
+      const list = vi.fn().mockResolvedValue({ code: 0, data: { items: [], has_more: true } });
+      if (kind === "peer") {
+        createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+      } else {
+        createFeishuClientMock.mockReturnValueOnce({ im: { chat: { list } } });
+      }
+      const directory =
+        kind === "peer" ? listFeishuDirectoryPeersLive : listFeishuDirectoryGroupsLive;
+
+      await expect(
+        directory({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+      ).rejects.toThrow(`Feishu live ${kind} directory is missing its next page token`);
+      expect(list).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("rejects repeated live peer directory page tokens", async () => {
+    const list = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: [], has_more: true, page_token: "repeat" },
+    });
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+    ).rejects.toThrow("Feishu live peer directory returned a repeated page token");
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds live peer directory pagination", async () => {
+    let page = 0;
+    const list = vi.fn(async () => ({
+      code: 0,
+      data: { items: [], has_more: true, page_token: `page-${++page}` },
+    }));
+    createFeishuClientMock.mockReturnValueOnce({ contact: { user: { list } } });
+
+    await expect(
+      listFeishuDirectoryPeersLive({ cfg: makeConfiguredCfg(), fallbackToStatic: false }),
+    ).rejects.toThrow("Feishu live peer directory pagination limit exceeded");
+    expect(list).toHaveBeenCalledTimes(100);
   });
 
   it("paginates live groups until the filtered result limit is reached", async () => {

--- a/extensions/feishu/src/directory.ts
+++ b/extensions/feishu/src/directory.ts
@@ -12,6 +12,77 @@ import {
 
 const MAX_FEISHU_DIRECTORY_PAGES = 100;
 
+function resolveFeishuDirectoryLimit(limit: number | undefined): number {
+  // Static directory treats nonpositive limits as unlimited; provider page sizes must stay valid.
+  return limit === undefined ? 50 : limit > 0 ? limit : Number.POSITIVE_INFINITY;
+}
+
+type FeishuDirectoryEntry = FeishuDirectoryGroup | FeishuDirectoryPeer;
+type FeishuDirectoryPage<Item> = {
+  code?: number;
+  msg?: string;
+  data?: {
+    items?: Item[];
+    has_more?: boolean;
+    page_token?: string;
+  };
+};
+
+async function listLiveFeishuDirectoryEntries<Item, Entry extends FeishuDirectoryEntry>(params: {
+  kind: "peer" | "group";
+  limit: number;
+  query?: string;
+  fetchPage: (pageToken?: string) => Promise<FeishuDirectoryPage<Item>>;
+  toEntry: (item: Item) => Entry | undefined;
+  filter?: (entry: Entry) => boolean;
+}): Promise<Entry[]> {
+  const entries: Entry[] = [];
+  const query = normalizeLowercaseStringOrEmpty(params.query);
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
+
+  for (let page = 0; page < MAX_FEISHU_DIRECTORY_PAGES; page += 1) {
+    const response = await params.fetchPage(pageToken);
+    if (response.code !== 0) {
+      throw new Error(response.msg || `code ${response.code}`);
+    }
+
+    for (const item of response.data?.items ?? []) {
+      const entry = params.toEntry(item);
+      if (!entry) {
+        continue;
+      }
+      const matchesQuery =
+        !query ||
+        normalizeLowercaseStringOrEmpty(entry.id).includes(query) ||
+        normalizeLowercaseStringOrEmpty(entry.name).includes(query);
+      if (matchesQuery && (!params.filter || params.filter(entry))) {
+        entries.push(entry);
+      }
+      if (entries.length >= params.limit) {
+        // A complete result must not fail on an unused, malformed continuation token.
+        return entries;
+      }
+    }
+
+    if (response.data?.has_more !== true) {
+      return entries;
+    }
+
+    const nextPageToken = response.data.page_token?.trim();
+    if (!nextPageToken) {
+      throw new Error(`Feishu live ${params.kind} directory is missing its next page token`);
+    }
+    if (seenPageTokens.has(nextPageToken)) {
+      throw new Error(`Feishu live ${params.kind} directory returned a repeated page token`);
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  throw new Error(`Feishu live ${params.kind} directory pagination limit exceeded`);
+}
+
 export async function listFeishuDirectoryPeersLive(params: {
   cfg: ClawdbotConfig;
   query?: string;
@@ -26,41 +97,21 @@ export async function listFeishuDirectoryPeersLive(params: {
 
   try {
     const client = createFeishuClient(account);
-    const peers: FeishuDirectoryPeer[] = [];
-    const limit = params.limit ?? 50;
-
-    const response = await client.contact.user.list({
-      params: {
-        page_size: Math.min(limit, 50),
-      },
+    const limit = resolveFeishuDirectoryLimit(params.limit);
+    return await listLiveFeishuDirectoryEntries({
+      kind: "peer",
+      limit,
+      query: params.query,
+      fetchPage: (pageToken) =>
+        client.contact.user.list({
+          params: {
+            page_size: Math.min(limit, 50),
+            ...(pageToken ? { page_token: pageToken } : {}),
+          },
+        }),
+      toEntry: (user) =>
+        user.open_id ? { kind: "user", id: user.open_id, name: user.name || undefined } : undefined,
     });
-
-    if (response.code !== 0) {
-      throw new Error(response.msg || `code ${response.code}`);
-    }
-
-    const q = normalizeLowercaseStringOrEmpty(params.query);
-    for (const user of response.data?.items ?? []) {
-      if (user.open_id) {
-        const name = user.name || "";
-        if (
-          !q ||
-          normalizeLowercaseStringOrEmpty(user.open_id).includes(q) ||
-          normalizeLowercaseStringOrEmpty(name).includes(q)
-        ) {
-          peers.push({
-            kind: "user",
-            id: user.open_id,
-            name: name || undefined,
-          });
-        }
-      }
-      if (peers.length >= limit) {
-        break;
-      }
-    }
-
-    return peers;
   } catch (err) {
     if (params.fallbackToStatic === false) {
       throw err instanceof Error ? err : new Error("Feishu live peer lookup failed");
@@ -84,57 +135,24 @@ export async function listFeishuDirectoryGroupsLive(params: {
 
   try {
     const client = createFeishuClient(account);
-    const groups: FeishuDirectoryGroup[] = [];
-    const limit = params.limit ?? 50;
-    const q = normalizeLowercaseStringOrEmpty(params.query);
-    let pageToken: string | undefined;
-    let pages = 0;
-    const seenPageTokens = new Set<string>();
-    do {
-      const response = await client.im.chat.list({
-        params: {
-          page_size: Math.min(limit, 100),
-          page_token: pageToken,
-        },
-      });
-      if (response.code !== 0) {
-        throw new Error(response.msg || `code ${response.code}`);
-      }
-      for (const chat of response.data?.items ?? []) {
-        if (chat.chat_id) {
-          const name = chat.name || "";
-          const group = {
-            kind: "group",
-            id: chat.chat_id,
-            name: name || undefined,
-          } satisfies FeishuDirectoryGroup;
-          const matchesQuery =
-            !q ||
-            normalizeLowercaseStringOrEmpty(chat.chat_id).includes(q) ||
-            normalizeLowercaseStringOrEmpty(name).includes(q);
-          if (matchesQuery && (!params.filter || params.filter(group))) {
-            groups.push(group);
-          }
-        }
-        if (groups.length >= limit) {
-          break;
-        }
-      }
-      pages += 1;
-      const nextPageToken = response.data?.has_more ? response.data.page_token : undefined;
-      if (nextPageToken && seenPageTokens.has(nextPageToken)) {
-        throw new Error("Feishu live group directory returned a repeated page token");
-      }
-      if (nextPageToken) {
-        seenPageTokens.add(nextPageToken);
-      }
-      pageToken = nextPageToken;
-    } while (pageToken && groups.length < limit && pages < MAX_FEISHU_DIRECTORY_PAGES);
-    if (pageToken && pages >= MAX_FEISHU_DIRECTORY_PAGES) {
-      throw new Error("Feishu live group directory pagination limit exceeded");
-    }
-
-    return groups;
+    const limit = resolveFeishuDirectoryLimit(params.limit);
+    return await listLiveFeishuDirectoryEntries({
+      kind: "group",
+      limit,
+      query: params.query,
+      fetchPage: (pageToken) =>
+        client.im.chat.list({
+          params: {
+            page_size: Math.min(limit, 100),
+            ...(pageToken ? { page_token: pageToken } : {}),
+          },
+        }),
+      toEntry: (chat) =>
+        chat.chat_id
+          ? { kind: "group", id: chat.chat_id, name: chat.name || undefined }
+          : undefined,
+      filter: params.filter,
+    });
   } catch (err) {
     if (params.fallbackToStatic === false) {
       throw err instanceof Error ? err : new Error("Feishu live group lookup failed");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu users listing or searching the live directory could not discover users beyond the first provider page, and public directory calls with zero or negative limits could send invalid provider page sizes and silently truncate results.

## Why This Change Was Made

Use one bounded plugin-owned paginator for Feishu users and groups, preserving authorization filters and static fallback while honoring the existing directory contract that nonpositive limits are unlimited and provider pages remain valid.

## User Impact

Feishu directory searches find matching users on later pages, larger listings include all requested results, and zero or negative limits enumerate safely. Provider failures and malformed or repeated cursors fail visibly without weakening group authorization.

## Evidence

- The focused existing owner suite passes all 29 cases; four real installed-SDK peer/group regressions failed before the fix.
- Hermetic, UNAUTHENTICATED real Lark Client HTTP tests prove actual GET routes, cursor forwarding, later transport errors, and repeated tokens; production authentication is unchanged and was not exercised.
- Configured standard and type-aware lint, formatting, and TruffleHog pass with zero verified or unverified secrets.
- Four independent hostile source reviews and the formal high-reasoning Codex Auto Review report zero P0–P3 findings; formal review confidence is 0.94.
