### PR TITLE
fix(discord): continue queued cleanup after settlement failures

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -583,6 +583,70 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
   });
 
+  it("continues queued durable cleanup after an earlier settlement failure", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const firstRun = createDeferred();
+    processDiscordMessageMock.mockImplementation(async () => {
+      await firstRun.promise;
+    });
+    preflightDiscordMessageMock.mockImplementation(
+      async (params: {
+        data: { channel_id: string };
+        abortSignal?: AbortSignal;
+        turnAdoptionLifecycle?: DiscordIngressLifecycle;
+      }) => ({
+        ...createPreflightContext(params.data.channel_id),
+        abortSignal: params.abortSignal,
+        turnAdoptionLifecycle: params.turnAdoptionLifecycle,
+      }),
+    );
+
+    const handlerParams = createDiscordHandlerParams();
+    const handler = createDiscordMessageHandler(handlerParams);
+    const activeIngress = createIngressLifecycle();
+    const failingQueuedIngress = createIngressLifecycle();
+    const laterQueuedIngress = createIngressLifecycle();
+    failingQueuedIngress.onAbandoned.mockRejectedValueOnce(
+      new Error("simulated durable release failure"),
+    );
+
+    await expect(
+      handler(createMessageData("m-1") as never, {} as never, {
+        turnAdoptionLifecycle: activeIngress,
+      }),
+    ).resolves.toEqual({ kind: "deferred" });
+    await flushQueueWork();
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      handler(createMessageData("m-2") as never, {} as never, {
+        turnAdoptionLifecycle: failingQueuedIngress,
+      }),
+    ).resolves.toEqual({ kind: "deferred" });
+    await expect(
+      handler(createMessageData("m-3") as never, {} as never, {
+        turnAdoptionLifecycle: laterQueuedIngress,
+      }),
+    ).resolves.toEqual({ kind: "deferred" });
+
+    const deactivation = handler.deactivate();
+    await vi.waitFor(() => expect(failingQueuedIngress.onAbandoned).toHaveBeenCalledTimes(1));
+    firstRun.resolve();
+
+    await expect(deactivation).resolves.toBeUndefined();
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(activeIngress.onAbandoned).toHaveBeenCalledTimes(1);
+    expect(laterQueuedIngress.onAbandoned).toHaveBeenCalledTimes(1);
+    const runtimeError = handlerParams.runtime.error as unknown as MockCallSource;
+    expect(
+      mockCalls(runtimeError).some(([message]) =>
+        String(message).includes("discord queued message cleanup failed"),
+      ),
+    ).toBe(true);
+  });
+
   it("preserves non-debounced message ordering by awaiting debouncer enqueue", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -112,6 +112,14 @@ export function createDiscordMessageRunQueue(
       const cleanupSkipped = async () => {
         try {
           await cleanupSkippedDiscordQueuedMessage({ job });
+        } catch (error) {
+          // Durable release is best-effort during shutdown. One failed claim
+          // must not strand the remaining accepted jobs or their pending tasks.
+          try {
+            params.runtime.error(danger(`discord queued message cleanup failed: ${String(error)}`));
+          } catch {
+            // Error reporting must not interrupt the remaining cleanup owners.
+          }
         } finally {
           settlePending();
         }


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

During Discord shutdown, skipped queued messages release their durable ingress claims in sequence. If one claim's abandon() callback rejected, cleanup stopped immediately: later accepted claims were not released, their pending tasks stayed unresolved, and dispatcher deactivation rejected before the remaining queue owners settled.

## Why This Change Was Made

Each skipped-job cleanup now owns and reports its own settlement failure while always settling its pending-task marker. The outer cleanup loop can therefore continue through every accepted queued job without turning one failed durable release into a shutdown-wide failure.

### Root Cause

cleanupSkippedQueuedMessages() awaited each cleanup callback without isolating rejections. Although cleanupSkipped() already removed its own pending marker in finally, its rejection escaped the loop, so later callbacks never ran and deactivate() never reached the final pending-task drain.

### Runtime ownership

The Discord dispatcher still closes admission and deactivates the shared keyed run queue. Each skipped job still asks its real ingress settlement owner to abandon the durable claim; the queue now treats that release as best-effort shutdown work, logs failures, and continues with later owners.

## User Impact

A Discord stop or reload can finish releasing later queued durable claims even when an earlier claim release fails. Those later messages remain replayable instead of being stranded behind one cleanup error. Queue ordering, active-run settlement, debounce behavior, and successful durable-release semantics remain unchanged.

## Evidence

Validated at exact head `34a1e8617425e96ded6fd5e9111c98e150f7a1d5`: 28 dispatcher, ingress, and keyed-queue tests passed; the complete test-type graph passed; and a standalone production-module proof continued from an induced first durable-release failure to the second claim and clean deactivation.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=deep-runtime tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `ea2e7f46a69744a6d1b346db20043a3388f9b001`
- **Proof head:** `34a1e8617425e96ded6fd5e9111c98e150f7a1d5`
- **Revalidated:** on the bound base

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=34a1e8617425e96ded6fd5e9111c98e150f7a1d5 -->

#### Discord queued durable cleanup command

```bash
node --import tsx --input-type=module -e "import{createDiscordMessageRunQueue as Q}from'./extensions/discord/src/monitor/message-run-queue.ts';import{fanInChannelIngressLifecycles as F}from'./src/plugin-sdk/channel-ingress-runtime.ts';let go,start,began=new Promise(r=>start=r),hold=new Promise(r=>go=r),a=[],s=[],e=[],z=new AbortController().signal;let life=(id,fail)=>({abortSignal:z,onAdopted:async()=>s.push(id),onAbandoned:async()=>{a.push(id);if(fail)throw Error('release failed')}}),job=(id,fail)=>({queueKey:'x',payload:{},runtime:{},ingressSettlement:F([life(id,fail)])});let q=Q({runtime:{error:x=>e.push(String(x))},testing:{processDiscordMessage:async()=>{start();await hold}}});q.enqueue(job('active'));await began;q.enqueue(job('first',true));q.enqueue(job('second'));let d=q.deactivate();go();await d;let r={test_runner:'none',abandoned:a,settled:s,errorCount:e.length};console.log(JSON.stringify(r));if(a+''!='first,second'||s+''!='active'||e.length!=1)process.exitCode=1"
```

- **Discord queued durable cleanup (PRODUCTION_RUNTIME; boundary: Discord dispatcher run-queue and durable ingress settlement boundary)** — Observed: The standalone process used the production Discord message run queue, shared channel run queue, and fan-in ingress lifecycle. With one active job and two queued jobs on the same key, the first queued durable release threw; the second queued claim was still abandoned, the active claim settled, exactly one cleanup error was reported, and deactivate() resolved. Result: the command exited 0 with abandoned=["first","second"], settled=["active"], errorCount=1, and deactivate() resolved. Proves one failed skipped-job settlement no longer prevents later durable releases or dispatcher shutdown completion. Preserves active-job settlement, per-key serialization, and ordered queued cleanup.

#### Redacted exact-head cleanup output

```text
$ git rev-parse HEAD
34a1e8617425e96ded6fd5e9111c98e150f7a1d5

$ node --import tsx --input-type=module -e <inline Discord cleanup proof>
{"test_runner":"none","abandoned":["first","second"],"settled":["active"],"errorCount":1}
```

### Automated verification

#### Discord dispatcher recovery regression

```bash
node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.queue.test.ts
```

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.queue.test.ts` — [TEST] 17/17 tests passed with 0 failures and 0 skips. Proves dispatcher deactivation continues to the later queued ingress lifecycle after an earlier abandon() rejection. Preserves debounce fan-in, active-run ordering, status lifecycle, abort handling, and normal queue recovery.

#### Ingress lifecycle ownership

```bash
node scripts/run-vitest.mjs src/plugin-sdk/channel-ingress-runtime.test.ts
```

- `node scripts/run-vitest.mjs src/plugin-sdk/channel-ingress-runtime.test.ts` — [TEST] 5/5 tests passed with 0 failures and 0 skips. Proves fan-in adoption, settlement, and abandonment retain their durable-claim contract. Preserves one logical Discord turn's ownership across every durable claim.

#### Shared keyed queue lifecycle

```bash
node scripts/run-vitest.mjs src/plugin-sdk/channel-lifecycle.queue.test.ts
```

- `node scripts/run-vitest.mjs src/plugin-sdk/channel-lifecycle.queue.test.ts` — [TEST] 6/6 tests passed with 0 failures and 0 skips. Proves the shared queue still serializes per key, isolates task failures, and deactivates without accepting meaningful queued work. Preserves unrelated-key concurrency and busy-state accounting.

#### Test type graph

```bash
pnpm check:test-types
```

- `pnpm check:test-types` — [STATIC] core-test, extensions-test, and test-root type graphs completed with exit code 0. Proves the Discord test and its owner contracts remain type-correct across core and extensions. Preserves cross-package test typing.

#### Scoped static verification

```bash
pnpm exec oxlint extensions/discord/src/monitor/message-run-queue.ts extensions/discord/src/monitor/message-handler.queue.test.ts
```

- `pnpm exec oxlint extensions/discord/src/monitor/message-run-queue.ts extensions/discord/src/monitor/message-handler.queue.test.ts` — [STATIC] 0 warnings and 0 errors. Proves the changed source and regression test satisfy the scoped lint contract. Preserves the bounded two-file implementation scope.

#### Formatting verification

```bash
pnpm exec oxfmt --check extensions/discord/src/monitor/message-run-queue.ts extensions/discord/src/monitor/message-handler.queue.test.ts
```

- `pnpm exec oxfmt --check extensions/discord/src/monitor/message-run-queue.ts extensions/discord/src/monitor/message-handler.queue.test.ts` — [STATIC] both files matched the repository format. Proves the final exact-head files require no formatting rewrite. Preserves repository formatting conventions.

#### Diff integrity

```bash
git diff --check origin/main...HEAD
```

- `git diff --check origin/main...HEAD` — [STATIC] completed with exit code 0 and no output. Proves the committed patch is whitespace-clean. Preserves the bounded review diff.

### Preserved boundaries

- active-job settlement, per-key serialization, and ordered queued cleanup.
- debounce fan-in, active-run ordering, status lifecycle, abort handling, and normal queue recovery.
- one logical Discord turn's ownership across every durable claim.
- unrelated-key concurrency and busy-state accounting.
- cross-package test typing.
- the bounded two-file implementation scope.
- repository formatting conventions.
- the bounded review diff.

### Proof gap

No live Discord credential or external transport was needed because the defect is owned by the in-process dispatcher, keyed queue, and durable-settlement boundary exercised directly here. The repository-wide test suite was not run; the complete test-type graph and 28 owner-adjacent tests passed, and no broader CI result is claimed.

</details>

### Artifacts

- None attached.
