### PR TITLE
fix(sessions): preserve small token counts in listings

### DIFF
--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -56,6 +56,95 @@ describe("sessionsCommand", () => {
     );
   });
 
+  it.each([
+    { totalTokens: 0, contextTokens: 420, expected: "0/420 (0%)" },
+    { totalTokens: 1, contextTokens: 999, expected: "1/999 (0%)" },
+    { totalTokens: 420, contextTokens: 999, expected: "420/999 (42%)" },
+    { totalTokens: 999, contextTokens: 1_000, expected: "999/1.0k (100%)" },
+    { totalTokens: 1_000, contextTokens: 200_000, expected: "1.0k/200k (1%)" },
+    { totalTokens: 999_499, contextTokens: 1_000_000, expected: "999k/1.0m (100%)" },
+    { totalTokens: 999_500, contextTokens: 1_000_000, expected: "1.0m/1.0m (100%)" },
+    { totalTokens: 1_000_000, contextTokens: 2_500_000, expected: "1.0m/2.5m (40%)" },
+  ])(
+    "formats actual session-table token boundaries ($totalTokens/$contextTokens)",
+    async ({ totalTokens, contextTokens, expected }) => {
+      const store = await writeStore({
+        "agent:main:boundary": {
+          sessionId: "boundary-session",
+          updatedAt: Date.now() - 60_000,
+          totalTokens,
+          totalTokensFresh: true,
+          contextTokens,
+          model: "test:opus",
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCommand({ store }, runtime);
+      cleanupStore(store);
+
+      const row = logs.find((line) => line.includes("id:boundary-session")) ?? "";
+      expect(row).toContain(expected);
+    },
+  );
+
+  it("formats unknown totals with the actual session context-token boundary", async () => {
+    const store = await writeStore({
+      "agent:main:unknown-boundary": {
+        sessionId: "unknown-boundary-session",
+        updatedAt: Date.now() - 60_000,
+        contextTokens: 999,
+        model: "test:opus",
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCommand({ store }, runtime);
+    cleanupStore(store);
+
+    const row = logs.find((line) => line.includes("id:unknown-boundary-session")) ?? "";
+    expect(row).toContain("unknown/999 (?%)");
+  });
+
+  it("keeps exact numeric token counts unchanged in JSON output", async () => {
+    const store = await writeStore({
+      "agent:main:small": {
+        sessionId: "small-boundary-session",
+        updatedAt: Date.now() - 60_000,
+        totalTokens: 420,
+        totalTokensFresh: true,
+        contextTokens: 999,
+        model: "test:opus",
+      },
+      "agent:main:large": {
+        sessionId: "large-boundary-session",
+        updatedAt: Date.now() - 120_000,
+        totalTokens: 1_000_000,
+        totalTokensFresh: true,
+        contextTokens: 2_500_000,
+        model: "test:opus",
+      },
+    });
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{ key: string; totalTokens: number; contextTokens: number }>;
+    }>(sessionsCommand, store);
+    expect(payload.sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "agent:main:small",
+          totalTokens: 420,
+          contextTokens: 999,
+        }),
+        expect.objectContaining({
+          key: "agent:main:large",
+          totalTokens: 1_000_000,
+          contextTokens: 2_500_000,
+        }),
+      ]),
+    );
+  });
+
   it("renders the agent runtime in the tabular view", async () => {
     setMockSessionsConfig(() => ({
       agents: {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -33,6 +33,7 @@ import {
   deliveryContextFromSession,
   sessionDeliveryOrigin,
 } from "../utils/delivery-context.shared.js";
+import { formatTokenCount } from "../utils/token-format.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   resolveSessionDisplayModelRef,
@@ -71,8 +72,6 @@ const TOKENS_PAD = 20;
 const DEFAULT_SESSIONS_LIMIT = 100;
 const TOP_N_SELECTION_LIMIT = 200;
 const contextLookupRuntimeLoader = createLazyImportLoader(() => import("../agents/context.js"));
-
-const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
 
 /**
  * Inline ACP model overlay — catalog #20.
@@ -176,12 +175,12 @@ const formatTokensCell = (
   rich: boolean,
 ) => {
   if (total === undefined) {
-    const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
+    const ctxLabel = contextTokens ? formatTokenCount(contextTokens) : "?";
     const label = `unknown/${ctxLabel} (?%)`;
     return rich ? theme.muted(label.padEnd(TOKENS_PAD)) : label.padEnd(TOKENS_PAD);
   }
-  const totalLabel = formatKTokens(total);
-  const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
+  const totalLabel = formatTokenCount(total);
+  const ctxLabel = contextTokens ? formatTokenCount(contextTokens) : "?";
   const pct = contextTokens ? Math.min(999, Math.round((total / contextTokens) * 100)) : null;
   const label = `${totalLabel}/${ctxLabel} (${pct ?? "?"}%)`;
   const padded = label.padEnd(TOKENS_PAD);


### PR DESCRIPTION
## What Problem This Solves

`openclaw sessions` and `openclaw sessions list` displayed recorded counts of 1–49 tokens as `0.0k`, making small nonzero usage indistinguishable from zero.

## User Impact

Human listings preserve small counts and use the shared `k`/`m` formatting for larger totals and context windows. Unknown totals, freshness-gated percentages, model/context selection, and exact JSON numbers retain their existing behavior.

## Why This Change Was Made

Use the existing token formatter for both labels and remove the duplicate sessions-only formatter. Document the human-label convention in the CLI reference.

## Evidence

- Current-main baseline: ten intended label assertions fail; 26 existing command tests pass.
- Candidate: all 66 tests across five command, model/context, ACP metadata, and formatter suites pass. The regression matrix runs the real SQLite-backed command and checks human output plus exact JSON values.
- The full changed gate passes with this checkout's own frozen dependency installation, including production and core-test typechecks, typed lint, dead-export scans, formatting, file-growth ratchets, and remaining guards. Independent P0–P2 review is clean.
- Both CLI spellings and the fast command route resolve to the tested command owner. Current proof exercises that owner; packaged CLI processes and live providers were not rerun.
