### PR TITLE
fix(bedrock): honor custom embedding endpoints without region drift

### DIFF
--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -1,11 +1,146 @@
 // Amazon Bedrock tests cover embedding provider plugin behavior.
+import { createHash, createHmac } from "node:crypto";
+import dns from "node:dns";
+import { once } from "node:events";
+import { createServer, type ServerHttp2Session } from "node:http2";
+import type { AddressInfo } from "node:net";
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { NodeHttp2Handler } from "@smithy/node-http-handler";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBedrockEmbeddingProvider, hasAwsCredentials } from "./embedding-provider.js";
 import { embeddingTesting as testing } from "./test-support.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
+
+function isValidBedrockSigV4(
+  headers: Record<string, string | string[] | undefined>,
+  path: string,
+): boolean {
+  const authorization = headers.authorization;
+  if (typeof authorization !== "string") {
+    return false;
+  }
+  const match =
+    /^AWS4-HMAC-SHA256 Credential=([^/]+)\/(\d{8})\/([^/]+)\/([^/]+)\/aws4_request, SignedHeaders=([^,]+), Signature=([a-f0-9]{64})$/u.exec(
+      authorization,
+    );
+  if (!match) {
+    return false;
+  }
+  const [, accessKey, date, region, service, signedHeaders, signature] = match;
+  if (accessKey !== "bedrock-test-access") {
+    return false;
+  }
+  const escapeUri = (value: string) =>
+    encodeURIComponent(value).replace(
+      /[!'()*]/gu,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
+  const queryStart = path.indexOf("?");
+  const pathname = queryStart < 0 ? path : path.slice(0, queryStart);
+  const query = queryStart < 0 ? "" : path.slice(queryStart + 1);
+  const canonicalQuery = query
+    ? query
+        .split("&")
+        .map((parameter) => {
+          const separator = parameter.indexOf("=");
+          const key = decodeURIComponent(separator < 0 ? parameter : parameter.slice(0, separator));
+          const value = decodeURIComponent(separator < 0 ? "" : parameter.slice(separator + 1));
+          return `${escapeUri(key)}=${escapeUri(value)}`;
+        })
+        .toSorted()
+        .join("&")
+    : "";
+  const canonicalHeaders = signedHeaders
+    .split(";")
+    .map((name) => {
+      const value = headers[name];
+      const text = Array.isArray(value) ? value.join(",") : (value ?? "");
+      return `${name}:${text.trim().replace(/\s+/gu, " ")}`;
+    })
+    .join("\n");
+  const canonicalRequest = [
+    "POST",
+    escapeUri(pathname).replace(/%2F/gu, "/"),
+    canonicalQuery,
+    `${canonicalHeaders}\n`,
+    signedHeaders,
+    headers["x-amz-content-sha256"],
+  ].join("\n");
+  const scope = `${date}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    headers["x-amz-date"],
+    scope,
+    createHash("sha256").update(canonicalRequest).digest("hex"),
+  ].join("\n");
+  let key: Buffer = Buffer.from("AWS4bedrock-test-secret");
+  for (const value of [date, region, service, "aws4_request"]) {
+    key = createHmac("sha256", key).update(value).digest();
+  }
+  return createHmac("sha256", key).update(stringToSign).digest("hex") === signature;
+}
+
+async function expectSignedBedrockEndpoint(endpoint: string): Promise<void> {
+  vi.stubEnv("AWS_ACCESS_KEY_ID", "bedrock-test-access");
+  vi.stubEnv("AWS_SECRET_ACCESS_KEY", "bedrock-test-secret");
+  vi.stubEnv("AWS_SESSION_TOKEN", undefined);
+  vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", undefined);
+  vi.stubEnv("AWS_PROFILE", "");
+
+  const observedRequests: Array<{ authority: string; authorization: string }> = [];
+  const server = createServer();
+  server.on("stream", (stream, headers) => {
+    observedRequests.push({
+      authority: headers[":authority"] ?? "",
+      authorization: headers.authorization ?? "",
+    });
+    stream.respond({ ":status": 200, "content-type": "application/json" });
+    stream.end(JSON.stringify({ embedding: [3, 4] }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address() as AddressInfo;
+  const transport = new NodeHttp2Handler();
+  const sdk = new BedrockRuntimeClient({
+    region: "us-east-1",
+    endpoint,
+    requestHandler: {
+      metadata: { handlerProtocol: "h2" },
+      handle: (request, options) =>
+        transport.handle(
+          { ...request, protocol: "http:", hostname: "127.0.0.1", port: address.port },
+          options,
+        ),
+      destroy: () => transport.destroy(),
+    },
+  });
+
+  try {
+    await sdk.send(
+      new InvokeModelCommand({
+        modelId: "amazon.titan-embed-text-v2:0",
+        body: "{}",
+        contentType: "application/json",
+        accept: "application/json",
+      }),
+    );
+    expect(observedRequests).toEqual([
+      {
+        authority: new URL(endpoint).host,
+        authorization: expect.stringMatching(/^AWS4-HMAC-SHA256 Credential=bedrock-test-access\//),
+      },
+    ]);
+  } finally {
+    sdk.destroy();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
 describe("bedrock embedding region resolution", () => {
   it.each([
@@ -37,6 +172,646 @@ describe("bedrock embedding region resolution", () => {
     });
 
     expect(client.region).toBe(expected);
+    expect(client).not.toHaveProperty("endpoint");
+  });
+
+  it.each([
+    {
+      name: "regional PrivateLink endpoint",
+      endpoint: "https://vpce-123.bedrock-runtime.eu-west-1.vpce.amazonaws.com",
+    },
+    {
+      name: "FIPS PrivateLink endpoint",
+      endpoint: "https://vpce-123.bedrock-runtime-fips.eu-west-1.vpce.amazonaws.com",
+    },
+  ])("infers the signing region from an SDK-owned $name", async ({ endpoint }) => {
+    vi.stubEnv("AWS_REGION", "us-east-1");
+
+    const { client } = await createBedrockEmbeddingProvider({
+      config: {},
+      model: "amazon.titan-embed-text-v2:0",
+      remote: { baseUrl: endpoint },
+    });
+
+    expect(client.region).toBe("eu-west-1");
+    expect(client.endpoint).toBe(endpoint);
+  });
+
+  it("preserves AWS FIPS region aliases for SDK-managed standard endpoints", async () => {
+    vi.stubEnv("AWS_REGION", "fips-eu-west-1");
+
+    const { client } = await createBedrockEmbeddingProvider({ config: {}, model: "" });
+    const sdk = new BedrockRuntimeClient({ region: client.region });
+    try {
+      expect(client.region).toBe("fips-eu-west-1");
+      expect(client).not.toHaveProperty("endpoint");
+      expect(await sdk.config.region()).toBe("eu-west-1");
+      expect(await sdk.config.useFipsEndpoint()).toBe(true);
+    } finally {
+      sdk.destroy();
+    }
+  });
+});
+
+describe("bedrock embedding endpoint ownership", () => {
+  it.each([
+    {
+      name: "memory endpoint with SigV4",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+    },
+    {
+      name: "provider endpoint with SigV4",
+      source: "provider",
+      auth: "sigv4",
+      providerRegion: undefined,
+    },
+    {
+      name: "memory endpoint with Bedrock bearer auth",
+      source: "remote",
+      auth: "bearer",
+      providerRegion: undefined,
+    },
+    {
+      name: "memory endpoint with its provider-configured signing region",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: "us-east-1",
+    },
+    {
+      name: "custom endpoint when inherited FIPS mode is enabled",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointModes: ["AWS_USE_FIPS_ENDPOINT"],
+    },
+    {
+      name: "custom endpoint when inherited dual-stack mode is enabled",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointModes: ["AWS_USE_DUALSTACK_ENDPOINT"],
+    },
+    {
+      name: "custom endpoint when inherited FIPS and dual-stack modes are enabled",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointModes: ["AWS_USE_FIPS_ENDPOINT", "AWS_USE_DUALSTACK_ENDPOINT"],
+    },
+    {
+      name: "custom endpoint when its configured region is an AWS FIPS alias",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      awsRegion: "fips-eu-west-1",
+      expectedSigningRegion: "eu-west-1",
+    },
+    {
+      name: "FIPS-looking private endpoint with its provider-configured signing region",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: "us-east-1",
+      proxyHostname: "bedrock-runtime-fips.us-west-2.private.test",
+    },
+    {
+      name: "FIPS-looking private endpoint with its environment-configured signing region",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      proxyHostname: "bedrock-runtime-fips.us-west-2.private.test",
+    },
+    {
+      name: "AWS-suffix-looking private endpoint with its provider-configured signing region",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: "us-east-1",
+      proxyHostname: "bedrock-runtime-fips.us-west-2.amazonaws.com.private.test",
+    },
+    {
+      name: "memory proxy endpoint with a trailing slash in its query value",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointQuery: "?upstream=https://bedrock/",
+    },
+    {
+      name: "memory proxy endpoint with repeated upstream query parameters",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointQuery: "?upstream=https://bedrock/&upstream=https://second/",
+    },
+    {
+      name: "SigV4 proxy endpoint with interleaved repeated query parameters",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointQuery: "?upstream=first&mode=failover&upstream=second",
+    },
+    {
+      name: "bearer proxy endpoint with interleaved repeated query parameters",
+      source: "remote",
+      auth: "bearer",
+      providerRegion: undefined,
+      endpointQuery: "?upstream=first&mode=failover&upstream=second",
+    },
+    {
+      name: "SigV4 proxy endpoint preserving raw pluses, escapes, equals, and flag parameters",
+      source: "remote",
+      auth: "sigv4",
+      providerRegion: undefined,
+      endpointQuery: "?upstream=a+b&mode=fail%20over&upstream=a%2Bb&token=a=b&flag",
+    },
+  ] as const)(
+    "sends authenticated embedding requests to the configured $name",
+    async (testCase) => {
+      const { source, auth, providerRegion } = testCase;
+      const endpointQuery = "endpointQuery" in testCase ? testCase.endpointQuery : "";
+      const configuredRequests: Array<{
+        url: string | undefined;
+        authorization: string;
+        signatureValid?: boolean;
+      }> = [];
+      const fallbackRequests: string[] = [];
+      const openSessions = new Set<ServerHttp2Session>();
+      const configuredServer = createServer();
+      configuredServer.on("stream", (stream, headers) => {
+        configuredRequests.push({
+          url: headers[":path"],
+          authorization: headers.authorization ?? "",
+          ...(headers.authorization?.startsWith("AWS4-HMAC-SHA256")
+            ? { signatureValid: isValidBedrockSigV4(headers, headers[":path"] ?? "") }
+            : {}),
+        });
+        stream.respond({ ":status": 200, "content-type": "application/json" });
+        stream.end(JSON.stringify({ embedding: [3, 4] }));
+      });
+      const fallbackServer = createServer();
+      fallbackServer.on("stream", (stream, headers) => {
+        fallbackRequests.push(headers[":path"] ?? "");
+        stream.respond({ ":status": 200, "content-type": "application/json" });
+        stream.end(JSON.stringify({ embedding: [0, 1] }));
+      });
+      for (const server of [configuredServer, fallbackServer]) {
+        server.on("session", (session) => {
+          openSessions.add(session);
+          session.once("close", () => openSessions.delete(session));
+        });
+      }
+      configuredServer.listen(0, "127.0.0.1");
+      fallbackServer.listen(0, "127.0.0.1");
+      await Promise.all([once(configuredServer, "listening"), once(fallbackServer, "listening")]);
+      const configuredAddress = configuredServer.address() as AddressInfo;
+      const fallbackAddress = fallbackServer.address() as AddressInfo;
+      const proxyHostname = "proxyHostname" in testCase ? testCase.proxyHostname : undefined;
+      const endpoint = `http://${proxyHostname ?? "127.0.0.1"}:${configuredAddress.port}`;
+      const paddedEndpoint = `  ${endpoint}/${endpointQuery}  `;
+      const fallbackEndpoint = `http://127.0.0.1:${fallbackAddress.port}`;
+      const configuredRegion = "awsRegion" in testCase ? testCase.awsRegion : "eu-west-1";
+      const signingRegion =
+        providerRegion ??
+        ("expectedSigningRegion" in testCase ? testCase.expectedSigningRegion : configuredRegion);
+      vi.stubEnv("AWS_REGION", configuredRegion);
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", undefined);
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", undefined);
+      vi.stubEnv("AWS_ACCESS_KEY_ID", auth === "sigv4" ? "bedrock-test-access" : undefined);
+      vi.stubEnv("AWS_SECRET_ACCESS_KEY", auth === "sigv4" ? "bedrock-test-secret" : undefined);
+      vi.stubEnv("AWS_SESSION_TOKEN", undefined);
+      vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", auth === "bearer" ? "bedrock-test-token" : undefined);
+      vi.stubEnv("AWS_PROFILE", "");
+      // Keep the unfixed SDK path on localhost while proving configured endpoints win.
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", fallbackEndpoint);
+      if ("endpointModes" in testCase) {
+        for (const endpointMode of testCase.endpointModes) {
+          vi.stubEnv(endpointMode, "true");
+        }
+      }
+      if (proxyHostname) {
+        const lookup = dns.lookup.bind(dns);
+        vi.spyOn(dns, "lookup").mockImplementation((hostname, ...args) =>
+          lookup(hostname === proxyHostname ? "127.0.0.1" : hostname, ...args),
+        );
+      }
+
+      try {
+        const { provider, client } = await createBedrockEmbeddingProvider({
+          config:
+            source === "provider"
+              ? {
+                  models: {
+                    providers: { "amazon-bedrock": { baseUrl: paddedEndpoint, models: [] } },
+                  },
+                }
+              : {
+                  models: {
+                    providers: {
+                      "amazon-bedrock": {
+                        baseUrl: providerRegion
+                          ? `https://bedrock-runtime.${providerRegion}.amazonaws.com`
+                          : fallbackEndpoint,
+                        models: [],
+                      },
+                    },
+                  },
+                },
+          model: "amazon.titan-embed-text-v2:0",
+          ...(source === "remote" ? { remote: { baseUrl: paddedEndpoint } } : {}),
+        });
+
+        await expect(
+          provider.embedQuery("route this embedding to its configured owner"),
+        ).resolves.toEqual([0.6, 0.8]);
+        expect(client.region).toBe(signingRegion);
+        expect(client.endpoint).toBe(`${endpoint}${endpointQuery}`);
+        expect(configuredRequests).toHaveLength(1);
+        expect(configuredRequests[0]).toMatchObject({
+          url: `/model/amazon.titan-embed-text-v2%3A0/invoke${endpointQuery}`,
+          authorization:
+            auth === "bearer"
+              ? "Bearer bedrock-test-token"
+              : expect.stringMatching(
+                  new RegExp(
+                    `^AWS4-HMAC-SHA256 Credential=bedrock-test-access/\\d{8}/${signingRegion}/bedrock/aws4_request, `,
+                  ),
+                ),
+          ...(auth === "sigv4" ? { signatureValid: true } : {}),
+        });
+        expect(fallbackRequests).toEqual([]);
+      } finally {
+        for (const session of openSessions) {
+          session.destroy();
+        }
+        await Promise.all([
+          new Promise<void>((resolve, reject) => {
+            configuredServer.close((error) => (error ? reject(error) : resolve()));
+          }),
+          new Promise<void>((resolve, reject) => {
+            fallbackServer.close((error) => (error ? reject(error) : resolve()));
+          }),
+        ]);
+      }
+    },
+  );
+
+  it.each([
+    {
+      env: "AWS_USE_FIPS_ENDPOINT",
+      mode: "FIPS",
+      hostnamePrefix: "bedrock-runtime-fips",
+      configuredHost: "bedrock-runtime.us-east-1.amazonaws.com",
+      region: "us-east-1",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.us-east-1.amazonaws.com",
+      region: "us-east-1",
+    },
+    {
+      env: "AWS_USE_FIPS_ENDPOINT",
+      mode: "an already-canonical FIPS",
+      hostnamePrefix: "bedrock-runtime-fips",
+      configuredHost: "bedrock-runtime-fips.us-east-1.amazonaws.com",
+      region: "us-east-1",
+    },
+    {
+      env: "AWS_USE_FIPS_ENDPOINT",
+      mode: "a configured FIPS region overriding the environment",
+      hostnamePrefix: "bedrock-runtime-fips",
+      configuredHost: "bedrock-runtime-fips.us-west-2.amazonaws.com",
+      region: "us-west-2",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "an already-canonical dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.us-east-1.api.aws",
+      region: "us-east-1",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "China dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.cn-north-1.api.amazonwebservices.com.cn",
+      region: "cn-north-1",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "European sovereign dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.eusc-de-east-1.api.amazonwebservices.eu",
+      region: "eusc-de-east-1",
+    },
+    {
+      env: "AWS_USE_FIPS_ENDPOINT",
+      mode: "AWS ISO FIPS",
+      hostnamePrefix: "bedrock-runtime-fips",
+      configuredHost: "bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+      region: "us-iso-east-1",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "AWS ISO-B dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.us-isob-east-1.api.aws.scloud",
+      region: "us-isob-east-1",
+    },
+    {
+      env: "AWS_USE_FIPS_ENDPOINT",
+      mode: "AWS ISO-E FIPS",
+      hostnamePrefix: "bedrock-runtime-fips",
+      configuredHost: "bedrock-runtime.eu-isoe-west-1.cloud.adc-e.uk",
+      region: "eu-isoe-west-1",
+    },
+    {
+      env: "AWS_USE_DUALSTACK_ENDPOINT",
+      mode: "AWS ISO-F dual-stack",
+      hostnamePrefix: "bedrock-runtime",
+      configuredHost: "bedrock-runtime.us-isof-south-1.api.aws.hci.ic.gov",
+      region: "us-isof-south-1",
+    },
+  ])("preserves SDK-managed $mode routing for standard Bedrock endpoints", async (testCase) => {
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_USE_FIPS_ENDPOINT", undefined);
+    vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+    vi.stubEnv(testCase.env, "true");
+    const { client } = await createBedrockEmbeddingProvider({
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: `https://${testCase.configuredHost}/`,
+              models: [],
+            },
+          },
+        },
+      },
+      model: "amazon.titan-embed-text-v2:0",
+    });
+    const sdk = new BedrockRuntimeClient({
+      region: client.region,
+      ...(client.endpoint ? { endpoint: client.endpoint } : {}),
+    });
+
+    try {
+      const resolved = sdk.config.endpointProvider({
+        Region: client.region,
+        UseFIPS: await sdk.config.useFipsEndpoint(),
+        UseDualStack: await sdk.config.useDualstackEndpoint(),
+        ...(client.endpoint ? { Endpoint: client.endpoint } : {}),
+      });
+
+      expect(resolved.url.hostname).toMatch(
+        new RegExp(`^${testCase.hostnamePrefix}\\.${testCase.region}\\.`),
+      );
+      expect(client).not.toHaveProperty("endpoint");
+    } finally {
+      sdk.destroy();
+    }
+  });
+
+  it.each([
+    {
+      mode: "FIPS",
+      endpoint: "https://bedrock-runtime-fips.us-east-1.amazonaws.com",
+    },
+    {
+      mode: "dual-stack",
+      endpoint: "https://bedrock-runtime.us-east-1.api.aws",
+    },
+    {
+      mode: "combined FIPS and dual-stack",
+      endpoint: "https://bedrock-runtime-fips.us-east-1.api.aws",
+    },
+  ])(
+    "preserves an explicitly configured $mode endpoint when SDK flags are disabled",
+    async ({ endpoint }) => {
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+
+      const { client } = await createBedrockEmbeddingProvider({
+        config: {
+          models: {
+            providers: { "amazon-bedrock": { baseUrl: endpoint, models: [] } },
+          },
+        },
+        model: "amazon.titan-embed-text-v2:0",
+      });
+
+      expect(client.endpoint).toBe(endpoint);
+      const sdk = new BedrockRuntimeClient({ region: client.region, endpoint: client.endpoint });
+      try {
+        const resolved = sdk.config.endpointProvider({
+          Region: client.region,
+          UseFIPS: await sdk.config.useFipsEndpoint(),
+          UseDualStack: await sdk.config.useDualstackEndpoint(),
+          Endpoint: client.endpoint,
+        });
+        expect(resolved.url.href).toBe(`${endpoint}/`);
+      } finally {
+        sdk.destroy();
+      }
+      await expectSignedBedrockEndpoint(endpoint);
+    },
+  );
+
+  it.each(["AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "AWS_ENDPOINT_URL"] as const)(
+    "does not route an explicitly configured standard endpoint to conflicting %s",
+    async (overrideName) => {
+      const endpoint = "https://bedrock-runtime.us-east-1.amazonaws.com";
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+      vi.stubEnv(overrideName, "http://127.0.0.1:41234");
+
+      const { client } = await createBedrockEmbeddingProvider({
+        config: {
+          models: {
+            providers: { "amazon-bedrock": { baseUrl: endpoint, models: [] } },
+          },
+        },
+        model: "amazon.titan-embed-text-v2:0",
+      });
+
+      expect(client.endpoint).toBe(endpoint);
+      const sdk = new BedrockRuntimeClient({ region: client.region, endpoint: client.endpoint });
+      try {
+        const resolved = sdk.config.endpointProvider({
+          Region: client.region,
+          UseFIPS: await sdk.config.useFipsEndpoint(),
+          UseDualStack: await sdk.config.useDualstackEndpoint(),
+          Endpoint: client.endpoint,
+        });
+        expect(resolved.url.hostname).toBe("bedrock-runtime.us-east-1.amazonaws.com");
+      } finally {
+        sdk.destroy();
+      }
+      await expectSignedBedrockEndpoint(endpoint);
+    },
+  );
+
+  it.each(["AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "AWS_ENDPOINT_URL"] as const)(
+    "retains an explicitly configured custom endpoint matching %s",
+    async (overrideName) => {
+      const endpoint = "https://proxy-a.internal.example";
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+      vi.stubEnv(overrideName, endpoint);
+
+      const { client } = await createBedrockEmbeddingProvider({
+        config: {
+          models: {
+            providers: { "amazon-bedrock": { baseUrl: endpoint, models: [] } },
+          },
+        },
+        model: "amazon.titan-embed-text-v2:0",
+      });
+
+      expect(client.endpoint).toBe(endpoint);
+      await expectSignedBedrockEndpoint(endpoint);
+    },
+  );
+
+  it.each(["AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "AWS_ENDPOINT_URL"] as const)(
+    "keeps an actual regional endpoint matching %s SDK-owned",
+    async (overrideName) => {
+      const endpoint = "https://bedrock-runtime.us-east-1.amazonaws.com";
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+      vi.stubEnv(overrideName, endpoint);
+
+      const { client } = await createBedrockEmbeddingProvider({
+        config: {
+          models: {
+            providers: { "amazon-bedrock": { baseUrl: endpoint, models: [] } },
+          },
+        },
+        model: "amazon.titan-embed-text-v2:0",
+      });
+
+      expect(client).not.toHaveProperty("endpoint");
+      await expectSignedBedrockEndpoint(endpoint);
+    },
+  );
+
+  it.each(["AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "AWS_ENDPOINT_URL"] as const)(
+    "retains a custom %s endpoint even without explicit OpenClaw configuration",
+    async (overrideName) => {
+      const endpoint = "https://proxy-a.internal.example";
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+      vi.stubEnv(overrideName, endpoint);
+
+      const { client } = await createBedrockEmbeddingProvider({ config: {}, model: "" });
+
+      expect(client.endpoint).toBe(endpoint);
+      await expectSignedBedrockEndpoint(endpoint);
+    },
+  );
+
+  it("keeps a genuine regional SDK override out of default embedding cache identity", async () => {
+    const endpoint = "https://bedrock-runtime.us-east-1.amazonaws.com";
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+    vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+    vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", endpoint);
+
+    const { client } = await createBedrockEmbeddingProvider({ config: {}, model: "" });
+
+    expect(client).not.toHaveProperty("endpoint");
+    await expectSignedBedrockEndpoint(endpoint);
+  });
+
+  it("prefers the service-specific custom endpoint over a global SDK override", async () => {
+    const serviceEndpoint = "https://service-proxy.internal.example";
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+    vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+    vi.stubEnv("AWS_ENDPOINT_URL", "https://global-proxy.internal.example");
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", serviceEndpoint);
+
+    const { client } = await createBedrockEmbeddingProvider({ config: {}, model: "" });
+
+    expect(client.endpoint).toBe(serviceEndpoint);
+    await expectSignedBedrockEndpoint(serviceEndpoint);
+  });
+
+  it.each([
+    {
+      flag: "AWS_USE_FIPS_ENDPOINT",
+      expectedHost: "bedrock-runtime-fips.us-east-1.amazonaws.com",
+    },
+    {
+      flag: "AWS_USE_DUALSTACK_ENDPOINT",
+      expectedHost: "bedrock-runtime.us-east-1.api.aws",
+    },
+  ] as const)(
+    "retains inherited $flag routing when no endpoint is configured",
+    async ({ flag, expectedHost }) => {
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", undefined);
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+      vi.stubEnv(flag, "true");
+
+      const { client } = await createBedrockEmbeddingProvider({ config: {}, model: "" });
+      expect(client).not.toHaveProperty("endpoint");
+
+      const sdk = new BedrockRuntimeClient({ region: client.region });
+      try {
+        const resolved = sdk.config.endpointProvider({
+          Region: client.region,
+          UseFIPS: await sdk.config.useFipsEndpoint(),
+          UseDualStack: await sdk.config.useDualstackEndpoint(),
+        });
+        expect(resolved.url.hostname).toBe(expectedHost);
+      } finally {
+        sdk.destroy();
+      }
+    },
+  );
+
+  it.each([
+    "https://vpce-123.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+    "https://bedrock-runtime.us-east-1.amazonaws.com/proxy",
+    "https://bedrock-runtime.us-east-1.amazonaws.com?proxy=1",
+    "https://bedrock-runtime.us-east-1.amazonaws.com?proxy=https://bedrock/",
+    "https://bedrock-runtime.us-east-1.amazonaws.com?proxy=1#cursor=/",
+    "http://bedrock-runtime.us-east-1.amazonaws.com",
+  ])("keeps noncanonical Bedrock endpoint %s explicit", async (endpoint) => {
+    const { client } = await createBedrockEmbeddingProvider({
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": { baseUrl: endpoint, models: [] },
+          },
+        },
+      },
+      model: "amazon.titan-embed-text-v2:0",
+    });
+
+    expect(client.endpoint).toBe(endpoint);
   });
 });
 

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -23,6 +23,7 @@ type BedrockEmbeddingClient = {
   region: string;
   model: string;
   dimensions?: number;
+  endpoint?: string;
 };
 
 /** Default Bedrock embedding model used when no explicit model is configured. */
@@ -149,15 +150,153 @@ function loadDefaultCredentialProvider(): Promise<AwsCredentialProvider | null> 
 // ---------------------------------------------------------------------------
 
 const MODEL_PREFIX_RE = /^(?:bedrock|amazon-bedrock|aws)\//;
-const REGION_RE = /bedrock-runtime\.([a-z0-9-]+)\./;
+const REGION_RE = /bedrock-runtime(?:-fips)?\.([a-z0-9-]+)\./u;
 
 function normalizeBedrockEmbeddingModel(model: string): string {
   const trimmed = model.trim();
   return trimmed ? trimmed.replace(MODEL_PREFIX_RE, "") : DEFAULT_BEDROCK_EMBEDDING_MODEL;
 }
 
-function regionFromUrl(url: string | undefined): string | undefined {
-  return url?.trim() ? REGION_RE.exec(url)?.[1] : undefined;
+function regionFromUrl(
+  url: string | undefined,
+  BedrockRuntimeClient: AwsSdk["BedrockRuntimeClient"],
+): string | undefined {
+  if (!url?.trim()) {
+    return undefined;
+  }
+  try {
+    const hostname = new URL(url).hostname;
+    const region = REGION_RE.exec(hostname)?.[1];
+    if (!region) {
+      return undefined;
+    }
+    const sdk = new BedrockRuntimeClient({ region });
+    try {
+      const useFipsEndpoint = hostname.includes("bedrock-runtime-fips.");
+      for (const useDualstackEndpoint of [false, true]) {
+        try {
+          const regionalHostname = sdk.config.endpointProvider({
+            Region: region,
+            UseFIPS: useFipsEndpoint,
+            UseDualStack: useDualstackEndpoint,
+          }).url.hostname;
+          if (hostname === regionalHostname) {
+            return region;
+          }
+
+          const servicePrefix = `bedrock-runtime${useFipsEndpoint ? "-fips" : ""}.${region}.`;
+          const privateLinkHostname = `${servicePrefix}vpce.${regionalHostname.slice(servicePrefix.length)}`;
+          if (hostname === privateLinkHostname || hostname.endsWith(`.${privateLinkHostname}`)) {
+            return region;
+          }
+        } catch {
+          // Some AWS partitions do not support every FIPS/dual-stack combination.
+        }
+      }
+      return undefined;
+    } finally {
+      sdk.destroy();
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeBedrockEmbeddingEndpoint(value: string): string {
+  const endpoint = new URL(value);
+  endpoint.pathname = endpoint.pathname.replace(/\/+$/u, "");
+  // URL keeps a root slash in href; remove only that pathname slash, never query/hash payload.
+  return endpoint.pathname === "/" ? endpoint.href.replace(/\/(?=[?#]|$)/u, "") : endpoint.href;
+}
+
+function parseBedrockEndpointQuery(search: string): Record<string, string | string[]> {
+  const valuesByName = new Map<string, string[]>();
+  for (const parameter of search.slice(1).split("&")) {
+    const separator = parameter.indexOf("=");
+    const name = decodeURIComponent(separator < 0 ? parameter : parameter.slice(0, separator));
+    // Smithy treats + literally; URLSearchParams would incorrectly sign it as a space.
+    const value = decodeURIComponent(separator < 0 ? "" : parameter.slice(separator + 1));
+    const existing = valuesByName.get(name);
+    if (existing) {
+      existing.push(value);
+    } else {
+      valuesByName.set(name, [value]);
+    }
+  }
+  return Object.fromEntries(
+    Array.from(valuesByName, ([name, values]) => [name, values.length === 1 ? values[0] : values]),
+  );
+}
+
+async function resolveEffectiveBedrockEmbeddingEndpoint(
+  client: BedrockEmbeddingClient,
+  BedrockRuntimeClient: AwsSdk["BedrockRuntimeClient"],
+): Promise<string | undefined> {
+  const region = client.region;
+  const sdk = new BedrockRuntimeClient({ region });
+  const retainEndpoint = async (endpoint: string): Promise<string> => {
+    // A FIPS region alias forces endpoint mode on even when SDK flags are explicitly disabled.
+    client.region = await sdk.config.region();
+    return endpoint;
+  };
+  let effectiveEndpoint = client.endpoint;
+  try {
+    const configuredSdkEndpoint = sdk.config.ignoreConfiguredEndpointUrls
+      ? undefined
+      : await sdk.config.serviceConfiguredEndpoint?.();
+    effectiveEndpoint ??= configuredSdkEndpoint
+      ? normalizeBedrockEmbeddingEndpoint(configuredSdkEndpoint)
+      : undefined;
+    if (!effectiveEndpoint) {
+      return undefined;
+    }
+
+    const candidate = new URL(effectiveEndpoint);
+    if (
+      candidate.protocol !== "https:" ||
+      candidate.port ||
+      candidate.href !== `${candidate.origin}/`
+    ) {
+      return retainEndpoint(effectiveEndpoint);
+    }
+
+    const [useFipsEndpoint, useDualstackEndpoint] = await Promise.all([
+      sdk.config.useFipsEndpoint(),
+      sdk.config.useDualstackEndpoint(),
+    ]);
+    const regionalEndpoint = sdk.config.endpointProvider({
+      Region: region,
+      UseFIPS: useFipsEndpoint,
+      UseDualStack: useDualstackEndpoint,
+    });
+    if (configuredSdkEndpoint) {
+      const effectiveSdkEndpoint = sdk.config.endpointProvider({
+        Region: region,
+        UseFIPS: useFipsEndpoint,
+        UseDualStack: useDualstackEndpoint,
+        Endpoint: configuredSdkEndpoint,
+      });
+      // Only genuine regional URLs may lose identity; matching custom overrides stay explicit.
+      return regionalEndpoint.url.href === candidate.href &&
+        effectiveSdkEndpoint.url.href === candidate.href
+        ? undefined
+        : retainEndpoint(effectiveEndpoint);
+    }
+    if (regionalEndpoint.url.href === candidate.href) {
+      return undefined;
+    }
+
+    // Plain regional config is shipped region metadata and must still inherit FIPS/dual-stack.
+    return sdk.config.endpointProvider({ Region: region, UseFIPS: false, UseDualStack: false }).url
+      .href === candidate.href
+      ? undefined
+      : retainEndpoint(effectiveEndpoint);
+  } catch {
+    // Invalid SDK endpoint modes must never turn an explicit operator endpoint into a fallback.
+    return effectiveEndpoint ? retainEndpoint(effectiveEndpoint) : undefined;
+  } finally {
+    sdk.destroy();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -306,8 +445,15 @@ if (process.env.VITEST === "true") {
 export async function createBedrockEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: BedrockEmbeddingClient }> {
-  const client = resolveBedrockEmbeddingClient(options);
   const { BedrockRuntimeClient, InvokeModelCommand } = await loadSdk();
+  const client = resolveBedrockEmbeddingClient(options, BedrockRuntimeClient);
+  const endpoint = await resolveEffectiveBedrockEmbeddingEndpoint(client, BedrockRuntimeClient);
+  if (endpoint) {
+    client.endpoint = endpoint;
+  } else {
+    // The SDK owns genuine regional endpoints, mode policy, and existing cache identity.
+    delete client.endpoint;
+  }
   const spec = resolveSpec(client.model);
   const family = spec?.family ?? inferFamily(client.model);
 
@@ -318,10 +464,50 @@ export async function createBedrockEmbeddingProvider(
     family,
   });
 
+  const endpointUrl = client.endpoint ? new URL(client.endpoint) : undefined;
+  const endpointSearch = endpointUrl?.search;
+  const endpointQuery = endpointSearch ? parseBedrockEndpointQuery(endpointSearch) : undefined;
+
   const invoke = async (body: string, signal?: AbortSignal): Promise<string> => {
     await refreshAwsSharedConfigCacheForBedrock();
-    const sdk = new BedrockRuntimeClient({ region: client.region });
+    const sdk = new BedrockRuntimeClient({
+      region: client.region,
+      ...(client.endpoint
+        ? { endpoint: client.endpoint, useFipsEndpoint: false, useDualstackEndpoint: false }
+        : {}),
+    });
     try {
+      if (endpointQuery && endpointSearch) {
+        // Smithy's EndpointV1 serializer drops endpoint query parameters; restore before signing.
+        sdk.middlewareStack.add(
+          (next) => (args) => {
+            const request = asRecord(args.request);
+            if (!request) {
+              throw new Error("Amazon Bedrock SDK did not create an HTTP request");
+            }
+            request.query = { ...endpointQuery, ...asRecord(request.query) };
+            return next(args);
+          },
+          { name: "bedrockCustomEndpointQuery", step: "build" },
+        );
+        sdk.middlewareStack.addRelativeTo(
+          (next) => (args) => {
+            const request = asRecord(args.request);
+            if (!request || typeof request.path !== "string") {
+              throw new Error("Amazon Bedrock SDK did not create a signed HTTP request");
+            }
+            // SigV4 canonicalizes the query bag; the post-sign wire path retains original ordering.
+            request.path += endpointSearch;
+            request.query = {};
+            return next(args);
+          },
+          {
+            name: "bedrockCustomEndpointWireQuery",
+            relation: "after",
+            toMiddleware: "httpSigningMiddleware",
+          },
+        );
+      }
       const res = await sdk.send(
         new InvokeModelCommand({
           modelId: client.model,
@@ -399,14 +585,21 @@ export async function createBedrockEmbeddingProvider(
 
 function resolveBedrockEmbeddingClient(
   options: MemoryEmbeddingProviderCreateOptions,
+  BedrockRuntimeClient: AwsSdk["BedrockRuntimeClient"],
 ): BedrockEmbeddingClient {
   const model = normalizeBedrockEmbeddingModel(options.model);
   const spec = resolveSpec(model);
   const providerConfig = options.config.models?.providers?.["amazon-bedrock"];
+  const configuredEndpointValue =
+    normalizeOptionalString(options.remote?.baseUrl) ??
+    normalizeOptionalString(providerConfig?.baseUrl);
+  const configuredEndpoint = configuredEndpointValue
+    ? normalizeBedrockEmbeddingEndpoint(configuredEndpointValue)
+    : undefined;
 
   const region =
-    regionFromUrl(options.remote?.baseUrl) ??
-    regionFromUrl(providerConfig?.baseUrl) ??
+    regionFromUrl(options.remote?.baseUrl, BedrockRuntimeClient) ??
+    regionFromUrl(providerConfig?.baseUrl, BedrockRuntimeClient) ??
     normalizeOptionalString(process.env.AWS_REGION) ??
     normalizeOptionalString(process.env.AWS_DEFAULT_REGION) ??
     "us-east-1";
@@ -423,7 +616,12 @@ function resolveBedrockEmbeddingClient(
     dimensions = spec?.dims;
   }
 
-  return { region, model, dimensions };
+  return {
+    region,
+    model,
+    dimensions,
+    ...(configuredEndpoint ? { endpoint: configuredEndpoint } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
@@ -23,7 +23,12 @@ function defaultCreateOptions() {
   };
 }
 
-function stubCreate(client: { region: string; model: string; dimensions?: number }) {
+function stubCreate(client: {
+  region: string;
+  model: string;
+  dimensions?: number;
+  endpoint?: string;
+}) {
   createBedrockEmbeddingProviderMock.mockResolvedValue({
     provider: {
       id: "bedrock",
@@ -43,6 +48,7 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterAll(() => {
@@ -88,6 +94,132 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
       },
     });
     expect(createBedrockEmbeddingProviderMock).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates the embedding cache when its configured endpoint changes", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    const endpointA = "https://bedrock-a.internal.example";
+    const endpointB = "https://bedrock-b.internal.example";
+
+    stubCreate({
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+      endpoint: endpointA,
+    });
+    const first = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    stubCreate({
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+      endpoint: endpointB,
+    });
+    const second = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    expect(first.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointA });
+    expect(second.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointB });
+    expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+  });
+
+  it("preserves trailing slashes in custom endpoint query values in cache identity", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    const actual =
+      await vi.importActual<typeof import("./embedding-provider.js")>("./embedding-provider.js");
+    createBedrockEmbeddingProviderMock.mockImplementation(actual.createBedrockEmbeddingProvider);
+
+    const result = await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      remote: {
+        baseUrl: "https://proxy.example/invoke/?upstream=https://bedrock/",
+      },
+    });
+
+    expect(result.runtime?.cacheKeyData).toMatchObject({
+      endpoint: "https://proxy.example/invoke?upstream=https://bedrock/",
+    });
+  });
+
+  it("invalidates cached embeddings when matching custom SDK endpoint overrides change", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    const actual =
+      await vi.importActual<typeof import("./embedding-provider.js")>("./embedding-provider.js");
+    createBedrockEmbeddingProviderMock.mockImplementation(actual.createBedrockEmbeddingProvider);
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+    vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+    vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+
+    const endpointA = "https://proxy-a.internal.example";
+    const endpointB = "https://proxy-b.internal.example";
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", endpointA);
+    const first = await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      remote: { baseUrl: endpointA },
+    });
+
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", endpointB);
+    const second = await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      remote: { baseUrl: endpointB },
+    });
+
+    expect(first.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointA });
+    expect(second.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointB });
+    expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+  });
+
+  it.each(["AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "AWS_ENDPOINT_URL"] as const)(
+    "invalidates cached embeddings when an env-only %s endpoint changes",
+    async (overrideName) => {
+      hasAwsCredentialsMock.mockResolvedValue(true);
+      const actual =
+        await vi.importActual<typeof import("./embedding-provider.js")>("./embedding-provider.js");
+      createBedrockEmbeddingProviderMock.mockImplementation(actual.createBedrockEmbeddingProvider);
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_USE_FIPS_ENDPOINT", "false");
+      vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", "false");
+      vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+      vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+
+      const endpointA = "https://proxy-a.internal.example";
+      const endpointB = "https://proxy-b.internal.example";
+      vi.stubEnv(overrideName, endpointA);
+      const first = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      vi.stubEnv(overrideName, endpointB);
+      const second = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(first.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointA });
+      expect(second.runtime?.cacheKeyData).toMatchObject({ endpoint: endpointB });
+      expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+    },
+  );
+
+  it("preserves existing cache identity for SDK-managed standard Bedrock endpoints", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0", dimensions: 1024 });
+
+    const result = await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.runtime?.cacheKeyData).toEqual({
+      provider: "bedrock",
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+    });
   });
 
   it("lets the auto-select loop skip bedrock when credentials are unavailable", async () => {

--- a/extensions/amazon-bedrock/memory-embedding-adapter.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.ts
@@ -45,6 +45,7 @@ export const bedrockMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
           region: client.region,
           model: client.model,
           dimensions: client.dimensions,
+          ...(client.endpoint ? { endpoint: client.endpoint } : {}),
         },
       },
     };


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock memory embeddings silently ignored configured VPC/proxy/custom endpoints and reused incompatible vector indexes after their effective custom endpoint changed. Configured proxy URLs with query parameters also encounter a pinned Smithy EndpointV1 serializer defect that drops those parameters before signed transport. Naively forwarding official AWS URLs breaks supported FIPS/dual-stack modes and existing indexes across AWS partitions.

## Why This Change Was Made

The Bedrock owner asks its directly declared, pinned AWS SDK public endpoint resolver whether an HTTPS origin belongs to any supported official FIPS/dual-stack mode. Official endpoints remain SDK-owned. True custom endpoints are parsed once and normalized only at the pathname, preserving query/fragment values and repeated parameters. A build-stage SDK middleware restores custom query parameters before SigV4 signing because the pinned Smithy EndpointV1 serializer discards them. The effective custom endpoint also enters the existing memory index identity. No guessed AWS hostname allowlist, transitive dependency, config surface, schema, or auth-policy change is introduced.

## User Impact

Configured private/VPC/proxy endpoints receive real signed or bearer-authenticated requests, including preserved proxy query payloads and repeated keys. Changing a true custom endpoint invalidates incompatible vector indexes. Existing standard, FIPS, dual-stack, commercial, China, European-sovereign, and isolated AWS partitions preserve SDK routing, signing region, and existing cache identity.

## Evidence

- Immutable head: 8cdd08e0ec0826e851b31181c1c4c00b6dacbd2c; tree: a67454e25382015c4e2b7e4a93b6a07a70cc515e; base: 3777f009d0d64e846031aebdb5dcca0b672ee5de.
- One canonical root cause: effective Bedrock endpoint ownership was split across authenticated transport, signing-region selection, and vector-cache identity.
- Initial red: 28 pass / 3 fail against actual pinned SDK HTTP/2 and cache identity.
- AWS compatibility red: 33 pass / 2 fail on real FIPS/dual-stack endpoint rules.
- Isolated partition/FIPS signing red: 44 pass / 5 fail across ISO/ISO-B/ISO-E/ISO-F and configured FIPS signing region.
- Earlier immutable formally withdrawn after genuine high-reasoning autoreview caught query-value slash corruption; fresh authentic signed SDK transport plus real adapter-cache red: 49 pass / 2 fail.
- A second candidate was withdrawn after a fresh dependency expert found explicit FIPS/dual-stack destinations could downgrade and service/global AWS endpoint overrides could capture configured traffic; authentic red: 49 pass / 5 fail.
- The correction compares the pinned SDK's real current mode and endpoint-override precedence, preserving the shipped plain-regional metadata case while retaining mismatched explicit FIPS/dual endpoints.
- Real SigV4 requests preserve each configured HTTPS :authority over isolated localhost HTTP/2 for FIPS, dual-stack, combined modes, and both conflicting service/global override paths.
- The next candidate was withdrawn after genuine formal review caught matching custom SDK overrides erasing cache identity; actual signed service/global override and real adapter A→B red: 61 pass / 3 fail.
- The owner now compares the current genuine AWS regional endpoint independently, retaining matching custom overrides in transport/cache while preserving matching actual regional cache compatibility.
- An additional preexisting sibling was found before approval: environment-only AWS service/global custom endpoints changed real backends without changing vector-cache identity; authentic red: 67 pass / 5 fail.
- One canonical effective-endpoint owner now resolves explicit and environment-only SDK custom destinations, preserves service-over-global precedence, and isolates actual A→B indexes.
- Genuine formal review identified Smithy QueryParameterBag's unavoidable key sorting; signed and bearer localhost HTTP/2 red: 62 pass / 2 fail.
- Full query parameters are now decoded using Smithy semantics and signed canonically, then a post-httpSigning middleware restores the exact original ordered raw query bytes on the wire.
- Captured HTTP/2 requests independently recompute the complete AWS SigV4 HMAC, proving valid signatures for interleaved duplicates, literal +, percent-encoded spaces/pluses, embedded =, and bare flags.
- Previous immutable formally rejected: retained custom endpoints inherited incompatible FIPS/dual-stack modes and private FIPS-looking hosts overrode intended signing regions.
- Authentic signed localhost HTTP/2 red: 65 passed / 5 failed across endpoint modes and private-host signing-region hijacks.
- Additional SDK FIPS-region-alias red: 71 passed / 1 failed despite disabled endpoint-mode flags.
- Canonical owner now derives genuine regional and PrivateLink hosts from pinned SDK partitions, rejects private/AWS-suffix spoofing, normalizes region aliases only for retained custom endpoints, and suppresses inherited modes only on that custom path.
- A separate streaming-region parser in extensions/amazon-bedrock/register.sync.runtime.ts remains an explicitly reported out-of-scope follow-up.
- Final green: 142 tests across four owner/sibling files, including real HTTP/2 SigV4 and bearer transport, repeated query keys, query/fragment trailing slash, VPC/proxy path, standard/FIPS/dual-stack/isolated-partition direct SDK execution, region precedence, default cache identity, and distinct custom indexes.
- Configured typed extension lint, formatting, and whitespace checks pass.
- No external AWS account contacted; all proof uses the real pinned AWS/Smithy SDK on isolated localhost HTTP/2 and its public in-memory endpoint resolver.
- Net production delta: +199 lines; necessary for direct SDK canonical partition authority, custom query preservation before signing, probe-client lifecycle, and endpoint-owned vector identity.
