### PR TITLE
fix(perf): separate warm and first-device health probes

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -807,7 +807,7 @@ jobs:
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
             node --import tsx scripts/bench-cli-startup.ts \
-            --case gatewayHealthJson \
+            --case gatewayHealthJsonConnected \
             --case gatewayHealthJsonFirstDevice \
             --case configGetGatewayPort \
             --runs "$source_runs" \

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -808,6 +808,7 @@ jobs:
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
             node --import tsx scripts/bench-cli-startup.ts \
             --case gatewayHealthJson \
+            --case gatewayHealthJsonFirstDevice \
             --case configGetGatewayPort \
             --runs "$source_runs" \
             --warmup 1 \

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -659,6 +659,7 @@ function buildConfigFixture(commandCase: CommandCase): Record<string, unknown> |
   if (
     commandCase.id !== "configGetGatewayPort" &&
     commandCase.id !== "gatewayHealthJson" &&
+    commandCase.id !== "gatewayHealthJsonFirstDevice" &&
     commandCase.id !== "health" &&
     commandCase.id !== "healthJson"
   ) {

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -447,12 +447,17 @@ const COMMAND_CASES: readonly CommandCase[] = [
     expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
   {
+    id: "gatewayHealthJsonConnected",
+    name: "gateway health --json (connected)",
+    args: ["gateway", "health", "--json"],
+    presets: [],
+    stateScope: "case",
+  },
+  {
     id: "gatewayHealthJsonFirstDevice",
     name: "gateway health --json (first device)",
     args: ["gateway", "health", "--json"],
     presets: [],
-    expectedExitCodes: [0, 1],
-    expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
   {
     id: "configGetGatewayPort",
@@ -659,6 +664,7 @@ function buildConfigFixture(commandCase: CommandCase): Record<string, unknown> |
   if (
     commandCase.id !== "configGetGatewayPort" &&
     commandCase.id !== "gatewayHealthJson" &&
+    commandCase.id !== "gatewayHealthJsonConnected" &&
     commandCase.id !== "gatewayHealthJsonFirstDevice" &&
     commandCase.id !== "health" &&
     commandCase.id !== "healthJson"

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -12,6 +12,7 @@ type CommandCase = {
   name: string;
   args: string[];
   presets: readonly string[];
+  stateScope?: "case" | "sample";
   expectedExitCodes?: readonly number[];
   expectedNonzeroOutputIncludes?: readonly string[];
   firstOutputBudgetMs?: number;
@@ -441,6 +442,15 @@ const COMMAND_CASES: readonly CommandCase[] = [
     name: "gateway health --json",
     args: ["gateway", "health", "--json"],
     presets: ["real"],
+    stateScope: "case",
+    expectedExitCodes: [0, 1],
+    expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
+  },
+  {
+    id: "gatewayHealthJsonFirstDevice",
+    name: "gateway health --json (first device)",
+    args: ["gateway", "health", "--json"],
+    presets: [],
     expectedExitCodes: [0, 1],
     expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
@@ -717,8 +727,10 @@ async function runSample(params: {
   cpuProfDir?: string;
   heapProfDir?: string;
   rssHookPath: string;
+  runRoot?: string;
 }): Promise<Sample> {
-  const runRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"));
+  const runRoot = params.runRoot ?? mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"));
+  const ownsRunRoot = params.runRoot == null;
   const stateDir = path.join(runRoot, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
   const configFixture = buildConfigFixture(params.commandCase);
@@ -849,7 +861,9 @@ async function runSample(params: {
       });
     });
   } finally {
-    rmSync(runRoot, { recursive: true, force: true });
+    if (ownsRunRoot) {
+      rmSync(runRoot, { recursive: true, force: true });
+    }
   }
 }
 
@@ -939,14 +953,24 @@ async function runCase(params: {
 }): Promise<Sample[]> {
   const samples: Sample[] = [];
   const totalRuns = params.warmup + params.runs;
-  for (let i = 0; i < totalRuns; i += 1) {
-    const sample = await runSample(params);
-    if (i < params.warmup) {
-      continue;
+  const caseRunRoot =
+    params.commandCase.stateScope === "case"
+      ? mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"))
+      : undefined;
+  try {
+    for (let i = 0; i < totalRuns; i += 1) {
+      const sample = await runSample({ ...params, runRoot: caseRunRoot });
+      if (i < params.warmup) {
+        continue;
+      }
+      samples.push(sample);
     }
-    samples.push(sample);
+    return samples;
+  } finally {
+    if (caseRunRoot) {
+      rmSync(caseRunRoot, { recursive: true, force: true });
+    }
   }
-  return samples;
 }
 
 function tailLines(value: string, maxLines: number): string {

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -442,7 +442,6 @@ const COMMAND_CASES: readonly CommandCase[] = [
     name: "gateway health --json",
     args: ["gateway", "health", "--json"],
     presets: ["real"],
-    stateScope: "case",
     expectedExitCodes: [0, 1],
     expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -463,6 +463,12 @@ describe("bench-cli-startup", () => {
         presets: ["real"],
       },
       {
+        id: "gatewayHealthJsonConnected",
+        name: "gateway health --json (connected)",
+        args: ["gateway", "health", "--json"],
+        presets: [],
+      },
+      {
         id: "gatewayHealthJsonFirstDevice",
         name: "gateway health --json (first device)",
         args: ["gateway", "health", "--json"],
@@ -491,7 +497,11 @@ describe("bench-cli-startup", () => {
     expect(testing.parseGatewayPortEnv("::1")).toBe(32123);
     expect(testing.parseGatewayPortEnv("[::1]")).toBe(32123);
 
-    for (const id of ["gatewayHealthJson", "gatewayHealthJsonFirstDevice"]) {
+    for (const id of [
+      "gatewayHealthJson",
+      "gatewayHealthJsonConnected",
+      "gatewayHealthJsonFirstDevice",
+    ]) {
       expect(
         withEnv({ OPENCLAW_GATEWAY_PORT: "45678" }, () =>
           testing.buildConfigFixture({

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -462,6 +462,12 @@ describe("bench-cli-startup", () => {
         args: ["gateway", "health", "--json"],
         presets: ["real"],
       },
+      {
+        id: "gatewayHealthJsonFirstDevice",
+        name: "gateway health --json (first device)",
+        args: ["gateway", "health", "--json"],
+        presets: [],
+      },
       { id: "health", name: "health", args: ["health"], presets: ["startup", "real"] },
       {
         id: "healthJson",
@@ -485,16 +491,18 @@ describe("bench-cli-startup", () => {
     expect(testing.parseGatewayPortEnv("::1")).toBe(32123);
     expect(testing.parseGatewayPortEnv("[::1]")).toBe(32123);
 
-    expect(
-      withEnv({ OPENCLAW_GATEWAY_PORT: "45678" }, () =>
-        testing.buildConfigFixture({
-          id: "gatewayHealthJson",
-          name: "gateway health --json",
-          args: ["gateway", "health", "--json"],
-          presets: ["real"],
-        }),
-      ),
-    ).toMatchObject({ gateway: { port: 45678 } });
+    for (const id of ["gatewayHealthJson", "gatewayHealthJsonFirstDevice"]) {
+      expect(
+        withEnv({ OPENCLAW_GATEWAY_PORT: "45678" }, () =>
+          testing.buildConfigFixture({
+            id,
+            name: "gateway health --json",
+            args: ["gateway", "health", "--json"],
+            presets: [],
+          }),
+        ),
+      ).toMatchObject({ gateway: { port: 45678 } });
+    }
 
     for (const invalid of ["45678abc", "127.0.0.1:45678abc"]) {
       expect(() =>

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -78,7 +78,7 @@ describe("CLI startup benchmark script spawners", () => {
         return fs.readFileSync(homeLogPath, "utf8").trim().split("\n");
       };
 
-      const warmedHomes = runCase("gatewayHealthJson");
+      const warmedHomes = runCase("gatewayHealthJsonConnected");
       expect(warmedHomes).toHaveLength(3);
       expect(new Set(warmedHomes).size).toBe(1);
       expect(warmedHomes.every((home) => !fs.existsSync(home))).toBe(true);
@@ -87,6 +87,49 @@ describe("CLI startup benchmark script spawners", () => {
       expect(firstDeviceHomes).toHaveLength(3);
       expect(new Set(firstDeviceHomes).size).toBe(3);
       expect(firstDeviceHomes.every((home) => !fs.existsSync(home))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires connected gateway health probes to exit successfully", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-connected-test-"));
+    try {
+      const fixturePath = path.join(tmpDir, "transport-error.mjs");
+      fs.writeFileSync(
+        fixturePath,
+        [
+          'console.log(\'{"ok":false,"gateway_transport_error":"closed"}\');',
+          "process.exitCode = 1;",
+          "",
+        ].join("\n"),
+      );
+
+      const runCase = (caseId: string) =>
+        spawnSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-cli-startup.ts",
+            "--entry",
+            fixturePath,
+            "--case",
+            caseId,
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+          ],
+          { cwd: process.cwd(), encoding: "utf8" },
+        );
+
+      expect(runCase("gatewayHealthJson").status).toBe(0);
+      for (const caseId of ["gatewayHealthJsonConnected", "gatewayHealthJsonFirstDevice"]) {
+        const result = runCase(caseId);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(`${caseId} sample 1: exited with code 1`);
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -34,6 +34,64 @@ describe("CLI startup benchmark script spawners", () => {
     );
   });
 
+  it("reuses warmed state for gateway health while isolating first-device samples", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-state-scope-test-"));
+    try {
+      const fixturePath = path.join(tmpDir, "record-home.mjs");
+      const homeLogPath = path.join(tmpDir, "homes.log");
+      fs.writeFileSync(
+        fixturePath,
+        [
+          'import { appendFileSync } from "node:fs";',
+          "appendFileSync(process.env.OPENCLAW_BENCH_HOME_LOG, `${process.env.HOME}\\n`);",
+          "console.log('{\"ok\":true}');",
+          "",
+        ].join("\n"),
+      );
+
+      const runCase = (caseId: string) => {
+        fs.rmSync(homeLogPath, { force: true });
+        execFileSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-cli-startup.ts",
+            "--entry",
+            fixturePath,
+            "--case",
+            caseId,
+            "--runs",
+            "2",
+            "--warmup",
+            "1",
+          ],
+          {
+            cwd: process.cwd(),
+            env: {
+              ...process.env,
+              OPENCLAW_BENCH_HOME_LOG: homeLogPath,
+            },
+            stdio: "pipe",
+          },
+        );
+        return fs.readFileSync(homeLogPath, "utf8").trim().split("\n");
+      };
+
+      const warmedHomes = runCase("gatewayHealthJson");
+      expect(warmedHomes).toHaveLength(3);
+      expect(new Set(warmedHomes).size).toBe(1);
+      expect(warmedHomes.every((home) => !fs.existsSync(home))).toBe(true);
+
+      const firstDeviceHomes = runCase("gatewayHealthJsonFirstDevice");
+      expect(firstDeviceHomes).toHaveLength(3);
+      expect(new Set(firstDeviceHomes).size).toBe(3);
+      expect(firstDeviceHomes.every((home) => !fs.existsSync(home))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not require unrelated fixture cases for a narrowed preset", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-budget-test-"));
     try {

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -83,10 +83,12 @@ describe("CLI startup benchmark script spawners", () => {
       expect(new Set(warmedHomes).size).toBe(1);
       expect(warmedHomes.every((home) => !fs.existsSync(home))).toBe(true);
 
-      const firstDeviceHomes = runCase("gatewayHealthJsonFirstDevice");
-      expect(firstDeviceHomes).toHaveLength(3);
-      expect(new Set(firstDeviceHomes).size).toBe(3);
-      expect(firstDeviceHomes.every((home) => !fs.existsSync(home))).toBe(true);
+      for (const caseId of ["gatewayHealthJson", "gatewayHealthJsonFirstDevice"]) {
+        const sampleHomes = runCase(caseId);
+        expect(sampleHomes).toHaveLength(3);
+        expect(new Set(sampleHomes).size).toBe(3);
+        expect(sampleHomes.every((home) => !fs.existsSync(home))).toBe(true);
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -254,6 +254,13 @@ describe("OpenClaw performance workflow", () => {
     expect(run.indexOf(probeCap)).toBeLessThan(run.indexOf(boundedProbe));
   });
 
+  it("measures warmed and first-device gateway health separately", () => {
+    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+
+    expect(run).toContain("--case gatewayHealthJson \\");
+    expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
+  });
+
   it("isolates required publication in a fresh artifact-consuming job", () => {
     const workflow = readWorkflow();
     const publisher = workflow.jobs?.publish;

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -257,7 +257,7 @@ describe("OpenClaw performance workflow", () => {
   it("measures warmed and first-device gateway health separately", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
 
-    expect(run).toContain("--case gatewayHealthJson \\");
+    expect(run).toContain("--case gatewayHealthJsonConnected \\");
     expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
   });
 


### PR DESCRIPTION
## What Problem This Solves

The source performance workflow labeled `gateway health --json` as warmed even though every sample received a fresh HOME and device identity. It also accepted exit code 1 from probes expected to connect to the workflow's running Gateway, allowing a transport error to become a timing sample.

## Why This Change Was Made

The benchmark keeps sample-isolated state as the default. The warmed connected-health case reuses one case-scoped HOME across warmup and measured samples, while a separate first-device case retains fresh state for every sample.

Both workflow-owned connected cases require exit code 0. The generic standalone health case remains sample-isolated and offline-tolerant for its existing real-preset contract.

## User Impact

Maintainers get two honest, fail-closed metrics:

- warmed Gateway health after device state has been established
- explicit first-device Gateway health with fresh state

No product runtime behavior changes.

## Evidence

- Exact head: `d40d08e91eda306807e7d5bfee663413f8dbf01d`.
- Exact base: `f4253da3e40b6b65560fa4f9aa9d3fce1faceb97`.
- Hosted connected-health run for the behaviorally identical benchmark diff passed: https://github.com/openclaw/openclaw/actions/runs/30711380810
- The source artifact contains both `gatewayHealthJsonConnected` and `gatewayHealthJsonFirstDevice`.
- All six connected-health samples exited code 0.
- Artifact results:
  - warmed connected health p50 `688.5ms`, p95 `7486.3ms`
  - first-device health p50 `628.3ms`, p95 `631.8ms`
- The warmed outlier remains observable and out of scope: no shared lock or abort mechanism has been proven, so this PR does not claim to fix it.
- Focused tests lock three state-lifetime contracts: generic sample isolation, connected case reuse, and first-device sample isolation.
- 60/60 focused tooling tests passed after the final correction and latest-main rebase.
- Targeted `oxfmt`, direct `oxlint`, and `git diff --check` passed.

The current head resolves the old ClawSweeper finding by removing case-scoped state from `gatewayHealthJson` and adding the focused generic-case regression assertion.
