### PR TITLE
fix(test): restore oxlint shard routing owner

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1986,6 +1986,7 @@ const EXACT_TOOLING_TARGETS = new Map([
     ],
   ],
   ["scripts/run-vitest.mjs", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
+  ["scripts/run-oxlint-shards.mjs", ["run-oxlint"]],
   ["scripts/docker-e2e-rerun.mjs", ["docker-e2e-helper-cli"]],
   ["scripts/openclaw-postpack.mjs", [TOOLING_VITEST_CONFIG]],
   ["scripts/openclaw-npm-prepublish-verify.ts", ["test/openclaw-npm-prepublish-verify.test.ts"]],


### PR DESCRIPTION
## Summary

- restore the precise changed-test owner for scripts/run-oxlint-shards.mjs
- prevent an incidental workflow-guard string reference from broadening the route
- keep the readable derived routing refactor and its existing assertions intact

## Root cause

The derived tooling router introduced in #117407 removed this genuinely ambiguous exact owner. Its import scan found test/scripts/run-oxlint.test.ts, but its later literal-reference scan also found a mention in test/scripts/ci-workflow-guards.test.ts. That extra target broke two deterministic routing assertions on main in both the fast routing job and the full tooling shard.

## Validation

- node --check scripts/test-projects.test-support.mjs
- git diff --check
- independent xhigh source review: clean
- exact GitHub CI pending