### PR TITLE
fix(release): allow beta validation child completion

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -808,7 +808,9 @@ jobs:
     needs: [resolve_target, evidence_reuse, prepare_release_candidate]
     if: ${{ always() && needs.resolve_target.result == 'success' && (needs.prepare_release_candidate.result == 'success' || needs.prepare_release_candidate.result == 'skipped') && contains(fromJSON('["all","release-checks","install-smoke","cross-os","live-e2e","package","qa","qa-parity","qa-live"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: ${{ inputs.release_profile != 'beta' && 240 || 60 }}
+    # The child owns lane timeouts; this monitor must also tolerate queue delay
+    # so it does not cancel healthy release checks before their final verifier.
+    timeout-minutes: 240
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
       url: ${{ steps.dispatch.outputs.url }}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4363,9 +4363,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       expect(workflow.env?.PNPM_VERSION, workflowPath).toBeUndefined();
     }
 
-    expect(fullRelease.jobs?.release_checks?.["timeout-minutes"]).toBe(
-      "${{ inputs.release_profile != 'beta' && 240 || 60 }}",
-    );
+    expect(fullRelease.jobs?.release_checks?.["timeout-minutes"]).toBe(240);
     expect(fullRelease.jobs?.prepare_release_package).toBeUndefined();
     expect(releaseChecks.jobs?.prepare_release_package?.["timeout-minutes"]).toBe(15);
     expect(

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -667,9 +667,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     expect(fullReleaseWorkflow.jobs.plugin_prerelease["timeout-minutes"]).toBe(
       "${{ inputs.release_profile == 'full' && 300 || inputs.release_profile == 'stable' && 240 || 60 }}",
     );
-    expect(fullReleaseWorkflow.jobs.release_checks["timeout-minutes"]).toBe(
-      "${{ inputs.release_profile != 'beta' && 240 || 60 }}",
-    );
+    expect(fullReleaseWorkflow.jobs.release_checks["timeout-minutes"]).toBe(240);
     const fullReleaseSource = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
     expect(fullReleaseWorkflow.on.workflow_dispatch.inputs.fail_fast).toEqual({
       description:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where beta Full Release Validation could cancel healthy release-check children after 60 minutes when queue delay and live QA extended the child run past the parent monitor deadline.

## Why This Change Was Made

The release-check child owns its individual lane timeouts. Give the parent monitor the existing 240-minute release ceiling so it can wait for the child's authoritative final verifier instead of cancelling valid work.

## User Impact

Release operators can complete beta validation without restarting an otherwise healthy release-check matrix at minute 60.

## Evidence

- Reproduced in Full Release Validation run 30696080585 attempt 4: the parent monitor timed out while child run 30702815121 remained healthy and in progress.
- `node scripts/run-vitest.mjs test/scripts/plugin-prerelease-test-plan.test.ts`
- `node scripts/check-workflows.mjs`
- targeted `oxfmt --check`
- `git diff --check`
- autoreview clean
