### PR TITLE
fix(cron): validate scratch operations before privileged requests

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1,6 +1,10 @@
 // Cron CLI tests cover cron command registration and schedule output.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CRON_JOB_SCRATCH_MAX_BYTES } from "../cron/scratch-contract.js";
 import type { CronJob } from "../cron/types.js";
 import { registerCronCli } from "./cron-cli.js";
 
@@ -338,6 +342,199 @@ async function runCronRunAndCaptureExit(params: {
 }
 
 describe("cron cli", () => {
+  describe("scratch preflight and compare-and-swap ownership", () => {
+    it.each(["", "   ", "0x10", "1e2", "1.5", "-1", "9007199254740992"])(
+      "rejects invalid revision %j before contacting the Gateway",
+      async (revision) => {
+        await expectCronCommandExit([
+          "cron",
+          "scratch",
+          "job-1",
+          "--set",
+          "updated",
+          "--expected-revision",
+          revision,
+        ]);
+
+        expectRuntimeErrorContaining("--expected-revision must be a non-negative integer");
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      },
+    );
+
+    it("rejects invalid read-only revisions without opening a Gateway connection", async () => {
+      await expectCronCommandExit(["cron", "scratch", "job-1", "--expected-revision", "invalid"]);
+
+      expectRuntimeErrorContaining("--expected-revision must be a non-negative integer");
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    });
+
+    it("rejects read-only revision preconditions before contacting the Gateway", async () => {
+      await expectCronCommandExit(["cron", "scratch", "job-1", "--expected-revision", "7"]);
+
+      expectRuntimeErrorContaining("--expected-revision requires --set, --file, or --unset");
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing scratch files before contacting the Gateway", async () => {
+      const missingPath = path.join(os.tmpdir(), "openclaw-cron-scratch-missing-never-create.txt");
+
+      await expectCronCommandExit(["cron", "scratch", "job-1", "--file", missingPath]);
+
+      expectRuntimeErrorContaining("ENOENT");
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    });
+
+    it("rejects oversized scratch files before contacting the Gateway", async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-scratch-preflight-"));
+      const filename = path.join(root, "oversized.txt");
+      try {
+        await fs.writeFile(filename, Buffer.alloc(CRON_JOB_SCRATCH_MAX_BYTES + 1));
+
+        await expectCronCommandExit(["cron", "scratch", "job-1", "--file", filename]);
+
+        expectRuntimeErrorContaining(`exceeds ${CRON_JOB_SCRATCH_MAX_BYTES} bytes`);
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects oversized multibyte inline scratch before contacting the Gateway", async () => {
+      const oversized = "é".repeat(Math.floor(CRON_JOB_SCRATCH_MAX_BYTES / 2) + 1);
+
+      await expectCronCommandExit(["cron", "scratch", "job-1", "--set", oversized]);
+
+      expectRuntimeErrorContaining(`exceeds ${CRON_JOB_SCRATCH_MAX_BYTES} bytes`);
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { label: "set", mutation: ["--set", "exact text\n"], content: "exact text\n" },
+      { label: "unset", mutation: ["--unset"], content: null },
+    ])(
+      "uses one Gateway write when $label has an explicit revision",
+      async ({ mutation, content }) => {
+        resetGatewayMock();
+        callGatewayFromCli.mockResolvedValue({ ok: true, currentRevision: 8, maxBytes: 262_144 });
+
+        await buildProgram().parseAsync(
+          ["cron", "scratch", "job-1", ...mutation, "--expected-revision", "7"],
+          { from: "user" },
+        );
+
+        expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+        expect(callGatewayFromCli).toHaveBeenCalledWith(
+          "cron.scratch.set",
+          expect.any(Object),
+          { id: "job-1", content, expectedRevision: 7 },
+          undefined,
+        );
+      },
+    );
+
+    it.each([
+      ["0", 0],
+      ["+7", 7],
+      ["0007", 7],
+      [" 7 ", 7],
+    ])("keeps canonical decimal revision %j", async (revision, expectedRevision) => {
+      resetGatewayMock();
+      callGatewayFromCli.mockResolvedValue({ ok: true });
+
+      await buildProgram().parseAsync(
+        ["cron", "scratch", "job-1", "--unset", "--expected-revision", revision],
+        { from: "user" },
+      );
+
+      expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+      expect(callGatewayFromCli.mock.calls[0]?.[2]).toMatchObject({ expectedRevision });
+    });
+
+    it("preserves exact file content with an explicit compare-and-swap revision", async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-scratch-valid-"));
+      const filename = path.join(root, "scratch.txt");
+      try {
+        await fs.writeFile(filename, " first line\nsecond line\n");
+        resetGatewayMock();
+        callGatewayFromCli.mockResolvedValue({ ok: true });
+
+        await buildProgram().parseAsync(
+          ["cron", "scratch", "job-1", "--file", filename, "--expected-revision", "0"],
+          { from: "user" },
+        );
+
+        expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+        expect(callGatewayFromCli.mock.calls[0]?.[2]).toEqual({
+          id: "job-1",
+          content: " first line\nsecond line\n",
+          expectedRevision: 0,
+        });
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts inline multibyte scratch at the exact 256 KiB boundary", async () => {
+      const content = "é".repeat(CRON_JOB_SCRATCH_MAX_BYTES / 2);
+      resetGatewayMock();
+      callGatewayFromCli.mockResolvedValue({ ok: true });
+
+      await buildProgram().parseAsync(
+        ["cron", "scratch", "job-1", "--set", content, "--expected-revision", "0"],
+        { from: "user" },
+      );
+
+      expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+      expect(callGatewayFromCli.mock.calls[0]?.[2]).toEqual({
+        id: "job-1",
+        content,
+        expectedRevision: 0,
+      });
+    });
+
+    it("keeps implicit revision reads before the compare-and-swap write", async () => {
+      resetGatewayMock();
+      callGatewayFromCli.mockImplementation(async (method: string) =>
+        method === "cron.scratch.get"
+          ? { scratch: null, currentRevision: 12, maxBytes: CRON_JOB_SCRATCH_MAX_BYTES }
+          : { ok: true, currentRevision: 13, maxBytes: CRON_JOB_SCRATCH_MAX_BYTES },
+      );
+
+      await buildProgram().parseAsync(["cron", "scratch", "job-1", "--set", "updated"], {
+        from: "user",
+      });
+
+      expect(callGatewayFromCli.mock.calls.map(([method]) => method)).toEqual([
+        "cron.scratch.get",
+        "cron.scratch.set",
+      ]);
+      expect(callGatewayFromCli.mock.calls[1]?.[2]).toEqual({
+        id: "job-1",
+        content: "updated",
+        expectedRevision: 12,
+      });
+    });
+
+    it("preserves read-only scratch retrieval and exact raw content", async () => {
+      resetGatewayMock();
+      callGatewayFromCli.mockResolvedValue({
+        scratch: { content: " exact text\n", revision: 4, updatedAtMs: 1 },
+        currentRevision: 4,
+        maxBytes: CRON_JOB_SCRATCH_MAX_BYTES,
+      });
+      const output = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      try {
+        await buildProgram().parseAsync(["cron", "scratch", "job-1"], { from: "user" });
+
+        expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+        expect(callGatewayFromCli.mock.calls[0]?.[0]).toBe("cron.scratch.get");
+        expect(output).toHaveBeenCalledWith(" exact text\n");
+      } finally {
+        output.mockRestore();
+      }
+    });
+  });
+
   it("documents the gateway-host timezone default for cron --tz help", () => {
     const program = buildProgram();
     const cronCommand = program.commands.find((command) => command.name() === "cron");

--- a/src/cli/cron-cli/register.cron-scratch.ts
+++ b/src/cli/cron-cli/register.cron-scratch.ts
@@ -1,5 +1,7 @@
 // Cron scratch CLI: private per-job prompt context reads and compare-and-swap writes.
 import type { Command } from "commander";
+import { assertCronJobScratchContent } from "../../cron/scratch-contract.js";
+import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { handleCronCliError, printCronJson } from "./shared.js";
 import { readCronScratchContent } from "./trigger-options.js";
@@ -18,8 +20,8 @@ function parseExpectedRevision(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const revision = Number(value);
-  if (!Number.isSafeInteger(revision) || revision < 0) {
+  const revision = parseStrictNonNegativeInteger(value);
+  if (revision === undefined) {
     throw new Error("--expected-revision must be a non-negative integer");
   }
   return revision;
@@ -46,10 +48,16 @@ export function registerCronScratchCommand(cron: Command) {
           if (mutations > 1) {
             throw new Error("choose only one of --set, --file, or --unset");
           }
-          const current = (await callGatewayFromCli("cron.scratch.get", opts, {
-            id: String(id),
-          })) as ScratchGetResult;
+          const explicitRevision = parseExpectedRevision(opts.expectedRevision);
+          if (mutations === 0 && explicitRevision !== undefined) {
+            throw new Error("--expected-revision requires --set, --file, or --unset");
+          }
+          const readScratch = async () =>
+            (await callGatewayFromCli("cron.scratch.get", opts, {
+              id: String(id),
+            })) as ScratchGetResult;
           if (mutations === 0) {
+            const current = await readScratch();
             if (opts.json) {
               printCronJson(current);
             } else if (current.scratch) {
@@ -57,14 +65,15 @@ export function registerCronScratchCommand(cron: Command) {
             }
             return;
           }
-
-          const explicitRevision = parseExpectedRevision(opts.expectedRevision);
-          const expectedRevision = explicitRevision ?? current.currentRevision;
           const content = opts.unset
             ? null
             : opts.file !== undefined
               ? await readCronScratchContent(String(opts.file))
               : String(opts.set ?? "");
+          if (content !== null) {
+            assertCronJobScratchContent(content);
+          }
+          const expectedRevision = explicitRevision ?? (await readScratch()).currentRevision;
           const result = (await callGatewayFromCli("cron.scratch.set", opts, {
             id: String(id),
             content,


### PR DESCRIPTION
## What Problem This Solves

Automation scratch commands contacted the privileged Gateway before rejecting malformed compare-and-swap revisions, missing or oversized files, and oversized inline UTF-8 content. Explicit revisions also forced an unnecessary Gateway read, and a valid revision supplied to a read-only command was silently ignored.

## Why This Change Was Made

Perform all mutation and revision preflight at the existing cron scratch Commander owner before any Gateway request. Reuse OpenClaw's canonical strict non-negative decimal parser and its existing 256 KiB scratch contract, reject revision-only reads, read local files first, and skip the preliminary read when an explicit revision already supplies the compare-and-swap precondition.

## User Impact

Invalid scratch commands fail clearly without opening a privileged Gateway request. Explicit scratch writes need one RPC, implicit writes retain their current read-then-write compare-and-swap sequence, read-only content/JSON output stays unchanged, and exact file bytes plus valid decimal revision forms remain supported. No config, protocol, database schema, public flag, or permission surface changes.

## Evidence

- Frozen commit `42a92f9e4a4f8e5f83184de839cc90163629edc3`, tree `d9025fa76f089c2235c366d9a1f86d2fb3293282`, parent `30972edaea784ccd501320b5b00f3a17e8e2ebda`; earlier `d3fdc92daa9a2d873fda08abc8affe8ec11d4259` was permanently revoked after hostile review.
- Authentic baseline: 13 Commander/Gateway-route cases fail before the repair; a fresh hostile review added one independently reproduced valid-revision/read-only failure before the corrected successor.
- Frozen existing full Commander test file: 145/145 pass, including zero-RPC failures, exact 256 KiB multibyte content, file/newline preservation, canonical decimal forms, explicit one-write CAS, implicit read/write CAS, and read-only raw output.
- Actual hosted Blacksmith Testbox `tbx_01kyz20zjtha77k0nja0ms7w2w` passed full `pnpm check:test-types` across core/extensions/root, exact-path type-aware oxlint, and the 145-test CLI suite; wrapper exit 0 and lease stopped. Hosted proof ran on the identical corrected dirty source immediately before the authorized immutable amend.
- Exactly two existing files; production `+17/-8` (net `+9`).
- Five wholly fresh independent hostile immutable-source reviews all returned CLEAN with zero P0/P1/P2/P3 findings; no review of the permanently revoked predecessor was carried forward.
- One expressly ROOT-granted genuine `gpt-5.6-sol` HIGH, max-P3 automated review returned CLEAN, confidence `0.98`, zero findings; the real TruffleHog `3.96` secret scan also completed CLEAN. ROOT alone owns GitHub mutation and final landing.
