### PR TITLE
fix(tui): isolate embedded approval listener failures

### DIFF
--- a/src/infra/embedded-plugin-approval-broker.test.ts
+++ b/src/infra/embedded-plugin-approval-broker.test.ts
@@ -135,4 +135,98 @@ describe("EmbeddedPluginApprovalBroker", () => {
     await expect(resultPromise).rejects.toThrow("local TUI stopped");
     expect(broker.listPending()).toEqual([]);
   });
+
+  it("isolates a failed listener when announcing a request", async () => {
+    const broker = new EmbeddedPluginApprovalBroker();
+    const events: string[] = [];
+    broker.subscribe((event) => {
+      if (event.event === "plugin.approval.requested") {
+        throw new Error("request listener failed");
+      }
+    });
+    broker.subscribe((event) => {
+      events.push(event.event);
+    });
+
+    const resultPromise = broker.request({
+      request: requestPayload(),
+      timeoutMs: 5_000,
+    });
+    const approval = expectDefined(
+      broker.listPending()[0],
+      "broker.listPending()[0] test invariant",
+    );
+
+    expect(broker.resolve(approval.id, "allow-once")).toBe(true);
+    await expect(resultPromise).resolves.toMatchObject({ decision: "allow-once" });
+    expect(events).toEqual(["plugin.approval.requested", "plugin.approval.resolved"]);
+    expect(broker.listPending()).toEqual([]);
+  });
+
+  it("isolates a failed listener when announcing a resolution", async () => {
+    const broker = new EmbeddedPluginApprovalBroker();
+    const events: string[] = [];
+    broker.subscribe((event) => {
+      if (event.event === "plugin.approval.resolved") {
+        throw new Error("resolution listener failed");
+      }
+    });
+    broker.subscribe((event) => {
+      events.push(event.event);
+    });
+
+    const resultPromise = broker.request({
+      request: requestPayload(),
+      timeoutMs: 5_000,
+    });
+    const approval = expectDefined(
+      broker.listPending()[0],
+      "broker.listPending()[0] test invariant",
+    );
+
+    expect(() => broker.resolve(approval.id, "allow-once")).not.toThrow();
+    await expect(resultPromise).resolves.toMatchObject({ decision: "allow-once" });
+    expect(events).toEqual(["plugin.approval.requested", "plugin.approval.resolved"]);
+    expect(broker.listPending()).toEqual([]);
+  });
+
+  it("isolates failed listeners while stopping every pending request", async () => {
+    vi.useFakeTimers();
+    const broker = new EmbeddedPluginApprovalBroker();
+    const removedIds: string[] = [];
+    broker.subscribe((event) => {
+      if (event.event === "plugin.approval.removed") {
+        throw new Error("removal listener failed");
+      }
+    });
+    broker.subscribe((event) => {
+      if (event.event === "plugin.approval.removed") {
+        removedIds.push(event.payload.id);
+      }
+    });
+    const first = broker.request({
+      request: requestPayload(),
+      timeoutMs: 5_000,
+    });
+    const second = broker.request({
+      request: requestPayload(),
+      timeoutMs: 5_000,
+    });
+    let stopError: unknown;
+
+    try {
+      broker.stop(new Error("local TUI stopped"));
+    } catch (error) {
+      stopError = error;
+    }
+    const settlementsPromise = Promise.allSettled([first, second]);
+    await vi.runAllTimersAsync();
+    const settlements = await settlementsPromise;
+
+    expect(stopError).toBeUndefined();
+    expect(settlements.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+    expect(removedIds).toHaveLength(2);
+    expect(new Set(removedIds).size).toBe(2);
+    expect(broker.listPending()).toEqual([]);
+  });
 });

--- a/src/infra/embedded-plugin-approval-broker.ts
+++ b/src/infra/embedded-plugin-approval-broker.ts
@@ -1,5 +1,6 @@
 // Provides the process-local plugin approval path used by embedded TUI runs.
 import { randomUUID } from "node:crypto";
+import { notifyListeners } from "../shared/listeners.js";
 import type { ExecApprovalDecision } from "./exec-approvals.js";
 import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "./plugin-approval-canonical-decisions.js";
 import type {
@@ -128,9 +129,7 @@ export class EmbeddedPluginApprovalBroker {
   }
 
   private emit(event: ApprovalEvent): void {
-    for (const listener of this.listeners) {
-      listener(event);
-    }
+    notifyListeners(this.listeners, event);
   }
 }
 


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

In embedded TUI mode, plugin approvals are broadcast to process-local event subscribers. If one subscriber throws while handling an approval event, that exception currently escapes the broker: a new request can be reported as unavailable while remaining pending until timeout, a completed resolution can be reported as failed, and shutdown cleanup can stop before later approvals are cleared.

### Failure mode

The broker mutates its pending state and then calls subscribers sequentially without isolating their failures. The first exception skips every later subscriber and changes the control flow of request, resolution, timeout, abort, or broker shutdown even though observers do not own those lifecycle transitions.

## Why This Change Was Made

The broker now routes approval events through the existing shared listener dispatcher. Each observer remains synchronous, but one observer failure no longer escapes the broadcast or prevents later observers from receiving the same event.

### Root Cause

The embedded approval broker had a private unguarded listener loop even though OpenClaw's shared event infrastructure already provides per-listener failure isolation.

### Layer ownership

The broker owns event fan-out plus pending approval and timer lifecycle. The embedded backend owns the TUI event callback, while the tool gate owns fail-closed approval policy. Keeping isolation in the broker protects every lifecycle transition without changing decisions, policy, protocol payloads, or presentation.

## User Impact

A faulty embedded TUI observer can no longer strand or misreport plugin approvals, block later observers, or interrupt broker cleanup. Allowed-decision filtering, denial, timeout, abort, and normal stop behavior remain unchanged.

## Evidence

At exact head `d04c8a080fcf25a289b9feca83bf128de5ed974f`, 134 focused and adjacent tests passed, both Core typechecks passed, scoped formatting/lint checks were clean, and a real broker run preserved delivery, resolution, rejection, and complete cleanup despite a throwing first observer.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=focused-code tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `9e43844264a736b234e32af5b018da1e4a058c87`
- **Proof head:** `d04c8a080fcf25a289b9feca83bf128de5ed974f`
- **Revalidated:** on the bound base

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=d04c8a080fcf25a289b9feca83bf128de5ed974f -->

#### Embedded approval broker lifecycle command

```bash
node --import tsx --input-type=module -
```

- **Embedded approval broker lifecycle (PRODUCTION_RUNTIME; boundary: the production EmbeddedPluginApprovalBroker, shared listener dispatcher, pending map, timers, and subscription API)** — Observed: The real broker accepted two requests while its first subscriber threw on every event; the healthy subscriber still received requested, resolved, and removed events, the first request resolved allow-once, the second rejected during stop, and no pending approval remained. Result: listener failure stayed inside event fan-out while request decisions and broker cleanup completed. Proves approval lifecycle ownership no longer leaks into observer callbacks. Preserves synchronous event order, decision settlement, stop rejection, and zero pending state after cleanup.

#### Sanitized exact-head production output

```text
head=d04c8a080fcf25a289b9feca83bf128de5ed974f
test_runner=none
affected_owners=embedded-broker,shared-listener-dispatch,pending-map,approval-timers
mocked_affected_owners=none
resolve_returned=true
first_status=fulfilled
first_decision=allow-once
second_status=rejected
healthy_events=requested,requested,resolved,removed
pending_after=0
result=PASS
```

### Automated verification

#### Broker lifecycle regression

```bash
pnpm exec vitest run src/infra/embedded-plugin-approval-broker.test.ts --reporter=verbose
```

- `pnpm exec vitest run src/infra/embedded-plugin-approval-broker.test.ts --reporter=verbose` — [TEST] 9/9 tests passed with 0 failures and 0 skips. Proves throwing listeners are isolated during request, resolution, and multi-request stop cleanup. Preserves allowed decisions, denial, timeout, abort, and ordinary stop behavior.

#### TUI and tool-gate boundaries

```bash
pnpm exec vitest run src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/tui/embedded-backend.test.ts --reporter=dot
```

- `pnpm exec vitest run src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/tui/embedded-backend.test.ts --reporter=dot` — [TEST] 125/125 tests passed across 3 test files with 0 failures. Proves embedded approval routing, TUI backend event handling, and the fail-closed tool gate remain compatible. Preserves the production owner chain around the changed broker.

#### Core type boundaries

```bash
pnpm tsgo:core
```

- `pnpm tsgo:core` — [TYPECHECK] completed with exit code 0. Proves the production broker change satisfies the Core TypeScript contract. Preserves the existing approval event and listener API surface.
```bash
pnpm tsgo:core:test
```

- `pnpm tsgo:core:test` — [TYPECHECK] completed with exit code 0. Proves the regression tests satisfy the Core test TypeScript contract. Preserves the existing Vitest typing boundary.

#### Static verification

```bash
pnpm exec oxlint src/infra/embedded-plugin-approval-broker.ts src/infra/embedded-plugin-approval-broker.test.ts
```

- `pnpm exec oxlint src/infra/embedded-plugin-approval-broker.ts src/infra/embedded-plugin-approval-broker.test.ts` — [LINT] reported 0 warnings and 0 errors. Proves the changed source and tests satisfy scoped lint rules. Preserves the repository lint boundary.
```bash
pnpm exec oxfmt --check src/infra/embedded-plugin-approval-broker.ts src/infra/embedded-plugin-approval-broker.test.ts
```

- `pnpm exec oxfmt --check src/infra/embedded-plugin-approval-broker.ts src/infra/embedded-plugin-approval-broker.test.ts` — [STATIC] reported both files correctly formatted. Proves the changed files match repository formatting. Preserves the bounded two-file diff.
```bash
git diff --check origin/main...HEAD
```

- `git diff --check origin/main...HEAD` — [STATIC] completed with exit code 0 and no output. Proves the exact-head patch is whitespace-clean. Preserves the bounded two-file diff.

### Preserved boundaries

- Approval decision filtering, denial, timeout, abort, and fail-closed tool behavior are unchanged.
- Approval event names, payloads, synchronous ordering, and TUI presentation are unchanged.
- The shared dispatcher isolates only observer exceptions; it does not alter pending-map or timer ownership.
- No configuration, persistence, transport, authentication, permission, protocol, visual, or localization contract changes.

### Proof gap

Focused broker and adjacent owner-chain tests, both Core typechecks, scoped static checks, and a real exact-head broker lifecycle proof were run. A manual interactive TUI session, the full repository test suite, and GitHub CI were not run locally; no manual rendering, repository-wide, or CI result is claimed.

</details>

### Artifacts

- None attached.
