### PR TITLE
refactor(plugins): deduplicate plugin TypeScript project boundaries

### DIFF
--- a/extensions/acpx/tsconfig.json
+++ b/extensions/acpx/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/admin-http-rpc/tsconfig.json
+++ b/extensions/admin-http-rpc/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/alibaba/tsconfig.json
+++ b/extensions/alibaba/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/amazon-bedrock-mantle/tsconfig.json
+++ b/extensions/amazon-bedrock-mantle/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/amazon-bedrock/tsconfig.json
+++ b/extensions/amazon-bedrock/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/anthropic-vertex/tsconfig.json
+++ b/extensions/anthropic-vertex/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/anthropic/tsconfig.json
+++ b/extensions/anthropic/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/arcee/tsconfig.json
+++ b/extensions/arcee/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/azure-speech/tsconfig.json
+++ b/extensions/azure-speech/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/baseten/tsconfig.json
+++ b/extensions/baseten/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/brave/tsconfig.json
+++ b/extensions/brave/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/browser/tsconfig.json
+++ b/extensions/browser/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/buzz/tsconfig.json
+++ b/extensions/buzz/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/byteplus/tsconfig.json
+++ b/extensions/byteplus/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/cerebras/tsconfig.json
+++ b/extensions/cerebras/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/chutes/tsconfig.json
+++ b/extensions/chutes/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/clawrouter/tsconfig.json
+++ b/extensions/clawrouter/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/clickclack/tsconfig.json
+++ b/extensions/clickclack/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/cloudflare-ai-gateway/tsconfig.json
+++ b/extensions/cloudflare-ai-gateway/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/codex/tsconfig.json
+++ b/extensions/codex/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/cohere/tsconfig.json
+++ b/extensions/cohere/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/comfy/tsconfig.json
+++ b/extensions/comfy/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/copilot-proxy/tsconfig.json
+++ b/extensions/copilot-proxy/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/copilot/tsconfig.json
+++ b/extensions/copilot/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/deepgram/tsconfig.json
+++ b/extensions/deepgram/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/deepinfra/tsconfig.json
+++ b/extensions/deepinfra/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/deepseek/tsconfig.json
+++ b/extensions/deepseek/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/diagnostics-otel/tsconfig.json
+++ b/extensions/diagnostics-otel/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/diagnostics-prometheus/tsconfig.json
+++ b/extensions/diagnostics-prometheus/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/diffs/tsconfig.json
+++ b/extensions/diffs/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/discord/tsconfig.json
+++ b/extensions/discord/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/duckduckgo/tsconfig.json
+++ b/extensions/duckduckgo/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/elevenlabs/tsconfig.json
+++ b/extensions/elevenlabs/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/exa/tsconfig.json
+++ b/extensions/exa/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/fal/tsconfig.json
+++ b/extensions/fal/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/featherless/tsconfig.json
+++ b/extensions/featherless/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/feishu/tsconfig.json
+++ b/extensions/feishu/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/firecrawl/tsconfig.json
+++ b/extensions/firecrawl/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/fireworks/tsconfig.json
+++ b/extensions/fireworks/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/github-copilot/tsconfig.json
+++ b/extensions/github-copilot/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/gmi/tsconfig.json
+++ b/extensions/gmi/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/google-meet/tsconfig.json
+++ b/extensions/google-meet/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/google/tsconfig.json
+++ b/extensions/google/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/googlechat/tsconfig.json
+++ b/extensions/googlechat/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/gradium/tsconfig.json
+++ b/extensions/gradium/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/groq/tsconfig.json
+++ b/extensions/groq/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/huggingface/tsconfig.json
+++ b/extensions/huggingface/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/image-generation-core/tsconfig.json
+++ b/extensions/image-generation-core/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/imessage/tsconfig.json
+++ b/extensions/imessage/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/inworld/tsconfig.json
+++ b/extensions/inworld/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/irc/tsconfig.json
+++ b/extensions/irc/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/kilocode/tsconfig.json
+++ b/extensions/kilocode/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/kimi-coding/tsconfig.json
+++ b/extensions/kimi-coding/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/line/tsconfig.json
+++ b/extensions/line/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/litellm/tsconfig.json
+++ b/extensions/litellm/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/llm-task/tsconfig.json
+++ b/extensions/llm-task/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/lobster/tsconfig.json
+++ b/extensions/lobster/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/longcat/tsconfig.json
+++ b/extensions/longcat/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/matrix/tsconfig.json
+++ b/extensions/matrix/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/mattermost/tsconfig.json
+++ b/extensions/mattermost/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/media-understanding-core/tsconfig.json
+++ b/extensions/media-understanding-core/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/memory-core/tsconfig.json
+++ b/extensions/memory-core/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/memory-lancedb/tsconfig.json
+++ b/extensions/memory-lancedb/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/memory-wiki/tsconfig.json
+++ b/extensions/memory-wiki/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/meta/tsconfig.json
+++ b/extensions/meta/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/microsoft-foundry/tsconfig.json
+++ b/extensions/microsoft-foundry/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/microsoft/tsconfig.json
+++ b/extensions/microsoft/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/minimax/tsconfig.json
+++ b/extensions/minimax/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/mistral/tsconfig.json
+++ b/extensions/mistral/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/moonshot/tsconfig.json
+++ b/extensions/moonshot/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/msteams/tsconfig.json
+++ b/extensions/msteams/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/mxc/tsconfig.json
+++ b/extensions/mxc/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/nextcloud-talk/tsconfig.json
+++ b/extensions/nextcloud-talk/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/nostr/tsconfig.json
+++ b/extensions/nostr/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/novita/tsconfig.json
+++ b/extensions/novita/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/nvidia/tsconfig.json
+++ b/extensions/nvidia/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/ollama/tsconfig.json
+++ b/extensions/ollama/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/open-prose/tsconfig.json
+++ b/extensions/open-prose/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/openai/tsconfig.json
+++ b/extensions/openai/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/opencode-go/tsconfig.json
+++ b/extensions/opencode-go/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/opencode/tsconfig.json
+++ b/extensions/opencode/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/openrouter/tsconfig.json
+++ b/extensions/openrouter/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/openshell/tsconfig.json
+++ b/extensions/openshell/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/parallel/tsconfig.json
+++ b/extensions/parallel/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/perplexity/tsconfig.json
+++ b/extensions/perplexity/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/pixverse/tsconfig.json
+++ b/extensions/pixverse/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/qa-channel/tsconfig.json
+++ b/extensions/qa-channel/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/qa-lab/tsconfig.json
+++ b/extensions/qa-lab/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/qianfan/tsconfig.json
+++ b/extensions/qianfan/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/qqbot/tsconfig.json
+++ b/extensions/qqbot/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/qwen/tsconfig.json
+++ b/extensions/qwen/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/raft/tsconfig.json
+++ b/extensions/raft/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/reef/tsconfig.json
+++ b/extensions/reef/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/runway/tsconfig.json
+++ b/extensions/runway/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/searxng/tsconfig.json
+++ b/extensions/searxng/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/sglang/tsconfig.json
+++ b/extensions/sglang/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/signal/tsconfig.json
+++ b/extensions/signal/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/slack/tsconfig.json
+++ b/extensions/slack/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/sms/tsconfig.json
+++ b/extensions/sms/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/stepfun/tsconfig.json
+++ b/extensions/stepfun/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/synology-chat/tsconfig.json
+++ b/extensions/synology-chat/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/synthetic/tsconfig.json
+++ b/extensions/synthetic/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/tavily/tsconfig.json
+++ b/extensions/tavily/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/teams-meetings/tsconfig.json
+++ b/extensions/teams-meetings/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/telegram/tsconfig.json
+++ b/extensions/telegram/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/tencent/tsconfig.json
+++ b/extensions/tencent/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/tlon/tsconfig.json
+++ b/extensions/tlon/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/together/tsconfig.json
+++ b/extensions/together/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/tokenjuice/tsconfig.json
+++ b/extensions/tokenjuice/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/tsconfig.package-boundary.base.json
+++ b/extensions/tsconfig.package-boundary.base.json
@@ -1,6 +1,17 @@
 {
   "extends": "./tsconfig.package-boundary.paths.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  }
+    "ignoreDeprecations": "6.0",
+    "rootDir": "${configDir}"
+  },
+  "include": ["${configDir}/*.ts", "${configDir}/src/**/*.ts"],
+  "exclude": [
+    "${configDir}/**/*.test.ts",
+    "${configDir}/dist/**",
+    "${configDir}/node_modules/**",
+    "${configDir}/src/test-support/**",
+    "${configDir}/src/**/*test-helpers.ts",
+    "${configDir}/src/**/*test-harness.ts",
+    "${configDir}/src/**/*test-support.ts"
+  ]
 }

--- a/extensions/twitch/tsconfig.json
+++ b/extensions/twitch/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/venice/tsconfig.json
+++ b/extensions/venice/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/vercel-ai-gateway/tsconfig.json
+++ b/extensions/vercel-ai-gateway/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/video-generation-core/tsconfig.json
+++ b/extensions/video-generation-core/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/vllm/tsconfig.json
+++ b/extensions/vllm/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/voice-call/tsconfig.json
+++ b/extensions/voice-call/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/volcengine/tsconfig.json
+++ b/extensions/volcengine/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/vydra/tsconfig.json
+++ b/extensions/vydra/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/webhooks/tsconfig.json
+++ b/extensions/webhooks/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/whatsapp/tsconfig.json
+++ b/extensions/whatsapp/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.package-boundary.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "paths": {
       "openclaw/plugin-sdk/*": [
         "../../dist/plugin-sdk/*.d.ts"
@@ -851,18 +850,5 @@
         "./.boundary-stubs/speech-core-runtime-api.d.ts"
       ]
     }
-  },
-  "include": [
-    "./*.ts",
-    "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  }
 }

--- a/extensions/xiaomi/tsconfig.json
+++ b/extensions/xiaomi/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/zai/tsconfig.json
+++ b/extensions/zai/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/zalo/tsconfig.json
+++ b/extensions/zalo/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/zalouser/tsconfig.json
+++ b/extensions/zalouser/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/extensions/zoom-meetings/tsconfig.json
+++ b/extensions/zoom-meetings/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../tsconfig.package-boundary.base.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**",
-    "./src/test-support/**",
-    "./src/**/*test-helpers.ts",
-    "./src/**/*test-harness.ts",
-    "./src/**/*test-support.ts"
-  ]
+  "extends": "../tsconfig.package-boundary.base.json"
 }

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -141,7 +141,7 @@ describe("opt-in extension package boundaries", () => {
     });
   });
 
-  it("keeps path aliases in a dedicated shared config", () => {
+  it("keeps package boundaries and path aliases in shared configs", () => {
     const pathsConfig = readJsonFile<TsConfigJson>(EXTENSION_PACKAGE_BOUNDARY_PATHS_CONFIG);
     expect(pathsConfig.extends).toBe("../tsconfig.json");
     expect(pathsConfig.compilerOptions?.paths).toEqual(EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS);
@@ -150,7 +150,15 @@ describe("opt-in extension package boundaries", () => {
     expect(baseConfig.extends).toBe("./tsconfig.package-boundary.paths.json");
     expect(baseConfig.compilerOptions).toEqual({
       ignoreDeprecations: "6.0",
+      rootDir: "${configDir}",
     });
+    const asPackageRelativeTemplate = (entry: string) => entry.replace(/^\.\//u, "${configDir}/");
+    expect(baseConfig.include).toEqual(
+      EXTENSION_PACKAGE_BOUNDARY_INCLUDE.map(asPackageRelativeTemplate),
+    );
+    expect(baseConfig.exclude).toEqual(
+      EXTENSION_PACKAGE_BOUNDARY_EXCLUDE.map(asPackageRelativeTemplate),
+    );
   });
 
   it("keeps every opt-in extension rooted inside its package and on the package sdk", () => {
@@ -162,9 +170,9 @@ describe("opt-in extension package boundaries", () => {
     for (const extensionName of optInExtensions) {
       const tsconfig = readExtensionPackageBoundaryTsconfig(extensionName, REPO_ROOT);
       expect(isOptInExtensionPackageBoundaryTsconfig(tsconfig)).toBe(true);
-      expect(tsconfig.compilerOptions?.rootDir).toBe(".");
-      expect(tsconfig.include).toEqual([...EXTENSION_PACKAGE_BOUNDARY_INCLUDE]);
-      expect(tsconfig.exclude).toEqual([...EXTENSION_PACKAGE_BOUNDARY_EXCLUDE]);
+      expect(tsconfig.compilerOptions?.rootDir).toBeUndefined();
+      expect(tsconfig.include).toBeUndefined();
+      expect(tsconfig.exclude).toBeUndefined();
 
       const packageJson = readExtensionPackageBoundaryPackageJson(extensionName, REPO_ROOT);
       expect(packageJson.devDependencies?.["@openclaw/plugin-sdk"]).toBe("workspace:*");


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested repository cleanup: 125 bundled plugin projects repeated the same package root and source inclusion/exclusion policy, creating 1,615 unnecessary configuration lines and 125 places where plugin boundaries could drift.

## Why This Change Was Made

Move the canonical `rootDir`, `include`, and `exclude` policy into the existing shared plugin project configuration using TypeScript's `${configDir}` substitution. Keep every package-local project and preserve xAI's complete custom path aliases and boundary stubs. Strengthen the existing contract test so individual projects cannot silently reintroduce duplicate policy.

## User Impact

No user-visible runtime, plugin installation, public API, or published package changes. Every plugin compiles the same 4,623 source files with the same effective compiler options and security boundaries. The repository loses 1,615 production/configuration lines, or 1,607 lines net including stronger regression coverage.

## Evidence

- Exhaustive before/after TypeScript 6.0.3 parser comparison: all 125 projects, all 4,623 included source files, effective compiler options, path aliases, wildcard roots, and diagnostics matched exactly.
- Verified pinned native `tsgo` configuration expansion, Windows drive-letter/case-insensitive path behavior, and published-plugin package allowlists.
- Blacksmith Testbox `tbx_01kyyxea2yttzv9mxnq2ytt4x9`: complete remote pipeline exited `0`.
- `pnpm test src/plugins/contracts/extension-package-project-boundaries.test.ts test/scripts/check-extension-package-tsc-boundary.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 48 tests passed.
- `pnpm run test:extensions:package-boundary` — all 125 plugin projects compiled; both deliberate outside-package import canaries remained rejected.
- `pnpm build` — complete production, public SDK, bundled-plugin, and Control UI build passed.
- `pnpm check:changed` — core, core-test, plugin, and plugin-test typechecks; complete core/plugin lint; formatting; dead-code scan; dependency/plugin/security guards all passed.
- Independent AI-assisted Codex autoreview with `gpt-5.6-sol`, `xhigh` reasoning, and P0–P2 scope: clean; TruffleHog scan clean.
