### PR TITLE
fix(systemd): parse all inline environment assignments

### DIFF
--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -104,7 +104,7 @@ export function parseSystemdExecStart(value: string): string[] {
   return splitArgsPreservingQuotes(value, { escapeMode: "backslash" });
 }
 
-export function parseSystemdEnvAssignment(raw: string): { key: string; value: string } | null {
+function parseSystemdEnvAssignment(raw: string): { key: string; value: string } | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1265,6 +1265,39 @@ describe("readSystemdServiceExecStart", () => {
     expect(command?.environmentValueSources?.OPENCLAW_GATEWAY_TOKEN).toBe("inline-and-file");
   });
 
+  it("reads all inline assignments in order before EnvironmentFile overrides", async () => {
+    mockReadGatewayServiceFile(
+      [
+        "[Service]",
+        "ExecStart=/usr/bin/openclaw gateway run",
+        'Environment=PLAIN=first "QUOTED=value with spaces" REPEATED=first',
+        "Environment='REPEATED=last value' INLINE_FILE=inline",
+        "EnvironmentFile=%h/.openclaw/.env",
+      ],
+      {
+        [`${TEST_SERVICE_HOME}/.openclaw/.env`]: ["INLINE_FILE=file", "FILE_ONLY=from-file"].join(
+          "\n",
+        ),
+      },
+    );
+
+    const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
+    expect(command?.environment).toEqual({
+      PLAIN: "first",
+      QUOTED: "value with spaces",
+      REPEATED: "last value",
+      INLINE_FILE: "file",
+      FILE_ONLY: "from-file",
+    });
+    expect(command?.environmentValueSources).toEqual({
+      PLAIN: "inline",
+      QUOTED: "inline",
+      REPEATED: "inline",
+      INLINE_FILE: "inline-and-file",
+      FILE_ONLY: "file",
+    });
+  });
+
   it("ignores missing optional EnvironmentFile entries", async () => {
     await expectExecStartWithoutEnvironment("EnvironmentFile=-%h/.openclaw/missing.env");
   });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -58,7 +58,6 @@ import {
 } from "./systemd-unavailable.js";
 import {
   buildSystemdUnit,
-  parseSystemdEnvAssignment,
   parseSystemdEnvAssignments,
   parseSystemdExecStart,
   renderSystemdEnvAssignment,
@@ -328,8 +327,7 @@ export async function readSystemdServiceExecStart(
         workingDirectory = line.slice("WorkingDirectory=".length).trim();
       } else if (line.startsWith("Environment=")) {
         const raw = line.slice("Environment=".length).trim();
-        const parsed = parseSystemdEnvAssignment(raw);
-        if (parsed) {
+        for (const parsed of parseSystemdEnvAssignments(raw)) {
           inlineEnvironment[parsed.key] = parsed.value;
         }
       } else if (line.startsWith("EnvironmentFile=")) {


### PR DESCRIPTION
Closes #117483

## What Problem This Solves

Fixes an issue where Linux operators with multiple assignments on one valid systemd `Environment=` directive could see OpenClaw parse a malformed service identity and report the wrong Gateway status.

## Why This Change Was Made

The installed-service reader now reuses the existing plural systemd assignment parser and applies every assignment in declaration order. Later inline duplicates keep normal last-write-wins behavior, `EnvironmentFile=` values retain precedence, and the now-private singular parser remains only an implementation detail of the canonical plural owner.

## User Impact

Gateway status and doctor paths read all inline systemd variables correctly, including profile and unit-name values, without changing generated units, environment-file semantics, service lifecycle, configuration, or public APIs.

## Evidence

- Focused Linux Testbox: 141/141 tests passed on https://github.com/openclaw/openclaw/actions/runs/30706511918.
- Regression covers quoted and unquoted assignments, repeated inline keys, `EnvironmentFile=` override precedence, and exact `inline` / `file` / `inline-and-file` provenance.
- Targeted formatter and `git diff --check` passed.
- Final P1 Codex autoreview: clean, no accepted/actionable findings, confidence 0.93.
- Exact-head hosted CI run https://github.com/openclaw/openclaw/actions/runs/30706854902 passed on attempt 2, including `openclaw/ci-gate`. Attempt 1's only failure was unrelated built TUI PTY; it passed unchanged on the failed-job rerun, and base-main CI https://github.com/openclaw/openclaw/actions/runs/30706700289 was green.
- Production delta: +2/-4 (net −2); tests: +33.
- No config, protocol, persistence, dependency, migration, or unit-generation changes.

Release-note context: OpenClaw now reads every assignment from valid multi-value systemd `Environment=` directives when inspecting installed Gateway services.

AI-assisted: yes. The implementation was independently reviewed and remotely validated.
