### PR TITLE
fix(doctor): preserve unresolved findings for each repair outcome

### DIFF
--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runDoctorHealthRepairs } from "./doctor-repair-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
 import type { RunnableHealthCheck, SplitHealthCheckInput } from "./health-check-runner-types.js";
-import type { HealthCheck, HealthRepairContext } from "./health-checks.js";
+import type { HealthCheck, HealthFinding, HealthRepairContext } from "./health-checks.js";
 
 function ctx(cfg: OpenClawConfig): HealthRepairContext {
   return {
@@ -16,6 +16,34 @@ function ctx(cfg: OpenClawConfig): HealthRepairContext {
     },
     cfg,
   };
+}
+
+function warningFinding(checkId: string): HealthFinding {
+  return {
+    checkId,
+    severity: "warning",
+    message: `Unresolved finding from ${checkId}.`,
+    path: checkId,
+  };
+}
+
+function successfullyRepairedCheck(): HealthCheck {
+  return normalizeHealthCheck({
+    id: "test/repaired-first",
+    kind: "core",
+    description: "repairs before the unresolved check",
+    async detect(checkContext) {
+      return checkContext.cfg.gateway?.mode === "local"
+        ? []
+        : [warningFinding("test/repaired-first")];
+    },
+    async repair(checkContext) {
+      return {
+        config: { ...checkContext.cfg, gateway: { ...checkContext.cfg.gateway, mode: "local" } },
+        changes: ["Set gateway.mode to local."],
+      };
+    },
+  });
 }
 
 describe("runDoctorHealthRepairs", () => {
@@ -114,7 +142,7 @@ describe("runDoctorHealthRepairs", () => {
     })).not.toMatchTypeOf<SplitRepair>();
   });
 
-  it("leaves non-repairable checks for legacy doctor behavior", async () => {
+  it("retains non-repairable findings for the legacy doctor owner", async () => {
     const checks: HealthCheck[] = [
       normalizeHealthCheck({
         id: "test/legacy-only",
@@ -136,7 +164,7 @@ describe("runDoctorHealthRepairs", () => {
 
     expect(result.config).toEqual({});
     expect(result.findings).toHaveLength(1);
-    expect(result.remainingFindings).toEqual([]);
+    expect(result.remainingFindings).toEqual(result.findings);
     expect(result.changes).toEqual([]);
     expect(result.checksRepaired).toBe(0);
     expect(result.checksValidated).toBe(0);
@@ -173,6 +201,7 @@ describe("runDoctorHealthRepairs", () => {
       },
     ]);
     expect(result.warnings).toEqual(["test/repair-throws repair failed: repair exploded"]);
+    expect(result.remainingFindings).toEqual(result.findings);
     expect(result.checksRepaired).toBe(0);
     expect(result.checksValidated).toBe(0);
   });
@@ -285,10 +314,89 @@ describe("runDoctorHealthRepairs", () => {
     expect(validationCalls).toBe(1);
     expect(result.checksRepaired).toBe(0);
     expect(result.checksValidated).toBe(0);
-    expect(result.remainingFindings).toEqual([]);
+    expect(result.remainingFindings).toEqual(result.findings);
     expect(result.changes).toEqual(["Review required before changing gateway.mode."]);
     expect(result.warnings).toEqual(["test/skipped repair skipped: manual confirmation required"]);
   });
+
+  it.each(["skipped", "failed", "throws", "unavailable", "validation-failed"] as const)(
+    "preserves unresolved split findings after a successful sibling repair (%s)",
+    async (outcome) => {
+      const unresolvedId = `test/split-${outcome}`;
+      const unresolvedCheck = normalizeHealthCheck({
+        id: unresolvedId,
+        kind: "core",
+        description: "unresolved split check",
+        async detect(_checkContext, scope) {
+          if (outcome === "validation-failed" && scope !== undefined) {
+            throw new Error("validation unavailable");
+          }
+          return [warningFinding(unresolvedId)];
+        },
+        ...(outcome === "unavailable"
+          ? {}
+          : {
+              async repair() {
+                if (outcome === "throws") {
+                  throw new Error("repair unavailable");
+                }
+                if (outcome === "skipped" || outcome === "failed") {
+                  return { status: outcome, reason: "manual repair required", changes: [] };
+                }
+                return { changes: ["Attempted unresolved repair."] };
+              },
+            }),
+      });
+
+      const result = await runDoctorHealthRepairs(ctx({}), {
+        checks: [successfullyRepairedCheck(), unresolvedCheck],
+      });
+
+      expect(result.config.gateway?.mode).toBe("local");
+      expect(result.findings.map((finding) => finding.checkId)).toEqual([
+        "test/repaired-first",
+        unresolvedId,
+      ]);
+      expect(result.remainingFindings).toEqual([warningFinding(unresolvedId)]);
+      expect(result.checksRun).toBe(2);
+      expect(result.checksRepaired).toBe(outcome === "validation-failed" ? 2 : 1);
+      expect(result.checksValidated).toBe(1);
+    },
+  );
+
+  it.each(["skipped", "failed", "unavailable", "validation-failed"] as const)(
+    "preserves unresolved runnable findings after a successful split sibling repair (%s)",
+    async (outcome) => {
+      const unresolvedId = `test/runnable-${outcome}`;
+      const runnable: RunnableHealthCheck = {
+        id: unresolvedId,
+        kind: "core",
+        description: "unresolved runnable check",
+        async run(checkContext) {
+          if (checkContext.mode === "lint") {
+            throw new Error("validation unavailable");
+          }
+          const findings = [warningFinding(unresolvedId)];
+          if (outcome === "skipped" || outcome === "failed") {
+            return { status: outcome, reason: "manual repair required", findings };
+          }
+          return outcome === "validation-failed"
+            ? { findings, changes: ["Attempted unresolved repair."] }
+            : { findings };
+        },
+      };
+
+      const result = await runDoctorHealthRepairs(ctx({}), {
+        checks: [successfullyRepairedCheck(), normalizeHealthCheck(runnable)],
+      });
+
+      expect(result.config.gateway?.mode).toBe("local");
+      expect(result.remainingFindings).toEqual([warningFinding(unresolvedId)]);
+      expect(result.checksRun).toBe(2);
+      expect(result.checksRepaired).toBe(outcome === "validation-failed" ? 2 : 1);
+      expect(result.checksValidated).toBe(1);
+    },
+  );
 
   it("supports dry-run repairs without applying returned config or validating", async () => {
     const repairContexts: HealthRepairContext[] = [];

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -60,7 +60,11 @@ export async function runDoctorHealthRepairs(
     const runResult = await runHealthCheck(check, detectCtx, opts);
     cfg = runResult.config;
     findings.push(...runResult.findings);
-    remainingFindings.push(...runResult.remainingFindings);
+    // Only a completed validation can replace this check's original findings;
+    // skipped, failed, and unvalidated siblings must remain visible in mixed batches.
+    remainingFindings.push(
+      ...(runResult.checksValidated > 0 ? runResult.remainingFindings : runResult.findings),
+    );
     changes.push(...runResult.changes);
     warnings.push(...runResult.warnings);
     diffs.push(...runResult.diffs);


### PR DESCRIPTION
## Root cause

The Doctor repair owner discarded each check's original finding when a repair was skipped, failed, unavailable, or could not be validated. Aggregate repair counters also hid these unresolved findings when another check in the same batch succeeded.

## Fix

Select the authoritative findings while each individual check's repair outcome is still available: use post-repair findings only after that same check completes validation; otherwise preserve its original findings. Existing caller contracts, check order, configuration threading, and repair counts remain unchanged.

## Verification

- Regression-first producer suite: 12 failing cases and 7 existing passes before the fix; all 19 pass afterward.
- Mixed batches cover successfully repaired siblings combined with skipped, failed, thrown, unavailable, and unvalidated split or runnable checks.
- Three targeted existing Doctor contribution tests pass; the complete 101-test contribution file exceeded the shared-host 120-second inactivity watchdog.
- Eight existing registered Workspaces owner tests also pass; the chosen Vitest config discovered that owner file only from a two-file sibling request.
- Real registered Workspaces check, real repair runner, and unchanged contribution consumer report the blocked repair while preserving the isolated workspace fixture.
- Exact-file configured type-aware lint, format, and whitespace checks pass.

### Real registered Doctor repair: exact before/after console proof

Ran Node **v24.18.0** against current `main` (`71a59512ba476df3328cf485d84748121cf341f2`) and this exact PR head (`b408623e10754e6155b4661aded28d764fc574d1`). The isolated fixture contains a real retired-Workspaces fingerprint at `<STATE_DIR>/workspaces/workspaces.sqlite` and deliberately configures that same directory as the active agent workspace. The actual production `CORE_HEALTH_CHECKS` registry selects `core/doctor/removed-workspaces-state`; the actual production `runCoreContributionHealth(...)` Doctor command path performs detection, safely skips the destructive repair, and renders the final structured result. No mocked check, repair, consumer, or Gateway is involved.

Exact commands:

```sh
/Users/steipete/.local/bin/node --import tsx /private/tmp/openclaw-qa401-doctor-registered-proof.mts /Users/steipete/Projects/openclaw before
/Users/steipete/.local/bin/node --import tsx /private/tmp/openclaw-qa401-doctor-registered-proof.mts /private/tmp/openclaw-qa401-doctor-repair-outcomes-133a fixed
```

Current `main`:

```text
checkout=before
registered-check=core/doctor/removed-workspaces-state
before-repair findings=1; repair-status=skipped; after-repair remaining=0; validated=0
actual-doctor-console-lines=0
workspace-database-preserved=true; network-attempts=0
```

Exact PR head:

```text
checkout=fixed
registered-check=core/doctor/removed-workspaces-state
before-repair findings=1; repair-status=skipped; after-repair remaining=1; validated=0
actual-doctor-console-lines=1
  [warning] core/doctor/removed-workspaces-state <STATE_DIR>/workspaces - Retired Workspaces plugin fingerprints remain at <STATE_DIR>/workspaces, but agents.defaults.workspace resolves to that directory or an overlapping path. Automatic removal is disabled.
workspace-database-preserved=true; network-attempts=0
```

Therefore the unchanged, real Doctor consumer previously emitted **no structured console outcome** after the real owner safely skipped repair; the exact PR head preserves and renders the unresolved warning while leaving the protected workspace database untouched. Network calls are denied and counted; both runs observed zero attempts. Fixture paths are redacted; no credentials or user state are read.

### Rank-up move response

- **Show real registered Doctor owner/harness output:** addressed above with exact commands, current-main/frozen-head console output, the real production registry/check/repair/consumer, persistent fixture verification, and zero-network proof. This check has no Gateway dependency; a mock Gateway would not exercise an additional user-visible boundary.
- **Document focused verification:** regression-first producer was 12 failures/7 passes before and 19/19 after; unchanged consumer regressions 3/3; registered Workspaces-owner regressions 8/8; configured typed lint, formatter, whitespace check, and fresh genuine independent autoreview passed. The broader 101-case consumer suite hit the shared-host inactivity watchdog; it is not claimed green.
