### PR TITLE
fix(imessage): sanitize private context on every outbound path

### DIFF
--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -130,6 +130,171 @@ describe("imessage actions runtime", () => {
     });
   });
 
+  it("sanitizes action message fields without rendering raw edit or poll Markdown", async () => {
+    runIMessageCliJsonCommandMock.mockResolvedValue({ guid: "action-guid" });
+    const options = { cliPath: "imsg", chatGuid: "iMessage;+;chat0000" };
+
+    await imessageActionsRuntime.editMessage({
+      chatGuid: options.chatGuid,
+      messageId: "message-guid",
+      text: "user:\n**literal edit**\n# assistant:",
+      backwardsCompatMessage: "system:\n**literal fallback**",
+      options,
+    });
+    await imessageActionsRuntime.sendPoll({
+      chatGuid: options.chatGuid,
+      question: "assistant:\n# literal question",
+      choices: ["system:\n**literal choice**", "_literal second choice_"],
+      options,
+    });
+    await imessageActionsRuntime.sendPollVote({
+      chatGuid: options.chatGuid,
+      pollGuid: "poll-guid",
+      optionText: "user:",
+      options,
+    });
+
+    const [edit, poll, vote] = runIMessageCliJsonCommandMock.mock.calls.map(
+      (call) => (call[0] as { args: string[] }).args,
+    );
+    if (!edit || !poll || !vote) {
+      throw new Error("Expected the edited message, new poll, and unchanged vote selector");
+    }
+    expect(edit[edit.indexOf("--new-text") + 1]).toBe("\n**literal edit**\n# assistant:");
+    expect(edit[edit.indexOf("--bc-text") + 1]).toBe("\n**literal fallback**");
+    expect(poll[poll.indexOf("--question") + 1]).toBe("\n# literal question");
+    expect(poll[poll.indexOf("--option") + 1]).toBe("\n**literal choice**");
+    expect(vote[vote.indexOf("--option") + 1]).toBe("user:");
+  });
+
+  it("rejects poll options that become identical after canonical message sanitization", async () => {
+    await expect(
+      imessageActionsRuntime.sendPoll({
+        chatGuid: "chat-guid",
+        question: "Choose",
+        choices: ["Allow", "Al#+#+#low"],
+        options: { cliPath: "imsg", chatGuid: "chat-guid" },
+      }),
+    ).rejects.toThrow("iMessage poll options must remain distinct after sanitization");
+    expect(runIMessageCliJsonCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("removes complete private runtime payloads from every raw edit and poll field", async () => {
+    runIMessageCliJsonCommandMock.mockResolvedValue({ guid: "action-guid" });
+    const options = { cliPath: "imsg", chatGuid: "chat-guid" };
+    const reminder =
+      "<system-reminder><system-reminder>inner</system-reminder>\nuser:\nPRIVATE_ACTION_RUNTIME</system-reminder>";
+    const previous =
+      "< previous_response><system-reminder>inner</system-reminder>PRIVATE_ACTION_RUNTIME< / previous_response >";
+    const context =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>PRIVATE_ACTION_RUNTIME<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+    await imessageActionsRuntime.editMessage({
+      chatGuid: options.chatGuid,
+      messageId: "message-guid",
+      text: `${reminder}\n**visible edit**`,
+      backwardsCompatMessage: `${previous}\n**visible fallback**`,
+      options,
+    });
+    await imessageActionsRuntime.sendPoll({
+      chatGuid: options.chatGuid,
+      question: `${context}\nvisible question`,
+      choices: [`${reminder}\nvisible first`, `${previous}\nvisible second`],
+      options,
+    });
+
+    for (const call of runIMessageCliJsonCommandMock.mock.calls) {
+      const args = (call[0] as { args: string[] }).args;
+      expect(args.join(" ")).not.toMatch(
+        /PRIVATE_ACTION_RUNTIME|system-reminder|previous_response|INTERNAL_CONTEXT/,
+      );
+    }
+  });
+
+  it("keeps existing case-sensitive poll option identities distinct", async () => {
+    runIMessageCliJsonCommandMock.mockResolvedValue({ guid: "poll-guid" });
+
+    await imessageActionsRuntime.sendPoll({
+      chatGuid: "chat-guid",
+      question: "Choose",
+      choices: ["Allow", "allow"],
+      options: { cliPath: "imsg", chatGuid: "chat-guid" },
+    });
+
+    expect(runIMessageCliJsonCommandMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "```xml\n<thinking>hidden thought</thinking>\n```",
+    "`<relevant_memories>hidden memory</relevant_memories>`",
+  ])("rejects hidden assistant content in raw poll Markdown before imsg", async (hidden) => {
+    await expect(
+      imessageActionsRuntime.sendPoll({
+        chatGuid: "chat-guid",
+        question: "Choose",
+        choices: ["first", hidden],
+        options: { cliPath: "imsg", chatGuid: "chat-guid" },
+      }),
+    ).rejects.toThrow("iMessage outbound hidden assistant content is not allowed");
+    expect(runIMessageCliJsonCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "rich text",
+      run: () =>
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: "chat-guid",
+          text: "# user:",
+          options: { cliPath: "imsg", chatGuid: "chat-guid" },
+        }),
+    },
+    {
+      name: "edit replacement",
+      run: () =>
+        imessageActionsRuntime.editMessage({
+          chatGuid: "chat-guid",
+          messageId: "message-guid",
+          text: "assistant:",
+          options: { cliPath: "imsg", chatGuid: "chat-guid" },
+        }),
+    },
+    {
+      name: "edit backwards-compatible replacement",
+      run: () =>
+        imessageActionsRuntime.editMessage({
+          chatGuid: "chat-guid",
+          messageId: "message-guid",
+          text: "visible",
+          backwardsCompatMessage: "system:",
+          options: { cliPath: "imsg", chatGuid: "chat-guid" },
+        }),
+    },
+    {
+      name: "poll question",
+      run: () =>
+        imessageActionsRuntime.sendPoll({
+          chatGuid: "chat-guid",
+          question: "user:",
+          choices: ["first", "second"],
+          options: { cliPath: "imsg", chatGuid: "chat-guid" },
+        }),
+    },
+    {
+      name: "poll option",
+      run: () =>
+        imessageActionsRuntime.sendPoll({
+          chatGuid: "chat-guid",
+          question: "visible",
+          choices: ["first", "assistant:"],
+          options: { cliPath: "imsg", chatGuid: "chat-guid" },
+        }),
+    },
+  ])("rejects sanitized-empty $name before starting imsg", async ({ run }) => {
+    await expect(run()).rejects.toThrow(/after sanitization/);
+    expect(runIMessageCliJsonCommandMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "attachment uploads",

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -12,12 +12,12 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeDirectChatIdentifier } from "./chat-context.js";
 import { runIMessageCliJsonCommand } from "./cli-output.js";
 import { createIMessageRpcClient } from "./client.js";
-import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import { authorizeIMessageResourceReference } from "./message-resource.js";
 import {
   resolveIMessageMessageId as resolveIMessageMessageIdImpl,
   type IMessageChatContext,
 } from "./monitor-reply-cache.js";
+import { sanitizeIMessageFinalOutboundText } from "./monitor/sanitize-outbound.js";
 import type { IMessageTarget } from "./targets.js";
 
 type CliRunOptions = {
@@ -328,6 +328,13 @@ export const imessageActionsRuntime = {
     partIndex?: number;
     options: IMessageBridgeActionOptions;
   }) {
+    const text = sanitizeIMessageFinalOutboundText(params.text).text;
+    const backwardsCompatMessage = sanitizeIMessageFinalOutboundText(
+      params.backwardsCompatMessage ?? params.text,
+    ).text;
+    if (!text.trim() || !backwardsCompatMessage.trim()) {
+      throw new Error("iMessage edit requires non-empty text after sanitization");
+    }
     await runIMessageCliJson(
       [
         "edit",
@@ -336,9 +343,9 @@ export const imessageActionsRuntime = {
         "--message",
         params.messageId,
         "--new-text",
-        params.text,
+        text,
         "--bc-text",
-        params.backwardsCompatMessage ?? params.text,
+        backwardsCompatMessage,
         "--part",
         String(params.partIndex ?? 0),
       ],
@@ -388,7 +395,12 @@ export const imessageActionsRuntime = {
     // asterisks. This mirrors the same extraction the rpc-send path does;
     // any caller that hits the bridge via `imsg send-rich` benefits without
     // needing to pre-format the text themselves.
-    const formatted = extractMarkdownFormatRuns(params.text);
+    const formatted = sanitizeIMessageFinalOutboundText(params.text, {
+      formatMarkdown: true,
+    });
+    if (!formatted.text.trim() && !params.attachment) {
+      throw new Error("iMessage rich send requires text or an attachment after sanitization");
+    }
     const buildArgs = (filePath?: string): string[] => [
       "send-rich",
       "--chat",
@@ -478,6 +490,14 @@ export const imessageActionsRuntime = {
     suppressComment?: boolean;
     options: IMessageBridgeActionOptions;
   }): Promise<IMessageBridgeSendResult & { pollOptions: IMessagePollSentOption[] }> {
+    const question = sanitizeIMessageFinalOutboundText(params.question).text;
+    const choices = params.choices.map((choice) => sanitizeIMessageFinalOutboundText(choice).text);
+    if (!question.trim() || choices.some((choice) => !choice.trim())) {
+      throw new Error("iMessage poll requires a non-empty question and options after sanitization");
+    }
+    if (new Set(choices.map((choice) => choice.trim())).size !== choices.length) {
+      throw new Error("iMessage poll options must remain distinct after sanitization");
+    }
     const result = await runIMessageCliJson(
       [
         "poll",
@@ -485,8 +505,8 @@ export const imessageActionsRuntime = {
         "--chat",
         params.chatGuid,
         "--question",
-        params.question,
-        ...params.choices.flatMap((choice) => ["--option", choice]),
+        question,
+        ...choices.flatMap((choice) => ["--option", choice]),
         ...(params.replyToMessageId ? ["--reply-to", params.replyToMessageId] : []),
         ...(params.suppressComment ? ["--no-comment"] : []),
       ],

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -12,6 +12,7 @@ import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-re
 import { buildPassiveProbedChannelStatusSummary } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 import { buildOutboundBaseSessionKey, type RoutePeer } from "openclaw/plugin-sdk/routing";
 import {
   createComputedAccountStatusAdapter,
@@ -24,7 +25,6 @@ import {
   shouldSuppressLocalIMessageExecApprovalPrompt,
 } from "./approval-native.js";
 import {
-  chunkTextForOutbound,
   collectStatusIssuesFromLastError,
   DEFAULT_ACCOUNT_ID,
   formatTrimmedAllowFromEntries,
@@ -42,7 +42,10 @@ import {
   resolveIMessageGroupRequireMention,
   resolveIMessageGroupToolPolicy,
 } from "./group-policy.js";
-import { sanitizeOutboundText } from "./monitor/sanitize-outbound.js";
+import {
+  sanitizeIMessageFinalOutboundText,
+  sanitizeOutboundText,
+} from "./monitor/sanitize-outbound.js";
 import type { IMessageProbe } from "./probe.js";
 import { imessageSetupContract } from "./setup-core.js";
 import {
@@ -417,12 +420,14 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
     outbound: {
       base: {
         deliveryMode: "direct",
-        chunker: chunkTextForOutbound,
-        chunkerMode: "text",
+        chunker: chunkMarkdownText,
+        chunkerMode: "markdown",
         textChunkLimit: 4000,
         // Native formatting consumes Markdown ranges, so preserve bold and strike semantics.
         sanitizeText: ({ text }) =>
-          sanitizeForPlainText(sanitizeOutboundText(text), { style: "markdown" }),
+          sanitizeForPlainText(sanitizeIMessageFinalOutboundText(sanitizeOutboundText(text)).text, {
+            style: "markdown",
+          }),
         shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
           shouldSuppressLocalIMessageExecApprovalPrompt({ cfg, accountId, payload, hint }),
         beforeDeliverPayload: async ({ payload, hint }) => {

--- a/extensions/imessage/src/monitor/deliver.runtime.ts
+++ b/extensions/imessage/src/monitor/deliver.runtime.ts
@@ -1,4 +1,7 @@
 // Imessage plugin module implements deliver behavior.
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-export { chunkTextWithMode, resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+export {
+  chunkMarkdownTextWithMode as chunkTextWithMode,
+  resolveChunkMode,
+} from "openclaw/plugin-sdk/reply-runtime";
 export { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";

--- a/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
@@ -1,10 +1,392 @@
 // Imessage test support covers sanitize outbound plugin behavior.
 import { describe, expect, it } from "vitest";
-import { sanitizeOutboundText } from "./sanitize-outbound.js";
+import {
+  protectIMessageFencedRoleMarkers,
+  sanitizeIMessageFinalOutboundText,
+  sanitizeOutboundText,
+} from "./sanitize-outbound.js";
 
 describe("sanitizeOutboundText", () => {
   it("returns empty string unchanged", () => {
     expect(sanitizeOutboundText("")).toBe("");
+  });
+
+  it("preserves raw Markdown for edit and poll transport while removing real private markers", () => {
+    const raw = ["user:", "# system:", "**assistant:**", "us#+#+#er:", "visible"].join("\n");
+    const sanitized = sanitizeIMessageFinalOutboundText(raw);
+
+    expect(sanitized.text).toContain("# system:");
+    expect(sanitized.text).toContain("**assistant:**");
+    expect(sanitized.text).not.toMatch(/^user:$/m);
+    expect(sanitized.ranges).toEqual([]);
+  });
+
+  it("removes formatted private headings while preserving native iMessage styles", () => {
+    const sanitized = sanitizeIMessageFinalOutboundText("# user:\n**😀 visible**", {
+      formatMarkdown: true,
+    });
+    const bold = sanitized.ranges.find((range) => range.styles.includes("bold"));
+
+    expect(sanitized.text).not.toMatch(/^user:$/m);
+    expect(sanitized.text.slice(bold?.start, (bold?.start ?? 0) + (bold?.length ?? 0))).toBe(
+      "😀 visible",
+    );
+  });
+
+  it("strips assistant reasoning before computing native style offsets", () => {
+    const sanitized = sanitizeIMessageFinalOutboundText(
+      "<thinking>hidden thought</thinking><relevant_memories>hidden memory</relevant_memories>**😀 visible**",
+      { formatMarkdown: true },
+    );
+    const bold = sanitized.ranges.find((range) => range.styles.includes("bold"));
+
+    expect(sanitized.text).toBe("😀 visible");
+    expect(sanitized.text.slice(bold?.start, (bold?.start ?? 0) + (bold?.length ?? 0))).toBe(
+      "😀 visible",
+    );
+  });
+
+  it("uses canonical delivery cleanup without changing clean outer whitespace", () => {
+    const hidden = [
+      '<function_calls><invoke name="exec">hidden tool</invoke></function_calls><function_response>',
+      "hidden tool response",
+      "</function_response>",
+    ].join("\n");
+    const sanitized = sanitizeIMessageFinalOutboundText(` \t${hidden}\nvisible\n `);
+
+    expect(sanitized.text).toBe(" \tvisible\n ");
+    expect(sanitizeIMessageFinalOutboundText(" \tclean raw text\n ").text).toBe(
+      " \tclean raw text\n ",
+    );
+    expect(sanitizeIMessageFinalOutboundText(" \t\n ").text).toBe(" \t\n ");
+  });
+
+  it.each([
+    "<<script>thinking>hidden</<script>thinking>",
+    "<t<script>hinking>hidden</t<script>hinking>",
+    "<thi<system-reminder>noise</system-reminder>nking>hidden</thi<system-reminder>noise</system-reminder>nking>",
+    "<thi< system-reminder>noise< / system-reminder>nking>hidden</thi< system-reminder>noise< / system-reminder>nking>",
+    "<thinking< system-reminder>noise< / system-reminder>>hidden</thinking< system-reminder>noise< / system-reminder>>",
+    "<relevant_<previous_response>noise</previous_response>memories>hidden</relevant_<previous_response>noise</previous_response>memories>",
+    "<relevant_memories< previous_response>noise< / previous_response>>hidden</relevant_memories< previous_response>noise< / previous_response>>",
+    "<function_response< system-reminder>noise< / system-reminder>>hidden</function_response< system-reminder>noise< / system-reminder>>",
+    "<thi<details><summary>noise</summary></details>nking>hidden</thi<details>nking>",
+    "<thi<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>nking>hidden</thi<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>nking>",
+    "<thinking<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>>hidden</thinking<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>>",
+    "<relevant_<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>memories>hidden</relevant_<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>memories>",
+    "<function_response<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>>hidden</function_response<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>>",
+  ])("rejects ambiguous nested HTML before any destructive sanitization", (source) => {
+    expect(() => sanitizeIMessageFinalOutboundText(source)).toThrow(
+      "iMessage outbound ambiguous nested HTML is not allowed",
+    );
+  });
+
+  it("preserves real code, comparisons, templates, and quoted HTML attribute contents", () => {
+    for (const source of [
+      "a < b && c < d",
+      "if(a<b && c<d)",
+      "std::vector<std::vector<int>>",
+      "t<int>",
+      "```cpp\nif(a<b && c<d)\nstd::vector<std::vector<int>>\n```",
+      "ordinary <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>> mention without an ending marker",
+      `<strong title="<previous_response>">bold</strong> <del data-note='<system-reminder>'>strike</del>`,
+      `<strong title="<tag>">bold</strong> <del data-note='s>'>strike</del>`,
+      `<strong title="b>">bold</strong> <del data-note='s>'>strike</del>`,
+    ]) {
+      expect(sanitizeIMessageFinalOutboundText(source).text).toBe(source);
+    }
+  });
+
+  it.each([
+    "<system-reminder>PRIVATE_RUNTIME_SECRET</system-reminder>",
+    "< SYSTEM-REMINDER data-origin='runtime'>PRIVATE_RUNTIME_SECRET< / SYSTEM-REMINDER >",
+    "<previous_response>PRIVATE_RUNTIME_SECRET</previous_response>",
+    "< previous_response data-origin='runtime'>PRIVATE_RUNTIME_SECRET< / previous_response >",
+    "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>PRIVATE_RUNTIME_SECRET<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+  ])("removes private runtime blocks and their payload before role protection", (hidden) => {
+    for (const source of [hidden, `\`${hidden}\``, `\`\`\`xml\n${hidden}\n\`\`\``]) {
+      const sanitized = sanitizeIMessageFinalOutboundText(`${source}\nvisible companion`);
+      expect(sanitized.text).toContain("visible companion");
+      expect(sanitized.text).not.toContain("PRIVATE_RUNTIME_SECRET");
+      expect(sanitized.text).not.toMatch(/system-reminder|previous_response|INTERNAL_CONTEXT/i);
+    }
+  });
+
+  it("removes private blocks with angle brackets and fake self-closing markers in quoted attrs", () => {
+    for (const name of ["system-reminder", "previous_response"]) {
+      for (const quote of ["'", '"']) {
+        for (const attribute of [">", "/>", "<previous_response>"]) {
+          const hidden = `<${name} data-x=${quote}${attribute}${quote}>QUOTED_PRIVATE_SECRET</${name}>`;
+          for (const source of [hidden, `\`${hidden}\``, `\`\`\`xml\n${hidden}\n\`\`\``]) {
+            const sanitized = sanitizeIMessageFinalOutboundText(`${source}\nvisible companion`);
+            expect(sanitized.text).toContain("visible companion");
+            expect(sanitized.text).not.toMatch(
+              /QUOTED_PRIVATE_SECRET|system-reminder|previous_response/i,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("ignores fake private tags inside bounded opaque HTML comment and declaration spans", () => {
+    for (const name of ["system-reminder", "previous_response"]) {
+      for (const opaque of [
+        `<!-- </${name}> <${name}> -->`,
+        `<![CDATA[</${name}> <${name}>]]>`,
+        `<!DOCTYPE message [ <!ENTITY hidden "</${name}>"> ]>`,
+        `<?private fake="</${name}> ?>" nested="<${name}>"?>`,
+        `<! </${name}>>`,
+        `<! <${name}>>`,
+        `</! </${name}>>`,
+        `</? </${name}>>`,
+        `</1 </${name}>>`,
+        `</ </${name}>>`,
+      ]) {
+        const source = `<${name}>${opaque}OPAQUE_PRIVATE_SECRET</${name}>\nvisible companion`;
+        const sanitized = sanitizeIMessageFinalOutboundText(source);
+        expect(sanitized.text).toContain("visible companion");
+        expect(sanitized.text).not.toContain("OPAQUE_PRIVATE_SECRET");
+      }
+    }
+    expect(sanitizeIMessageFinalOutboundText("ordinary <!-- unfinished user example").text).toBe(
+      "ordinary <!-- unfinished user example",
+    );
+    expect(sanitizeIMessageFinalOutboundText("ordinary <! unfinished user example").text).toBe(
+      "ordinary <! unfinished user example",
+    );
+  });
+
+  it("ignores fake private closers inside code nested under a real private wrapper", () => {
+    for (const outer of ["system-reminder", "previous_response"]) {
+      for (const inner of ["system-reminder", "previous_response"]) {
+        for (const fakeClose of [
+          `\`</${inner}>\``,
+          `\n\`\`\`xml\n</${inner}>\n\`\`\`\n`,
+          `\n\n    </${inner}>\n`,
+        ]) {
+          const source = `<${outer}>${fakeClose}CODE_PRIVATE_SECRET</${outer}>\nvisible companion`;
+          const sanitized = sanitizeIMessageFinalOutboundText(source);
+          expect(sanitized.text).toContain("visible companion");
+          expect(sanitized.text).not.toContain("CODE_PRIVATE_SECRET");
+        }
+      }
+    }
+  });
+
+  it("ignores fake private tags inside raw-text and escapable-raw HTML element bodies", () => {
+    for (const name of ["system-reminder", "previous_response"]) {
+      for (const rawText of [
+        "script",
+        "style",
+        "textarea",
+        "title",
+        "xmp",
+        "iframe",
+        "noembed",
+        "noframes",
+        "noscript",
+      ]) {
+        for (const opener of [
+          `<${rawText} title=">">`,
+          `<${rawText.toUpperCase()} data-x=">" />`,
+        ]) {
+          const source = `<${name}>${opener}</${name}><${name}></${rawText}>RAW_TEXT_PRIVATE_SECRET</${name}>\nvisible companion`;
+          const sanitized = sanitizeIMessageFinalOutboundText(source);
+          expect(sanitized.text).toContain("visible companion");
+          expect(sanitized.text).not.toContain("RAW_TEXT_PRIVATE_SECRET");
+        }
+      }
+      expect(() =>
+        sanitizeIMessageFinalOutboundText(
+          `<${name}><plaintext></${name}>RAW_TEXT_PRIVATE_SECRET</${name}>`,
+        ),
+      ).toThrow("iMessage outbound runtime scaffolding is malformed");
+      expect(() =>
+        sanitizeIMessageFinalOutboundText(
+          `<${name}><PLAINTEXT /></${name}>RAW_TEXT_PRIVATE_SECRET</${name}>`,
+        ),
+      ).toThrow("iMessage outbound runtime scaffolding is malformed");
+    }
+    expect(sanitizeIMessageFinalOutboundText("<script>ordinary unfinished user example").text).toBe(
+      "<script>ordinary unfinished user example",
+    );
+    expect(
+      sanitizeIMessageFinalOutboundText(
+        "<script><system-reminder>RAW_TEXT_PRIVATE_SECRET</system-reminder></script>visible",
+      ).text,
+    ).not.toContain("RAW_TEXT_PRIVATE_SECRET");
+  });
+
+  it("retains user-authored XML while removing paired private runtime context", () => {
+    expect(sanitizeIMessageFinalOutboundText("<note>visible XML</note>").text).toBe(
+      "<note>visible XML</note>",
+    );
+    expect(
+      sanitizeIMessageFinalOutboundText(
+        "before <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>private<<<END_OPENCLAW_INTERNAL_CONTEXT>>> after",
+      ).text,
+    ).toBe("before  after");
+  });
+
+  it("removes the producer's self-closing and orphan private runtime tags", () => {
+    const source = [
+      "< system-reminder origin='runtime' />",
+      "</ system-reminder >",
+      "<previous_response>",
+      "visible companion",
+    ].join("\n");
+
+    expect(sanitizeIMessageFinalOutboundText(source).text).toContain("visible companion");
+    expect(sanitizeIMessageFinalOutboundText(source).text).not.toMatch(
+      /system-reminder|previous_response/i,
+    );
+  });
+
+  it.each([
+    "<system-reminder><system-reminder>inner</system-reminder>PRIVATE_NESTED_SECRET</system-reminder>",
+    "<previous_response><previous_response>inner</previous_response>PRIVATE_NESTED_SECRET</previous_response>",
+    "<system-reminder><previous_response>inner</previous_response>PRIVATE_NESTED_SECRET</system-reminder>",
+    "< previous_response data-origin='runtime'>< SYSTEM-REMINDER>inner< / SYSTEM-REMINDER>PRIVATE_NESTED_SECRET< / previous_response >",
+    "<system-reminder><previous_response />PRIVATE_NESTED_SECRET</system-reminder>",
+    "<system-reminder><system-reminder>first</system-reminder><previous_response>second</previous_response>PRIVATE_NESTED_SECRET</system-reminder>",
+  ])(
+    "removes complete balanced nested private wrappers without leaking outer payload",
+    (hidden) => {
+      for (const source of [hidden, `\`${hidden}\``, `\`\`\`xml\n${hidden}\n\`\`\``]) {
+        const sanitized = sanitizeIMessageFinalOutboundText(`${source}\nvisible companion`);
+        expect(sanitized.text).toContain("visible companion");
+        expect(sanitized.text).not.toMatch(
+          /PRIVATE_NESTED_SECRET|system-reminder|previous_response/i,
+        );
+      }
+    },
+  );
+
+  it("fails closed for crossed or unterminated nested private runtime wrappers", () => {
+    for (const source of [
+      "<system-reminder><previous_response>private</system-reminder></previous_response>",
+      "<system-reminder><previous_response>private",
+      "<system-reminder><system-reminder>inner</system-reminder>OUTER_PRIVATE_SECRET",
+      "<system-reminder><previous_response>inner</previous_response>OUTER_PRIVATE_SECRET",
+      "<system-reminder><previous_response />OUTER_PRIVATE_SECRET",
+      "<system-reminder>`</system-reminder>`OUTER_PRIVATE_SECRET",
+      "<system-reminder>`prefix </system-reminder> suffix`OUTER_PRIVATE_SECRET",
+      "<system-reminder>``prefix </system-reminder> suffix``OUTER_PRIVATE_SECRET",
+      "<system-reminder>`prefix </previous_response> suffix`OUTER_PRIVATE_SECRET",
+      "<system-reminder>```xml\n</previous_response>\n```\nOUTER_PRIVATE_SECRET",
+      "<system-reminder data-x=<previous_response>>OUTER_PRIVATE_SECRET",
+      "<system-reminder <previous_response>>OUTER_PRIVATE_SECRET",
+      "<previous_response data-x=<system-reminder>>OUTER_PRIVATE_SECRET",
+      "</previous_response data-x=<system-reminder>>OUTER_PRIVATE_SECRET",
+      `<system-reminder data-x='>PRIVATE_UNTERMINATED_QUOTE</system-reminder>`,
+      "<system-reminder><!-- </system-reminder> OUTER_PRIVATE_SECRET",
+      "<system-reminder><! unfinished bogus declaration OUTER_PRIVATE_SECRET",
+    ]) {
+      expect(() => sanitizeIMessageFinalOutboundText(source)).toThrow(
+        "iMessage outbound runtime scaffolding is malformed",
+      );
+    }
+    expect(() =>
+      sanitizeIMessageFinalOutboundText("<system-reminder>".repeat(33) + "private"),
+    ).toThrow("iMessage outbound runtime scaffolding exceeded its limit");
+    expect(sanitizeIMessageFinalOutboundText("<system-reminder>visible orphan").text).toBe(
+      "visible orphan",
+    );
+  });
+
+  it.each([
+    "<system-reminder>`</system-reminder>`OUTER_PRIVATE_SECRET",
+    "<system-reminder>`prefix </system-reminder> suffix`OUTER_PRIVATE_SECRET",
+    "<system-reminder>``prefix </system-reminder> suffix``OUTER_PRIVATE_SECRET",
+    "<previous_response>```xml\n</system-reminder>\n```\nOUTER_PRIVATE_SECRET",
+  ])("fails closed when nested Markdown literals impersonate private owners", (malformed) => {
+    for (const [wrapper, source] of [
+      ["raw", malformed],
+      ["inline", `\`${malformed}\``],
+      ["fenced", `\`\`\`xml\n${malformed}\n\`\`\``],
+      ["wide-fenced", `\`\`\`\`xml\n${malformed}\n\`\`\`\``],
+    ] as const) {
+      expect(
+        () => sanitizeIMessageFinalOutboundText(source),
+        JSON.stringify({ malformed, wrapper, source }),
+      ).toThrow("iMessage outbound runtime scaffolding is malformed");
+    }
+  });
+
+  it("reserves private-use glyphs from original hidden blocks before protecting real YAML roles", () => {
+    const source = [
+      "<system-reminder>\ue000</system-reminder>",
+      "<previous_response>\ue001</previous_response>",
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\ue002<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "```yaml",
+      "user:",
+      "system:",
+      "assistant:",
+      "```",
+    ].join("\n");
+    const protection = protectIMessageFencedRoleMarkers(source);
+
+    expect(protection.text).toContain("\ue003".repeat("user".length));
+    expect(protection.text).not.toMatch(/[\ue000-\ue002]/);
+    const sanitized = sanitizeIMessageFinalOutboundText(protection.text, { protection });
+    for (const role of ["user", "system", "assistant"]) {
+      expect(sanitized.text).toMatch(new RegExp(`^${role}:$`, "m"));
+    }
+    expect(sanitized.text).not.toMatch(/[\ue000-\uf8ff]/);
+  });
+
+  it("drops native style metadata when fenced assistant reasoning is exposed after formatting", () => {
+    const sanitized = sanitizeIMessageFinalOutboundText(
+      ["```xml", "<thinking>hidden thought</thinking>", "```", "**😀 visible**"].join("\n"),
+      { formatMarkdown: true },
+    );
+
+    expect(sanitized.text).not.toContain("hidden thought");
+    expect(sanitized.text).toContain("😀 visible");
+    expect(sanitized.ranges).toEqual([]);
+  });
+
+  it.each([
+    { name: "fenced thinking", source: "```xml\n<thinking>hidden</thinking>\n```" },
+    {
+      name: "fenced memories",
+      source: "```xml\n<relevant_memories>hidden</relevant_memories>\n```",
+    },
+    { name: "inline thinking", source: "`<thinking>hidden</thinking>`" },
+    { name: "inline memories", source: "`<relevant-memories>hidden</relevant-memories>`" },
+    { name: "unterminated fenced memories", source: "```xml\n<relevant_memories>hidden\n```" },
+  ])("rejects $name instead of leaking private payload through raw Markdown", ({ source }) => {
+    expect(() => sanitizeIMessageFinalOutboundText(source)).toThrow(
+      "iMessage outbound hidden assistant content is not allowed",
+    );
+  });
+
+  it("recursively rejects assistant reasoning through multiple closed Markdown fence layers", () => {
+    let nested = "<thinking>hidden nested thought</thinking>";
+    for (let depth = 0; depth < 5; depth += 1) {
+      const fence = "`".repeat(depth + 3);
+      nested = `${fence}xml\n${nested}\n${fence}`;
+    }
+
+    expect(() => sanitizeIMessageFinalOutboundText(nested)).toThrow(
+      "iMessage outbound hidden assistant content is not allowed",
+    );
+    expect(() => sanitizeIMessageFinalOutboundText(nested, { formatMarkdown: true })).toThrow(
+      "iMessage outbound hidden assistant content is not allowed",
+    );
+  });
+
+  it("fails closed when recursive Markdown unwrapping exceeds its security budget", () => {
+    let nested = "safe but unreasonably nested";
+    for (let depth = 0; depth < 80; depth += 1) {
+      const fence = "`".repeat(depth + 3);
+      nested = `${fence}xml\n${nested}\n${fence}`;
+    }
+
+    expect(() => sanitizeIMessageFinalOutboundText(nested)).toThrow(
+      "iMessage outbound Markdown security projection exceeded its limit",
+    );
   });
 
   it("preserves normal user-facing text", () => {
@@ -75,12 +457,12 @@ describe("sanitizeOutboundText", () => {
       expected: "~~~yaml\nsystem:\n  enabled: true\n~~~",
     },
     {
-      name: "indented code preserves assistant while stripping prose assistant",
-      input: "keep\n\nassistant:\n\n    assistant:\n    enabled: true",
-      expected: "keep\n\n    assistant:\n    enabled: true",
+      name: "closed fence preserves assistant while stripping prose assistant",
+      input: "assistant:\n```yaml\nassistant:\n  enabled: true\n```",
+      expected: "```yaml\nassistant:\n  enabled: true\n```",
     },
     {
-      name: "unterminated fence preserves every marker family after offset shifts",
+      name: "unterminated fence never exposes internal marker families",
       input: [
         "#+#+#",
         "assistant to=final",
@@ -90,10 +472,187 @@ describe("sanitizeOutboundText", () => {
         "assistant to=tool",
         "user:",
       ].join("\n"),
-      expected: ["```text", "#+#+#", "assistant to=tool", "user:"].join("\n"),
+      expected: "```text",
+    },
+    {
+      name: "longer matching closing fence preserves role mappings",
+      input: "```yaml\nuser:\n  id: 1\n````",
+      expected: "```yaml\nuser:\n  id: 1\n````",
+    },
+    {
+      name: "three-space-indented fences preserve role mappings",
+      input: "Example:\n   ```yaml\n   user:\n     id: 1\n   ```",
+      expected: "Example:\n   ```yaml\n   user:\n     id: 1\n   ```",
+    },
+    {
+      name: "CRLF fences preserve role mappings",
+      input: "```yaml\r\nuser:\r\n  id: 1\r\n```",
+      expected: "```yaml\r\nuser:\r\n  id: 1\r\n```",
+    },
+    {
+      name: "closing fence whitespace preserves role mappings",
+      input: "```yaml\nuser:\n  id: 1\n``` \t",
+      expected: "```yaml\nuser:\n  id: 1\n```",
     },
   ] as const)("$name", ({ input, expected }) => {
     expect(sanitizeOutboundText(input)).toBe(expected);
+  });
+
+  it.each([
+    { name: "an unterminated backtick fence", text: "```yaml\nuser:" },
+    { name: "an unterminated tilde fence", text: "~~~yaml\nsystem:" },
+    { name: "a mismatched closing fence", text: "```yaml\nassistant:\n~~~" },
+    { name: "a shorter closing fence", text: "````yaml\nuser:\n```" },
+    { name: "indented code", text: "    user:\n    enabled: true" },
+    { name: "inline code", text: "prefix `user:` suffix" },
+    { name: "multiline inline code", text: "prefix ```\nuser:\n``` suffix" },
+    { name: "a midline opener", text: "prefix ```yaml\nuser:\n```" },
+    { name: "a quoted fence", text: "> ```yaml\n> user:\n> ```" },
+  ])("does not exempt role markers in $name", ({ text }) => {
+    expect(sanitizeOutboundText(text)).not.toMatch(/^[ \t]*(?:user|system|assistant):\s*$/m);
+  });
+
+  it.each(["user", "system", "assistant"] as const)(
+    "strips quoted %s role headers without removing quoted prose",
+    (role) => {
+      for (const prefix of ["> ", ">> ", "> > ", ">\t"]) {
+        for (const closed of [false, true]) {
+          const source = [
+            `${prefix}\`\`\`yaml`,
+            `${prefix}${role}:`,
+            `${prefix}safe: value`,
+            ...(closed ? [`${prefix}\`\`\``] : []),
+          ].join("\n");
+          const sanitized = sanitizeOutboundText(source);
+
+          expect(sanitized).toContain(`${prefix}safe: value`);
+          expect(sanitized).not.toMatch(
+            /^[ \t]*(?:>[ \t]*)*(?:user|system|assistant)[ \t]*:[ \t]*$/gim,
+          );
+        }
+      }
+      expect(sanitizeOutboundText(`> Please reply to the ${role}:`)).toBe(
+        `> Please reply to the ${role}:`,
+      );
+    },
+  );
+
+  it("preserves role provenance and remaps native UTF-16 styles after final scrubbing", () => {
+    const source = "```yaml\nuser:\n  name: alice\n```";
+    const protectedText = protectIMessageFencedRoleMarkers(source);
+    const token = protectedText.text.match(/[\ue000-\uf8ff]+/)?.[0];
+    expect(token).toHaveLength("user".length);
+    const hidden = "assistant:\n";
+    const visible = `😀 ${token}:\n`;
+    const sanitized = protectedText.sanitizeFormatted({
+      text: hidden + visible,
+      ranges: [
+        { start: 0, length: "assistant".length, styles: ["bold"] },
+        { start: hidden.length, length: 3, styles: ["italic"] },
+      ],
+    });
+
+    expect(sanitized.text).toBe("\n😀 user:\n");
+    expect(sanitized.ranges).toEqual([{ start: 1, length: 3, styles: ["italic"] }]);
+    expect(sanitized.text).not.toMatch(/[\ue000-\uf8ff]/);
+  });
+
+  it("fails closed when formatted content forges an authenticated role marker", () => {
+    const protectedText = protectIMessageFencedRoleMarkers("```yaml\nuser:\n```");
+    const token = protectedText.text.match(/[\ue000-\uf8ff]+/)?.[0];
+    expect(token).toBeDefined();
+
+    expect(() =>
+      protectedText.sanitizeFormatted({ text: `${token}:\n${token}:`, ranges: [] }),
+    ).toThrow("iMessage outbound role protection failed");
+  });
+
+  it("rejects partial authenticated-marker glyphs before they can replace a removed role", () => {
+    const protectedText = protectIMessageFencedRoleMarkers("```yaml\nuser:\n```");
+    const token = protectedText.text.match(/[\ue000-\uf8ff]+/)?.[0];
+    expect(token).toBeDefined();
+
+    expect(() =>
+      protectedText.sanitizeFormatted({
+        text: `<thinking>${token}:</thinking>${token?.slice(0, 2)}<relevant_memories>hidden</relevant_memories>${token?.slice(2)}:`,
+        ranges: [],
+      }),
+    ).toThrow("iMessage outbound role protection failed");
+  });
+
+  it("fails closed when marker removal assembles a second authenticated role token", () => {
+    const protectedText = protectIMessageFencedRoleMarkers("```yaml\nuser:\n```");
+    const token = protectedText.text.match(/[\ue000-\uf8ff]+/)?.[0];
+    expect(token).toBeDefined();
+    const splitToken = `${token?.slice(0, 2)}#+#+#${token?.slice(2)}`;
+
+    expect(() =>
+      protectedText.sanitizeFormatted({ text: `${token}:\n${splitToken}:`, ranges: [] }),
+    ).toThrow("iMessage outbound role protection failed");
+  });
+
+  it("remaps native UTF-16 ranges across every private-marker removal pass", () => {
+    const protectedText = protectIMessageFencedRoleMarkers("safe");
+    const disguised = "us#+#+#er:";
+    const sanitized = protectedText.sanitizeFormatted({
+      text: `${disguised}\n😀 styled`,
+      ranges: [{ start: disguised.length + 1, length: "😀 styled".length, styles: ["bold"] }],
+    });
+
+    expect(sanitized.text).toBe("\n😀 styled");
+    expect(sanitized.ranges).toEqual([{ start: 1, length: "😀 styled".length, styles: ["bold"] }]);
+  });
+
+  it("selects a distinct role marker when user content already contains private-use text", () => {
+    const existing = "\ue000".repeat("user".length);
+    const protectedText = protectIMessageFencedRoleMarkers(
+      ["```yaml", "user:", "```", existing].join("\n"),
+    );
+    const token = protectedText.text.split("\n")[1]?.match(/[\ue000-\uf8ff]+/)?.[0];
+
+    expect(token).not.toBe(existing);
+    expect(token).toHaveLength("user".length);
+  });
+
+  it("never chooses a protected glyph that already occurs as a user-authored partial marker", () => {
+    const existing = "\ue000";
+    const protectedText = protectIMessageFencedRoleMarkers(
+      ["```yaml", "user:", "```", existing].join("\n"),
+    );
+
+    expect(protectedText.text.split("\n")[1]).not.toContain(existing);
+  });
+
+  it("removes every private marker family after final Markdown rendering", () => {
+    const protectedText = protectIMessageFencedRoleMarkers("safe");
+    const sanitized = protectedText.sanitizeFormatted({
+      text: "assistant to=tool\n#+#+#\nUSER:\nVisible",
+      ranges: [],
+    });
+
+    expect(sanitized.text).not.toMatch(/assistant\s+to\s*=\s*\w+|(?:#\+){2,}|^user:/gim);
+    expect(sanitized.text).toContain("Visible");
+  });
+
+  it("keeps internal metadata stripped inside closed code fences", () => {
+    const text = ["```text", "#+#+#", "assistant to=tool", "user:", "```"].join("\n");
+    const result = sanitizeOutboundText(text);
+
+    expect(result).toContain("user:");
+    expect(result).not.toContain("#+#+#");
+    expect(result).not.toContain("assistant to=tool");
+  });
+
+  it("strips prose roles while preserving adjacent closed-fence YAML keys", () => {
+    const text = ["assistant:", "```yaml", "user:", "```", "system:"].join("\n");
+
+    expect(sanitizeOutboundText(text)).toBe("```yaml\nuser:\n```");
+  });
+
+  it("keeps fenced roles aligned after earlier internal-marker removal", () => {
+    const text = ["#+#+#", "assistant to=final", "```yaml", "user:", "  id: 1", "```"].join("\n");
+
+    expect(sanitizeOutboundText(text)).toBe("```yaml\nuser:\n  id: 1\n```");
   });
 
   it("handles combined internal markers in one message", () => {

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -3,7 +3,11 @@ import {
   findCodeRegions,
   isInsideCode,
   sanitizeAssistantVisibleText,
+  stripMarkdown,
+  tokenizeHtmlTags,
+  type CodeRegion,
 } from "openclaw/plugin-sdk/text-chunking";
+import { extractMarkdownFormatRuns } from "../markdown-format.js";
 
 /**
  * Patterns that indicate assistant-internal metadata leaked into text.
@@ -11,21 +15,650 @@ import {
  */
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
-// Only a standalone role marker on its own line (a leaked turn boundary) — not
-// any line that merely ends with the word "user/system/assistant:" in prose.
-const ROLE_TURN_MARKER_RE = /^[ \t]*(?:user|system|assistant)\s*:\s*$/gm;
+// Blockquote prefixes are stripped by the iMessage Markdown formatter, so a
+// quoted standalone role marker is just as unsafe as an unquoted turn boundary.
+const ROLE_TURN_MARKER_RE = /^[ \t]*(?:>[ \t]*)*(?:user|system|assistant)[ \t]*:[ \t]*(?=\r?$)/gim;
+const FENCED_ROLE_MARKER_RE = /^[ \t]*(user|system|assistant)[ \t]*:[ \t]*(?=\r?$)/gim;
+const FINAL_PRIVATE_MARKER_RE =
+  /(?:#\+){2,}#?|\bassistant\s+to\s*=\s*\w+|^[ \t]*(?:user|system|assistant)[ \t]*:[ \t]*(?=\r?$)/gim;
+const PRIVATE_USE_START = 0xe000;
+const PRIVATE_USE_END = 0xf8ff;
+const MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES = 32;
+// Mirror the private shared plain-text HTML grammar to inspect every destructive removal stage.
+const PLAIN_TEXT_HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
+const PRIVATE_PROVIDER_TAG_NAMES = [
+  "think",
+  "thinking",
+  "thought",
+  "reasoning",
+  "antthinking",
+  "antml:think",
+  "antml:thinking",
+  "antml:thought",
+  "antml:reasoning",
+  "mm:think",
+  "mm:thinking",
+  "mm:thought",
+  "mm:reasoning",
+  "relevant_memories",
+  "relevant-memories",
+  "tool_call",
+  "tool_result",
+  "function_call",
+  "function_calls",
+  "function_response",
+  "function",
+  "tool_calls",
+  "antml:invoke",
+  "antml:parameter",
+  "invoke",
+  "parameter",
+] as const;
+const PRIVATE_PROVIDER_TAG_NAME_SET = new Set<string>(PRIVATE_PROVIDER_TAG_NAMES);
+// The canonical private runtime context block can erase an inline hidden-tag name fragment.
+const OPAQUE_PRIVATE_RUNTIME_CONTEXT_BLOCK_RE =
+  /^<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>(?:(?!<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>)[\s\S])*<<<END_OPENCLAW_INTERNAL_CONTEXT>>>/;
+const PRIVATE_RUNTIME_CONTEXT_BLOCK_RE =
+  /<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>(?:(?!<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>)[\s\S])*<<<END_OPENCLAW_INTERNAL_CONTEXT>>>/g;
+const NESTED_PRIVATE_MARKUP_START_RE =
+  /<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>|<\s*\/?\s*[A-Za-z][A-Za-z0-9_.:-]*(?=\s|\/?>)/g;
+const OUTER_PRIVATE_TAG_FRAGMENT_RE = /^\s*\/?\s*([a-z][a-z0-9_.:-]*)?$/i;
+const OPAQUE_PRIVATE_MARKUP_BLOCK_RE =
+  /^<\s*(system-reminder|previous_response|details|summary)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/i;
+const REMOVABLE_PRIVATE_MARKUP_TAG_RE = /^<\s*\/?\s*[a-z][a-z0-9_.:-]*(?=\s|\/?>)[^>]*>/i;
+const PRIVATE_PROVIDER_TAG_FRAGMENT_RE = /^[a-z0-9_.:-]*/i;
+// Classify the private producer's names before lexing quoted HTML attributes safely.
+const PRIVATE_RUNTIME_SCAFFOLDING_TAG_TOKEN_RE =
+  /<\s*(\/?)\s*(system-reminder|previous_response)\b/gi;
 
-/**
- * Strip an internal-marker pattern from prose while leaving matches that fall
- * inside a fenced/indented/inline code region untouched: there a bare `user:`
- * mapping key or `#+#` line is the user's own content, not leaked scaffolding.
- * Regions are recomputed per call because the prior strip shifted later offsets.
- */
-function stripMarkerOutsideCode(text: string, marker: RegExp): string {
+function assertSafeIMessageOutboundMarkup(text: string): void {
+  for (const nested of text.matchAll(NESTED_PRIVATE_MARKUP_START_RE)) {
+    const nestedStart = nested.index ?? 0;
+    const outerStart = text.lastIndexOf("<", nestedStart - 1);
+    if (outerStart < 0) {
+      continue;
+    }
+    const outer = OUTER_PRIVATE_TAG_FRAGMENT_RE.exec(text.slice(outerStart + 1, nestedStart));
+    if (!outer) {
+      continue;
+    }
+
+    let candidate = (outer[1] ?? "").toLowerCase();
+    if (!PRIVATE_PROVIDER_TAG_NAMES.some((name) => name.startsWith(candidate))) {
+      continue;
+    }
+
+    let cursor = nestedStart;
+    for (let depth = 0; depth < MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES; depth += 1) {
+      const remaining = text.slice(cursor);
+      // Runtime scaffolding erases whole blocks; ordinary HTML erases just its tag.
+      const removed =
+        OPAQUE_PRIVATE_RUNTIME_CONTEXT_BLOCK_RE.exec(remaining)?.[0] ??
+        OPAQUE_PRIVATE_MARKUP_BLOCK_RE.exec(remaining)?.[0] ??
+        REMOVABLE_PRIVATE_MARKUP_TAG_RE.exec(remaining)?.[0];
+      if (!removed) {
+        break;
+      }
+      cursor += removed.length;
+
+      const suffix = PRIVATE_PROVIDER_TAG_FRAGMENT_RE.exec(text.slice(cursor))?.[0] ?? "";
+      candidate += suffix.toLowerCase();
+      cursor += suffix.length;
+      if (PRIVATE_PROVIDER_TAG_NAME_SET.has(candidate) && /[\s/>]/.test(text.charAt(cursor))) {
+        throw new Error("iMessage outbound ambiguous nested HTML is not allowed");
+      }
+      if (!PRIVATE_PROVIDER_TAG_NAMES.some((name) => name.startsWith(candidate))) {
+        break;
+      }
+      if (
+        depth + 1 >= MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES &&
+        (OPAQUE_PRIVATE_RUNTIME_CONTEXT_BLOCK_RE.test(text.slice(cursor)) ||
+          REMOVABLE_PRIVATE_MARKUP_TAG_RE.test(text.slice(cursor)))
+      ) {
+        throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+      }
+    }
+  }
+}
+
+function stripIMessageBalancedPrivateRuntimeBlocks(
+  text: string,
+  verifyProtectedRoles?: (visible: string) => void,
+): string {
+  type HtmlRegion = { start: number; end: number; terminated: boolean };
+  const openBlocks: Array<{
+    name: string;
+    start: number;
+    end: number;
+    sawNested: boolean;
+    codeRegion?: CodeRegion;
+    nestedCodeRegions?: CodeRegion[];
+  }> = [];
+  const completedBlocks: Array<{ start: number; end: number }> = [];
   const codeRegions = findCodeRegions(text);
-  return text.replace(marker, (match, offset: number) =>
-    isInsideCode(offset, codeRegions) ? match : "",
+  const parsedHtmlTags = [...tokenizeHtmlTags(text)];
+  const htmlTags: HtmlRegion[] = parsedHtmlTags.map(({ start, end }) => ({
+    start,
+    end,
+    terminated: true,
+  }));
+  const rawTextHtml: HtmlRegion[] = [];
+  const rawTextTagNames = new Set([
+    "script",
+    "style",
+    "textarea",
+    "title",
+    "xmp",
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+  ]);
+  for (const [index, opener] of parsedHtmlTags.entries()) {
+    if (opener.closing || !rawTextTagNames.has(opener.name)) {
+      continue;
+    }
+    const closing =
+      opener.name === "plaintext"
+        ? undefined
+        : parsedHtmlTags.slice(index + 1).find((candidate) => {
+            return candidate.closing && candidate.name === opener.name;
+          });
+    rawTextHtml.push({
+      start: opener.start,
+      end: closing?.end ?? text.length,
+      terminated: Boolean(closing),
+    });
+    if (rawTextHtml.length > MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 2) {
+      throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+    }
+  }
+  const opaqueHtml: HtmlRegion[] = [];
+  for (let cursor = 0; cursor < text.length;) {
+    const start = text.indexOf("<", cursor);
+    if (start < 0) {
+      break;
+    }
+    const enclosingTag = htmlTags.find((tag) => tag.start < start && start < tag.end);
+    if (enclosingTag) {
+      cursor = enclosingTag.end;
+      continue;
+    }
+
+    let end = -1;
+    let delimiterLength = 0;
+    if (text.startsWith("<!--", start)) {
+      end = text.indexOf("-->", start + 4);
+      delimiterLength = 3;
+    } else if (/^<!\[CDATA\[/i.test(text.slice(start, start + 9))) {
+      end = text.indexOf("]]>", start + 9);
+      delimiterLength = 3;
+    } else if (text.startsWith("<?", start)) {
+      let quote: "'" | '"' | undefined;
+      for (let index = start + 2; index < text.length - 1; index += 1) {
+        const character = text[index];
+        if (quote) {
+          if (character === quote) {
+            quote = undefined;
+          }
+        } else if (character === "'" || character === '"') {
+          quote = character;
+        } else if (character === "?" && text[index + 1] === ">") {
+          end = index;
+          delimiterLength = 2;
+          break;
+        }
+      }
+    } else if (/^<![a-z][a-z0-9_.:-]*\b/i.test(text.slice(start))) {
+      let quote: "'" | '"' | undefined;
+      let bracketDepth = 0;
+      for (let index = start + 2; index < text.length; index += 1) {
+        const character = text[index];
+        if (quote) {
+          if (character === quote) {
+            quote = undefined;
+          }
+        } else if (character === "'" || character === '"') {
+          quote = character;
+        } else if (character === "[") {
+          bracketDepth += 1;
+        } else if (character === "]" && bracketDepth > 0) {
+          bracketDepth -= 1;
+        } else if (character === ">" && bracketDepth === 0) {
+          end = index;
+          delimiterLength = 1;
+          break;
+        }
+      }
+    } else if (
+      text.startsWith("<!", start) ||
+      (text.startsWith("</", start) &&
+        start + 2 < text.length &&
+        !/[A-Za-z>]/.test(text[start + 2] ?? ""))
+    ) {
+      // HTML's bogus-comment state consumes malformed declarations through their first `>`.
+      end = text.indexOf(">", start + 2);
+      delimiterLength = 1;
+    } else {
+      cursor = start + 1;
+      continue;
+    }
+    if (opaqueHtml.length >= MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 2) {
+      throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+    }
+    const terminated = end >= 0;
+    const regionEnd = terminated ? end + delimiterLength : text.length;
+    opaqueHtml.push({ start, end: regionEnd, terminated });
+    cursor = regionEnd;
+  }
+  htmlTags.push(...opaqueHtml);
+  htmlTags.sort((left, right) => left.start - right.start || right.end - left.end);
+  let htmlTagIndex = 0;
+  let scannedTags = 0;
+  let scannedThrough = 0;
+
+  for (const token of text.matchAll(PRIVATE_RUNTIME_SCAFFOLDING_TAG_TOKEN_RE)) {
+    const start = token.index ?? 0;
+    if (start < scannedThrough) {
+      continue;
+    }
+    while ((htmlTags[htmlTagIndex]?.end ?? 0) <= start && htmlTagIndex < htmlTags.length) {
+      htmlTagIndex += 1;
+    }
+    const enclosingHtmlTag = htmlTags[htmlTagIndex];
+    if (enclosingHtmlTag && enclosingHtmlTag.start < start && start < enclosingHtmlTag.end) {
+      continue;
+    }
+    const codeRegion = codeRegions.find((region) => isInsideCode(start, [region]));
+    const enclosingBlock = openBlocks.at(-1);
+    const enclosingRawText = rawTextHtml.find((region) => {
+      return region.start < start && start < region.end;
+    });
+    if (enclosingBlock && enclosingRawText && enclosingBlock.start < enclosingRawText.start) {
+      enclosingBlock.sawNested = true;
+      continue;
+    }
+    if (enclosingBlock && codeRegion && enclosingBlock.codeRegion !== codeRegion) {
+      enclosingBlock.sawNested = true;
+      continue;
+    }
+    if (enclosingBlock?.codeRegion && enclosingBlock.codeRegion !== codeRegion) {
+      throw new Error("iMessage outbound runtime scaffolding is malformed");
+    }
+    if (++scannedTags > MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 2) {
+      throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+    }
+
+    let quote: "'" | '"' | undefined;
+    let end = start + token[0].length;
+    for (; end < text.length; end += 1) {
+      if (end - start > MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 2) {
+        throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+      }
+      const character = text[end];
+      if (quote) {
+        if (character === quote) {
+          quote = undefined;
+        }
+      } else if (character === "'" || character === '"') {
+        quote = character;
+      } else if (character === "<") {
+        throw new Error("iMessage outbound runtime scaffolding is malformed");
+      } else if (character === ">") {
+        break;
+      }
+    }
+    if (end >= text.length || quote) {
+      throw new Error("iMessage outbound runtime scaffolding is malformed");
+    }
+    end += 1;
+
+    if (enclosingBlock?.codeRegion && enclosingBlock.codeRegion === codeRegion) {
+      if (!enclosingBlock.nestedCodeRegions) {
+        const nestedCodeLength = codeRegion.end - enclosingBlock.end;
+        if (nestedCodeLength > MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 3) {
+          throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+        }
+        enclosingBlock.nestedCodeRegions = findCodeRegions(
+          text.slice(enclosingBlock.end, codeRegion.end),
+        );
+        if (enclosingBlock.nestedCodeRegions.length > MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES ** 2) {
+          throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+        }
+      }
+
+      // Reparse only the owning wrapper's contents so a nested literal tag cannot close it.
+      if (isInsideCode(start - enclosingBlock.end, enclosingBlock.nestedCodeRegions)) {
+        enclosingBlock.sawNested = true;
+        continue;
+      }
+    }
+
+    scannedThrough = end;
+    const markup = text.slice(start, end);
+    const closing = token[1] === "/";
+    if (!closing && /\/\s*>$/.test(markup)) {
+      const parent = openBlocks.at(-1);
+      if (parent) {
+        parent.sawNested = true;
+      } else {
+        completedBlocks.push({ start, end });
+      }
+      continue;
+    }
+    const name = (token[2] ?? "").toLowerCase();
+    if (!closing) {
+      if (openBlocks.length >= MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES) {
+        throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+      }
+      const parent = openBlocks.at(-1);
+      if (parent) {
+        parent.sawNested = true;
+      }
+      openBlocks.push({ name, start, end, sawNested: false, codeRegion });
+      continue;
+    }
+
+    const opening = openBlocks.at(-1);
+    if (!opening) {
+      completedBlocks.push({ start, end });
+      continue;
+    }
+    if (opening.name !== name) {
+      throw new Error("iMessage outbound runtime scaffolding is malformed");
+    }
+    openBlocks.pop();
+    completedBlocks.push({ start: opening.start, end });
+  }
+  if (
+    openBlocks.length > 1 ||
+    openBlocks[0]?.sawNested ||
+    (openBlocks[0] &&
+      [...opaqueHtml, ...rawTextHtml].some(
+        (region) => !region.terminated && openBlocks[0]!.start < region.start,
+      ))
+  ) {
+    throw new Error("iMessage outbound runtime scaffolding is malformed");
+  }
+  const orphan = openBlocks[0];
+  if (orphan) {
+    completedBlocks.push({ start: orphan.start, end: orphan.end });
+  }
+
+  completedBlocks.sort((left, right) => left.start - right.start || right.end - left.end);
+  const outermost: typeof completedBlocks = [];
+  for (const block of completedBlocks) {
+    const previous = outermost.at(-1);
+    if (!previous || block.start >= previous.end) {
+      outermost.push(block);
+    }
+  }
+  let current = text;
+  for (const block of outermost.toReversed()) {
+    verifyProtectedRoles?.(current);
+    const stripped = current.slice(0, block.start) + current.slice(block.end);
+    assertSafeIMessageOutboundMarkup(stripped);
+    verifyProtectedRoles?.(stripped);
+    current = stripped;
+  }
+  return current;
+}
+
+function stripIMessagePrivateRuntimeScaffolding(
+  text: string,
+  verifyProtectedRoles?: (visible: string) => void,
+): string {
+  assertSafeIMessageOutboundMarkup(text);
+  let current = text;
+  for (let depth = 0; depth < MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES; depth += 1) {
+    let changed = false;
+    for (const strip of [
+      (value: string) => value.replace(PRIVATE_RUNTIME_CONTEXT_BLOCK_RE, ""),
+      (value: string) => stripIMessageBalancedPrivateRuntimeBlocks(value, verifyProtectedRoles),
+    ]) {
+      verifyProtectedRoles?.(current);
+      const stripped = strip(current);
+      assertSafeIMessageOutboundMarkup(stripped);
+      verifyProtectedRoles?.(stripped);
+      if (stripped !== current) {
+        current = stripped;
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return current;
+    }
+  }
+  throw new Error("iMessage outbound runtime scaffolding exceeded its limit");
+}
+
+// Delivery owns the complete assistant-scaffolding policy, but its final trim is not a raw
+// iMessage wire contract. Restore only the original outer whitespace around surviving prose.
+function sanitizeIMessageAssistantVisibleText(
+  text: string,
+  verifyProtectedRoles?: (visible: string) => void,
+): string {
+  const cleaned = stripIMessagePrivateRuntimeScaffolding(text, verifyProtectedRoles);
+  if (!text.trim()) {
+    return text;
+  }
+  const leadingWhitespace = /^\s*/u.exec(text)?.[0] ?? "";
+  const trailingWhitespace = /\s*$/u.exec(text)?.[0] ?? "";
+  verifyProtectedRoles?.(cleaned);
+  const canonical = cleaned.trim();
+  verifyProtectedRoles?.(canonical);
+  const visible = sanitizeAssistantVisibleText(canonical);
+  verifyProtectedRoles?.(visible);
+  return visible ? `${leadingWhitespace}${visible}${trailingWhitespace}` : "";
+}
+
+// SDK regions merge fenced, inline, indented, and unterminated code. Only a
+// closed fence on its own physical lines may preserve YAML role mapping keys.
+function isClosedFencedCodeRegion(text: string, region: CodeRegion): boolean {
+  const lineStart = text.lastIndexOf("\n", region.start - 1) + 1;
+  if (!/^ {0,3}$/.test(text.slice(lineStart, region.start))) {
+    return false;
+  }
+
+  const source = text.slice(region.start, region.end);
+  const openingFence = /^ {0,3}(`{3,}|~{3,})[^\r\n]*\r?\n/.exec(source)?.[1];
+  if (!openingFence) {
+    return false;
+  }
+
+  const closingFence = new RegExp(
+    `\r?\n {0,3}${openingFence[0]}{${openingFence.length},}[\t ]*(?:\r?\n)?$`,
   );
+  const lineEnd = text.indexOf("\n", region.end);
+  return (
+    closingFence.test(source) &&
+    /^[\t ]*\r?$/.test(text.slice(region.end, lineEnd < 0 ? text.length : lineEnd))
+  );
+}
+
+type OutboundFormattingRange = { start: number; length: number };
+
+type ProtectedOutboundText = {
+  text: string;
+  verifyProtectedRoles: (visible: string) => void;
+  sanitizeFormatted: <T extends OutboundFormattingRange>(formatted: {
+    text: string;
+    ranges: T[];
+  }) => { text: string; ranges: T[] };
+};
+
+/** Preserve authenticated fenced role mappings through the final native-render scrub. */
+export function protectIMessageFencedRoleMarkers(text: string): ProtectedOutboundText {
+  const source = stripIMessagePrivateRuntimeScaffolding(text);
+  const closedFencedRegions = findCodeRegions(source).filter((region) =>
+    isClosedFencedCodeRegion(source, region),
+  );
+  const protectedRoles = new Map<string, string>();
+  let privateUseCodePoint = PRIVATE_USE_START;
+
+  const protectedText = source.replace(
+    FENCED_ROLE_MARKER_RE,
+    (marker, role: string, offset: number) => {
+      if (!isInsideCode(offset, closedFencedRegions)) {
+        return marker;
+      }
+
+      while (privateUseCodePoint <= PRIVATE_USE_END) {
+        const protectedGlyph = String.fromCharCode(privateUseCodePoint++);
+        const token = protectedGlyph.repeat(role.length);
+        if (text.includes(protectedGlyph) || protectedRoles.has(token)) {
+          continue;
+        }
+        protectedRoles.set(token, role);
+        return marker.replace(role, token);
+      }
+      throw new Error("iMessage outbound role protection is unavailable");
+    },
+  );
+  const verifyProtectedRoles = (visible: string) => {
+    assertSafeIMessageOutboundMarkup(visible);
+    let previous = -1;
+    for (const token of protectedRoles.keys()) {
+      const first = visible.indexOf(token);
+      if (first < 0 || first < previous || visible.includes(token, first + token.length)) {
+        throw new Error("iMessage outbound role protection failed");
+      }
+      for (let offset = visible.indexOf(token[0] ?? ""); offset >= 0;) {
+        if (offset < first || offset >= first + token.length) {
+          throw new Error("iMessage outbound role protection failed");
+        }
+        offset = visible.indexOf(token[0] ?? "", offset + 1);
+      }
+      previous = first + token.length;
+    }
+  };
+
+  return {
+    text: protectedText,
+    verifyProtectedRoles,
+    sanitizeFormatted: <T extends OutboundFormattingRange>(formatted: {
+      text: string;
+      ranges: T[];
+    }): { text: string; ranges: T[] } => {
+      verifyProtectedRoles(formatted.text);
+
+      let visible = formatted.text;
+      let ranges = formatted.ranges;
+      for (let remainingPasses = visible.length; ; remainingPasses--) {
+        verifyProtectedRoles(visible);
+        const assistantVisible = sanitizeIMessageAssistantVisibleText(
+          visible,
+          verifyProtectedRoles,
+        );
+        const assistantTextChanged = assistantVisible !== visible;
+        if (assistantTextChanged) {
+          // SDK cleanup can insert separators, so stale attributed offsets must never reach imsg.
+          visible = assistantVisible;
+          ranges = [];
+          verifyProtectedRoles(visible);
+        }
+
+        const removed: Array<{ start: number; end: number }> = [];
+        const cleaned = visible.replace(FINAL_PRIVATE_MARKER_RE, (marker, offset: number) => {
+          removed.push({ start: offset, end: offset + marker.length });
+          return "";
+        });
+        if (removed.length > 0) {
+          const mapOffset = (offset: number) =>
+            offset -
+            removed.reduce(
+              (total, edit) => total + Math.max(0, Math.min(offset, edit.end) - edit.start),
+              0,
+            );
+          ranges = ranges.flatMap((range) => {
+            const start = mapOffset(range.start);
+            const length = mapOffset(range.start + range.length) - start;
+            return length > 0 ? [{ ...range, start, length }] : [];
+          });
+          visible = cleaned;
+          verifyProtectedRoles(visible);
+        }
+
+        if (removed.length === 0) {
+          // Nested fences can reveal one protected layer per render. Never mutate the raw wire
+          // payload; recursively inspect bounded projections until no hidden layer remains.
+          let projection = visible;
+          for (let depth = 0; ; depth += 1) {
+            verifyProtectedRoles(projection);
+            const renderedProjection = extractMarkdownFormatRuns(projection).text;
+            verifyProtectedRoles(renderedProjection);
+            const unwrappedProjection = stripMarkdown(renderedProjection);
+            verifyProtectedRoles(unwrappedProjection);
+            let htmlProjection = unwrappedProjection;
+            for (let htmlDepth = 0; ; htmlDepth += 1) {
+              verifyProtectedRoles(htmlProjection);
+              const assistantProjection = sanitizeIMessageAssistantVisibleText(
+                htmlProjection,
+                verifyProtectedRoles,
+              );
+              verifyProtectedRoles(assistantProjection);
+              if (assistantProjection !== htmlProjection) {
+                throw new Error("iMessage outbound hidden assistant content is not allowed");
+              }
+
+              const htmlRemoved = htmlProjection.replace(PLAIN_TEXT_HTML_TAG_RE, "");
+              verifyProtectedRoles(htmlRemoved);
+              if (htmlRemoved === htmlProjection) {
+                break;
+              }
+              if (htmlDepth + 1 >= MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES) {
+                throw new Error("iMessage outbound HTML security projection exceeded its limit");
+              }
+              htmlProjection = htmlRemoved;
+            }
+            if (unwrappedProjection === projection) {
+              break;
+            }
+            if (depth + 1 >= MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES) {
+              throw new Error("iMessage outbound Markdown security projection exceeded its limit");
+            }
+            projection = unwrappedProjection;
+          }
+          if (!assistantTextChanged) {
+            break;
+          }
+        }
+        if (remainingPasses <= 0) {
+          throw new Error("iMessage outbound role sanitization failed");
+        }
+      }
+      verifyProtectedRoles(visible);
+      for (const [token, role] of protectedRoles) {
+        visible = visible.replace(token, role);
+      }
+
+      return {
+        text: visible,
+        ranges,
+      };
+    },
+  };
+}
+
+/** Keep each transport's existing rendered or raw wire contract behind one final security gate. */
+export function sanitizeIMessageFinalOutboundText(
+  text: string,
+  options: { formatMarkdown?: boolean; protection?: ProtectedOutboundText } = {},
+) {
+  const protection = options.protection ?? protectIMessageFencedRoleMarkers(text);
+  const source = options.protection ? text : protection.text;
+  protection.verifyProtectedRoles(source);
+  const protectedText = sanitizeIMessageAssistantVisibleText(
+    source,
+    protection.verifyProtectedRoles,
+  );
+  protection.verifyProtectedRoles(protectedText);
+  const formatted =
+    options.formatMarkdown && protectedText.trim()
+      ? extractMarkdownFormatRuns(protectedText)
+      : { text: protectedText, ranges: [] };
+  return protection.sanitizeFormatted(formatted);
 }
 
 /**
@@ -38,11 +671,17 @@ export function sanitizeOutboundText(text: string): string {
     return text;
   }
 
-  let cleaned = sanitizeAssistantVisibleText(text);
+  let cleaned = sanitizeIMessageAssistantVisibleText(text);
 
-  cleaned = stripMarkerOutsideCode(cleaned, INTERNAL_SEPARATOR_RE);
-  cleaned = stripMarkerOutsideCode(cleaned, ASSISTANT_ROLE_MARKER_RE);
-  cleaned = stripMarkerOutsideCode(cleaned, ROLE_TURN_MARKER_RE);
+  cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
+  cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
+
+  const closedFencedRegions = findCodeRegions(cleaned).filter((region) =>
+    isClosedFencedCodeRegion(cleaned, region),
+  );
+  cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, (marker, offset: number) =>
+    isInsideCode(offset, closedFencedRegions) ? marker : "",
+  );
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -3,9 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IMessageRpcClient } from "./client.js";
+import {
+  sanitizeIMessageFinalOutboundText,
+  sanitizeOutboundText,
+} from "./monitor/sanitize-outbound.js";
 import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
 
 type ApprovalReactionsModule = typeof import("./approval-reactions.js");
@@ -100,6 +105,1202 @@ describe("sendMessageIMessage receipts", () => {
     fs.writeFileSync(sourcePath, contents);
     return sourcePath;
   }
+
+  it("scrubs private markers before delivering fenced YAML over real iMessage RPC", async () => {
+    const cliPath = openClawState.path("fake-imsg");
+    const requestLogPath = openClawState.path("fake-imsg-requests.jsonl");
+    const actionLogPath = openClawState.path("fake-imsg-actions.jsonl");
+    fs.writeFileSync(
+      cliPath,
+      [
+        "#!" + process.execPath,
+        'const fs = require("node:fs");',
+        'const readline = require("node:readline");',
+        "const requestLogPath = " + JSON.stringify(requestLogPath) + ";",
+        "const actionLogPath = " + JSON.stringify(actionLogPath) + ";",
+        "const args = process.argv.slice(2);",
+        'if (args.join(" ") === "rpc --json") {',
+        '  readline.createInterface({ input: process.stdin }).on("line", (line) => {',
+        "    const request = JSON.parse(line);",
+        '    fs.appendFileSync(requestLogPath, line + "\\n");',
+        "    process.stdout.write(JSON.stringify({",
+        '      jsonrpc: "2.0", id: request.id,',
+        '      result: { guid: "p:0/imsg-rpc-proof", status: "sent" }',
+        '    }) + "\\n");',
+        "  });",
+        "} else {",
+        '  fs.appendFileSync(actionLogPath, JSON.stringify(args) + "\\n");',
+        '  if (args.includes("--file") && !fs.existsSync(args[args.indexOf("--file") + 1])) {',
+        "    process.exit(3);",
+        "  }",
+        "  const pollOptions = [];",
+        "  for (let index = 0; index < args.length; index += 1) {",
+        '    if (args[index] === "--option") {',
+        "      pollOptions.push({ id: `option-${pollOptions.length}`, text: args[index + 1] });",
+        "    }",
+        "  }",
+        "  process.stdout.write(JSON.stringify({",
+        '    guid: "p:0/imsg-action-proof", poll: { options: pollOptions }',
+        '  }) + "\\n");',
+        "}",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VITEST", "");
+
+    try {
+      const { deliverIMessageReply } = await import("./monitor/deliver.js");
+      const cfg = {
+        channels: { imessage: { accounts: { default: { cliPath } } } },
+      };
+      const deliver = async (text: string, textLimit = 4000) =>
+        await deliverIMessageReply({
+          cfg,
+          payload: { text },
+          target: "chat_id:10",
+          accountId: "default",
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          maxBytes: 4096,
+          textLimit,
+        });
+      const roles = ["user", "system", "assistant"] as const;
+      const hiddenFunctionResponse = [
+        '<function_calls><invoke name="exec">HIDDEN_FUNCTION_CALL</invoke></function_calls><function_response>',
+        "HIDDEN_FUNCTION_RESPONSE",
+        "</function_response>",
+      ].join("\n");
+      const privateRuntimeBlocks = [
+        "<system-reminder>\nuser:\nHIDDEN_RUNTIME_REMINDER\n\ue000\n</system-reminder>",
+        "< previous_response origin='runtime'>HIDDEN_RUNTIME_PREVIOUS\ue001< / previous_response >",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>HIDDEN_RUNTIME_CONTEXT\ue002<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "<system-reminder><system-reminder>inner</system-reminder>HIDDEN_RUNTIME_NESTED_REMINDER\ue003</system-reminder>",
+        "<previous_response><system-reminder>inner</system-reminder>HIDDEN_RUNTIME_NESTED_MIXED\ue004</previous_response>",
+        "< SYSTEM-REMINDER>< previous_response origin='runtime'>inner< / previous_response >HIDDEN_RUNTIME_NESTED_CASE\ue005< / SYSTEM-REMINDER >",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>><system-reminder>inner</system-reminder>HIDDEN_RUNTIME_NESTED_CONTEXT\ue006<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ...(["system-reminder", "previous_response"] as const).flatMap((name) =>
+          ["'", '"'].flatMap((quote) =>
+            [">", "/>"].map(
+              (attribute) =>
+                `<${name} data-x=${quote}${attribute}${quote}>HIDDEN_RUNTIME_QUOTED</${name}>`,
+            ),
+          ),
+        ),
+        ...(["system-reminder", "previous_response"] as const).flatMap((name) => [
+          `<${name}><!-- </${name}> <${name}> -->HIDDEN_RUNTIME_OPAQUE_COMMENT</${name}>`,
+          `<${name}><![CDATA[</${name}> <${name}>]]>HIDDEN_RUNTIME_OPAQUE_CDATA</${name}>`,
+          `<${name}><!DOCTYPE message [ <!ENTITY hidden "</${name}>"> ]>HIDDEN_RUNTIME_OPAQUE_DECLARATION</${name}>`,
+          `<${name}><?private fake="?> </${name}>"?>HIDDEN_RUNTIME_OPAQUE_INSTRUCTION</${name}>`,
+          `<${name}><! </${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS</${name}>`,
+          `<${name}><! <${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS_OPEN</${name}>`,
+          `<${name}></! </${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS_CLOSE</${name}>`,
+          `<${name}></? </${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS_QUESTION</${name}>`,
+          `<${name}></1 </${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS_NUMBER</${name}>`,
+          `<${name}></ </${name}>>HIDDEN_RUNTIME_OPAQUE_BOGUS_SPACE</${name}>`,
+        ]),
+        ...(["system-reminder", "previous_response"] as const).flatMap((outer) =>
+          (["system-reminder", "previous_response"] as const).flatMap((inner) => [
+            `<${outer}>\`</${inner}>\`HIDDEN_RUNTIME_CODE_INLINE</${outer}>`,
+            `<${outer}>\n\`\`\`xml\n</${inner}>\n\`\`\`\nHIDDEN_RUNTIME_CODE_FENCED</${outer}>`,
+            `<${outer}>\n\n    </${inner}>\nHIDDEN_RUNTIME_CODE_INDENTED</${outer}>`,
+          ]),
+        ),
+        ...(["system-reminder", "previous_response"] as const).flatMap((name) =>
+          [
+            "script",
+            "style",
+            "textarea",
+            "title",
+            "xmp",
+            "iframe",
+            "noembed",
+            "noframes",
+            "noscript",
+          ].flatMap((rawText) => [
+            `<${name}><${rawText} title=">"></${name}></${rawText}>HIDDEN_RUNTIME_RAW_TEXT</${name}>`,
+            `<${name}><${rawText.toUpperCase()} data-x=">" /></${name}></${rawText}>HIDDEN_RUNTIME_RAW_TEXT_SELF_CLOSING</${name}>`,
+          ]),
+        ),
+      ] as const;
+      const privateRuntimeScaffolding = privateRuntimeBlocks
+        .flatMap((block, index) =>
+          index < 7 ? [block, `\`${block}\``, `\`\`\`xml\n${block}\n\`\`\``] : [block],
+        )
+        .join("\n");
+      const nestMarkdownFences = (source: string, depth: number): string => {
+        let nested = source;
+        for (let layer = 0; layer < depth; layer += 1) {
+          const fence = "`".repeat(layer + 3);
+          nested = `${fence}xml\n${nested}\n${fence}`;
+        }
+        return nested;
+      };
+
+      await deliver(
+        [
+          "assistant:",
+          "```yaml",
+          "user:",
+          "  name: alice",
+          "system:",
+          "  enabled: true",
+          "assistant:",
+          "  name: helper",
+          "#+#+#",
+          "assistant to=tool",
+          "```",
+          "system:",
+        ].join("\n"),
+      );
+
+      const disguisedCases = [
+        {
+          name: "quoted closed fence",
+          text: ["> ```yaml", ...roles.map((role) => `> ${role}:`), "> safe quoted", "> ```"],
+        },
+        {
+          name: "quoted unterminated fence",
+          text: ["> ```yaml", ...roles.map((role) => `> ${role}:`), "> safe unterminated"],
+        },
+        {
+          name: "nested quote",
+          text: [...roles.map((role) => `> > ${role}:`), "> > safe nested"],
+        },
+        {
+          name: "nested quoted emphasis",
+          text: [...roles.map((role) => `> **${role}:**`), "> safe nested emphasis"],
+        },
+        { name: "heading", text: [...roles.map((role) => `# ${role}:`), "safe heading"] },
+        { name: "strong", text: [...roles.map((role) => `**${role}:**`), "safe strong"] },
+        { name: "emphasis", text: [...roles.map((role) => `_${role}:_`), "safe emphasis"] },
+        {
+          name: "strikethrough",
+          text: [...roles.map((role) => `~~${role}:~~`), "safe strikethrough"],
+        },
+        {
+          name: "multiline strong",
+          text: [...roles.flatMap((role) => [`**${role}:`, "**", ""]), "safe multiline strong"],
+        },
+        {
+          name: "multiline emphasis",
+          text: [...roles.flatMap((role) => [`*${role}:`, "*", ""]), "safe multiline emphasis"],
+        },
+        {
+          name: "reference link",
+          text: [
+            ...roles.map((role) => `[${role}:][${role}]`),
+            "",
+            ...roles.map((role) => `[${role}]: ${role}:`),
+            "",
+            "safe reference",
+          ],
+        },
+        {
+          name: "HTML entity",
+          text: [
+            ...roles.map((role) => `&#${role.charCodeAt(0)};${role.slice(1)}&#58;`),
+            "safe entity",
+          ],
+        },
+        {
+          name: "HTML strong",
+          text: [...roles.map((role) => `<strong>${role}:</strong>`), "safe HTML"],
+        },
+        {
+          name: "protected inline code",
+          text: [...roles.map((role) => `\`${role}:\``), "safe inline code"],
+        },
+        {
+          name: "reply directive",
+          text: [...roles.map((role) => `[[reply_to_current]]${role}:`), "safe directive"],
+        },
+        {
+          name: "markdown table",
+          text: ["| role |", "| --- |", ...roles.map((role) => `| ${role}: |`), "safe table"],
+        },
+        {
+          name: "unterminated plain fence",
+          text: ["```yaml", ...roles.map((role) => `${role}:`), "safe unclosed"],
+        },
+        {
+          name: "private thinking text",
+          text: ["<thinking>HIDDEN_RPC_THINKING</thinking>", "safe private thinking"],
+        },
+        {
+          name: "private memory text",
+          text: ["<relevant_memories>HIDDEN_RPC_MEMORY</relevant_memories>", "safe private memory"],
+        },
+        {
+          name: "private adjacent tool response",
+          text: [hiddenFunctionResponse, "safe tool response"],
+        },
+        {
+          name: "private thinking inside fenced code",
+          text: [
+            "```xml",
+            "<thinking>HIDDEN_RPC_FENCED_THINKING</thinking>",
+            "```",
+            "safe fenced thinking",
+          ],
+        },
+        {
+          name: "private memory inside fenced code",
+          text: [
+            "```xml",
+            "<relevant-memories>HIDDEN_RPC_FENCED_MEMORY</relevant-memories>",
+            "```",
+            "safe fenced memory",
+          ],
+        },
+      ];
+      for (const testCase of disguisedCases) {
+        await deliver(testCase.text.join("\n"));
+      }
+
+      await sendMessageIMessage(
+        "chat_id:10",
+        ["# assistant:", "**😀 styled**", "#+#+#", "assistant to=tool"].join("\n"),
+        { config: cfg },
+      );
+
+      const { imessagePlugin } = await import("./channel.js");
+      const channelChunker = imessagePlugin.outbound?.chunker;
+      const channelSanitizer = imessagePlugin.outbound?.sanitizeText;
+      if (!channelChunker || !channelSanitizer) {
+        throw new Error("Expected the iMessage outbound Markdown sanitizer and chunker");
+      }
+      expect(imessagePlugin.outbound?.chunkerMode).toBe("markdown");
+
+      const countNativeRequests = () =>
+        fs.readFileSync(requestLogPath, "utf8").trim().split("\n").length;
+      const deliverThroughChannel = async (source: string, limit = 4000) => {
+        const sanitized = channelSanitizer({ text: source, payload: { text: source } });
+        const chunks = channelChunker(sanitized, limit);
+        for (const chunk of chunks) {
+          await sendMessageIMessage("chat_id:10", chunk, { config: cfg });
+        }
+        return { sanitized, chunks };
+      };
+
+      const channelYaml = ["```yaml", ...roles.map((role) => `${role}:`), "```"].join("\n");
+      const channelYamlResult = await deliverThroughChannel(channelYaml);
+      expect(channelYamlResult.sanitized).toContain("```yaml");
+      const channelYamlRequest = JSON.parse(
+        fs.readFileSync(requestLogPath, "utf8").trim().split("\n").at(-1) ?? "{}",
+      ) as { params?: { text?: string } };
+      for (const role of roles) {
+        expect(channelYamlRequest.params?.text).toMatch(new RegExp(`^${role}:$`, "m"));
+      }
+
+      let channelContractRequestCount = 1;
+      for (const [html, bold, strike] of [
+        [
+          `<strong title="b>">😀 channel bold</strong> <del data-note='s>'>channel strike</del>`,
+          "😀 channel bold",
+          "channel strike",
+        ],
+        [
+          `<strong title="<tag>">😀 quoted bold</strong> <del data-note='<tag>'>quoted strike</del>`,
+          "😀 quoted bold",
+          "quoted strike",
+        ],
+        [
+          `<strong title="<previous_response>">😀 private-looking bold</strong> <del data-note='<system-reminder>'>private-looking strike</del>`,
+          "😀 private-looking bold",
+          "private-looking strike",
+        ],
+        [
+          `<strong title="<!--">😀 opaque-looking bold</strong> <del data-note='<?'>opaque-looking strike</del>`,
+          "😀 opaque-looking bold",
+          "opaque-looking strike",
+        ],
+      ] as const) {
+        const attributedHtml = await deliverThroughChannel(html);
+        expect(attributedHtml.sanitized).toBe(`**${bold}** ~~${strike}~~`);
+        const attributedRequest = JSON.parse(
+          fs.readFileSync(requestLogPath, "utf8").trim().split("\n").at(-1) ?? "{}",
+        ) as {
+          params?: {
+            text: string;
+            formatting?: Array<{ start: number; length: number; styles: string[] }>;
+          };
+        };
+        for (const [style, expected] of [
+          ["bold", bold],
+          ["strikethrough", strike],
+        ] as const) {
+          const range = attributedRequest.params?.formatting?.find((item) =>
+            item.styles.includes(style),
+          );
+          expect(
+            attributedRequest.params?.text.slice(
+              range?.start,
+              (range?.start ?? 0) + (range?.length ?? 0),
+            ),
+          ).toBe(expected);
+        }
+        channelContractRequestCount += attributedHtml.chunks.length;
+      }
+
+      for (const source of [
+        "if(a<b && c<d)",
+        "std::vector<std::vector<int>>",
+        "t<int>",
+        "```cpp\nif(a<b && c<d)\nstd::vector<std::vector<int>>\n```",
+        "ordinary <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>> marker mention",
+        "ordinary <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>opaque prose<<<END_OPENCLAW_INTERNAL_CONTEXT>>> remains safe",
+      ]) {
+        // Unknown generic tags already follow the shared renderer's shipped stripping semantics.
+        const baseline = sanitizeForPlainText(sanitizeOutboundText(source), { style: "markdown" });
+        const delivered = await deliverThroughChannel(source);
+        expect(delivered.sanitized).toBe(baseline);
+        const request = JSON.parse(
+          fs.readFileSync(requestLogPath, "utf8").trim().split("\n").at(-1) ?? "{}",
+        ) as { params?: { text?: string } };
+        expect(request.params?.text).toBe(
+          sanitizeIMessageFinalOutboundText(baseline, { formatMarkdown: true }).text,
+        );
+        channelContractRequestCount += delivered.chunks.length;
+      }
+
+      const runtimeCompanion = `${privateRuntimeScaffolding}\nvisible runtime companion`;
+      for (const sendPrivateRuntime of [
+        () => sendMessageIMessage("chat_id:10", runtimeCompanion, { config: cfg }),
+        () => deliver(runtimeCompanion),
+        () => deliverThroughChannel(runtimeCompanion),
+      ]) {
+        const previousRequestCount = countNativeRequests();
+        await sendPrivateRuntime();
+        const runtimeRequests = fs
+          .readFileSync(requestLogPath, "utf8")
+          .trim()
+          .split("\n")
+          .slice(previousRequestCount)
+          .map((line) => JSON.parse(line) as { params?: { text?: string } });
+        expect(runtimeRequests.length).toBeGreaterThan(0);
+        expect(
+          runtimeRequests.some((request) =>
+            request.params?.text?.includes("visible runtime companion"),
+          ),
+        ).toBe(true);
+        for (const request of runtimeRequests) {
+          expect(request.params?.text).not.toContain("HIDDEN_RUNTIME_");
+          expect(request.params?.text).not.toMatch(
+            /system-reminder|previous_response|INTERNAL_CONTEXT/i,
+          );
+        }
+        channelContractRequestCount += runtimeRequests.length;
+      }
+
+      for (const hidden of [
+        "```xml\n<thinking>HIDDEN_CHANNEL_FENCED_THINKING</thinking>\n```",
+        "`<thinking>HIDDEN_CHANNEL_INLINE_THINKING</thinking>`",
+        "```xml\n<relevant_memories>HIDDEN_CHANNEL_FENCED_MEMORY</relevant_memories>\n```",
+        "`<relevant-memories>HIDDEN_CHANNEL_INLINE_MEMORY</relevant-memories>`",
+        nestMarkdownFences("<thinking>HIDDEN_CHANNEL_DEEPLY_NESTED_THINKING</thinking>", 4),
+        nestMarkdownFences(
+          "<relevant_memories>HIDDEN_CHANNEL_DEEPLY_NESTED_MEMORY</relevant_memories>",
+          4,
+        ),
+        `\`\`\`xml\n${hiddenFunctionResponse}\n\`\`\``,
+        nestMarkdownFences(hiddenFunctionResponse, 4),
+      ]) {
+        const requestCount = countNativeRequests();
+        await expect(deliverThroughChannel(`${hidden}\nsafe channel text`)).rejects.toThrow(
+          "iMessage outbound hidden assistant content is not allowed",
+        );
+        expect(countNativeRequests()).toBe(requestCount);
+      }
+      const malformedHiddenFunctionResponse = [
+        '<<script>function_calls><<script>invoke name="exec">HIDDEN_CHANNEL_SYNTH_FUNCTION_CALL</<script>invoke></<script>function_calls><<script>function_response>',
+        "HIDDEN_CHANNEL_SYNTH_FUNCTION_RESPONSE",
+        "</<script>function_response>",
+      ].join("\n");
+      for (const malformed of [
+        "<<script>thinking>HIDDEN_CHANNEL_SYNTH_THINKING</<script>thinking>",
+        "<t<script>hinking>HIDDEN_CHANNEL_INNER_THINKING</t<script>hinking>",
+        "<<script>relevant_memories>HIDDEN_CHANNEL_SYNTH_MEMORY</<script>relevant_memories>",
+        "<<script>relevant-memories>HIDDEN_CHANNEL_SYNTH_HYPHEN_MEMORY</<script>relevant-memories>",
+        "<thi<system-reminder>noise</system-reminder>nking>HIDDEN_CHANNEL_REMINDER_THINKING</thi<system-reminder>noise</system-reminder>nking>",
+        "<relevant_<previous_response>noise</previous_response>memories>HIDDEN_CHANNEL_PREVIOUS_MEMORY</relevant_<previous_response>noise</previous_response>memories>",
+        "<thi<details><summary>noise</summary></details>nking>HIDDEN_CHANNEL_DETAILS_THINKING</thi<details>nking>",
+        malformedHiddenFunctionResponse,
+      ]) {
+        const requestCount = countNativeRequests();
+        await expect(deliverThroughChannel(`${malformed}\nsafe channel text`)).rejects.toThrow(
+          "iMessage outbound ambiguous nested HTML is not allowed",
+        );
+        expect(countNativeRequests()).toBe(requestCount);
+      }
+      for (const [context, splice] of [
+        ["script", "<script>"],
+        ["system-reminder", "<system-reminder>noise</system-reminder>"],
+        ["spaced_system_reminder", "< system-reminder>noise< / system-reminder>"],
+        ["previous_response", "<previous_response>noise</previous_response>"],
+        ["spaced_previous_response", "< previous_response>noise< / previous_response>"],
+        ["details", "<details><summary>noise</summary></details>"],
+        ["spaced_details", "< details>< summary>noise< / summary>< / details>"],
+        [
+          "runtime_context",
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ],
+      ] as const) {
+        for (const [kind, malformed] of [
+          ["thinking", `<thi${splice}nking>HIDDEN_CHANNEL_${context}_THINKING</thi${splice}nking>`],
+          [
+            "underscore memory",
+            `<relevant_${splice}memories>HIDDEN_CHANNEL_${context}_MEMORY</relevant_${splice}memories>`,
+          ],
+          [
+            "hyphen memory",
+            `<relevant-${splice}memories>HIDDEN_CHANNEL_${context}_MEMORY</relevant-${splice}memories>`,
+          ],
+          [
+            "tool response",
+            [
+              `<function_${splice}calls><invoke>HIDDEN_CHANNEL_${context}_CALL</invoke></function_${splice}calls>`,
+              `<function_${splice}response>HIDDEN_CHANNEL_${context}_RESPONSE</function_${splice}response>`,
+            ].join("\n"),
+          ],
+        ] as const) {
+          for (const wrapper of [
+            malformed,
+            `\`${malformed}\``,
+            `\`\`\`xml\n${malformed}\n\`\`\``,
+          ]) {
+            const requestCount = countNativeRequests();
+            await expect(
+              deliverThroughChannel(`${wrapper}\nsafe ${kind} ${context}`),
+            ).rejects.toThrow("iMessage outbound ambiguous nested HTML is not allowed");
+            expect(countNativeRequests()).toBe(requestCount);
+          }
+        }
+      }
+
+      for (const splice of [
+        "< system-reminder>noise< / system-reminder>",
+        "< previous_response>noise< / previous_response>",
+        "< details>< summary>noise< / summary>< / details>",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>noise<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ]) {
+        for (const name of [
+          "thinking",
+          "thought",
+          "reasoning",
+          "antml:thinking",
+          "mm:thought",
+          "relevant_memories",
+          "relevant-memories",
+          "function_calls",
+          "function_response",
+          "tool_calls",
+          "tool_result",
+        ]) {
+          const malformed = `<${name}${splice}>HIDDEN_FULL_CHANNEL_${name}</${name}${splice}>`;
+          const requestCount = countNativeRequests();
+          await expect(deliverThroughChannel(malformed)).rejects.toThrow(
+            "iMessage outbound ambiguous nested HTML is not allowed",
+          );
+          expect(countNativeRequests()).toBe(requestCount);
+        }
+      }
+
+      const rawSeparator = "#+#+#";
+      const entitySeparator = "&#35;&#43;&#35;&#43;&#35;";
+      let embeddedRequestCount = 0;
+      for (const separator of [rawSeparator, entitySeparator]) {
+        for (const role of roles) {
+          const injectedRole = `${role.slice(0, 2)}${separator}${role.slice(2)}:`;
+          const candidate = [injectedRole, `safe ${role}`].join("\n");
+
+          await sendMessageIMessage("chat_id:10", candidate, { config: cfg });
+          await deliver(candidate);
+          const sanitized = channelSanitizer({ text: candidate, payload: { text: candidate } });
+          for (const chunk of channelChunker(sanitized, 4000)) {
+            await sendMessageIMessage("chat_id:10", chunk, { config: cfg });
+            embeddedRequestCount += 1;
+          }
+          embeddedRequestCount += 2;
+        }
+      }
+
+      const oversizedYaml = [
+        "```yaml",
+        ...Array.from({ length: 6 }, (_, index) =>
+          roles.flatMap((role) => [`${role}:`, `  value: ${role}-${index}-${"x".repeat(24)}`]),
+        ).flat(),
+        "```",
+      ].join("\n");
+      const fixedRequestCount = fs.readFileSync(requestLogPath, "utf8").trim().split("\n").length;
+      await deliver(oversizedYaml, 110);
+      const monitorRequestCount =
+        fs.readFileSync(requestLogPath, "utf8").trim().split("\n").length - fixedRequestCount;
+
+      const sanitizedOversizedYaml = channelSanitizer({
+        text: oversizedYaml,
+        payload: { text: oversizedYaml },
+      });
+      const channelChunks = channelChunker(sanitizedOversizedYaml, 110);
+      expect(channelChunks.length).toBeGreaterThan(1);
+      for (const chunk of channelChunks) {
+        await sendMessageIMessage("chat_id:10", chunk, { config: cfg });
+      }
+
+      const readRequests = () =>
+        fs
+          .readFileSync(requestLogPath, "utf8")
+          .trim()
+          .split("\n")
+          .map(
+            (line) =>
+              JSON.parse(line) as {
+                method: string;
+                params: {
+                  text: string;
+                  formatting?: Array<{ start: number; length: number; styles: string[] }>;
+                };
+              },
+          );
+      const requests = readRequests();
+      const expectedFixedRequestCount =
+        1 + disguisedCases.length + 1 + channelContractRequestCount + embeddedRequestCount;
+      expect(fixedRequestCount).toBe(expectedFixedRequestCount);
+      const monitorRequests = requests.slice(
+        expectedFixedRequestCount,
+        expectedFixedRequestCount + monitorRequestCount,
+      );
+      const channelRequests = requests.slice(expectedFixedRequestCount + monitorRequestCount);
+
+      expect(requests[0]).toMatchObject({
+        jsonrpc: "2.0",
+        method: "send",
+        params: { chat_id: 10 },
+      });
+      for (const role of roles) {
+        expect(requests[0]?.params.text).toMatch(new RegExp(`^${role}:$`, "m"));
+      }
+      for (const chunkRequests of [monitorRequests, channelRequests]) {
+        expect(chunkRequests.length).toBeGreaterThan(1);
+        for (const role of roles) {
+          expect(
+            chunkRequests.some((request) =>
+              new RegExp(`^${role}:$`, "m").test(request.params.text),
+            ),
+          ).toBe(true);
+        }
+      }
+      const channelYamlRequestIndex = 1 + disguisedCases.length + 1;
+      for (const [index, request] of requests.slice(1, expectedFixedRequestCount).entries()) {
+        // This channel request is authenticated closed-fence YAML, not leaked prose role headers.
+        if (index + 1 !== channelYamlRequestIndex) {
+          expect(request.params.text).not.toMatch(/^[ \t]*(?:user|system|assistant):[ \t]*$/gim);
+        }
+      }
+      for (const request of requests) {
+        expect(request.params.text).not.toContain("#+#+#");
+        expect(request.params.text).not.toContain("HIDDEN_RPC_");
+        expect(request.params.text).not.toContain("HIDDEN_FUNCTION_");
+        expect(request.params.text).not.toContain("HIDDEN_RUNTIME_");
+        expect(request.params.text).not.toMatch(
+          /system-reminder|previous_response|INTERNAL_CONTEXT/i,
+        );
+        expect(request.params.text).not.toMatch(/<(?:thinking|relevant[-_]memories)\b/i);
+        expect(request.params.text).not.toMatch(/assistant\s+to\s*=\s*\w+/i);
+        expect(request.params.text).not.toMatch(/[\ue000-\uf8ff]/);
+        for (const range of request.params.formatting ?? []) {
+          expect(range.start).toBeGreaterThanOrEqual(0);
+          expect(range.start + range.length).toBeLessThanOrEqual(request.params.text.length);
+        }
+      }
+      const styled = requests[1 + disguisedCases.length];
+      const boldRange = styled?.params.formatting?.find((range) => range.styles.includes("bold"));
+      expect(
+        styled?.params.text.slice(
+          boldRange?.start,
+          (boldRange?.start ?? 0) + (boldRange?.length ?? 0),
+        ),
+      ).toBe("😀 styled");
+
+      const { imessageActionsRuntime } = await import("./actions.runtime.js");
+      const actionOptions = { cliPath, chatGuid: "iMessage;+;chat0000" };
+      const fencedYaml = ["```yaml", ...roles.map((role) => `${role}:`), "```"].join("\n");
+      await imessageActionsRuntime.sendRichMessage({
+        chatGuid: actionOptions.chatGuid,
+        text: [
+          "# user:",
+          "**system:**",
+          "&#97;ssistant&#58;",
+          `us${rawSeparator}er:`,
+          "<thinking>HIDDEN_ACTION_REPLY_THINKING</thinking>",
+          hiddenFunctionResponse,
+          privateRuntimeScaffolding,
+          "**😀 reply styled**",
+          "assistant to=tool",
+        ].join("\n"),
+        replyToMessageId: "reply-message-guid",
+        options: actionOptions,
+      });
+      await imessageActionsRuntime.sendRichMessage({
+        chatGuid: actionOptions.chatGuid,
+        text: [
+          "# system:",
+          "<relevant_memories>HIDDEN_ACTION_EFFECT_MEMORY</relevant_memories>",
+          hiddenFunctionResponse,
+          privateRuntimeScaffolding,
+          "effect visible",
+          "assistant to=tool",
+        ].join("\n"),
+        effectId: "com.apple.MobileSMS.expressivesend.loud",
+        options: actionOptions,
+      });
+      await imessageActionsRuntime.sendRichMessage({
+        chatGuid: actionOptions.chatGuid,
+        text: [
+          fencedYaml,
+          "```xml",
+          "<thinking>HIDDEN_ACTION_ATTACHMENT_THINKING</thinking>",
+          "<relevant_memories>HIDDEN_ACTION_ATTACHMENT_MEMORY</relevant_memories>",
+          "```",
+          privateRuntimeScaffolding,
+          "**😀 attachment styled**",
+          rawSeparator,
+        ].join("\n"),
+        attachment: { kind: "buffer", filename: "proof.txt", buffer: Uint8Array.from([1, 2]) },
+        options: actionOptions,
+      });
+      await imessageActionsRuntime.sendRichMessage({
+        chatGuid: actionOptions.chatGuid,
+        text: "user:",
+        attachment: { kind: "buffer", filename: "empty-proof.txt", buffer: Uint8Array.from([3]) },
+        options: actionOptions,
+      });
+
+      const rawNewText = [
+        "user:",
+        "**literal edit styling**",
+        "<thinking>HIDDEN_ACTION_EDIT_THINKING</thinking>",
+        hiddenFunctionResponse,
+        privateRuntimeScaffolding,
+        "# system:",
+        `as${rawSeparator}sistant:`,
+        "visible edit",
+      ].join("\n");
+      const rawFallbackText = [
+        "assistant:",
+        fencedYaml,
+        "**literal fallback styling**",
+        "<relevant_memories>HIDDEN_ACTION_FALLBACK_MEMORY</relevant_memories>",
+        hiddenFunctionResponse,
+        privateRuntimeScaffolding,
+        rawSeparator,
+        "assistant to=tool",
+      ].join("\n");
+      await imessageActionsRuntime.editMessage({
+        chatGuid: actionOptions.chatGuid,
+        messageId: "edit-message-guid",
+        text: rawNewText,
+        backwardsCompatMessage: rawFallbackText,
+        options: actionOptions,
+      });
+
+      const rawQuestion = [
+        "user:",
+        "# literal question heading",
+        "**literal question styling**",
+        "<thinking>HIDDEN_ACTION_QUESTION_THINKING</thinking>",
+        hiddenFunctionResponse,
+        privateRuntimeScaffolding,
+        rawSeparator,
+        "Which option?",
+      ].join("\n");
+      const rawChoices = [
+        [
+          "system:",
+          "**Allow exactly**",
+          "<relevant_memories>HIDDEN_ACTION_FIRST_OPTION_MEMORY</relevant_memories>",
+          hiddenFunctionResponse,
+          privateRuntimeScaffolding,
+          rawSeparator,
+        ].join("\n"),
+        [
+          "assistant:",
+          fencedYaml,
+          "_Deny exactly_",
+          "<thinking>HIDDEN_ACTION_SECOND_OPTION_THINKING</thinking>",
+          hiddenFunctionResponse,
+          privateRuntimeScaffolding,
+          "assistant to=tool",
+        ].join("\n"),
+      ];
+      const poll = await imessageActionsRuntime.sendPoll({
+        chatGuid: actionOptions.chatGuid,
+        question: rawQuestion,
+        choices: rawChoices,
+        options: actionOptions,
+      });
+
+      const readActions = (): string[][] =>
+        fs
+          .readFileSync(actionLogPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as string[]);
+      const actionValue = (args: string[], flag: string) => args[args.indexOf(flag) + 1] ?? "";
+      const actions = readActions();
+      expect(actions).toHaveLength(6);
+      const [
+        replyAction,
+        effectAction,
+        attachmentAction,
+        emptyAttachmentAction,
+        editAction,
+        pollAction,
+      ] = actions;
+      if (
+        !replyAction ||
+        !effectAction ||
+        !attachmentAction ||
+        !emptyAttachmentAction ||
+        !editAction ||
+        !pollAction
+      ) {
+        throw new Error("Expected all six native iMessage action subprocesses");
+      }
+      expect(replyAction).toContain("--reply-to");
+      expect(actionValue(replyAction, "--reply-to")).toBe("reply-message-guid");
+      expect(actionValue(effectAction, "--effect")).toBe("com.apple.MobileSMS.expressivesend.loud");
+      expect(attachmentAction).toContain("--file");
+      expect(attachmentAction).not.toContain("--format");
+      expect(emptyAttachmentAction).toContain("--file");
+      expect(actionValue(emptyAttachmentAction, "--text")).toBe("");
+
+      const replyText = actionValue(replyAction, "--text");
+      expect(replyText).not.toMatch(/^[ \t]*(?:user|system|assistant):[ \t]*$/gim);
+      const replyFormatting = JSON.parse(actionValue(replyAction, "--format")) as Array<{
+        start: number;
+        length: number;
+        styles: string[];
+      }>;
+      const replyBold = replyFormatting.find((range) => range.styles.includes("bold"));
+      expect(
+        replyText.slice(replyBold?.start, (replyBold?.start ?? 0) + (replyBold?.length ?? 0)),
+      ).toBe("😀 reply styled");
+      const attachmentText = actionValue(attachmentAction, "--text");
+      for (const role of roles) {
+        expect(attachmentText).toMatch(new RegExp(`^${role}:$`, "m"));
+      }
+
+      const editedText = actionValue(editAction, "--new-text");
+      const backwardsCompatText = actionValue(editAction, "--bc-text");
+      expect(editedText).toContain("**literal edit styling**");
+      expect(editedText).toContain("# system:");
+      expect(editedText).not.toMatch(/^[ \t]*(?:user|system|assistant):[ \t]*$/gim);
+      expect(backwardsCompatText).toContain(fencedYaml);
+      expect(backwardsCompatText).toContain("**literal fallback styling**");
+
+      const question = actionValue(pollAction, "--question");
+      const pollChoices = pollAction.flatMap((arg, index) =>
+        arg === "--option" ? [pollAction[index + 1] ?? ""] : [],
+      );
+      expect(question).toContain("# literal question heading");
+      expect(question).toContain("**literal question styling**");
+      expect(pollChoices[0]).toContain("**Allow exactly**");
+      expect(pollChoices[1]).toContain(fencedYaml);
+      expect(pollChoices[1]).toContain("_Deny exactly_");
+      expect(poll.pollOptions.map((option) => option.text)).toEqual(
+        pollChoices.map((choice) => choice.trim()),
+      );
+
+      for (const args of actions) {
+        for (const flag of ["--text", "--new-text", "--bc-text", "--question", "--option"]) {
+          for (let index = 0; index < args.length; index += 1) {
+            if (args[index] !== flag) {
+              continue;
+            }
+            const value = args[index + 1] ?? "";
+            expect(value).not.toContain(rawSeparator);
+            expect(value).not.toContain("HIDDEN_ACTION_");
+            expect(value).not.toContain("HIDDEN_FUNCTION_");
+            expect(value).not.toContain("HIDDEN_RUNTIME_");
+            expect(value).not.toMatch(/system-reminder|previous_response|INTERNAL_CONTEXT/i);
+            expect(value).not.toMatch(/<(?:thinking|relevant[-_]memories)\b/i);
+            expect(value).not.toMatch(/assistant\s+to\s*=\s*\w+/i);
+            expect(value).not.toMatch(/[\ue000-\uf8ff]/);
+          }
+        }
+      }
+
+      const forgedTokenEntity = "&#xE000;".repeat("user".length);
+      const roleTokenSwap = [
+        "```xml",
+        "<thinking>",
+        "user:",
+        "</thinking>",
+        "```",
+        "&#xE000;&#xE000;&lt;relevant_memories&gt;HIDDEN_ROLE_SWAP&lt;/relevant_memories&gt;&#xE000;&#xE000;:",
+      ].join("\n");
+      for (const malformed of [
+        "<system-reminder><system-reminder>inner</system-reminder>OUTER_PRIVATE_SECRET",
+        "<system-reminder><previous_response>inner</previous_response>OUTER_PRIVATE_SECRET",
+        "<previous_response><system-reminder />OUTER_PRIVATE_SECRET",
+        "<system-reminder>`</system-reminder>`OUTER_PRIVATE_SECRET",
+        "<system-reminder>`prefix </system-reminder> suffix`OUTER_PRIVATE_SECRET",
+        "<system-reminder>``prefix </system-reminder> suffix``OUTER_PRIVATE_SECRET",
+        "<system-reminder>`prefix </previous_response> suffix`OUTER_PRIVATE_SECRET",
+        "<previous_response>```xml\n</system-reminder>\n```\nOUTER_PRIVATE_SECRET",
+        "<system-reminder><plaintext></system-reminder>OUTER_PRIVATE_SECRET",
+        "<previous_response><plaintext></previous_response>OUTER_PRIVATE_SECRET",
+        "<system-reminder><PLAINTEXT /></system-reminder>OUTER_PRIVATE_SECRET",
+        "<previous_response><PLAINTEXT /></previous_response>OUTER_PRIVATE_SECRET",
+        "<system-reminder data-x=<previous_response>>OUTER_PRIVATE_SECRET",
+        "<system-reminder <previous_response>>OUTER_PRIVATE_SECRET",
+        "<previous_response data-x=<system-reminder>>OUTER_PRIVATE_SECRET",
+        "</previous_response data-x=<system-reminder>>OUTER_PRIVATE_SECRET",
+      ]) {
+        for (const [wrapper, source] of [
+          ["raw", malformed],
+          ["inline", `\`${malformed}\``],
+          ["fenced", `\`\`\`xml\n${malformed}\n\`\`\``],
+          ["wide-fenced", `\`\`\`\`xml\n${malformed}\n\`\`\`\``],
+        ] as const) {
+          const previousActionCount = readActions().length;
+          const previousRequestCount = readRequests().length;
+          for (const [route, sendMalformed] of [
+            ["rpc", () => sendMessageIMessage("chat_id:10", source, { config: cfg })],
+            ["monitor", () => deliver(source)],
+            ["channel", () => deliverThroughChannel(source)],
+            [
+              "rich",
+              () =>
+                imessageActionsRuntime.sendRichMessage({
+                  chatGuid: actionOptions.chatGuid,
+                  text: source,
+                  options: actionOptions,
+                }),
+            ],
+            [
+              "edit",
+              () =>
+                imessageActionsRuntime.editMessage({
+                  chatGuid: actionOptions.chatGuid,
+                  messageId: "edit-message-guid",
+                  text: source,
+                  backwardsCompatMessage: "visible fallback",
+                  options: actionOptions,
+                }),
+            ],
+            [
+              "edit-fallback",
+              () =>
+                imessageActionsRuntime.editMessage({
+                  chatGuid: actionOptions.chatGuid,
+                  messageId: "edit-message-guid",
+                  text: "visible edit",
+                  backwardsCompatMessage: source,
+                  options: actionOptions,
+                }),
+            ],
+            [
+              "poll-question",
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: source,
+                  choices: ["first", "second"],
+                  options: actionOptions,
+                }),
+            ],
+            [
+              "poll-first-option",
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: "visible question",
+                  choices: [source, "second"],
+                  options: actionOptions,
+                }),
+            ],
+            [
+              "poll-second-option",
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: "visible question",
+                  choices: ["first", source],
+                  options: actionOptions,
+                }),
+            ],
+          ] as const) {
+            await expect(
+              sendMalformed(),
+              JSON.stringify({ malformed, wrapper, route }),
+            ).rejects.toThrow("iMessage outbound runtime scaffolding is malformed");
+          }
+          expect(readActions()).toHaveLength(previousActionCount);
+          expect(readRequests()).toHaveLength(previousRequestCount);
+        }
+      }
+      for (const hidden of privateRuntimeBlocks) {
+        const previousActionCount = readActions().length;
+        const previousRequestCount = readRequests().length;
+        await expect(sendMessageIMessage("chat_id:10", hidden, { config: cfg })).rejects.toThrow(
+          "iMessage send requires text or media",
+        );
+        await expect(
+          imessageActionsRuntime.sendRichMessage({
+            chatGuid: actionOptions.chatGuid,
+            text: hidden,
+            options: actionOptions,
+          }),
+        ).rejects.toThrow("iMessage rich send requires text or an attachment after sanitization");
+        for (const [text, backwardsCompatMessage] of [
+          [hidden, "visible fallback"],
+          ["visible edit", hidden],
+        ] as const) {
+          await expect(
+            imessageActionsRuntime.editMessage({
+              chatGuid: actionOptions.chatGuid,
+              messageId: "edit-message-guid",
+              text,
+              backwardsCompatMessage,
+              options: actionOptions,
+            }),
+          ).rejects.toThrow("iMessage edit requires non-empty text after sanitization");
+        }
+        for (const [questionText, choices] of [
+          [hidden, ["first", "second"]],
+          ["visible question", [hidden, "second"]],
+          ["visible question", ["first", hidden]],
+        ] as const) {
+          await expect(
+            imessageActionsRuntime.sendPoll({
+              chatGuid: actionOptions.chatGuid,
+              question: questionText,
+              choices,
+              options: actionOptions,
+            }),
+          ).rejects.toThrow(
+            "iMessage poll requires a non-empty question and options after sanitization",
+          );
+        }
+        expect(readActions()).toHaveLength(previousActionCount);
+        expect(readRequests()).toHaveLength(previousRequestCount);
+      }
+      await expect(sendMessageIMessage("chat_id:10", "# user:", { config: cfg })).rejects.toThrow(
+        "iMessage send requires text or media",
+      );
+      await expect(
+        sendMessageIMessage(
+          "chat_id:10",
+          ["```yaml", "user:", "```", forgedTokenEntity].join("\n"),
+          { config: cfg },
+        ),
+      ).rejects.toThrow("iMessage outbound role protection failed");
+      const splitForgedToken = "&#xE000;&#xE000;" + entitySeparator + "&#xE000;&#xE000;";
+      await expect(
+        sendMessageIMessage(
+          "chat_id:10",
+          ["```yaml", "user:", "```", splitForgedToken].join("\n"),
+          { config: cfg },
+        ),
+      ).rejects.toThrow("iMessage outbound role protection failed");
+      await expect(
+        sendMessageIMessage("chat_id:10", "`<thinking>HIDDEN_RPC_INLINE_THINKING</thinking>`", {
+          config: cfg,
+        }),
+      ).rejects.toThrow("iMessage outbound hidden assistant content is not allowed");
+      await expect(
+        sendMessageIMessage("chat_id:10", roleTokenSwap, { config: cfg }),
+      ).rejects.toThrow("iMessage outbound role protection failed");
+      await expect(
+        sendMessageIMessage(
+          "chat_id:10",
+          nestMarkdownFences("<thinking>HIDDEN_RPC_DEEPLY_NESTED</thinking>", 4),
+          { config: cfg },
+        ),
+      ).rejects.toThrow("iMessage outbound hidden assistant content is not allowed");
+      await expect(
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: actionOptions.chatGuid,
+          text: [fencedYaml, forgedTokenEntity].join("\n"),
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage outbound role protection failed");
+      await expect(
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: actionOptions.chatGuid,
+          text: "`<relevant_memories>HIDDEN_ACTION_INLINE_MEMORY</relevant_memories>`",
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage outbound hidden assistant content is not allowed");
+      await expect(
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: actionOptions.chatGuid,
+          text: roleTokenSwap,
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage outbound role protection failed");
+      await expect(
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: actionOptions.chatGuid,
+          text: nestMarkdownFences("<relevant_memories>HIDDEN_RICH_NESTED</relevant_memories>", 4),
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage outbound hidden assistant content is not allowed");
+      await expect(
+        imessageActionsRuntime.sendRichMessage({
+          chatGuid: actionOptions.chatGuid,
+          text: "# user:",
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage rich send requires text or an attachment after sanitization");
+      await expect(
+        imessageActionsRuntime.editMessage({
+          chatGuid: actionOptions.chatGuid,
+          messageId: "edit-message-guid",
+          text: "user:",
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage edit requires non-empty text after sanitization");
+      await expect(
+        imessageActionsRuntime.editMessage({
+          chatGuid: actionOptions.chatGuid,
+          messageId: "edit-message-guid",
+          text: "safe edit",
+          backwardsCompatMessage: "system:",
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage edit requires non-empty text after sanitization");
+      for (const [questionText, choices] of [
+        ["assistant:", ["first", "second"]],
+        ["safe question", ["first", "system:"]],
+      ] as const) {
+        await expect(
+          imessageActionsRuntime.sendPoll({
+            chatGuid: actionOptions.chatGuid,
+            question: questionText,
+            choices,
+            options: actionOptions,
+          }),
+        ).rejects.toThrow(
+          "iMessage poll requires a non-empty question and options after sanitization",
+        );
+      }
+      await expect(
+        imessageActionsRuntime.sendPoll({
+          chatGuid: actionOptions.chatGuid,
+          question: "Choose one",
+          choices: ["Allow", `Al${rawSeparator}low`],
+          options: actionOptions,
+        }),
+      ).rejects.toThrow("iMessage poll options must remain distinct after sanitization");
+
+      for (const sendSwappedRole of [
+        () =>
+          imessageActionsRuntime.editMessage({
+            chatGuid: actionOptions.chatGuid,
+            messageId: "edit-message-guid",
+            text: roleTokenSwap,
+            backwardsCompatMessage: "visible fallback",
+            options: actionOptions,
+          }),
+        () =>
+          imessageActionsRuntime.editMessage({
+            chatGuid: actionOptions.chatGuid,
+            messageId: "edit-message-guid",
+            text: "visible replacement",
+            backwardsCompatMessage: roleTokenSwap,
+            options: actionOptions,
+          }),
+        () =>
+          imessageActionsRuntime.sendPoll({
+            chatGuid: actionOptions.chatGuid,
+            question: roleTokenSwap,
+            choices: ["first", "second"],
+            options: actionOptions,
+          }),
+        () =>
+          imessageActionsRuntime.sendPoll({
+            chatGuid: actionOptions.chatGuid,
+            question: "visible question",
+            choices: [roleTokenSwap, "second"],
+            options: actionOptions,
+          }),
+        () =>
+          imessageActionsRuntime.sendPoll({
+            chatGuid: actionOptions.chatGuid,
+            question: "visible question",
+            choices: ["first", roleTokenSwap],
+            options: actionOptions,
+          }),
+      ]) {
+        await expect(sendSwappedRole()).rejects.toThrow("iMessage outbound role protection failed");
+      }
+
+      for (const tag of ["thinking", "relevant_memories"] as const) {
+        for (const hidden of [
+          `<${tag}>HIDDEN_RAW_CODE_PAYLOAD</${tag}>`,
+          `<${tag}>HIDDEN_UNTERMINATED_RAW_CODE_PAYLOAD`,
+          ...(tag === "thinking" ? [hiddenFunctionResponse] : []),
+        ]) {
+          for (const wrapped of [
+            `\`\`\`xml\n${hidden}\n\`\`\``,
+            `\`${hidden}\``,
+            nestMarkdownFences(hidden, 3),
+          ]) {
+            const actionsWithHiddenCode = [
+              () =>
+                imessageActionsRuntime.editMessage({
+                  chatGuid: actionOptions.chatGuid,
+                  messageId: "edit-message-guid",
+                  text: wrapped,
+                  backwardsCompatMessage: "visible fallback",
+                  options: actionOptions,
+                }),
+              () =>
+                imessageActionsRuntime.editMessage({
+                  chatGuid: actionOptions.chatGuid,
+                  messageId: "edit-message-guid",
+                  text: "visible replacement",
+                  backwardsCompatMessage: wrapped,
+                  options: actionOptions,
+                }),
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: wrapped,
+                  choices: ["first", "second"],
+                  options: actionOptions,
+                }),
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: "visible question",
+                  choices: [wrapped, "second"],
+                  options: actionOptions,
+                }),
+              () =>
+                imessageActionsRuntime.sendPoll({
+                  chatGuid: actionOptions.chatGuid,
+                  question: "visible question",
+                  choices: ["first", wrapped],
+                  options: actionOptions,
+                }),
+            ];
+            for (const sendHiddenCode of actionsWithHiddenCode) {
+              await expect(sendHiddenCode()).rejects.toThrow(
+                "iMessage outbound hidden assistant content is not allowed",
+              );
+            }
+          }
+        }
+      }
+      expect(readActions()).toHaveLength(actions.length);
+      expect(readRequests()).toHaveLength(requests.length);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  }, 30_000);
 
   it("attaches a text receipt for native send ids", async () => {
     const client = createClient({ guid: "p:0/imsg-1" });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -40,13 +40,16 @@ import { runIMessageCliJsonCommand } from "./cli-output.js";
 import { resolveIMessageChatDbLookupPath } from "./cli-path.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
-import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import { resolveAuthorizedIMessageReplyReference } from "./message-resource.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import {
   forgetPersistedIMessageEchoKey,
   rememberPersistedIMessageEcho,
 } from "./monitor/persisted-echo-cache.js";
+import {
+  protectIMessageFencedRoleMarkers,
+  sanitizeIMessageFinalOutboundText,
+} from "./monitor/sanitize-outbound.js";
 import {
   formatIMessageChatTarget,
   type IMessageService,
@@ -780,6 +783,8 @@ export async function sendMessageIMessage(
         : 16 * 1024 * 1024;
   let message =
     text && opts.approvalKind ? appendIMessageApprovalReactionHintForOutboundMessage(text) : text;
+  const protectedRoles = protectIMessageFencedRoleMarkers(message);
+  message = protectedRoles.text;
   let filePath: string | undefined;
   let mediaContentType: string | undefined;
 
@@ -802,18 +807,23 @@ export async function sendMessageIMessage(
       channel: "imessage",
       accountId: account.accountId,
     });
+    protectedRoles.verifyProtectedRoles(message);
     message = convertMarkdownTables(message, tableMode);
+    protectedRoles.verifyProtectedRoles(message);
   }
+  protectedRoles.verifyProtectedRoles(message);
   message = stripInlineDirectiveTagsForDelivery(message).text;
+  protectedRoles.verifyProtectedRoles(message);
   if (!message.trim() && !filePath) {
     throw new Error("iMessage send requires text or media");
   }
   // Extract markdown bold/italic/underline/strikethrough into typed-run
   // ranges that the imsg bridge applies via attributedBody. The sender needs
   // macOS 15+; pre-Sequoia recipients see the same marker-stripped plain text.
-  const formatted = message.trim()
-    ? extractMarkdownFormatRuns(message)
-    : { text: message, ranges: [] };
+  const formatted = sanitizeIMessageFinalOutboundText(message, {
+    formatMarkdown: true,
+    protection: protectedRoles,
+  });
   message = formatted.text;
   if (!message.trim() && !filePath) {
     throw new Error("iMessage send requires text or media");


### PR DESCRIPTION
## Security corrective follow-up

Corrects the remaining iMessage outbound disclosure after #117159 prematurely closed #116942. Normalize private/system-reminder context at the iMessage owner boundary and every action, channel, monitor and native-send path; reject malformed HTML/Markdown wrappers and nested private fragments without changing public behavior.

## Exact reviewed proof

- Final eight-file owner patch SHA256: 4cd567de9c69416afd5661ecdd89ce86253ad832dba6efc277c0c378ecb09a93; only the existing iMessage plugin owner files change.
- Fresh real remote proof: https://github.com/openclaw/openclaw/actions/runs/30707151001
- 420/420 real native/fake-imsg security and owner tests passed, including the previously reproduced outbound private-context leak.
- Both plugin production and test tsgo lanes, canonical formatting, targeted oxlint, dependency/plugin boundaries, database-first, deadcode, and every changed security guard passed.
- Two independent source/security reviewers and a separately self-invoked authenticated Codex review approved these exact bytes.
- Dedicated TruffleHog was not run; the security owner explicitly waived that unavailable scanner.

The linked issue is already closed by the incomplete earlier change; this maintainer security-owner-approved corrective PR completes its protection.

Refs #116942