### PR TITLE
fix(active-memory): preserve recall after lane-one timeout

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2158,6 +2158,32 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("continues model recall when lane-1 stalls until the preflight deadline", async () => {
+    const stalledLookup = () => new Promise<never>(() => {});
+    hoisted.getActiveMemorySearchManager.mockResolvedValueOnce({
+      manager: {
+        search: vi.fn(stalledLookup),
+        listTriggerCandidates: vi.fn(stalledLookup),
+      },
+    } as never);
+
+    const result = await runPromptBuild(
+      { prompt: "what did we decide? stalled lane one" },
+      {
+        sessionKey: "agent:main:telegram:direct:owner",
+        messageProvider: "telegram",
+        channelId: "owner",
+      },
+    );
+
+    expectPrependContextContains(result, "lemon pepper wings");
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    const warnLines = vi
+      .mocked(api.logger.warn)
+      .mock.calls.map((call: unknown[]) => String(call[0]));
+    expectLinesNotToContain(warnLines, "before_prompt_build preflight timed out");
+  });
+
   it("lets active memory inherit the main QMD search mode when configured", async () => {
     api.config = {
       agents: {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -81,6 +81,7 @@ import {
 } from "./types.js";
 
 const MEMORY_CORE_PLUGIN_ID = "memory-core";
+const TRIGGER_RECALL_TIMEOUT_HEADROOM_MS = 250;
 
 /** Plugin entry registering Active Memory hooks, tools, config schema, and doctor cleanup. */
 export default definePluginEntry({
@@ -372,7 +373,11 @@ export default definePluginEntry({
                 query: searchQuery,
                 message: event.prompt,
                 activeProjectKeys: ctx.activeProjectKeys,
-                signal: AbortSignal.timeout(HOOK_TIMEOUT_RECOVERY_GRACE_MS),
+                // Leave the outer preflight watchdog enough time to observe this
+                // fail-soft abort and continue into model recall.
+                signal: AbortSignal.timeout(
+                  Math.max(1, HOOK_TIMEOUT_RECOVERY_GRACE_MS - TRIGGER_RECALL_TIMEOUT_HEADROOM_MS),
+                ),
                 runId: ctx.runId,
               }).catch((error: unknown) => {
                 api.logger.debug?.(


### PR DESCRIPTION
## Summary
- reserve 250 ms of preflight headroom for lane-one fail-soft abort settlement
- continue model-based recall when deterministic trigger lookup stalls
- add a regression covering the lane-one/outer-watchdog race

## Verification
- focused regression: 1 passed
- timeout/deadline tests: 28 passed
- active-memory suite: 199 passed
- changed-file formatting and lint passed
- full build passed