### PR TITLE
fix(update): return failure when dirty checkout blocks update

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6140,7 +6140,7 @@ describe("update-cli", () => {
       "Commit, stash, or discard the local changes, then rerun `openclaw update`.",
     );
     expect(serviceStop).not.toHaveBeenCalled();
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
   it.each([
     {

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -44,6 +44,45 @@ async function finishFailedUpdate(result: UpdateRunResult): Promise<void> {
   } as unknown as FinishUpdateParams);
 }
 
+async function finishSkippedUpdate(reason: string): Promise<void> {
+  await finishUpdate({
+    result: {
+      status: "skipped",
+      mode: reason === "dirty" ? "git" : "unknown",
+      reason,
+      steps: [],
+      durationMs: 1,
+    },
+    opts: {},
+    showProgress: false,
+    controlPlaneUpdateSentinelMeta: undefined,
+  } as unknown as FinishUpdateParams);
+}
+
+describe("skipped update exit status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+  });
+
+  it("exits nonzero when local changes block a Git update", async () => {
+    await finishSkippedUpdate("dirty");
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Update blocked: local files are edited"),
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps a non-Git install skip successful", async () => {
+    await finishSkippedUpdate("not-git-install");
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+  });
+});
+
 describe("failed Git update recovery restart", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -169,7 +169,7 @@ export async function finishUpdate(params: {
         ),
       );
     }
-    defaultRuntime.exit(0);
+    defaultRuntime.exit(params.result.reason === "dirty" ? 1 : 0);
     return;
   }
 


### PR DESCRIPTION
[AI-assisted]

Original contributor: @IWhatsskill. The contributor's original human Git author, email, first authored timestamp, and existing PR are preserved.

## What Problem This Solves

`openclaw update` correctly refuses to mutate a dirty Git checkout, prints an actionable `Update blocked` diagnostic, and then incorrectly exits with status 0. Shell automation therefore records an update that did not happen as successful.

## Why This Change Was Made

Keep dirty detection and the pre-mutation safety boundary in the existing Git update runner. At the post-update owner, map only skipped reason `dirty` to exit 1; intentional skips such as `not-git-install` continue to exit 0. Preserve the contributor's original production change and focused owner tests, and correct the existing stale full-CLI dirty-checkout assertion that incorrectly expected success.

The refreshed branch changes exactly three files: the original two contributor files plus the stale caller-level assertion. The production delta is net zero lines; there is no config, dependency, protocol, migration, service lifecycle, or Git mutation change.

## User Impact

Automation receives a failing process status when operator changes prevent the requested update. Existing actionable recovery guidance stays visible. The real checkout, current commit, user-edited file, and dirty status are untouched, and intentional non-Git-install skips remain successful.

## Evidence

Created a real temporary Git checkout with a real committed `package.json`, entrypoint, and README; edited the actual tracked README; invoked production `runGatewayUpdate` using actual Git subprocesses, then passed its real structured result into production `finishUpdate`. Also invoked the existing intentional non-Git skip sibling.

Before, current main:

```json
{
  "dirty": {
    "status": "skipped",
    "reason": "dirty",
    "steps": [
      "clean check"
    ],
    "exitCode": 0,
    "beforeGitMutationCalls": 0,
    "diagnostic": "Update blocked: local files are edited in this checkout.",
    "repoHeadPreserved": true,
    "statusPreserved": true,
    "dirtyFilePreserved": true
  },
  "intentionalNonGit": {
    "reason": "not-git-install",
    "exitCode": 0
  }
}
```

After, exact original contributor head `976161e7c015964701c661788ad9b56ffb3d59de`:

```json
{
  "dirty": {
    "status": "skipped",
    "reason": "dirty",
    "steps": [
      "clean check"
    ],
    "exitCode": 1,
    "beforeGitMutationCalls": 0,
    "diagnostic": "Update blocked: local files are edited in this checkout.",
    "repoHeadPreserved": true,
    "statusPreserved": true,
    "dirtyFilePreserved": true
  },
  "intentionalNonGit": {
    "reason": "not-git-install",
    "exitCode": 0
  }
}
```

The only attempted Git update step is the real `clean check`; `beforeGitMutation` is never called; repository HEAD, git status, and the operator-edited README are identical afterward.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-117452-update node scripts/run-vitest.mjs src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli.test.ts src/infra/update-runner.test.ts -t 'skipped update exit status|explains why git updates cannot run with edited files|skips git update when worktree is dirty'
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --thinking xhigh
```

All four matching owner/caller/runner regressions pass across three files; targeted formatter and `git diff --check` pass; fresh Codex Sol xhigh structured autoreview is clean. The latest ClawSweeper rank-up move is addressed by refreshing current main, correcting the preexisting failing CLI expectation, and rerunning all directly relevant checks; exact-head hosted CI must still finish green before landing.