### PR TITLE
fix(release): accept legacy Codex follow-through delivery

### DIFF
--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -661,6 +661,8 @@ function assertFollowthroughTranscript({ transcriptEvents, progressMarker, compl
       (call, index) =>
         call.text !== expected[index] ||
         call.args.action !== "send" ||
+        // Extended-stable candidates can predate this optional Codex control.
+        // A successful ordered completion send is valid evidence; `false` is not.
         (index === 0
           ? call.args.final !== undefined
           : call.args.final !== undefined && call.args.final !== true),

--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -654,21 +654,20 @@ function assertFollowthroughTranscript({ transcriptEvents, progressMarker, compl
     );
     return text === progressMarker || text === completeMarker ? [{ ...entry, args, text }] : [];
   });
-  const expected = [
-    { text: progressMarker, final: undefined },
-    { text: completeMarker, final: true },
-  ];
+  const expected = [progressMarker, completeMarker];
   if (
     markerCalls.length !== expected.length ||
     markerCalls.some(
       (call, index) =>
-        call.text !== expected[index].text ||
+        call.text !== expected[index] ||
         call.args.action !== "send" ||
-        call.args.final !== expected[index].final,
+        (index === 0
+          ? call.args.final !== undefined
+          : call.args.final !== undefined && call.args.final !== true),
     )
   ) {
     throw new Error(
-      `expected exact message final controls ${JSON.stringify(expected)}, got ${JSON.stringify(markerCalls.map((call) => ({ text: call.text, action: call.args.action, final: call.args.final })))}`,
+      `expected ordered message sends with an optional final completion marker ${JSON.stringify(expected)}, got ${JSON.stringify(markerCalls.map((call) => ({ text: call.text, action: call.args.action, final: call.args.final })))}`,
     );
   }
   const [progressCall, completeCall] = markerCalls;

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -880,9 +880,22 @@ describe("Codex install helpers", () => {
     expect(result.stderr).toContain("expected all workspace work to settle before completion");
   });
 
+  it("accepts a terminal completion message without the optional final marker", () => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-npm-followthrough-legacy-completion-");
+    const fixture = createCodexNpmPluginLiveFollowthroughFixture({
+      root,
+      messageFinals: [undefined, undefined],
+    });
+
+    const result = runCodexNpmPluginLiveFollowthroughAssertions(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
   it.each([
     ["explicit progress", [false, true]],
-    ["missing completion", [undefined, undefined]],
+    ["nonfinal completion", [undefined, false]],
   ] as const)("rejects %s Codex message final controls", (_label, messageFinals) => {
     const root = makeTempDir(tempDirs, "openclaw-codex-npm-followthrough-final-controls-");
     const fixture = createCodexNpmPluginLiveFollowthroughFixture({
@@ -893,7 +906,9 @@ describe("Codex install helpers", () => {
     const result = runCodexNpmPluginLiveFollowthroughAssertions(fixture);
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("expected exact message final controls");
+    expect(result.stderr).toContain(
+      "expected ordered message sends with an optional final completion marker",
+    );
   });
 
   it("accepts the explicit frozen-target JSON session and sidecar binding contract", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation rejected an otherwise successful frozen candidate because its Codex follow-through completion delivery omitted a later-added `final: true` control.

## Why This Change Was Made

The validator now accepts the two equivalent terminal forms: an ordered successful completion send with `final: true`, or the same send with that optional control omitted. It still rejects non-final controls, wrong order, extra marker sends, failed delivery, and incomplete workspace work.

## User Impact

No runtime or user-facing product behavior changes. This lets release validation assess the candidate behavior that was actually shipped rather than requiring a post-candidate tool argument.

## Evidence

- Reproduced against Full Release Validation [30701565603](https://github.com/openclaw/openclaw/actions/runs/30701565603): the Docker E2E completed all three Codex turns and delivered both markers; only the post-candidate strict control assertion failed.
- `node scripts/run-vitest.mjs test/scripts/codex-install-assertions.test.ts` — 30 passing tests, including omitted, true, and false completion-control cases.
- `git diff --check`, `oxfmt`, and fresh autoreview pass.

AI-assisted; no transcript is included.