### PR TITLE
docs(heartbeat): use heartbeatVisibility in per-channel examples

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -91,7 +91,7 @@ Use `channels.defaults` for shared group-policy, implicit-mention, and heartbeat
         quotedBot: true,
         threadParticipation: true,
       },
-      heartbeat: {
+      heartbeatVisibility: {
         showOk: false,
         showAlerts: true,
         useIndicator: true,

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -104,9 +104,9 @@ Use `channels.defaults` for shared group-policy, implicit-mention, and heartbeat
 - `channels.defaults.groupPolicy`: fallback group policy when a provider-level `groupPolicy` is unset.
 - `channels.defaults.contextVisibility`: default supplemental context visibility mode for all channels. Values: `all` (default, include all quoted/thread/history context), `allowlist` (only include context from allowlisted senders), `allowlist_quote` (same as allowlist but keep explicit quote/reply context). Per-channel override: `channels.<channel>.contextVisibility`.
 - `channels.defaults.implicitMentions`: controls which supported inbound facts count as mentions. `replyToBot`, `quotedBot`, and `threadParticipation` each default to `true`, preserving current behavior. Override per channel with `channels.<channel>.implicitMentions` or per account with `channels.<channel>.accounts.<id>.implicitMentions`; each flag resolves account -> channel -> defaults independently. The names are positive: set a flag to `false` to stop that fact from bypassing mention gating. Native explicit mentions are always allowed, and a flag has no effect when the channel does not produce that fact. See [Mention gating](/channels/groups#mention-gating-default) for the current producer matrix. These settings do not change outbound reply/thread modes or authorized command handling.
-- `channels.defaults.heartbeat.showOk`: include healthy channel statuses in heartbeat output (default `false`).
-- `channels.defaults.heartbeat.showAlerts`: include degraded/error statuses in heartbeat output (default `true`).
-- `channels.defaults.heartbeat.useIndicator`: render compact indicator-style heartbeat output (default `true`).
+- `channels.defaults.heartbeatVisibility.showOk`: include healthy channel statuses in heartbeat output (default `false`).
+- `channels.defaults.heartbeatVisibility.showAlerts`: include degraded/error statuses in heartbeat output (default `true`).
+- `channels.defaults.heartbeatVisibility.useIndicator`: render compact indicator-style heartbeat output (default `true`).
 
 ### WhatsApp
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -328,17 +328,17 @@ By default, `HEARTBEAT_OK` acknowledgments are suppressed while alert content is
 ```yaml
 channels:
   defaults:
-    heartbeat:
+    heartbeatVisibility:
       showOk: false # Hide HEARTBEAT_OK (default)
       showAlerts: true # Show alert messages (default)
       useIndicator: true # Emit indicator events (default)
   telegram:
-    heartbeat:
+    heartbeatVisibility:
       showOk: true # Show OK acknowledgments on Telegram
   whatsapp:
     accounts:
       work:
-        heartbeat:
+        heartbeatVisibility:
           showAlerts: false # Suppress alert delivery for this account
 ```
 
@@ -357,19 +357,19 @@ If **all three** are false, OpenClaw skips the heartbeat run entirely (no model 
 ```yaml
 channels:
   defaults:
-    heartbeat:
+    heartbeatVisibility:
       showOk: false
       showAlerts: true
       useIndicator: true
   slack:
-    heartbeat:
+    heartbeatVisibility:
       showOk: true # all Slack accounts
     accounts:
       ops:
-        heartbeat:
+        heartbeatVisibility:
           showAlerts: false # suppress alerts for the ops account only
   telegram:
-    heartbeat:
+    heartbeatVisibility:
       showOk: true
 ```
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -375,12 +375,12 @@ channels:
 
 ### Common patterns
 
-| Goal                                     | Config                                                                                   |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Default behavior (silent OKs, alerts on) | _(no config needed)_                                                                     |
-| Fully silent (no messages, no indicator) | `channels.defaults.heartbeat: { showOk: false, showAlerts: false, useIndicator: false }` |
-| Indicator-only (no messages)             | `channels.defaults.heartbeat: { showOk: false, showAlerts: false, useIndicator: true }`  |
-| OKs in one channel only                  | `channels.telegram.heartbeat: { showOk: true }`                                          |
+| Goal                                     | Config                                                                                             |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Default behavior (silent OKs, alerts on) | _(no config needed)_                                                                               |
+| Fully silent (no messages, no indicator) | `channels.defaults.heartbeatVisibility: { showOk: false, showAlerts: false, useIndicator: false }` |
+| Indicator-only (no messages)             | `channels.defaults.heartbeatVisibility: { showOk: false, showAlerts: false, useIndicator: true }`  |
+| OKs in one channel only                  | `channels.telegram.heartbeatVisibility: { showOk: true }`                                          |
 
 ## Monitor scratch (optional)
 


### PR DESCRIPTION
## What Problem This Solves

Six documentation lines tell users to write `channels.defaults.heartbeat` or `channels.telegram.heartbeat`, but that key is retired and config validation refuses it. Copying either example straight from the docs produces an invalid config.

Verified against current `main` (`ea2e7f46a69`):

```
channels.defaults.heartbeat        -> channels.defaults: Unrecognized key: "heartbeat"
channels.telegram.heartbeat        -> channels.telegram: invalid config: must not have additional properties: "heartbeat"
channels.defaults.heartbeatVisibility -> accepted
channels.telegram.heartbeatVisibility -> accepted
```

The canonical name is `heartbeatVisibility`:

- `src/config/zod-schema.channels-config.ts:59` declares `heartbeatVisibility` on `channels.defaults`, and there is no `heartbeat` sibling.
- `src/config/dead-config-keys.test.ts:90` already pins `channels.defaults.heartbeat` as a dead key.
- `openclaw doctor --fix` rewrites the old spelling: `src/commands/doctor/shared/channel-legacy-config-migrate.ts:49-53` emits "Moved `<path>.heartbeat` → `<path>.heartbeatVisibility`".

The same `heartbeat.md` page already documents the correct name at `:136-137`, so the page currently contradicts itself: the scope list says `heartbeatVisibility` and the recipe table below it says `heartbeat`.

## Why This Change Was Made

The docs are the stale side here, not the schema. `heartbeatVisibility` is the migration target that doctor writes and the only name the schema accepts, so the examples are updated to match rather than reintroducing the retired key.

Changed lines:

- `docs/gateway/heartbeat.md:381-383`, the three recipe-table rows.
- `docs/gateway/config-channels.md:107-109`, the `showOk` / `showAlerts` / `useIndicator` bullets.

## User Impact

Following the heartbeat docs now produces a config that loads. Previously the fully-silent, indicator-only, and single-channel-OK recipes were all copy-paste-to-broken, and the failure surfaced as a whole-config rejection rather than a hint about the key name.

## Evidence

Docs-only change, so there is no behavior diff to test. Validation of the exact documented shapes before and after, run in-process against current `main`:

```
before (as documented):
  channels.defaults: Unrecognized key: "heartbeat"
  channels.telegram: invalid config: must not have additional properties: "heartbeat"

after (as documented in this PR):
  channels.defaults.heartbeatVisibility: { showOk: false, showAlerts: false, useIndicator: false }  -> accepted
  channels.telegram.heartbeatVisibility: { showOk: true }                                           -> accepted
```

```
$ git diff --check
(clean)
```

What I checked and deliberately did **not** change:

- I did not touch `docs/gateway/doctor.md:333`, which lists `channels.defaults.heartbeat` as a migration target for a top-level `heartbeat` block. That row describes what doctor writes internally and matches the strings in `src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts:150,1563`. Whether doctor should migrate straight to `heartbeatVisibility` is a behavior question for the owner, not a docs fix.
- I did not touch `agents.defaults.heartbeat`, which is a different and still-valid key (cadence, target, model settings). Only the channel-side visibility spelling was wrong.
- I did not add a docs-lint test for dead config keys in docs prose. It would be new infrastructure well beyond this fix, and `src/config/dead-config-keys.test.ts` already guards the schema side.
- No schema, doctor, or runtime code is touched, so no metadata regeneration was needed.

---

AI-assisted: researched, written, and validated with Claude Code under my direction. I have read and understand the change.
