### PR TITLE
fix(hooks): reject duplicate packaged hook identities before installation

### DIFF
--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -344,6 +344,52 @@ describe("installHooksFromPath", () => {
     expect(result).toEqual({ ok: false, error, code });
   });
 
+  it.each([
+    { mode: "install", options: {}, names: ["shared-hook", "shared-hook"] },
+    { mode: "dry run", options: { dryRun: true }, names: ["shared-hook", "shared-hook"] },
+    {
+      mode: "package inspection",
+      options: { inspection: "package-kind" as const },
+      names: ["shared-hook", "shared-hook"],
+    },
+    { mode: "case-sensitive install", options: {}, names: ["shared-hook", "Shared-Hook"] },
+  ])("validates hook-name uniqueness before $mode side effects", async ({ options, names }) => {
+    const pkgDir = makeTempDir();
+    const hooksDir = path.join(makeTempDir(), "managed-hooks");
+    writeHookPackManifest({
+      pkgDir,
+      hooks: names.map((_, index) => `./hooks/${index}`),
+    });
+    for (const [index, name] of names.entries()) {
+      const hookDir = path.join(pkgDir, "hooks", String(index));
+      fs.mkdirSync(hookDir, { recursive: true });
+      fs.writeFileSync(path.join(hookDir, "HOOK.md"), `---\nname: ${name}\n---\n`);
+      fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+    }
+    const targetAvailability = vi.spyOn(hookInstallRuntime, "ensureInstallTargetAvailable");
+
+    try {
+      const result = await installHooksFromPath({ path: pkgDir, hooksDir, ...options });
+      if (names[0] !== names[1]) {
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.hooks).toEqual(names);
+        }
+        return;
+      }
+      expect(result).toEqual({
+        ok: false,
+        error: 'duplicate hook name "shared-hook" in hook package',
+      });
+      expect(targetAvailability).not.toHaveBeenCalled();
+      expect(scanPackageInstallSourceMock).not.toHaveBeenCalled();
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      expect(fs.existsSync(hooksDir)).toBe(false);
+    } finally {
+      targetAvailability.mockRestore();
+    }
+  });
+
   it("uses --ignore-scripts for dependency install", async () => {
     const workDir = makeTempDir();
     const stateDir = makeTempDir();

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -434,7 +434,7 @@ async function installHookPackageFromDir(
     };
   }
 
-  const resolvedHooks = [] as string[];
+  const resolvedHooks = new Set<string>();
   for (const entry of hookEntries) {
     const hookDir = path.resolve(params.packageDir, entry);
     // Validate both lexical containment and realpath containment so archive
@@ -457,8 +457,12 @@ async function installHookPackageFromDir(
       };
     }
     const hookName = await resolveHookNameFromDir(hookDir);
-    resolvedHooks.push(hookName);
+    if (resolvedHooks.has(hookName)) {
+      return { ok: false, error: `duplicate hook name "${hookName}" in hook package` };
+    }
+    resolvedHooks.add(hookName);
   }
+  const hookNames = [...resolvedHooks];
 
   if (params.inspection === "package-kind") {
     const targetDirResult = resolveHookInstallTargetPath(hookPackId, params.hooksDir);
@@ -468,7 +472,7 @@ async function installHookPackageFromDir(
     return {
       ok: true,
       hookPackId,
-      hooks: resolvedHooks,
+      hooks: hookNames,
       packageKind,
       targetDir: targetDirResult.targetDir,
       version: typeof manifest.version === "string" ? manifest.version : undefined,
@@ -504,7 +508,7 @@ async function installHookPackageFromDir(
     return {
       ok: true,
       hookPackId,
-      hooks: resolvedHooks,
+      hooks: hookNames,
       packageKind,
       targetDir,
       version: typeof manifest.version === "string" ? manifest.version : undefined,
@@ -538,7 +542,7 @@ async function installHookPackageFromDir(
   return {
     ok: true,
     hookPackId,
-    hooks: resolvedHooks,
+    hooks: hookNames,
     packageKind,
     targetDir,
     version: typeof manifest.version === "string" ? manifest.version : undefined,


### PR DESCRIPTION
## What Problem This Solves

A hook package can declare two different handler directories with the same resolved `HOOK.md` name. Installation, dry-run, and package inspection all currently report success, but the hook loader silently keeps only the later same-source handler, so the first handler and its event disappear.

## Why This Change Was Made

Hook identity is established while the package owner validates its manifest and reads each hook's frontmatter. Record each resolved name once in an ordered `Set`, reject an exact duplicate at that producer boundary, and derive the existing ordered result array from the validated identities before inspection, target preparation, install policy, dependency installation, or persistence.

## User Impact

Operators receive an actionable duplicate-name error instead of a successful installation with a silently missing handler. No target directory or install side effect occurs for an invalid package. Valid differently cased names, ordered hook results, existing single-hook and archive/npm/local flows, path-containment checks, and intentional cross-source hook overrides retain their behavior.

## Evidence

- Immutable candidate `66c3525d70e0aa6e32bf6449bd7e66aeb5910b9e`, tree `11ee570dd2fe51932024ea9410cf5f66e3b370e4`, parent `bba7b939ce3df46f6a3cc9403fd8448d023cf33f`; exactly `src/hooks/install.ts` and `src/hooks/install.test.ts`.
- Authentic unchanged-production proof fails all **three** install, dry-run, and package-inspection collision regressions; the identical frozen-source probe passes all three and verifies there is no target directory. Durable evidence: `/private/tmp/openclaw-qa400-hook-duplicate-baseline-red3.log` and `/private/tmp/openclaw-qa400-hook-duplicate-frozen-green3.log`.
- Real isolated package installation plus hook loading and event dispatch proves the baseline installs both files but registers only one handler: the first event produces no messages while the second handler fires. The frozen owner rejects the package before target creation. Durable evidence: `/private/tmp/openclaw-qa400-hook-duplicate-baseline-real.log` and `/private/tmp/openclaw-qa400-hook-duplicate-frozen-real.log`.
- Full frozen focused suites pass **41/41**: 34 install-owner tests, six precedence/override policy tests, and one real install/loader/dispatch lifecycle test. Durable evidence: `/private/tmp/openclaw-qa400-hook-duplicate-final41.log`.
- Actual configured type-aware oxlint and `oxfmt --check` pass both changed files without exemptions or max-lines suppressions. Production change is **+4 net lines**. Fresh independent hostile review, root-owned strict official autoreview, exact-head hosted gates, and repository-native landing remain mandatory.

