### PR TITLE
fix(tlon): chunk outbound text over the declared delivery limit

### DIFF
--- a/extensions/tlon/src/channel.outbound.test.ts
+++ b/extensions/tlon/src/channel.outbound.test.ts
@@ -1,0 +1,23 @@
+// Tlon outbound chunking tests cover the declared text delivery limit.
+import { describe, expect, it } from "vitest";
+import { tlonPlugin } from "./channel.js";
+
+describe("tlon channel outbound", () => {
+  it("declares bounded Markdown chunking for text delivery", () => {
+    const outbound = tlonPlugin.outbound;
+    expect(outbound.chunkerMode).toBe("markdown");
+    expect(outbound.textChunkLimit).toBe(10_000);
+    expect(outbound.chunker).toBeTypeOf("function");
+  });
+
+  it("splits text above the declared limit into bounded chunks", () => {
+    const outbound = tlonPlugin.outbound;
+    const chunker = outbound.chunker;
+    if (!chunker) {
+      throw new Error("expected tlon outbound to declare a chunker");
+    }
+    const chunks = chunker("x".repeat(10_001), 10_000);
+    expect(chunks).toEqual(["x".repeat(10_000), "x"]);
+    expect(chunks.every((chunk) => chunk.length <= 10_000)).toBe(true);
+  });
+});

--- a/extensions/tlon/src/channel.outbound.test.ts
+++ b/extensions/tlon/src/channel.outbound.test.ts
@@ -1,17 +1,26 @@
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 // Tlon outbound chunking tests cover the declared text delivery limit.
 import { describe, expect, it } from "vitest";
 import { tlonPlugin } from "./channel.js";
 
+function requireTlonOutbound(): ChannelOutboundAdapter {
+  const outbound = tlonPlugin.outbound;
+  if (!outbound) {
+    throw new Error("expected tlon plugin to declare an outbound adapter");
+  }
+  return outbound;
+}
+
 describe("tlon channel outbound", () => {
   it("declares bounded Markdown chunking for text delivery", () => {
-    const outbound = tlonPlugin.outbound;
+    const outbound = requireTlonOutbound();
     expect(outbound.chunkerMode).toBe("markdown");
     expect(outbound.textChunkLimit).toBe(10_000);
     expect(outbound.chunker).toBeTypeOf("function");
   });
 
   it("splits text above the declared limit into bounded chunks", () => {
-    const outbound = tlonPlugin.outbound;
+    const outbound = requireTlonOutbound();
     const chunker = outbound.chunker;
     if (!chunker) {
       throw new Error("expected tlon outbound to declare a chunker");

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonSetupWizard } from "./setup-surface.js";
@@ -140,6 +141,8 @@ async function withHttpPokeAccountApi<T>(
 
 export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
+  chunker: chunkTextForOutbound,
+  chunkerMode: "markdown",
   textChunkLimit: 10000,
   resolveTarget: ({ to }) => resolveTlonOutboundTarget(to),
   deliveryCapabilities: {

--- a/extensions/tlon/src/channel.ts
+++ b/extensions/tlon/src/channel.ts
@@ -11,7 +11,10 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 import { tlonChannelConfigSchema } from "./config-schema.js";
 import { tlonDoctor } from "./doctor.js";
 import { resolveTlonOutboundSessionRoute } from "./session-route.js";
@@ -64,6 +67,8 @@ const tlonConfigAdapter = createHybridChannelConfigAdapter({
 
 const tlonChannelOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
+  chunker: chunkTextForOutbound,
+  chunkerMode: "markdown",
   textChunkLimit: 10000,
   sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   resolveTarget: ({ to }) => resolveTlonOutboundTarget(to),

--- a/extensions/tlon/src/outbound.loopback.test.ts
+++ b/extensions/tlon/src/outbound.loopback.test.ts
@@ -1,0 +1,152 @@
+// Tlon outbound loopback tests exercise the real HTTP poke path against a mock
+// urbit ship: authenticate then one bounded poke per chunked text unit.
+import { once } from "node:events";
+import * as http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { tlonPlugin } from "./channel.js";
+
+const TEXT_LIMIT = 10_000;
+
+type TlonPoke = {
+  app?: string;
+  mark?: string;
+  json?: {
+    ship?: string;
+    diff?: {
+      delta?: {
+        add?: {
+          memo?: { content?: unknown; author?: string };
+        };
+      };
+    };
+  };
+};
+
+/** Join the plain-string run of a Tlon story the same way a reader reconstructs text. */
+function extractStoryText(content: unknown): string {
+  const verses = Array.isArray(content) ? (content as unknown[]) : [];
+  const parts: string[] = [];
+  for (const verse of verses) {
+    if (
+      verse &&
+      typeof verse === "object" &&
+      "inline" in verse &&
+      Array.isArray((verse as { inline?: unknown }).inline)
+    ) {
+      for (const item of (verse as { inline: unknown[] }).inline) {
+        if (typeof item === "string") {
+          parts.push(item);
+        }
+      }
+    }
+  }
+  return parts.join("");
+}
+
+describe("tlon outbound chunking loopback", () => {
+  let server: http.Server | undefined;
+
+  async function listenLoopback(handler: http.RequestListener): Promise<number> {
+    server = http.createServer(handler);
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+    return address.port;
+  }
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((err) => (err ? reject(err) : resolve()));
+        server?.closeAllConnections?.();
+      });
+      server = undefined;
+    }
+  });
+
+  it("delivers each chunked unit as a bounded independent poke the urbit transport accepts", async () => {
+    const pokes: TlonPoke[] = [];
+    const rejectedOversized: Array<{ length: number }> = [];
+    let loginCount = 0;
+    const port = await listenLoopback((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (req.method === "POST" && url.pathname === "/~/login") {
+        loginCount += 1;
+        res.writeHead(200, {
+          "Content-Type": "text/plain",
+          "set-cookie": "urbauth-~zod=mock-cookie",
+        });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "PUT" && url.pathname.startsWith("/~/channel/")) {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          const received = JSON.parse(body) as TlonPoke[];
+          pokes.push(...received);
+          const oversized = received.some(
+            (poke) =>
+              extractStoryText(poke.json?.diff?.delta?.add?.memo?.content).length > TEXT_LIMIT,
+          );
+          if (oversized) {
+            rejectedOversized.push({ length: received.length });
+            res.writeHead(413, { "Content-Type": "text/plain" });
+            res.end("memo too long");
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("ok");
+        });
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("not found");
+    });
+
+    const cfg = {
+      channels: {
+        tlon: {
+          enabled: true,
+          ship: "~zod",
+          url: `http://127.0.0.1:${port}`,
+          code: "mock-code",
+          network: { dangerouslyAllowPrivateNetwork: true },
+        },
+      },
+    };
+
+    const outbound = tlonPlugin.outbound;
+    if (!outbound) {
+      throw new Error("expected tlon plugin to declare an outbound adapter");
+    }
+    const chunker = outbound.chunker;
+    if (!chunker || outbound.textChunkLimit !== TEXT_LIMIT) {
+      throw new Error("expected tlon outbound to declare a bounded chunker");
+    }
+
+    const text = "x".repeat(10_001);
+    const chunks = chunker(text, TEXT_LIMIT);
+    for (const chunk of chunks) {
+      await outbound.sendText?.({ cfg, to: "~nec", text: chunk });
+    }
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(pokes).toHaveLength(chunks.length);
+    expect(loginCount).toBeGreaterThan(0);
+    // Every unit fits the transport limit, so the urbit transport accepts each poke.
+    expect(rejectedOversized).toEqual([]);
+    const delivered = pokes.map((poke) =>
+      extractStoryText(poke.json?.diff?.delta?.add?.memo?.content),
+    );
+    expect(delivered.every((part) => part.length <= TEXT_LIMIT)).toBe(true);
+    expect(delivered.join("")).toBe(text);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long Tlon (Urbit) outbound messages could be delivered as a single oversized poke. The channel adapter declared a `textChunkLimit` of 10000 but never implemented a `chunker`, so core's delivery planner (`src/infra/outbound/message-plan.ts`) treated the limit as dead config and sent the whole text in one unit. Messages above the practical platform delivery size are sent unbroken, matching the silent-delivery-failure class that the sibling synology-chat fix (#116645) addressed.

## Why This Change Was Made

`ChannelOutboundAdapter.chunker` is optional. When it is absent, `planOutboundTextMessageUnits` returns the entire text as a single `text` unit regardless of `textChunkLimit`. Every other bundled channel that declares a limit either provides a `chunker` (zalo, matrix, msteams, signal, telegram, sms, irc, qqbot, feishu, googlechat, imessage, nextcloud-talk, discord, line, twitch, reef, nostr, buzz) or explicitly opts out with `chunker: null` plus internal truncation (slack). Tlon was the only adapter declaring a limit with neither. The `textChunkLimit: 10000` has been present since the plugin's original introduction but never wired to an actual chunker.

The fix adds the same standard declaration used across sibling channels:

```ts
chunker: chunkTextForOutbound,
chunkerMode: "markdown",
```

`chunkTextForOutbound` splits on newline/space boundaries first and falls back to a hard character split, so bounded sends always succeed.

## User Impact

Long Tlon messages are now split into bounded chunks at the declared 10000-character limit instead of being delivered as one oversized unit. The `textChunkLimit` config becomes effective rather than dead.

## Evidence

- Root cause: `extensions/tlon/src/channel.ts` and `extensions/tlon/src/channel.runtime.ts` declared `textChunkLimit: 10000` without a `chunker`. `src/infra/outbound/deliver-core.ts:130` reads `sendHandler.chunker` (typed as `ChannelOutboundAdapter["chunker"]` in `src/infra/outbound/deliver-contracts.ts:62`) and `planOutboundTextMessageUnits` returns the whole text as one unit when the chunker is absent (`src/infra/outbound/message-plan.ts:144`). Tlon was the only bundled channel declaring a limit with neither a chunker nor `chunker: null`.
- Regression coverage: `extensions/tlon/src/channel.outbound.test.ts` verifies the gateway adapter declares bounded Markdown chunking (`chunkerMode: "markdown"`, `textChunkLimit: 10000`) and that the chunker splits a 10001-character string into two bounded chunks.
- Real behavior proof: `extensions/tlon/src/outbound.loopback.test.ts` starts a mock urbit ship over loopback HTTP (rejects pokes whose memo exceeds 10000 characters with HTTP 413) and sends a 10001-character text through the real adapter path — `tlonPlugin.outbound.sendText` authenticates against the mock ship and issues one poke per chunked unit. The test asserts every poke is accepted (no oversized rejection), each delivered memo stays at or below 10000 characters, the pokes rejoin to the original text, and the poke count equals the chunk count. Full command + result:

```text
$ node scripts/run-vitest.mjs extensions/tlon/src/outbound.loopback.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- Static checks run locally: `git diff --check`, `oxfmt --check` on the changed files, and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` shows no tlon errors.
- Tlon suite: 256/257 passing; the single failure is a pre-existing setup-wizard `Unexpected prompt: Ship 名称` baseline in `extensions/tlon/src/core.test.ts` unrelated to this change (that file is untouched by this PR).
- No real Urbit ship is reachable in this environment; live-ship behavior remains a CI/reviewer follow-up rather than a claimed pass.

## AI Assistance

This PR was prepared with AI-assisted tooling. The author reviewed and understands the changes and their verification limits.
