### PR TITLE
fix(discord): preserve component waiter message ownership

### DIFF
--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -106,6 +106,44 @@ describe("ComponentRegistry", () => {
     );
   });
 
+  it("preserves each message owner when replacing a one-off component wait", async () => {
+    const registry = new ComponentRegistry<Button>();
+    const firstMessage = {
+      id: "message-1",
+      channelId: "channel-1",
+      owner: "first",
+    } as never;
+    const secondMessage = {
+      id: "message-1",
+      channelId: "channel-1",
+      owner: "second",
+    } as never;
+
+    const first = registry.waitForMessageComponent(firstMessage, 5_000);
+    const second = registry.waitForMessageComponent(secondMessage, 5_000);
+    const firstResult = await first;
+    const resolved = registry.resolveOneOffComponent({
+      channelId: "channel-1",
+      customId: "choice:one",
+      messageId: "message-1",
+      values: ["one"],
+    });
+    const secondResult = await second;
+
+    expect(firstResult).toMatchObject({
+      success: false,
+      reason: "timed out",
+    });
+    expect(firstResult.message).toBe(firstMessage);
+    expect(resolved).toBe(true);
+    expect(secondResult).toMatchObject({
+      success: true,
+      customId: "choice:one",
+      values: ["one"],
+    });
+    expect(secondResult.message).toBe(secondMessage);
+  });
+
   it("caps oversized one-off component wait timers", () => {
     vi.useFakeTimers();
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/discord/src/internal/component-registry.ts
+++ b/extensions/discord/src/internal/component-registry.ts
@@ -58,7 +58,7 @@ export class ComponentRegistry<
       const existing = this.oneOffComponents.get(key);
       if (existing) {
         clearTimeout(existing.timer);
-        existing.resolve({ success: false, message, reason: "timed out" });
+        existing.resolve({ success: false, message: existing.message, reason: "timed out" });
       }
       const timer = setTimeout(
         () => {


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

When Discord starts a second component wait for the same message and channel, the component registry intentionally replaces the first waiter. The displaced promise currently receives the second call's Message object instead of the Message instance that originally created that wait.

### Failure mode

The replacement branch resolves the stored waiter with its timeout-shaped result, but closes over the new method argument for the message field. That crosses ownership between two distinct callers even though the registry already stores the original Message beside the resolver and timer.

## Why This Change Was Made

Resolve a replaced waiter with the Message instance stored in its own registry entry. The newly registered waiter remains active and continues to resolve through the normal component interaction path.

### Root Cause

The replacement path used the incoming `message` parameter rather than `existing.message` from the waiter being displaced.

### Layer ownership

`replyAndWaitForComponent` supplies the caller-owned Message, `ComponentRegistry` owns waiter identity and replacement, and interaction dispatch owns later resolution. The fix stays in the registry owner layer without changing Discord transport, interaction payloads, component parsing, or presentation.

## User Impact

Each caller now receives the same Message instance that created its wait, including when a later wait replaces it. The replaced waiter still ends with `success: false` and `reason: timed out`, while the replacement waiter still resolves normally from a component interaction.

## Evidence

At exact head `ba23fcf7dd412a4e67603a19c4304cdfd35b8d78`, 36 focused and adjacent Discord tests passed, Extension source and test typechecks passed, scoped formatting/lint checks were clean, and a real registry run preserved both distinct Message owners across replacement and normal resolution.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=focused-code tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `b83a966c056288adaef187e3e5826188d9f67724`
- **Proof head:** `ba23fcf7dd412a4e67603a19c4304cdfd35b8d78`
- **Revalidated:** on the bound base

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=ba23fcf7dd412a4e67603a19c4304cdfd35b8d78 -->

#### Discord component waiter ownership command

```bash
node --import tsx --input-type=module -
```

- **Discord component waiter ownership (PRODUCTION_RUNTIME; boundary: node --import tsx --input-type=module - running the production Discord ComponentRegistry, one-off waiter map, Message class, and resolution path)** — Observed: Two real production Message instances shared the same registry key; replacing the first wait returned its original Message by identity, kept the second Message distinct, and the production resolver then completed the second wait with its own Message and selected value. Result: the displaced waiter retained its first Message owner and the active waiter retained and resolved with its second Message owner. Proves registry replacement no longer crosses Message ownership between callers. Preserves timeout-shaped replacement settlement and normal component interaction resolution.

#### Sanitized exact-head production output

```text
head=ba23fcf7dd412a4e67603a19c4304cdfd35b8d78
test_runner=none
owners=all-real
mocks=none
distinct_messages=true
first_owner_preserved=true
second_owner_preserved=true
first_status=timed-out
second_status=resolved
resolve_returned=true
values=one
result=PASS
```

### Automated verification

#### Discord registry and owner chain

```bash
pnpm exec vitest run extensions/discord/src/internal/client.test.ts extensions/discord/src/internal/interaction-dispatch.test.ts extensions/discord/src/internal/interactions.test.ts --reporter=dot
```

- `pnpm exec vitest run extensions/discord/src/internal/client.test.ts extensions/discord/src/internal/interaction-dispatch.test.ts extensions/discord/src/internal/interactions.test.ts --reporter=dot` — [TEST] 36/36 tests passed across 3 test files with 0 failures. Proves replacement preserves both caller Message identities and adjacent interaction routing remains compatible. Preserves wildcard and custom-id resolution, interaction dispatch, timer caps, and reply-and-wait behavior.

#### Extension source type boundary

```bash
pnpm tsgo:extensions
```

- `pnpm tsgo:extensions` — [TYPECHECK] completed with exit code 0. Proves the registry source change satisfies the Extension TypeScript contract. Preserves the existing component result and Message API surface.

#### Extension test type boundary

```bash
pnpm tsgo:extensions:test
```

- `pnpm tsgo:extensions:test` — [TYPECHECK] completed with exit code 0. Proves the identity regression test satisfies the Extension test TypeScript contract. Preserves the existing Vitest typing boundary.

#### Static verification

```bash
pnpm exec oxlint extensions/discord/src/internal/component-registry.ts extensions/discord/src/internal/client.test.ts
```

- `pnpm exec oxlint extensions/discord/src/internal/component-registry.ts extensions/discord/src/internal/client.test.ts` — [LINT] reported 0 warnings and 0 errors. Proves the changed source and regression test satisfy scoped lint rules. Preserves the repository lint boundary.
```bash
pnpm exec oxfmt --check extensions/discord/src/internal/component-registry.ts extensions/discord/src/internal/client.test.ts
```

- `pnpm exec oxfmt --check extensions/discord/src/internal/component-registry.ts extensions/discord/src/internal/client.test.ts` — [STATIC] reported both files correctly formatted. Proves the changed files match repository formatting. Preserves the bounded two-file diff.
```bash
git diff --check origin/main...HEAD
```

- `git diff --check origin/main...HEAD` — [STATIC] completed with exit code 0 and no output. Proves the exact-head patch is whitespace-clean. Preserves the bounded two-file diff.

### Preserved boundaries

- A replaced waiter still settles with `success: false` and `reason: timed out`; only its Message owner is corrected.
- The replacement waiter remains registered and resolves through the existing interaction path with custom ID and values unchanged.
- One-off key construction, timeout scheduling, wildcard component parsing, and ordinary component registration are unchanged.
- No Discord API, authentication, permission, configuration, persistence, protocol, visual, or localization contract changes.

### Proof gap

Focused registry and adjacent owner-chain tests, both Extension typechecks, scoped static checks, and a real exact-head ComponentRegistry plus Message proof were run. A credentialed live Discord interaction, the full repository test suite, and GitHub CI were not run locally; no live Discord API, repository-wide, or CI result is claimed.

</details>

### Artifacts

- None attached.
