### PR TITLE
fix(onboarding): ignore presence heartbeats during browser handoff

### DIFF
--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import {
   detectGraphicalSession,
   probeBrowserHatchGateway,
+  resolveConnectedControlUiPresenceKeys,
   runBrowserHatchHandoff,
 } from "./onboard-browser-handoff.js";
 
@@ -47,7 +52,68 @@ describe("detectGraphicalSession", () => {
   });
 });
 
+const connectedControlUiPresence = {
+  host: GATEWAY_CLIENT_IDS.CONTROL_UI,
+  mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+  reason: "connect",
+  deviceId: "same-device",
+  instanceId: "existing-tab",
+  text: "Control UI",
+  ts: 1,
+};
+
+describe("resolveConnectedControlUiPresenceKeys", () => {
+  it("uses connection identity instead of mutable presence freshness", () => {
+    const baseline = resolveConnectedControlUiPresenceKeys([connectedControlUiPresence]);
+
+    expect(
+      resolveConnectedControlUiPresenceKeys([{ ...connectedControlUiPresence, ts: 2 }]),
+    ).toEqual(baseline);
+    expect(
+      resolveConnectedControlUiPresenceKeys([
+        { ...connectedControlUiPresence, instanceId: "new-tab", ts: 2 },
+      ]),
+    ).not.toEqual(baseline);
+    expect(
+      resolveConnectedControlUiPresenceKeys([
+        { ...connectedControlUiPresence, reason: "disconnect", ts: 2 },
+      ]),
+    ).toEqual([]);
+  });
+});
+
 describe("runBrowserHatchHandoff", () => {
+  it("does not hand off when only an existing Control UI heartbeat changes", async () => {
+    const prompter = createWizardPrompter();
+    let elapsedMs = 0;
+
+    const result = await runBrowserHatchHandoff(
+      { config: {}, prompter },
+      {
+        env: { DISPLAY: ":0" },
+        platform: "linux",
+        openBrowser: vi.fn(async () => true),
+        resolveTarget: async () => target,
+        probePresence: async () => ({
+          reachable: true,
+          clientKeys: resolveConnectedControlUiPresenceKeys([
+            { ...connectedControlUiPresence, ts: elapsedMs },
+          ]),
+        }),
+        now: () => elapsedMs,
+        sleep: async (ms) => {
+          elapsedMs += ms;
+        },
+      },
+    );
+
+    expect(result).toEqual({ handedOff: false, reason: "timeout" });
+    expect(prompter.note).not.toHaveBeenCalledWith(
+      "Dashboard connected — continuing in your browser.",
+      expect.anything(),
+    );
+  });
+
   it.each([
     { platform: "darwin" as const, env: {} },
     { platform: "linux" as const, env: { DISPLAY: ":0" } },

--- a/src/commands/onboard-browser-handoff.ts
+++ b/src/commands/onboard-browser-handoff.ts
@@ -172,8 +172,12 @@ function isConnectedControlUi(entry: SystemPresence): boolean {
   );
 }
 
-function dashboardPresenceKey(entry: SystemPresence): string {
-  return [entry.deviceId, entry.instanceId, entry.host, entry.mode, entry.ts].join("\0");
+export function resolveConnectedControlUiPresenceKeys(
+  entries: readonly SystemPresence[],
+): string[] {
+  return entries
+    .filter(isConnectedControlUi)
+    .map((entry) => [entry.deviceId, entry.instanceId, entry.host, entry.mode].join("\0"));
 }
 
 async function probeDashboardPresence(
@@ -203,7 +207,7 @@ async function probeDashboardPresence(
     });
     return {
       reachable: true,
-      clientKeys: (presence ?? []).filter(isConnectedControlUi).map(dashboardPresenceKey),
+      clientKeys: resolveConnectedControlUiPresenceKeys(presence ?? []),
     };
   } catch (error) {
     return {


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

Guided onboarding snapshots the currently connected Control UI clients before opening the dashboard and should continue only when a new browser client connects. An existing browser's routine Gateway heartbeat refreshed its presence timestamp, changed the snapshot key, and could make onboarding report a successful browser handoff even though no new browser had opened.

### Failure mode

During the handoff wait, the Gateway's WebSocket pong path touches the existing presence lease. Because the mutable timestamp was part of the client key, the next poll classified the same Control UI connection as new and left the terminal flow early.

## Why This Change Was Made

Connected Control UI keys now use the stable connection fields—device, instance, client, and mode—while presence timestamps remain lease freshness only. The existing disconnect filter still removes closed clients, and each new Control UI tab retains its unique instance identity.

### Root Cause

The handoff key combined connection identity with `ts`, but `touchPresence` intentionally rewrites `ts` on every WebSocket pong. Polling therefore compared a lifecycle signal as if it were identity.

### Runtime ownership

The Control UI instance ID owns per-browser connection identity; Gateway presence timestamps own liveness and expiration. Onboarding now compares only identity while preserving the existing heartbeat, authorization, and presence lifecycle.

## User Impact

Onboarding now stays in the terminal fallback until a genuinely new Control UI browser connects instead of advancing on an unrelated heartbeat from an already-open dashboard. New tabs still complete the handoff, and disconnected clients remain excluded.

## Evidence

Validated at exact head `808668450ec9b9f747e584461f9525fdea067a1f`: 21/21 focused tests passed, and a real Gateway plus two real Chromium Control UI instances proved heartbeat rejection and genuine-client acceptance.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=deep-runtime tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `2576d844c436f8120713e8dc4783e07e9e288980`
- **Proof head:** `808668450ec9b9f747e584461f9525fdea067a1f`
- **Revalidated:** on the bound base

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=808668450ec9b9f747e584461f9525fdea067a1f -->

#### Gateway and Control UI handoff command

```bash
OPENCLAW_PROOF_ROOT=<proof-run> node --import tsx <proof-run>/onboard-presence-runtime-proof.mts
```

- **Gateway and Control UI handoff (PRODUCTION_RUNTIME; boundary: runBrowserHatchHandoff against a real token-authenticated Gateway, real WebSocket heartbeat, real system-presence RPC, and real Chromium Control UI clients)** — Observed: With one real Chromium Control UI connected, a production Gateway pong advanced that connection's presence timestamp and the 60-second production handoff returned timeout; opening a second real Chromium context then created a distinct Control UI instance and completed the handoff, leaving two connected clients with two unique instance IDs. Result: the existing heartbeat did not complete onboarding, while the genuinely new browser connection did. Proves browser handoff detection now follows stable Control UI connection identity instead of mutable presence freshness. Preserves Gateway heartbeat liveness, token authentication, disconnected-client filtering, and new-tab detection.

#### Redacted exact-head production output

```text
head=808668450ec9b9f747e584461f9525fdea067a1f
test_runner=none
affected_owners=runBrowserHatchHandoff,Gateway-WebSocket-pong,system-presence,Chromium-Control-UI
mocked_affected_owners=none
heartbeat_timestamp_advanced=true
existing_client_result={"handedOff":false,"reason":"timeout"}
new_client_result={"handedOff":true}
connected_control_ui_count=2
unique_control_ui_instances=2
result=PASS
```

### Automated verification

#### Focused onboarding behavior

```bash
node scripts/run-vitest.mjs src/commands/onboard-browser-handoff.test.ts
```

- `node scripts/run-vitest.mjs src/commands/onboard-browser-handoff.test.ts` — [TEST] 21/21 tests passed with 0 failures and 0 skips. Proves timestamp-only refreshes keep the same key, new instance IDs remain distinct, disconnect rows remain excluded, and heartbeat-only polling times out without claiming a handoff. Preserves GUI and headless handoff timing, browser-open signaling, and gateway-unreachable fallback coverage.

#### Core type boundaries

```bash
pnpm tsgo:core
```

- `pnpm tsgo:core` — [TYPECHECK] completed with exit code 0. Proves the production onboarding and presence-key changes satisfy the Core TypeScript contract. Preserves the existing command and Gateway type surfaces.
```bash
pnpm tsgo:core:test
```

- `pnpm tsgo:core:test` — [TYPECHECK] completed with exit code 0. Proves the focused regression fixtures satisfy the Core test TypeScript contract. Preserves the existing Vitest command-project typing.

#### Static verification

```bash
pnpm exec oxlint src/commands/onboard-browser-handoff.ts src/commands/onboard-browser-handoff.test.ts
```

- `pnpm exec oxlint src/commands/onboard-browser-handoff.ts src/commands/onboard-browser-handoff.test.ts` — [LINT] reported 0 warnings and 0 errors. Proves the changed source and regression tests satisfy the scoped lint rules. Preserves the repository lint boundary.
```bash
pnpm exec oxfmt --check src/commands/onboard-browser-handoff.ts src/commands/onboard-browser-handoff.test.ts
```

- `pnpm exec oxfmt --check src/commands/onboard-browser-handoff.ts src/commands/onboard-browser-handoff.test.ts` — [STATIC] reported both files correctly formatted. Proves the changed files match repository formatting. Preserves the bounded two-file diff.
```bash
git diff --check origin/main...HEAD
```

- `git diff --check origin/main...HEAD` — [STATIC] completed with exit code 0 and no output. Proves the exact-head patch is whitespace-clean. Preserves the bounded two-file diff.

### Preserved boundaries

- Presence timestamps continue to refresh on WebSocket pong and retain their existing liveness and expiration role.
- A new Control UI instance remains detectable even when it shares the same device, client, and mode.
- Disconnected Control UI entries, authentication resolution, SSH hints, browser launch behavior, and timeout fallback remain unchanged.
- No configuration, persisted-data, protocol, permission, visual, or localization contract changes.

### Proof gap

The full repository test suite and GitHub CI were not run locally because the patch is bounded to browser-handoff presence identity; no repository-wide compatibility or CI result is claimed.

</details>

### Artifacts

- None attached.
