### PR TITLE
fix(slack): prevent stalled presence polling from hanging shutdown

### DIFF
--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -1,3 +1,4 @@
+import { WebAPIRateLimitedError } from "@slack/web-api";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { PreparedSlackMessage } from "./message-handler/types.js";
@@ -341,6 +342,37 @@ describe("Slack presence monitor", () => {
       await polling;
       vi.useRealTimers();
     }
+  });
+
+  it("honors Slack Retry-After before resuming presence polling", async () => {
+    let now = 1_000;
+    const getPresence = vi
+      .fn()
+      .mockRejectedValueOnce(new WebAPIRateLimitedError(120))
+      .mockResolvedValue({ presence: "away" });
+    const monitor = createSlackPresenceMonitor({
+      accountId: "default",
+      accountConfig: { mode: "auto" },
+      client: { getPresence } as never,
+      cooldownStore: createCooldownStore(),
+      enqueue: vi.fn(() => true),
+      wake: vi.fn(),
+      nowMs: () => now,
+    });
+    monitor.observe(createPrepared({ userId: "U1" }));
+    monitor.observe(createPrepared({ userId: "U2" }));
+
+    await monitor.pollOnce();
+    expect(getPresence).toHaveBeenCalledExactlyOnceWith({ user: "U1" });
+
+    now += 119_999;
+    await monitor.pollOnce();
+    expect(getPresence).toHaveBeenCalledTimes(1);
+
+    now += 1;
+    await monitor.pollOnce();
+    expect(getPresence).toHaveBeenNthCalledWith(2, { user: "U1" });
+    expect(getPresence).toHaveBeenNthCalledWith(3, { user: "U2" });
   });
 
   it("bounds stop while a presence request is stalled", async () => {

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -1,7 +1,11 @@
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { PreparedSlackMessage } from "./message-handler/types.js";
-import { createSlackPresenceMonitor, hasSlackPresenceEventsEnabled } from "./presence-monitor.js";
+import {
+  createSlackPresenceMonitor,
+  hasSlackPresenceEventsEnabled,
+  SLACK_PRESENCE_REQUEST_TIMEOUT_MS,
+} from "./presence-monitor.js";
 
 const AUTO_MAX_PARTICIPANTS = 8;
 
@@ -296,6 +300,84 @@ describe("Slack presence monitor", () => {
 
     expect(getPresence).toHaveBeenCalledTimes(2);
     expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("times out a stalled presence request and polls the next user", async () => {
+    vi.useFakeTimers();
+    let resolveStalled!: (value: { presence: string }) => void;
+    const stalled = new Promise<{ presence: string }>((resolve) => {
+      resolveStalled = resolve;
+    });
+    let polling: Promise<void> | undefined;
+    try {
+      const getPresence = vi
+        .fn()
+        .mockReturnValueOnce(stalled)
+        .mockResolvedValueOnce({ presence: "away" });
+      const monitor = createSlackPresenceMonitor({
+        accountId: "default",
+        accountConfig: { mode: "auto" },
+        client: { getPresence } as never,
+        cooldownStore: createCooldownStore(),
+        enqueue: vi.fn(() => true),
+        wake: vi.fn(),
+      });
+      monitor.observe(createPrepared({ userId: "U1", channelId: "D1" }));
+      monitor.observe(createPrepared({ userId: "U2", channelId: "D2" }));
+
+      polling = monitor.pollOnce();
+      let pollSettled = false;
+      void polling.then(() => {
+        pollSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(SLACK_PRESENCE_REQUEST_TIMEOUT_MS);
+      expect(pollSettled).toBe(true);
+      await polling;
+
+      expect(getPresence).toHaveBeenNthCalledWith(1, { user: "U1" });
+      expect(getPresence).toHaveBeenNthCalledWith(2, { user: "U2" });
+    } finally {
+      resolveStalled({ presence: "away" });
+      await polling;
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds stop while a presence request is stalled", async () => {
+    vi.useFakeTimers();
+    let resolveStalled!: (value: { presence: string }) => void;
+    const stalled = new Promise<{ presence: string }>((resolve) => {
+      resolveStalled = resolve;
+    });
+    let polling: Promise<void> | undefined;
+    try {
+      const getPresence = vi.fn(() => stalled);
+      const monitor = createSlackPresenceMonitor({
+        accountId: "default",
+        accountConfig: { mode: "auto" },
+        client: { getPresence } as never,
+        cooldownStore: createCooldownStore(),
+        enqueue: vi.fn(() => true),
+        wake: vi.fn(),
+      });
+      monitor.observe(createPrepared({ userId: "U1" }));
+
+      polling = monitor.pollOnce();
+      const stopping = monitor.stop();
+      let stopSettled = false;
+      void stopping.then(() => {
+        stopSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(SLACK_PRESENCE_REQUEST_TIMEOUT_MS);
+      expect(stopSettled).toBe(true);
+      await Promise.all([polling, stopping]);
+
+      expect(getPresence).toHaveBeenCalledOnce();
+    } finally {
+      resolveStalled({ presence: "away" });
+      await polling;
+      vi.useRealTimers();
+    }
   });
 
   it("quiesces an in-flight poll before stop returns", async () => {

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -344,7 +344,7 @@ describe("Slack presence monitor", () => {
     }
   });
 
-  it("honors Slack Retry-After before resuming presence polling", async () => {
+  it("honors Slack Retry-After without skipping the unpolled page", async () => {
     let now = 1_000;
     const getPresence = vi
       .fn()
@@ -352,18 +352,19 @@ describe("Slack presence monitor", () => {
       .mockResolvedValue({ presence: "away" });
     const monitor = createSlackPresenceMonitor({
       accountId: "default",
-      accountConfig: { mode: "auto" },
+      accountConfig: { mode: "on" },
       client: { getPresence } as never,
       cooldownStore: createCooldownStore(),
       enqueue: vi.fn(() => true),
       wake: vi.fn(),
       nowMs: () => now,
     });
-    monitor.observe(createPrepared({ userId: "U1" }));
-    monitor.observe(createPrepared({ userId: "U2" }));
+    for (let index = 1; index <= 46; index += 1) {
+      monitor.observe(createPrepared({ userId: `U${String(index).padStart(4, "0")}` }));
+    }
 
     await monitor.pollOnce();
-    expect(getPresence).toHaveBeenCalledExactlyOnceWith({ user: "U1" });
+    expect(getPresence).toHaveBeenCalledExactlyOnceWith({ user: "U0001" });
 
     now += 119_999;
     await monitor.pollOnce();
@@ -371,8 +372,12 @@ describe("Slack presence monitor", () => {
 
     now += 1;
     await monitor.pollOnce();
-    expect(getPresence).toHaveBeenNthCalledWith(2, { user: "U1" });
-    expect(getPresence).toHaveBeenNthCalledWith(3, { user: "U2" });
+    expect(getPresence).toHaveBeenNthCalledWith(2, { user: "U0001" });
+    expect(getPresence).toHaveBeenNthCalledWith(3, { user: "U0002" });
+    expect(getPresence).toHaveBeenCalledTimes(46);
+
+    await monitor.pollOnce();
+    expect(getPresence).toHaveBeenNthCalledWith(47, { user: "U0046" });
   });
 
   it("bounds stop while a presence request is stalled", async () => {

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -272,11 +272,11 @@ export function createSlackPresenceMonitor(params: {
       { length: count },
       (_, index) => candidates[(pollOffset + index) % candidates.length],
     ).filter((userId): userId is string => Boolean(userId));
-    pollOffset = (pollOffset + count) % candidates.length;
     for (const userId of selected) {
       if (stopped) {
         return;
       }
+      let consumed = false;
       try {
         const response = await withTimeout(
           params.client.getPresence({ user: userId }),
@@ -288,6 +288,7 @@ export function createSlackPresenceMonitor(params: {
         if (stopped) {
           return;
         }
+        consumed = true;
         const next =
           response.presence === "active" || response.presence === "away"
             ? response.presence
@@ -312,7 +313,12 @@ export function createSlackPresenceMonitor(params: {
           params.error?.(`slack presence polling rate limited; retrying after ${err.retryAfter}s`);
           return;
         }
+        consumed = true;
         params.error?.(`slack presence poll failed for user ${userId}: ${String(err)}`);
+      } finally {
+        if (consumed) {
+          pollOffset = (pollOffset + 1) % candidates.length;
+        }
       }
     }
   };

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -4,9 +4,11 @@ import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { PreparedSlackMessage } from "./message-handler/types.js";
 
 export const SLACK_PRESENCE_GREETING_COOLDOWN_MS = 8 * 60 * 60 * 1000;
+export const SLACK_PRESENCE_REQUEST_TIMEOUT_MS = 30_000;
 const SLACK_PRESENCE_POLL_INTERVAL_MS = 60_000;
 const SLACK_PRESENCE_AUTO_MAX_PARTICIPANTS = 8;
 const SLACK_PRESENCE_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
@@ -271,7 +273,13 @@ export function createSlackPresenceMonitor(params: {
         return;
       }
       try {
-        const response = await params.client.getPresence({ user: userId });
+        const response = await withTimeout(
+          params.client.getPresence({ user: userId }),
+          SLACK_PRESENCE_REQUEST_TIMEOUT_MS,
+          {
+            message: `Slack presence request timed out after ${SLACK_PRESENCE_REQUEST_TIMEOUT_MS}ms`,
+          },
+        );
         if (stopped) {
           return;
         }

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -1,5 +1,5 @@
 // Slack plugin module polls selected participants and routes away-to-active transitions.
-import type { WebClient } from "@slack/web-api";
+import { type WebClient, WebAPIRateLimitedError } from "@slack/web-api";
 import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -144,6 +144,7 @@ export function createSlackPresenceMonitor(params: {
   let pollOffset = 0;
   let timer: NodeJS.Timeout | undefined;
   let activePoll: Promise<void> | undefined;
+  let rateLimitedUntilMs = 0;
   let stopped = false;
 
   const pruneTargets = (now: number) => {
@@ -251,6 +252,10 @@ export function createSlackPresenceMonitor(params: {
 
   const performPoll = async () => {
     const now = nowMs();
+    if (rateLimitedUntilMs > now) {
+      return;
+    }
+    rateLimitedUntilMs = 0;
     pruneTargets(now);
     const candidates = Array.from(
       new Set(
@@ -297,6 +302,14 @@ export function createSlackPresenceMonitor(params: {
         }
       } catch (err) {
         if (stopped) {
+          return;
+        }
+        if (err instanceof WebAPIRateLimitedError) {
+          rateLimitedUntilMs = Math.max(
+            rateLimitedUntilMs,
+            nowMs() + Math.max(0, err.retryAfter) * 1_000,
+          );
+          params.error?.(`slack presence polling rate limited; retrying after ${err.retryAfter}s`);
           return;
         }
         params.error?.(`slack presence poll failed for user ${userId}: ${String(err)}`);

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,6 +1,8 @@
 // Slack tests cover auth.test token handling during provider boot.
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   disposeSlackTestRuntime,
@@ -13,6 +15,7 @@ import {
   stopSlackMonitor,
   useRealSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
+import { getSlackRuntime } from "../runtime.js";
 
 const { monitorSlackProvider } = await import("./provider.js");
 
@@ -338,6 +341,87 @@ describe("auth.test boot call", () => {
     await expect(monitor.run).rejects.toThrow(
       /supports DMs only with dm\.enabled=false.*dmPolicy="open"/,
     );
+  });
+});
+
+describe("presence polling transport", () => {
+  it("aborts a stalled presence request when the provider stops", async () => {
+    const events: string[] = [];
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, "");
+    }
+    const server = await startStalledSlackApiServer(events);
+    vi.stubEnv("SLACK_API_URL", server.apiUrl);
+    resetSlackTestState({
+      channels: {
+        slack: {
+          dm: { enabled: true },
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+          presenceEvents: { mode: "on" },
+        },
+      },
+    });
+    getSlackRuntime().state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateSyncKeyedStoreForTests<T>("slack", {
+        ...options,
+        env: options.env ?? process.env,
+      });
+    getSlackTestState().replyMock.mockResolvedValue({ text: "ok" });
+
+    const nativeSetInterval = globalThis.setInterval;
+    let triggerPresencePoll: (() => void) | undefined;
+    const intervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(((
+      handler: (...args: unknown[]) => void,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (timeout === 60_000 && !triggerPresencePoll) {
+        triggerPresencePoll = () => handler(...args);
+        return nativeSetInterval(() => undefined, 60 * 60 * 1_000);
+      }
+      return nativeSetInterval(handler, timeout, ...args);
+    }) as typeof setInterval);
+
+    const monitor = startSlackMonitor(monitorSlackProvider);
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await handler({
+        event: {
+          type: "message",
+          user: "U_STALLED",
+          text: "hello",
+          ts: "100.000",
+          channel: "D_STALLED",
+          channel_type: "im",
+        },
+        context: { botUserId: "bot-user" },
+        body: {},
+      });
+      expect(triggerPresencePoll).toBeTypeOf("function");
+      triggerPresencePoll?.();
+      await vi.waitFor(() => expect(server.requestCount).toBe(1), { timeout: 1_000 });
+
+      const startedAt = Date.now();
+      monitor.controller.abort();
+      const outcome = await Promise.race([
+        monitor.run.then(() => "settled" as const),
+        new Promise<"timed-out">((resolve) => {
+          setTimeout(() => resolve("timed-out"), 2_000);
+        }),
+      ]);
+
+      expect(outcome).toBe("settled");
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      await vi.waitFor(() => expect(events).toContain("socket-closed"), { timeout: 1_000 });
+      expect(server.requestUrl).toBe("/api/users.getPresence");
+    } finally {
+      intervalSpy.mockRestore();
+      monitor.controller.abort();
+      await server.close();
+      await monitor.run;
+    }
   });
 });
 

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -1,5 +1,6 @@
 // Slack provider module implements model/runtime integration.
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { type FetchFunction, WebClient } from "@slack/web-api";
 import {
   addAllowlistUserEntriesFromConfigEntry,
   buildAllowlistResolutionSummary,
@@ -33,7 +34,11 @@ import {
   resolveSlackAccountDmPolicy,
 } from "../accounts.js";
 import { isSlackAnyNativeApprovalClientEnabled } from "../approval-native-gates.js";
-import { resolveSlackProxyDispatcher, resolveSlackWebClientOptions } from "../client-options.js";
+import {
+  resolveSlackLookupClientOptions,
+  resolveSlackProxyDispatcher,
+  resolveSlackWebClientOptions,
+} from "../client-options.js";
 import { createSlackStartupAuthClient } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
@@ -66,7 +71,11 @@ import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackDurableIngress } from "./ingress.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import { openSlackPresenceCooldownStore } from "./presence-cooldown-store.js";
-import { createSlackPresenceMonitor, hasSlackPresenceEventsEnabled } from "./presence-monitor.js";
+import {
+  createSlackPresenceMonitor,
+  hasSlackPresenceEventsEnabled,
+  SLACK_PRESENCE_REQUEST_TIMEOUT_MS,
+} from "./presence-monitor.js";
 import {
   createSlackBoltApp,
   formatSlackChannelResolved,
@@ -91,6 +100,17 @@ import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
 
 let slackBoltInterop: SlackBoltResolvedExports | undefined;
+
+function withSlackPresenceLifecycleSignal(
+  fetchImpl: FetchFunction,
+  lifecycleSignal: AbortSignal,
+): FetchFunction {
+  return async (input, init) =>
+    await fetchImpl(input, {
+      ...init,
+      signal: init?.signal ? AbortSignal.any([init.signal, lifecycleSignal]) : lifecycleSignal,
+    });
+}
 
 async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
   if (!slackBoltInterop) {
@@ -614,17 +634,34 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     account: slackCfg.presenceEvents,
     channels: slackCfg.channels,
   });
-  const presenceMonitor =
+  const presenceRequestAbort =
     installationIdentity.kind !== "enterprise" && presenceEventsEnabled
-      ? createSlackPresenceMonitor({
-          accountId: account.accountId,
-          accountConfig: slackCfg.presenceEvents,
-          client: app.client.users,
-          cooldownStore: openSlackPresenceCooldownStore(),
-          log: runtime.log,
-          error: runtime.error,
-        })
+      ? new AbortController()
       : undefined;
+  const presenceClient =
+    presenceRequestAbort === undefined
+      ? undefined
+      : (() => {
+          const options = resolveSlackLookupClientOptions(
+            { ...clientOptions, timeout: SLACK_PRESENCE_REQUEST_TIMEOUT_MS },
+            slackDispatcher,
+          );
+          options.fetch = withSlackPresenceLifecycleSignal(
+            options.fetch ?? globalThis.fetch,
+            presenceRequestAbort.signal,
+          );
+          return new WebClient(token, options).users;
+        })();
+  const presenceMonitor = presenceClient
+    ? createSlackPresenceMonitor({
+        accountId: account.accountId,
+        accountConfig: slackCfg.presenceEvents,
+        client: presenceClient,
+        cooldownStore: openSlackPresenceCooldownStore(),
+        log: runtime.log,
+        error: runtime.error,
+      })
+    : undefined;
   if (installationIdentity.kind === "enterprise" && presenceEventsEnabled) {
     runtime.log?.(warn("slack presence events are unavailable for Enterprise Grid org installs"));
   }
@@ -945,6 +982,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       }
     }
   } finally {
+    presenceRequestAbort?.abort();
     await presenceMonitor?.stop();
     if (slackMode === "relay") {
       setSlackDefaultSendIdentity(account.accountId, undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack presence polling could freeze permanently when a `users.getPresence` request never returned. One stalled user prevented later users from being polled, and provider shutdown could remain blocked indefinitely.

## Why This Change Was Made

Each presence lookup now has a 30-second monitor deadline and runs through a dedicated no-retry lookup client with a matching SDK transport timeout. The monitor stops the current batch on Slack rate limits and suppresses later polls through `Retry-After`. Provider teardown aborts the lookup client's in-flight fetch before waiting for the monitor, while the shared Bolt client remains timeout-free because it also carries mutation requests.

## Root Cause and Design Boundary

Classification: root-cause fix. The presence monitor owns serial per-user progress and the task awaited by `stop()`, while the provider owns the Slack SDK transport lifecycle. Bounding only the outer promise would leave the socket alive; setting a timeout on the shared Bolt client would also change mutation behavior. The dedicated lookup client therefore applies real transport cancellation, and the monitor applies the same deadline to guarantee bounded task settlement.

The 30-second value is inherited from the existing canonical Slack read-client timeout in `resolveSlackReadClientOptions`: both paths are read-only Web API calls with the same stalled-transport failure semantics. It also remains below the 60-second presence polling cadence. Slack's server-provided `Retry-After` remains authoritative for rate limits; the fix adds no independent retry policy value.

Compatibility and scope: this changes no public API, config schema, protocol, token selection, authorization decision, or message/write retry behavior. The shared mutation-capable Bolt client, Enterprise Grid presence availability, presence eligibility, greeting, and cooldown behavior remain unchanged. A fresh broad open-PR scan found no semantically equivalent Slack presence deadline or shutdown fix; recalled timeout PRs were in unrelated owners and runtimes.

Merge risk is limited to Slack presence availability and provider cleanup. The dedicated client reuses the same token, proxy dispatcher, Slack API URL, and read timeout policy; focused tests and the real-SDK live proof cover continuity, rate limits, shutdown, and socket cleanup.

## User Impact

Slack presence transitions continue polling after a stalled lookup, and stopping or restarting the Slack provider no longer waits forever on that request.

## Evidence

Fresh `origin/main` at `1130f30445c4c5b5f242d2423061844e6f6e5949` still reproduced the bug before submission:

```text
SOURCE presence_request_deadline=false shared_bolt_presence_client=true
TRIGGER latest_main_poll users=U0001,U0002 first_request=never_resolves
OUTCOME latest_main requests_started=1 later_user_polled=false poll_settled=false stop_settled=false
PASS problem_present=true
```

Near-real proof used the real `@slack/web-api` client against a loopback Slack HTTP API. The first scenario withheld response headers for U0001; the second aborted a stalled request at the provider shutdown boundary:

```text
TRIGGER continuity_poll users=U0001,U0002
SLACK_API users.getPresence user=U0001 action=stall
[WARN] web-api:WebClient:0 http request failed The operation was aborted due to timeout
TRANSITION request_deadline user=U0001 timeout_ms=30000 poll_error_observed=true
TRANSITION stalled_socket user=U0001 socket_closed=true
SLACK_API users.getPresence user=U0002 action=respond presence=away
OUTCOME continuity elapsed_ms=29979 timeout_observed=true later_user_polled=true poll_settled=true
TRIGGER rate_limit_poll users=46 page_size=45 retry_after_s=120
SLACK_API users.getPresence user=U_RATE0001 action=rate_limit retry_after_s=120
TRANSITION retry_after_recorded retry_after_s=120 batch_stopped=true
SLACK_API users.getPresence user=U_RATE0001 action=respond presence=away
SLACK_API users.getPresence user=U_RATE0002 action=respond presence=away
SLACK_API users.getPresence user=U_RATE0046 action=respond presence=away
OUTCOME rate_limit observed=true batch_stopped=true requests_during_backoff=0 resumed_page_first=U_RATE0001 resumed_page_second=U_RATE0002 next_page_first=U_RATE0046 cursor_preserved=true
TRIGGER provider_presence_poll user=U_STOP
SLACK_API users.getPresence user=U_STOP action=stall
TRIGGER provider_stop request_in_flight=true gateway_budget_ms=5000
[WARN] web-api:WebClient:1 http request failed This operation was aborted
TRANSITION stalled_socket user=U_STOP socket_closed=true
OUTCOME provider_stop elapsed_ms=3 bounded_under_5000=true socket_closed=true
PASS provider_shutdown_settled=true
PASS no_open_sockets=true
```

Regression and repository checks:

- `presence-monitor.test.ts`: 11 passed, including Retry-After batch and interval suppression
- `provider.auth-test-token.test.ts`: 22 passed, including the real stalled-socket shutdown regression
- `oxfmt --check`: 26,802 files matched
