### PR TITLE
fix(cli): preserve machine output through fatal terminal restores

### DIFF
--- a/src/cli/config-output-mode.ts
+++ b/src/cli/config-output-mode.ts
@@ -43,9 +43,10 @@ function resolveConfigSubcommand(argv: readonly string[]): string | null {
   return null;
 }
 
-/** Config get reserves stdout for the requested value, including bare scalar output. */
+/** Config values, paths, and schemas reserve stdout for machine-consumed output. */
 export function isConfigMachineOutput(argv: readonly string[]): boolean {
-  return resolveConfigSubcommand(argv) === "get";
+  const subcommand = resolveConfigSubcommand(argv);
+  return subcommand === "get" || subcommand === "file" || subcommand === "schema";
 }
 
 /** Config set uses --json as a parser alias except when dry-run emits a JSON report. */

--- a/src/cli/machine-output-modes.test.ts
+++ b/src/cli/machine-output-modes.test.ts
@@ -67,23 +67,21 @@ describe("built-in machine-output resolvers", () => {
     ).toBe(true);
   });
 
-  it("reserves raw cron scratch and config get output", () => {
+  it("reserves raw cron scratch output", () => {
     expect(isCronMachineOutput(["node", "openclaw", "cron", "scratch", "job"])).toBe(true);
-    expect(isConfigMachineOutput(["node", "openclaw", "config", "get", "gateway.port"])).toBe(true);
+  });
+
+  it.each(["get", "file", "schema"])("reserves config %s machine output", (subcommand) => {
+    expect(isConfigMachineOutput(["node", "openclaw", "config", subcommand])).toBe(true);
     expect(
-      isConfigMachineOutput([
-        "node",
-        "openclaw",
-        "config",
-        "--section",
-        "agents",
-        "get",
-        "gateway.port",
-      ]),
+      isConfigMachineOutput(["node", "openclaw", "config", "--section", "agents", subcommand]),
     ).toBe(true);
   });
 
   it("treats config set --json as parse-only except for JSON dry-run reports", () => {
+    expect(isConfigMachineOutput(["node", "openclaw", "config", "set", "gateway.port"])).toBe(
+      false,
+    );
     expect(
       isConfigSetJsonParseOnly([
         "node",

--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -296,4 +296,86 @@ describe("one-shot CLI exit", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toHaveLength(payloadBytes);
   });
+
+  it.each([
+    { name: "deferred hooks success", exitCode: 0, explicitRequest: true },
+    { name: "deferred hooks failure", exitCode: 1, explicitRequest: true },
+    { name: "automatic macOS system-CA success", exitCode: 0, explicitRequest: false },
+  ])("keeps real dual-TTY JSON clean for $name", ({ exitCode, explicitRequest }) => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    delete env.VITEST_POOL_ID;
+    delete env.VITEST_WORKER_ID;
+    const oneShotExitUrl = new URL("./one-shot-exit.ts", import.meta.url).href;
+    const runtimeUrl = new URL("../runtime.ts", import.meta.url).href;
+    const loggingStateUrl = new URL("../logging/state.ts", import.meta.url).href;
+    const script = `
+      import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from ${JSON.stringify(oneShotExitUrl)};
+      import { defaultRuntime } from ${JSON.stringify(runtimeUrl)};
+      import { loggingState } from ${JSON.stringify(loggingStateUrl)};
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+      loggingState.forceConsoleToStderr = true;
+      await runCliWithExitFinalization({
+        run: async () => {
+          defaultRuntime.writeStdout(JSON.stringify({ ok: ${exitCode === 0} }));
+          ${explicitRequest ? `requestExitAfterOneShotOutput(defaultRuntime, ${exitCode});` : ""}
+        },
+        onError: (error) => { throw error; },
+        ${explicitRequest ? "" : 'env: { NODE_USE_SYSTEM_CA: "1" }, execArgv: [], platform: "darwin", markers: {},'}
+      });
+    `;
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { encoding: "utf8", env, timeout: 30_000 },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(exitCode);
+    expect(result.signal).toBeNull();
+    expect(JSON.parse(result.stdout)).toEqual({ ok: exitCode === 0 });
+    expect(result.stderr).toContain("\x1b[?25h");
+  });
+
+  it.each([
+    { name: "fatal unhandled rejection", errorCode: "ERR_OUT_OF_MEMORY", exitCode: 1 },
+    { name: "invalid configuration rejection", errorCode: "INVALID_CONFIG", exitCode: 78 },
+  ])("keeps real dual-TTY JSON clean after $name", ({ errorCode, exitCode }) => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    delete env.VITEST_POOL_ID;
+    delete env.VITEST_WORKER_ID;
+    const runtimeUrl = new URL("../runtime.ts", import.meta.url).href;
+    const loggingStateUrl = new URL("../logging/state.ts", import.meta.url).href;
+    const unhandledRejectionsUrl = new URL("../infra/unhandled-rejections.ts", import.meta.url)
+      .href;
+    const script = `
+      import { defaultRuntime } from ${JSON.stringify(runtimeUrl)};
+      import { loggingState } from ${JSON.stringify(loggingStateUrl)};
+      import { installUnhandledRejectionHandler } from ${JSON.stringify(unhandledRejectionsUrl)};
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+      loggingState.forceConsoleToStderr = true;
+      installUnhandledRejectionHandler();
+      defaultRuntime.writeJson({ ok: false });
+      const error = Object.assign(new Error("expected fatal test"), {
+        code: ${JSON.stringify(errorCode)},
+      });
+      process.emit("unhandledRejection", error, Promise.resolve());
+    `;
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { encoding: "utf8", env, timeout: 30_000 },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(exitCode);
+    expect(result.signal).toBeNull();
+    expect(JSON.parse(result.stdout)).toEqual({ ok: false });
+    expect(result.stderr).toContain("\x1b[?25h");
+  });
 });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -83,7 +83,7 @@ const loadPluginCliDescriptorsMock = vi.hoisted(() =>
 const resolveManifestCommandAliasOwnerMock = vi.hoisted(() => vi.fn());
 const resolveManifestToolOwnerMock = vi.hoisted(() => vi.fn());
 const resolveManifestCliCommandSurfaceOwnerMock = vi.hoisted(() => vi.fn());
-const restoreTerminalStateMock = vi.hoisted(() => vi.fn());
+const restoreRuntimeTerminalStateMock = vi.hoisted(() => vi.fn());
 const hasEnvHttpProxyAgentConfiguredMock = vi.hoisted(() => vi.fn(() => false));
 const ensureGlobalUndiciEnvProxyDispatcherMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() =>
@@ -350,9 +350,13 @@ vi.mock("../plugins/manifest-command-aliases.runtime.js", () => ({
   resolveManifestToolOwner: resolveManifestToolOwnerMock,
 }));
 
-vi.mock("../../packages/terminal-core/src/restore.js", () => ({
-  restoreTerminalState: restoreTerminalStateMock,
-}));
+vi.mock("../runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime.js")>();
+  return {
+    ...actual,
+    restoreRuntimeTerminalState: restoreRuntimeTerminalStateMock,
+  };
+});
 
 vi.mock("../infra/net/proxy-env.js", () => ({
   hasEnvHttpProxyAgentConfigured: hasEnvHttpProxyAgentConfiguredMock,
@@ -4071,43 +4075,48 @@ describe("runCli exit behavior", () => {
     ]);
   });
 
-  it("restores terminal state before uncaught CLI exits", async () => {
-    buildProgramMock.mockReturnValueOnce({
-      commands: [{ name: () => "status" }],
-      parseAsync: vi.fn().mockResolvedValueOnce(undefined),
-    });
-
-    const processOnSpy = vi.spyOn(process, "on");
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${String(code)})`);
-    }) as typeof process.exit);
-
-    await runCli(["node", "openclaw", "status"]);
-
-    const handler = processOnSpy.mock.calls.find(([event]) => event === "uncaughtException")?.[1];
-    if (typeof handler !== "function") {
-      throw new Error("uncaughtException handler was not registered");
-    }
-
-    try {
-      expect(() => handler(new Error("boom"))).toThrow("process.exit(1)");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[openclaw] OpenClaw hit an unexpected runtime error.",
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith("[openclaw] Reason: boom");
-      expect(restoreTerminalStateMock).toHaveBeenCalledWith("uncaught exception", {
-        resumeStdinIfPaused: false,
+  it.each([false, true])(
+    "restores terminal state before uncaught CLI exits (machine output: %s)",
+    async (machineOutput) => {
+      buildProgramMock.mockReturnValueOnce({
+        commands: [{ name: () => "status" }],
+        parseAsync: vi.fn().mockResolvedValueOnce(undefined),
       });
-    } finally {
-      if (typeof handler === "function") {
-        process.off("uncaughtException", handler);
+
+      const processOnSpy = vi.spyOn(process, "on");
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${String(code)})`);
+      }) as typeof process.exit);
+
+      await runCli(["node", "openclaw", "status"]);
+
+      const handler = processOnSpy.mock.calls.find(([event]) => event === "uncaughtException")?.[1];
+      if (typeof handler !== "function") {
+        throw new Error("uncaughtException handler was not registered");
       }
-      consoleErrorSpy.mockRestore();
-      exitSpy.mockRestore();
-      processOnSpy.mockRestore();
-    }
-  });
+
+      try {
+        loggingState.forceConsoleToStderr = machineOutput;
+        expect(() => handler(new Error("boom"))).toThrow("process.exit(1)");
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "[openclaw] OpenClaw hit an unexpected runtime error.",
+        );
+        expect(consoleErrorSpy).toHaveBeenCalledWith("[openclaw] Reason: boom");
+        expect(restoreRuntimeTerminalStateMock).toHaveBeenCalledWith("uncaught exception", {
+          resumeStdinIfPaused: false,
+        });
+      } finally {
+        loggingState.forceConsoleToStderr = false;
+        if (typeof handler === "function") {
+          process.off("uncaughtException", handler);
+        }
+        consoleErrorSpy.mockRestore();
+        exitSpy.mockRestore();
+        processOnSpy.mockRestore();
+      }
+    },
+  );
 
   it("does not exit for transient uncaught CLI exceptions", async () => {
     buildProgramMock.mockReturnValueOnce({
@@ -4136,7 +4145,7 @@ describe("runCli exit behavior", () => {
       expect(consoleWarnSpy.mock.calls).toEqual([
         ["[openclaw] Non-fatal uncaught exception (continuing):", hostUnreachable.stack],
       ]);
-      expect(restoreTerminalStateMock).not.toHaveBeenCalled();
+      expect(restoreRuntimeTerminalStateMock).not.toHaveBeenCalled();
       expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       if (typeof handler === "function") {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1456,7 +1456,7 @@ async function runCliWithPreparedOutputMode(
           isBenignUncaughtExceptionError,
           isUncaughtExceptionHandled,
         },
-        { restoreTerminalState },
+        { restoreRuntimeTerminalState },
       ] = await startupTrace.measure("core-imports", () =>
         Promise.all([
           import("./program.js"),
@@ -1464,7 +1464,7 @@ async function runCliWithPreparedOutputMode(
           import("./failure-output.js"),
           import("../infra/fatal-error-hooks.js"),
           import("../infra/unhandled-rejections.js"),
-          import("../../packages/terminal-core/src/restore.js"),
+          import("../runtime.js"),
         ]),
       );
       const program = await startupTrace.measure("build-program", () => buildProgram());
@@ -1494,7 +1494,7 @@ async function runCliWithPreparedOutputMode(
         for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
           console.error("[openclaw]", message);
         }
-        restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
+        restoreRuntimeTerminalState("uncaught exception", { resumeStdinIfPaused: false });
         process.exit(1);
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ if (!isMain) {
 }
 
 if (isMain) {
-  const { restoreTerminalState } = await import("../packages/terminal-core/src/restore.js");
+  const { restoreRuntimeTerminalState } = await import("./runtime.js");
 
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
@@ -124,7 +124,7 @@ if (isMain) {
     for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
       console.error("[openclaw]", message);
     }
-    restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
+    restoreRuntimeTerminalState("uncaught exception", { resumeStdinIfPaused: false });
     process.exit(1);
   });
 
@@ -145,7 +145,7 @@ if (isMain) {
       for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
         console.error("[openclaw]", message);
       }
-      restoreTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
+      restoreRuntimeTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
       process.exitCode = 1;
     },
   });

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -2,12 +2,13 @@
 import process from "node:process";
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 
-const restoreTerminalStateMock = vi.hoisted(() => vi.fn());
+const restoreRuntimeTerminalStateMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../packages/terminal-core/src/restore.js", () => ({
-  restoreTerminalState: restoreTerminalStateMock,
+vi.mock("../runtime.js", () => ({
+  restoreRuntimeTerminalState: restoreRuntimeTerminalStateMock,
 }));
 
+import { loggingState } from "../logging/state.js";
 import { resetFatalErrorHooksForTest } from "./fatal-error-hooks.js";
 import {
   installUnhandledRejectionHandler,
@@ -20,6 +21,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   let originalExit: typeof process.exit;
+  const originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
 
   beforeAll(() => {
     originalExit = process.exit.bind(process);
@@ -43,6 +45,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    loggingState.forceConsoleToStderr = originalForceConsoleToStderr;
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
   });
@@ -71,16 +74,16 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
     expectedRestoreReason?: string,
   ): void {
     exitCalls = [];
-    restoreTerminalStateMock.mockClear();
+    restoreRuntimeTerminalStateMock.mockClear();
     emitUnhandled(reason);
     expect(exitCalls).toEqual(expected);
     if (expectedRestoreReason) {
-      expect(restoreTerminalStateMock).toHaveBeenCalledWith(expectedRestoreReason, {
+      expect(restoreRuntimeTerminalStateMock).toHaveBeenCalledWith(expectedRestoreReason, {
         resumeStdinIfPaused: false,
       });
       return;
     }
-    expect(restoreTerminalStateMock).not.toHaveBeenCalled();
+    expect(restoreRuntimeTerminalStateMock).not.toHaveBeenCalled();
   }
 
   describe("fatal errors", () => {
@@ -105,6 +108,35 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         "Out of memory",
       );
     });
+
+    it.each([
+      {
+        name: "fatal runtime rejection",
+        errorCode: "ERR_OUT_OF_MEMORY",
+        exitCode: 1,
+        restoreReason: "fatal unhandled rejection",
+      },
+      {
+        name: "invalid configuration rejection",
+        errorCode: "INVALID_CONFIG",
+        exitCode: 78,
+        restoreReason: "configuration error",
+      },
+    ])(
+      "routes $name terminal resets through the machine-aware runtime owner",
+      ({ errorCode, exitCode, restoreReason }) => {
+        loggingState.forceConsoleToStderr = true;
+
+        emitUnhandled(
+          Object.assign(new Error("expected machine-output failure"), { code: errorCode }),
+        );
+
+        expect(exitCalls).toEqual([exitCode]);
+        expect(restoreRuntimeTerminalStateMock).toHaveBeenCalledWith(restoreReason, {
+          resumeStdinIfPaused: false,
+        });
+      },
+    );
   });
 
   describe("scoped uncaught exception handlers", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -1,7 +1,7 @@
 // Installs fatal and transient unhandled rejection/exception handlers.
 import process from "node:process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
+import { restoreRuntimeTerminalState } from "../runtime.js";
 import { isAbortError } from "./abort-signal.js";
 import {
   collectErrorGraphCandidates,
@@ -522,7 +522,7 @@ export function installUnhandledRejectionHandler(): void {
     for (const message of runFatalErrorHooks({ reason: hookReason, error })) {
       console.error("[openclaw]", message);
     }
-    restoreTerminalState(reason, { resumeStdinIfPaused: false });
+    restoreRuntimeTerminalState(reason, { resumeStdinIfPaused: false });
     process.exit(exitCode);
   };
 

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,5 +1,5 @@
 // Tests for terminal runtime helpers.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies
 vi.mock("../packages/terminal-core/src/progress-line.js", () => ({
@@ -10,8 +10,11 @@ vi.mock("../packages/terminal-core/src/restore.js", () => ({
   restoreTerminalState: vi.fn(),
 }));
 
+import { restoreTerminalState } from "../packages/terminal-core/src/restore.js";
+import { loggingState } from "./logging/state.js";
 import {
   createNonExitingRuntime,
+  defaultRuntime,
   ExitError,
   writeRuntimeJson,
   writeRuntimeStdout,
@@ -117,5 +120,109 @@ describe("writeRuntimeStdout", () => {
     writeRuntimeStdout(runtime, "plain output");
 
     expect(runtime.log).toHaveBeenCalledWith("plain output");
+  });
+});
+
+describe("defaultRuntime terminal restoration", () => {
+  const originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  const originalStderrIsTTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(restoreTerminalState).mockReset();
+    loggingState.forceConsoleToStderr = originalForceConsoleToStderr;
+    if (originalStdoutIsTTY) {
+      Object.defineProperty(process.stdout, "isTTY", originalStdoutIsTTY);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
+    }
+    if (originalStderrIsTTY) {
+      Object.defineProperty(process.stderr, "isTTY", originalStderrIsTTY);
+    } else {
+      Reflect.deleteProperty(process.stderr, "isTTY");
+    }
+  });
+
+  it.each([0, 1])("keeps machine-readable stdout clean on exit %i", async (exitCode) => {
+    const actualRestore = await vi.importActual<
+      typeof import("../packages/terminal-core/src/restore.js")
+    >("../packages/terminal-core/src/restore.js");
+    vi.mocked(restoreTerminalState).mockImplementation(actualRestore.restoreTerminalState);
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0);
+    }) as typeof process.exit);
+    loggingState.forceConsoleToStderr = true;
+
+    defaultRuntime.writeJson({ ok: exitCode === 0 });
+    expect(() => defaultRuntime.exit(exitCode)).toThrow(ExitError);
+
+    expect(JSON.parse(stdout.join(""))).toEqual({ ok: exitCode === 0 });
+    expect(stderr.join("")).toContain("\x1b[?25h");
+  });
+
+  it("preserves stdout terminal restoration for human output", async () => {
+    const actualRestore = await vi.importActual<
+      typeof import("../packages/terminal-core/src/restore.js")
+    >("../packages/terminal-core/src/restore.js");
+    vi.mocked(restoreTerminalState).mockImplementation(actualRestore.restoreTerminalState);
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new ExitError(1);
+    }) as typeof process.exit);
+    loggingState.forceConsoleToStderr = false;
+
+    defaultRuntime.writeStdout("operator-visible output");
+    expect(() => defaultRuntime.exit(1)).toThrow(ExitError);
+
+    expect(stdout.join("")).toContain("operator-visible output\n");
+    expect(stdout.join("")).toContain("\x1b[?25h");
+    expect(stderr).toEqual([]);
+  });
+
+  it("honors an explicitly selected reset stream in machine-output mode", async () => {
+    const actualRestore = await vi.importActual<
+      typeof import("../packages/terminal-core/src/restore.js")
+    >("../packages/terminal-core/src/restore.js");
+    vi.mocked(restoreTerminalState).mockImplementation(actualRestore.restoreTerminalState);
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const resetWrite = vi.fn(() => true);
+    const resetStream = { isTTY: true, write: resetWrite } as unknown as NodeJS.WriteStream;
+    vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new ExitError(1);
+    }) as typeof process.exit);
+    loggingState.forceConsoleToStderr = true;
+
+    expect(() => defaultRuntime.exit(1, { resetStream })).toThrow(ExitError);
+
+    expect(resetWrite).toHaveBeenCalledWith(expect.stringContaining("\x1b[?25h"));
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
   });
 });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,7 @@
 // Re-exports terminal runtime helpers used by CLI command implementations.
 import { clearActiveProgressLine } from "../packages/terminal-core/src/progress-line.js";
 import { restoreTerminalState } from "../packages/terminal-core/src/restore.js";
+import { loggingState } from "./logging/state.js";
 
 export type RuntimeExitOptions = {
   /** Route ANSI terminal-reset bytes away from structured stdout when needed. */
@@ -96,12 +97,25 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
   };
 }
 
+/** Keep terminal reset bytes off stdout when the invocation owns machine-readable output. */
+export function restoreRuntimeTerminalState(
+  reason?: string,
+  options: NonNullable<Parameters<typeof restoreTerminalState>[1]> = {},
+): void {
+  const resetStream =
+    options.resetStream ?? (loggingState.forceConsoleToStderr ? process.stderr : undefined);
+  restoreTerminalState(reason, {
+    ...options,
+    ...(resetStream ? { resetStream } : {}),
+  });
+}
+
 export const defaultRuntime: OutputRuntimeEnv = {
   ...createRuntimeIo(),
   exit: (code, opts) => {
-    restoreTerminalState("runtime exit", {
+    restoreRuntimeTerminalState("runtime exit", {
       resumeStdinIfPaused: false,
-      resetStream: opts?.resetStream,
+      ...(opts?.resetStream ? { resetStream: opts.resetStream } : {}),
     });
     process.exit(code);
     throw new Error("unreachable"); // satisfies tests when mocked


### PR DESCRIPTION
## What Problem This Solves

Machine-readable CLI commands could append terminal-reset escape sequences to stdout during normal, deferred, uncaught-exception, unhandled-rejection, configuration-failure, or legacy exits. Configuration path and schema commands also failed to reserve their machine-output stream. Downstream operators therefore received invalid JSON precisely when commands succeeded, failed, or terminated fatally.

## Why This Change Was Made

Move terminal-reset stream selection into the existing application runtime owner and route every normal and fatal CLI exit through that single boundary. Preserve explicitly selected reset streams, human terminal behavior, interactive onboarding, public plugin SDK contracts, dynamic startup imports, existing exit codes, and config-set JSON parsing behavior.

## User Impact

Automation receives clean JSON or raw machine output even on fatal exit 1 and invalid-configuration exit 78. Terminal cleanup still occurs on stderr for machine output and on stdout for human sessions; config get, file, and schema consistently reserve their output stream.

## Evidence

- Authentic baseline: 12 failing regressions, including real dual-TTY subprocess exits 1 and 78.
- Fixed tree: 140 focused passing tests across runtime restoration, fatal and benign rejection handling, uncaught exceptions, deferred/macOS exits, machine-output detection, JSON compatibility, cold startup, and existing partial-runtime mocks.
- Configured type-aware lint, exact-file formatting, and whitespace checks passed.
- Exact frozen commit 59c106c05a0d3ebd629d2bd80ee860039d18a8fe and tree 569216cabcce765625e6fa73e390083682af4e5d were verified on a dedicated Blacksmith Testbox before running the complete package build.
- Full pnpm build passed in 2 minutes 58.3 seconds, including all dynamic-import bundles, CLI bootstrap validation, UI build, and all 148 public plugin SDK entrypoints.
- Separate plugin-SDK surface gate passed: 321 entrypoints, 7,589 exports, and zero forbidden public subpaths.
- At least nine independent exact-commit hostile reviews reported no remaining P0–P3 findings; the earlier missing-build hold was explicitly resolved after successful remote verification.
- Verification: https://github.com/openclaw/openclaw/actions/runs/30705742496
