### PR TITLE
fix(tui): show attachment-only assistant replies

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -2020,6 +2020,54 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(loadHistory).not.toHaveBeenCalled();
   });
 
+  it("finalizes an attachment-only assistant reply instead of dropping it", () => {
+    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-external-image",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            data: "secret-image",
+            url: "file:///Users/operator/private/image.png",
+          },
+        ],
+      },
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("Attached image", "run-external-image");
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it.each(["input_text", "output_text"] as const)(
+    "does not preserve canonical %s as an attachment in the optimistic projection",
+    (type) => {
+      const { state, chatLog, handleChatEvent } = createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+      handleChatEvent({
+        runId: `run-${type}`,
+        sessionKey: state.currentSessionKey,
+        state: "final",
+        message: { role: "assistant", content: [{ type, text: "One visible reply." }] },
+      });
+
+      expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("One visible reply.", `run-${type}`);
+      expect(state.sessionProjection?.entries[0]?.message).toMatchObject({
+        role: "assistant",
+        content: "One visible reply.",
+      });
+    },
+  );
+
   it("preserves the assembled delta-only final across an older history snapshot", () => {
     const { state, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-streamed-final" },
@@ -2829,6 +2877,74 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted: cancelled by user");
     expect(state.activeChatRunId).toBeNull();
   });
+
+  it("ignores an attachment final that arrives after the run was aborted", () => {
+    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-abort-late-final" },
+    });
+    const message = {
+      role: "assistant",
+      content: [{ type: "image", data: "secret-image" }],
+    };
+
+    handleChatEvent({
+      runId: "run-abort-late-final",
+      sessionKey: state.currentSessionKey,
+      seq: 1,
+      state: "aborted",
+      errorMessage: "cancelled by user",
+      message,
+    });
+    handleChatEvent({
+      runId: "run-abort-late-final",
+      sessionKey: state.currentSessionKey,
+      seq: 2,
+      state: "final",
+      message,
+    });
+
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted: cancelled by user");
+    expect(state.sessionProjection?.runs["run-abort-late-final"]?.status).toBe("aborted");
+  });
+
+  it.each([
+    {
+      name: "abort",
+      terminal: { state: "aborted" as const, errorMessage: "cancelled by user" },
+      expectedStatus: "aborted",
+    },
+    {
+      name: "error",
+      terminal: { state: "error" as const, errorMessage: "provider failed" },
+      expectedStatus: "error",
+    },
+  ])(
+    "renders a text-bearing recovered final after a message-less $name",
+    ({ terminal, expectedStatus }) => {
+      const runId = `run-recovered-${expectedStatus}`;
+      const { state, chatLog, handleChatEvent } = createHandlersHarness({
+        state: { activeChatRunId: runId },
+      });
+
+      handleChatEvent({
+        runId,
+        sessionKey: state.currentSessionKey,
+        seq: 1,
+        ...terminal,
+      });
+      handleChatEvent({
+        runId,
+        sessionKey: state.currentSessionKey,
+        seq: 2,
+        state: "final",
+        message: { role: "assistant", content: [{ type: "text", text: "Recovered reply." }] },
+      });
+
+      expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("Recovered reply.", runId);
+      expect(state.sessionProjection?.runs[runId]?.status).toBe(expectedStatus);
+    },
+  );
 
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,14 +1,15 @@
 // Handles TUI keyboard, paste, backend, and command events.
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   hasSessionProjectionAcceptedFinal,
   reduceSessionProjectionRunEvent,
+  type SessionProjectionRunStatus,
 } from "../../packages/gateway-client/src/session-projection.js";
 import {
   asString,
   extractTextFromMessage,
+  extractTuiAbortedText,
+  formatTuiAbortDiagnostic,
   isCommandMessage,
-  sanitizeRenderableText,
 } from "./tui-formatters.js";
 import { createTuiRunLifecycle } from "./tui-run-lifecycle.js";
 import { matchesSelectedTuiSession, readTuiSessionUserMessage } from "./tui-session-events.js";
@@ -60,17 +61,8 @@ type EventHandlerBtwPresenter = {
   clear: () => void;
 };
 
-const MAX_ABORT_DIAGNOSTIC_LENGTH = 160;
-
-function formatAbortDiagnostic(value: string | undefined): string | undefined {
-  const diagnostic = sanitizeRenderableText(value ?? "")
-    .replace(/\s+/g, " ")
-    .trim();
-  return diagnostic
-    ? diagnostic.length > MAX_ABORT_DIAGNOSTIC_LENGTH
-      ? `${truncateUtf16Safe(diagnostic, MAX_ABORT_DIAGNOSTIC_LENGTH - 1)}…`
-      : diagnostic
-    : undefined;
+function isFailedTuiRunStatus(status: SessionProjectionRunStatus | undefined): boolean {
+  return status === "aborted" || status === "error" || status === "timeout";
 }
 
 type EventHandlerContext = {
@@ -206,6 +198,17 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const previousProjectedRun = reducedRun.previousRun;
     state.sessionProjection = reducedRun.projection;
+    if (evt.state === "final" && isFailedTuiRunStatus(previousProjectedRun?.status)) {
+      const hasRecoverableFinalText =
+        Boolean(extractTuiAbortedText(evt.message, state.showThinking).trim()) ||
+        streamAssembler.hasDisplayText(evt.runId);
+      if (!hasRecoverableFinalText) {
+        // The shared projection keeps failure precedence while allowing a real
+        // recovered reply. Attachment fallback alone cannot turn failure into completion.
+        clearStaleStreamingIfNoTrackedRunRemains();
+        return;
+      }
+    }
     if (evt.state === "aborted" && previousProjectedRun?.status === "aborted") {
       clearStaleStreamingIfNoTrackedRunRemains();
       return;
@@ -345,18 +348,17 @@ export function createEventHandlers(context: EventHandlerContext) {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       // Determine content from the message and stream, not the user-visible
-      // empty placeholder: "(no output)" is also valid assistant text.
+      // fallbacks: attachment-only aborts remain cancellation diagnostics.
       const hasDisplayableAbortedText =
-        Boolean(
-          extractTextFromMessage(evt.message, { includeThinking: state.showThinking }).trim(),
-        ) || streamAssembler.hasDisplayText(evt.runId);
+        Boolean(extractTuiAbortedText(evt.message, state.showThinking).trim()) ||
+        streamAssembler.hasDisplayText(evt.runId);
       // Abort envelopes carry the complete buffered reply, including text
       // suppressed by Gateway delta throttling; finalize it before run cleanup.
       const abortedText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
       if (hasDisplayableAbortedText) {
         chatLog.finalizeAssistant(abortedText, evt.runId);
       }
-      const diagnostic = formatAbortDiagnostic(evt.errorMessage);
+      const diagnostic = formatTuiAbortDiagnostic(evt.errorMessage);
       chatLog.addSystem(diagnostic ? `run aborted: ${diagnostic}` : "run aborted");
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
       maybeRefreshHistoryForRun(evt.runId, {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -196,6 +196,71 @@ describe("extractTextFromMessage", () => {
     ).toBe("Attached file: report.pdf");
   });
 
+  it.each([
+    { name: "image", block: { type: "image", data: "secret-image" }, expected: "Attached image" },
+    {
+      name: "audio",
+      block: { type: "audio", source: { type: "base64", data: "secret-audio" } },
+      expected: "Attached audio",
+    },
+    {
+      name: "video",
+      block: { type: "video", url: "file:///Users/operator/private/clip.mp4" },
+      expected: "Attached video",
+    },
+    {
+      name: "file",
+      block: { type: "file", url: "file:///etc/passwd", title: "private.txt" },
+      expected: "Attached file",
+    },
+    {
+      name: "nested audio attachment",
+      block: {
+        type: "attachment",
+        attachment: {
+          kind: "audio",
+          label: "private.ogg",
+          url: "file:///Users/operator/private/audio.ogg",
+        },
+      },
+      expected: "Attached audio",
+    },
+    {
+      name: "provider image URL block",
+      block: { type: "image_url", image_url: { url: "https://secret.test/image?ticket=secret" } },
+      expected: "Attached image",
+    },
+  ])("renders a terminal-safe assistant $name summary", ({ block, expected }) => {
+    const text = extractTextFromMessage({ role: "assistant", content: [block] });
+    expect(text).toBe(expected);
+    expect(text).not.toMatch(/secret|file:|operator|passwd|private/i);
+  });
+
+  it("renders canonical and legacy assistant media without exposing references", () => {
+    expect(
+      extractTextFromMessage({
+        role: "assistant",
+        content: [],
+        __openclaw: {
+          media: [
+            { kind: "image", path: "/private/generated.png" },
+            { kind: "audio", url: "https://secret.test/voice.ogg?ticket=secret" },
+            { kind: "video", fileName: "private.mov" },
+            { kind: "document", path: "/etc/passwd" },
+          ],
+        },
+      }),
+    ).toBe("Attached image\nAttached audio\nAttached video\nAttached file");
+    expect(
+      extractTextFromMessage({
+        role: "assistant",
+        content: [],
+        mediaUrl: "file:///private/one.png",
+        mediaUrls: ["https://secret.test/two.mp3?ticket=secret"],
+      }),
+    ).toBe("Attached media\nAttached media");
+  });
+
   it("prefers final_answer text over commentary text for assistant messages", () => {
     const text = extractTextFromMessage({
       role: "assistant",

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Formats terminal-safe strings for TUI messages and status surfaces.
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
@@ -15,6 +16,7 @@ const MAX_TOKEN_CHARS = 32;
 const LONG_TOKEN_RE = /\S{33,}/g;
 const LONG_TOKEN_TEST_RE = /\S{33,}/;
 const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
+const MAX_TUI_ABORT_DIAGNOSTIC_LENGTH = 160;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
@@ -227,10 +229,22 @@ export function formatTuiErrorMessage(error: unknown): string {
   return sanitizeRenderableText(formatErrorMessage(error));
 }
 
+export function formatTuiAbortDiagnostic(value: string | undefined): string | undefined {
+  const diagnostic = sanitizeRenderableText(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return diagnostic
+    ? diagnostic.length > MAX_TUI_ABORT_DIAGNOSTIC_LENGTH
+      ? `${truncateUtf16Safe(diagnostic, MAX_TUI_ABORT_DIAGNOSTIC_LENGTH - 1)}…`
+      : diagnostic
+    : undefined;
+}
+
 export function resolveFinalAssistantText(params: {
   finalText?: string | null;
   streamedText?: string | null;
   errorMessage?: string | null;
+  attachmentText?: string | null;
 }) {
   const finalText = params.finalText ?? "";
   if (finalText.trim()) {
@@ -243,6 +257,10 @@ export function resolveFinalAssistantText(params: {
   const errorMessage = params.errorMessage ?? "";
   if (errorMessage.trim()) {
     return formatRawAssistantErrorForUi(errorMessage);
+  }
+  const attachmentText = params.attachmentText ?? "";
+  if (attachmentText.trim()) {
+    return attachmentText;
   }
   return "(no output)";
 }
@@ -271,6 +289,91 @@ function asMessageRecord(message: unknown): Record<string, unknown> | undefined 
     return undefined;
   }
   return message as Record<string, unknown>;
+}
+
+type TuiAttachmentKind = "image" | "audio" | "video" | "file" | "media";
+
+const TUI_ATTACHMENT_BLOCK_KINDS: Readonly<Record<string, TuiAttachmentKind>> = {
+  image: "image",
+  input_image: "image",
+  image_url: "image",
+  audio: "audio",
+  video: "video",
+  file: "file",
+  document: "file",
+};
+
+function resolveTuiAttachmentBlockKind(block: Record<string, unknown>): TuiAttachmentKind | null {
+  const type = typeof block.type === "string" ? block.type : "";
+  const directKind = TUI_ATTACHMENT_BLOCK_KINDS[type];
+  if (directKind) {
+    return directKind;
+  }
+  if (type !== "attachment") {
+    return null;
+  }
+  const attachment = asMessageRecord(block.attachment);
+  const declaredKind = attachment?.kind;
+  if (declaredKind === "image" || declaredKind === "sticker") {
+    return "image";
+  }
+  if (declaredKind === "audio" || declaredKind === "video") {
+    return declaredKind;
+  }
+  const mimeKind =
+    typeof attachment?.mimeType === "string" ? attachment.mimeType.split("/", 1)[0] : "";
+  return mimeKind === "image" || mimeKind === "audio" || mimeKind === "video" ? mimeKind : "file";
+}
+
+/** Keep optimistic session projection aligned with the terminal's attachment renderer. */
+export function isTuiAssistantAttachmentBlock(block: unknown): boolean {
+  const entry = asMessageRecord(block);
+  return entry ? resolveTuiAttachmentBlockKind(entry) !== null : false;
+}
+
+function resolvePersistedTuiAttachmentKind(
+  fact: NonNullable<ReturnType<typeof readPersistedMediaFacts>>[number],
+): TuiAttachmentKind {
+  if (isImageMediaFact(fact)) {
+    return "image";
+  }
+  if (fact.kind === "audio" || fact.kind === "video") {
+    return fact.kind;
+  }
+  return "file";
+}
+
+/** Render assistant attachments without exposing their sources or capability URLs. */
+export function extractAssistantAttachmentText(message: unknown): string {
+  const record = asMessageRecord(message);
+  if (!record) {
+    return "";
+  }
+  const contentAttachments = Array.isArray(record.content)
+    ? record.content.flatMap((block) => {
+        const entry = asMessageRecord(block);
+        const kind = entry ? resolveTuiAttachmentBlockKind(entry) : null;
+        return kind ? [`Attached ${kind}`] : [];
+      })
+    : [];
+  if (contentAttachments.length > 0) {
+    return contentAttachments.join("\n");
+  }
+
+  const persistedAttachments = (readPersistedMediaFacts(record) ?? [])
+    .filter((fact) => fact.path || fact.url || fact.contentType || fact.kind)
+    .map((fact) => `Attached ${resolvePersistedTuiAttachmentKind(fact)}`);
+  if (persistedAttachments.length > 0) {
+    return persistedAttachments.join("\n");
+  }
+
+  const legacyMedia = [
+    ...(typeof record.mediaUrl === "string" && record.mediaUrl.trim() ? [record.mediaUrl] : []),
+    ...(Array.isArray(record.mediaUrls)
+      ? record.mediaUrls.filter((value) => typeof value === "string" && value.trim())
+      : []),
+  ];
+  return legacyMedia.map(() => "Attached media").join("\n");
 }
 
 function resolveMessageRecord(
@@ -465,16 +568,19 @@ function extractUserAttachmentText(record: Record<string, unknown>): string {
 
 export function extractTextFromMessage(
   message: unknown,
-  opts?: { includeThinking?: boolean },
+  opts?: { includeThinking?: boolean; includeAttachments?: boolean },
 ): string {
   const record = asMessageRecord(message);
   if (!record) {
     return "";
   }
   if (record.role === "assistant") {
+    const contentText = extractAssistantRenderableContent(record);
     return composeThinkingAndContent({
       thinkingText: extractThinkingFromMessage(record),
-      contentText: extractAssistantRenderableContent(record),
+      contentText:
+        contentText ||
+        (opts?.includeAttachments !== false ? extractAssistantAttachmentText(record) : ""),
       showThinking: opts?.includeThinking ?? false,
     });
   }
@@ -495,6 +601,11 @@ export function extractTextFromMessage(
     return "";
   }
   return errorText;
+}
+
+/** Extract abort-visible text while keeping attachment-only aborts diagnostic-only. */
+export function extractTuiAbortedText(message: unknown, includeThinking: boolean): string {
+  return extractTextFromMessage(message, { includeThinking, includeAttachments: false });
 }
 
 export function isCommandMessage(message: unknown): boolean {

--- a/src/tui/tui-pty-assistant-fixture-test-support.ts
+++ b/src/tui/tui-pty-assistant-fixture-test-support.ts
@@ -1,0 +1,45 @@
+/** Generated-script fragment for assistant-specific PTY fixture messages. */
+export const TUI_PTY_ASSISTANT_FIXTURE_SCRIPT = `
+  function assistantMessageFromSourceReplyPayloads(
+    payloads: ReturnType<typeof buildEmbeddedRunPayloads>,
+  ) {
+    if (payloads.length === 0) {
+      throw new Error("expected source reply payload");
+    }
+    for (const payload of payloads) {
+      const metadata = getReplyPayloadMetadata(payload);
+      if (!metadata?.sourceReplyTranscriptMirror) {
+        throw new Error("expected source reply transcript mirror metadata");
+      }
+      record("sourceReplyMetadata", metadata.sourceReplyTranscriptMirror);
+    }
+    const normalized = normalizeReplyPayloadsForDelivery(payloads);
+    const content = normalized.flatMap((payload) => {
+      const text = payload.text?.trim();
+      return text ? [{ type: "text", text }] : [];
+    });
+    if (content.length === 0) {
+      throw new Error("expected displayable source reply content");
+    }
+    return { role: "assistant", content, timestamp: Date.now() };
+  }
+
+  function buildAttachmentOnlyAssistantMessage(prompt: string, runId: string) {
+    if (prompt !== "attachment-only assistant proof") {
+      return null;
+    }
+    record("attachmentOnlyComplete", { runId });
+    return {
+      role: "assistant",
+      content: [
+        {
+          type: "image",
+          data: "SECRET_PTY_IMAGE_BYTES",
+          url: "file:///Users/operator/private/image.png",
+          artifactId: "SECRET_PTY_ARTIFACT",
+        },
+      ],
+      timestamp: Date.now(),
+    };
+  }
+`;

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -2,6 +2,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { TUI_PTY_ASSISTANT_FIXTURE_SCRIPT } from "./tui-pty-assistant-fixture-test-support.js";
 import { TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT } from "./tui-pty-gap-fixture-test-support.js";
 import { TUI_PTY_RESET_FIXTURE } from "./tui-pty-reset-fixture-test-support.js";
 import { TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT } from "./tui-pty-subscription-fixture-test-support.js";
@@ -88,33 +89,8 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         };
       }
 
-      function assistantMessageFromSourceReplyPayloads(payloads: ReturnType<typeof buildEmbeddedRunPayloads>) {
-        if (payloads.length === 0) {
-          throw new Error("expected source reply payload");
-        }
-        for (const payload of payloads) {
-          const metadata = getReplyPayloadMetadata(payload);
-          if (!metadata?.sourceReplyTranscriptMirror) {
-            throw new Error("expected source reply transcript mirror metadata");
-          }
-          record("sourceReplyMetadata", metadata.sourceReplyTranscriptMirror);
-        }
-        const normalized = normalizeReplyPayloadsForDelivery(payloads);
-        const content = normalized.flatMap((payload) => {
-          const text = payload.text?.trim();
-          return text ? [{ type: "text", text }] : [];
-        });
-        if (content.length === 0) {
-          throw new Error("expected displayable source reply content");
-        }
-        return {
-          role: "assistant",
-          content,
-          timestamp: Date.now(),
-        };
-      }
-
       ${TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT}
+      ${TUI_PTY_ASSISTANT_FIXTURE_SCRIPT}
 
       class FixtureBackend implements TuiBackend {
         connection = { url: "pty-fixture://local" };
@@ -362,13 +338,14 @@ export async function writeTuiPtyFixtureScript(dir: string) {
                   runId,
                 })
               : [];
+            const attachmentOnlyMessage = buildAttachmentOnlyAssistantMessage(opts.message, runId);
             const message = isSourceReplyProof
               ? assistantMessageFromSourceReplyPayloads(sourceReplyPayloads)
-              : {
+              : (attachmentOnlyMessage ?? {
                   role: "assistant",
                   content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
                   timestamp: Date.now(),
-                };
+                });
             this.onEvent?.({
               event: "chat",
               payload: {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -560,6 +560,21 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
+    "renders an attachment-only assistant reply without exposing its source",
+    async () => {
+      await fixture.run.write("attachment-only assistant proof\r");
+      await fixture.waitForLogEntry((entry) => entry.method === "attachmentOnlyComplete");
+      await fixture.run.waitForOutput("Attached image");
+
+      const rendered = fixture.run.visibleOutput();
+      expect(rendered).not.toContain("SECRET_PTY_IMAGE_BYTES");
+      expect(rendered).not.toContain("SECRET_PTY_ARTIFACT");
+      expect(rendered).not.toContain("/Users/operator/private");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
     "preserves xAI account limit errors in terminal output",
     async () => {
       await fixture.run.write("xai limit proof\r");

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -2300,6 +2300,40 @@ describe("tui session actions", () => {
     expect(result).toEqual({ loaded: true, inFlightRunId: null });
   });
 
+  it("restores attachment-only assistant rows from history without exposing references", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [
+        { role: "assistant", content: [{ type: "image", data: "secret-image" }] },
+        {
+          role: "assistant",
+          content: [{ type: "audio", source: { type: "url", url: "file:///private/audio.mp3" } }],
+        },
+        { role: "assistant", content: [{ type: "video", url: "file:///private/video.mp4" }] },
+        { role: "assistant", content: [{ type: "file", url: "file:///etc/passwd" }] },
+      ],
+    });
+    const chatLog = {
+      addSystem: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+    };
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    await runLoadHistory();
+
+    expect(chatLog.finalizeAssistant.mock.calls.map(([text]) => text)).toEqual([
+      "Attached image",
+      "Attached audio",
+      "Attached video",
+      "Attached file",
+    ]);
+  });
+
   it("releases a pending submit when reconnect history proves it was accepted", async () => {
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-main",

--- a/src/tui/tui-session-projection.ts
+++ b/src/tui/tui-session-projection.ts
@@ -8,7 +8,7 @@ import {
   type SessionProjectionState,
 } from "../../packages/gateway-client/src/session-projection.js";
 import { agentSessionKeysMatchByRequestKey } from "../routing/session-key.js";
-import { extractTextFromMessage } from "./tui-formatters.js";
+import { extractTextFromMessage, isTuiAssistantAttachmentBlock } from "./tui-formatters.js";
 import type {
   ChatEvent,
   SessionChangedEvent,
@@ -16,33 +16,7 @@ import type {
   TuiStateAccess,
 } from "./tui-types.js";
 
-function hasDisplayableNonTextSessionContent(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const record = message as Record<string, unknown>;
-  if (typeof record.mediaUrl === "string" && record.mediaUrl.trim()) {
-    return true;
-  }
-  if (
-    Array.isArray(record.mediaUrls) &&
-    record.mediaUrls.some((media) => typeof media === "string" && media.trim())
-  ) {
-    return true;
-  }
-  if (!Array.isArray(record.content)) {
-    return false;
-  }
-  return record.content.some((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    const type = (block as Record<string, unknown>).type;
-    return typeof type === "string" && type !== "text" && type !== "thinking";
-  });
-}
-
-/** Keep attachment-only and provider-diagnostic finals visible in the TUI. */
+/** Admit only finals the terminal formatter can actually render. */
 export function hasDisplayableTuiSessionFinal(event: ChatEvent, showThinking: boolean): boolean {
   if (typeof event.errorMessage === "string" && event.errorMessage.trim()) {
     return true;
@@ -50,10 +24,7 @@ export function hasDisplayableTuiSessionFinal(event: ChatEvent, showThinking: bo
   if (!event.message) {
     return false;
   }
-  return (
-    extractTextFromMessage(event.message, { includeThinking: showThinking }).trim().length > 0 ||
-    hasDisplayableNonTextSessionContent(event.message)
-  );
+  return extractTextFromMessage(event.message, { includeThinking: showThinking }).trim().length > 0;
 }
 
 /** Distinguish a legacy batch invalidation from an individually replayable message. */
@@ -158,13 +129,7 @@ export function projectTuiSessionFinal(
       ? (event.message as Record<string, unknown>)
       : {};
   const attachments = Array.isArray(source.content)
-    ? source.content.filter((block) => {
-        if (!block || typeof block !== "object") {
-          return false;
-        }
-        const type = (block as { type?: unknown }).type;
-        return type !== "text" && type !== "thinking";
-      })
+    ? source.content.filter(isTuiAssistantAttachmentBlock)
     : [];
   reduceTuiSessionProjection(state, {
     type: "messagePersisted",

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -131,6 +131,63 @@ describe("TuiStreamAssembler", () => {
     expect(finalText).toContain("Missing scopes: model.request");
   });
 
+  it("renders attachment-only assistant finals without exposing media fields", () => {
+    const assembler = new TuiStreamAssembler();
+    const finalText = assembler.finalize(
+      "run-media-only",
+      messageWithContent([
+        {
+          type: "image",
+          data: "secret-image",
+          url: "file:///Users/operator/private/image.png",
+          artifactId: "secret-artifact",
+        },
+      ]),
+      false,
+    );
+    expect(finalText).toBe("Attached image");
+  });
+
+  it("keeps visible thinking ahead of an attachment-only final", () => {
+    const assembler = new TuiStreamAssembler();
+    const finalText = assembler.finalize(
+      "run-media-thinking",
+      messageWithContent([
+        thinking("Preparing the attachment"),
+        { type: "image", data: "secret-image" },
+      ]),
+      true,
+    );
+    expect(finalText).toBe("[thinking]\nPreparing the attachment\n\nAttached image");
+  });
+
+  it("keeps a streamed caption ahead of an attachment-only final", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-media-caption",
+      messageWithContent([text("Generated chart")]),
+      false,
+    );
+    const finalText = assembler.finalize(
+      "run-media-caption",
+      messageWithContent([{ type: "image", data: "secret-image" }]),
+      false,
+    );
+    expect(finalText).toBe("Generated chart");
+  });
+
+  it("keeps an error ahead of an attachment summary", () => {
+    const assembler = new TuiStreamAssembler();
+    const finalText = assembler.finalize(
+      "run-media-error",
+      messageWithContent([{ type: "video", url: "file:///private/clip.mp4" }]),
+      false,
+      "media generation failed",
+    );
+    expect(finalText).toContain("media generation failed");
+    expect(finalText).not.toContain("Attached video");
+  });
+
   it("returns null when delta text is unchanged", () => {
     const assembler = new TuiStreamAssembler();
     const first = assembler.ingestDelta("run-4", messageWithContent([text("Repeat")]), false);

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -1,6 +1,7 @@
 // Assembles streamed backend events into TUI-visible messages.
 import {
   composeThinkingAndContent,
+  extractAssistantAttachmentText,
   extractContentFromMessage,
   extractThinkingFromMessage,
   resolveFinalAssistantText,
@@ -215,27 +216,35 @@ export class TuiStreamAssembler {
   finalize(runId: string, message: unknown, showThinking: boolean, errorMessage?: string): string {
     // Late finals must not insert an evicted run and displace a live stream.
     const state = this.runs.get(runId) ?? this.createRunState();
-    const streamedDisplayText = state.displayText;
+    const streamedContentText = state.contentText;
     const streamedTextBlocks = [...state.contentBlocks];
     const streamedSawNonTextContentBlocks = state.sawNonTextContentBlocks;
     this.updateRunState(state, message, showThinking, {
       boundaryDropMode: "streamed-only",
     });
-    const finalComposed = state.displayText;
     const shouldKeepStreamedText =
       streamedSawNonTextContentBlocks &&
       isDroppedBoundaryTextBlockSubset({
         streamedTextBlocks,
         finalTextBlocks: state.contentBlocks,
       });
-    const finalText = resolveFinalAssistantText({
-      finalText: shouldKeepStreamedText ? streamedDisplayText : finalComposed,
-      streamedText: streamedDisplayText,
+    const responseText = resolveFinalAssistantText({
+      finalText: shouldKeepStreamedText ? streamedContentText : state.contentText,
+      streamedText: streamedContentText,
       errorMessage,
+      attachmentText: extractAssistantAttachmentText(message),
+    });
+    // Thinking is optional presentation around the selected response content;
+    // it must not hide errors or attachments when the final has no text.
+    const omitEmptyPlaceholder = responseText === "(no output)" && Boolean(state.thinkingText);
+    const finalText = composeThinkingAndContent({
+      thinkingText: state.thinkingText,
+      contentText: omitEmptyPlaceholder ? "" : responseText,
+      showThinking,
     });
 
     this.runs.delete(runId);
-    return finalText;
+    return finalText || "(no output)";
   }
 
   /** Drops stored stream state for an aborted or discarded run. */


### PR DESCRIPTION
Closes #117469

## What Problem This Solves

Fixes an issue where TUI users receiving an attachment-only assistant reply would see no completed assistant row, and the reply would remain absent after history reload.

## Why This Change Was Made

The terminal formatter now owns one privacy-safe attachment summary for structured content blocks, canonical persisted media, and legacy media fields. Stream finalization selects real final text, streamed text, errors, then attachment summaries before composing optional thinking; session projection preserves only attachment blocks the formatter can actually render.

The same owner keeps attachment-only aborts diagnostic-only, rejects fallback-only late finals after abort/error/timeout, preserves text-bearing recovered finals, and never interpolates attachment bytes, paths, URLs, tickets, labels, or artifact IDs.

## User Impact

Completed image, audio, video, file, and generic media replies remain visible as `Attached …` in the live TUI and after session reload. Existing captions, error diagnostics, streamed text, thinking visibility, pairing QR output, and cancellation semantics retain their established precedence.

### Before

```text
You        attachment-only assistant proof

           [no assistant row rendered]
```

### After

```text
You        attachment-only assistant proof

Assistant  Attached image
```

These are sanitized deterministic PTY transcript renderings using synthetic fixture text only. PNG upload was unavailable because the existing Chrome DevTools bridge could not attach; no isolated browser or public image host was used.

## Evidence

- Before repair: 317 focused tests passed and 8 attachment-focused regressions failed.
- Source-blind behavior validation: 333/333 focused tests and 51/51 real-PTY tests passed; all 8 contract clauses passed with no contamination.
- Focused local closeout after the max-lines refactor: 242/242 event-handler and formatter tests passed.
- Final autoreview at P1 breadth: clean, no accepted/actionable findings, confidence 0.91.
- Blacksmith Testbox: changed gate, 333 focused tests, 51 PTY tests, and `pnpm build` passed on the final diff. Run: https://github.com/openclaw/openclaw/actions/runs/30704218535
- No config, protocol, persistent-state, plugin SDK, dependency, or migration surface changes.

Release-note context: TUI attachment-only assistant replies now remain visible through live finalization and history reload without exposing attachment internals.

AI-assisted: yes. The implementation was independently reviewed and source-blind behavior-validated.
