### PR TITLE
fix(cli): align sessions cleanup label summary by visible width

### DIFF
--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -1,5 +1,6 @@
 // Sessions cleanup tests cover stale session cleanup and runtime output.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { RuntimeEnv } from "../runtime.js";
 
@@ -641,6 +642,76 @@ describe("sessionsCleanupCommand", () => {
     );
     expect(logs.join("\n")).not.toContain("\u001b[31m");
     expectLogsToInclude(logs, "Total: 3 kept, 4 pruned");
+  });
+
+  it("aligns the label summary columns for emoji and CJK labels", async () => {
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.runSessionsCleanup.mockResolvedValue({
+      mode: "warn",
+      previewResults: [
+        {
+          summary: {
+            agentId: "main",
+            storePath: "/resolved/sessions.json",
+            mode: "warn",
+            dryRun: true,
+            beforeCount: 2,
+            afterCount: 2,
+            missing: 0,
+            dmScopeRetired: 0,
+            pruned: 0,
+            capped: 0,
+            unreferencedArtifacts: {
+              scannedFiles: 0,
+              removedFiles: 0,
+              freedBytes: 0,
+              olderThanMs: 604800000,
+            },
+            diskBudget: null,
+            wouldMutate: true,
+          },
+          beforeStore: {
+            emojiKept: {
+              sessionId: "emoji-kept",
+              updatedAt: 2,
+              model: "test:opus",
+              label: "🔥修复",
+            },
+            plainKept: {
+              sessionId: "plain-kept",
+              updatedAt: 1,
+              model: "test:opus",
+              label: "plain",
+            },
+          },
+          missingKeys: new Set<string>(),
+          staleKeys: new Set<string>(),
+          cappedKeys: new Set<string>(),
+          budgetEvictedKeys: new Set<string>(),
+          dmScopeRetiredKeys: new Set<string>(),
+        },
+      ],
+      appliedSummaries: [],
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    expectLogsToInclude(logs, "Summary by Label:");
+    const summaryLogs = logs.slice(logs.indexOf("Summary by Label:") + 1);
+    const emojiLine = summaryLogs.find((line) => line.includes("🔥修复"));
+    const plainLine = summaryLogs.find((line) => line.includes("plain"));
+    expect(emojiLine).toBeDefined();
+    expect(plainLine).toBeDefined();
+    // "🔥修复" is 6 visible columns (wide emoji + 2 CJK) but only 5 UTF-16 code
+    // units; padding by code-unit length would shift the counts column left.
+    const keptColumn = (line: string) => visibleWidth(line.slice(0, line.indexOf("1 kept")));
+    expect(keptColumn(emojiLine ?? "")).toBe(keptColumn(plainLine ?? ""));
   });
 
   it("returns grouped JSON for --all-agents dry-runs", async () => {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -4,6 +4,7 @@
  * It can delegate cleanup to a live gateway or run local store maintenance,
  * with dry-run tables that explain every planned pruning action.
  */
+import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -129,15 +130,15 @@ function renderLabelSummaries(params: {
   if (summaries.length === 0) {
     return;
   }
-  const labelPad = Math.max(...summaries.map((summary) => summary.label.length));
+  const labelPad = Math.max(...summaries.map((summary) => visibleWidth(summary.label)));
   const totalKept = summaries.reduce((total, summary) => total + summary.kept, 0);
   const totalPruned = summaries.reduce((total, summary) => total + summary.pruned, 0);
   params.runtime.log("");
   params.runtime.log("Summary by Label:");
   for (const summary of summaries) {
-    params.runtime.log(
-      `${summary.label.padEnd(labelPad)}  ${summary.kept} kept, ${summary.pruned} pruned`,
-    );
+    const remaining = labelPad - visibleWidth(summary.label);
+    const paddedLabel = remaining > 0 ? `${summary.label}${" ".repeat(remaining)}` : summary.label;
+    params.runtime.log(`${paddedLabel}  ${summary.kept} kept, ${summary.pruned} pruned`);
   }
   params.runtime.log(`Total: ${totalKept} kept, ${totalPruned} pruned`);
 }


### PR DESCRIPTION
## Summary

Fix the `sessions cleanup` dry-run "Summary by Label" table so labels containing emoji or CJK characters no longer shift the kept/pruned counts column out of alignment.

## What Problem This Solves

Session labels are user-controlled via `/name`, and users routinely put emoji or CJK text in them. The dry-run summary groups sessions by label and aligns the counts column by padding each label to the widest label:

- In `src/commands/sessions-cleanup.ts:132`, the column width was computed with `summary.label.length` — the UTF-16 code-unit count, not the terminal cell width.
- In `src/commands/sessions-cleanup.ts:139`, `label.padEnd(labelPad)` padded by code units for the same reason.

A label like `🔥修复` occupies 6 terminal cells (wide emoji + 2 wide CJK) but only 5 UTF-16 code units, so the padding math disagrees with what the terminal renders and the `kept, pruned` counts no longer line up across rows. Any user running `openclaw sessions cleanup --dry-run` with emoji/CJK session names sees a crooked summary table.

**Code evidence**: in `src/commands/sessions-cleanup.ts:132,139`, the width and padding were based on `.length`/`padEnd`, which count UTF-16 code units instead of visible terminal columns.

## Root Cause

- Bug introduced by commit `a89e6e05efa` ("fix(cli): summarize cleanup dry-run by label", #93565, 2026-06-16), which added the label summary table.
- Violated invariant: the code assumed `string.length` equals the number of terminal cells a string occupies. That holds only for narrow ASCII; wide emoji, CJK, and combining characters break it.
- Trigger condition: any two labels in the same summary whose UTF-16 length and visible width differ (e.g. `/name 🔥修复` next to `/name plain`).

## Why This Fix

- The repository already solved this exact problem in #117062 by introducing `visibleWidth` (`packages/terminal-core/src/ansi.ts`), which measures terminal cell width (ANSI-aware, wide-grapheme-aware).
- Option A (this PR): compute the column width with `visibleWidth` and pad with `" ".repeat(labelPad - visibleWidth(label))` — the same idiom already used by `src/cli/cron-cli/shared.ts` and `src/commands/models/list.format.ts`.
- Option B (rejected): keep `padEnd` and special-case wide characters — duplicates `visibleWidth` logic inline and drifts from the shared implementation.
- Option C (rejected): strip emoji/CJK from labels before display — loses user information; the table should show the real label.

## User Impact

- Affected operation: `openclaw sessions cleanup` (dry-run and applied runs that print the "Summary by Label" table) when session labels contain emoji or CJK text.
- After the fix, the counts column stays aligned regardless of label content; plain ASCII labels render exactly as before.

## Evidence

- **Before**: on `main`, seeding a real session store with `/name 🔥修复` and `/name plain` and running the dry-run cleanup prints the counts at visible columns 9 and 7 — misaligned (FAIL).
- **After**: on this branch, the same store prints both counts at visible column 8 — aligned (PASS).

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
=== sessions cleanup --dry-run label summary ===
🔥修复   1 kept, 0 pruned
plain  1 kept, 0 pruned
counts column visible offsets: 9, 7
FAIL: counts column is misaligned (UTF-16 .length used as column width)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
=== sessions cleanup --dry-run label summary ===
🔥修复  1 kept, 0 pruned
plain   1 kept, 0 pruned
counts column visible offsets: 8, 8
PASS: counts column is aligned for emoji/CJK and ASCII labels
```

Proof setup: a real sqlite session store was seeded through the repository's own `upsertSessionEntry` API with two sessions labeled `🔥修复` and `plain`, then the real `sessionsCleanupCommand({ dryRun: true, store })` code path printed the summary above.

## Tests and Validation

- Added a regression test in `src/commands/sessions-cleanup.test.ts` ("aligns the label summary columns for emoji and CJK labels") that asserts the counts column starts at the same visible offset for `🔥修复` and `plain` labels.
- `pnpm vitest run src/commands/sessions-cleanup.test.ts` — 9/9 tests passed.
- `pnpm check` passed.
- Sibling audit: the other `padEnd` sites in this file (`Action`/`Key`/`Age`/`Model` columns) pad fixed ASCII enums, literals, or truncated ASCII-safe cells, so they are not affected.
