### PR TITLE
fix(doctor): fail visibly on contradictory lint selectors

### DIFF
--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -174,6 +174,43 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("rejects a requested health check that --skip also excludes", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      path: "/tmp/openclaw.json",
+    });
+
+    const checkId = "core/doctor/final-config-validation";
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        severityMin: "error",
+        onlyIds: [checkId],
+        skipIds: [checkId],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 0,
+        findings: [
+          {
+            checkId: "core/doctor/lint-selection",
+            severity: "error",
+            message: `Health check id cannot be selected by --only and excluded by --skip: ${checkId}.`,
+            path: checkId,
+          },
+        ],
+      });
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("reports disabled Codex plugin routes through doctor lint", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -1,5 +1,5 @@
 // Doctor lint flow tests cover lint diagnostics surfaced by doctor.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { exitCodeFromFindings, runDoctorLintChecks } from "./doctor-lint-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
 import type { RunnableHealthCheck } from "./health-check-runner-types.js";
@@ -32,11 +32,86 @@ describe("runDoctorLintChecks", () => {
         check("b", async () => [{ checkId: "b", severity: "error", message: "err" }]),
       ],
       onlyIds: ["a"],
+      skipIds: ["b"],
     });
 
     expect(result.checksRun).toBe(1);
     expect(result.checksSkipped).toBe(1);
     expect(result.findings.map((finding) => finding.checkId)).toEqual(["a"]);
+  });
+
+  it.each([
+    ["array", ["critical", "critical"], ["critical"]],
+    ["set", new Set(["critical"]), new Set(["critical"])],
+  ] as const)("rejects contradictory %s check selectors", async (_kind, onlyIds, skipIds) => {
+    const detect = vi.fn(async () => []);
+
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [check("critical", detect)],
+      onlyIds,
+      skipIds,
+    });
+
+    expect(detect).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      checksRun: 0,
+      checksSkipped: 1,
+      findings: [
+        {
+          checkId: "core/doctor/lint-selection",
+          severity: "error",
+          message: "Health check id cannot be selected by --only and excluded by --skip: critical.",
+          path: "critical",
+        },
+      ],
+    });
+    expect(exitCodeFromFindings(result.findings, "error")).toBe(1);
+  });
+
+  it("runs other explicitly selected checks when one selector conflicts", async () => {
+    const skippedDetect = vi.fn(async () => []);
+    const selectedDetect = vi.fn(async () => [
+      { checkId: "selected", severity: "warning" as const, message: "still runs" },
+    ]);
+
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [check("skipped", skippedDetect), check("selected", selectedDetect)],
+      onlyIds: ["skipped", "selected"],
+      skipIds: ["skipped"],
+    });
+
+    expect(skippedDetect).not.toHaveBeenCalled();
+    expect(selectedDetect).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      checksRun: 1,
+      checksSkipped: 1,
+      findings: [
+        {
+          checkId: "core/doctor/lint-selection",
+          severity: "error",
+          message: "Health check id cannot be selected by --only and excluded by --skip: skipped.",
+          path: "skipped",
+        },
+        { checkId: "selected", severity: "warning", message: "still runs" },
+      ],
+    });
+  });
+
+  it("keeps an unknown selected check as one unknown-id finding when it is also skipped", async () => {
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [],
+      onlyIds: ["missing"],
+      skipIds: ["missing"],
+    });
+
+    expect(result.findings).toEqual([
+      {
+        checkId: "core/doctor/lint-selection",
+        severity: "error",
+        message: "Unknown health check id selected by --only: missing.",
+        path: "missing",
+      },
+    ]);
   });
 
   it("skips default-disabled checks unless explicitly selected", async () => {

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -57,6 +57,15 @@ export async function runDoctorLintChecks(
         message: `Unknown health check id selected by --only: ${id}.`,
         path: id,
       });
+      continue;
+    }
+    if (skip.has(id)) {
+      findings.push({
+        checkId: "core/doctor/lint-selection",
+        severity: "error",
+        message: `Health check id cannot be selected by --only and excluded by --skip: ${id}.`,
+        path: id,
+      });
     }
   }
   for (const check of selected) {


### PR DESCRIPTION
## Summary

- Reject contradictory Doctor lint check selections using the existing canonical `core/doctor/lint-selection` error.
- Preserve skip precedence, unknown-ID errors, non-conflicting checks, and existing JSON/human output contracts.
- Prevent `openclaw doctor --lint --only CHECK --skip CHECK` from incorrectly reporting success after running no requested checks.

## Verification

- Baseline: actual flow had three failing regressions; actual Doctor CLI returned exit 0 instead of exit 1.
- Fixed immutable commit: 12 focused flow tests and 14 actual CLI tests pass.
- Exact three touched files pass configured type-aware lint, formatter checks, and `git diff --check`.
- Four independent source-hostile reviews found no P0–P3 issues.
- Genuine exact-commit Codex review (`gpt-5.6-sol`, high, P3) found zero findings; confidence 0.98.
- TruffleHog 3.96.0 secret scan passed clean.
