### PR TITLE
fix(feishu): preserve opaque Bitable pagination tokens

### DIFF
--- a/extensions/feishu/src/bitable.test.ts
+++ b/extensions/feishu/src/bitable.test.ts
@@ -1,5 +1,5 @@
 // Feishu tests cover bitable plugin behavior.
-import type * as Lark from "@larksuiteoapi/node-sdk";
+import * as Lark from "@larksuiteoapi/node-sdk";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
@@ -70,6 +70,63 @@ function createBitableClient(records: MockRecord[]) {
 
   return { batchDelete, client };
 }
+
+type BitableSdkResponse = {
+  code: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+};
+
+function createSdkBitableClient(responses: Array<BitableSdkResponse | Error>) {
+  const request = vi.fn(async (options: Lark.HttpRequestOptions<unknown>) => {
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Feishu SDK request: ${String(options.url)}`);
+    }
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  });
+  const post = vi.fn(() => {
+    throw new Error("Unexpected Feishu SDK authentication request");
+  });
+  const httpInstance = Object.assign(Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance, {
+    request,
+    post,
+  });
+  createFeishuClientMock.mockReturnValue(
+    new Lark.Client({
+      appId: "cli_bitable_pagination",
+      appSecret: "bitable-test-placeholder", // pragma: allowlist secret
+      disableTokenCache: true,
+      loggerLevel: Lark.LoggerLevel.error,
+      httpInstance,
+    }),
+  );
+  return { request, post };
+}
+
+const bitablePaginationCases = [
+  {
+    name: "table metadata",
+    toolName: "feishu_bitable_get_meta",
+    params: { url: "https://example.feishu.cn/base/appToken123" },
+    resourcePath: "/open-apis/bitable/v1/apps/appToken123/tables",
+    firstItem: { table_id: "tblFirst", name: "First" },
+    secondItem: { table_id: "tblSecond", name: "Second" },
+    prefix: [{ code: 0, data: { app: { name: "Project Tracker" } } }],
+  },
+  {
+    name: "table fields",
+    toolName: "feishu_bitable_list_fields",
+    params: { app_token: "appToken123", table_id: "tblMain" },
+    resourcePath: "/open-apis/bitable/v1/apps/appToken123/tables/tblMain/fields",
+    firstItem: { field_id: "fldFirst", field_name: "First", type: 1 },
+    secondItem: { field_id: "fldSecond", field_name: "Second", type: 2 },
+    prefix: [],
+  },
+] as const;
 
 describe("feishu bitable create app cleanup", () => {
   afterAll(() => {
@@ -170,6 +227,229 @@ describe("feishu bitable create app cleanup", () => {
       "page_size must be a positive integer between 1 and 500",
     );
     expect(client.bitable.appTableRecord.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the selected table in a Bitable URL without listing other tables", async () => {
+    const { request, post } = createSdkBitableClient([
+      { code: 0, data: { app: { name: "Project Tracker" } } },
+    ]);
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_get_meta").execute("call_selected_table", {
+      url: "https://example.feishu.cn/base/appToken123?table=tblSelected",
+    });
+
+    expect(result.details).toMatchObject({
+      app_token: "appToken123",
+      table_id: "tblSelected",
+      url_type: "base",
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("resolves wiki Bitable URLs through the installed Feishu SDK", async () => {
+    const { request, post } = createSdkBitableClient([
+      { code: 0, data: { node: { obj_type: "bitable", obj_token: "appToken123" } } },
+      { code: 0, data: { app: { name: "Project Tracker" } } },
+      { code: 0, data: { items: [{ table_id: "tblMain", name: "Main" }] } },
+    ]);
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_get_meta").execute("call_wiki_table", {
+      url: "https://example.feishu.cn/wiki/wikiToken123",
+    });
+
+    expect(result.details).toMatchObject({
+      app_token: "appToken123",
+      url_type: "wiki",
+      tables: [{ table_id: "tblMain", name: "Main" }],
+    });
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it.each(bitablePaginationCases)(
+    "returns every $name page through the installed Feishu SDK transport",
+    async ({ toolName, params, resourcePath, firstItem, secondItem, prefix }) => {
+      const { request, post } = createSdkBitableClient([
+        ...prefix,
+        {
+          code: 0,
+          data: { items: [firstItem], has_more: true, page_token: " page-2 ", total: 2 },
+        },
+        { code: 0, data: { items: [secondItem], has_more: false, total: 2 } },
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_pages", params);
+      const rows =
+        toolName === "feishu_bitable_get_meta" ? result.details.tables : result.details.fields;
+
+      expect(rows).toEqual([
+        expect.objectContaining(firstItem),
+        expect.objectContaining(secondItem),
+      ]);
+      if (toolName === "feishu_bitable_list_fields") {
+        expect(result.details.total).toBe(2);
+      }
+      const resourceCalls = request.mock.calls.filter(([options]) =>
+        options.url?.endsWith(resourcePath),
+      );
+      expect(resourceCalls.map(([options]) => options)).toEqual([
+        expect.objectContaining({ method: "GET", params: { page_size: 100 } }),
+        expect.objectContaining({
+          method: "GET",
+          params: { page_size: 100, page_token: " page-2 " },
+        }),
+      ]);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "preserves distinct whitespace-bearing opaque $name page tokens",
+    async ({ toolName, params, resourcePath, firstItem, secondItem, prefix }) => {
+      const { request, post } = createSdkBitableClient([
+        ...prefix,
+        { code: 0, data: { items: [firstItem], has_more: true, page_token: "page-2" } },
+        { code: 0, data: { items: [], has_more: true, page_token: " page-2 " } },
+        { code: 0, data: { items: [secondItem], has_more: false } },
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_opaque_pages", params);
+      const rows =
+        toolName === "feishu_bitable_get_meta" ? result.details.tables : result.details.fields;
+
+      expect(rows).toEqual([
+        expect.objectContaining(firstItem),
+        expect.objectContaining(secondItem),
+      ]);
+      const resourceCalls = request.mock.calls.filter(([options]) =>
+        options.url?.endsWith(resourcePath),
+      );
+      expect(resourceCalls.map(([options]) => options.params)).toEqual([
+        { page_size: 100 },
+        { page_size: 100, page_token: "page-2" },
+        { page_size: 100, page_token: " page-2 " },
+      ]);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "surfaces a later $name provider failure instead of returning partial success",
+    async ({ toolName, params, firstItem, prefix }) => {
+      const { request, post } = createSdkBitableClient([
+        ...prefix,
+        { code: 0, data: { items: [firstItem], has_more: true, page_token: "page-2" } },
+        { code: 91403, msg: "Bitable access was revoked" },
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_provider_error", params);
+
+      expect(result.details.error).toContain("Bitable access was revoked");
+      expect(request).toHaveBeenCalledTimes(prefix.length + 2);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "rejects a missing next-page cursor for $name",
+    async ({ toolName, params, firstItem, prefix }) => {
+      const { post } = createSdkBitableClient([
+        ...prefix,
+        { code: 0, data: { items: [firstItem], has_more: true, page_token: "  " } },
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_missing_cursor", params);
+
+      expect(result.details.error).toMatch(/missing.*page token/i);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "propagates a later $name HTTP transport failure",
+    async ({ toolName, params, firstItem, prefix }) => {
+      const { request, post } = createSdkBitableClient([
+        ...prefix,
+        { code: 0, data: { items: [firstItem], has_more: true, page_token: "page-2" } },
+        new Error("Feishu transport disconnected"),
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_transport_error", params);
+
+      expect(result.details.error).toContain("Feishu transport disconnected");
+      expect(request).toHaveBeenCalledTimes(prefix.length + 2);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "rejects a repeated next-page cursor for $name",
+    async ({ toolName, params, firstItem, prefix }) => {
+      const { request, post } = createSdkBitableClient([
+        ...prefix,
+        { code: 0, data: { items: [firstItem], has_more: true, page_token: "same-page" } },
+        { code: 0, data: { items: [], has_more: true, page_token: "same-page" } },
+      ]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_repeated_cursor", params);
+
+      expect(result.details.error).toMatch(/repeated.*page token/i);
+      expect(request).toHaveBeenCalledTimes(prefix.length + 2);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(bitablePaginationCases)(
+    "rejects a successful $name response without provider data",
+    async ({ toolName, params, prefix }) => {
+      const { post } = createSdkBitableClient([...prefix, { code: 0 }]);
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_bitable_missing_data", params);
+
+      expect(result.details.error).toMatch(/missing.*data/i);
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
+
+  it("bounds table field pagination before a provider can loop indefinitely", async () => {
+    const pages = Array.from({ length: 101 }, (_, index) => ({
+      code: 0,
+      data: { items: [], has_more: true, page_token: `page-${index + 1}` },
+    }));
+    const { request, post } = createSdkBitableClient(pages);
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_list_fields").execute(
+      "call_bitable_page_cap",
+      {
+        app_token: "appToken123",
+        table_id: "tblMain",
+      },
+    );
+
+    expect(result.details.error).toMatch(/pagination exceeded 100 pages/i);
+    expect(request).toHaveBeenCalledTimes(100);
+    expect(post).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -22,6 +22,11 @@ type BitableRecordFields = NonNullable<NonNullable<BitableRecordCreatePayload["d
 type BitableRecordUpdateFields = NonNullable<
   NonNullable<BitableRecordUpdatePayload["data"]>["fields"]
 >;
+type BitableListPage<T> = { items?: T[]; has_more?: boolean; page_token?: string };
+type BitablePageParams = { page_size: number; page_token?: string };
+
+const BITABLE_LIST_PAGE_SIZE = 100;
+const MAX_BITABLE_LIST_PAGES = 100;
 
 class LarkApiError extends Error {
   readonly code: number;
@@ -44,6 +49,43 @@ function ensureLarkSuccess<T>(
   if (res.code !== 0) {
     throw new LarkApiError(res.code ?? -1, res.msg ?? "unknown error", api, context);
   }
+}
+
+async function listBitableItems<T>(
+  listPage: (params: BitablePageParams) => Promise<LarkResponse<BitableListPage<T>>>,
+  api: string,
+  context: Record<string, unknown>,
+): Promise<T[]> {
+  const items: T[] = [];
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
+
+  for (let page = 0; page < MAX_BITABLE_LIST_PAGES; page += 1) {
+    const response = await listPage({
+      page_size: BITABLE_LIST_PAGE_SIZE,
+      ...(pageToken ? { page_token: pageToken } : {}),
+    });
+    ensureLarkSuccess(response, api, context);
+    if (!response.data) {
+      throw new Error(`${api} returned missing response data`);
+    }
+    items.push(...(response.data.items ?? []));
+    if (response.data.has_more !== true) {
+      return items;
+    }
+
+    // Provider cursors are opaque: reject blank values without changing token identity.
+    const nextPageToken = response.data.page_token;
+    if (!nextPageToken?.trim() || seenPageTokens.has(nextPageToken)) {
+      throw new Error(
+        `${api} pagination returned a ${nextPageToken?.trim() ? "repeated" : "missing"} page token`,
+      );
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  throw new Error(`${api} pagination exceeded ${MAX_BITABLE_LIST_PAGES} pages`);
 }
 
 /** Field type ID to human-readable name */
@@ -76,28 +118,16 @@ const FIELD_TYPE_NAMES: Record<number, string> = {
 /** Parse bitable URL and extract tokens */
 function parseBitableUrl(url: string): { token: string; tableId?: string; isWiki: boolean } | null {
   try {
-    const u = new URL(url);
-    const tableId = u.searchParams.get("table") ?? undefined;
-
-    // Wiki format: /wiki/XXXXX?table=YYY
-    const wikiMatch = u.pathname.match(/\/wiki\/([A-Za-z0-9]+)/);
-    if (wikiMatch) {
-      const wikiPathSegment = wikiMatch[1];
-      return wikiPathSegment === undefined
-        ? null
-        : { token: wikiPathSegment, tableId, isWiki: true };
-    }
-
-    // Base format: /base/XXXXX?table=YYY
-    const baseMatch = u.pathname.match(/\/base\/([A-Za-z0-9]+)/);
-    if (baseMatch) {
-      const basePathSegment = baseMatch[1];
-      return basePathSegment === undefined
-        ? null
-        : { token: basePathSegment, tableId, isWiki: false };
-    }
-
-    return null;
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/(wiki|base)\/([A-Za-z0-9]+)/);
+    const token = match?.[2];
+    return token
+      ? {
+          token,
+          tableId: parsed.searchParams.get("table") ?? undefined,
+          isWiki: match[1] === "wiki",
+        }
+      : null;
   } catch {
     return null;
   }
@@ -128,12 +158,7 @@ async function getBitableMeta(client: Lark.Client, url: string) {
     throw new Error("Invalid URL format. Expected /base/XXX or /wiki/XXX URL");
   }
 
-  let appToken: string;
-  if (parsed.isWiki) {
-    appToken = await getAppTokenFromWiki(client, parsed.token);
-  } else {
-    appToken = parsed.token;
-  }
+  const appToken = parsed.isWiki ? await getAppTokenFromWiki(client, parsed.token) : parsed.token;
 
   // Get bitable app info
   const res = await client.bitable.app.get({
@@ -142,18 +167,19 @@ async function getBitableMeta(client: Lark.Client, url: string) {
   ensureLarkSuccess(res, "bitable.app.get", { appToken });
 
   // List tables if no table_id specified
-  let tables: { table_id: string; name: string }[] = [];
-  if (!parsed.tableId) {
-    const tablesRes = await client.bitable.appTable.list({
-      path: { app_token: appToken },
-    });
-    if (tablesRes.code === 0) {
-      tables = (tablesRes.data?.items ?? []).map((t) => ({
-        table_id: t.table_id!,
-        name: t.name!,
-      }));
-    }
-  }
+  const tables = parsed.tableId
+    ? []
+    : (
+        await listBitableItems(
+          (params) =>
+            client.bitable.appTable.list({
+              path: { app_token: appToken },
+              params,
+            }),
+          "bitable.appTable.list",
+          { appToken },
+        )
+      ).map((table) => ({ table_id: table.table_id!, name: table.name! }));
 
   return {
     app_token: appToken,
@@ -168,12 +194,15 @@ async function getBitableMeta(client: Lark.Client, url: string) {
 }
 
 async function listFields(client: Lark.Client, appToken: string, tableId: string) {
-  const res = await client.bitable.appTableField.list({
-    path: { app_token: appToken, table_id: tableId },
-  });
-  ensureLarkSuccess(res, "bitable.appTableField.list", { appToken, tableId });
-
-  const fields = res.data?.items ?? [];
+  const fields = await listBitableItems(
+    (params) =>
+      client.bitable.appTableField.list({
+        path: { app_token: appToken, table_id: tableId },
+        params,
+      }),
+    "bitable.appTableField.list",
+    { appToken, tableId },
+  );
   return {
     fields: fields.map((f) => ({
       field_id: f.field_id,
@@ -494,18 +523,16 @@ const GetMetaSchema = Type.Object({
   }),
 });
 
-const ListFieldsSchema = Type.Object({
+const BitableTableSchema = {
   app_token: Type.String({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-});
+};
 
+const ListFieldsSchema = Type.Object(BitableTableSchema);
 const ListRecordsSchema = Type.Object({
-  app_token: Type.String({
-    description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
-  }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  ...BitableTableSchema,
   page_size: optionalPositiveIntegerSchema({
     description: "Number of records per page (1-500, default 100)",
     maximum: 500,
@@ -516,10 +543,7 @@ const ListRecordsSchema = Type.Object({
 });
 
 const GetRecordSchema = Type.Object({
-  app_token: Type.String({
-    description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
-  }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  ...BitableTableSchema,
   record_id: Type.String({ description: "Record ID to retrieve" }),
 });
 
@@ -530,10 +554,7 @@ const BitableFieldValueSchema = Type.Unsafe<unknown>({
 });
 
 const CreateRecordSchema = Type.Object({
-  app_token: Type.String({
-    description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
-  }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  ...BitableTableSchema,
   fields: Type.Record(Type.String(), BitableFieldValueSchema, {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
@@ -571,10 +592,7 @@ const CreateFieldSchema = Type.Object({
 });
 
 const UpdateRecordSchema = Type.Object({
-  app_token: Type.String({
-    description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
-  }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  ...BitableTableSchema,
   record_id: Type.String({ description: "Record ID to update" }),
   fields: Type.Record(Type.String(), BitableFieldValueSchema, {
     description: "Field values to update (same format as create_record)",
@@ -599,6 +617,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
   }
 
   type AccountAwareParams = { accountId?: string };
+  type BitableTableParams = AccountAwareParams & { app_token: string; table_id: string };
 
   const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) => {
     const account = resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId });
@@ -652,7 +671,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{ app_token: string; table_id: string; accountId?: string }>({
+  registerBitableTool<BitableTableParams>({
     name: "feishu_bitable_list_fields",
     label: "Feishu Bitable List Fields",
     description: "List all fields (columns) in a Bitable table with their types and properties",
@@ -662,13 +681,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{
-    app_token: string;
-    table_id: string;
-    page_size?: number;
-    page_token?: string;
-    accountId?: string;
-  }>({
+  registerBitableTool<BitableTableParams & { page_size?: number; page_token?: string }>({
     name: "feishu_bitable_list_records",
     label: "Feishu Bitable List Records",
     description: "List records (rows) from a Bitable table with pagination support",
@@ -684,12 +697,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{
-    app_token: string;
-    table_id: string;
-    record_id: string;
-    accountId?: string;
-  }>({
+  registerBitableTool<BitableTableParams & { record_id: string }>({
     name: "feishu_bitable_get_record",
     label: "Feishu Bitable Get Record",
     description: "Get a single record by ID from a Bitable table",
@@ -704,12 +712,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{
-    app_token: string;
-    table_id: string;
-    fields: BitableRecordFields;
-    accountId?: string;
-  }>({
+  registerBitableTool<BitableTableParams & { fields: BitableRecordFields }>({
     name: "feishu_bitable_create_record",
     label: "Feishu Bitable Create Record",
     description: "Create a new record (row) in a Bitable table",
@@ -724,13 +727,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{
-    app_token: string;
-    table_id: string;
-    record_id: string;
-    fields: BitableRecordUpdateFields;
-    accountId?: string;
-  }>({
+  registerBitableTool<
+    BitableTableParams & { record_id: string; fields: BitableRecordUpdateFields }
+  >({
     name: "feishu_bitable_update_record",
     label: "Feishu Bitable Update Record",
     description: "Update an existing record (row) in a Bitable table",
@@ -759,14 +758,13 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  registerBitableTool<{
-    app_token: string;
-    table_id: string;
-    field_name: string;
-    field_type: number;
-    property?: Record<string, unknown>;
-    accountId?: string;
-  }>({
+  registerBitableTool<
+    BitableTableParams & {
+      field_name: string;
+      field_type: number;
+      property?: Record<string, unknown>;
+    }
+  >({
     name: "feishu_bitable_create_field",
     label: "Feishu Bitable Create Field",
     description: "Create a new field (column) in a Bitable table",


### PR DESCRIPTION
## What This PR Does

Fixes the shared Feishu Bitable metadata pagination owner used by table discovery and field listing. Both operations now drain every page, preserve opaque provider continuation tokens exactly, detect blank or exactly repeated cursors, enforce a 100-page bound, and surface provider or transport failures instead of silently returning partial metadata.

## Why This Change Was Made

Both metadata endpoints previously read only the first provider page. A rejected intermediate revision also trimmed opaque continuation tokens, changing provider-owned cursor identity and collapsing legitimately distinct values. The corrected implementation validates whitespace-only tokens without modifying the raw token used for subsequent requests or repeat detection. It also consolidates existing table schemas and URL parsing, reducing production code by two lines.

## User Impact

Operators and agents receive complete Bitable table and field metadata, including entries beyond the first page. Existing wiki links, explicitly selected tables, account routing, record pagination, field schemas, provider errors, and placeholder-row cleanup retain their existing behavior. No configuration option, dependency, public API, or compatibility fallback is introduced.

## Evidence

- Frozen commit: `07658d1961ef35a82e4fafc4c2ea469e0e9777e8`; tree: `878df4376586f6b3c94e342e1649fe5e2bffd072`.
- Authentic pre-fix regression: **4 failed, 18 passed**; exact frozen corrected owner: **22 passed**.
- Regression cases exercise the real installed Lark SDK with an injected, **unauthenticated hermetic fake HTTP transport**. This is not a live-provider test and does not establish provider authentication.
- Both metadata resources preserve padded raw cursor bytes, distinguish padded and unpadded values, reject exact repeats and blank cursors, propagate provider and transport errors, and enforce the page bound.
- Four entirely fresh independent hostile reviews reported **zero P0–P3 findings** after all reviews for the rejected intermediate revision were withdrawn.
- Genuine `gpt-5.6-sol` high-reasoning autoreview through P3: **zero findings, 0.98 confidence**. Native TruffleHog 3.96.0: **zero findings**.
- Full owner lint, formatting, exact-parent diff checks, and immutable clean-worktree checks passed; production diff is **+97/-99**.
