### PR TITLE
fix(doctor): reject conflicting lint check selection

### DIFF
--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -2,6 +2,11 @@
 import { describe, expect, it } from "vitest";
 import { exitCodeFromFindings, runDoctorLintChecks } from "./doctor-lint-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
+import {
+  clearHealthChecksForTest,
+  listHealthChecks,
+  registerHealthCheck,
+} from "./health-check-registry.js";
 import type { RunnableHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheck, HealthCheckContext } from "./health-checks.js";
 
@@ -37,6 +42,87 @@ describe("runDoctorLintChecks", () => {
     expect(result.checksRun).toBe(1);
     expect(result.checksSkipped).toBe(1);
     expect(result.findings.map((finding) => finding.checkId)).toEqual(["a"]);
+  });
+
+  it.each(["array", "set"] as const)(
+    "reports conflicting selectors for a registered health check (%s)",
+    async (selectorShape) => {
+      const checkId = "plugin/example/critical";
+      let detections = 0;
+      const existingChecks = listHealthChecks();
+      registerHealthCheck(
+        check(checkId, async () => {
+          detections += 1;
+          return [{ checkId, severity: "error", message: "critical failure" }];
+        }),
+      );
+
+      try {
+        const selectors = selectorShape === "set" ? new Set([checkId]) : [checkId];
+        const result = await runDoctorLintChecks(ctx, {
+          onlyIds: selectors,
+          skipIds: selectors,
+        });
+
+        expect(detections).toBe(0);
+        expect(result.checksRun).toBe(0);
+        expect(result.checksSkipped).toBe(1);
+        expect(result.findings).toEqual([
+          {
+            checkId: "core/doctor/lint-selection",
+            severity: "error",
+            message: `Health check ${checkId} cannot be selected by --only and excluded by --skip.`,
+            path: checkId,
+          },
+        ]);
+        expect(exitCodeFromFindings(result.findings)).toBe(1);
+      } finally {
+        clearHealthChecksForTest();
+        for (const existingCheck of existingChecks) {
+          registerHealthCheck(existingCheck);
+        }
+      }
+    },
+  );
+
+  it("keeps non-conflicting selection and exclusion filters independent", async () => {
+    let selectedDetections = 0;
+    let skippedDetections = 0;
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [
+        check("plugin/example/selected", async () => {
+          selectedDetections += 1;
+          return [];
+        }),
+        check("plugin/example/skipped", async () => {
+          skippedDetections += 1;
+          return [];
+        }),
+      ],
+      onlyIds: ["plugin/example/selected"],
+      skipIds: ["plugin/example/skipped"],
+    });
+
+    expect(result).toEqual({ findings: [], checksRun: 1, checksSkipped: 1 });
+    expect(selectedDetections).toBe(1);
+    expect(skippedDetections).toBe(0);
+  });
+
+  it("preserves forward-compatible skips for unregistered plugin checks", async () => {
+    let detections = 0;
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [
+        check("plugin/example/available", async () => {
+          detections += 1;
+          return [];
+        }),
+      ],
+      skipIds: ["plugin/future/not-loaded"],
+    });
+
+    expect(result).toEqual({ findings: [], checksRun: 1, checksSkipped: 0 });
+    expect(detections).toBe(1);
+    expect(exitCodeFromFindings(result.findings)).toBe(0);
   });
 
   it("skips default-disabled checks unless explicitly selected", async () => {

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -50,14 +50,20 @@ export async function runDoctorLintChecks(
 
   const findings: HealthFinding[] = [];
   for (const id of only) {
+    let message: string;
     if (!allIds.has(id)) {
-      findings.push({
-        checkId: "core/doctor/lint-selection",
-        severity: "error",
-        message: `Unknown health check id selected by --only: ${id}.`,
-        path: id,
-      });
+      message = `Unknown health check id selected by --only: ${id}.`;
+    } else if (skip.has(id)) {
+      message = `Health check ${id} cannot be selected by --only and excluded by --skip.`;
+    } else {
+      continue;
     }
+    findings.push({
+      checkId: "core/doctor/lint-selection",
+      severity: "error",
+      message,
+      path: id,
+    });
   }
   for (const check of selected) {
     try {


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --lint --only <registered-check> --skip <registered-check>` silently reported success despite running zero requested checks. The same valid health-check ID was selected and excluded, producing an empty finding set, `ok: true`, and exit status 0.

## Why This Change Was Made

The canonical Doctor lint selection owner already detects unknown `--only` IDs but previously did not diagnose contradictory valid selectors. Reuse that same `core/doctor/lint-selection` structured error and the already-established exit status 1; preserve forward-compatible unknown `--skip` IDs, plugin-owned checks, array/Set selectors, and all existing public contracts.

## User Impact

Contradictory lint selectors now fail visibly and actionably instead of falsely claiming a clean Doctor report. No database, repair, configuration, plugin SDK, credential, network, or public CLI surface changes.

## Evidence

Authentic regression-first execution against the actual registered health-check owner failed **2 new cases** while **10 existing cases** passed before the production change. Frozen owner tests pass **12/12**; untouched existing Doctor CLI consumer tests pass **13/13**, including registered plugin checks and existing unknown-selector exit behavior.

Real production `runDoctorLintCli`, **56 actual registered core checks**, selecting and skipping actual `core/doctor/final-config-validation`:

Before:
```text
checkout=before; selected-check=core/doctor/final-config-validation
{"ok":true,"checksRun":0,"checksSkipped":56,"findings":[]}
actual-cli-exit-code=0; network-attempts=0
```

After:
```text
checkout=fixed; selected-check=core/doctor/final-config-validation
{"ok":false,"checksRun":0,"checksSkipped":56,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Health check core/doctor/final-config-validation cannot be selected by --only and excluded by --skip.","path":"core/doctor/final-config-validation"}]}
actual-cli-exit-code=1; network-attempts=0
```

Configured type-aware lint, targeted formatter, and whitespace checks pass. The configured lint used documented `OPENCLAW_OXLINT_SKIP_PREPARE=1` because unrelated baseline SDK declaration preparation fails at `packages/terminal-core/src/ansi.ts:194`; configured type-aware lint itself passed. More than seven independent hostile source reviews were clean. A fresh genuine `gpt-5.6-sol` high-reasoning autoreview through P3 returned zero findings and **0.99 confidence**; actual TruffleHog **3.96.0** secret scanning passed. Frozen commit `88dc40eb2672848a8a849a7a3799343c9370b0f2`, tree `fd81fb1ea8e0a3e02160b29f14eef1ffb3e927e9`, sole parent `7bcbe743bd421064010d6abba1a1859962e19ec2`, one root cause, exactly two existing files, production net **+6 lines**.
