### PR TITLE
perf(gateway): skip empty session recovery stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway multi-agent startup:** skip session restart-recovery writer scans for agent databases without running sessions, avoiding per-agent startup delay from unrelated auth or model-catalog state while preserving recovery and corruption handling for durable stores.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway multi-agent startup:** skip session restart-recovery writer scans for agent databases without running sessions, avoiding per-agent startup delay from unrelated auth or model-catalog state while preserving recovery and corruption handling for durable stores.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -4,7 +4,10 @@ import {
   type InternalSessionEntry as SessionEntry,
   resolveAllAgentSessionStoreTargetsSync,
 } from "../config/sessions.js";
-import type { SessionTranscriptTurnExpectedState } from "../config/sessions/session-accessor.js";
+import {
+  hasSessionEntriesByStatusReadOnly,
+  type SessionTranscriptTurnExpectedState,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isMainRestartRecoveryCandidate } from "./main-session-recovery-state.js";
@@ -90,14 +93,18 @@ export async function resolveRestartRecoveryStorePaths(params: {
 }): Promise<string[]> {
   const storePaths = new Set<string>();
   const stateDir = params.stateDir ?? resolveStateDir(process.env);
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
   for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
     storePaths.add(path.join(sessionsDir, "sessions.json"));
   }
   if (params.cfg) {
-    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg, { env })) {
       storePaths.add(path.resolve(target.storePath));
     }
   }
-  return [...storePaths].toSorted((a, b) => a.localeCompare(b));
+  // Agent databases also hold auth and model-catalog state. Enter the writer
+  // lane only when the session owner proves that a running row may need repair.
+  return [...storePaths]
+    .filter((storePath) => hasSessionEntriesByStatusReadOnly({ env, storePath }, ["running"]))
+    .toSorted((a, b) => a.localeCompare(b));
 }

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -44,6 +44,10 @@ import {
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
 } from "../sessions/session-lifecycle-admission.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createDeferred } from "../test-utils/deferred.js";
@@ -2004,6 +2008,60 @@ describe("main-session-restart-recovery", () => {
     store = readStore(path.join(sessionsDir, "sessions.json"));
     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
     expect(store["agent:main:already-marked"]?.abortedLastRun).toBe(false);
+  });
+
+  it("does not create empty agent databases while scanning startup recovery", async () => {
+    const agentIds = Array.from({ length: 12 }, (_, index) => `agent-${index + 1}`);
+    const databasePaths = await Promise.all(
+      agentIds.map(async (agentId) => {
+        await makeSessionsDir(agentId);
+        return path.join(tmpDir, "agents", agentId, "agent", "openclaw-agent.sqlite");
+      }),
+    );
+
+    await expect(markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir })).resolves.toEqual(
+      { marked: 0, skipped: 0 },
+    );
+    for (const databasePath of databasePaths) {
+      await expect(fs.stat(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("does not enter the writer lane for agent databases without running sessions", async () => {
+    const agentIds = Array.from({ length: 12 }, (_, index) => `agent-${index + 1}`);
+    const env = { ...process.env, OPENCLAW_STATE_DIR: tmpDir };
+    for (const agentId of agentIds) {
+      openOpenClawAgentDatabase({
+        agentId,
+        env,
+        path: path.join(tmpDir, "agents", agentId, "agent", "openclaw-agent.sqlite"),
+      });
+    }
+    closeOpenClawAgentDatabasesForTest();
+    const applySessionEntryReplacements = vi.spyOn(
+      sessionAccessor,
+      "applySessionEntryReplacements",
+    );
+
+    try {
+      await expect(
+        markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
+      ).resolves.toEqual({ marked: 0, skipped: 0 });
+      expect(applySessionEntryReplacements).not.toHaveBeenCalled();
+    } finally {
+      applySessionEntryReplacements.mockRestore();
+    }
+  });
+
+  it("keeps corrupt existing agent databases on the startup recovery error path", async () => {
+    await makeSessionsDir();
+    const databasePath = path.join(tmpDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    await fs.writeFile(databasePath, "not a sqlite database");
+
+    await expect(
+      markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
+    ).rejects.toThrow();
   });
 
   it.each([

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -12,6 +12,7 @@ import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
   countSqliteSessionEntryRowsReadOnly as countSessionEntryRowsReadOnly,
   copySqliteSessionOwnedStateForCanonicalRepair as copySessionOwnedStateForCanonicalRepair,
+  hasSqliteSessionEntriesByStatusReadOnly as hasSessionEntriesByStatusReadOnly,
   listSqliteSessionGenerationIdsForCanonicalRepair as listSessionGenerationIdsForCanonicalRepair,
   listSqliteSessionChildEntriesReadOnly as listSessionChildEntriesReadOnly,
   listSqliteSessionEntries,
@@ -61,6 +62,7 @@ export { clearPluginOwnedSessionState };
 export {
   countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
+  hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,
   listSessionChildEntriesReadOnly,
   listSessionEntriesReadOnly,

--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -4,6 +4,7 @@ import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js"
 import {
   closeOpenClawAgentDatabasesForTest,
   isOpenClawAgentDatabaseOpen,
+  openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import {
@@ -11,6 +12,7 @@ import {
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import {
+  hasSessionEntriesByStatusReadOnly,
   listSessionEntries,
   listSessionEntriesReadOnly,
   resolveTranscriptSessionKeyBySessionId,
@@ -65,6 +67,42 @@ describe("session accessor readonly listing", () => {
 
     expect(listSessionEntriesReadOnly({ agentId, env })).toEqual([]);
     expect(fs.existsSync(databasePath)).toBe(false);
+    expect(countRegisteredAgentDatabases(env)).toBe(0);
+  });
+
+  it("probes lifecycle status without creating or registering a missing database", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-session-readonly-status-missing-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentId = "worker-1";
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env });
+    clearRegisteredAgentDatabases(env);
+
+    expect(hasSessionEntriesByStatusReadOnly({ agentId, env }, ["running"])).toBe(false);
+    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(countRegisteredAgentDatabases(env)).toBe(0);
+  });
+
+  it("distinguishes non-session agent state from a running session row", async () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-session-readonly-status-existing-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentId = "worker-1";
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env });
+    openOpenClawAgentDatabase({ agentId, env, path: databasePath });
+    closeOpenClawAgentDatabasesForTest();
+    clearRegisteredAgentDatabases(env);
+
+    expect(hasSessionEntriesByStatusReadOnly({ agentId, env }, ["running"])).toBe(false);
+    expect(countRegisteredAgentDatabases(env)).toBe(0);
+
+    await upsertSessionEntry(
+      { agentId, env, sessionKey: "agent:worker-1:main" },
+      { sessionId: "session-1", status: "running", updatedAt: 10 },
+    );
+    closeOpenClawAgentDatabasesForTest();
+    clearRegisteredAgentDatabases(env);
+
+    expect(hasSessionEntriesByStatusReadOnly({ agentId, env }, ["running"])).toBe(true);
+    expect(hasSessionEntriesByStatusReadOnly({ agentId, env }, ["done"])).toBe(false);
     expect(countRegisteredAgentDatabases(env)).toBe(0);
   });
 

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -297,6 +297,35 @@ export function countSqliteSessionEntryRowsReadOnly(scope: SessionEntryListScope
   return result.found ? result.value : 0;
 }
 
+/**
+ * Proves whether a durable store has a row in one of the requested lifecycle states.
+ * Unknown existing schemas stay eligible so the writable owner can surface or repair them.
+ */
+export function hasSqliteSessionEntriesByStatusReadOnly(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">>,
+  statuses: readonly SessionEntryStatus[],
+): boolean {
+  const selectedStatuses = [...new Set(statuses)];
+  if (selectedStatuses.length === 0) {
+    return false;
+  }
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    const db = getSessionKysely(database.db);
+    return Boolean(
+      executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("session_nodes")
+          .select("session_key")
+          .where("status", "in", selectedStatuses)
+          .limit(1),
+      ),
+    );
+  }, toDatabaseOptions(resolved));
+  return result.found ? result.value : result.reason !== "database-missing";
+}
+
 function listSqliteSessionEntriesFromDatabase(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,6 +1,7 @@
 // Stable SQLite accessor surface. Domain owners live in the focused modules below.
 export {
   countSqliteSessionEntryRowsReadOnly,
+  hasSqliteSessionEntriesByStatusReadOnly,
   listSqliteSessionEntries,
   listSqliteSessionChildEntriesReadOnly,
   listSqliteSessionEntriesReadOnly,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -121,6 +121,7 @@ export type {
 export {
   countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
+  hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,
   clearPluginOwnedSessionState,
   listSessionChildEntriesReadOnly,


### PR DESCRIPTION
## What Problem This Solves

Gateways with many configured agents can have per-agent SQLite databases before any durable session exists because unrelated auth or model-catalog state uses the same database. Restart recovery was opening the session writer path for every such store even when it had no interrupted run.

Kova exposed this on the 12-agent prepared-runtime fixture: `sidecars.main-session-recovery` took about 1.3 seconds on a fresh fixture.

## Why This Change Was Made

The first implementation only checked whether the database file existed. Exact-head Kova disproved that approach: the databases already existed, so startup time was unchanged.

The corrected implementation adds a generic read-only indexed status probe and enters the recovery writer lane only for stores proven to contain `running` session rows. Missing databases return false without being created. Existing databases with an unknown or unreadable schema remain eligible for the writer path so diagnostics and compatibility behavior stay visible.

## User Impact

Fresh multi-agent gateways avoid unnecessary recovery writer initialization for databases that contain only unrelated state. Interrupted durable sessions continue to recover normally, and unknown or corrupt durable stores retain the existing diagnostic path.

## Evidence

- Current exact head: `3361c7550266396befd56d551aad052d479e622f`.
- Runtime implementation head: `3890fea5705ca20538600ed9205b7f11d7ae3338`; the only later change removes the release-owned `CHANGELOG.md` entry requested by ClawSweeper.
- Clean merge tree against current `main` (`877843422ec61bc3e9b9510a79e9362c4f4fc051`): `75da17442a493a58b27fc26abd57aae8162932e6`.
- Current-main commits since the exact-head baseline touch no PR files.
- First Kova run disproved the original file-existence optimization: https://github.com/openclaw/openclaw/actions/runs/30707835369
- Corrected runtime Kova passed the full release matrix: https://github.com/openclaw/openclaw/actions/runs/30708677202
- Fresh exact-head Kova passed the full matrix: https://github.com/openclaw/openclaw/actions/runs/30709072569
- `sidecars.main-session-recovery` measured about `2.8-3.4ms` across the recorded release scenarios, with no span errors.
- 155 focused tests passed: 7 read-only session accessor tests and 148 restart-recovery tests.
- Coverage includes missing databases, inactive stores, running rows, and corrupt or unknown stores retaining the existing diagnostic path.
- Targeted `oxfmt`, direct `oxlint`, `git diff --check`, and autoreview passed.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/30709074222 failed only the current-main tooling fixture regression reproduced identically by unrelated PR #117508. The corrective PR is https://github.com/openclaw/openclaw/pull/117523; CI will be rerun after it lands.
