### PR TITLE
fix(doctor): classify critically low disk space as an error

### DIFF
--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,6 +1,12 @@
 // Doctor disk-space tests cover byte formatting, warning generation, and note rendering.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
+import { registerMaintenanceCommands } from "../cli/program/register.maintenance.js";
+import { defaultRuntime } from "../runtime.js";
 import { collectDiskSpaceHealthFindings, formatBytes, noteDiskSpace } from "./doctor-disk-space.js";
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
@@ -60,6 +66,7 @@ describe("collectDiskSpaceHealthFindings thresholds", () => {
   it("returns a warning finding when space is low (below 500 MB)", () => {
     expect(collectFindingsAt(300 * 1024 * 1024)).toEqual([
       expect.objectContaining({
+        severity: "warning",
         message: expect.stringContaining("Low disk space"),
         target: "300 MB",
         requirement: "low-free-space",
@@ -70,6 +77,7 @@ describe("collectDiskSpaceHealthFindings thresholds", () => {
   it("returns a critical finding when space is very low (below 100 MB)", () => {
     expect(collectFindingsAt(50 * 1024 * 1024)).toEqual([
       expect.objectContaining({
+        severity: "error",
         message: expect.stringContaining("CRITICAL"),
         target: "50 MB",
         requirement: "critical-free-space",
@@ -79,7 +87,13 @@ describe("collectDiskSpaceHealthFindings thresholds", () => {
 
   it("returns critical at exactly 0 bytes", () => {
     expect(collectFindingsAt(0)).toEqual([
-      expect.objectContaining({ requirement: "critical-free-space" }),
+      expect.objectContaining({ severity: "error", requirement: "critical-free-space" }),
+    ]);
+  });
+
+  it("keeps exactly 100 MB at warning severity", () => {
+    expect(collectFindingsAt(100 * 1024 * 1024)).toEqual([
+      expect.objectContaining({ severity: "warning", requirement: "low-free-space" }),
     ]);
   });
 
@@ -95,9 +109,78 @@ describe("collectDiskSpaceHealthFindings thresholds", () => {
 
   it("returns critical at exactly 99 MB (just below critical)", () => {
     expect(collectFindingsAt(99 * 1024 * 1024)).toEqual([
-      expect.objectContaining({ requirement: "critical-free-space" }),
+      expect.objectContaining({ severity: "error", requirement: "critical-free-space" }),
     ]);
   });
+});
+
+describe("registered doctor disk-space lint", () => {
+  it.each([
+    { availableMegabytes: 50, expectedExitCode: 1, expectedSeverity: "error" },
+    { availableMegabytes: 100, expectedExitCode: 0, expectedSeverity: undefined },
+  ])(
+    "applies the actual error threshold and exit status at $availableMegabytes MB",
+    async ({ availableMegabytes, expectedExitCode, expectedSeverity }) => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-disk-space-"));
+      fs.writeFileSync(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({ gateway: { mode: "local" } }),
+      );
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+      const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue({
+        type: 0,
+        bsize: 1024 * 1024,
+        blocks: 1000,
+        bfree: availableMegabytes,
+        bavail: availableMegabytes,
+        files: 0,
+        frsize: 1024 * 1024,
+        ffree: 0,
+      });
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+      try {
+        const program = new Command();
+        registerMaintenanceCommands(program);
+        await program.parseAsync(
+          [
+            "doctor",
+            "--lint",
+            "--only",
+            "core/doctor/disk-space",
+            "--severity-min",
+            "error",
+            "--json",
+          ],
+          { from: "user" },
+        );
+
+        expect(exit).toHaveBeenCalledWith(expectedExitCode);
+        const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+        expect(payload).toMatchObject({
+          ok: expectedExitCode === 0,
+          checksRun: 1,
+          findings:
+            expectedSeverity === undefined
+              ? []
+              : [
+                  expect.objectContaining({
+                    checkId: "core/doctor/disk-space",
+                    severity: expectedSeverity,
+                  }),
+                ],
+        });
+      } finally {
+        exit.mockRestore();
+        stdout.mockRestore();
+        statfs.mockRestore();
+        vi.unstubAllEnvs();
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("noteDiskSpace", () => {
@@ -181,7 +264,7 @@ describe("collectDiskSpaceHealthFindings", () => {
     ]);
   });
 
-  it("returns a critical-space warning finding", () => {
+  it("returns a critical-space error finding", () => {
     const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
       env: { HOME: "/home/test" },
       readDiskSpace: () => ({ availableBytes: 50 * 1024 * 1024 }),
@@ -190,7 +273,7 @@ describe("collectDiskSpaceHealthFindings", () => {
     expect(findings).toEqual([
       expect.objectContaining({
         checkId: "core/doctor/disk-space",
-        severity: "warning",
+        severity: "error",
         message: "CRITICAL: only 50 MB free on the partition containing /home/test/.openclaw.",
         path: "/home/test/.openclaw",
         target: "50 MB",

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -112,15 +112,15 @@ export function collectDiskSpaceHealthFindings(
   }
 
   const [message, ...details] = result.warnings;
+  const critical = result.availableBytes < CRITICAL_BYTES;
   return [
     {
       checkId: DISK_SPACE_CHECK_ID,
-      severity: "warning",
+      severity: critical ? "error" : "warning",
       message: expectDefined(message, "disk-space warning message").replace(/^- /, ""),
       path: result.stateDir,
       target: formatBytes(result.availableBytes),
-      requirement:
-        result.availableBytes < CRITICAL_BYTES ? "critical-free-space" : "low-free-space",
+      requirement: critical ? "critical-free-space" : "low-free-space",
       fixHint: details.map((line) => line.replace(/^- /, "")).join(" "),
     },
   ];


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --lint --only core/doctor/disk-space --severity-min error --json` silently hid critically low disk space and exited successfully. The existing health producer described disks below 100 MiB as `CRITICAL`, but always classified the structured finding as a warning, so the already-correct severity filter removed it.

## Why This Change Was Made

Calculate the existing critical-threshold fact once in the disk-space finding owner and derive both structured severity and requirement from it. This removes the duplicated threshold expression, adds no production lines, and preserves the existing thresholds, opt-in behavior, and human-readable Doctor notes.

## User Impact

Scripted and automated Doctor checks now receive an error finding and exit code 1 when available disk space is below 100 MiB. Exactly 100 MiB and other existing low-space results remain warnings, 500 MiB remains healthy, and ordinary Doctor output, configuration, storage, permissions, and public CLI flags do not change.

## Evidence

- Frozen PR head: `8b12a15043f6d1c6f78a4cffaa093616e3196c17`. The contributor patch was rebased unchanged onto current `main` after the old dependency snapshot acquired three high-severity advisories; stable patch id remains `183d7083f3991d009557ad17c04fca03d9fcd745`. The patch touches two existing owner/test files: production `+3/-3` (net zero), tests `+87/-4`.
- Current-main repro and patched behavior were exercised on a real Linux Blacksmith Testbox using a loop-mounted ext4 image, `fallocate`, and the real `fs.statfsSync` path. Provider `blacksmith-testbox`, lease `tbx_01kza465nz888y2hny1pmqyv2v`, run: https://github.com/openclaw/openclaw/actions/runs/31056568668.
- At `main` SHA `d3d25737cf31547bd70ef9f0e1fcf2e3e7115f64`, 104,853,504 bytes free (100 MiB minus one 4 KiB block) produced exit `0`, `checksRun: 1`, and no error-filtered finding.
- With the exact PR patch (`183d7083f3991d009557ad17c04fca03d9fcd745` stable patch id), the same 104,853,504-byte volume produced exit `1` and exactly one `error` finding with requirement `critical-free-space`.
- With exactly 104,857,600 bytes free, the PR produced exit `0` and no finding under the `error` filter, then exit `1` and exactly one `warning` finding with requirement `low-free-space` under the `warning` filter. `fs.statfsSync` reported the exact target bytes before and after every command.
- Focused owner/flow/registration proof passes 72 tests across `src/commands/doctor-disk-space.test.ts`, `src/commands/doctor-lint.test.ts`, and `src/cli/program/register.maintenance.test.ts` via `node scripts/run-vitest.mjs`.
- Strict touched-file oxlint (`--type-aware --type-check --deny-warnings`), formatting, and `git diff --check` pass. Fresh exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/31057722726.
- Fresh `gpt-5.6-sol` high-reasoning autoreview through P1 found no actionable issue and judged the patch correct with 0.98 confidence. TruffleHog found no secrets.
