### PR TITLE
fix(test): align derived tooling route fixtures

### DIFF
--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1211,7 +1211,7 @@ describe("scripts/test-projects changed-target routing", () => {
   it("keeps sharded oxlint runner edits on oxlint runner tests", () => {
     expect(resolveChangedTestTargetPlan(["scripts/run-oxlint-shards.mjs"])).toEqual({
       mode: "targets",
-      targets: ["test/scripts/run-oxlint.test.ts"],
+      targets: ["test/scripts/run-oxlint.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
     });
   });
 
@@ -2474,6 +2474,7 @@ describe("scripts/test-projects changed-target routing", () => {
         includePatterns: [
           "test/scripts/build-all.test.ts",
           "test/scripts/check-dynamic-import-warts.test.ts",
+          "test/scripts/ci-workflow-guards.test.ts",
           "test/scripts/run-oxlint.test.ts",
           "test/scripts/tsdown-build.test.ts",
         ],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where unrelated pull requests fail the `checks-node-compact-small-2` CI shard after the tooling-route derivation change landed on `main`.

## Why This Change Was Made

The derived route for `scripts/run-oxlint-shards.mjs` correctly includes both its direct owner test and `ci-workflow-guards.test.ts`, which references that runner. This updates the two stale exact expectations without changing routing behavior.

Regression source: https://github.com/openclaw/openclaw/pull/117407

## User Impact

No product behavior changes. Pull requests can complete the affected CI shard against current `main`.

## Evidence

- Reproduced identically in unrelated PR runs:
  - https://github.com/openclaw/openclaw/actions/runs/30709074222
  - https://github.com/openclaw/openclaw/actions/runs/30709074462
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts -t 'sharded oxlint|explicit tooling implementation'` (2 passed)
- `./node_modules/.bin/oxlint test/scripts/test-projects.test.ts`
- `git diff --check`
- autoreview clean (0.99)
