### PR TITLE
fix(status): preserve explicit gateway RPC timeouts

### DIFF
--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -1,8 +1,19 @@
 // Status scan shared tests cover gateway probe snapshots, Tailscale URLs, and shared scan helpers.
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { parseStatusRouteArgs } from "../cli/program/route-args.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "../gateway/minimal-gateway.test-helpers.js";
 import {
   buildTailscaleHttpsUrl,
   resolveGatewayProbeSnapshot,
@@ -325,39 +336,118 @@ describe("resolveGatewayProbeSnapshot", () => {
     expect(gatewayCall.timeoutMs).toBe(2000);
   });
 
-  it("does not raise an explicit local status RPC fallback timeout", async () => {
+  it.each([1, 50, 999, 1000, 2000, 8000])(
+    "does not raise an explicit local status RPC fallback timeout (%i ms)",
+    async (timeoutMs) => {
+      mocks.resolveGatewayProbeTarget.mockReturnValue({
+        mode: "local",
+        gatewayMode: "local",
+        remoteUrlMissing: false,
+      });
+      mocks.probeGateway.mockResolvedValue({
+        ok: false,
+        url: "ws://127.0.0.1:18789",
+        connectLatencyMs: null,
+        error: "timeout",
+        close: null,
+        auth: {
+          role: null,
+          scopes: [],
+          capability: "unknown",
+        },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      });
+      mocks.callGateway.mockResolvedValue({ sessions: 1 });
+
+      await resolveGatewayProbeSnapshot({
+        cfg: {},
+        opts: { timeoutMs },
+      });
+
+      const probeCall = readProbeCall();
+      expect(probeCall).not.toHaveProperty("preauthHandshakeTimeoutMs");
+      expect(probeCall.timeoutMs).toBe(timeoutMs);
+      expect(readGatewayCall().timeoutMs).toBe(Math.min(2000, timeoutMs));
+    },
+  );
+
+  it("enforces an explicit CLI timeout against a real local fallback status RPC", async () => {
+    const gateway = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(gateway, "listening");
+    const address = gateway.address() as AddressInfo;
+    const url = `ws://127.0.0.1:${address.port}`;
+    const observedMethods: string[] = [];
+    gateway.on("connection", (socket) => {
+      sendMinimalGatewayConnectChallenge(socket);
+      socket.on("message", (data) => {
+        const frame = parseMinimalGatewayRequestFrame(data);
+        if (frame.type !== "req" || !frame.id || !frame.method) {
+          return;
+        }
+        const requestId = frame.id;
+        if (frame.method === "connect") {
+          sendMinimalGatewayResponse(
+            socket,
+            requestId,
+            buildMinimalGatewayHelloOkPayload({
+              methods: ["system-presence", "status"],
+              auth: { role: "operator", scopes: ["operator.read"] },
+            }),
+          );
+          return;
+        }
+        observedMethods.push(frame.method);
+        if (frame.method === "status") {
+          const responseTimer = setTimeout(() => {
+            if (socket.readyState === socket.OPEN) {
+              sendMinimalGatewayResponse(socket, requestId, { sessions: 1 });
+            }
+          }, 400);
+          responseTimer.unref();
+        }
+      });
+    });
+
+    mocks.buildGatewayConnectionDetailsWithResolvers.mockReturnValue({
+      url,
+      urlSource: "local loopback",
+      message: `Gateway target: ${url}`,
+    });
     mocks.resolveGatewayProbeTarget.mockReturnValue({
       mode: "local",
       gatewayMode: "local",
       remoteUrlMissing: false,
     });
-    mocks.probeGateway.mockResolvedValue({
-      ok: false,
-      url: "ws://127.0.0.1:18789",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
+    mocks.probeGateway.mockImplementation(async (...args: unknown[]) => {
+      const { probeGateway } =
+        await vi.importActual<typeof import("../gateway/probe.js")>("../gateway/probe.js");
+      return await probeGateway(...(args as Parameters<typeof probeGateway>));
     });
-    mocks.callGateway.mockResolvedValue({ sessions: 1 });
-
-    await resolveGatewayProbeSnapshot({
-      cfg: {},
-      opts: { timeoutMs: 1000 },
+    mocks.callGateway.mockImplementation(async (...args: unknown[]) => {
+      const { callGateway } =
+        await vi.importActual<typeof import("../gateway/call.js")>("../gateway/call.js");
+      return await callGateway(...(args as Parameters<typeof callGateway>));
     });
+    const parsed = parseStatusRouteArgs(["node", "openclaw", "status", "--timeout", "250"]);
+    expect(parsed?.timeoutMs).toBe(250);
 
-    const probeCall = readProbeCall();
-    expect(probeCall).not.toHaveProperty("preauthHandshakeTimeoutMs");
-    expect(probeCall.timeoutMs).toBe(1000);
-    expect(readGatewayCall().timeoutMs).toBe(1000);
+    try {
+      const result = await resolveGatewayProbeSnapshot({
+        cfg: { gateway: { auth: { mode: "none" } } },
+        opts: { timeoutMs: parsed?.timeoutMs },
+      });
+
+      expect(readProbeCall().timeoutMs).toBe(250);
+      expect(readGatewayCall().timeoutMs).toBe(250);
+      expect(observedMethods).toEqual(["system-presence", "status"]);
+      expect(result.gatewayProbe?.ok).toBe(false);
+      expect(result.gatewayProbe?.error).toContain("timeout");
+    } finally {
+      await closeMinimalGatewayServer(gateway);
+    }
   });
 
   it("lets callGateway reuse paired-device auth for local status RPC fallback", async () => {

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -208,7 +208,11 @@ async function applyLocalStatusRpcFallback(params: {
   if (!shouldTryLocalStatusRpcFallback(params)) {
     return params.gatewayProbe;
   }
-  const boundedFallbackTimeoutMs = Math.min(2000, Math.max(1000, params.timeoutMs));
+  // Explicit probe budgets are operator-owned; only implicit fallback defaults get a floor.
+  const boundedFallbackTimeoutMs = Math.min(
+    2000,
+    params.timeoutMsExplicit ? params.timeoutMs : Math.max(1000, params.timeoutMs),
+  );
   // The fallback uses the gateway status RPC because it can succeed after probe handshake ambiguity.
   const status = await loadGatewayCallModule()
     .then(({ callGateway }) =>


### PR DESCRIPTION
## What Problem This Solves

`openclaw status --timeout 250` correctly uses the requested deadline for its initial local Gateway probe, but the local fallback status RPC previously raised that explicit deadline to 1,000 ms. A delayed fallback response could therefore keep running well after the operator's requested deadline.

The earlier unrelated red hosted check came from existing `main`: `test/scripts/test-projects.test.ts` expected the old changed-test owner route for `scripts/run-oxlint-shards.mjs`, while the new generic reference scanner also selected `test/scripts/ci-workflow-guards.test.ts`. The identical two failures occurred on existing main-branch CI runs. That separate main-branch regression was fixed by #117531; this change does not alter tooling or CI routing.

## Why This Change Was Made

Keep timeout ownership at the existing local fallback RPC owner. Explicit operator-supplied deadlines remain authoritative; only implicit fallback defaults retain their existing 1,000 ms floor. The existing 2,000 ms cap, remote Gateway behavior, authentication handling, and unrelated commands remain unchanged.

Changed files:

- `src/commands/status.scan.shared.ts`
- `src/commands/status.scan.shared.test.ts`

## User Impact

An explicitly requested short status deadline now bounds both the initial local Gateway probe and its local fallback RPC. Existing normal deadlines and implicit defaults continue to work. No configuration shape, public SDK, Gateway protocol, or machine-readable output contract changes.

## Evidence

Exact refreshed candidate: `a64c4e51b4d7f77a7cc6bb5852d7ebd2db01ca09`, tree `d29558d55f6ae4a08a6357bd40f86ed999b66cb2`, based on `a14ada134f91c92f76d2bc886ae75b7c7dc0cc0d` after #117531.

The complete build and real CLI proof below ran on precursor `ce327ead4964d329bddf185a2b3862fb943eb2b3`; both changed source and test Git blobs are byte-for-byte identical in the refreshed candidate. The only difference is the repaired main-branch ancestry. The refreshed exact HEAD was separately verified with 88 focused tests, configured type-aware lint, formatting, and a clean exact two-file diff.

A dedicated Blacksmith Testbox built the complete production application with `pnpm build`: all nine unified bundles, CLI bootstrap guard, all 148 public plugin SDK entrypoints, runtime postbuild, and the production Control UI passed. Total build time: 3 minutes, 32.9 seconds.

The test then ran the **actual built CLI executable** against a real localhost WebSocket Gateway. The server intentionally left `system-presence` unanswered and delayed the fallback `status` response by 400 ms. A parent-equivalent runtime was reconstructed by reversing exactly one compiled fallback-timeout expression in a copied build artifact; the candidate checkout and its compiled output remained unchanged.

Before:

```text
$ openclaw status --timeout 250
│ Gateway              │ local · ws://127.0.0.1:43649 (local loopback) · reachable 16ms · auth none                    │
stderr: empty
exit: 0

system-presence: 0 ms
fallback status request: 342 ms
delayed fallback response: 743 ms; socket open: true
fallback socket closed: 744 ms
```

After:

```text
$ openclaw status --timeout 250
│ Gateway              │ local · ws://127.0.0.1:34117 (local loopback) · reachable 15ms · auth none                    │
stderr: empty
exit: 0

system-presence: 0 ms
fallback status request: 331 ms
fallback socket closed: 577 ms; request duration: approximately 246 ms
delayed fallback response: 731 ms; socket open: false
```

Valid-deadline control:

```text
$ openclaw status --timeout 1000
│ Gateway              │ local · ws://127.0.0.1:35927 (local loopback) · reachable 15ms · auth none                    │
stderr: empty
exit: 0

fallback status request: 1,087 ms
delayed fallback response: 1,487 ms; socket open: true
fallback socket closed: 1,488 ms
```

Both short-timeout runs correctly report the Gateway as reachable because the initial connection handshake succeeds; the observable repaired invariant is that the actual fallback WebSocket request closes within its explicitly requested deadline instead of accepting a response 400 ms later.

Additional precursor verification: 110 focused status, scan, CLI, Gateway, and integration tests passed, and all three hosted test-type lanes passed. Exact refreshed HEAD verification: 88 focused tests passed across the five affected CLI/status files; both previously failing changed-tooling-routing tests now pass; configured type-aware lint, formatting, and the exact two-file diff passed. Four independent exact-commit hostile source reviews and genuine Codex `gpt-5.6-sol` high-effort formal review found no P0–P3 issues; formal confidence was 97%, and native TruffleHog secret scanning passed. The built precursor checkout HEAD and tree were verified before and after the real CLI proof, and the dedicated Testbox lease was stopped.
