### PR TITLE
fix(google): honor Gemini Live new-session activation deadlines

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -620,6 +620,32 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     ]);
   });
 
+  it("returns browser expiry in the epoch milliseconds required by the Talk gateway", async () => {
+    vi.useFakeTimers();
+    const nowMs = Date.UTC(2026, 7, 1, 12, 34, 56, 789);
+    vi.setSystemTime(nowMs);
+    const provider = buildGoogleRealtimeVoiceProvider();
+
+    const sessionLocal = await provider.createBrowserSession?.({
+      providerConfig: { apiKey: "gemini-key" },
+    });
+
+    const tokenConfig = requireFirstMockArg(createTokenMock, "Google Live auth token config") as {
+      config?: {
+        expireTime?: string;
+        newSessionExpireTime?: string;
+      };
+    };
+    expect(tokenConfig.config?.expireTime).toBe(new Date(nowMs + 30 * 60 * 1000).toISOString());
+    expect(tokenConfig.config?.newSessionExpireTime).toBe(
+      new Date(nowMs + 60 * 1000).toISOString(),
+    );
+    expect(sessionLocal?.expiresAt).toBeGreaterThan(nowMs + 5_000);
+    vi.advanceTimersByTime(60_001);
+    expect(sessionLocal?.expiresAt).toBeLessThanOrEqual(Date.now() + 5_000);
+    expect(sessionLocal?.expiresAt).toBe(nowMs + 60 * 1000);
+  });
+
   it("constrains default browser sessions to Gemini 3.1 capabilities", async () => {
     const provider = buildGoogleRealtimeVoiceProvider();
 

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -1155,7 +1155,7 @@ async function createGoogleRealtimeBrowserSession(
     initialMessage: buildBrowserInitialSetup(model),
     model,
     voice,
-    expiresAt: Math.floor(expiresAtMs / 1000),
+    expiresAt: newSessionExpiresAtMs,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Google Live browser Talk sessions were rejected during startup because the Google provider returned an epoch-seconds expiration while the Gateway and persisted session owner require epoch milliseconds. A naive 30-minute conversion also misrepresents token validity: Google permits creating a new Live connection for only 60 seconds, even though an already established session remains valid for 30 minutes.

## Why This Change Was Made

The provider now returns the existing `newSessionExpiresAtMs` value as its browser-session expiration. Google SDK requests retain their independent ISO expiration fields: `newSessionExpireTime` remains 60 seconds, `expireTime` remains 30 minutes, and all token constraints, authentication, cancellation, and protocol shapes stay unchanged.

## User Impact

Google Live Talk can start normally, and delayed microphone permission or other startup delays cannot cause OpenClaw to treat an already-expired new-connection token as valid. Existing connected Live sessions retain their full 30-minute lifetime.

## Evidence

- Authentic fake-clock regression reproduced the revoked 30-minute candidate accepting an expired new-session token after 60,001 ms; the corrected provider returns the exact 60-second epoch-millisecond deadline and preserves both Google SDK ISO expirations.
- `node scripts/run-vitest.mjs extensions/google/realtime-voice-provider.test.ts`: 50/50 passed.
- Four entirely fresh independent hostile source reviews: zero P0-P3 findings.
- Genuine `gpt-5.6-sol` high autoreview with `--max-priority P3`: zero findings, confidence 0.99.
- Native TruffleHog 3.96 TXT and JSON scans: zero secrets; targeted formatting and whitespace checks passed.
- Type-aware lint has one unchanged pre-existing `RealtimeVoiceBridgeCreateRequest` warning on the clean baseline; no clean typecheck is claimed.
- Live exact-head verification on August 2, 2026:
  - A real Google token mint returned `provider-websocket` / `google-live-bidi`, a 13-digit epoch-millisecond expiry, and an activation delta of exactly 60,000 ms.
  - The browser Google Live WebSocket reached `setupComplete`, accepted a JPEG video frame, invoked `describe_view`, and accepted the matching function response using `gemini-3.1-flash-live-preview`.
  - OpenAI regression proof also passed: backend bridge connected, PCM audio talkback returned the requested single word, and browser WebRTC connected with remote audio.
  - The browser relay adapter exercised `talk.client.toolCall`, audio append, tool-result submission, close, listening/thinking states, and user/assistant transcripts.
  - No credentials, private endpoints, or raw provider payloads were retained in this evidence.

