### PR TITLE
fix(ui): surface aborted-run diagnostics

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -395,4 +395,44 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .toBe("");
     await gateway.resolveDeferred("sessions.list");
   });
+
+  it("renders a safe self-abort diagnostic while preserving interrupted status", async () => {
+    const artifactDir = path.resolve(".artifacts/control-ui-e2e/chat-abort-diagnostic");
+    const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+    if (captureProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage);
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.locator(".agent-chat__input textarea").fill("run the edit");
+    await currentPage.getByRole("button", { name: "Send message" }).click();
+    const send = await gateway.waitForRequest("chat.send");
+    const params = send.params as { idempotencyKey?: unknown };
+    expect(typeof params.idempotencyKey).toBe("string");
+    const runId = params.idempotencyKey as string;
+    const diagnostic = "edit tool validation failed: edits: must be an array";
+
+    await gateway.emitGatewayEvent("chat", {
+      errorMessage: diagnostic,
+      runId,
+      sessionKey: "main",
+      state: "aborted",
+    });
+
+    const alert = currentPage.getByRole("alert").filter({ hasText: diagnostic });
+    await alert.waitFor();
+    expect((await alert.textContent())?.trim()).toContain(`Error: ${diagnostic}`);
+    await currentPage.getByLabel("Run status: Interrupted").waitFor();
+    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+    if (captureProof) {
+      await currentPage.screenshot({
+        path: path.join(artifactDir, "abort-diagnostic-alert.png"),
+        fullPage: true,
+      });
+    }
+  });
 });

--- a/ui/src/pages/chat/chat-gateway.abort-diagnostic.test.ts
+++ b/ui/src/pages/chat/chat-gateway.abort-diagnostic.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleChatGatewayEvent, type ChatEventPayload } from "./chat-gateway.ts";
+import type { ChatState } from "./chat-history.ts";
+
+type AbortDiagnosticState = ChatState & {
+  chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
+  lastLocalTerminalReconcile?: { sessionStatus: string } | null;
+  sessionsResult?: {
+    ts: number;
+    path: string;
+    count: number;
+    defaults: Record<string, unknown>;
+    sessions: Array<Record<string, unknown>>;
+  };
+};
+
+function createAbortDiagnosticState(runId = "run-validation-abort"): AbortDiagnosticState {
+  return {
+    chatAttachments: [],
+    chatLoading: false,
+    chatMessage: "",
+    chatMessages: [],
+    chatQueue: [],
+    chatRunError: null,
+    chatRunId: runId,
+    chatSending: false,
+    chatStream: "Partial assistant reply",
+    chatStreamStartedAt: 100,
+    chatRunStartup: null,
+    chatThinkingLevel: null,
+    chatVerboseLevel: null,
+    client: null,
+    connected: true,
+    connectionEpoch: 0,
+    hello: null,
+    lastError: null,
+    sessionKey: "main",
+    sessionsResult: {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 1,
+          hasActiveRun: true,
+          activeRunIds: [runId],
+          status: "running",
+          startedAt: 100,
+        },
+      ],
+    },
+  };
+}
+
+describe("aborted chat diagnostics", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    { name: "plain cancellation", errorMessage: undefined, expectedError: null },
+    {
+      name: "validation self-abort",
+      errorMessage: "edit tool validation failed: edits: must be an array",
+      expectedError: "Error: edit tool validation failed: edits: must be an array",
+    },
+  ])("keeps first-terminal $name killed and interrupted", ({ errorMessage, expectedError }) => {
+    const state = createAbortDiagnosticState();
+    const payload: ChatEventPayload = {
+      runId: "run-validation-abort",
+      sessionKey: "main",
+      state: "aborted",
+      ...(errorMessage ? { errorMessage } : {}),
+    };
+
+    expect(handleChatGatewayEvent(state, payload)).toBe("aborted");
+
+    expect(state.chatRunError?.summary ?? null).toBe(expectedError);
+    expect(state.chatRunStatus).toMatchObject({
+      phase: "interrupted",
+      runId: "run-validation-abort",
+      sessionKey: "main",
+    });
+    expect(state.lastLocalTerminalReconcile?.sessionStatus).toBe("killed");
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      activeRunIds: [],
+      hasActiveRun: false,
+      status: "killed",
+    });
+    expect(state.chatRunId).toBeNull();
+  });
+
+  it("surfaces one late aborted diagnostic and ignores its replay", () => {
+    const state = createAbortDiagnosticState();
+    const aborted = {
+      runId: "run-validation-abort",
+      sessionKey: "main",
+      state: "aborted" as const,
+    };
+    const diagnostic = {
+      ...aborted,
+      errorMessage: "edit tool validation failed: edits: must be an array",
+    };
+
+    expect(handleChatGatewayEvent(state, aborted)).toBe("aborted");
+    expect(state.chatRunError).toBeNull();
+    expect(handleChatGatewayEvent(state, diagnostic)).toBe("aborted");
+    const displayedDiagnostic = state.chatRunError;
+    expect(handleChatGatewayEvent(state, diagnostic)).toBe("aborted");
+
+    expect(state.chatRunError).toBe(displayedDiagnostic);
+    expect(state.chatRunError).toEqual({
+      summary: "Error: edit tool validation failed: edits: must be an array",
+    });
+    expect(state.chatRunId).toBeNull();
+  });
+
+  it("does not publish a late aborted diagnostic over a newer active run", () => {
+    const state = createAbortDiagnosticState("run-old");
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+      }),
+    ).toBe("aborted");
+    state.chatRunId = "run-new";
+    state.chatStream = "New run output";
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+        errorMessage: "edit tool validation failed: invalid arguments",
+      }),
+    ).toBe("aborted");
+
+    expect(state.chatRunError).toBeNull();
+    expect(state.chatRunId).toBe("run-new");
+    expect(state.chatStream).toBe("New run output");
+  });
+
+  it("does not restore an old diagnostic while a newer send awaits its ACK", () => {
+    const state = createAbortDiagnosticState("run-old");
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+      }),
+    ).toBe("aborted");
+    state.chatQueue = [
+      {
+        id: "pending-new-send",
+        text: "New request",
+        createdAt: 200,
+        sendRunId: "run-new",
+        sendState: "sending",
+      },
+    ];
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+        errorMessage: "edit tool validation failed: invalid arguments",
+      }),
+    ).toBe("aborted");
+
+    expect(state.chatRunError).toBeNull();
+    expect(state.chatRunId).toBeNull();
+    expect(state.lastLocalTerminalReconcile?.runId).toBe("run-old");
+  });
+
+  it("does not publish an old aborted diagnostic after a newer run completes", () => {
+    const state = createAbortDiagnosticState("run-old");
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+      }),
+    ).toBe("aborted");
+    state.chatRunId = "run-new";
+    state.chatStream = "New final answer";
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-new",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "New final answer" }],
+        },
+      }),
+    ).toBe("final");
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-old",
+        sessionKey: "main",
+        state: "aborted",
+        errorMessage: "edit tool validation failed: invalid arguments",
+      }),
+    ).toBe("aborted");
+
+    expect(state.chatRunError).toBeNull();
+    expect(state.lastLocalTerminalReconcile?.runId).toBe("run-new");
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatMessages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "New final answer" }],
+    });
+  });
+});

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -271,17 +271,24 @@ function handleChatEvent(
     if (payload.state === "delta") {
       return null;
     }
-    if (payload.state === "error") {
+    if (payload.state === "error" || payload.state === "aborted") {
+      const pendingRunId = state.chatQueue.find(
+        (item) => item.sendState === "sending" && item.sendRunId,
+      )?.sendRunId;
+      const diagnosticOwnerRunId =
+        state.chatRunId ?? pendingRunId ?? state.lastLocalTerminalReconcile?.runId;
       if (
-        (!state.chatRunId || state.chatRunId === payload.runId) &&
+        diagnosticOwnerRunId === payload.runId &&
         payload.errorMessage?.trim() &&
         projectedRun.currentRun?.errorMessage !== previousTerminalRun.errorMessage
       ) {
-        // Completed-run diagnostics belong to an idle composer or that same run;
+        // Late diagnostics belong to the active, pending, or latest locally terminal run;
         // publishing them over a newer response falsely marks the new run failed.
         setChatRunError(state, resolveGatewayErrorText(payload, null));
       }
-      return "error";
+      if (payload.state === "error") {
+        return "error";
+      }
     }
     const incomingFinal = normalizedFinalMessage;
     if (
@@ -418,6 +425,9 @@ function handleChatEvent(
       state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, normalizedMessage);
     } else {
       state.chatMessages = materializeVisibleStream();
+    }
+    if (payload.errorMessage?.trim()) {
+      setChatRunError(state, resolveGatewayErrorText(payload, null));
     }
     reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -289,6 +289,7 @@ export type ChatState = {
   lastError: string | null;
   chatError?: string | null;
   chatRunError?: { summary: string } | null;
+  lastLocalTerminalReconcile?: { runId: string | null } | null;
   chatReplyTarget?: unknown;
   agentsError?: string | null;
   onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => void;


### PR DESCRIPTION
Closes #117496

## What Problem This Solves

Fixes an issue where Control UI users saw only “Interrupted” when a run aborted with a safe, actionable Gateway diagnostic, leaving the actual validation failure invisible.

## Why This Change Was Made

The Control UI chat projection now publishes a nonempty abort `errorMessage` through the existing `chatRunError` owner while preserving killed/interrupted lifecycle semantics. First-terminal and one late same-run diagnostic are supported; replays and diagnostics belonging to older runs cannot overwrite a newer active, pending, or completed run.

Plain cancellation still has no error alert. The Gateway remains the owner that bounds and sanitizes the diagnostic; no protocol or persistence shape changes.

## User Impact

Operators now see the repairable abort reason in the existing alert while the status remains “Interrupted”. Ordinary cancellation stays unchanged, and stale diagnostics cannot contaminate a newer conversation.

### Before

```text
Run status: Interrupted
[no diagnostic alert]
```

### After

```text
Run status: Interrupted
Error: edit tool validation failed: invalid arguments
```

These are sanitized deterministic mocked-Gateway renderings. The real Chromium test asserts the visible `role="alert"` and interrupted status together.

## Evidence

- Final Testbox run https://github.com/openclaw/openclaw/actions/runs/30707123348 passed 6/6 focused tests, 6/6 mocked Control UI E2E tests, and the full changed gate.
- The E2E drives a real Chromium page, emits the diagnostic-bearing abort through the Gateway boundary, and verifies both `role="alert"` and `Run status: Interrupted`.
- Coverage includes plain cancellation, first-terminal diagnostics, one late same-run diagnostic, replay dedupe, newer active run, pre-ACK pending send, and newer completed run.
- Independent diff review found no actionable issue.
- Final P1 Codex autoreview and TruffleHog were clean with no accepted/actionable findings at 0.91 confidence.
- Production delta: +15/-4; tests: +263.
- No protocol, config, persistence, dependency, migration, or server-side event changes.

Release-note context: Control UI now keeps safe aborted-run diagnostics visible alongside the interrupted run status.

AI-assisted: yes. The implementation was independently reviewed and remotely validated.
