### PR TITLE
fix(ci): bound trufflehog installer download timeouts

### DIFF
--- a/scripts/install-trufflehog.sh
+++ b/scripts/install-trufflehog.sh
@@ -93,7 +93,12 @@ install_trufflehog() {
   url="https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/${archive}"
   tmp_dir="$(mktemp -d)"
 
-  if ! curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url" ||
+  # Bound individual transfers and the retry window. curl resets --max-time for
+  # each retry, while a started retry can outlive --retry-max-time.
+  if ! curl -fsSL \
+    --connect-timeout 30 --max-time 300 \
+    --retry 3 --retry-max-time 300 \
+    --output "$tmp_dir/$archive" "$url" ||
     ! (
       cd "$tmp_dir"
       printf '%s  %s\n' "$checksum" "$archive" | sha256sum -c -

--- a/scripts/install-trufflehog.sh
+++ b/scripts/install-trufflehog.sh
@@ -93,7 +93,12 @@ install_trufflehog() {
   url="https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/${archive}"
   tmp_dir="$(mktemp -d)"
 
-  if ! curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url" ||
+  # Bound individual transfers and the retry window: --retry only covers failed
+  # transfers, so a silent peer would otherwise hang the download forever.
+  if ! curl -fsSL \
+    --connect-timeout 10 --max-time 300 \
+    --retry 3 --retry-max-time 300 \
+    --output "$tmp_dir/$archive" "$url" ||
     ! (
       cd "$tmp_dir"
       printf '%s  %s\n' "$checksum" "$archive" | sha256sum -c -

--- a/test/scripts/install-trufflehog.test.ts
+++ b/test/scripts/install-trufflehog.test.ts
@@ -1,15 +1,11 @@
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT = "scripts/install-trufflehog.sh";
-const tempDirs = new Set<string>();
-
-afterEach(() => {
-  cleanupTempDirs(tempDirs);
-});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runBash(command: string, env: NodeJS.ProcessEnv = {}): string {
   return execFileSync("/bin/bash", ["--noprofile", "--norc", "-c", command], {
@@ -65,7 +61,7 @@ describe("scripts/install-trufflehog.sh", () => {
   });
 
   it("does not download TruffleHog again when the pinned version is installed", () => {
-    const root = makeTempDir(tempDirs, "openclaw-trufflehog-install-");
+    const root = tempDirs.make("openclaw-trufflehog-install-");
     const binDir = join(root, "bin");
     const downloadMarker = join(root, "downloaded");
     mkdirSync(binDir);
@@ -95,7 +91,7 @@ describe("scripts/install-trufflehog.sh", () => {
   });
 
   it("creates a missing user-writable install directory without sudo", () => {
-    const root = makeTempDir(tempDirs, "openclaw-trufflehog-user-bin-");
+    const root = tempDirs.make("openclaw-trufflehog-user-bin-");
     const binDir = join(root, "nested", "bin");
     const fakeBin = join(root, "fake-bin");
     const sudoMarker = join(root, "sudo-used");
@@ -114,7 +110,7 @@ describe("scripts/install-trufflehog.sh", () => {
   });
 
   it("does not change permissions on an existing writable install directory", () => {
-    const root = makeTempDir(tempDirs, "openclaw-trufflehog-existing-bin-");
+    const root = tempDirs.make("openclaw-trufflehog-existing-bin-");
     const binDir = join(root, "bin");
     const fakeBin = join(root, "fake-bin");
     const installMarker = join(root, "install-used");
@@ -135,10 +131,54 @@ describe("scripts/install-trufflehog.sh", () => {
     expect(existsSync(installMarker)).toBe(false);
   });
 
+  it("passes bounded download options to curl and cleans up after curl times out", () => {
+    const root = tempDirs.make("openclaw-trufflehog-curl-");
+    const binDir = join(root, "bin");
+    const argsFile = join(root, "curl-args");
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, "curl"),
+      '#!/bin/sh\nprintf "%s\\n" "$@" >"$CURL_ARGS_FILE"\nexit 28\n',
+      { mode: 0o755 },
+    );
+
+    expect(() =>
+      runBash(
+        `uname() { if [ "$1" = "-s" ]; then printf "Linux\\n"; else printf "x86_64\\n"; fi; }\nsource ${SCRIPT}\ninstall_trufflehog`,
+        {
+          CURL_ARGS_FILE: argsFile,
+          OPENCLAW_TRUFFLEHOG_BIN_DIR: join(root, "install"),
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      ),
+    ).toThrow();
+
+    const archive = "trufflehog_3.95.9_linux_amd64.tar.gz";
+    const args = readFileSync(argsFile, "utf8").trimEnd().split("\n");
+    const outputPath = args[10] ?? "";
+    expect(args.slice(0, 10)).toEqual([
+      "-fsSL",
+      "--connect-timeout",
+      "30",
+      "--max-time",
+      "300",
+      "--retry",
+      "3",
+      "--retry-max-time",
+      "300",
+      "--output",
+    ]);
+    expect(outputPath).toBe(join(dirname(outputPath), archive));
+    expect(args[11]).toBe(
+      `https://github.com/trufflesecurity/trufflehog/releases/download/v3.95.9/${archive}`,
+    );
+    expect(existsSync(dirname(outputPath))).toBe(false);
+  });
+
   it("verifies the archive before extraction and replaces the binary atomically", () => {
     const script = readFileSync(SCRIPT, "utf8");
     expect(script).toContain('"$binary" --no-update --version');
-    const download = script.indexOf('curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url"');
+    const download = script.indexOf("curl -fsSL");
     const verify = script.indexOf("sha256sum -c -");
     const extract = script.indexOf(
       'tar --no-same-owner -xzf "$tmp_dir/$archive" -C "$tmp_dir" trufflehog',

--- a/test/scripts/install-trufflehog.test.ts
+++ b/test/scripts/install-trufflehog.test.ts
@@ -135,10 +135,19 @@ describe("scripts/install-trufflehog.sh", () => {
     expect(existsSync(installMarker)).toBe(false);
   });
 
+  it("bounds the download with connect, transfer, and retry-window timeouts", () => {
+    const script = readFileSync(SCRIPT, "utf8");
+    const download = script.slice(script.indexOf("curl -fsSL"), script.indexOf('"$url"'));
+
+    expect(download).toContain("--connect-timeout");
+    expect(download).toContain("--max-time");
+    expect(download).toContain("--retry-max-time");
+  });
+
   it("verifies the archive before extraction and replaces the binary atomically", () => {
     const script = readFileSync(SCRIPT, "utf8");
     expect(script).toContain('"$binary" --no-update --version');
-    const download = script.indexOf('curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url"');
+    const download = script.indexOf("curl -fsSL");
     const verify = script.indexOf("sha256sum -c -");
     const extract = script.indexOf(
       'tar --no-same-owner -xzf "$tmp_dir/$archive" -C "$tmp_dir" trufflehog',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Testbox hydration could hang indefinitely when the pinned
TruffleHog download connected successfully but then stopped transferring data.
The existing `--retry 3` only retried failed transfers; it did not create a
deadline for a silent in-progress transfer.

## Why This Change Was Made

The installer now follows the established sibling installer policy:

- 30-second connection deadline
- 300-second deadline for each transfer attempt
- 3 retries for transient failures
- 300-second window in which another retry may start

This is intentionally not a strict 300-second whole-operation deadline. curl
resets `--max-time` for each retry, and a retry that starts before
`--retry-max-time` expires may finish after that window.

The regression test executes the installer with a fake curl instead of reading
the script text. It verifies the exact option values, pinned release URL,
failure propagation from curl exit 28, and temporary-directory cleanup.

## User Impact

CI and local Testbox setup no longer wait indefinitely on a silent TruffleHog
download. Slow valid transfers can still complete, transient 5xx responses are
retried, and failures remain visible through the existing installer error path.

## Evidence

- Current-main reproduction: the original `curl -fsSL --retry 3` command
  remained blocked against a silent local peer until an external 3-second
  watchdog terminated it with status 124.
- Focused regression: `test/scripts/install-trufflehog.test.ts` passes 8/8.
- Executed fake-curl proof: exact 30/300/3/300 options and pinned v3.95.9 URL
  observed; curl exit 28 failed the installer; its temporary directory was
  removed.
- Retry proof: a local endpoint returned 503 twice and 200 once; curl completed
  successfully after exactly 3 attempts.
- Slow-progress proof: an 8-byte response delivered over 2 seconds completed
  successfully.
- Real asset proof: downloaded the 33,648,591-byte pinned amd64 archive with the
  production flags; SHA-256 matched
  `f6d1106b85107d79527ed7a5b98b592beadd8b770dc3c9e8c1ad99e1b2cf127e`.
- Syntax and static proof: `bash -n`, formatting, script lint, test-root
  typecheck, dependency guards, and changed-surface checks passed.
- Blacksmith Testbox changed gate:
  `tbx_01m0qhx7ddnjcsjn1djdhgzmt0` (exit 0).
- Max-P1 structured autoreview: no accepted or actionable findings.

AI-assisted maintainer rewrite; the contributor remains the commit author.

Punchcard-Session: cobalt-orchard-harbor-y7
