### PR TITLE
improve(models): avoid Ollama runtime load during model listing

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -153,6 +153,12 @@ describe("ollama tool-schema compatibility", () => {
       });
     }
   });
+
+  it("keeps configured-row projection aligned with absent runtime model normalizers", () => {
+    for (const provider of registerProvidersWithPluginConfig({})) {
+      expect(provider.normalizeResolvedModel).toBeUndefined();
+    }
+  });
 });
 
 function createOllamaResetValidationContext(

--- a/extensions/ollama/provider-policy-api.test.ts
+++ b/extensions/ollama/provider-policy-api.test.ts
@@ -1,7 +1,11 @@
 // Ollama tests cover provider policy api plugin behavior.
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
-import { normalizeConfig, resolveThinkingProfile } from "./provider-policy-api.js";
+import {
+  normalizeConfig,
+  projectConfiguredModelRow,
+  resolveThinkingProfile,
+} from "./provider-policy-api.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 
 function createModel(id: string, name: string): ModelDefinitionConfig {
@@ -58,6 +62,48 @@ describe("ollama provider policy public artifact", () => {
         providerConfig: {},
       }),
     ).toStrictEqual({});
+  });
+
+  it.each(["ollama", " OLLAMA-CLOUD "])("skips runtime row normalization for %s", (provider) => {
+    expect(
+      projectConfiguredModelRow({
+        provider,
+        modelId: "qwen3.5:9b",
+        model: {
+          provider: provider.trim().toLowerCase(),
+          id: "qwen3.5:9b",
+          api: "ollama",
+          baseUrl: OLLAMA_DEFAULT_BASE_URL,
+          input: ["text"],
+          name: "Qwen 3.5 9B",
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 8_192,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps unrelated providers on the runtime normalization path", () => {
+    expect(
+      projectConfiguredModelRow({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: {
+          provider: "openai",
+          id: "gpt-5.5",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          input: ["text"],
+          name: "GPT-5.5",
+          reasoning: true,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 8_192,
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it("exposes max thinking for reasoning-capable models without full plugin activation", () => {

--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -1,7 +1,10 @@
 // Ollama API module exposes the plugin public contract.
-import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  ProviderNormalizeResolvedModelContext,
+  ProviderThinkingProfile,
+} from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
+import { OLLAMA_CLOUD_PROVIDER_ID, OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 
 type OllamaProviderConfigDraft = Partial<ModelProviderConfig>;
 
@@ -49,6 +52,15 @@ export function normalizeConfig({
   }
 
   return next;
+}
+
+/**
+ * Ollama's local and cloud providers do not normalize resolved models.
+ * Skip full plugin activation when the model-list path asks for that no-op.
+ */
+export function projectConfiguredModelRow(ctx: ProviderNormalizeResolvedModelContext) {
+  const provider = ctx.provider.trim().toLowerCase();
+  return provider === "ollama" || provider === OLLAMA_CLOUD_PROVIDER_ID ? null : undefined;
 }
 
 export function resolveThinkingProfile({


### PR DESCRIPTION
Related: #117323

## What Problem This Solves

Listing configured Ollama models could activate the full Ollama plugin for each row even though neither the local nor cloud provider performs runtime model normalization.

## Why This Change Was Made

The lightweight Ollama provider-policy artifact now explicitly marks configured local and cloud rows as unchanged. This keeps the decision at the provider-owned boundary and avoids loading discovery, embeddings, media, setup, and web-search modules for a normalization hook that does not exist.

The full plugin remains responsible for live discovery and every runtime capability. Unrelated provider ids still fall through to the normal runtime path.

## User Impact

Operators with configured Ollama models should see less model-list startup work without any change to returned rows or live Ollama discovery.

## Evidence

- Exact head: `037287be2110005f62a7c47a59bf2f3bef3feee2`.
- 98 focused tests passed across `extensions/ollama/provider-policy-api.test.ts` and `extensions/ollama/index.test.ts`.
- Parity coverage proves both registered Ollama providers still expose no runtime `normalizeResolvedModel` hook.
- Targeted `oxfmt`, direct touched-file `oxlint`, and `git diff --check` passed.
- Import tracing measured approximately 31.8 ms for full Ollama plugin activation.
- Clean merge tree against current `main` `4cbbccd0a0d20c11e123c2356db682dc51c4dde8`: `e532fab95c303fcc0df0297a40bcc30b8c98cdeb`.
- Exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/30707674687) passed on attempt 2.
  - 28 jobs passed.
  - `openclaw/ci-gate` passed.
  - The first SQLite flip-proof attempt hit an unrelated harness failure; the immediately preceding mainline run passed that job, and its isolated rerun passed without a code change.
- The standard Kova provider-pressure fixture is OpenAI/Anthropic-focused and does not isolate this Ollama-only import; exact CI plus focused import/runtime parity proof are the relevant gates.

## Merge Gate

Merge only after the latest exact-head ClawSweeper review has no unresolved `Before merge`, finding, security, owner-decision, merge-risk, or blocking rank-up item.
