### PR TITLE
fix(gateway): keep unavailable routes out of Control UI fallback

### DIFF
--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -126,6 +126,48 @@ describe("classifyControlUiRequest", () => {
         expected: { kind: "not-control-ui" as const },
       },
       {
+        name: "keeps the standalone MCP App shell outside the SPA catch-all",
+        pathname: "/__openclaw__/mcp-app",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps the standalone MCP App view outside the SPA catch-all",
+        pathname: "/__openclaw__/mcp-app/view",
+        method: "HEAD",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "preserves SPA routes that only resemble the standalone MCP App namespace",
+        pathname: "/__openclaw__/mcp-apps",
+        method: "GET",
+        expected: { kind: "serve" as const },
+      },
+      {
+        name: "keeps MCP App descendants outside the SPA catch-all",
+        pathname: "/__openclaw__/mcp-app/other",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps health probe descendants outside the SPA catch-all",
+        pathname: "/healthz/details",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps readiness probe trailing slashes outside the SPA catch-all",
+        pathname: "/readyz/",
+        method: "HEAD",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "preserves SPA routes that only resemble probe paths",
+        pathname: "/healthcheck",
+        method: "GET",
+        expected: { kind: "serve" as const },
+      },
+      {
         name: "preserves the SPA root that only resembles the OpenAI-compatible API",
         pathname: "/v12",
         method: "GET",

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -1,5 +1,9 @@
 // Control UI route classifier for base-path and root-mounted SPA serving.
 import { isReadHttpMethod } from "./control-ui-http-utils.js";
+import {
+  classifyGatewayProbePath,
+  classifyMcpAppStandalonePath,
+} from "./gateway-http-route-contracts.js";
 
 type ControlUiRequestClassification =
   | { kind: "not-control-ui" }
@@ -7,7 +11,6 @@ type ControlUiRequestClassification =
   | { kind: "redirect"; location: string }
   | { kind: "serve" };
 
-const ROOT_MOUNTED_GATEWAY_PROBE_PATHS = new Set(["/health", "/healthz", "/ready", "/readyz"]);
 const CONTROL_UI_PLUGIN_MANAGER_PATH = "/settings/plugins";
 
 /** Keep the plugin recovery surface ahead of plugin-owned HTTP routes. */
@@ -52,9 +55,14 @@ export function classifyControlUiRequest(params: {
     if (pathname === "/ui" || pathname.startsWith("/ui/")) {
       return { kind: "not-found" };
     }
-    // Keep core probe routes outside the root-mounted SPA catch-all so the
-    // gateway probe handler can answer them even when the Control UI owns `/`.
-    if (ROOT_MOUNTED_GATEWAY_PROBE_PATHS.has(pathname)) {
+    // Keep probe namespaces outside the root SPA: exact paths reach the probe
+    // handler, while malformed variants must not look healthy by serving HTML.
+    if (classifyGatewayProbePath(pathname) !== "outside") {
+      return { kind: "not-control-ui" };
+    }
+    // The standalone host owns this namespace when enabled. When disabled or
+    // malformed, plugins may still claim it before the final Gateway 404.
+    if (classifyMcpAppStandalonePath(pathname) !== "outside") {
       return { kind: "not-control-ui" };
     }
     // Keep plugin-owned HTTP routes outside the root-mounted Control UI SPA

--- a/src/gateway/gateway-http-route-contracts.ts
+++ b/src/gateway/gateway-http-route-contracts.ts
@@ -1,0 +1,35 @@
+const GATEWAY_PROBE_ROUTES = new Map<string, "live" | "ready">([
+  ["/health", "live"],
+  ["/healthz", "live"],
+  ["/ready", "ready"],
+  ["/readyz", "ready"],
+]);
+
+export const MCP_APP_STANDALONE_PATH = "/__openclaw__/mcp-app";
+export const MCP_APP_STANDALONE_VIEW_PATH = `${MCP_APP_STANDALONE_PATH}/view`;
+
+export function classifyGatewayProbePath(
+  pathname: string,
+): "live" | "ready" | "namespace" | "outside" {
+  for (const [root, status] of GATEWAY_PROBE_ROUTES) {
+    if (pathname === root) {
+      return status;
+    }
+    if (pathname.startsWith(`${root}/`)) {
+      return "namespace";
+    }
+  }
+  return "outside";
+}
+
+export function classifyMcpAppStandalonePath(
+  pathname: string,
+): "shell" | "view" | "namespace" | "outside" {
+  if (pathname === MCP_APP_STANDALONE_PATH) {
+    return "shell";
+  }
+  if (pathname === MCP_APP_STANDALONE_VIEW_PATH) {
+    return "view";
+  }
+  return pathname.startsWith(`${MCP_APP_STANDALONE_PATH}/`) ? "namespace" : "outside";
+}

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -5,6 +5,11 @@ import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-
 import { getMcpAppViewLease, type McpAppViewLease } from "../agents/mcp-ui-resource.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
+import {
+  classifyMcpAppStandalonePath,
+  MCP_APP_STANDALONE_PATH,
+  MCP_APP_STANDALONE_VIEW_PATH,
+} from "./gateway-http-route-contracts.js";
 import { readJsonBodyOrError, sendJson } from "./http-common.js";
 import {
   executeMcpAppOperation,
@@ -13,8 +18,6 @@ import {
   withMcpAppActiveView,
 } from "./mcp-app-operations.js";
 
-const MCP_APP_STANDALONE_PATH = "/__openclaw__/mcp-app";
-const MCP_APP_STANDALONE_VIEW_PATH = `${MCP_APP_STANDALONE_PATH}/view`;
 const MCP_APP_STANDALONE_TICKET_SCOPE = "mcp-app-standalone-view";
 const MCP_APP_STANDALONE_TICKET_TTL_MS = 2 * 60_000;
 const MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS = 15_000;
@@ -559,7 +562,8 @@ export async function handleMcpAppStandaloneHttpRequest(
   } catch {
     return false;
   }
-  if (url.pathname !== MCP_APP_STANDALONE_PATH && url.pathname !== MCP_APP_STANDALONE_VIEW_PATH) {
+  const route = classifyMcpAppStandalonePath(url.pathname);
+  if (route === "namespace" || route === "outside") {
     return false;
   }
   if (
@@ -587,7 +591,7 @@ export async function handleMcpAppStandaloneHttpRequest(
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("X-Content-Type-Options", "nosniff");
-  if (url.pathname === MCP_APP_STANDALONE_PATH) {
+  if (route === "shell") {
     const frameOrigin = resolveShellSandboxOrigin({
       req,
       sandboxOrigin: options.sandboxOrigin,

--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -1,6 +1,9 @@
 // Server HTTP probe tests cover readiness, health, disabled compat routes, and
 // auth handling through the in-memory HTTP harness.
+import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import nodePath from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   prepareGatewaySuspend,
@@ -31,6 +34,16 @@ async function sendGatewayRequest(server: GatewayServerHarness, options: Gateway
   const { res, getBody } = createResponse();
   await dispatchRequest(server, req, res);
   return { res, getBody };
+}
+
+async function withMarkedControlUiRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await fs.mkdtemp(nodePath.join(os.tmpdir(), "openclaw-http-routing-"));
+  try {
+    await fs.writeFile(nodePath.join(root, "index.html"), "<html>spa fallback</html>\n");
+    await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 }
 
 describe("gateway OpenAI-compatible disabled HTTP routes", () => {
@@ -112,7 +125,143 @@ describe("gateway OpenAI-compatible disabled HTTP routes", () => {
   });
 });
 
+describe("standalone MCP App HTTP routing", () => {
+  it.each([
+    {
+      name: "disabled shell",
+      enabled: false,
+      requestPath: "/__openclaw__/mcp-app",
+    },
+    {
+      name: "disabled view",
+      enabled: false,
+      requestPath: "/__openclaw__/mcp-app/view",
+    },
+    {
+      name: "enabled malformed child",
+      enabled: true,
+      requestPath: "/__openclaw__/mcp-app/other",
+    },
+  ])(
+    "returns 404 for the $name instead of Control UI HTML",
+    async ({ name, enabled, requestPath }) => {
+      await withMarkedControlUiRoot(async (controlUiRoot) => {
+        await withGatewayServer({
+          prefix: `mcp-app-routing-${name}`,
+          resolvedAuth: AUTH_NONE,
+          overrides: {
+            controlUiEnabled: true,
+            controlUiBasePath: "",
+            controlUiRoot: { kind: "resolved", path: controlUiRoot },
+            getRuntimeConfig: () => ({
+              gateway: { trustedProxies: [] },
+              mcp: { apps: { enabled } },
+            }),
+          },
+          run: async (server) => {
+            const { res, getBody } = await sendGatewayRequest(server, {
+              path: requestPath,
+              method: "GET",
+            });
+
+            expect(res.statusCode).toBe(404);
+            expect(getBody()).toBe("Not Found");
+          },
+        });
+      });
+    },
+  );
+
+  it.each([
+    { name: "disabled endpoint", enabled: false, requestPath: "/__openclaw__/mcp-app" },
+    { name: "malformed child", enabled: true, requestPath: "/__openclaw__/mcp-app/other" },
+  ])("preserves plugin precedence for a $name", async ({ enabled, requestPath }) => {
+    const handlePluginRequest = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 204;
+      res.end();
+      return true;
+    });
+    await withGatewayServer({
+      prefix: "mcp-app-routing-plugin-precedence",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth: () => false,
+        getRuntimeConfig: () => ({
+          gateway: { trustedProxies: [] },
+          mcp: { apps: { enabled } },
+        }),
+      },
+      run: async (server) => {
+        const { res } = await sendGatewayRequest(server, {
+          path: requestPath,
+          method: "GET",
+        });
+
+        expect(res.statusCode).toBe(204);
+        expect(handlePluginRequest).toHaveBeenCalledOnce();
+      },
+    });
+  });
+});
+
 describe("gateway probe endpoints", () => {
+  it("returns 404 for probe namespace variants instead of false-green Control UI HTML", async () => {
+    const getReadiness: ReadinessChecker = () => ({
+      ready: false,
+      failing: ["gateway-draining"],
+      uptimeMs: 1_000,
+    });
+    await withMarkedControlUiRoot(async (controlUiRoot) => {
+      await withGatewayServer({
+        prefix: "probe-namespace-root-control-ui",
+        resolvedAuth: AUTH_NONE,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "resolved", path: controlUiRoot },
+          getReadiness,
+        },
+        run: async (server) => {
+          const exact = await sendGatewayRequest(server, { path: "/readyz" });
+          expect(exact.res.statusCode).toBe(503);
+          expect(JSON.parse(exact.getBody())).toMatchObject({ ready: false });
+
+          for (const routePath of ["/health/", "/healthz/details", "/ready/", "/readyz/details"]) {
+            const { res, getBody } = await sendGatewayRequest(server, { path: routePath });
+            expect(res.statusCode, routePath).toBe(404);
+            expect(getBody(), routePath).toBe("Not Found");
+          }
+        },
+      });
+    });
+  });
+
+  it("preserves plugin precedence for an unclaimed probe descendant", async () => {
+    const handlePluginRequest = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 204;
+      res.end();
+      return true;
+    });
+    await withGatewayServer({
+      prefix: "probe-namespace-plugin-precedence",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth: () => false,
+      },
+      run: async (server) => {
+        const { res } = await sendGatewayRequest(server, { path: "/readyz/details" });
+        expect(res.statusCode).toBe(204);
+        expect(handlePluginRequest).toHaveBeenCalledOnce();
+      },
+    });
+  });
+
   it("keeps liveness green while a prepared suspension lease makes readiness red", async () => {
     resetGatewayWorkAdmission();
     const channelManager = {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -37,6 +37,10 @@ import {
   isControlUiPluginManagerRequest,
 } from "./control-ui-routing.js";
 import type { ControlUiRootState } from "./control-ui.js";
+import {
+  classifyGatewayProbePath,
+  classifyMcpAppStandalonePath,
+} from "./gateway-http-route-contracts.js";
 import type { AuthorizedGatewayHttpRequest } from "./http-auth-utils.js";
 import {
   finishFailedGatewayHttpResponse,
@@ -142,13 +146,6 @@ const getPluginRouteRuntimeScopesModule = createLazyRuntimeModule(
   () => import("./server/plugin-route-runtime-scopes.js"),
 );
 
-const GATEWAY_PROBE_STATUS_BY_PATH = new Map<string, "live" | "ready">([
-  ["/health", "live"],
-  ["/healthz", "live"],
-  ["/ready", "ready"],
-  ["/readyz", "ready"],
-]);
-
 function isControlUiCatalogIconRequest(pathname: string, basePath: string): boolean {
   const normalizedBasePath =
     basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
@@ -198,10 +195,6 @@ function getCachedPluginGatewayAuthBypassPaths(
 
 function isOpenAiModelsPath(pathname: string): boolean {
   return pathname === "/v1/models" || pathname.startsWith("/v1/models/");
-}
-
-function isMcpAppStandalonePath(pathname: string): boolean {
-  return pathname === "/__openclaw__/mcp-app" || pathname === "/__openclaw__/mcp-app/view";
 }
 
 function isBoardWidgetPath(pathname: string): boolean {
@@ -282,8 +275,8 @@ async function handleGatewayProbeRequest(
   allowRealIpFallback: boolean,
   getReadiness?: ReadinessChecker,
 ): Promise<boolean> {
-  const status = GATEWAY_PROBE_STATUS_BY_PATH.get(requestPath);
-  if (!status) {
+  const status = classifyGatewayProbePath(requestPath);
+  if (status === "namespace" || status === "outside") {
     return false;
   }
 
@@ -589,7 +582,7 @@ export function createGatewayHttpServer(opts: {
         sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
         return;
       }
-      if (GATEWAY_PROBE_STATUS_BY_PATH.get(requestPath) === "live") {
+      if (classifyGatewayProbePath(requestPath) === "live") {
         await handleGatewayProbeRequest(
           req,
           res,
@@ -881,7 +874,11 @@ export function createGatewayHttpServer(opts: {
             }),
         });
       }
-      if (configSnapshot.mcp?.apps?.enabled === true && isMcpAppStandalonePath(scopedRequestPath)) {
+      const mcpAppRoute = classifyMcpAppStandalonePath(scopedRequestPath);
+      if (
+        configSnapshot.mcp?.apps?.enabled === true &&
+        (mcpAppRoute === "shell" || mcpAppRoute === "view")
+      ) {
         requestStages.push({
           name: "mcp-app-standalone",
           run: async () =>


### PR DESCRIPTION
Closes #117435

## What Problem This Solves

Fixes an issue where operators using a root-mounted Control UI could receive dashboard HTML with HTTP 200 when requesting disabled MCP App endpoints or malformed health/readiness routes. In the worst case, exact `/readyz` could correctly report 503 while `/readyz/` appeared healthy because it returned the SPA.

## Why This Change Was Made

Gateway probe paths and the standalone MCP App namespace now share one dependency-light, closed route contract used by the core router, standalone handler, and Control UI admission. Exact routes keep their existing owners, malformed variants fall through explicitly registered plugins and then end in the Gateway 404, and near-prefix SPA paths remain available.

The change is intentionally limited to the root-mounted SPA. It does not change configured nonempty Control UI base-path collision policy, plugin-owned media/icon/canvas routes, auth, protocol, persistence, or MCP ticket behavior.

AI-assisted: yes. The complete patch received a fresh independent Codex autoreview.

## User Impact

Unavailable or malformed Gateway service URLs now have an honest HTTP outcome instead of a misleading dashboard success page. Health and readiness monitoring cannot become false-green merely because of a trailing slash or child path.

## Evidence

Before the fix on current main `bba7b939ce3df46f6a3cc9403fd8448d023cf33f`:

- Focused reproduction: 6 failed, 54 passed.
- Disabled MCP shell/view and an enabled malformed child returned HTTP 200 SPA HTML.
- `/readyz` could return 503 JSON while `/readyz/` and `/readyz/details` returned HTTP 200 HTML.

After the fix at `c61c8696847bde8158a76ec180cc6644c06a547d`:

- Focused Gateway matrix: 104/104 passed across Control UI classification, real HTTP routing, MCP handler/admission, and plugin fallthrough.
- Blacksmith Testbox `tbx_01kyyre7p6eqp4bexvddhpwee7`: complete `core, coreTests` changed gate passed, including production/test typechecks, oxlint, dead exports, import cycles, boundaries, and guards.
- The same Testbox passed the full `pnpm build`; Control UI assets and all 148 public plugin SDK subpaths verified.
- Hosted Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/30701947865
- Source-blind built-CLI proof on the exact commit passed every exercised route and anti-cheat clause: disabled MCP shell/view/child returned plain 404; enabled shell/view/child returned 200/401/404; probe variants returned plain 404; ordinary and near-prefix SPA routes remained HTML. The isolated public Gateway exposed readiness only as healthy JSON, so the 503 contrast remained blocked there and is covered by the real HTTP boundary regression.
- Fresh autoreview: clean, no accepted/actionable findings, confidence 0.98.
- Diff: six files, `+258/-23`; production `+67/-23`, tests `+191`.

No screenshot is included because the regression is an HTTP status/content-type boundary rather than a visual rendering change.
