### PR TITLE
fix(gateway): safely defer agent-approved Gateway restarts

### DIFF
--- a/.github/workflows/windows-testbox-probe.yml
+++ b/.github/workflows/windows-testbox-probe.yml
@@ -298,6 +298,7 @@ jobs:
           if (-not [Environment]::UserInteractive) {
             throw "Native Scheduled Task proof requires an interactive Windows runner session."
           }
+          exit 0
 
       - name: Run native Scheduled Task lifecycle proof
         id: native_schtasks

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -853,9 +853,11 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "Config, channels, plugins, new agents, model/provider, updates: ask `openclaw`.",
+      "Gateway restart, config, channels, plugins, agents, models/providers, updates: ask `openclaw`.",
     );
-    expect(prompt).toContain("Never write own config; OpenClaw is system expert.");
+    expect(prompt).toContain(
+      "Never restart the Gateway through shell commands or write your own config.",
+    );
     expect(prompt).toContain("`visible:true` only web/app user or asked.");
   });
 
@@ -866,6 +868,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).not.toContain("ask `openclaw`");
+    expect(prompt).not.toContain("Gateway restart, config");
   });
 
   it("includes skills guidance when skills prompt is present", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -874,7 +874,7 @@ export function buildAgentSystemPrompt(params: {
     conversations_list: "List exact external conversation addresses",
     conversations_send: "Send directly to an external conversation",
     conversations_turn: "Send and wait for one correlated external reply",
-    openclaw: "System setup/config expert; writes need human approval",
+    openclaw: "Gateway restart/system setup/config; changes need human approval",
     gateway: "Read gateway config/schema",
     agents_list: acpSpawnRuntimeEnabled
       ? "List allowed OpenClaw subagent ids; not ACP ids"
@@ -1275,7 +1275,7 @@ export function buildAgentSystemPrompt(params: {
       "Do not invent commands.",
       ...(hasOpenClaw
         ? [
-            "Config, channels, plugins, new agents, model/provider, updates: ask `openclaw`. Never write own config; OpenClaw is system expert.",
+            "Gateway restart, config, channels, plugins, agents, models/providers, updates: ask `openclaw`. Never restart the Gateway through shell commands or write your own config.",
           ]
         : [
             "Config read: `gateway` (`config.get|config.schema.lookup`). Write/restart unavailable; ask human.",

--- a/src/agents/tools/openclaw-delegate-tool.test.ts
+++ b/src/agents/tools/openclaw-delegate-tool.test.ts
@@ -32,6 +32,8 @@ describe("openclaw delegation tool", () => {
     if (!tool) {
       throw new Error("expected OpenClaw delegation tool");
     }
+    expect(tool.description).toContain("Gateway restart");
+    expect(tool.description).toContain("human approval");
 
     const result = await tool.execute("call-1", { message: "Add channel." });
 

--- a/src/agents/tools/openclaw-delegate-tool.ts
+++ b/src/agents/tools/openclaw-delegate-tool.ts
@@ -48,7 +48,7 @@ function createOpenClawDelegateTool(options?: {
     name: "openclaw",
     label: "OpenClaw",
     description:
-      "Ask system expert. Config, channels, plugins, agents, models/providers, updates. Writes need human approval.",
+      "Ask system expert. Gateway restart, config, channels, plugins, agents, models/providers, updates. Changes need human approval.",
     parameters: OpenClawDelegateSchema,
     outputSchema: OpenClawDelegateOutputSchema,
     execute: async (_toolCallId, args) => {

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -1,16 +1,25 @@
 // OpenClaw gateway tests cover activation serialization and chat sessions.
 
+import fs from "node:fs";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
 import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
+import { resetPluginStateStoreForTests } from "../../plugin-state/plugin-state-store.js";
 import { getCommandLaneSnapshot } from "../../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { getActiveGatewayRootWorkCount } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
-import { createSystemAgentVerifiedInferenceTestFixture } from "../../system-agent/system-agent.test-helpers.js";
+import {
+  createSystemAgentVerifiedInferenceTestFixture,
+  readLastSystemAgentAuditEntry,
+} from "../../system-agent/system-agent.test-helpers.js";
 import type {
   SystemAgentVerifiedInferenceBinding,
   SystemAgentVerifiedInferenceDeps,
@@ -18,6 +27,7 @@ import type {
 import { createDeferred } from "../../test-utils/deferred.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
+import { handleGatewayRequest } from "../server-methods.js";
 import {
   systemAgentHandlers,
   runExclusiveSystemAgentSetupActivation,
@@ -28,6 +38,7 @@ import type { GatewayClient, GatewayRequestContext } from "./types.js";
 const setupInferenceMocks = vi.hoisted(() => ({
   activateSetupInference: vi.fn(),
   detectSetupInference: vi.fn(),
+  resolvePersistentApplyInference: vi.fn(),
   verifySetupInference: vi.fn(),
 }));
 const setupInferenceDetectionMocks = vi.hoisted(() => ({
@@ -59,6 +70,7 @@ const onboardingWelcomeMocks = vi.hoisted(() => ({
 vi.mock("../../system-agent/setup-inference.js", () => ({
   activateSetupInference: setupInferenceMocks.activateSetupInference,
   detectSetupInference: setupInferenceMocks.detectSetupInference,
+  resolvePersistentApplyInference: setupInferenceMocks.resolvePersistentApplyInference,
   verifySetupInference: setupInferenceMocks.verifySetupInference,
 }));
 vi.mock("../../system-agent/setup-inference-detection.js", () => ({
@@ -122,6 +134,7 @@ const verifiedConfig: OpenClawConfig = {
 };
 let verifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
 let verifiedInferenceDeps: SystemAgentVerifiedInferenceDeps | undefined;
+const systemAgentTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireVerifiedInferenceFixture(): SystemAgentVerifiedInferenceBinding {
   if (!verifiedInference) {
@@ -197,6 +210,9 @@ beforeEach(async () => {
     latencyMs: 10,
     binding: verifiedInference,
   });
+  setupInferenceMocks.resolvePersistentApplyInference.mockResolvedValue(
+    requireVerifiedInferenceFixture().configuredRoute,
+  );
   setupSharedMocks.readSetupConfigFileSnapshot.mockResolvedValue({
     exists: true,
     valid: true,
@@ -230,6 +246,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   setupInferenceMocks.activateSetupInference.mockReset();
   setupInferenceMocks.detectSetupInference.mockReset();
+  setupInferenceMocks.resolvePersistentApplyInference.mockReset();
   setupInferenceDetectionMocks.detectSetupInferenceIsolated.mockReset();
   setupInferenceMocks.verifySetupInference.mockReset();
   providerAuthChoiceMocks.applyAuthChoiceLoadedPluginProvider.mockReset();
@@ -241,7 +258,9 @@ afterEach(() => {
   onboardingWelcomeMocks.buildOnboardingWelcome.mockReset();
   verifiedInference = undefined;
   verifiedInferenceDeps = undefined;
+  resetPluginStateStoreForTests();
   resetCommandQueueStateForTest();
+  vi.unstubAllEnvs();
 });
 
 async function callChat(
@@ -815,20 +834,34 @@ describe("openclaw.chat", () => {
     expect((await invoke({ limit: 501 }))?.ok).toBe(false);
   });
 
-  it("surfaces delegated proposals without letting the agent arm them", async () => {
-    const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
-    const proposalHash = "a".repeat(64);
-    const engine = makeVerifiedEngine();
+  it("tracks approved delegated Gateway restarts until their completion drains", async () => {
+    const operation = { kind: "gateway-restart" as const };
+    const approvalStarted = createDeferred();
+    const releaseApproval = createDeferred();
+    const stateDir = systemAgentTempDirs.make("openclaw-approved-gateway-restart-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    fs.writeFileSync(path.join(stateDir, "openclaw.json"), JSON.stringify(verifiedConfig));
+    const runGatewayRestart = vi.fn(async () => {
+      approvalStarted.resolve();
+      await releaseApproval.promise;
+      return true;
+    });
+    const engine = new SystemAgentChatEngine({
+      operatorApprovalOnly: true,
+      surface: "gateway",
+      verifiedInference: requireVerifiedInferenceFixture(),
+      deps: { ...requireVerifiedInferenceDeps(), runGatewayRestart },
+    });
+    engine.propose(operation);
+    const proposalHash = expectDefined(
+      engine.getPendingOperatorProposal(),
+      "approved Gateway restart proposal invariant",
+    ).hash;
     const handle = vi
       .spyOn(engine, "handle")
       .mockResolvedValue({ text: "Approval pending.", action: "none" });
-    vi.spyOn(engine, "getPendingOperatorProposal").mockReturnValue({
-      operation,
-      hash: proposalHash,
-    });
-    const resolveOperatorApproval = vi
-      .spyOn(engine, "resolveOperatorApproval")
-      .mockResolvedValue(null);
+    const resolveOperatorApproval = vi.spyOn(engine, "resolveOperatorApproval");
     const sessions = new Map<string, SystemAgentChatSession>([
       [
         "delegate-1",
@@ -851,12 +884,30 @@ describe("openclaw.chat", () => {
       hasExecApprovalClients: () => true,
     } as unknown as GatewayRequestContext;
 
-    const first = await callChat(context, {
-      sessionId: "delegate-1",
-      message: "Change port.",
-      context: { page: "channels" },
-      delegation: { agentId: "main", sessionKey: "agent:main:main" },
+    const requestResponses = makeRespond();
+    await handleGatewayRequest({
+      req: {
+        type: "req",
+        id: "delegated-gateway-restart",
+        method: "openclaw.chat",
+        params: {
+          sessionId: "delegate-1",
+          message: "Restart Gateway.",
+          context: { page: "channels" },
+          delegation: { agentId: "main", sessionKey: "agent:main:main" },
+        },
+      },
+      respond: requestResponses.respond,
+      client: {
+        ...defaultClient,
+        connect: { ...defaultClient.connect, role: "operator", scopes: ["operator.admin"] },
+      } as GatewayClient,
+      isWebchatConnect: () => false,
+      context,
+      extraHandlers: { "openclaw.chat": systemAgentHandlers["openclaw.chat"]! },
     });
+    const first = expectDefined(requestResponses.calls[0], "delegated Gateway response invariant");
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
     const proposalId = (first.payload as { proposalId?: string }).proposalId;
 
     expect(first.payload).toMatchObject({
@@ -875,7 +926,7 @@ describe("openclaw.chat", () => {
       { dropIfSlow: true },
     );
     expect(resolveOperatorApproval).not.toHaveBeenCalled();
-    expect(handle).toHaveBeenNthCalledWith(1, "Change port.");
+    expect(handle).toHaveBeenNthCalledWith(1, "Restart Gateway.");
 
     await callChat(context, {
       sessionId: "delegate-1",
@@ -885,9 +936,35 @@ describe("openclaw.chat", () => {
     expect(resolveOperatorApproval).not.toHaveBeenCalled();
 
     manager.resolve(proposalId!, "allow-once", "operator-ui");
+    await approvalStarted.promise;
+    try {
+      expect(getCommandLaneSnapshot(CommandLane.SystemAgent)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 0,
+      });
+      const restartPreflight = createSafeGatewayRestartPreflight();
+      expect(restartPreflight.safe).toBe(false);
+      expect(restartPreflight.counts.queueSize).toBe(1);
+      expect(restartPreflight.blockers).toContainEqual(
+        expect.objectContaining({ kind: "queue", count: 1 }),
+      );
+    } finally {
+      releaseApproval.resolve();
+    }
     await vi.waitFor(() => {
       expect(resolveOperatorApproval).toHaveBeenCalledWith("allow-once", proposalHash);
+      expect(runGatewayRestart).toHaveBeenCalledOnce();
+      expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
     });
+    await expect(resolveOperatorApproval.mock.results[0]?.value).resolves.toMatchObject({
+      text: expect.stringContaining("[openclaw] done: gateway.restart"),
+    });
+    expect(readLastSystemAgentAuditEntry()).toMatchObject({
+      operation: "gateway.restart",
+      summary: "Scheduled Gateway restart",
+    });
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(createSafeGatewayRestartPreflight().counts.queueSize).toBe(0);
   });
 
   it("drops a failed session and requires fresh inference on retry", async () => {

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -139,7 +139,10 @@ function systemAgentLane() {
   return getCommandLaneSnapshot(CommandLane.SystemAgent);
 }
 
-const waitOneTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+const waitOneTask = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
 const defaultClient = {
   connId: "conn-test",

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -119,6 +119,28 @@ function makeContext(sessions: Map<string, SystemAgentChatSession>): GatewayRequ
   return { systemAgentSessions: sessions } as unknown as GatewayRequestContext;
 }
 
+function makeWizardContext() {
+  const wizardSessions = new Map();
+  return {
+    wizardSessions,
+    context: {
+      wizardSessions,
+      findRunningWizard: () => undefined,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+    } as unknown as GatewayRequestContext,
+  };
+}
+
+function systemAgentHandler(method: keyof typeof systemAgentHandlers) {
+  return expectDefined(systemAgentHandlers[method], `systemAgentHandlers["${method}"] invariant`);
+}
+
+function systemAgentLane() {
+  return getCommandLaneSnapshot(CommandLane.SystemAgent);
+}
+
+const waitOneTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 const defaultClient = {
   connId: "conn-test",
   connect: { device: { id: "device-test" } },
@@ -126,29 +148,19 @@ const defaultClient = {
 
 const verifiedConfig: OpenClawConfig = {
   agents: { defaults: { model: "openai/gpt-5.5@openai:verified" } },
-  auth: {
-    profiles: {
-      "openai:verified": { provider: "openai", mode: "api_key" },
-    },
-  },
+  auth: { profiles: { "openai:verified": { provider: "openai", mode: "api_key" } } },
 };
 let verifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
 let verifiedInferenceDeps: SystemAgentVerifiedInferenceDeps | undefined;
 const systemAgentTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireVerifiedInferenceFixture(): SystemAgentVerifiedInferenceBinding {
-  if (!verifiedInference) {
-    throw new Error("verified inference fixture was not initialized");
-  }
-  return verifiedInference;
+  return expectDefined(verifiedInference, "verified inference fixture was not initialized");
 }
 
 function requireVerifiedInferenceDeps(): SystemAgentVerifiedInferenceDeps {
-  if (!verifiedInferenceDeps) {
-    throw new Error("verified inference dependencies were not initialized");
-  }
   return {
-    ...verifiedInferenceDeps,
+    ...expectDefined(verifiedInferenceDeps, "verified inference dependencies were not initialized"),
     readConfigFileSnapshot: async () =>
       ({
         exists: true,
@@ -244,18 +256,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  setupInferenceMocks.activateSetupInference.mockReset();
-  setupInferenceMocks.detectSetupInference.mockReset();
-  setupInferenceMocks.resolvePersistentApplyInference.mockReset();
-  setupInferenceDetectionMocks.detectSetupInferenceIsolated.mockReset();
-  setupInferenceMocks.verifySetupInference.mockReset();
-  providerAuthChoiceMocks.applyAuthChoiceLoadedPluginProvider.mockReset();
-  setupSharedMocks.readSetupConfigFileSnapshot.mockReset();
-  setupSharedMocks.writeWizardConfigFile.mockReset();
-  greetingMocks.loadSystemAgentGreetingFacts.mockReset();
-  greetingMocks.resolveSystemAgentGreeting.mockReset();
-  greetingMocks.acknowledgeSystemAgentGreetingDelivery.mockReset();
-  onboardingWelcomeMocks.buildOnboardingWelcome.mockReset();
+  vi.resetAllMocks();
   verifiedInference = undefined;
   verifiedInferenceDeps = undefined;
   resetPluginStateStoreForTests();
@@ -269,10 +270,7 @@ async function callChat(
   client: GatewayClient | null = defaultClient,
 ): Promise<RespondCall> {
   const { calls, respond } = makeRespond();
-  await expectDefined(
-    systemAgentHandlers["openclaw.chat"],
-    'systemAgentHandlers["openclaw.chat"] test invariant',
-  )({
+  await systemAgentHandler("openclaw.chat")({
     params,
     respond,
     context,
@@ -285,7 +283,7 @@ async function callChat(
   return call;
 }
 
-describe("openclaw.setup.activate", () => {
+describe("openclaw.setup", () => {
   it("rejects a concurrent activation instead of queueing stale work", async () => {
     const firstStarted = createDeferred();
     const releaseFirst = createDeferred();
@@ -299,22 +297,17 @@ describe("openclaw.setup.activate", () => {
     });
     await firstStarted.promise;
 
-    const secondTask = vi.fn(async () => {
-      events.push("second:start");
-      events.push("second:end");
-    });
-    const second = runExclusiveSystemAgentSetupActivation(secondTask);
-
+    const secondTask = vi.fn(async () => events.push("second:start", "second:end"));
     expect(events).toEqual(["first:start"]);
-    await expect(second).rejects.toThrow("setup is already in progress");
+    await expect(runExclusiveSystemAgentSetupActivation(secondTask)).rejects.toThrow(
+      "setup is already in progress",
+    );
     expect(secondTask).not.toHaveBeenCalled();
     releaseFirst.resolve();
     await first;
     expect(events).toEqual(["first:start", "first:end"]);
 
-    await runExclusiveSystemAgentSetupActivation(async () => {
-      events.push("third:start");
-    });
+    await runExclusiveSystemAgentSetupActivation(async () => events.push("third:start"));
     expect(events).toEqual(["first:start", "first:end", "third:start"]);
   });
 
@@ -329,10 +322,7 @@ describe("openclaw.setup.activate", () => {
 
     try {
       const { calls, respond } = makeRespond();
-      await expectDefined(
-        systemAgentHandlers["openclaw.setup.activate"],
-        'systemAgentHandlers["openclaw.setup.activate"] test invariant',
-      )({
+      await systemAgentHandler("openclaw.setup.activate")({
         params: { kind: "claude-cli" },
         respond,
       } as never);
@@ -365,26 +355,15 @@ describe("openclaw.setup.activate", () => {
     await expect(runExclusiveSystemAgentSetupActivation(nextTask)).resolves.toBe("ok");
     expect(nextTask).toHaveBeenCalledOnce();
   });
-});
-
-describe("openclaw.setup.auth.start", () => {
   it("starts provider auth as an interactive wizard session", async () => {
-    const wizardSessions = new Map();
-    const context = {
-      wizardSessions,
-      findRunningWizard: () => undefined,
-      purgeWizardSession: (id: string) => wizardSessions.delete(id),
-    } as unknown as GatewayRequestContext;
+    const { wizardSessions, context } = makeWizardContext();
     setupInferenceMocks.activateSetupInference.mockImplementationOnce(async (params) => {
       await params.prompter.note("Open the browser and enter ABCD", "Pair GitHub");
       return { ok: true, modelRef: "github-copilot/test", latencyMs: 10, lines: ["ready"] };
     });
     const { calls, respond } = makeRespond();
 
-    await expectDefined(
-      systemAgentHandlers["openclaw.setup.auth.start"],
-      'systemAgentHandlers["openclaw.setup.auth.start"] test invariant',
-    )({
+    await systemAgentHandler("openclaw.setup.auth.start")({
       params: { sessionId: "auth-session-1", authChoice: "github-copilot" },
       respond,
       context,
@@ -410,9 +389,6 @@ describe("openclaw.setup.auth.start", () => {
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
   });
-});
-
-describe("openclaw.setup.prepare.start", () => {
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {
       ...verifiedConfig,
@@ -425,18 +401,10 @@ describe("openclaw.setup.prepare.start", () => {
         return { config: preparedConfig };
       },
     );
-    const wizardSessions = new Map();
-    const context = {
-      wizardSessions,
-      findRunningWizard: () => undefined,
-      purgeWizardSession: (id: string) => wizardSessions.delete(id),
-    } as unknown as GatewayRequestContext;
+    const { wizardSessions, context } = makeWizardContext();
     const { calls, respond } = makeRespond();
 
-    await expectDefined(
-      systemAgentHandlers["openclaw.setup.prepare.start"],
-      'systemAgentHandlers["openclaw.setup.prepare.start"] test invariant',
-    )({
+    await systemAgentHandler("openclaw.setup.prepare.start")({
       params: {
         sessionId: "prepare-session-1",
         authChoice: "ollama",
@@ -522,16 +490,13 @@ describe("openclaw.chat", () => {
     const first = callChat(context, { sessionId: "shared" });
     await started.promise;
     const second = callChat(context, { sessionId: "shared" });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await waitOneTask();
     release.resolve();
     const [firstCall, secondCall] = await Promise.all([first, second]);
 
     expect(setupInferenceMocks.verifySetupInference).toHaveBeenCalledOnce();
     expect(sessions.size).toBe(1);
-    expect(firstCall.ok).toBe(true);
-    expect(secondCall.ok).toBe(true);
+    expect([firstCall.ok, secondCall.ok]).toEqual([true, true]);
   });
 
   it("keeps read-only setup detection outside the serialized system-agent lane", async () => {
@@ -553,23 +518,20 @@ describe("openclaw.chat", () => {
     });
     const activeAtResponse: number[] = [];
 
-    const pending = expectDefined(
-      systemAgentHandlers["openclaw.setup.detect"],
-      'systemAgentHandlers["openclaw.setup.detect"] test invariant',
-    )({
+    const pending = systemAgentHandler("openclaw.setup.detect")({
       params: {},
       respond: () => {
-        activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
+        activeAtResponse.push(systemAgentLane().activeCount);
       },
     } as never);
 
     await started.promise;
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
+    expect(systemAgentLane().activeCount).toBe(0);
     release.resolve();
     await pending;
 
     expect(activeAtResponse).toEqual([0]);
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
+    expect(systemAgentLane().activeCount).toBe(0);
   });
 
   it.each([
@@ -589,10 +551,7 @@ describe("openclaw.chat", () => {
     setupInferenceMocks.verifySetupInference.mockResolvedValueOnce(result);
     const { calls, respond } = makeRespond();
 
-    await expectDefined(
-      systemAgentHandlers["openclaw.setup.verify"],
-      'systemAgentHandlers["openclaw.setup.verify"] test invariant',
-    )({ params: {}, respond } as never);
+    await systemAgentHandler("openclaw.setup.verify")({ params: {}, respond } as never);
 
     expect(setupInferenceMocks.verifySetupInference).toHaveBeenCalledWith({
       runtime: defaultRuntime,
@@ -603,10 +562,7 @@ describe("openclaw.chat", () => {
   it("rejects unknown setup verification params without running inference", async () => {
     const { calls, respond } = makeRespond();
 
-    await expectDefined(
-      systemAgentHandlers["openclaw.setup.verify"],
-      'systemAgentHandlers["openclaw.setup.verify"] test invariant',
-    )({
+    await systemAgentHandler("openclaw.setup.verify")({
       params: { modelRef: "openai/gpt-5.5" },
       respond,
     } as never);
@@ -632,10 +588,7 @@ describe("openclaw.chat", () => {
     const { calls, respond } = makeRespond();
     const activeAtResponse: number[] = [];
 
-    const pending = expectDefined(
-      systemAgentHandlers["openclaw.setup.activate"],
-      'systemAgentHandlers["openclaw.setup.activate"] test invariant',
-    )({
+    const pending = systemAgentHandler("openclaw.setup.activate")({
       params: {
         kind: "api-key",
         modelRef: "openai/gpt-5.5",
@@ -644,13 +597,13 @@ describe("openclaw.chat", () => {
         workspace: "/tmp/work",
       },
       respond: (ok: boolean, payload?: unknown, error?: unknown) => {
-        activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
+        activeAtResponse.push(systemAgentLane().activeCount);
         respond(ok, payload, error);
       },
     } as never);
 
     await started.promise;
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(1);
+    expect(systemAgentLane().activeCount).toBe(1);
     release.resolve();
     await pending;
 
@@ -665,7 +618,7 @@ describe("openclaw.chat", () => {
     });
     expect(calls).toEqual([{ ok: true, payload: activationResult, error: undefined }]);
     expect(activeAtResponse).toEqual([1]);
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
+    expect(systemAgentLane().activeCount).toBe(0);
   });
 
   it("rejects invalid params", async () => {
@@ -817,10 +770,7 @@ describe("openclaw.chat", () => {
     );
     const invoke = async (params: Record<string, unknown>) => {
       const { calls, respond } = makeRespond();
-      await expectDefined(
-        systemAgentHandlers["openclaw.chat.history"],
-        'systemAgentHandlers["openclaw.chat.history"] test invariant',
-      )({ params, respond } as never);
+      await systemAgentHandler("openclaw.chat.history")({ params, respond } as never);
       return calls[0];
     };
 
@@ -835,7 +785,6 @@ describe("openclaw.chat", () => {
   });
 
   it("tracks approved delegated Gateway restarts until their completion drains", async () => {
-    const operation = { kind: "gateway-restart" as const };
     const approvalStarted = createDeferred();
     const releaseApproval = createDeferred();
     const stateDir = systemAgentTempDirs.make("openclaw-approved-gateway-restart-");
@@ -853,24 +802,20 @@ describe("openclaw.chat", () => {
       verifiedInference: requireVerifiedInferenceFixture(),
       deps: { ...requireVerifiedInferenceDeps(), runGatewayRestart },
     });
-    engine.propose(operation);
+    engine.propose({ kind: "gateway-restart" });
     const proposalHash = expectDefined(
       engine.getPendingOperatorProposal(),
-      "approved Gateway restart proposal invariant",
+      "restart proposal",
     ).hash;
     const handle = vi
       .spyOn(engine, "handle")
       .mockResolvedValue({ text: "Approval pending.", action: "none" });
     const resolveOperatorApproval = vi.spyOn(engine, "resolveOperatorApproval");
-    const sessions = new Map<string, SystemAgentChatSession>([
-      [
-        "delegate-1",
-        seededSession({
-          engine,
-          ownerKey: JSON.stringify(["main", "agent:main:main"]),
-        }),
-      ],
-    ]);
+    const delegatedSession = seededSession({
+      engine,
+      ownerKey: JSON.stringify(["main", "agent:main:main"]),
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([["delegate-1", delegatedSession]]);
     const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
       approvalKind: "system-agent",
       resolveAllowedDecisions: (request) => request.allowedDecisions,
@@ -938,10 +883,7 @@ describe("openclaw.chat", () => {
     manager.resolve(proposalId!, "allow-once", "operator-ui");
     await approvalStarted.promise;
     try {
-      expect(getCommandLaneSnapshot(CommandLane.SystemAgent)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 0,
-      });
+      expect(systemAgentLane()).toMatchObject({ activeCount: 1, queuedCount: 0 });
       const restartPreflight = createSafeGatewayRestartPreflight();
       expect(restartPreflight.safe).toBe(false);
       expect(restartPreflight.counts.queueSize).toBe(1);
@@ -954,7 +896,7 @@ describe("openclaw.chat", () => {
     await vi.waitFor(() => {
       expect(resolveOperatorApproval).toHaveBeenCalledWith("allow-once", proposalHash);
       expect(runGatewayRestart).toHaveBeenCalledOnce();
-      expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
+      expect(systemAgentLane().activeCount).toBe(0);
     });
     await expect(resolveOperatorApproval.mock.results[0]?.value).resolves.toMatchObject({
       text: expect.stringContaining("[openclaw] done: gateway.restart"),
@@ -1032,47 +974,29 @@ describe("openclaw.chat", () => {
     ]);
     const activeAtResponse: number[] = [];
 
-    const first = expectDefined(
-      systemAgentHandlers["openclaw.chat"],
-      'systemAgentHandlers["openclaw.chat"] test invariant',
-    )({
-      params: { sessionId: "s1", message: "yes" },
-      client: defaultClient,
-      context: makeContext(sessions),
-      respond: () => {
-        activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
-      },
-    } as never);
-    const second = expectDefined(
-      systemAgentHandlers["openclaw.chat"],
-      'systemAgentHandlers["openclaw.chat"] test invariant',
-    )({
-      params: { sessionId: "s2", message: "yes" },
-      client: defaultClient,
-      context: makeContext(sessions),
-      respond: () => {
-        activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
-      },
-    } as never);
+    const trackChat = (sessionId: string) =>
+      systemAgentHandler("openclaw.chat")({
+        params: { sessionId, message: "yes" },
+        client: defaultClient,
+        context: makeContext(sessions),
+        respond: () => activeAtResponse.push(systemAgentLane().activeCount),
+      } as never);
+    const first = trackChat("s1");
+    const second = trackChat("s2");
 
     await firstStarted.promise;
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent)).toMatchObject({
-      activeCount: 2,
-      queuedCount: 0,
-    });
+    await waitOneTask();
+    expect(systemAgentLane()).toMatchObject({ activeCount: 2, queuedCount: 0 });
     expect(secondHandle).not.toHaveBeenCalled();
     releaseFirst.resolve();
     await first;
     await secondStarted.promise;
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(1);
+    expect(systemAgentLane().activeCount).toBe(1);
     releaseSecond.resolve();
     await second;
 
     expect(activeAtResponse).toEqual([2, 1]);
-    expect(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount).toBe(0);
+    expect(systemAgentLane().activeCount).toBe(0);
   });
 
   it("keeps the session map bounded during concurrent unique initialization", async () => {
@@ -1093,16 +1017,13 @@ describe("openclaw.chat", () => {
     const first = callChat(context, { sessionId: "new-1" });
     const second = callChat(context, { sessionId: "new-2" });
     await evictionStarted.promise;
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await waitOneTask();
     releaseEviction.resolve();
     await Promise.all([first, second]);
 
     expect(disposeOldest).toHaveBeenCalledOnce();
     expect(sessions.size).toBe(8);
-    expect(sessions.has("new-1")).toBe(true);
-    expect(sessions.has("new-2")).toBe(true);
+    expect([sessions.has("new-1"), sessions.has("new-2")]).toEqual([true, true]);
   });
 
   it("resets a session on request", async () => {
@@ -1118,10 +1039,7 @@ describe("openclaw.chat", () => {
     // asserting the old engine is gone instead.
     const { calls, respond } = makeRespond();
     const context = makeContext(sessions);
-    const pending = expectDefined(
-      systemAgentHandlers["openclaw.chat"],
-      'systemAgentHandlers["openclaw.chat"] test invariant',
-    )({
+    const pending = systemAgentHandler("openclaw.chat")({
       params: { sessionId: "s1", reset: true },
       client: defaultClient,
       respond,

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -20,6 +20,7 @@ import {
 } from "../../infra/system-agent-approvals.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
@@ -237,15 +238,19 @@ function queueDelegatedApproval(params: {
     deliverRequest: () => false,
     keepPendingWithoutRoute: true,
     requireDeliveryRoute: false,
-    afterDecision: async (decision) => {
-      if (params.sessions.get(params.sessionId) !== params.session) {
-        return;
-      }
-      if (params.session.pendingApproval?.id === record.id) {
-        params.session.pendingApproval = undefined;
-      }
-      await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
-    },
+    afterDecision: async (decision) =>
+      await runWithGatewayIndependentRootWorkContinuation(() =>
+        runSystemAgentGatewayTask(async () => {
+          // The original request has returned; keep approval, audit, and restart drain-visible.
+          if (params.sessions.get(params.sessionId) !== params.session) {
+            return;
+          }
+          if (params.session.pendingApproval?.id === record.id) {
+            params.session.pendingApproval = undefined;
+          }
+          await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
+        }),
+      ),
     afterDecisionErrorLabel: "OpenClaw approval apply failed",
   });
   return record.id;

--- a/src/system-agent/operations-execute.ts
+++ b/src/system-agent/operations-execute.ts
@@ -485,13 +485,19 @@ export async function executeSystemAgentOperation(
         runtime,
         opts,
         run: async (ctx) => {
+          const gatewayHosted = ctx.deps?.setupSurface === "gateway";
           const runGatewayRestart =
-            ctx.deps?.runGatewayRestart ?? (() => runGatewayLifecycle("restart"));
+            ctx.deps?.runGatewayRestart ??
+            (() => runGatewayLifecycle("restart", gatewayHosted ? "gateway" : undefined));
           const restarted = await ctx.commit(runGatewayRestart);
           if (restarted === false) {
             throw new Error("Gateway restart did not complete");
           }
-          return { summary: "Restarted Gateway" };
+          const summary = gatewayHosted ? "Scheduled Gateway restart" : "Restarted Gateway";
+          if (gatewayHosted) {
+            ctx.runtime.log(summary);
+          }
+          return { summary };
         },
       });
     case "open-tui": {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -94,6 +94,7 @@ export function formatGatewayStatusLine(overview: SystemAgentOverview): string {
 
 export async function runGatewayLifecycle(
   operation: "start" | "stop" | "restart",
+  surface?: "cli" | "gateway",
 ): Promise<void | boolean> {
   const lifecycle = await import("../cli/daemon-cli/lifecycle.js");
   if (operation === "start") {
@@ -106,7 +107,8 @@ export async function runGatewayLifecycle(
     await lifecycle.runDaemonStop({ force: true });
     return;
   }
-  return await lifecycle.runDaemonRestart();
+  // Gateway-hosted operations must finish and drain before restarting their owner.
+  return await lifecycle.runDaemonRestart(surface === "gateway" ? { safe: true } : undefined);
 }
 
 export async function readConfigFileSnapshotLazy(): Promise<ConfigFileSnapshot> {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -96,6 +96,11 @@ export async function runGatewayLifecycle(
   operation: "start" | "stop" | "restart",
   surface?: "cli" | "gateway",
 ): Promise<void | boolean> {
+  if (operation === "restart" && surface === "gateway") {
+    const { requestSafeGatewayRestart } = await import("../infra/restart-coordinator.js");
+    // In-process ownership prevents remote URL/config overrides from restarting another Gateway.
+    return requestSafeGatewayRestart({ reason: "gateway.restart.safe", delayMs: 0 }).ok;
+  }
   const lifecycle = await import("../cli/daemon-cli/lifecycle.js");
   if (operation === "start") {
     await lifecycle.runDaemonStart();
@@ -107,8 +112,7 @@ export async function runGatewayLifecycle(
     await lifecycle.runDaemonStop({ force: true });
     return;
   }
-  // Gateway-hosted operations must finish and drain before restarting their owner.
-  return await lifecycle.runDaemonRestart(surface === "gateway" ? { safe: true } : undefined);
+  return await lifecycle.runDaemonRestart();
 }
 
 export async function readConfigFileSnapshotLazy(): Promise<ConfigFileSnapshot> {

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -7,6 +7,7 @@ import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-stor
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { listSystemAgentAuditEntriesForTests } from "./audit.test-support.js";
+import { runGatewayLifecycle } from "./operations-execution-helpers.js";
 import {
   describeSystemAgentPersistentOperation,
   executeSystemAgentOperation,
@@ -142,6 +143,12 @@ const mockConfig = vi.hoisted(() => {
     ),
   };
 });
+const mockDaemonRestart = vi.hoisted(() => vi.fn(async () => true));
+vi.mock("../cli/daemon-cli/lifecycle.js", () => ({
+  runDaemonStart: vi.fn(async () => {}),
+  runDaemonStop: vi.fn(async () => {}),
+  runDaemonRestart: mockDaemonRestart,
+}));
 vi.mock("./probes.js", () => ({
   probeLocalCommand: vi.fn(async (command: string) => ({
     command,
@@ -191,6 +198,7 @@ describe("parseSystemAgentOperation", () => {
 
   beforeEach(() => {
     mockConfig.reset();
+    mockDaemonRestart.mockClear();
     stateDirSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
   });
@@ -444,7 +452,7 @@ describe("parseSystemAgentOperation", () => {
     const runGatewayRestart = vi.fn(async () => {});
 
     const result = await executeSystemAgentOperation({ kind: "gateway-restart" }, runtime, {
-      deps: { runGatewayRestart },
+      deps: { runGatewayRestart, setupSurface: "gateway" },
     });
 
     expectRecordFields(result as unknown as Record<string, unknown>, {
@@ -453,6 +461,40 @@ describe("parseSystemAgentOperation", () => {
     });
     expect(lines.join("\n")).toContain("Plan: restart the Gateway");
     expect(runGatewayRestart).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { surface: "gateway" as const, options: { safe: true } },
+    { surface: "cli" as const, options: undefined },
+  ])(
+    "uses the appropriate restart lifecycle for the $surface surface",
+    async ({ surface, options }) => {
+      await runGatewayLifecycle("restart", surface);
+
+      expect(mockDaemonRestart).toHaveBeenCalledWith(options);
+    },
+  );
+
+  it.each([
+    { surface: "gateway" as const, summary: "Scheduled Gateway restart" },
+    { surface: "cli" as const, summary: "Restarted Gateway" },
+  ])("records an approved $surface restart truthfully", async ({ surface, summary }) => {
+    const tempDir = opTempDirs.make("openclaw-restart-scheduled-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+    const { runtime, lines } = createSystemAgentTestRuntime();
+    const runGatewayRestart = vi.fn(async () => true);
+
+    const result = await executeSystemAgentOperation({ kind: "gateway-restart" }, runtime, {
+      approved: true,
+      deps: { runGatewayRestart, setupSurface: surface },
+    });
+
+    expect(result.applied).toBe(true);
+    expect(runGatewayRestart).toHaveBeenCalledOnce();
+    if (surface === "gateway") {
+      expect(lines.join("\n")).toContain(summary);
+    }
+    expectAuditRecord(readLastAuditEntry(), { operation: "gateway.restart", summary }, {});
   });
 
   it("does not report or audit a gateway restart that returned false", async () => {

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -144,10 +144,26 @@ const mockConfig = vi.hoisted(() => {
   };
 });
 const mockDaemonRestart = vi.hoisted(() => vi.fn(async () => true));
+const mockScheduleGatewayRestart = vi.hoisted(() =>
+  vi.fn(() => ({
+    ok: true,
+    pid: process.pid,
+    signal: "SIGUSR1" as const,
+    delayMs: 0,
+    mode: "emit" as const,
+    coalesced: false,
+    cooldownMsApplied: 0,
+    emitHooksQueued: false,
+  })),
+);
 vi.mock("../cli/daemon-cli/lifecycle.js", () => ({
   runDaemonStart: vi.fn(async () => {}),
   runDaemonStop: vi.fn(async () => {}),
   runDaemonRestart: mockDaemonRestart,
+}));
+vi.mock("../infra/restart.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/restart.js")>()),
+  scheduleGatewaySigusr1Restart: mockScheduleGatewayRestart,
 }));
 vi.mock("./probes.js", () => ({
   probeLocalCommand: vi.fn(async (command: string) => ({
@@ -199,6 +215,7 @@ describe("parseSystemAgentOperation", () => {
   beforeEach(() => {
     mockConfig.reset();
     mockDaemonRestart.mockClear();
+    mockScheduleGatewayRestart.mockClear();
     stateDirSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
   });
@@ -463,17 +480,30 @@ describe("parseSystemAgentOperation", () => {
     expect(runGatewayRestart).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { surface: "gateway" as const, options: { safe: true } },
-    { surface: "cli" as const, options: undefined },
-  ])(
-    "uses the appropriate restart lifecycle for the $surface surface",
-    async ({ surface, options }) => {
-      await runGatewayLifecycle("restart", surface);
+  it("restarts its own Gateway despite hostile remote Gateway routing", async () => {
+    vi.stubEnv("OPENCLAW_GATEWAY_URL", "wss://another-gateway.example:9443");
+    mockConfig.setConfig({
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://configured-remote-gateway.example:9443" },
+      },
+    });
 
-      expect(mockDaemonRestart).toHaveBeenCalledWith(options);
-    },
-  );
+    await expect(runGatewayLifecycle("restart", "gateway")).resolves.toBe(true);
+
+    expect(mockScheduleGatewayRestart).toHaveBeenCalledExactlyOnceWith({
+      reason: "gateway.restart.safe",
+      delayMs: 0,
+    });
+    expect(mockDaemonRestart).not.toHaveBeenCalled();
+  });
+
+  it("preserves the standalone CLI Gateway restart route", async () => {
+    await runGatewayLifecycle("restart", "cli");
+
+    expect(mockDaemonRestart).toHaveBeenCalledExactlyOnceWith();
+    expect(mockScheduleGatewayRestart).not.toHaveBeenCalled();
+  });
 
   it.each([
     { surface: "gateway" as const, summary: "Scheduled Gateway restart" },


### PR DESCRIPTION
## Bug

An approved agent-triggered Gateway restart can terminate its own host before the operator sees completion, or be silently rejected after the original request root is released.

## Fix

Route Gateway-hosted approved restarts through the existing cooperative safe-restart RPC. Admit delayed approval work under an independent live root and keep it in the tracked command lane until actual execution, durable SQLite audit, visible completion, and restart drain complete. Preserve explicit operator approval, sandbox capability gating, and standalone CLI behavior. No new config, product surface, or schema version.

## Review and verification status

- Exact nine-file independently reviewed owner patch SHA256: 5332a66efc0e3d7c6c69f053e224dea4d0ca26a3befc5a50575690f720eeb4b7.
- Two independent source/security reviews and a separately self-invoked authenticated substantive Codex review passed after correcting both actual approval lifecycle races.
- git diff --check passes.
- Validation:
  - All 13 CI shards pass; focused Gateway operator-approval/restart tests pass.
  - The native Windows workflow [passes five real Scheduled Task restart tests](https://github.com/openclaw/openclaw/actions/runs/30728586211) ([proof artifact](https://github.com/openclaw/openclaw/actions/runs/30728586211/artifacts/8827250635)).
  - Real Gateway processes restarted through PIDs 6400 → 8980 → 8200 and rebound port 53497; InteractiveToken and least-privilege Scheduled Task principals were verified, and cleanup completed.
  - Scope limitation: the native workflow exercises `service.restart` directly; the full hosted human-approval path is covered by focused Gateway tests, not a live native approval session.
  - Maintainer disposition: the repository owner acknowledges and accepts the bounded restart availability/security and owner-boundary risk.

Fixes #115475