### PR TITLE
fix(gateway): avoid internal-hook first-boot delay

### DIFF
--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -148,6 +148,51 @@ describe("pristine startup state", () => {
     expect(canSkipPristineStartupStateMigrations(env)).toBe(true);
   });
 
+  it("accepts canonical internal hook configuration", () => {
+    const env = createFixture({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            "session-memory": {
+              enabled: true,
+              env: { OPENCLAW_HOOK_TEST: "enabled" },
+              customOption: "value",
+            },
+          },
+        },
+      },
+    });
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: true,
+      skipCoreStateMigrations: true,
+    });
+  });
+
+  it("retains migrations for legacy, external, and malformed hook configuration", () => {
+    const unsafeHooks = [
+      { gmail: { account: "operator@example.com" } },
+      { internal: { installs: { "session-memory": { source: "bundled" } } } },
+      { internal: { handlers: [] } },
+      { internal: { load: { extraDirs: ["/tmp/hooks"] } } },
+      { internal: { enabled: "yes" } },
+      { internal: { entries: [] } },
+      { internal: { entries: { "session-memory": { enabled: "yes" } } } },
+      { internal: { entries: { "session-memory": { env: { INVALID: true } } } } },
+    ];
+
+    for (const hooks of unsafeHooks) {
+      expect(
+        planPristineStartupStateMigrations(createFixture({ hooks })),
+        JSON.stringify(hooks),
+      ).toEqual({
+        skipAllStateMigrations: false,
+        skipCoreStateMigrations: false,
+      });
+    }
+  });
+
   it("retains migrations for bundled plugins with doctor state surfaces", () => {
     const env = addBundledPlugin(
       createFixture({ plugins: { entries: { example: { enabled: true } } } }),

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -31,7 +31,6 @@ const STATEFUL_CONFIG_KEYS = new Set([
   "cron",
   "discovery",
   "env",
-  "hooks",
   "marketplaces",
   "mcp",
   "media",
@@ -47,6 +46,51 @@ const STATEFUL_CONFIG_KEYS = new Set([
   "transcripts",
   "web",
 ]);
+
+// Canonical internal entries have no legacy machine state to import. Keep every
+// older or external hook shape on Doctor's full migration path.
+function hasOnlyMigrationSafeInternalHooks(config: Record<string, unknown>): boolean {
+  const hooks = config.hooks;
+  if (hooks === undefined) {
+    return true;
+  }
+  if (!isRecord(hooks) || Object.keys(hooks).some((key) => key !== "internal")) {
+    return false;
+  }
+
+  const internal = hooks.internal;
+  if (internal === undefined) {
+    return true;
+  }
+  if (
+    !isRecord(internal) ||
+    Object.keys(internal).some((key) => !["enabled", "entries"].includes(key)) ||
+    (internal.enabled !== undefined && typeof internal.enabled !== "boolean")
+  ) {
+    return false;
+  }
+
+  if (internal.entries === undefined) {
+    return true;
+  }
+  if (!isRecord(internal.entries)) {
+    return false;
+  }
+  return Object.values(internal.entries).every((entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+    if (entry.enabled !== undefined && typeof entry.enabled !== "boolean") {
+      return false;
+    }
+    if (entry.env === undefined) {
+      return true;
+    }
+    return (
+      isRecord(entry.env) && Object.values(entry.env).every((value) => typeof value === "string")
+    );
+  });
+}
 
 function containsObjectKey(value: unknown, targetKey: string): boolean {
   if (Array.isArray(value)) {
@@ -140,6 +184,9 @@ function hasOnlyMigrationSafePluginEntries(
 
 function configIsPristineCoreStateSafe(config: Record<string, unknown>): boolean {
   if ([...STATEFUL_CONFIG_KEYS].some((key) => Object.hasOwn(config, key))) {
+    return false;
+  }
+  if (!hasOnlyMigrationSafeInternalHooks(config)) {
     return false;
   }
   if (containsObjectKey(config.agents, "memorySearch")) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling the canonical bundled internal hooks on a fresh install would wait several extra seconds for the Gateway to become ready because startup unnecessarily loaded the full legacy state-migration path.

## Why This Change Was Made

Canonical `hooks.internal.enabled` and `hooks.internal.entries` contain no legacy machine state, so the pristine-startup planner now keeps those validated shapes on its fast path. Legacy `installs`, `handlers`, `load`, external hook surfaces, includes, and malformed values still retain the full Doctor migration path.

## User Impact

Fresh Gateways using normal internal hooks, including the default session-memory onboarding choice, can become ready without paying the legacy migration import cost. Existing upgrade and external-hook migration behavior is unchanged.

## Evidence

- Exact head: `cab94f84b909cd3dcdf185da9f068f6355a35088`.
- Clean merge tree against current `main` (`877843422ec61bc3e9b9510a79e9362c4f4fc051`): `433291617f2a1eb9ec453b6b72d5ef4e506768e4`.
- Current-main commits since the frozen Kova baseline touch no PR files.
- 42 focused tests passed:
  - `src/commands/doctor/shared/pristine-startup-state.test.ts` (14)
  - `src/commands/doctor-config-preflight.state-migration.test.ts` (28)
- Targeted `oxfmt`, `oxlint`, `git diff --check`, and autoreview passed.
- Exact-head full CI passed: https://github.com/openclaw/openclaw/actions/runs/30708355506
- Exact-head Kova passed the full matrix with the corrected evaluator pin: https://github.com/openclaw/openclaw/actions/runs/30708677218
- Frozen-latest-main synthetic merge Kova passed the full matrix:
  - frozen `main`: `fdec6fe7d4da182682236aa5973fc213555d65c5`
  - PR head: `cab94f84b909cd3dcdf185da9f068f6355a35088`
  - synthetic merge: `4c19ecc71762e568a91d3f0c07ad889ecf1359a6`
  - run: https://github.com/openclaw/openclaw/actions/runs/30709087823
- Targeted startup evidence:
  - one internal hook: readyz `2731ms`, bootstrap `76.7ms`, hook work `41.4ms`
  - all internal hooks: readyz `2715ms`, bootstrap `74.0ms`, hook work `35.4ms`
  - prior main evidence was roughly `9.0-9.1s` readyz with `7.6-7.7s` in Gateway bootstrap
