### PR TITLE
fix(tts): preserve canonical voice selections through normalization

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -97,6 +97,11 @@ preset and adapt the provider block. The `speakerVoice`/`speakerVoiceId`
 fields shown below are canonical; each provider's own `voice`/`voiceId`/
 `voiceName` field names still work as legacy aliases.
 
+OpenRouter and DeepInfra use the first nonblank value from `speakerVoice`,
+`speakerVoiceId`, `voice`, and `voiceId`, in that order, before the provider default.
+Talk applies the same order to its provider block; when all four fields are absent
+or blank, it keeps the base TTS voice.
+
 <Tabs>
   <Tab title="Azure Speech">
 ```json5

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -1,6 +1,27 @@
 // OpenAI-compatible speech provider tests cover speech request and file output.
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { createOpenAiCompatibleSpeechProvider } from "./openai-compatible-speech-provider.js";
+import { withSpeakerSelectionCompat, withSpeakerSelectionFallbackCompat } from "./speaker.js";
+import { getResolvedSpeechProviderConfig } from "./tts-provider-resolution.js";
+import { resolveTtsConfig } from "./tts-settings.js";
+
+const providerState = vi.hoisted(() => ({
+  provider: undefined as SpeechProviderPlugin | undefined,
+}));
+
+vi.mock("./provider-registry.js", async () => {
+  const { createSpeechProviderRegistry, normalizeSpeechProviderId } =
+    await import("./provider-registry-core.js");
+  return {
+    ...createSpeechProviderRegistry({
+      getProvider: () => providerState.provider,
+      listProviders: () => (providerState.provider ? [providerState.provider] : []),
+    }),
+    normalizeSpeechProviderId,
+  };
+});
 
 const {
   assertOkOrThrowHttpErrorMock,
@@ -54,10 +75,113 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
     postJsonRequestMock.mockReset();
     readProviderBinaryResponseMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
+    providerState.provider = undefined;
     vi.unstubAllEnvs();
   });
 
-  it("normalizes config with built-in base URL policies", () => {
+  it.each([
+    {
+      name: "canonical name before canonical id and legacy aliases",
+      selection: {
+        speakerVoice: " cedar ",
+        speakerVoiceId: "canonical-id",
+        voice: "legacy",
+        voiceId: "legacy-id",
+      },
+      expected: "cedar",
+    },
+    {
+      name: "canonical id before a legacy name",
+      selection: { speakerVoiceId: " canonical-id ", voice: "legacy", voiceId: "legacy-id" },
+      expected: "canonical-id",
+    },
+    {
+      name: "canonical id after a blank canonical name",
+      selection: { speakerVoice: " ", speakerVoiceId: " canonical-id ", voice: "legacy" },
+      expected: "canonical-id",
+    },
+    {
+      name: "legacy name after blank canonical fields",
+      selection: {
+        speakerVoice: " ",
+        speakerVoiceId: " ",
+        voice: " legacy ",
+        voiceId: "legacy-id",
+      },
+      expected: "legacy",
+    },
+    {
+      name: "legacy id after a blank legacy name",
+      selection: { speakerVoice: " ", speakerVoiceId: " ", voice: " ", voiceId: " legacy-id " },
+      expected: "legacy-id",
+    },
+    { name: "provider default without a selection", selection: {}, expected: "alloy" },
+  ])(
+    "preserves $name through direct, normalized, runtime, and Talk synthesis",
+    async ({ selection, expected }) => {
+      const provider = createOpenAiCompatibleSpeechProvider({
+        id: "demo",
+        label: "Demo",
+        autoSelectOrder: 40,
+        models: ["demo-tts"],
+        voices: ["alloy"],
+        defaultModel: "demo-tts",
+        defaultVoice: "alloy",
+        defaultBaseUrl: "https://example.test/v1",
+        envKey: "DEMO_API_KEY",
+        responseFormats: ["mp3"],
+        defaultResponseFormat: "mp3",
+        voiceCompatibleResponseFormats: ["mp3"],
+      });
+      providerState.provider = provider;
+      postJsonRequestMock.mockImplementation(async () => ({
+        response: new Response(new Uint8Array([4, 5, 6]), { status: 200 }),
+        release: async () => {},
+      }));
+      const providerConfig = { apiKey: "test-key", ...selection };
+      const rawConfig = { provider: "demo", providers: { demo: providerConfig } };
+      const cfg = { tts: rawConfig };
+      const normalized = provider.resolveConfig?.({ cfg, rawConfig, timeoutMs: 1000 });
+      const resolved = getResolvedSpeechProviderConfig(resolveTtsConfig(cfg), "demo", cfg);
+      const talkConfig = provider.resolveTalkConfig?.({
+        cfg,
+        baseTtsConfig: { providers: { demo: { apiKey: "test-key", voice: "base-voice" } } },
+        talkProviderConfig: withSpeakerSelectionFallbackCompat(selection),
+        timeoutMs: 1000,
+      });
+      const inheritedTalkConfig = provider.resolveTalkConfig?.({
+        cfg,
+        baseTtsConfig: { providers: { demo: withSpeakerSelectionCompat(providerConfig) } },
+        talkProviderConfig: { speakerVoice: " ", speakerVoiceId: " ", voice: " ", voiceId: " " },
+        timeoutMs: 1000,
+      });
+      for (const config of [
+        providerConfig,
+        expectDefined(normalized, "normalized provider config"),
+        resolved,
+        expectDefined(talkConfig, "Talk provider config"),
+        expectDefined(inheritedTalkConfig, "inherited Talk provider config"),
+      ]) {
+        await provider.synthesize({
+          text: "Voice precedence",
+          cfg,
+          providerConfig: config,
+          target: "audio-file",
+          timeoutMs: 1000,
+        });
+      }
+      expect(postJsonRequestMock.mock.calls.map(([request]) => request.body.voice)).toEqual([
+        expected,
+        expected,
+        expected,
+        Object.keys(selection).length === 0 ? "base-voice" : expected,
+        expected,
+      ]);
+      expect(providerConfig).toEqual({ apiKey: "test-key", ...selection });
+    },
+  );
+
+  it("normalizes config with built-in base URL policies and preserves secret error paths", () => {
     const provider = createOpenAiCompatibleSpeechProvider({
       id: "demo",
       label: "Demo",
@@ -103,6 +227,22 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
       speed: 1.25,
       responseFormat: "pcm",
     });
+    const apiKey = { source: "env", provider: "default", id: "UNRESOLVED_SPEECH_KEY" } as const;
+    expect(() =>
+      provider.resolveConfig?.({
+        cfg: {},
+        rawConfig: { providers: { demo: { apiKey } } },
+        timeoutMs: 1000,
+      }),
+    ).toThrow("tts.providers.demo.apiKey");
+    expect(() =>
+      provider.resolveTalkConfig?.({
+        cfg: {},
+        baseTtsConfig: {},
+        talkProviderConfig: { apiKey },
+        timeoutMs: 1000,
+      }),
+    ).toThrow("talk.providers.demo.apiKey");
   });
 
   it("maps configured extra JSON body fields into synthesis requests", async () => {

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -1,5 +1,6 @@
 // OpenAI-compatible speech provider tests cover speech request and file output.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withSpeakerSelectionFallbackCompat } from "../../packages/speech-core/speaker.js";
 import { createOpenAiCompatibleSpeechProvider } from "./openai-compatible-speech-provider.js";
 
 const {
@@ -193,12 +194,21 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
       if (!resolvedConfig) {
         throw new Error("missing resolved speech config");
       }
+      const talkConfig = provider.resolveTalkConfig?.({
+        cfg: {} as never,
+        baseTtsConfig: { providers: { [providerId]: { voice: "base-voice" } } },
+        talkProviderConfig: withSpeakerSelectionFallbackCompat(providerConfig),
+        timeoutMs: 1_000,
+      });
+      if (!talkConfig) {
+        throw new Error("missing resolved Talk speech config");
+      }
 
       postJsonRequestMock.mockImplementation(async () => ({
         response: new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
         release: async () => {},
       }));
-      for (const config of [providerConfig, resolvedConfig]) {
+      for (const config of [providerConfig, resolvedConfig, talkConfig]) {
         await provider.synthesize({
           text: "Speak in the configured voice.",
           cfg: {} as never,
@@ -211,8 +221,9 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
       const requestVoices = postJsonRequestMock.mock.calls.map(
         ([request]) => (request as { body: { voice: unknown } }).body.voice,
       );
-      expect(requestVoices).toEqual([expectedVoice, expectedVoice]);
+      expect(requestVoices).toEqual([expectedVoice, expectedVoice, expectedVoice]);
       expect(resolvedConfig.voice).toBe(expectedVoice);
+      expect(talkConfig.voice).toBe(expectedVoice);
     },
   );
 

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -105,6 +105,117 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
     });
   });
 
+  it.each([
+    {
+      providerId: "openrouter",
+      scenario: "speakerVoice before every legacy alias",
+      voiceConfig: {
+        speakerVoice: " af_sky ",
+        speakerVoiceId: "canonical-id",
+        voice: "legacy-voice",
+        voiceId: "legacy-id",
+      },
+      expectedVoice: "af_sky",
+    },
+    {
+      providerId: "deepinfra",
+      scenario: "speakerVoiceId after a blank speakerVoice",
+      voiceConfig: {
+        speakerVoice: "  ",
+        speakerVoiceId: " af_heart ",
+        voice: "legacy-voice",
+        voiceId: "legacy-id",
+      },
+      expectedVoice: "af_heart",
+    },
+    {
+      providerId: "openrouter",
+      scenario: "the shipped voice alias after blank canonical values",
+      voiceConfig: {
+        speakerVoice: "  ",
+        speakerVoiceId: "  ",
+        voice: " af_nova ",
+        voiceId: "legacy-id",
+      },
+      expectedVoice: "af_nova",
+    },
+    {
+      providerId: "deepinfra",
+      scenario: "the shipped voiceId alias after a blank voice",
+      voiceConfig: {
+        speakerVoice: "  ",
+        speakerVoiceId: "  ",
+        voice: "  ",
+        voiceId: " af_echo ",
+      },
+      expectedVoice: "af_echo",
+    },
+  ] as const)(
+    "$providerId honors $scenario",
+    async ({ providerId, voiceConfig, expectedVoice }) => {
+      const providers = {
+        openrouter: {
+          label: "OpenRouter",
+          model: "hexgrad/kokoro-82m",
+          defaultVoice: "af_alloy",
+          baseUrl: "https://openrouter.ai/api/v1",
+          envKey: "OPENROUTER_API_KEY",
+        },
+        deepinfra: {
+          label: "DeepInfra",
+          model: "hexgrad/Kokoro-82M",
+          defaultVoice: "af_bella",
+          baseUrl: "https://api.deepinfra.com/v1/openai",
+          envKey: "DEEPINFRA_API_KEY",
+        },
+      } as const;
+      const fixture = providers[providerId];
+      const provider = createOpenAiCompatibleSpeechProvider({
+        id: providerId,
+        label: fixture.label,
+        autoSelectOrder: 40,
+        models: [fixture.model],
+        voices: [fixture.defaultVoice],
+        defaultModel: fixture.model,
+        defaultVoice: fixture.defaultVoice,
+        defaultBaseUrl: fixture.baseUrl,
+        envKey: fixture.envKey,
+        responseFormats: ["mp3"],
+        defaultResponseFormat: "mp3",
+        voiceCompatibleResponseFormats: ["mp3"],
+      });
+      const providerConfig = { apiKey: "test-api-key", ...voiceConfig };
+      const resolvedConfig = provider.resolveConfig?.({
+        cfg: {} as never,
+        timeoutMs: 1_000,
+        rawConfig: { providers: { [providerId]: providerConfig } },
+      });
+      if (!resolvedConfig) {
+        throw new Error("missing resolved speech config");
+      }
+
+      postJsonRequestMock.mockImplementation(async () => ({
+        response: new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+        release: async () => {},
+      }));
+      for (const config of [providerConfig, resolvedConfig]) {
+        await provider.synthesize({
+          text: "Speak in the configured voice.",
+          cfg: {} as never,
+          providerConfig: config,
+          target: "audio-file",
+          timeoutMs: 1_000,
+        });
+      }
+
+      const requestVoices = postJsonRequestMock.mock.calls.map(
+        ([request]) => (request as { body: { voice: unknown } }).body.voice,
+      );
+      expect(requestVoices).toEqual([expectedVoice, expectedVoice]);
+      expect(resolvedConfig.voice).toBe(expectedVoice);
+    },
+  );
+
   it("maps configured extra JSON body fields into synthesis requests", async () => {
     const release = vi.fn(async () => {});
     postJsonRequestMock.mockResolvedValue({

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -74,6 +74,17 @@ type ModelProviderConfig = {
   baseUrl?: unknown;
 };
 
+function resolveConfiguredSpeechVoice(
+  config: SpeechProviderConfig | undefined,
+): string | undefined {
+  return (
+    trimToUndefined(config?.speakerVoice) ??
+    trimToUndefined(config?.speakerVoiceId) ??
+    trimToUndefined(config?.voice) ??
+    trimToUndefined(config?.voiceId)
+  );
+}
+
 function normalizeResponseFormat(params: {
   providerLabel: string;
   responseFormats: readonly string[];
@@ -210,53 +221,39 @@ export function createOpenAiCompatibleSpeechProvider<
     rawConfig: Record<string, unknown>,
   ): OpenAiCompatibleSpeechProviderConfig<ExtraConfig> {
     const raw = resolveProviderConfigRecord(rawConfig, providerConfigKey);
-    return {
+    return readProviderConfig(raw, {
+      model: options.defaultModel,
+      voice: options.defaultVoice,
       apiKey: normalizeResolvedSecretInputString({
         value: raw?.apiKey,
         path: `tts.providers.${providerConfigKey}.apiKey`,
       }),
-      baseUrl:
-        trimToUndefined(raw?.baseUrl) == null
-          ? undefined
-          : normalizeBaseUrl({
-              value: raw?.baseUrl,
-              fallback: options.defaultBaseUrl,
-              policy: options.baseUrlPolicy,
-            }),
-      model: normalizeModel(trimToUndefined(raw?.model ?? raw?.modelId), options.defaultModel),
-      voice: trimToUndefined(raw?.voice ?? raw?.voiceId) ?? options.defaultVoice,
-      speed: asFiniteNumber(raw?.speed),
-      responseFormat: normalizeResponseFormat({
-        providerLabel: options.label,
-        responseFormats: options.responseFormats,
-        value: raw?.responseFormat,
-      }),
-      ...readExtraConfig(raw),
-    };
+    });
   }
 
   function readProviderConfig(
-    config: SpeechProviderConfig,
+    config: SpeechProviderConfig | undefined,
+    // Raw config supplies base defaults; direct synthesis retains normalized plugin defaults.
+    normalized: OpenAiCompatibleSpeechProviderBaseConfig = normalizeConfig({}),
   ): OpenAiCompatibleSpeechProviderConfig<ExtraConfig> {
-    const normalized = normalizeConfig({});
     return {
-      apiKey: trimToUndefined(config.apiKey) ?? normalized.apiKey,
+      apiKey: trimToUndefined(config?.apiKey) ?? normalized.apiKey,
       baseUrl:
-        trimToUndefined(config.baseUrl) == null
+        trimToUndefined(config?.baseUrl) == null
           ? normalized.baseUrl
           : normalizeBaseUrl({
-              value: config.baseUrl,
+              value: config?.baseUrl,
               fallback: options.defaultBaseUrl,
               policy: options.baseUrlPolicy,
             }),
-      model: normalizeModel(trimToUndefined(config.model ?? config.modelId), normalized.model),
-      voice: trimToUndefined(config.voice ?? config.voiceId) ?? normalized.voice,
-      speed: asFiniteNumber(config.speed) ?? normalized.speed,
+      model: normalizeModel(trimToUndefined(config?.model ?? config?.modelId), normalized.model),
+      voice: resolveConfiguredSpeechVoice(config) ?? normalized.voice,
+      speed: asFiniteNumber(config?.speed) ?? normalized.speed,
       responseFormat:
         normalizeResponseFormat({
           providerLabel: options.label,
           responseFormats: options.responseFormats,
-          value: config.responseFormat,
+          value: config?.responseFormat,
         }) ?? normalized.responseFormat,
       ...readExtraConfig(config),
     };
@@ -324,10 +321,7 @@ export function createOpenAiCompatibleSpeechProvider<
       if (modelId !== undefined) {
         next.model = normalizeModel(modelId, options.defaultModel);
       }
-      const voiceId = trimToUndefined(talkProviderConfig.voiceId);
-      if (voiceId !== undefined) {
-        next.voice = voiceId;
-      }
+      next.voice = resolveConfiguredSpeechVoice(talkProviderConfig) ?? base.voice;
       const speed = asFiniteNumber(talkProviderConfig.speed);
       if (speed !== undefined) {
         next.speed = speed;

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -331,9 +331,9 @@ export function createOpenAiCompatibleSpeechProvider<
       if (modelId !== undefined) {
         next.model = normalizeModel(modelId, options.defaultModel);
       }
-      const voiceId = trimToUndefined(talkProviderConfig.voiceId);
-      if (voiceId !== undefined) {
-        next.voice = voiceId;
+      const voice = resolveConfiguredSpeechVoice(talkProviderConfig);
+      if (voice !== undefined) {
+        next.voice = voice;
       }
       const speed = asFiniteNumber(talkProviderConfig.speed);
       if (speed !== undefined) {

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -125,6 +125,17 @@ function resolveProviderConfigRecord(
   return asObject(providers?.[providerConfigKey]) ?? asObject(rawConfig[providerConfigKey]);
 }
 
+function resolveConfiguredSpeechVoice(
+  config: SpeechProviderConfig | undefined,
+): string | undefined {
+  return (
+    trimToUndefined(config?.speakerVoice) ??
+    trimToUndefined(config?.speakerVoiceId) ??
+    trimToUndefined(config?.voice) ??
+    trimToUndefined(config?.voiceId)
+  );
+}
+
 function readModelProviderConfig(
   cfg: unknown,
   providerConfigKey: string,
@@ -220,7 +231,7 @@ export function createOpenAiCompatibleSpeechProvider<
               policy: options.baseUrlPolicy,
             }),
       model: normalizeModel(trimToUndefined(raw?.model ?? raw?.modelId), options.defaultModel),
-      voice: trimToUndefined(raw?.voice ?? raw?.voiceId) ?? options.defaultVoice,
+      voice: resolveConfiguredSpeechVoice(raw) ?? options.defaultVoice,
       speed: asFiniteNumber(raw?.speed),
       responseFormat: normalizeResponseFormat({
         providerLabel: options.label,
@@ -246,7 +257,7 @@ export function createOpenAiCompatibleSpeechProvider<
               policy: options.baseUrlPolicy,
             }),
       model: normalizeModel(trimToUndefined(config.model ?? config.modelId), normalized.model),
-      voice: trimToUndefined(config.voice ?? config.voiceId) ?? normalized.voice,
+      voice: resolveConfiguredSpeechVoice(config) ?? normalized.voice,
       speed: asFiniteNumber(config.speed) ?? normalized.speed,
       responseFormat:
         normalizeResponseFormat({

--- a/src/tts/speaker.ts
+++ b/src/tts/speaker.ts
@@ -14,8 +14,10 @@ export function withSpeakerSelectionCompat(
   const voice = readString(next.voice);
   const voiceName = readString(next.voiceName);
   const voiceId = readString(next.voiceId);
-  const canonicalVoice = speakerVoice ?? voice ?? voiceName;
-  const canonicalVoiceId = speakerVoiceId ?? voiceId;
+  // Do not promote a legacy alias above an authored canonical selection of the
+  // other kind. Providers may accept both names and ids with their own precedence.
+  const canonicalVoice = speakerVoice ?? (speakerVoiceId ? undefined : (voice ?? voiceName));
+  const canonicalVoiceId = speakerVoiceId ?? (speakerVoice ? undefined : voiceId);
   if (canonicalVoice) {
     next.speakerVoice = canonicalVoice;
     next.voice = canonicalVoice;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where configured canonical speaker voices could be replaced by a legacy voice value or the provider default in OpenRouter/DeepInfra speech synthesis and Talk.

## Why This Change Was Made

The compatibility producer was manufacturing a canonical name from a legacy alias even when the operator had authored a canonical voice ID. That erased the intended precedence before the provider saw it. The producer now preserves authored canonical choices; the compatible speech factory applies independently trimmed `speakerVoice`, `speakerVoiceId`, `voice`, then `voiceId` through one normalization body. Talk uses the same selection and inherits the base TTS voice when its local selection is blank.

Strict secret-reference paths, plugin default normalization, extra-config hooks, per-request overrides, and legacy-only input remain unchanged. No operator configuration option, schema, dependency, or provider API request format was added.

## User Impact

Canonical voice settings reach synthesis consistently through direct configuration, the actual TTS resolver, and Talk inheritance or local overrides. Production code shrinks by four lines (+30/-34); tests grow by 140 and docs by five.

## Evidence

Five regression cases failed on the pre-fix producer/factory for wrong voice selection. The repaired code passed 219 tests across 10 owner/sibling files, including shared TTS, Talk, OpenRouter, DeepInfra, OpenAI, ElevenLabs, and Google. A final focused run passed all 10 factory cases, the complete changed-code gate passed, and fresh independent Codex review through P2 was scoped-clean.

Four authenticated requests exercised the shared factory against the real OpenAI `/v1/audio/speech` API with `gpt-4o-mini-tts`, plus the actual TTS and `talk.speak` handlers. Canonical name, canonical ID with conflicting legacy input, Talk inheritance, and Talk-local override all selected `cedar` and returned valid mono 24-kHz MP3 audio (54528, 52224, 48768, and 42624 bytes). This is shared-factory/OpenAI API proof, not a claim of authenticated OpenRouter or DeepInfra backend testing. A separate synthetic-synthesis probe used the real OpenRouter plugin through the same TTS/Talk entry points.

The initial changed-code gate caught test-only type errors (registry absence and missing assertion context labels); these were corrected, focused tests and review refreshed, and the complete gate rerun successfully. An early synthetic transport experiment was rejected by OpenRouter because its fake key reached the guarded transport; that harness approach was removed without weakening transport policy.

The previous review's rank-up requests are addressed: the helper comes from current `./speaker.js`, `asOptionalRecord` is retained, and direct/normalized/Talk proof is refreshed. Direct upstream Codex inspection covered realtime voice selection in `core/src/realtime_conversation.rs:1320–1453` and `protocol/src/protocol.rs:239–359`; Codex's single typed realtime voice does not define OpenClaw's canonical/legacy TTS alias contract. No Codex realtime protocol behavior changes.

CI follow-through: the first head hit the already-repaired UI startup-size failure (346770 bytes versus346761). Rebased onto main including #133446; all four TTS candidate files are byte-identical. The rebased local UI build passed at345472 bytes under the unchanged346761-byte limit. Exact-head hosted CI33331643919 passed at3aea2c110bd2090ccdfd0660b8f290eb26b8c59d.

The review's canonical-versus-legacy conflict behavior is intentional: an authored canonical field is authoritative, as documented and covered by direct, normalized, blank/default and Talk tests. Legacy-only configuration remains accepted. The rank-up CI requirement is now satisfied; no duplicate repair is needed.
