### PR TITLE
fix(line): honor provider message action and delivery contracts

### DIFF
--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -1,6 +1,7 @@
 // Line plugin module implements actions behavior.
 import type { messagingApi } from "@line/bot-sdk";
 import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import { hasNonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
@@ -12,11 +13,78 @@ const LINE_ACTION_DATA_LIMIT = 300;
 const LINE_ACTION_URI_LIMIT = 1000;
 const LINE_CLIPBOARD_TEXT_LIMIT = 1000;
 const LINE_RICH_MENU_ALIAS_LIMIT = 32;
+const LINE_QUICK_REPLY_ITEM_LIMIT = 13;
+const LINE_QUICK_REPLY_IMAGE_URL_LIMIT = 2000;
 const LINE_IMAGEMAP_ACTION_LABEL_LIMIT = 100;
 const LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT = 400;
 const LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT = 30;
 const LINE_IMAGEMAP_ACTION_LIMIT = 50;
+const lineActionUriProtocols = new Set(["http:", "https:", "line:", "tel:"]);
+const linePostbackInputOptions = new Set([
+  "closeRichMenu",
+  "openRichMenu",
+  "openKeyboard",
+  "openVoice",
+]);
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function isValidLineUri(value: unknown, icon = false): value is string {
+  const limit = icon ? LINE_QUICK_REPLY_IMAGE_URL_LIMIT : LINE_ACTION_URI_LIMIT;
+  if (typeof value !== "string" || value.length > limit) {
+    return false;
+  }
+  try {
+    const protocol = new URL(value).protocol;
+    return icon ? protocol === "https:" : lineActionUriProtocols.has(protocol);
+  } catch {
+    return false;
+  }
+}
+
+function invalidLineUriReason(value: unknown): string {
+  return typeof value === "string" && value.length > LINE_ACTION_URI_LIMIT
+    ? "URL exceeds LINE's limit."
+    : "URL scheme is not supported by LINE.";
+}
+
+function isValidLineDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return false;
+  }
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  if (year < 1900 || year > 2100) {
+    return false;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+function isValidLinePickerValue(value: unknown, mode: string): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const isTime = (time: string) => /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(time);
+  if (mode === "date") {
+    return isValidLineDate(value);
+  }
+  if (mode === "time") {
+    return isTime(value);
+  }
+  const [date, time, ...extra] = value.split(/[Tt]/);
+  return (
+    extra.length === 0 &&
+    date !== undefined &&
+    time !== undefined &&
+    isValidLineDate(date) &&
+    isTime(time)
+  );
+}
 
 function truncateLineActionText(text: string, limit: number): string {
   let result = "";
@@ -72,15 +140,79 @@ function isLineAction(value: unknown): value is Action {
   return isRecord(value) && typeof value.type === "string" && actionTypes.has(value.type);
 }
 
+function isValidQuickReplyAction(value: unknown): value is Action {
+  if (!isLineAction(value) || !hasNonEmptyString(value.label)) {
+    return false;
+  }
+  switch (value.type) {
+    case "message":
+      return typeof value.text === "string";
+    case "uri":
+      return hasNonEmptyString(value.uri);
+    case "postback":
+      // Callback data explicitly allows an empty string; only a missing value is invalid.
+      return typeof value.data === "string";
+    case "datetimepicker":
+      return (
+        typeof value.data === "string" &&
+        (value.mode === "date" || value.mode === "time" || value.mode === "datetime")
+      );
+    default:
+      return true;
+  }
+}
+
 function isUnavailableAction(action: Action): action is UnavailableAction {
   return (action as Partial<UnavailableAction>)[unavailableActionMarker] === true;
 }
 
-function normalizeNestedActions(value: unknown, labelLimit: number, warnings?: string[]): unknown {
+type LineMessageActionSurface = "flex" | "template" | "image-carousel" | "quick-reply";
+
+function normalizeMessageSurfaceAction(
+  action: Action,
+  labelLimit: number,
+  surface: LineMessageActionSurface,
+  requireLabel = false,
+): Action {
+  if (surface === "quick-reply" && !isValidQuickReplyAction(action)) {
+    // Existing malformed buttons remain filterable instead of consuming visible reply slots.
+    return action;
+  }
+  if (requireLabel && !hasNonEmptyString(action.label)) {
+    return unavailableAction("Action", "action label is missing.");
+  }
+  // Rich-menu switching is valid only on menu areas, never on message-owned actions.
+  if (action.type === "richmenuswitch") {
+    return unavailableAction("Action", "rich menu switching is only available in rich menus.");
+  }
+  // Camera, camera-roll, and location controls are exclusive to quick-reply buttons.
+  if (
+    surface !== "quick-reply" &&
+    (action.type === "camera" || action.type === "cameraRoll" || action.type === "location")
+  ) {
+    return unavailableAction("Action", "this action is only available in quick replies.");
+  }
+  if (surface === "quick-reply" && action.type === "postback" && action.text !== undefined) {
+    // Quick replies reject deprecated text; displayText preserves its visible wording.
+    const { text, ...postback } = action;
+    return normalizeLineAction(
+      { ...postback, displayText: postback.displayText ?? text },
+      labelLimit,
+    );
+  }
+  return normalizeLineAction(action, labelLimit);
+}
+
+function normalizeNestedActions(
+  value: unknown,
+  labelLimit: number,
+  surface: LineMessageActionSurface = "flex",
+  warnings?: string[],
+): unknown {
   if (Array.isArray(value)) {
     const normalized: unknown[] = [];
     for (const item of value) {
-      normalized.push(normalizeNestedActions(item, labelLimit, warnings));
+      normalized.push(normalizeNestedActions(item, labelLimit, surface, warnings));
     }
     return normalized;
   }
@@ -90,8 +222,25 @@ function normalizeNestedActions(value: unknown, labelLimit: number, warnings?: s
 
   const normalized: Record<string, unknown> = { ...value };
   for (const [key, nested] of Object.entries(value)) {
-    if ((key === "action" || key === "defaultAction") && isLineAction(nested)) {
-      const action = normalizeLineAction(nested, labelLimit);
+    if (key === "action" || key === "defaultAction") {
+      if (!isLineAction(nested)) {
+        if (surface === "quick-reply") {
+          continue;
+        }
+        if (key === "defaultAction" || (surface === "flex" && value.type !== "button")) {
+          delete normalized[key];
+          if (warnings && key === "action") {
+            warnings.push("Action unavailable: action type is not supported by LINE.");
+          }
+        } else {
+          normalized[key] = unavailableAction("Action", "action type is not supported by LINE.");
+        }
+        continue;
+      }
+      const requiresLabel =
+        key !== "defaultAction" &&
+        (surface === "template" || (surface === "flex" && value.type === "button"));
+      const action = normalizeMessageSurfaceAction(nested, labelLimit, surface, requiresLabel);
       if (
         warnings &&
         key === "action" &&
@@ -109,10 +258,14 @@ function normalizeNestedActions(value: unknown, labelLimit: number, warnings?: s
       }
     } else if (key === "actions" && Array.isArray(nested)) {
       normalized[key] = nested.map((action) =>
-        isLineAction(action) ? normalizeLineAction(action, labelLimit) : action,
+        isLineAction(action)
+          ? normalizeMessageSurfaceAction(action, labelLimit, surface, surface === "template")
+          : surface === "quick-reply"
+            ? action
+            : unavailableAction("Action", "action type is not supported by LINE."),
       );
     } else {
-      normalized[key] = normalizeNestedActions(nested, labelLimit, warnings);
+      normalized[key] = normalizeNestedActions(nested, labelLimit, surface, warnings);
     }
   }
   return normalized;
@@ -124,7 +277,7 @@ function normalizeFlexBubbleActions(value: unknown): unknown {
   }
 
   const warnings: string[] = [];
-  const normalized = normalizeNestedActions(value, 40, warnings);
+  const normalized = normalizeNestedActions(value, 40, "flex", warnings);
   if (!isRecord(normalized) || warnings.length === 0) {
     return normalized;
   }
@@ -182,13 +335,16 @@ function normalizeImagemapAction(action: ImagemapAction): ImagemapAction {
       : truncateLineActionText(action.label, LINE_IMAGEMAP_ACTION_LABEL_LIMIT);
 
   if (action.type === "uri") {
-    if (truncateUtf16Safe(action.linkUri, LINE_ACTION_URI_LIMIT) !== action.linkUri) {
-      return unavailableImagemapAction("Link", "URL exceeds LINE's limit.", action.area);
+    if (!isValidLineUri(action.linkUri)) {
+      return unavailableImagemapAction("Link", invalidLineUriReason(action.linkUri), action.area);
     }
     return { ...action, label };
   }
 
   if (action.type === "message") {
+    if (typeof action.text !== "string") {
+      return unavailableImagemapAction("Action", "message text is missing.", action.area);
+    }
     const text = truncateUtf16Safe(action.text, LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT);
     if (text !== action.text) {
       return unavailableImagemapAction("Action", "message text exceeds LINE's limit.", action.area);
@@ -196,6 +352,9 @@ function normalizeImagemapAction(action: ImagemapAction): ImagemapAction {
     return { ...action, label, text };
   }
 
+  if (typeof action.clipboardText !== "string" || action.clipboardText.length === 0) {
+    return unavailableImagemapAction("Action", "clipboard text must not be empty.", action.area);
+  }
   if (truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !== action.clipboardText) {
     return unavailableImagemapAction("Action", "clipboard text exceeds LINE's limit.", action.area);
   }
@@ -207,18 +366,13 @@ function normalizeImagemapVideo(video: ImagemapVideo): {
   fallbackAction?: ImagemapAction;
 } {
   const externalLink = video.externalLink;
-  if (!externalLink) {
+  if (externalLink === undefined) {
     return { video };
   }
-
-  const label =
-    externalLink.label === undefined
-      ? undefined
-      : truncateUtf16Safe(externalLink.label, LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT) ||
-        (externalLink.label ? "…" : "");
   if (
-    externalLink.linkUri !== undefined &&
-    truncateUtf16Safe(externalLink.linkUri, LINE_ACTION_URI_LIMIT) !== externalLink.linkUri
+    !isRecord(externalLink) ||
+    !isValidLineUri(externalLink.linkUri) ||
+    !hasNonEmptyString(externalLink.label)
   ) {
     const normalizedVideo = { ...video };
     delete normalizedVideo.externalLink;
@@ -227,9 +381,23 @@ function normalizeImagemapVideo(video: ImagemapVideo): {
       fallbackAction:
         video.area === undefined
           ? undefined
-          : unavailableImagemapAction("Link", "URL exceeds LINE's limit.", video.area),
+          : unavailableImagemapAction(
+              "Link",
+              isRecord(externalLink) && isValidLineUri(externalLink.linkUri)
+                ? "video link label is missing."
+                : invalidLineUriReason(
+                    isRecord(externalLink) ? externalLink.linkUri : externalLink,
+                  ),
+              video.area,
+            ),
     };
   }
+
+  const label =
+    externalLink.label === undefined
+      ? undefined
+      : truncateUtf16Safe(externalLink.label, LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT) ||
+        (externalLink.label ? "…" : "");
   return { video: { ...video, externalLink: { ...externalLink, label } } };
 }
 
@@ -244,7 +412,11 @@ export function normalizeLineMessageActions(message: Message): Message {
     const labelLimit = message.template.type === "image_carousel" ? 12 : 20;
     normalized = {
       ...message,
-      template: normalizeNestedActions(message.template, labelLimit) as messagingApi.Template,
+      template: normalizeNestedActions(
+        message.template,
+        labelLimit,
+        message.template.type === "image_carousel" ? "image-carousel" : "template",
+      ) as messagingApi.Template,
     };
   } else if (message.type === "imagemap") {
     const actions = message.actions.map(normalizeImagemapAction);
@@ -265,11 +437,36 @@ export function normalizeLineMessageActions(message: Message): Message {
     normalized = { ...message };
   }
 
-  if (message.quickReply) {
-    normalized = {
-      ...normalized,
-      quickReply: normalizeNestedActions(message.quickReply, 20) as messagingApi.QuickReply,
-    };
+  if (Array.isArray(message.quickReply?.items) && message.quickReply.items.length > 0) {
+    const quickReply = normalizeNestedActions(
+      message.quickReply,
+      LINE_ACTION_LABEL_LIMIT,
+      "quick-reply",
+    ) as messagingApi.QuickReply;
+    // Invalid buttons must not consume LINE's 13 visible quick-reply slots.
+    const items: messagingApi.QuickReplyItem[] = [];
+    for (const item of quickReply.items ?? []) {
+      if (!isRecord(item) || !isValidQuickReplyAction(item.action)) {
+        continue;
+      }
+      const { imageUrl, ...itemWithoutImage } = item;
+      items.push({
+        ...(imageUrl === undefined || isValidLineUri(imageUrl, true) ? item : itemWithoutImage),
+        type: "action",
+        action: item.action,
+      });
+      if (items.length === LINE_QUICK_REPLY_ITEM_LIMIT) {
+        break;
+      }
+    }
+    if (items.length > 0) {
+      normalized = { ...normalized, quickReply: { ...quickReply, items } };
+    } else {
+      delete normalized.quickReply;
+    }
+  } else if (message.quickReply) {
+    // LINE rejects empty quick replies; retain the visible message without an invalid action.
+    delete normalized.quickReply;
   }
 
   return normalized;
@@ -281,82 +478,128 @@ export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LAB
   }
   const label =
     action.label === undefined ? undefined : truncateLineActionLabel(action.label, labelLimit);
+  const normalizedLabel = label === undefined ? {} : { label };
 
   if (action.type === "uri") {
-    const uriTooLong =
-      action.uri !== undefined &&
-      truncateUtf16Safe(action.uri, LINE_ACTION_URI_LIMIT) !== action.uri;
-    const desktopUri = action.altUri?.desktop;
-    const desktopUriTooLong =
-      desktopUri !== undefined &&
-      truncateUtf16Safe(desktopUri, LINE_ACTION_URI_LIMIT) !== desktopUri;
-    if (uriTooLong || desktopUriTooLong) {
-      return unavailableAction("Link", "URL exceeds LINE's limit.");
+    if (!isValidLineUri(action.uri)) {
+      return unavailableAction("Link", invalidLineUriReason(action.uri));
     }
-    return { ...action, label };
+    if (
+      action.altUri !== undefined &&
+      (!isRecord(action.altUri) ||
+        (action.altUri.desktop !== undefined && !isValidLineUri(action.altUri.desktop)))
+    ) {
+      // Raw Flex input may include a malformed optional container; retain the primary link.
+      const normalized = { ...action, ...normalizedLabel };
+      delete normalized.altUri;
+      return normalized;
+    }
+    return { ...action, ...normalizedLabel };
   }
 
   if (action.type === "postback") {
-    const data = action.data === undefined ? undefined : truncateLineActionData(action.data);
+    if (typeof action.data !== "string") {
+      return unavailableAction("Action", "callback data is missing.");
+    }
+    const { text: deprecatedText, ...postback } = action;
+    const data = truncateLineActionData(action.data);
     if (data !== action.data) {
       // Callback data is opaque and echoed back by LINE. Never dispatch a value
       // whose identity changed merely to satisfy the transport cap.
       return unavailableAction("Action", "callback data exceeds LINE's limit.");
     }
+    const legacyText = action.displayText === undefined ? deprecatedText : undefined;
     const text =
-      action.text === undefined
+      legacyText === undefined
         ? undefined
-        : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT);
+        : truncateLineActionText(legacyText, LINE_ACTION_DATA_LIMIT);
     const fillInText =
       action.fillInText === undefined
         ? undefined
         : truncateLineActionText(action.fillInText, LINE_ACTION_DATA_LIMIT);
-    if (text !== action.text || fillInText !== action.fillInText) {
+    if (text !== legacyText || fillInText !== action.fillInText) {
       return unavailableAction("Action", "message text exceeds LINE's limit.");
     }
-    return {
-      ...action,
-      label,
+    // Modern displayText wins: LINE rejects requests containing both text fields.
+    const normalized = {
+      ...postback,
+      ...normalizedLabel,
       data,
       displayText:
         action.displayText === undefined
           ? undefined
           : truncateLineActionText(action.displayText, LINE_ACTION_DATA_LIMIT),
-      text,
+      ...(text === undefined ? {} : { text }),
       fillInText,
     };
+    if (
+      normalized.inputOption !== undefined &&
+      !linePostbackInputOptions.has(normalized.inputOption)
+    ) {
+      delete normalized.inputOption;
+    }
+    if (normalized.inputOption !== "openKeyboard") {
+      delete normalized.fillInText;
+    }
+    return normalized;
   }
 
   if (action.type === "datetimepicker") {
-    const data = action.data === undefined ? undefined : truncateLineActionData(action.data);
+    if (
+      typeof action.data !== "string" ||
+      (action.mode !== "date" && action.mode !== "time" && action.mode !== "datetime")
+    ) {
+      return unavailableAction("Action", "date picker data or mode is missing.");
+    }
+    const data = truncateLineActionData(action.data);
     if (data !== action.data) {
       return unavailableAction("Action", "callback data exceeds LINE's limit.");
     }
-    return { ...action, label, data };
+    const normalized = { ...action, ...normalizedLabel, data };
+    for (const field of ["initial", "min", "max"] as const) {
+      if (
+        normalized[field] !== undefined &&
+        !isValidLinePickerValue(normalized[field], action.mode)
+      ) {
+        delete normalized[field];
+      }
+    }
+    if (
+      normalized.min !== undefined &&
+      normalized.max !== undefined &&
+      normalized.min.toUpperCase() >= normalized.max.toUpperCase()
+    ) {
+      delete normalized.min;
+      delete normalized.max;
+    }
+    return normalized;
   }
 
   if (action.type === "message") {
-    const text =
-      action.text === undefined
-        ? undefined
-        : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT);
+    if (typeof action.text !== "string") {
+      return unavailableAction("Action", "message text is missing.");
+    }
+    const text = truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT);
     if (text !== action.text) {
       return unavailableAction("Action", "message text exceeds LINE's limit.");
     }
     return {
       ...action,
-      label,
+      ...normalizedLabel,
       text,
     };
   }
 
   if (action.type === "clipboard") {
+    if (typeof action.clipboardText !== "string" || action.clipboardText.length === 0) {
+      return unavailableAction("Action", "clipboard text must not be empty.");
+    }
     if (
       truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !== action.clipboardText
     ) {
       return unavailableAction("Action", "clipboard text exceeds LINE's limit.");
     }
-    return { ...action, label };
+    return { ...action, ...normalizedLabel };
   }
 
   if (action.type === "richmenuswitch") {
@@ -368,7 +611,7 @@ export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LAB
     if (data !== action.data || aliasTooLong) {
       return unavailableAction("Action", "rich menu data exceeds LINE's limit.");
     }
-    return { ...action, label, data };
+    return { ...action, ...normalizedLabel, data };
   }
 
   return action.label === label ? action : { ...action, label };

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -7,6 +7,7 @@ import {
   datetimePickerAction,
   messageAction,
   normalizeLineAction,
+  normalizeLineMessageActions,
   postbackAction,
   truncateLineActionLabel,
   uriAction,
@@ -36,33 +37,23 @@ import {
 } from "./template-messages.js";
 
 const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+function unavailableLineAction(kind: "Action" | "Link", reason: string): Action {
+  return { type: "message", label: "Unavailable", text: `${kind} unavailable: ${reason}` };
+}
+const unavailableCallback = unavailableLineAction("Action", "callback data exceeds LINE's limit.");
+const unavailableLink = unavailableLineAction("Link", "URL exceeds LINE's limit.");
 const lineFlexCardCommandScenarios = [
-  {
-    kind: "info",
-    args: (body: string) => `info "Title" "${body}"`,
-    expectedAltText: (body: string) => `Title: ${body}`,
-  },
-  {
-    kind: "image",
-    args: (body: string) => `image "Title" "${body}" --url https://example.test/image.png`,
-    expectedAltText: (body: string) => `Title: ${body}`,
-  },
-  {
-    kind: "action",
-    args: (body: string) => `action "Title" "${body}" --actions "Open|ok"`,
-    expectedAltText: (body: string) => `Title: ${body}`,
-  },
-  {
-    kind: "list",
-    args: (body: string) => `list "Title" "${body}|Description"`,
-    expectedAltText: (body: string) => `Title: ${body}`,
-  },
-  {
-    kind: "receipt",
-    args: (body: string) => `receipt "Title" "${body}:$1" --total "$1"`,
-    expectedAltText: (body: string) => `Title: ${body} $1`,
-  },
+  ["info", (body: string) => `info "Title" "${body}"`],
+  ["image", (body: string) => `image "Title" "${body}" --url https://example.test/image.png`],
+  ["action", (body: string) => `action "Title" "${body}" --actions "Open|ok"`],
+  ["list", (body: string) => `list "Title" "${body}|Description"`],
+  ["receipt", (body: string) => `receipt "Title" "${body}:$1" --total "$1"`],
 ] as const;
+const lineFlexCardScenarios = lineFlexCardCommandScenarios.map(([kind, args]) => ({
+  kind,
+  args,
+  expectedAltText: (body: string) => `Title: ${body}${kind === "receipt" ? " $1" : ""}`,
+}));
 
 const lineTemplateMessageScenarios = [
   {
@@ -99,25 +90,25 @@ const lineTemplateMessageScenarios = [
 async function runLineFlexCardCommand(
   args: string,
 ): Promise<{ altText: string; contents: messagingApi.FlexContainer }> {
-  const result = (await registerCommandWithHandler((command: unknown) => {
-    const { handler } = command as {
-      handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
-    };
-    return handler({ channel: "line", args });
-  })) as {
-    channelData: {
-      line: { flexMessage: { altText: string; contents: messagingApi.FlexContainer } };
-    };
-  };
-  return result.channelData.line.flexMessage;
+  let result: Promise<unknown> | undefined;
+  registerLineCardCommand({
+    registerCommand(command: unknown) {
+      const { handler } = command as {
+        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
+      };
+      result = handler({ channel: "line", args });
+    },
+  } as never);
+  return (
+    (await result) as {
+      channelData: {
+        line: { flexMessage: { altText: string; contents: messagingApi.FlexContainer } };
+      };
+    }
+  ).channelData.line.flexMessage;
 }
 
-type LineProviderRequest = {
-  path: string;
-  authenticated: boolean;
-  type: string;
-  altText: string;
-};
+type LineProviderRequest = { path: string; authenticated: boolean; type: string; altText: string };
 
 async function withLineProvider(
   run: (client: messagingApi.MessagingApiClient, requests: LineProviderRequest[]) => Promise<void>,
@@ -165,55 +156,36 @@ async function withLineProvider(
 }
 
 describe("createConfirmTemplate", () => {
-  it("truncates text to 240 characters", () => {
+  it("truncates text and drops a split surrogate-pair emoji", () => {
     const longText = "x".repeat(300);
     const template = createConfirmTemplate(longText, messageAction("Yes"), messageAction("No"));
-
     expect((template.template as { text: string }).text.length).toBe(240);
-  });
-
-  it("drops a surrogate-pair emoji from fallback altText instead of splitting it", () => {
-    const template = createConfirmTemplate(
+    const emojiTemplate = createConfirmTemplate(
       `${"x".repeat(1499)}😀`,
       messageAction("Yes"),
       messageAction("No"),
     );
-
-    expect(template.altText).toBe("x".repeat(1499));
-    expect(loneHighSurrogate.test(template.altText)).toBe(false);
+    expect(emojiTemplate.altText).toBe("x".repeat(1499));
+    expect(loneHighSurrogate.test(emojiTemplate.altText)).toBe(false);
   });
 });
 
 describe("createButtonTemplate", () => {
-  it("omits a blank optional title", () => {
+  it("normalizes missing titles, title bounds, and visible action limits", () => {
     const template = createButtonTemplate(undefined, "Text", [messageAction("OK")]);
-    expect(template).toMatchObject({
-      altText: "Text",
-      template: { type: "buttons", text: "Text" },
-    });
+    expect(template.altText).toBe("Text");
+    expect(template.template).toMatchObject({ type: "buttons", text: "Text" });
     expect(template.template).not.toHaveProperty("title");
-  });
-
-  it("uses the titleless 160-character text limit for an empty title", () => {
-    const template = createButtonTemplate("", "x".repeat(160), [messageAction("OK")]);
-    expect(template.template).toMatchObject({ text: "x".repeat(160) });
-  });
-
-  it("limits actions to 4", () => {
+    const titleless = createButtonTemplate("", "x".repeat(160), [messageAction("OK")]);
+    expect(titleless.template).toMatchObject({ text: "x".repeat(160) });
     const actions = Array.from({ length: 6 }, (_, i) => messageAction(`Button ${i}`));
-    const template = createButtonTemplate("Title", "Text", actions);
-
-    expect((template.template as { actions: unknown[] }).actions.length).toBe(4);
+    const limited = createButtonTemplate("Title", "Text", actions);
+    expect((limited.template as { actions: unknown[] }).actions.length).toBe(4);
+    const titled = createButtonTemplate("x".repeat(50), "Text", [messageAction("OK")]);
+    expect((titled.template as { title: string }).title.length).toBe(40);
   });
 
-  it("truncates title to 40 characters", () => {
-    const longTitle = "x".repeat(50);
-    const template = createButtonTemplate(longTitle, "Text", [messageAction("OK")]);
-
-    expect((template.template as { title: string }).title.length).toBe(40);
-  });
-
-  it("drops a surrogate-pair emoji from the title instead of splitting it", () => {
+  it("drops split surrogate-pair emojis from titles and explicit alternative text", () => {
     // 39 chars + an emoji land the truncation boundary inside the surrogate pair;
     // a raw code-unit slice would keep only the lone high surrogate.
     const template = createButtonTemplate(`${"x".repeat(39)}😀`, "Text", [messageAction("OK")]);
@@ -221,121 +193,66 @@ describe("createButtonTemplate", () => {
 
     expect(title).toBe("x".repeat(39));
     expect(loneHighSurrogate.test(title)).toBe(false);
-  });
-
-  it("drops a surrogate-pair emoji from explicit altText instead of splitting it", () => {
-    const template = createButtonTemplate("Title", "Text", [messageAction("OK")], {
+    const altTextTemplate = createButtonTemplate("Title", "Text", [messageAction("OK")], {
       altText: `${"x".repeat(1499)}😀`,
     });
-
-    expect(template.altText).toBe("x".repeat(1499));
-    expect(loneHighSurrogate.test(template.altText)).toBe(false);
+    expect(altTextTemplate.altText).toBe("x".repeat(1499));
+    expect(loneHighSurrogate.test(altTextTemplate.altText)).toBe(false);
   });
 
-  it("truncates text to 60 chars when no thumbnail is provided", () => {
-    const longText = "x".repeat(100);
-    const template = createButtonTemplate("Title", longText, [messageAction("OK")]);
-
-    expect((template.template as { text: string }).text.length).toBe(60);
-  });
-
-  it("truncates text to 60 chars when title and thumbnail are provided", () => {
-    const longText = "x".repeat(100);
-    const template = createButtonTemplate("Title", longText, [messageAction("OK")], {
-      thumbnailImageUrl: "https://example.com/thumb.jpg",
-    });
-
-    expect((template.template as { text: string }).text.length).toBe(60);
-  });
+  it.each([undefined, { thumbnailImageUrl: "https://example.com/thumb.jpg" }])(
+    "truncates titled text to 60 characters with thumbnail options %o",
+    (options) => {
+      const template = createButtonTemplate(
+        "Title",
+        "x".repeat(100),
+        [messageAction("OK")],
+        options,
+      );
+      expect((template.template as { text: string }).text).toHaveLength(60);
+    },
+  );
 });
 
 describe("createCarouselColumn", () => {
   it("limits actions to 3", () => {
     const column = createCarouselColumn({
       text: "Text",
-      actions: [
-        messageAction("A1"),
-        messageAction("A2"),
-        messageAction("A3"),
-        messageAction("A4"),
-        messageAction("A5"),
-      ],
+      actions: Array.from({ length: 5 }, (_, index) => messageAction(`A${index + 1}`)),
     });
 
     expect(column.actions.length).toBe(3);
   });
 
-  it("truncates text to 120 characters when no title or image is set", () => {
-    const longText = "x".repeat(150);
-    const column = createCarouselColumn({ text: longText, actions: [messageAction("OK")] });
-
-    expect(column.text.length).toBe(120);
-  });
-
-  it("truncates text to 60 characters when a title is set", () => {
-    const longText = "x".repeat(150);
+  it.each([
+    { name: "neither title nor image", options: {}, limit: 120 },
+    { name: "a title", options: { title: "Title" }, limit: 60 },
+    {
+      name: "a thumbnail",
+      options: { thumbnailImageUrl: "https://example.com/thumb.jpg" },
+      limit: 60,
+    },
+  ])("truncates text to $limit characters with $name", ({ options, limit }) => {
     const column = createCarouselColumn({
-      title: "Title",
-      text: longText,
-      actions: [messageAction("OK")],
-    });
-
-    expect(column.text.length).toBe(60);
-  });
-
-  it("drops a surrogate-pair emoji from the title instead of splitting it", () => {
-    const column = createCarouselColumn({
-      title: `${"x".repeat(39)}😀`,
-      text: "Text",
-      actions: [messageAction("OK")],
-    });
-
-    expect(column.title).toBe("x".repeat(39));
-    expect(loneHighSurrogate.test(column.title ?? "")).toBe(false);
-  });
-
-  it("does not split an emoji grapheme at the 60-code-unit boundary", () => {
-    const text = `${"x".repeat(59)}👨‍👩‍👧‍👦after`;
-    const column = createCarouselColumn({
-      title: "Title",
-      text,
-      actions: [messageAction("OK")],
-    });
-
-    expect(column.text).toBe("x".repeat(59));
-  });
-
-  it("keeps required text when the first grapheme exceeds the limit", () => {
-    const text = `😀${"\u0301".repeat(59)}`;
-    const column = createCarouselColumn({
-      title: "Title",
-      text,
-      actions: [messageAction("OK")],
-    });
-
-    expect(column.text.length).toBe(60);
-    expect(column.text.startsWith("😀")).toBe(true);
-  });
-
-  it("uses the compact limit when a whitespace-only title is present", () => {
-    const column = createCarouselColumn({
-      title: " ",
+      ...options,
       text: "x".repeat(150),
       actions: [messageAction("OK")],
     });
 
-    expect(column.text).toBe("x".repeat(60));
+    expect(column.text).toHaveLength(limit);
   });
 
-  it("truncates text to 60 characters when a thumbnail image is set", () => {
-    const longText = "x".repeat(150);
-    const column = createCarouselColumn({
-      text: longText,
-      thumbnailImageUrl: "https://example.com/thumb.jpg",
-      actions: [messageAction("OK")],
-    });
-
-    expect(column.text.length).toBe(60);
+  it("preserves Unicode boundaries and compact carousel title limits", () => {
+    const createColumn = (title: string, text: string) =>
+      createCarouselColumn({ title, text, actions: [messageAction("OK")] });
+    const title = createColumn(`${"x".repeat(39)}😀`, "Text").title;
+    expect(title).toBe("x".repeat(39));
+    expect(loneHighSurrogate.test(title ?? "")).toBe(false);
+    expect(createColumn("Title", `${"x".repeat(59)}👨‍👩‍👧‍👦after`).text).toBe("x".repeat(59));
+    const oversizedGrapheme = createColumn("Title", `😀${"\u0301".repeat(59)}`).text;
+    expect(oversizedGrapheme).toHaveLength(60);
+    expect(oversizedGrapheme.startsWith("😀")).toBe(true);
+    expect(createColumn(" ", "x".repeat(150)).text).toBe("x".repeat(60));
   });
 });
 
@@ -362,56 +279,31 @@ describe("carousel column limits", () => {
     expect((template.template as { columns: unknown[] }).columns.length).toBe(10);
   });
 
-  it("drops a surrogate-pair emoji from image-carousel altText instead of splitting it", () => {
+  it("preserves image-carousel Unicode bounds and unavailable action labels", () => {
     const template = createImageCarousel(
-      [createImageCarouselColumn("https://example.com/0.jpg", messageAction("View"))],
+      [
+        createImageCarouselColumn(
+          "https://example.com/0.jpg",
+          uriAction("Open", `https://example.com/?q=${"x".repeat(1200)}`),
+        ),
+      ],
       `${"x".repeat(1499)}😀`,
     );
+    const column = (template.template as messagingApi.ImageCarouselTemplate).columns[0];
 
     expect(template.altText).toBe("x".repeat(1499));
     expect(loneHighSurrogate.test(template.altText)).toBe(false);
-  });
-
-  it("keeps unavailable action labels within the image-carousel cap", () => {
-    const template = createImageCarousel([
-      createImageCarouselColumn(
-        "https://example.com/0.jpg",
-        uriAction("Open", `https://example.com/?q=${"x".repeat(1200)}`),
-      ),
-    ]);
-    const column = (
-      template.template as {
-        columns: Array<{ action: { label?: string; text?: string; type: string } }>;
-      }
-    ).columns[0];
-
-    expect(column?.action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
+    expect(column?.action).toEqual(unavailableLink);
     expect(column?.action.label).toHaveLength(11);
   });
 });
 
 describe("createProductCarousel", () => {
   it.each([
-    {
-      title: "Product",
-      description: "Desc",
-      actionLabel: "Buy",
-      actionUrl: "https://shop.com/buy",
-      expectedType: "uri",
-    },
-    {
-      title: "Product",
-      description: "Desc",
-      actionLabel: "Select",
-      actionData: "product_id=123",
-      expectedType: "postback",
-    },
+    { actionLabel: "Buy", actionUrl: "https://shop.com/buy", expectedType: "uri" },
+    { actionLabel: "Select", actionData: "product_id=123", expectedType: "postback" },
   ])("uses expected action type for product action", ({ expectedType, ...item }) => {
-    const template = createProductCarousel([item]);
+    const template = createProductCarousel([{ title: "Product", description: "Desc", ...item }]);
     const columns = (template.template as { columns: Array<{ actions: Array<{ type: string }> }> })
       .columns;
     const column = expectDefined(columns[0], "product carousel column");
@@ -420,11 +312,7 @@ describe("createProductCarousel", () => {
 
   it("preserves the complete price when truncating a long description", () => {
     const template = createProductCarousel([
-      {
-        title: "Product",
-        description: "x".repeat(59),
-        price: "$12.99",
-      },
+      { title: "Product", description: "x".repeat(59), price: "$12.99" },
     ]);
     const columns = (template.template as { columns: Array<{ text: string }> }).columns;
 
@@ -435,73 +323,349 @@ describe("createProductCarousel", () => {
 });
 
 describe("flex cards", () => {
-  it("includes footer when provided", () => {
-    const card = createInfoCard("Title", "Body", "Footer text");
-
-    const footer = card.footer as { contents: Array<{ text: string }> };
+  it("preserves optional footer, image-body, and event fields", () => {
+    const info = createInfoCard("Title", "Body", "Footer text");
+    const footer = info.footer as { contents: Array<{ text: string }> };
     expect(expectDefined(footer.contents[0], "info-card footer content").text).toBe("Footer text");
-  });
-
-  it("limits list items to 8", () => {
-    const items = Array.from({ length: 15 }, (_, i) => ({ title: `Item ${i}` }));
-    const card = createListCard("List", items);
-
-    const body = card.body as { contents: Array<{ type: string; contents?: unknown[] }> };
-    const listBox = body.contents[2] as { contents: unknown[] };
-    expect(listBox.contents.length).toBe(8);
-  });
-
-  it("includes image-card body text when provided", () => {
-    const card = createImageCard("https://example.com/img.jpg", "Title", "Body text");
-
-    const body = card.body as { contents: Array<{ text: string }> };
-    expect(body.contents.length).toBe(2);
-    expect(expectDefined(body.contents[1], "image-card body content").text).toBe("Body text");
-  });
-
-  it("limits action-card actions to 4", () => {
-    const actions = Array.from({ length: 6 }, (_, i) => ({
-      label: `Action ${i}`,
-      action: { type: "message" as const, label: `A${i}`, text: `action${i}` },
-    }));
-    const card = createActionCard("Title", "Body", actions);
-
-    const footer = card.footer as { contents: unknown[] };
-    expect(footer.contents.length).toBe(4);
-  });
-
-  it("limits carousels to 12 bubbles", () => {
-    const bubbles = Array.from({ length: 15 }, (_, i) => createInfoCard(`Card ${i}`, `Body ${i}`));
-    const carousel = createCarousel(bubbles);
-
-    expect(carousel.contents.length).toBe(12);
-  });
-
-  it("limits device controls to 6", () => {
-    const card = createDeviceControlCard({
-      deviceName: "Device",
-      controls: Array.from({ length: 10 }, (_, i) => ({
-        label: `Control ${i}`,
-        data: `action=${i}`,
-      })),
-    });
-
-    const footer = card.footer as { contents: unknown[] };
-    expect(footer.contents.length).toBeLessThanOrEqual(3);
-  });
-
-  it("keeps event-card optional fields together", () => {
-    const card = createEventCard({
+    const image = createImageCard("https://example.com/img.jpg", "Title", "Body text");
+    const imageBody = image.body as { contents: Array<{ text: string }> };
+    expect(imageBody.contents.length).toBe(2);
+    expect(expectDefined(imageBody.contents[1], "image-card body content").text).toBe("Body text");
+    const event = createEventCard({
       title: "Team Offsite",
       date: "February 15, 2026",
       time: "9:00 AM - 5:00 PM",
       location: "Mountain View Office",
       description: "Annual team building event",
     });
+    expect(event.size).toBe("mega");
+    expect((event.body as { contents: unknown[] }).contents).toHaveLength(3);
+  });
 
-    expect(card.size).toBe("mega");
-    const body = card.body as { contents: Array<{ type: string }> };
-    expect(body.contents).toHaveLength(3);
+  it("bounds list items, actions, carousel bubbles, and device controls", () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({ title: `Item ${i}` }));
+    const list = createListCard("List", items);
+    const body = list.body as { contents: Array<{ type: string; contents?: unknown[] }> };
+    expect((body.contents[2] as { contents: unknown[] }).contents).toHaveLength(8);
+    const actions = Array.from({ length: 6 }, (_, i) => ({
+      label: `Action ${i}`,
+      action: { type: "message" as const, label: `A${i}`, text: `action${i}` },
+    }));
+    const actionCard = createActionCard("Title", "Body", actions);
+    expect((actionCard.footer as { contents: unknown[] }).contents).toHaveLength(4);
+    const bubbles = Array.from({ length: 15 }, (_, i) => createInfoCard(`Card ${i}`, `Body ${i}`));
+    expect(createCarousel(bubbles).contents).toHaveLength(12);
+    const device = createDeviceControlCard({
+      deviceName: "Device",
+      controls: Array.from({ length: 10 }, (_, i) => ({
+        label: `Control ${i}`,
+        data: `action=${i}`,
+      })),
+    });
+    expect((device.footer as { contents: unknown[] }).contents.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("LINE message action surface restrictions", () => {
+  it.each([
+    { type: "camera", label: "Open camera" },
+    { type: "cameraRoll", label: "Open camera roll" },
+    { type: "location", label: "Share location" },
+    { type: "richmenuswitch", label: "Switch", richMenuAliasId: "menu", data: "switch" },
+  ] satisfies Action[])("keeps $type on its supported provider surface", (action) => {
+    const richMenuOnly = action.type === "richmenuswitch";
+    const unavailable = {
+      type: "message",
+      label: "Unavailable",
+      text: `Action unavailable: ${richMenuOnly ? "rich menu switching is only available in rich menus." : "this action is only available in quick replies."}`,
+    };
+    const quickReply = { items: [{ type: "action", action }] } satisfies messagingApi.QuickReply;
+    const flex: messagingApi.Message = {
+      type: "flex",
+      altText: "Choose",
+      contents: {
+        type: "bubble",
+        body: { type: "box", layout: "vertical", contents: [{ type: "button", action }] },
+      },
+      quickReply,
+    };
+    const template: messagingApi.Message = {
+      type: "template",
+      altText: "Choose",
+      template: { type: "buttons", text: "Choose", defaultAction: action, actions: [action] },
+      quickReply,
+    };
+    const [normalizedFlex, normalizedTemplate] = [flex, template].map(normalizeLineMessageActions);
+    const expectedQuickReplyAction = richMenuOnly ? unavailable : action;
+
+    expect(normalizedFlex).toMatchObject({
+      contents: { body: { contents: [{ action: unavailable }] } },
+      quickReply: { items: [{ action: expectedQuickReplyAction }] },
+    });
+    expect(normalizedTemplate).toMatchObject({
+      template: { defaultAction: unavailable, actions: [unavailable] },
+      quickReply: { items: [{ action: expectedQuickReplyAction }] },
+    });
+    expect(normalizeLineAction(action)).toEqual(action);
+    if (richMenuOnly) {
+      expect(
+        normalizeLineMessageActions({ type: "text", text: "Choose", quickReply }),
+      ).toMatchObject({
+        quickReply: { items: [{ action: unavailable }] },
+      });
+    }
+  });
+
+  it.each([
+    { items: [] },
+    {},
+    { items: [{ type: "action", action: { type: "message", label: " \t ", text: "blank" } }] },
+    { items: [{ type: "action" }] },
+    ...[null, { length: 1 }, "invalid", 1].map((items) => ({ items: items as never })),
+  ] satisfies messagingApi.QuickReply[])(
+    "omits provider-invalid empty quick replies",
+    (quickReply) => {
+      const message: messagingApi.TextMessage = { type: "text", text: "Choose", quickReply };
+      expect(normalizeLineMessageActions(message)).toEqual({ type: "text", text: "Choose" });
+      expect(message.quickReply).toBe(quickReply);
+    },
+  );
+
+  it("repairs envelopes and filters malformed actions before retaining 13 valid quick replies", () => {
+    const malformed: Action[] = [
+      { type: "message", label: "Missing message" },
+      { type: "uri", label: "Missing URI" },
+      { type: "postback", label: "Missing data" },
+      { type: "datetimepicker", label: "Missing data", mode: "date" },
+      { type: "datetimepicker", label: "Missing mode", data: "" },
+      { type: "datetimepicker", label: "Invalid mode", data: "", mode: "invalid" as never },
+    ];
+    const repaired = {
+      imageUrl: "https://example.com/icon.png",
+      action: messageAction("Repaired"),
+    };
+    const valid = [
+      { type: "action" as const, action: postbackAction("Empty data", "") },
+      { type: "action" as const, action: datetimePickerAction("Date", "", "date") },
+      ...Array.from({ length: 14 }, (_, index) => ({
+        type: "action" as const,
+        action: messageAction(`Option ${index + 1}`),
+      })),
+    ];
+    const items = [
+      null as never,
+      { type: "action" as const },
+      ...malformed.map((action) => ({ type: "action" as const, action })),
+      repaired,
+      { ...repaired, type: "unsupported" },
+      ...valid,
+    ];
+    const message: messagingApi.TextMessage = {
+      type: "text",
+      text: "Choose",
+      quickReply: { items },
+    };
+
+    expect(normalizeLineMessageActions(message).quickReply?.items).toEqual([
+      { ...repaired, type: "action" },
+      { ...repaired, type: "action" },
+      ...valid.slice(0, 11),
+    ]);
+    expect(message.quickReply?.items).toBe(items);
+  });
+
+  it("prefers modern postback text and upgrades deprecated quick-reply text", () => {
+    const action: Action = { type: "postback", label: "Open", data: "open", text: "Legacy" };
+    const modern = normalizeLineAction({ ...action, displayText: "Modern" });
+    const quickReply = normalizeLineMessageActions({
+      type: "text",
+      text: "Choose",
+      quickReply: { items: [{ type: "action", action }] },
+    }).quickReply?.items?.[0]?.action;
+
+    expect(modern).toMatchObject({ data: "open", displayText: "Modern" });
+    expect(modern).not.toHaveProperty("text");
+    expect(quickReply).toMatchObject({ data: "open", displayText: "Legacy" });
+    expect(quickReply).not.toHaveProperty("text");
+    expect(normalizeLineAction(action)).toMatchObject({ text: "Legacy" });
+  });
+
+  it("enforces provider action contracts while preserving valid controls", () => {
+    for (const clipboardText of [undefined, ""]) {
+      expect(
+        normalizeLineAction({ type: "clipboard", label: "Copy", clipboardText } as Action),
+      ).toEqual(unavailableLineAction("Action", "clipboard text must not be empty."));
+    }
+    expect(
+      normalizeLineAction({ type: "clipboard", label: "Copy", clipboardText: " " }),
+    ).toMatchObject({ clipboardText: " " });
+    for (const uri of ["ftp://example.com", "javascript:alert(1)", "/relative"]) {
+      expect(normalizeLineAction({ type: "uri", label: "Open", uri })).toEqual(
+        unavailableLineAction("Link", "URL scheme is not supported by LINE."),
+      );
+    }
+    for (const uri of ["http://e.co", "https://e.co", "line://app", "tel:+1"]) {
+      expect(normalizeLineAction({ type: "uri", label: "Open", uri })).toMatchObject({ uri });
+    }
+    for (const type of ["message", "uri", "postback", "datetimepicker"] as const) {
+      expect(normalizeLineAction({ type, label: "Missing" } as Action).label).toBe("Unavailable");
+    }
+    for (const [field, options] of [
+      ["fillInText", { fillInText: "hello" }],
+      ["inputOption", { inputOption: "unsupported" }],
+    ] as const) {
+      const action = normalizeLineAction({
+        type: "postback",
+        label: "Run",
+        data: "",
+        ...options,
+      } as Action);
+      expect(action).toMatchObject({ type: "postback", data: "" });
+      expect(action).not.toHaveProperty(field);
+    }
+    const keyboard = {
+      ...postbackAction("Run", ""),
+      inputOption: "openKeyboard",
+      fillInText: "hello",
+    } as Action;
+    expect(normalizeLineAction(keyboard)).toMatchObject(keyboard);
+    for (const [mode, initial] of [
+      ["date", "not-a-date"],
+      ["time", "25:99"],
+    ] as const) {
+      const action = datetimePickerAction("Pick", "", mode, { initial });
+      expect(action).toMatchObject({ type: "datetimepicker", data: "", mode });
+      expect(action).not.toHaveProperty("initial");
+    }
+    for (const [mode, min, max, valid] of [
+      ["date", "2026-06-01", "2026-06-01", false],
+      ["time", "06:15", "06:15", false],
+      ["datetime", "2026-06-01T06:15", "2026-06-01T06:15", false],
+      ["date", "2026-02-01", "2026-01-01", false],
+      ["datetime", "2026-06-01T10:00", "2026-06-01t09:00", false],
+      ["datetime", "2026-06-01T09:00", "2026-06-01t09:00", false],
+      ["datetime", "2026-06-01t09:00", "2026-06-01T10:00", true],
+    ] as const) {
+      const action = datetimePickerAction("Pick", "", mode, { min, max });
+      expect(action).toMatchObject(valid ? { min, max } : { type: "datetimepicker" });
+      expect(["min", "max"].map((field) => field in action)).toEqual([valid, valid]);
+      expect(datetimePickerAction("Pick", "", mode, { initial: min })).toMatchObject({
+        initial: min,
+      });
+    }
+    for (const imageUrl of [
+      "http://example.com/icon.png",
+      "javascript:bad()",
+      `https://e.co/${"x".repeat(2000)}`,
+    ]) {
+      const items = [{ type: "action" as const, imageUrl, action: messageAction("Keep", "Keep") }];
+      expect(
+        normalizeLineMessageActions({ type: "text", text: "Choose", quickReply: { items } })
+          .quickReply?.items,
+      ).toEqual([{ type: "action", action: messageAction("Keep", "Keep") }]);
+    }
+    const area = { x: 0, y: 0, width: 1, height: 1 };
+    for (const [action, externalLink] of [
+      [{ type: "uri", label: "Open", linkUri: "ftp://example.com", area }, null],
+      [{ type: "clipboard", label: "Copy", clipboardText: "", area }, 1],
+      [{ type: "message", label: "Missing text", area }, "invalid"],
+      [{ type: "uri", label: "Missing URI", area }, { linkUri: "https://e.co" }],
+      [
+        { type: "uri", linkUri: "ftp://e.co", area },
+        { linkUri: "https://e.co", label: "" },
+      ],
+      [
+        { type: "uri", linkUri: "ftp://e.co", area },
+        { linkUri: "https://e.co", label: null },
+      ],
+      [
+        { type: "uri", linkUri: "ftp://e.co", area },
+        { linkUri: "https://e.co", label: 1 },
+      ],
+    ] as Array<[messagingApi.ImagemapAction, unknown]>) {
+      const message: messagingApi.ImagemapMessage = {
+        type: "imagemap",
+        baseUrl: "https://example.com",
+        altText: "Choose",
+        baseSize: { width: 1040, height: 1040 },
+        actions: [action],
+        video: {
+          originalContentUrl: "https://example.com/video.mp4",
+          previewImageUrl: "https://example.com/preview.jpg",
+          area,
+          externalLink: externalLink as never,
+        },
+      };
+      const normalized = normalizeLineMessageActions(message);
+      expect(normalized.actions[0]).toMatchObject({ type: "message", label: "Unavailable", area });
+      expect(normalized.actions[1]).toMatchObject({ type: "message", label: "Unavailable", area });
+      expect(normalized.video).not.toHaveProperty("externalLink");
+    }
+
+    const unlabeled = { type: "uri", uri: "https://example.com" } as Action;
+    expect(normalizeLineAction(unlabeled)).toEqual(unlabeled);
+    for (const type of ["image", "text", "box", "button"] as const) {
+      const malformed = { image: null, text: 1, box: "invalid", button: { type: "bogus" } }[type];
+      const message = {
+        type: "flex",
+        altText: "Tap",
+        contents: {
+          type: "bubble",
+          body: {
+            type: "box",
+            layout: "vertical",
+            contents: [
+              { type, action: unlabeled },
+              { type, action: malformed },
+            ],
+          },
+        },
+      } as messagingApi.Message;
+      const bubble = (normalizeLineMessageActions(message) as messagingApi.FlexMessage)
+        .contents as {
+        body: { contents: Array<{ action: Action }> };
+      };
+      expect(bubble.body.contents[0]?.action).toEqual(
+        type === "button" ? unavailableLineAction("Action", "action label is missing.") : unlabeled,
+      );
+      expect(bubble.body.contents[1]?.action).toEqual(
+        type === "button"
+          ? unavailableLineAction("Action", "action type is not supported by LINE.")
+          : undefined,
+      );
+    }
+    for (const [template, expected] of [
+      [
+        { type: "buttons", text: "Tap", actions: [unlabeled] },
+        unavailableLineAction("Action", "action label is missing."),
+      ],
+      [
+        { type: "buttons", text: "Tap", actions: [{ type: "bogus" }] },
+        unavailableLineAction("Action", "action type is not supported by LINE."),
+      ],
+      [
+        {
+          type: "image_carousel",
+          columns: [{ imageUrl: "https://e.co/image.png", action: unlabeled }],
+        },
+        unlabeled,
+      ],
+      [
+        {
+          type: "image_carousel",
+          columns: [{ imageUrl: "https://e.co/image.png", action: { type: "bogus" } }],
+        },
+        unavailableLineAction("Action", "action type is not supported by LINE."),
+      ],
+    ] as const) {
+      const message = { type: "template", altText: "Tap", template } as messagingApi.Message;
+      const normalized = normalizeLineMessageActions(message) as messagingApi.TemplateMessage;
+      const action =
+        "actions" in normalized.template
+          ? normalized.template.actions[0]
+          : normalized.template.columns[0]?.action;
+      expect(action).toEqual(expected);
+    }
   });
 });
 
@@ -510,43 +674,37 @@ describe("action label/data surrogate-safe truncation", () => {
   // .slice(0, 20) would keep the first 19 chars plus the lone high surrogate.
   const labelWithEmoji = "1234567890123456789😀";
 
-  it("messageAction drops a half emoji instead of leaving a lone surrogate", () => {
-    const action = messageAction(labelWithEmoji) as { label: string };
-
-    expect(action.label).toBe(labelWithEmoji);
-    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  it.each([
+    { kind: "message emoji", action: messageAction(labelWithEmoji), expected: labelWithEmoji },
+    { kind: "message ASCII", action: messageAction("Yes"), expected: "Yes" },
+    {
+      kind: "URI emoji",
+      action: uriAction(labelWithEmoji, "https://example.com"),
+      expected: labelWithEmoji,
+    },
+  ])("$kind preserves labels without splitting surrogate pairs", ({ action, expected }) => {
+    expect(action.label).toBe(expected);
+    expect(loneHighSurrogate.test(action.label ?? "")).toBe(false);
   });
 
-  it("messageAction leaves a short ASCII label unchanged", () => {
-    const action = messageAction("Yes");
-
-    expect(action.label).toBe("Yes");
-  });
-
-  it("uriAction drops a half emoji instead of leaving a lone surrogate", () => {
-    const action = uriAction(labelWithEmoji, "https://example.com") as { label: string };
-
-    expect(action.label).toBe(labelWithEmoji);
-    expect(loneHighSurrogate.test(action.label)).toBe(false);
-  });
-
-  it("postbackAction preserves valid grapheme labels but disables overlong callback data", () => {
+  it.each([
+    { kind: "postback", create: (label: string, data: string) => postbackAction(label, data) },
+    {
+      kind: "datetime picker",
+      create: (label: string, data: string) => datetimePickerAction(label, data, "datetime"),
+    },
+  ])("$kind preserves grapheme labels but disables overlong callback data", ({ create }) => {
     const exactData = `${"d".repeat(298)}😀`;
     const overlongData = `${"d".repeat(299)}😀`;
-    const action = postbackAction(labelWithEmoji, "data") as { label: string };
-    const exact = postbackAction("Label", exactData) as { data: string };
-    const unavailable = postbackAction("Label", overlongData);
+    const action = create(labelWithEmoji, "data") as { label: string };
+    const exact = create("Label", exactData) as { data: string };
 
     expect(exactData).toHaveLength(300);
     expect(overlongData).toHaveLength(301);
     expect(action.label).toBe(labelWithEmoji);
     expect(loneHighSurrogate.test(action.label)).toBe(false);
     expect(exact.data).toBe(exactData);
-    expect(unavailable).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
+    expect(create("Label", overlongData)).toEqual(unavailableCallback);
   });
 
   it("postbackAction truncates displayText by grapheme cluster but keeps undefined", () => {
@@ -561,80 +719,28 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(withoutDisplay.displayText).toBeUndefined();
   });
 
-  it("datetimePickerAction preserves valid grapheme labels but disables overlong callback data", () => {
-    const exactData = `${"d".repeat(298)}😀`;
-    const overlongData = `${"d".repeat(299)}😀`;
-    const action = datetimePickerAction(labelWithEmoji, "data", "datetime") as { label: string };
-    const exact = datetimePickerAction("Pick", exactData, "datetime") as { data: string };
-    const unavailable = datetimePickerAction("Pick", overlongData, "datetime");
-
-    expect(exactData).toHaveLength(300);
-    expect(overlongData).toHaveLength(301);
-    expect(action.label).toBe(labelWithEmoji);
-    expect(loneHighSurrogate.test(action.label)).toBe(false);
-    expect(exact.data).toBe(exactData);
-    expect(unavailable).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
-  });
-
   it("/card action command visibly disables overlong callback data", async () => {
-    const registerCommand = (command: unknown) => {
-      const { handler } = command as {
-        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
-      };
-      return handler({
-        channel: "line",
-        args: `action "Menu" "Body" --actions "${labelWithEmoji}|k=${"d".repeat(297)}😀"`,
-      });
-    };
-    const result = (await registerCommandWithHandler(registerCommand)) as {
-      channelData: {
-        line: {
-          flexMessage: {
-            contents: {
-              footer: {
-                contents: Array<{
-                  action: { type: string; label: string; text?: string };
-                }>;
-              };
-            };
-          };
-        };
-      };
-    };
-    const action = expectDefined(
-      result.channelData.line.flexMessage.contents.footer.contents[0],
-      "LINE flex-message footer action",
-    ).action;
-
-    expect(action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
+    const { contents } = await runLineFlexCardCommand(
+      `action "Menu" "Body" --actions "${labelWithEmoji}|k=${"d".repeat(297)}😀"`,
+    );
+    const footer = (contents as { footer: { contents: Array<{ action: Action }> } }).footer;
+    expect(expectDefined(footer.contents[0], "LINE flex-message footer action").action).toEqual(
+      unavailableCallback,
+    );
   });
 
-  it.each(lineFlexCardCommandScenarios)(
-    "/card $kind preserves provider-valid Flex alternative text",
+  it.each(lineFlexCardScenarios)(
+    "/card $kind preserves valid Flex alternative text and bounds surrogate pairs",
     async (scenario) => {
       const body = "a".repeat(1200);
-      const message = await runLineFlexCardCommand(scenario.args(body));
+      const valid = await runLineFlexCardCommand(scenario.args(body));
+      const oversized = await runLineFlexCardCommand(
+        scenario.args(`${"a".repeat(1492)}😀 overflow`),
+      );
 
-      expect(message.altText).toBe(scenario.expectedAltText(body));
-    },
-  );
-
-  it.each(lineFlexCardCommandScenarios)(
-    "/card $kind bounds alternative text without splitting a Unicode surrogate pair",
-    async (scenario) => {
-      const body = `${"a".repeat(1492)}😀 overflow`;
-      const { altText } = await runLineFlexCardCommand(scenario.args(body));
-
-      expect(altText).toBe(`Title: ${"a".repeat(1492)}`);
-      expect(loneHighSurrogate.test(altText)).toBe(false);
+      expect(valid.altText).toBe(scenario.expectedAltText(body));
+      expect(oversized.altText).toBe(`Title: ${"a".repeat(1492)}`);
+      expect(loneHighSurrogate.test(oversized.altText)).toBe(false);
     },
   );
 
@@ -642,7 +748,7 @@ describe("action label/data surrogate-safe truncation", () => {
     await withLineProvider(async (client, received) => {
       const body = "a".repeat(1200);
 
-      for (const scenario of lineFlexCardCommandScenarios) {
+      for (const scenario of lineFlexCardScenarios) {
         const message = await runLineFlexCardCommand(scenario.args(body));
         await client.pushMessage({
           to: "U123",
@@ -650,22 +756,25 @@ describe("action label/data surrogate-safe truncation", () => {
         });
       }
 
-      expect(received).toHaveLength(lineFlexCardCommandScenarios.length);
+      expect(received).toHaveLength(lineFlexCardScenarios.length);
       expect(received.every((request) => request.authenticated)).toBe(true);
       expect(received.every((request) => request.type === "flex")).toBe(true);
       expect(received.map((request) => request.altText)).toEqual(
-        lineFlexCardCommandScenarios.map((scenario) => scenario.expectedAltText(body)),
+        lineFlexCardScenarios.map((scenario) => scenario.expectedAltText(body)),
       );
     });
   });
 
   it.each(lineTemplateMessageScenarios)(
-    "preserves provider-valid $kind alternative text without changing inner text limits",
+    "preserves valid $kind alternative text and Unicode-safe provider bounds",
     (scenario) => {
       const altText = "a".repeat(1200);
       const message = scenario.create(altText);
+      const oversized = scenario.create(`${"a".repeat(1499)}😀 overflow`);
 
       expect(message.altText).toBe(altText);
+      expect(oversized.altText).toBe("a".repeat(1499));
+      expect(loneHighSurrogate.test(oversized.altText)).toBe(false);
       if ("bodyLimit" in scenario) {
         const template = message.template as {
           text?: string;
@@ -673,16 +782,6 @@ describe("action label/data surrogate-safe truncation", () => {
         };
         expect((template.text ?? template.columns?.[0]?.text)?.length).toBe(scenario.bodyLimit);
       }
-    },
-  );
-
-  it.each(lineTemplateMessageScenarios)(
-    "bounds $kind alternative text at the provider's Unicode-safe 1500-unit limit",
-    (scenario) => {
-      const message = scenario.create(`${"a".repeat(1499)}😀 overflow`);
-
-      expect(message.altText).toBe("a".repeat(1499));
-      expect(loneHighSurrogate.test(message.altText)).toBe(false);
     },
   );
 
@@ -706,20 +805,9 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("/card receipt preserves a provider-valid Unicode alternative-text boundary", async () => {
-    const registerCommand = (command: unknown) => {
-      const { handler } = command as {
-        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
-      };
-      return handler({
-        channel: "line",
-        args: `receipt "R" "${"a".repeat(395)}:😀x" --total "$30"`,
-      });
-    };
-    const result = (await registerCommandWithHandler(registerCommand)) as {
-      channelData: { line: { flexMessage: { altText: string } } };
-    };
-    const altText = result.channelData.line.flexMessage.altText;
-
+    const { altText } = await runLineFlexCardCommand(
+      `receipt "R" "${"a".repeat(395)}:😀x" --total "$30"`,
+    );
     expect(altText).toBe(`R: ${"a".repeat(395)} 😀x`);
     expect(loneHighSurrogate.test(altText)).toBe(false);
   });
@@ -754,50 +842,50 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(validUri).toHaveLength(1000);
     expect(validAction).toMatchObject({ type: "uri", uri: validUri });
-    expect(overlongAction).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
+    expect(overlongAction).toEqual(unavailableLink);
+    for (const altUri of [
+      null,
+      1,
+      "invalid",
+      { desktop: null },
+      { desktop: 1 },
+      { desktop: {} },
+      { desktop: `${validUri}x` },
+    ]) {
+      expect(
+        normalizeLineAction({ type: "uri", label: "Open", uri: validUri, altUri } as Action),
+      ).toEqual({ type: "uri", label: "Open", uri: validUri });
+    }
   });
 
-  it("buttons template payload visibly disables URIs past the 1000-unit cap", () => {
-    const template = buildTemplateMessageFromPayload({
-      type: "buttons",
-      text: "Pick",
-      actions: [{ type: "uri", label: "Open", uri: `https://e.example/?q=${"u".repeat(1200)}` }],
-    });
+  it.each([
+    {
+      action: { type: "uri", label: "Open", uri: `https://e.example/?q=${"u".repeat(1200)}` },
+      error: "Link unavailable: URL exceeds LINE's limit.",
+    },
+    {
+      action: { type: "postback", label: "Open", data: `action=open&token=${"x".repeat(300)}` },
+      error: "Action unavailable: callback data exceeds LINE's limit.",
+    },
+  ])(
+    "buttons template payload visibly disables invalid $action.type actions",
+    ({ action, error }) => {
+      const template = buildTemplateMessageFromPayload({
+        type: "buttons",
+        text: "Pick",
+        actions: [action],
+      });
+      const buttonsTemplate = expectDefined(template, "buttons template message").template as {
+        actions: Array<{ type: string; label?: string; text?: string }>;
+      };
 
-    const buttonsTemplate = expectDefined(template, "buttons template message").template as {
-      actions: Array<{ type: string; label?: string; text?: string }>;
-    };
-    const uriTemplateAction = expectDefined(
-      buttonsTemplate.actions[0],
-      "buttons template uri action",
-    );
-    expect(uriTemplateAction).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
-  });
-
-  it("buttons template payload visibly disables overlong postback data", () => {
-    const template = buildTemplateMessageFromPayload({
-      type: "buttons",
-      text: "Pick",
-      actions: [{ type: "postback", label: "Open", data: `action=open&token=${"x".repeat(300)}` }],
-    });
-    const buttonsTemplate = expectDefined(template, "buttons template message").template as {
-      actions: Array<{ type: string; label?: string; text?: string }>;
-    };
-
-    expect(buttonsTemplate.actions[0]).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
-  });
+      expect(buttonsTemplate.actions[0]).toEqual({
+        type: "message",
+        label: "Unavailable",
+        text: error,
+      });
+    },
+  );
 
   it("normalizes raw actions at exported template builder boundaries", () => {
     const oversizedPostback: Action = {
@@ -810,24 +898,13 @@ describe("action label/data surrogate-safe truncation", () => {
       label: "Open",
       uri: `https://e.example/?q=${"x".repeat(1200)}`,
     };
-    const unavailableAction = {
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    };
-    const unavailableLink = {
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    };
-
     const buttons = createButtonTemplate(undefined, "Pick", [oversizedPostback], {
       defaultAction: oversizedUri,
     }).template as {
       actions: Action[];
       defaultAction?: Action;
     };
-    expect(buttons.actions).toEqual([unavailableAction]);
+    expect(buttons.actions).toEqual([unavailableCallback]);
     expect(buttons.defaultAction).toEqual(unavailableLink);
 
     const carousel = createTemplateCarousel([
@@ -839,29 +916,38 @@ describe("action label/data surrogate-safe truncation", () => {
     ]).template as {
       columns: Array<{ actions: Action[]; defaultAction?: Action }>;
     };
-    expect(carousel.columns[0]?.actions).toEqual([unavailableAction]);
+    expect(carousel.columns[0]?.actions).toEqual([unavailableCallback]);
     expect(carousel.columns[0]?.defaultAction).toEqual(unavailableLink);
+
+    const unlabeled = { type: "uri", uri: "https://example.com" } as Action;
+    for (const action of [unlabeled, null, 1, "invalid", { type: "bogus" }]) {
+      for (const template of [
+        { type: "buttons", text: "Pick", actions: [messageAction("Keep")], defaultAction: action },
+        {
+          type: "carousel",
+          columns: [{ text: "Pick", actions: [messageAction("Keep")], defaultAction: action }],
+        },
+      ]) {
+        const normalized = normalizeLineMessageActions({
+          type: "template",
+          altText: "Pick",
+          template,
+        } as messagingApi.Message) as messagingApi.TemplateMessage;
+        const defaultAction =
+          normalized.template.type === "buttons"
+            ? normalized.template.defaultAction
+            : normalized.template.columns[0]?.defaultAction;
+        expect(defaultAction).toEqual(action === unlabeled ? unlabeled : undefined);
+      }
+    }
 
     const imageCarousel = createImageCarousel([
       { imageUrl: "https://e.example/image.jpg", action: oversizedPostback },
     ]).template as { columns: Array<{ action: Action }> };
-    expect(imageCarousel.columns[0]?.action).toEqual(unavailableAction);
+    expect(imageCarousel.columns[0]?.action).toEqual(unavailableCallback);
   });
 
   it("normalizes every length-constrained raw action field", () => {
-    expect(
-      normalizeLineAction({
-        type: "uri",
-        label: "Open",
-        uri: "https://e.example",
-        altUri: { desktop: `https://e.example/?q=${"x".repeat(1200)}` },
-      }),
-    ).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
-
     const postback = normalizeLineAction({
       type: "postback",
       label: "Open",
@@ -872,45 +958,23 @@ describe("action label/data surrogate-safe truncation", () => {
       displayText: "d".repeat(300),
     });
 
-    expect(normalizeLineAction({ type: "message", label: "Open", text: "x".repeat(301) })).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: message text exceeds LINE's limit.",
-    });
-    expect(
-      normalizeLineAction({
-        type: "postback",
-        label: "Open",
-        data: "action=open",
-        fillInText: "x".repeat(301),
-      }),
-    ).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: message text exceeds LINE's limit.",
-    });
-    expect(
-      normalizeLineAction({
-        type: "postback",
-        label: "Open",
-        data: "action=open",
-        text: "x".repeat(301),
-      }),
-    ).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: message text exceeds LINE's limit.",
-    });
+    for (const action of [
+      { type: "message", label: "Open", text: "x".repeat(301) },
+      { type: "postback", label: "Open", data: "action=open", fillInText: "x".repeat(301) },
+      { type: "postback", label: "Open", data: "action=open", text: "x".repeat(301) },
+    ] satisfies Action[]) {
+      expect(normalizeLineAction(action)).toEqual(
+        unavailableLineAction("Action", "message text exceeds LINE's limit."),
+      );
+    }
     const emojiText = "😀".repeat(300);
     expect(messageAction("Open", emojiText)).toMatchObject({ text: emojiText });
     const familyEmoji = "👨‍👩‍👧‍👦";
     expect(truncateLineActionLabel(familyEmoji.repeat(3))).toBe(familyEmoji.repeat(2));
     expect(truncateLineActionLabel(`👩${"‍👩".repeat(10)}`)).toBe("…");
-    expect(messageAction("Open", familyEmoji.repeat(43))).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: message text exceeds LINE's limit.",
-    });
+    expect(messageAction("Open", familyEmoji.repeat(43))).toEqual(
+      unavailableLineAction("Action", "message text exceeds LINE's limit."),
+    );
     expect(messageAction("Open", familyEmoji.repeat(42))).toMatchObject({
       text: familyEmoji.repeat(42),
     });
@@ -920,11 +984,7 @@ describe("action label/data surrogate-safe truncation", () => {
         label: "Copy",
         clipboardText: "x".repeat(1001),
       }),
-    ).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: clipboard text exceeds LINE's limit.",
-    });
+    ).toEqual(unavailableLineAction("Action", "clipboard text exceeds LINE's limit."));
   });
 
   it("normalizes raw actions at exported flex builder boundaries", () => {
@@ -942,19 +1002,11 @@ describe("action label/data surrogate-safe truncation", () => {
     const image = createImageCard("https://e.example/image.jpg", "Image", undefined, {
       action: oversizedUri,
     });
-    expect((image.hero as { action?: Action }).action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
+    expect((image.hero as { action?: Action }).action).toEqual(unavailableLink);
 
     const card = createActionCard("Title", "Body", [{ label: "Open", action: oversizedPostback }]);
     const button = (card.footer as { contents: Array<{ action: Action }> }).contents[0];
-    expect(button?.action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
+    expect(button?.action).toEqual(unavailableCallback);
 
     const validLongLabel = "x".repeat(40);
     const labeledCard = createActionCard("Title", "Body", [
@@ -969,129 +1021,55 @@ describe("action label/data surrogate-safe truncation", () => {
     const listBox = listBody[2] as {
       contents: Array<{ action?: Action }>;
     };
-    expect(listBox.contents[0]?.action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
+    expect(listBox.contents[0]?.action).toEqual(unavailableCallback);
 
     const event = createEventCard({
       title: "Event",
       date: "Today",
       action: oversizedUri,
     });
-    expect((event.body as { action?: Action }).action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    });
+    expect((event.body as { action?: Action }).action).toEqual(unavailableLink);
   });
 
-  it("media control cards visibly disable overlong opaque callbacks", () => {
-    const overlongData = `${"d".repeat(299)}😀`;
-    const card = createMediaPlayerCard({
-      title: "Track",
-      controls: {
-        previous: { data: overlongData },
-        play: { data: overlongData },
-        pause: { data: overlongData },
-        next: { data: overlongData },
-      },
-      extraActions: [{ label: "Extra", data: overlongData }],
-    });
-    const footer = card.footer as {
-      contents: Array<{
-        contents?: Array<{
-          action?: { type: string; data?: string; label?: string; text?: string };
-        }>;
-      }>;
+  it.each([
+    {
+      kind: "media",
+      expectedCount: 5,
+      create: (data: string) =>
+        createMediaPlayerCard({
+          title: "Track",
+          controls: { previous: { data }, play: { data }, pause: { data }, next: { data } },
+          extraActions: [{ label: "Extra", data }],
+        }).footer,
+    },
+    {
+      kind: "device",
+      expectedCount: 1,
+      create: (data: string) =>
+        createDeviceControlCard({ deviceName: "Device", controls: [{ label: "On", data }] }).footer,
+    },
+    {
+      kind: "Apple TV",
+      expectedCount: 12,
+      create: (data: string) =>
+        createAppleTvRemoteCard({
+          deviceName: "TV",
+          actionData: Object.fromEntries(
+            "up down left right select menu home play pause volumeUp volumeDown mute"
+              .split(" ")
+              .map((action) => [action, data]),
+          ) as never,
+        }).body,
+    },
+  ])("$kind controls visibly disable overlong opaque callbacks", ({ create, expectedCount }) => {
+    const surface = create(`${"d".repeat(299)}😀`) as {
+      contents: Array<{ contents?: Array<{ action?: Action }> }>;
     };
-    const actions = footer.contents
-      .flatMap((content) => content.contents ?? [])
-      .flatMap((button) => (button.action ? [button.action] : []));
-
-    expect(actions).toHaveLength(5);
-    for (const action of actions) {
-      expect(action).toEqual({
-        type: "message",
-        label: "Unavailable",
-        text: "Action unavailable: callback data exceeds LINE's limit.",
-      });
-    }
-  });
-
-  it("device controls visibly disable overlong opaque callbacks", () => {
-    const card = createDeviceControlCard({
-      deviceName: "Device",
-      controls: [{ label: "On", data: `${"d".repeat(299)}😀` }],
-    });
-    const footer = card.footer as {
-      contents: Array<{
-        contents: Array<{
-          action?: { type: string; data?: string; label?: string; text?: string };
-        }>;
-      }>;
-    };
-    const action = footer.contents
-      .flatMap((row) => row.contents)
-      .find((button) => button.action)?.action;
-
-    expect(action).toEqual({
-      type: "message",
-      label: "Unavailable",
-      text: "Action unavailable: callback data exceeds LINE's limit.",
-    });
-  });
-
-  it("Apple TV controls visibly disable overlong opaque callbacks", () => {
-    const overlongData = `${"d".repeat(299)}😀`;
-    const card = createAppleTvRemoteCard({
-      deviceName: "TV",
-      actionData: {
-        up: overlongData,
-        down: overlongData,
-        left: overlongData,
-        right: overlongData,
-        select: overlongData,
-        menu: overlongData,
-        home: overlongData,
-        play: overlongData,
-        pause: overlongData,
-        volumeUp: overlongData,
-        volumeDown: overlongData,
-        mute: overlongData,
-      },
-    });
-    const body = card.body as {
-      contents: Array<{
-        contents?: Array<{
-          action?: { type: string; data?: string; label?: string; text?: string };
-        }>;
-      }>;
-    };
-    const actions = body.contents
+    const actions = surface.contents
       .flatMap((row) => row.contents ?? [])
       .flatMap((button) => (button.action ? [button.action] : []));
 
-    expect(actions).toHaveLength(12);
-    for (const action of actions) {
-      expect(action).toEqual({
-        type: "message",
-        label: "Unavailable",
-        text: "Action unavailable: callback data exceeds LINE's limit.",
-      });
-    }
+    expect(actions).toHaveLength(expectedCount);
+    expect(actions).toEqual(Array.from({ length: expectedCount }, () => unavailableCallback));
   });
 });
-
-async function registerCommandWithHandler(
-  runHandler: (command: unknown) => Promise<unknown>,
-): Promise<unknown> {
-  let result: unknown;
-  registerLineCardCommand({
-    registerCommand(command: unknown) {
-      result = runHandler(command);
-    },
-  } as never);
-  return result;
-}

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -1,6 +1,5 @@
 import { HTTPFetchError } from "@line/bot-sdk";
 // Line tests cover send plugin behavior.
-import { expectDefined } from "@openclaw/normalization-core";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -114,6 +113,28 @@ function createCredentialBearingHttpUrl(): string {
 describe("LINE send helpers", () => {
   const fixedSentAt = 1_800_000_000_000;
 
+  function expectedMediaSendResult(chatId: string, messageId: string, messageCount: number) {
+    const raw = {
+      channel: "line",
+      chatId,
+      conversationId: chatId,
+      messageId,
+      meta: { messageCount },
+    };
+    return {
+      chatId,
+      messageId,
+      receipt: {
+        parts: [{ index: 0, kind: "media", platformMessageId: messageId, raw, threadId: chatId }],
+        platformMessageIds: [messageId],
+        primaryPlatformMessageId: messageId,
+        raw: [raw],
+        sentAt: fixedSentAt,
+        threadId: chatId,
+      },
+    };
+  }
+
   beforeAll(async () => {
     sendModule = await import("./send.js");
   });
@@ -184,10 +205,19 @@ describe("LINE send helpers", () => {
   });
 
   it("limits quick reply items to 13", () => {
-    const labels = Array.from({ length: 20 }, (_, index) => `Option ${index + 1}`);
+    const labels = [
+      ...Array.from({ length: 13 }, () => " \t "),
+      ...Array.from({ length: 14 }, (_, index) => `  Option ${index + 1}  `),
+    ];
     const quickReply = sendModule.createQuickReplyItems(labels);
 
     expect(quickReply.items).toHaveLength(13);
+    expect(quickReply.items?.map((item) => item.action?.label)).toEqual(
+      Array.from({ length: 13 }, (_, index) => `Option ${index + 1}`),
+    );
+    expect(
+      sendModule.createTextMessageWithQuickReplies("Pick one", [" \t "]).quickReply,
+    ).toBeUndefined();
   });
 
   it("counts quick reply labels in grapheme clusters", () => {
@@ -200,19 +230,15 @@ describe("LINE send helpers", () => {
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(item?.action.label ?? "")).toBe(false);
   });
 
-  it("keeps provider-valid Flex alternative text and bounds oversized Unicode safely", () => {
+  it("keeps provider-valid Flex text across helpers and direct pushes", async () => {
     const contents = { type: "bubble" as const };
+    const altText = "a".repeat(1200);
 
-    expect(sendModule.createFlexMessage("a".repeat(1200), contents).altText).toBe("a".repeat(1200));
+    expect(sendModule.createFlexMessage(altText, contents).altText).toBe(altText);
 
     const oversized = sendModule.createFlexMessage(`${"a".repeat(1499)}😀 overflow`, contents);
     expect(oversized.altText).toBe("a".repeat(1499));
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(oversized.altText)).toBe(false);
-  });
-
-  it("sends the same provider-valid Flex alternative text through direct pushes", async () => {
-    const altText = "a".repeat(1200);
-
     await sendModule.pushFlexMessage("U123", altText, { type: "bubble" }, { cfg: LINE_TEST_CFG });
 
     expect(pushMessageMock).toHaveBeenCalledWith({
@@ -455,58 +481,7 @@ describe("LINE send helpers", () => {
       direction: "outbound",
     });
     expect(logVerboseMock).toHaveBeenCalledWith("line: pushed image to U123");
-    expect(result).toEqual({
-      chatId: "U123",
-      messageId: "push",
-      receipt: {
-        parts: [
-          {
-            index: 0,
-            kind: "media",
-            platformMessageId: "push",
-            raw: {
-              channel: "line",
-              chatId: "U123",
-              conversationId: "U123",
-              messageId: "push",
-              meta: { messageCount: 1 },
-            },
-            threadId: "U123",
-          },
-        ],
-        platformMessageIds: ["push"],
-        primaryPlatformMessageId: "push",
-        raw: [
-          {
-            channel: "line",
-            chatId: "U123",
-            conversationId: "U123",
-            messageId: "push",
-            meta: { messageCount: 1 },
-          },
-        ],
-        sentAt: fixedSentAt,
-        threadId: "U123",
-      },
-    });
-  });
-
-  it("preserves every provider message id returned by a LINE push", async () => {
-    pushMessageMock.mockResolvedValueOnce({
-      sentMessages: [{ id: "613452345678901234" }, { id: "613452345678901235" }],
-    });
-
-    const result = await sendModule.pushMessagesLine(
-      "line:user:U123",
-      [
-        { type: "text", text: "first" },
-        { type: "text", text: "second" },
-      ],
-      { cfg: LINE_TEST_CFG },
-    );
-
-    expect(result.messageId).toBe("613452345678901234");
-    expect(result.receipt.platformMessageIds).toEqual(["613452345678901234", "613452345678901235"]);
+    expect(result).toEqual(expectedMediaSendResult("U123", "push", 1));
   });
 
   it("replies when reply token is provided", async () => {
@@ -534,56 +509,44 @@ describe("LINE send helpers", () => {
       ],
     });
     expect(logVerboseMock).toHaveBeenCalledWith("line: replied to C1");
-    expect(result).toEqual({
-      chatId: "C1",
-      messageId: "reply",
-      receipt: {
-        parts: [
-          {
-            index: 0,
-            kind: "media",
-            platformMessageId: "reply",
-            raw: {
-              channel: "line",
-              chatId: "C1",
-              conversationId: "C1",
-              messageId: "reply",
-              meta: { messageCount: 2 },
-            },
-            threadId: "C1",
-          },
-        ],
-        platformMessageIds: ["reply"],
-        primaryPlatformMessageId: "reply",
-        raw: [
-          {
-            channel: "line",
-            chatId: "C1",
-            conversationId: "C1",
-            messageId: "reply",
-            meta: { messageCount: 2 },
-          },
-        ],
-        sentAt: fixedSentAt,
-        threadId: "C1",
-      },
-    });
+    expect(result).toEqual(expectedMediaSendResult("C1", "reply", 2));
   });
 
-  it("preserves every provider message id returned by a LINE reply", async () => {
-    replyMessageMock.mockResolvedValueOnce({
-      sentMessages: [{ id: "713452345678901234" }, { id: "713452345678901235" }],
-    });
-
-    const result = await sendModule.sendMessageLine("line:group:C1", "Hello", {
-      cfg: LINE_TEST_CFG,
-      replyToken: "reply-token",
-      mediaUrl: "https://example.com/media.jpg",
-    });
-
-    expect(result.messageId).toBe("713452345678901234");
-    expect(result.receipt.platformMessageIds).toEqual(["713452345678901234", "713452345678901235"]);
-  });
+  it.each([
+    {
+      route: "push",
+      ids: ["613452345678901234", "613452345678901235"],
+      provider: pushMessageMock,
+      send: () =>
+        sendModule.pushMessagesLine(
+          "line:user:U123",
+          [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+          { cfg: LINE_TEST_CFG },
+        ),
+    },
+    {
+      route: "reply",
+      ids: ["713452345678901234", "713452345678901235"],
+      provider: replyMessageMock,
+      send: () =>
+        sendModule.sendMessageLine("line:group:C1", "Hello", {
+          cfg: LINE_TEST_CFG,
+          replyToken: "reply-token",
+          mediaUrl: "https://example.com/media.jpg",
+        }),
+    },
+  ])(
+    "preserves every provider message id returned by a LINE $route",
+    async ({ ids, provider, send }) => {
+      provider.mockResolvedValueOnce({ sentMessages: ids.map((id) => ({ id })) });
+      const result = await send();
+      expect(result.messageId).toBe(ids[0]);
+      expect(result.receipt.platformMessageIds).toEqual(ids);
+    },
+  );
 
   it.each([
     {
@@ -817,31 +780,37 @@ describe("LINE send helpers", () => {
     });
   });
 
-  it("sends video with explicit image preview URL", async () => {
-    await sendModule.sendMessageLine("line:user:U100", "Video", {
-      cfg: LINE_TEST_CFG,
-      mediaUrl: "https://example.com/video.mp4",
-      mediaKind: "video",
-      previewImageUrl: "https://example.com/preview.jpg",
-      trackingId: "track-1",
-    });
+  it.each([
+    { target: "line:user:U100", chatId: "U100", trackingId: "track-1", expected: "track-1" },
+    { target: "line:group:C100", chatId: "C100", trackingId: "track-group", expected: undefined },
+  ])(
+    "normalizes video tracking by recipient $target",
+    async ({ target, chatId, trackingId, expected }) => {
+      await sendModule.sendMessageLine(target, "Video", {
+        cfg: LINE_TEST_CFG,
+        mediaUrl: "https://example.com/video.mp4",
+        mediaKind: "video",
+        previewImageUrl: "https://example.com/preview.jpg",
+        trackingId,
+      });
 
-    expect(pushMessageMock).toHaveBeenCalledWith({
-      to: "U100",
-      messages: [
-        {
-          type: "video",
-          originalContentUrl: "https://example.com/video.mp4",
-          previewImageUrl: "https://example.com/preview.jpg",
-          trackingId: "track-1",
-        },
-        {
-          type: "text",
-          text: "Video",
-        },
-      ],
-    });
-  });
+      expect(pushMessageMock).toHaveBeenCalledWith({
+        to: chatId,
+        messages: [
+          {
+            type: "video",
+            originalContentUrl: "https://example.com/video.mp4",
+            previewImageUrl: "https://example.com/preview.jpg",
+            ...(expected ? { trackingId: expected } : {}),
+          },
+          {
+            type: "text",
+            text: "Video",
+          },
+        ],
+      });
+    },
+  );
 
   it("throws when video preview URL is missing", async () => {
     await expect(
@@ -908,31 +877,6 @@ describe("LINE send helpers", () => {
     await expect(run()).rejects.toThrow(new Error("LINE outbound media URL must use HTTPS"));
     expect(pushMessageMock).not.toHaveBeenCalled();
     expect(replyMessageMock).not.toHaveBeenCalled();
-  });
-
-  it("omits trackingId for non-user destinations", async () => {
-    await sendModule.sendMessageLine("line:group:C100", "Video", {
-      cfg: LINE_TEST_CFG,
-      mediaUrl: "https://example.com/video.mp4",
-      mediaKind: "video",
-      previewImageUrl: "https://example.com/preview.jpg",
-      trackingId: "track-group",
-    });
-
-    expect(pushMessageMock).toHaveBeenCalledWith({
-      to: "C100",
-      messages: [
-        {
-          type: "video",
-          originalContentUrl: "https://example.com/video.mp4",
-          previewImageUrl: "https://example.com/preview.jpg",
-        },
-        {
-          type: "text",
-          text: "Video",
-        },
-      ],
-    });
   });
 
   it("throws when push messages are empty", async () => {
@@ -1050,21 +994,101 @@ describe("LINE send helpers", () => {
     );
   });
 
-  it("pushes quick-reply text and caps to 13 buttons", async () => {
+  it("normalizes quick replies across push and reply provider boundaries", async () => {
+    const options = { cfg: LINE_TEST_CFG };
     await sendModule.pushTextMessageWithQuickReplies(
       "U-quick",
       "Pick one",
-      Array.from({ length: 20 }, (_, index) => `Choice ${index + 1}`),
-      { cfg: LINE_TEST_CFG },
+      [
+        ...Array.from({ length: 13 }, () => " \t "),
+        ...Array.from({ length: 14 }, (_, index) => `  Choice ${index + 1}  `),
+      ],
+      options,
     );
 
     expect(pushMessageMock).toHaveBeenCalledTimes(1);
-    const firstCall = pushMessageMock.mock.calls.at(0) as [
+    const [{ messages }] = pushMessageMock.mock.calls[0] as [
       { messages: Array<{ quickReply?: { items: unknown[] } }> },
     ];
-    const payload = expectDefined(firstCall[0], "LINE push payload");
-    expect(expectDefined(payload.messages[0], "LINE push message").quickReply?.items).toHaveLength(
-      13,
-    );
+    const items = messages[0]?.quickReply?.items;
+    expect(items).toHaveLength(13);
+    expect(items?.[0]).toMatchObject({ action: { label: "Choice 1", text: "Choice 1" } });
+
+    const validActions = Array.from({ length: 13 }, (_, index) => ({
+      type: "message" as const,
+      label: `Option ${index + 1}`,
+      text: `Option ${index + 1}`,
+    }));
+    const legacy = { type: "postback" as const, label: "Legacy", data: "old", text: "Old" };
+    const modern = { ...legacy, label: "Modern", data: "new", displayText: "New" };
+    const repaired = {
+      imageUrl: "https://example.com/icon.png",
+      action: { type: "message" as const, label: "Repaired", text: "Repaired" },
+    };
+    const emptyDataActions = [
+      { type: "postback" as const, label: "Empty callback", data: "" },
+      { type: "datetimepicker" as const, label: "Empty date", data: "", mode: "date" as const },
+    ];
+    const rawItems = [
+      { type: "action" as const },
+      ...[
+        { type: "message" as const, label: " \t ", text: "blank" },
+        ...(["message", "uri", "postback", "datetimepicker"] as const).map((type) => ({
+          type,
+          label: `Missing ${type}`,
+        })),
+      ].map((action) => ({ type: "action" as const, action })),
+      repaired,
+      { ...repaired, type: "unsupported" },
+      ...[modern, legacy, ...emptyDataActions, ...validActions].map((action) => ({
+        type: "action" as const,
+        action,
+      })),
+    ];
+    const expectedItems = [
+      { ...repaired, type: "action" },
+      { ...repaired, type: "action" },
+      ...[
+        { type: "postback", label: "Modern", data: "new", displayText: "New" },
+        { type: "postback", label: "Legacy", data: "old", displayText: "Old" },
+        ...emptyDataActions,
+        ...validActions.slice(0, 7),
+      ].map((action) => ({ type: "action", action })),
+    ];
+    for (const route of ["quick-reply push", "raw push", "reply"] as const) {
+      for (const raw of route === "quick-reply push" ? [false] : [false, true]) {
+        const provider = route === "reply" ? replyMessageMock : pushMessageMock;
+        provider.mockClear();
+        const message = {
+          type: "text" as const,
+          text: "Pick one",
+          quickReply: { items: raw ? rawItems : [] },
+        };
+        if (route === "quick-reply push") {
+          await sendModule.pushTextMessageWithQuickReplies("U-quick", message.text, [""], options);
+        } else if (route === "raw push") {
+          await sendModule.pushMessagesLine("U-quick", [message], options);
+        } else {
+          await sendModule.replyMessageLine("reply-token", [message], options);
+        }
+
+        expect(provider).toHaveBeenCalledExactlyOnceWith({
+          ...(route === "reply" ? { replyToken: "reply-token" } : { to: "U-quick" }),
+          messages: [
+            {
+              type: "text",
+              text: "Pick one",
+              ...(raw
+                ? {
+                    quickReply: {
+                      items: expectedItems,
+                    },
+                  }
+                : {}),
+            },
+          ],
+        });
+      }
+    }
   });
 });

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
+import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import { messageAction, normalizeLineMessageActions } from "./actions.js";
@@ -552,21 +553,24 @@ export async function pushTextMessageWithQuickReplies(
 }
 
 export function createQuickReplyItems(labels: string[]): QuickReply {
-  const items: QuickReplyItem[] = labels.slice(0, 13).map((label) => ({
-    type: "action",
-    action: messageAction(label, label),
-  }));
+  const items: QuickReplyItem[] = normalizeStringEntries(labels)
+    .slice(0, 13)
+    .map((label) => ({
+      type: "action",
+      action: messageAction(label, label),
+    }));
   return { items };
 }
 
 export function createTextMessageWithQuickReplies(
   text: string,
   quickReplyLabels: string[],
-): TextMessage & { quickReply: QuickReply } {
+): TextMessage {
+  const quickReply = createQuickReplyItems(quickReplyLabels);
   return {
     type: "text",
     text,
-    quickReply: createQuickReplyItems(quickReplyLabels),
+    ...(quickReply.items?.length ? { quickReply } : {}),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

LINE messages could be rejected, silently lose valid controls, or expose malformed action payloads because quick replies, templates, Flex components, imagemaps, and generated text-message actions applied competing or incomplete provider contracts.

The seven distinct affected owner-level invariants are:

1. Supported action types, required labels, optional default actions, and surface-specific action ownership.
2. Quick-reply envelopes, required per-type fields, icon validation, filtering before the 13-item cap, and omission of empty replies.
3. URI schemes and length limits, including preserving a valid primary link when optional desktop metadata is malformed.
4. Opaque postback callback data, deprecated-versus-modern response text, and provider-valid keyboard input options.
5. Datetime picker formats, real calendar values, and chronological bounds that accept both `T` and `t` without rewriting the caller's original timestamp bytes.
6. Clipboard actions' required nonempty text and provider size limits.
7. Imagemap action bounds and optional video links, which require both a valid URI and a nonempty visible label when present.

## Why This Change Was Made

Keep all action-contract decisions in the existing LINE action owner and existing generated quick-reply owner. Unsupported visible actions become explanatory provider-valid fallbacks; malformed optional actions or desktop metadata are removed without discarding valid controls; invalid quick replies are filtered before they consume a capped slot.

The initial formal review correctly found an additional mixed-case datetime bug: raw lexicographic comparison treated otherwise equivalent `T` and `t` differently. The corrected owner compares validated bounds case-insensitively while preserving the original outgoing values. Equal and inverted bounds are removed, valid reverse-casing bounds survive, and no unsupported initial-versus-range constraint is invented.

## User Impact

Operators keep working controls, complete quick replies, intact callback identities, valid optional template defaults, and the original spelling of provider-valid datetime values. Invalid or unsupported message actions produce visible, understandable fallbacks instead of rejected requests or silent failures. Existing configuration, authorization, storage, protocol, and public plugin SDK surfaces are unchanged.

## Evidence

- Frozen candidate: `da2c049fb43f3610f11a39222fd8933c22530d5d`; tree `5cac43347baf9020bcbf08e8d594f525ac9dedb6`; parent `a88f3ffc9609d6fc0b70e370160801dc66d8d14c`.
- Test-first reproduction: the rejected predecessor produced **36 failures across 1,305 authenticated localhost provider requests** for mixed-case inverted, equal, and valid datetime ranges across quick replies, Flex messages, and templates.
- Corrected owner proof: **106/106** existing LINE message-card and send tests pass, including the mixed-case chronology regression and prior action-surface coverage.
- Independent provider proof: installed `@line/bot-sdk@11.2.0`, production push/reply paths, and model-ingress surfaces execute **1,305/1,305 authenticated localhost HTTP requests** with **zero rejected requests, crashes, or semantic failures**. This is a real authenticated local LINE-compatible provider fixture; **no external live LINE API was contacted**.
- Configured normal and type-aware lint, four-file formatting checks, and `git diff --check` all pass.
- Five wholly fresh independent hostile reviews report no P0-P3 findings on this exact immutable candidate.
- Genuine `gpt-5.6-sol` high-reasoning autoreview reports **zero P0-P3 findings**, overall confidence **0.98**; genuine TruffleHog **3.96.0** is clean.
- Current canonical `main` has independently changed the existing LINE send and test owners after this candidate's base; reconcile those current owner changes before landing instead of replacing newer code.
