### PR TITLE
fix(ci): repair full release validation regressions

### DIFF
--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -1684,9 +1684,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(approvalID))
         await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
-        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        let deadline = ContinuousClock().now.advanced(by: .seconds(10))
         while await !writeGate.hasStarted(), ContinuousClock().now < deadline {
-            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
         }
         let writeCount = await writeGate.callCount()
         #expect(writeCount == 1)

--- a/extensions/memory-wiki/src/agent-vault-isolation.test.ts
+++ b/extensions/memory-wiki/src/agent-vault-isolation.test.ts
@@ -263,5 +263,5 @@ describe("agent-scoped memory-wiki tools", () => {
     } finally {
       clearMemoryPluginState();
     }
-  }, 240_000);
+  }, 360_000);
 });

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -76,6 +76,8 @@ export class WorktreeSnapshotError extends Error {
     this.snapshotError = snapshotError;
   }
 }
+
+export class WorktreeRepositoryError extends Error {}
 const SNAPSHOT_REF_PREFIX = "refs/openclaw/snapshots";
 const log = createSubsystemLogger("agents/worktrees");
 
@@ -181,9 +183,13 @@ async function resolveRepositoryFromRealPath(
 ): Promise<ResolvedRepository> {
   const rootResult = await runGit(requested, ["rev-parse", "--show-toplevel"]);
   if (rootResult.code !== 0) {
-    throw new Error(`not a git checkout: ${requestedLabel}`);
+    throw new WorktreeRepositoryError(`not a git checkout: ${requestedLabel}`);
   }
   const sourceRoot = await fs.realpath(rootResult.stdout.trim());
+  const headResult = await runGit(sourceRoot, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (headResult.code !== 0) {
+    throw new WorktreeRepositoryError(`git checkout has no commits: ${requestedLabel}`);
+  }
   const commonRaw = await requireGit(sourceRoot, ["rev-parse", "--git-common-dir"]);
   const commonDir = await fs.realpath(
     path.isAbsolute(commonRaw) ? commonRaw : path.resolve(sourceRoot, commonRaw),

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -15,7 +15,7 @@ import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import { insideGitCheckout } from "../../agents/worktrees/git.js";
 import { slugifyWorktreeTitle } from "../../agents/worktrees/name.js";
-import { managedWorktrees } from "../../agents/worktrees/service.js";
+import { managedWorktrees, WorktreeRepositoryError } from "../../agents/worktrees/service.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import { sessionEntryForkedFromParent } from "../../config/sessions/session-entry-lineage.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -375,6 +375,14 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
           provisionedSessionWorktree = true;
         }
       } catch (error) {
+        if (error instanceof WorktreeRepositoryError) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "agent workspace is not a git checkout"),
+          );
+          return;
+        }
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(error)));
         return;
       }

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1405,6 +1405,28 @@ test("sessions.create rejects worktrees for non-git agent workspaces", async () 
   }
 });
 
+test("sessions.create rejects worktrees for agent workspaces without a commit", async () => {
+  const workspace = await makeNonGitTempDir("openclaw-session-unborn-workspace-");
+  await execFileAsync("git", ["init", workspace]);
+  testState.agentConfig = { workspace };
+  await createSessionStoreDir();
+  try {
+    const created = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", worktree: true },
+      { client: { connect: { scopes: ["operator.admin"] } } as never },
+    );
+
+    expect(created.ok).toBe(false);
+    expect(created.error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: "agent workspace is not a git checkout",
+    });
+  } finally {
+    testState.agentConfig = undefined;
+  }
+});
+
 test("sessions.create stores dashboard model, thinking, and parent linkage, and creates a transcript", async () => {
   const { storePath } = await createSessionStoreDir();
   agentDiscoveryMock.enabled = true;


### PR DESCRIPTION
## Summary

Repairs three deterministic release-validation failures found by the full release pipeline on exact main SHA `355295bfef4abadeb94286dce2b911d12531b98b`:

- classify an initialized-but-unborn Git repository as an invalid agent workspace before attempting `git worktree add`
- give the memory-wiki agent-isolation test measured shard-contention headroom without changing any product performance threshold
- replace the iOS queued-approval test's two-second hot yield loop with a bounded ten-second sleep-backed wait

## Failure evidence

Parent release validation: https://github.com/openclaw/openclaw/actions/runs/30702049252

- CI / iOS build: https://github.com/openclaw/openclaw/actions/runs/30702161749/job/91374998351
  - `canonical pending readback resumes queued watch decision`
  - `writeCount` remained `0` after the two-second busy wait
- CI / agentic control plane agent chat: https://github.com/openclaw/openclaw/actions/runs/30702161749/job/91374999445
  - expected stable `INVALID_REQUEST`; received `UNAVAILABLE` from `git worktree add` against an unborn `HEAD`
- Plugin prerelease / extensions shard 3: https://github.com/openclaw/openclaw/actions/runs/30702575681/job/91376101219
  - memory-wiki agent-vault isolation exceeded the 240-second per-test timeout
  - focused runs completed in 234.13s cold and 152.51s warm, leaving effectively no cold shard-contention margin

## Validation

- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/agents/worktrees/service.test.ts`
- focused post-rebase gateway and worktree cases
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/agent-vault-isolation.test.ts` (234.13s cold; 152.51s warm)
- `./node_modules/.bin/oxfmt --check` on changed TypeScript files
- targeted `oxlint` on changed TypeScript files
- `swiftformat --lint apps/ios/Tests/NodeAppModelInvokeTests.swift --config config/swiftformat`
- `git diff --check`
- autoreview: clean, no actionable P0 findings

Direct SwiftLint on the existing large iOS test file reports 29 pre-existing file/type length and existing-line violations; this patch introduces none of them.

## Release notes

No changelog entry: these are release-validation and test-harness repairs with no user-visible behavior change.
