### PR TITLE
fix(doctor): reject conflicting maintenance operations before side effects

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -186,6 +186,18 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(0);
   });
 
+  it("preserves standalone post-upgrade diagnostics", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--post-upgrade", "--json"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, options] = commandCall(doctorCommand);
+    expect(options.postUpgrade).toBe(true);
+    expect(options.json).toBe(true);
+    expect(runtime.exit).toHaveBeenCalledWith(0);
+  });
+
   it("rejects simultaneous shared-state and session SQLite modes", async () => {
     await runMaintenanceCli(["doctor", "--state-sqlite", "compact", "--session-sqlite", "compact"]);
 
@@ -241,6 +253,51 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
+  it.each([
+    ["lint and session SQLite import", ["--lint", "--session-sqlite", "import"]],
+    [
+      "lint and selected session SQLite import",
+      ["--lint", "--session-sqlite", "import", "--session-sqlite-agent", "main"],
+    ],
+    ["lint and repair", ["--lint", "--fix"]],
+    ["lint and repair alias", ["--lint", "--repair"]],
+    ["lint and gateway-token mutation", ["--lint", "--generate-gateway-token"]],
+    ["lint and post-upgrade checks", ["--lint", "--post-upgrade"]],
+    [
+      "session inspection and post-upgrade checks",
+      ["--session-sqlite", "inspect", "--post-upgrade"],
+    ],
+    ["session import and repair", ["--session-sqlite", "import", "--fix"]],
+    ["post-upgrade checks and repair", ["--post-upgrade", "--fix"]],
+  ])("rejects %s before either doctor operation runs", async (_label, args) => {
+    await runMaintenanceCli(["doctor", ...args]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("mutually exclusive"));
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it("rejects lint with session selectors before running read-only checks", async () => {
+    await runMaintenanceCli(["doctor", "--lint", "--session-sqlite-agent", "main"]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it("rejects GitHub issue creation for non-recovery session operations", async () => {
+    await runMaintenanceCli(["doctor", "--session-sqlite", "inspect", "--github-issue"]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith("--github-issue requires --session-sqlite recover.");
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
   it("runs doctor lint mode without invoking repair doctor", async () => {
     runDoctorLintCli.mockResolvedValue(1);
 
@@ -256,6 +313,7 @@ describe("registerMaintenanceCommands doctor action", () => {
       "--only",
       "b",
       "--allow-exec",
+      "--deep",
     ]);
 
     expect(doctorCommand).not.toHaveBeenCalled();
@@ -266,7 +324,7 @@ describe("registerMaintenanceCommands doctor action", () => {
       skipIds: ["a"],
       onlyIds: ["b"],
       allowExec: true,
-      deep: false,
+      deep: true,
     });
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -110,6 +110,35 @@ export function registerMaintenanceCommands(program: Command) {
         defaultRuntime.exit(2);
         return;
       }
+      if (hasSessionSqliteOnlyDoctorOptions(opts)) {
+        defaultRuntime.error(
+          "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
+        );
+        defaultRuntime.exit(2);
+        return;
+      }
+      const requestedOperationCount = [
+        opts.lint === true,
+        opts.postUpgrade === true,
+        typeof opts.stateSqlite === "string",
+        typeof opts.sessionSqlite === "string",
+        opts.repair === true ||
+          opts.fix === true ||
+          opts.force === true ||
+          opts.generateGatewayToken === true,
+      ].filter(Boolean).length;
+      if (requestedOperationCount > 1) {
+        defaultRuntime.error(
+          "doctor operations are mutually exclusive: choose one of --lint, --fix/--repair, --post-upgrade, --state-sqlite, or --session-sqlite.",
+        );
+        defaultRuntime.exit(2);
+        return;
+      }
+      if (opts.githubIssue === true && opts.sessionSqlite !== "recover") {
+        defaultRuntime.error("--github-issue requires --session-sqlite recover.");
+        defaultRuntime.exit(2);
+        return;
+      }
       if (opts.lint === true) {
         await runCommandWithRuntime(
           defaultRuntime,
@@ -131,13 +160,6 @@ export function registerMaintenanceCommands(program: Command) {
             defaultRuntime.exit(2);
           },
         );
-        return;
-      }
-      if (hasSessionSqliteOnlyDoctorOptions(opts)) {
-        defaultRuntime.error(
-          "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
-        );
-        defaultRuntime.exit(2);
         return;
       }
       if (hasLintOnlyDoctorOptions(opts)) {


### PR DESCRIPTION
## What Problem This Solves

Doctor silently ignores one request when conflicting maintenance operations are combined, and accepts `--github-issue` with session modes that cannot create an issue.

## User Impact

Conflicting operations now fail with exit code 2 before either handler runs. Valid standalone operations, repair aliases, and `--session-sqlite recover --github-issue --yes` remain available. Bare `doctor --json` keeps its advisory exit code, and failures keep structured, redacted output.

No flags, configuration, database schema, or permissions change. Normal updater-generated Doctor commands remain single operations and retain their existing behavior.

## Why This Change Was Made

Validate the request in the existing command registration before importing an operational handler. This adapts @steipete's original change to current main and preserves its ancestry, including the newer JSON, lint, and triage contracts.

## Evidence

- Unmodified main baseline: 14 regression cases failed because a handler ran; 110 controls passed.
- Candidate: all 124 cases passed on Linux with Node 24.18.1 and pnpm 12.3.4.
- Independent review through P2 found no actionable code issues. Formatting changes were mechanical.
- Exact `c6862219`: full changed checks and build passed. Seven invalid built-CLI cases exited 2 without persistent files; valid state maintenance exited 0.
- Four fresh-state standalone controls passed. Bare JSON and plain noninteractive Doctor exited 0; explicit lint and post-upgrade returned their structured diagnostic findings with exit 1, not argument errors.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34928690686) passed.
- [Published-updater compatibility](https://github.com/openclaw/openclaw/actions/runs/34929343972/job/104257552157) passed in one 341-second attempt: `openclaw@2026.9.4` to this exact candidate, scenario `base`. Automatic migration, standalone Doctor, state survival and Gateway health passed. Package integrity and npm 12 installer checks also passed. The fixture used manual restart and retained recoverable Doctor warnings; no additional baseline or scenario coverage is claimed.

[Baseline reproduction](https://crabbox.openclaw.ai/portal/runs/run_8593617a6477) · [Candidate tests](https://crabbox.openclaw.ai/portal/runs/run_ccd482659515) · [Checks, build and CLI](https://crabbox.openclaw.ai/portal/runs/run_0174eccf64a2) · [Standalone controls](https://crabbox.openclaw.ai/portal/runs/run_13a11bfaaaba)

The task-owned AWS lease was released after proof. Initial formatting and remote Git-metadata failures were diagnosed and retained; no baselines were changed to satisfy checks.
