### PR TITLE
fix(plugins): report registered inspection capabilities

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -31,7 +31,7 @@ This is the **deep architecture reference** for the OpenClaw plugin system. For 
 
 ## Public capability model
 
-Capabilities are the public **native plugin** model inside OpenClaw. Every native OpenClaw plugin registers against one or more capability types:
+Capabilities are the public **native plugin** model inside OpenClaw. Native plugins can register one or more capability types:
 
 | Capability             | Registration method                              | Example plugins                                             |
 | ---------------------- | ------------------------------------------------ | ----------------------------------------------------------- |
@@ -50,9 +50,10 @@ Capabilities are the public **native plugin** model inside OpenClaw. Every nativ
 | Web search             | `api.registerWebSearchProvider(...)`             | `brave`, `firecrawl`, `google`                              |
 | Channel / messaging    | `api.registerChannel(...)`                       | `matrix`, `msteams`                                         |
 | Gateway discovery      | `api.registerGatewayDiscoveryService(...)`       | `bonjour`                                                   |
+| Migration              | `api.registerMigrationProvider(...)`             | `migrate-claude`, `migrate-hermes`                          |
 
 <Note>
-A plugin that registers zero capabilities but provides hooks, tools, discovery services, or background services is a **legacy hook-only** plugin. That pattern is still fully supported.
+A plugin that registers only hooks is **hook-only**. Plugins with tools, commands, background services, or routes but no capabilities are **non-capability** plugins. Both patterns remain supported; gateway discovery is an explicit capability listed above.
 </Note>
 
 ### External compatibility stance

--- a/src/plugins/inspect-shape.ts
+++ b/src/plugins/inspect-shape.ts
@@ -2,25 +2,7 @@
 import type { PluginRegistry } from "./registry.js";
 import { hasKind } from "./slots.js";
 
-export type PluginCapabilityKind =
-  | "cli-backend"
-  | "text-inference"
-  | "embedding"
-  | "speech"
-  | "realtime-transcription"
-  | "realtime-voice"
-  | "media-understanding"
-  | "transcript-source"
-  | "document-extractors"
-  | "image-generation"
-  | "video-generation"
-  | "music-generation"
-  | "web-search"
-  | "worker-provider"
-  | "session-catalog"
-  | "agent-harness"
-  | "context-engine"
-  | "channel";
+export type PluginCapabilityKind = ReturnType<typeof buildPluginCapabilityEntries>[number]["kind"];
 
 export type PluginInspectShape =
   | "hook-only"
@@ -43,7 +25,7 @@ type PluginShapeSummary = {
 function buildPluginCapabilityEntries(
   plugin: PluginRegistry["plugins"][number],
   report: Pick<PluginRegistry, "sessionCatalogs">,
-): PluginCapabilityEntry[] {
+) {
   return [
     { kind: "cli-backend" as const, ids: plugin.cliBackendIds ?? [] },
     { kind: "text-inference" as const, ids: plugin.providerIds },
@@ -57,7 +39,10 @@ function buildPluginCapabilityEntries(
     { kind: "image-generation" as const, ids: plugin.imageGenerationProviderIds },
     { kind: "video-generation" as const, ids: plugin.videoGenerationProviderIds },
     { kind: "music-generation" as const, ids: plugin.musicGenerationProviderIds },
+    { kind: "web-content-extractors" as const, ids: plugin.contracts?.webContentExtractors ?? [] },
+    { kind: "web-fetch" as const, ids: plugin.webFetchProviderIds },
     { kind: "web-search" as const, ids: plugin.webSearchProviderIds },
+    { kind: "migration-provider" as const, ids: plugin.migrationProviderIds },
     { kind: "worker-provider" as const, ids: plugin.contracts?.workerProviders ?? [] },
     {
       kind: "session-catalog" as const,
@@ -74,6 +59,7 @@ function buildPluginCapabilityEntries(
           : [],
     },
     { kind: "channel" as const, ids: plugin.channelIds },
+    { kind: "gateway-discovery" as const, ids: plugin.gatewayDiscoveryServiceIds },
   ].filter((entry) => entry.ids.length > 0);
 }
 
@@ -85,7 +71,6 @@ function derivePluginInspectShape(params: {
   commandCount: number;
   cliCount: number;
   serviceCount: number;
-  gatewayDiscoveryServiceCount: number;
   gatewayMethodCount: number;
   httpRouteCount: number;
 }): PluginInspectShape {
@@ -101,7 +86,6 @@ function derivePluginInspectShape(params: {
     params.commandCount === 0 &&
     params.cliCount === 0 &&
     params.serviceCount === 0 &&
-    params.gatewayDiscoveryServiceCount === 0 &&
     params.gatewayMethodCount === 0 &&
     params.httpRouteCount === 0;
   if (hasOnlyHooks) {
@@ -140,7 +124,6 @@ export function buildPluginShapeSummary(params: {
     commandCount: params.plugin.commands.length,
     cliCount: params.plugin.cliCommands.length,
     serviceCount: params.plugin.services.length,
-    gatewayDiscoveryServiceCount: params.plugin.gatewayDiscoveryServiceIds.length,
     gatewayMethodCount,
     httpRouteCount: params.plugin.httpRoutes,
   });

--- a/src/plugins/inspect-shape.ts
+++ b/src/plugins/inspect-shape.ts
@@ -15,12 +15,14 @@ export type PluginCapabilityKind =
   | "image-generation"
   | "video-generation"
   | "music-generation"
+  | "web-fetch"
   | "web-search"
   | "worker-provider"
   | "session-catalog"
   | "agent-harness"
   | "context-engine"
-  | "channel";
+  | "channel"
+  | "gateway-discovery";
 
 export type PluginInspectShape =
   | "hook-only"
@@ -57,6 +59,7 @@ function buildPluginCapabilityEntries(
     { kind: "image-generation" as const, ids: plugin.imageGenerationProviderIds },
     { kind: "video-generation" as const, ids: plugin.videoGenerationProviderIds },
     { kind: "music-generation" as const, ids: plugin.musicGenerationProviderIds },
+    { kind: "web-fetch" as const, ids: plugin.webFetchProviderIds },
     { kind: "web-search" as const, ids: plugin.webSearchProviderIds },
     { kind: "worker-provider" as const, ids: plugin.contracts?.workerProviders ?? [] },
     {
@@ -74,6 +77,7 @@ function buildPluginCapabilityEntries(
           : [],
     },
     { kind: "channel" as const, ids: plugin.channelIds },
+    { kind: "gateway-discovery" as const, ids: plugin.gatewayDiscoveryServiceIds },
   ].filter((entry) => entry.ids.length > 0);
 }
 
@@ -85,7 +89,6 @@ function derivePluginInspectShape(params: {
   commandCount: number;
   cliCount: number;
   serviceCount: number;
-  gatewayDiscoveryServiceCount: number;
   gatewayMethodCount: number;
   httpRouteCount: number;
 }): PluginInspectShape {
@@ -101,7 +104,6 @@ function derivePluginInspectShape(params: {
     params.commandCount === 0 &&
     params.cliCount === 0 &&
     params.serviceCount === 0 &&
-    params.gatewayDiscoveryServiceCount === 0 &&
     params.gatewayMethodCount === 0 &&
     params.httpRouteCount === 0;
   if (hasOnlyHooks) {
@@ -140,7 +142,6 @@ export function buildPluginShapeSummary(params: {
     commandCount: params.plugin.commands.length,
     cliCount: params.plugin.cliCommands.length,
     serviceCount: params.plugin.services.length,
-    gatewayDiscoveryServiceCount: params.plugin.gatewayDiscoveryServiceIds.length,
     gatewayMethodCount,
     httpRouteCount: params.plugin.httpRoutes,
   });

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -756,6 +756,82 @@ describe("plugin status reports", () => {
     ]);
   });
 
+  it.each([
+    {
+      id: "extractor-only",
+      providers: { contracts: { webContentExtractors: ["readability"] } },
+      capabilities: [{ kind: "web-content-extractors", ids: ["readability"] }],
+      shape: "plain-capability",
+      mode: "plain",
+    },
+    {
+      id: "fetch-only",
+      providers: { webFetchProviderIds: ["fetch-only"] },
+      capabilities: [{ kind: "web-fetch", ids: ["fetch-only"] }],
+      shape: "plain-capability",
+      mode: "plain",
+    },
+    {
+      id: "firecrawl",
+      providers: {
+        webFetchProviderIds: ["firecrawl"],
+        webSearchProviderIds: ["firecrawl", "firecrawl-free"],
+      },
+      capabilities: [
+        { kind: "web-fetch", ids: ["firecrawl"] },
+        { kind: "web-search", ids: ["firecrawl", "firecrawl-free"] },
+      ],
+      shape: "hybrid-capability",
+      mode: "hybrid",
+    },
+    {
+      id: "migration-only",
+      providers: { migrationProviderIds: ["importer"] },
+      capabilities: [{ kind: "migration-provider", ids: ["importer"] }],
+      shape: "plain-capability",
+      mode: "plain",
+    },
+  ])(
+    "projects $id capabilities from cold metadata without a hook-only warning",
+    ({ id, providers, capabilities, shape, mode }) => {
+      setSinglePluginLoadResult(createPluginRecord({ id, ...providers }), {
+        hooks: [createCustomHook({ pluginId: id, events: ["message"] })],
+      });
+      const report = buildPluginSnapshotReport({ config: {} });
+      const inspect = expectInspectReport(id, { config: {}, report });
+      expect(inspect).toMatchObject({
+        shape,
+        capabilityMode: mode,
+        capabilityCount: capabilities.length,
+        capabilities,
+        compatibility: [],
+      });
+      expect(buildAllPluginInspectReports({ config: {}, report })).toEqual([inspect]);
+      expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("exposes gateway discovery only after its service is registered", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "bonjour" }));
+    const report = buildPluginSnapshotReport({ config: {} });
+    expect(expectInspectReport("bonjour", { config: {}, report })).toMatchObject({
+      shape: "non-capability",
+      capabilityCount: 0,
+      capabilities: [],
+    });
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    setSinglePluginLoadResult(
+      createPluginRecord({ id: "bonjour", gatewayDiscoveryServiceIds: ["bonjour"] }),
+    );
+    expect(expectInspectReport("bonjour", { config: {} })).toMatchObject({
+      shape: "plain-capability",
+      capabilityMode: "plain",
+      capabilityCount: 1,
+      capabilities: [{ kind: "gateway-discovery", ids: ["bonjour"] }],
+    });
+    expect(mockInput(loadOpenClawPluginsMock).activate).toBe(false);
+  });
+
   it("treats a CLI-command-only plugin as a plain capability", () => {
     setSinglePluginLoadResult(
       createPluginRecord({

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -734,6 +734,46 @@ describe("plugin status reports", () => {
     ]);
   });
 
+  it("classifies manifest-declared web fetch providers without importing runtime", () => {
+    setPluginLoadResult({
+      plugins: [
+        createPluginRecord({
+          id: "firecrawl",
+          webFetchProviderIds: ["firecrawl"],
+          webSearchProviderIds: ["firecrawl", "firecrawl-free"],
+        }),
+        createPluginRecord({ id: "fetch-only", webFetchProviderIds: ["fetch-only"] }),
+      ],
+    });
+    const report = buildPluginSnapshotReport({ config: {} });
+    const firecrawl = expectInspectReport("firecrawl", { config: {}, report });
+    expect(firecrawl.shape).toBe("hybrid-capability");
+    expect(firecrawl.capabilities).toEqual([
+      { kind: "web-fetch", ids: ["firecrawl"] },
+      { kind: "web-search", ids: ["firecrawl", "firecrawl-free"] },
+    ]);
+    const fetchOnly = expectInspectReport("fetch-only", { config: {}, report });
+    expect(fetchOnly.shape).toBe("plain-capability");
+    expect(fetchOnly.capabilities).toEqual([{ kind: "web-fetch", ids: ["fetch-only"] }]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("exposes gateway discovery only after its service is actually registered", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "bonjour" }));
+    const coldReport = buildPluginSnapshotReport({ config: {} });
+    const coldInspect = expectInspectReport("bonjour", { config: {}, report: coldReport });
+    expect(coldInspect.shape).toBe("non-capability");
+    expect(coldInspect.capabilities).toEqual([]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    setSinglePluginLoadResult(
+      createPluginRecord({ id: "bonjour", gatewayDiscoveryServiceIds: ["bonjour"] }),
+    );
+    const runtimeInspect = expectInspectReport("bonjour", { config: {} });
+    expect(runtimeInspect.shape).toBe("plain-capability");
+    expect(runtimeInspect.capabilities).toEqual([{ kind: "gateway-discovery", ids: ["bonjour"] }]);
+    expect(mockInput(loadOpenClawPluginsMock).activate).toBe(false);
+  });
+
   it("treats a CLI-command-only plugin as a plain capability", () => {
     setSinglePluginLoadResult(
       createPluginRecord({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators inspecting plugins receive incomplete capability lists and incorrect plain, hybrid, or hook-only classifications. Firecrawl loses its fetch capability; Bonjour loses runtime gateway discovery; migration-only plugins and Web Readability are reported as non-capabilities. A capability-bearing plugin with hooks can also receive a misleading hook-only compatibility notice.

## Why This Change Was Made

Complete the existing inspection projection using authoritative registry IDs and manifest contracts for web fetch, gateway discovery, migration providers, and web-content extractors. Derive the capability-kind type from that same table and remove discovery's obsolete separate classification predicate. No new registry fields, runtime imports, activation rules, configuration, storage, provider calls, or plugin SDK contracts are introduced.

This refreshes the existing PR onto current main instead of opening a duplicate. It also corrects the architecture page's contradictory description of hook-only versus non-capability plugins. The shipped `v2026.7.1` projection has the same omissions; blame traces the retained projection through `30cbfa3457ed` (Peter Steinberger, April 18, 2026), with subsequent capability additions leaving these families absent.

## User Impact

Individual inspection and `--all`, JSON and human output, now reflect the capabilities already declared or registered by each plugin. Cold inspection stays lazy. Bonjour remains non-capability in cold metadata and reports gateway discovery only after non-activating runtime registration. Migration and extraction behavior themselves do not change.

Production: **+6 / -23, net -17 lines**. Tests: **+76**. Docs: **+3 / -2**. The cleanup removes a duplicated type inventory rather than adding another policy layer.

## Evidence

- Frozen main baseline: `99a2434f7b89c682f934326be9f7cc786f7ddeca`.
- Refreshed candidate: `2dcd36abf173a624279393f74ec3a762533ee8db`; replaces stale head `7b7f15a31bcdce8178b5b3100d72dcdcd71f0767` in this same maintainer-owned PR.
- Tests-first reproduction: four owner regressions failed before the initial repair; an additional web-content-extractor regression failed before completing that sibling projection. Failures demonstrate missing IDs, wrong capability counts/shapes, and false hook-only notices.
- Final focused owner/producer/compatibility proof: **42 passing tests in three files** (`status.test.ts`, `status.compatibility.integration.test.ts`, `loader-records.test.ts`), plus **one passing shape-contract test** and **five passing CLI inspection tests**. The shared shape contract was rerun after the final production edit.
- Real built-CLI RED: **10 successful command executions exposing incorrect reports** across Firecrawl cold/runtime, Bonjour cold/runtime, both migration-only plugins, Web Readability, aggregate JSON, and human output. This uses the retained CI-built runtime at `48e3e7e2e979e6c6ed565dd76ee1ab2e4bf20000`, whose compiled projection has the same omissions. It is older built-runtime evidence, not a claim that this artifact is the new baseline. Current-source regressions provide the baseline evidence.
- Real built-CLI GREEN: the same **10 commands pass** using `dist-runtime-build` artifact **9625662491** from [candidate CI run 33018601837](https://github.com/openclaw/openclaw/actions/runs/33018601837). The artifact records CI merge-ref commit `8ed53396a28e1c90061f630c937003734c14e130`, whose verified parents are `ce138ad420e6fea543c56db48a4bf0fe77a5bd08` and candidate `2dcd36abf173a624279393f74ec3a762533ee8db`. Its inspection source and the exported launcher, node-version module, and package metadata match the candidate blobs. This is a merge-ref build, not a literal head-only build or fresh package installation.
- The candidate reports Firecrawl as hybrid fetch/search; both migration plugins and Web Readability as plain capabilities; and Bonjour as cold non-capability versus runtime discovery. Aggregate JSON agrees with individual reports, human output names fetch/discovery, and cold probes retain `imported: false`. All 10 child processes exit 0.
- All CLI probes use disposable state/config/workspace and no provider credentials; temporary state is removed afterward. Inspection does not execute migration providers, extraction, provider tools, or Bonjour advertising. First-launch state migration touches only disposable state. The compiled probes use the same explicit primary-checkout dependency fallback described below.
- Fresh final Codex autoreview passed with no actionable findings. Independent source review checks producer ownership, CLI consumers, cold/runtime boundaries, siblings, and the canonical refactor.
- Targeted formatting, AST lint, diff checks, max-lines and assertion-safety ratchets pass. [Full exact-head CI 33018601837](https://github.com/openclaw/openclaw/actions/runs/33018601837) completed **successfully** on attempt 1 at `2026-08-26T22:33:42Z`, verified through the live run API on head `2dcd36abf173a624279393f74ec3a762533ee8db`. Candidate artifact proof is complete; old-head CI is not reused.

Local environment limits: this linked checkout resolves missing dependencies from the installed primary checkout through a private test harness. It is not a clean install or exact-lock dependency proof. One broader registry-snapshot test reports the genuine missing-workspace-dependencies diagnostic from `bundled-dir.ts` because this checkout lacks `node_modules/.pnpm`; its empty-diagnostics expectation therefore fails locally. No test expectation, environment guard, or production diagnostic was weakened. Full changed-gate completion is also limited by missing local tool binaries; hosted validation remains mandatory.

### Prior review follow-through

The migration-provider finding is addressed, and web-content extraction is included using existing `plugin.contracts`, just like document extraction; no dedicated record field is necessary. Fresh main-based code, focused proof, and exact-head CI replace the stale branch evidence. The earlier live check's expectation that Firecrawl should report gateway discovery is incorrect: Firecrawl owns fetch/search, while Bonjour owns discovery. Separate real CLI probes verify those boundaries.

AI-assisted maintainer repair. No agent transcript included.
