### PR TITLE
fix(plugins): return failure when policy blocks plugin enablement

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -118,7 +118,7 @@ describe("plugins cli policy mutations", () => {
       plugins: { allow: ["other-plugin"] },
       reason: "blocked by allowlist",
     },
-  ])("does not mutate plugin state when $policy blocks enablement", async ({ plugins, reason }) => {
+  ])("fails without mutations when $policy blocks enablement", async ({ plugins, reason }) => {
     const sourceConfig = { plugins } as OpenClawConfig;
     loadConfig.mockReturnValue(sourceConfig);
     enablePluginInConfig.mockReturnValue({
@@ -129,11 +129,13 @@ describe("plugins cli policy mutations", () => {
     });
     mockPluginRegistry(["alpha"]);
 
-    await runPluginsCommand(["plugins", "enable", "alpha"]);
+    await expect(runPluginsCommand(["plugins", "enable", "alpha"])).rejects.toThrow("__exit__:1");
 
+    expect(replaceConfigFile).not.toHaveBeenCalled();
     expect(writeConfigFile).not.toHaveBeenCalled();
     expect(refreshPluginRegistry).not.toHaveBeenCalled();
-    expect(runtimeLogs).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
+    expect(runtimeErrors).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
+    expect(runtimeLogs).not.toContain(`Plugin "alpha" could not be enabled (${reason}).`);
   });
 
   it("refuses plugin enablement in Nix mode before config mutation", async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -205,12 +205,10 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   });
   // A blocked request must not displace the active slot or rewrite persisted state.
   if (!enableResult.enabled) {
-    defaultRuntime.log(
-      theme.warn(
-        `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
-      ),
+    defaultRuntime.error(
+      `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
     );
-    return;
+    return defaultRuntime.exit(1);
   }
 
   const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins enable <id>` previously returned a successful exit status and wrote its failure to standard output when global plugin disablement, an explicit denylist, or a restrictive allowlist blocked the requested plugin. Automations and operators therefore saw success although no plugin was enabled.

## Why This Change Was Made

The existing plugin-enable command already detects the canonical policy failure before slot selection, configuration replacement, persistence, or registry refresh. Route that existing failure through the runtime error stream and return the runtime's standard nonzero exit instead of logging a warning and returning normally; do not alter plugin policy, configuration, authentication, or persisted state.

## User Impact

All three blocked-policy cases now report their existing explanatory reason on standard error, exit with status 1, and leave configuration, plugin slots, and registry state untouched. Successful enablement, disablement, compatibility aliases, Nix restrictions, and the explicit ClickClack trust exception retain their existing behavior.

## Evidence

- Real registered Commander commands were executed in isolated state directories against both the unchanged parent and the immutable fixed commit. These are genuine subprocess exit statuses and literal captured stdout/stderr; the plugin was identical in every case:

  ```text
  BEFORE: globally disabled
  $ openclaw plugins enable memory-core
  stdout: Plugin "memory-core" could not be enabled (plugins disabled).
  stderr: <empty>
  exit: 0
  config changed: false
  plugin enabled: false
  plugin registry rows: 0
  plugin state rows: 0
  remaining lifecycle lease rows: 0

  BEFORE: explicit denylist
  $ openclaw plugins enable memory-core
  stdout: Plugin "memory-core" could not be enabled (blocked by denylist).
  stderr: <empty>
  exit: 0
  config changed: false
  plugin enabled: false
  plugin registry rows: 0
  plugin state rows: 0
  remaining lifecycle lease rows: 0

  AFTER: globally disabled
  $ openclaw plugins enable memory-core
  stdout: <empty>
  stderr: Plugin "memory-core" could not be enabled (plugins disabled).
  exit: 1
  config changed: false
  plugin enabled: false
  plugin registry rows: 0
  plugin state rows: 0
  remaining lifecycle lease rows: 0

  AFTER: explicit denylist
  $ openclaw plugins enable memory-core
  stdout: <empty>
  stderr: Plugin "memory-core" could not be enabled (blocked by denylist).
  exit: 1
  config changed: false
  plugin enabled: false
  plugin registry rows: 0
  plugin state rows: 0
  remaining lifecycle lease rows: 0

  AFTER: allowed success control
  $ openclaw plugins enable memory-core
  stdout: Exclusive slot "memory" switched from "none" to "memory-core".
          Enabled plugin "memory-core". Restart the gateway to apply.
  stderr: <empty>
  exit: 0
  config changed: true
  plugin enabled: true
  plugin registry rows: 1
  plugin state rows: 0
  remaining lifecycle lease rows: 0
  ```

- Authentic test-first baseline: the actual registered Commander command incorrectly resolved successfully in all **three** blocked-policy cases; its other **10** policy controls passed.
- Final registered Commander policy plus lazy-registration sibling suites: **19/19 tests passed**. Each blocked case verifies the captured error stream, the runtime's nonzero-exit sentinel, no standard-output failure, and zero configuration replacement, configuration writes, or registry refreshes.
- Configured repository **type-aware oxlint**, exact-file **oxfmt**, and **git diff --check** passed. Production owner change removes two net lines; exactly two existing owner/test files change.
- Six fresh independent source-only hostile reviews found **zero P0–P3 issues** and separately verified actual Commander dependency rejection behavior, the real runtime's process-exit implementation, and synchronous lifecycle-lease cleanup.
- Genuine exclusive Codex `gpt-5.6-sol` high P3 autoreview: **zero findings**, correct patch, confidence **0.93**. Real TruffleHog **3.96.0** exact-commit secret scan: **clean**.
- Immutable commit `61c61346a8562cd08f86f38ce50df7f8260aa075`, tree `953a23578170bb35a19819b7cb773c9ced4d3137`, parent `ea2e7f46a69744a6d1b346db20043a3388f9b001`. Hosted CI remains pending and is not claimed complete.

Permanent terminal capture: [actual registered Commander before/after and unchanged SQLite evidence](https://github.com/openclaw/openclaw/pull/117536#issuecomment-5152693428).
