### PR TITLE
refactor(memory): keep Dreams data authoritative across agent switches

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -975,7 +975,6 @@ ui/src/lib/skills/index.test.ts
 ui/src/lib/workboard/index.test.ts
 ui/src/pages/agents/agents-page.ts
 ui/src/pages/agents/memory/dreaming.test.ts
-ui/src/pages/agents/memory/dreaming.ts
 ui/src/pages/agents/memory/view.ts
 ui/src/pages/agents/panels-tools-skills.ts
 ui/src/pages/chat/chat-command-executor.test.ts

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -121,10 +121,40 @@ function getConfigPatchRawPayload(config: DreamingConfigCapability): Record<stri
   return patch;
 }
 
+const wikiResources = [
+  {
+    label: "import insights",
+    key: "wikiImportInsights",
+    method: "wiki.importInsights",
+    load: loadWikiImportInsights,
+    payload: () => ({
+      sourceType: "chatgpt" as const,
+      totalItems: 0,
+      totalClusters: 0,
+      clusters: [],
+    }),
+  },
+  {
+    label: "overview",
+    key: "wikiOverview",
+    method: "wiki.overview",
+    load: loadWikiOverview,
+    payload: () => ({
+      totalItems: 0,
+      totalPages: 0,
+      pageCounts: { source: 0, synthesis: 0, report: 0, entity: 0, concept: 0 },
+      totalClaims: 0,
+      totalQuestions: 0,
+      totalContradictions: 0,
+      clusters: [],
+    }),
+  },
+] as const;
+
 describe("dreaming controller", () => {
-  it("loads and normalizes dreaming status from doctor.memory.status", async () => {
+  it("retains the authoritative dreaming status from doctor.memory.status", async () => {
     const { state, request } = createState();
-    request.mockResolvedValue({
+    const payload = {
       dreaming: {
         enabled: true,
         timezone: "America/Los_Angeles",
@@ -223,12 +253,14 @@ describe("dreaming controller", () => {
           },
         },
       },
-    });
+    };
+    request.mockResolvedValue(payload);
 
     await loadDreamingStatus(state);
 
     expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
     const status = state.dreamingStatus;
+    expect(status).toBe(payload.dreaming);
     expect(status?.enabled).toBe(true);
     expect(status?.shortTermCount).toBe(8);
     expect(status?.groundedSignalCount).toBe(5);
@@ -340,35 +372,74 @@ describe("dreaming controller", () => {
     expect(state.dreamingStatusError).toBeNull();
   });
 
-  it("preserves unknown phase state when status omits phase metadata", async () => {
-    const { state, request } = createState();
-    request.mockResolvedValue({
-      dreaming: {
-        enabled: true,
-        shortTermCount: 1,
-        recallSignalCount: 0,
-        dailySignalCount: 0,
-        groundedSignalCount: 0,
-        totalSignalCount: 1,
-        phaseSignalCount: 0,
-        lightPhaseHitCount: 0,
-        remPhaseHitCount: 0,
-        promotedTotal: 0,
-        promotedToday: 0,
-        shortTermEntries: [],
-        signalEntries: [],
-        promotedEntries: [],
-      },
-    });
+  it.each(wikiResources)(
+    "keeps the newest $label response across an A-to-B-to-A agent switch",
+    async ({ key, method, load, payload }) => {
+      const { state, request } = createState();
+      const firstAgentA = createDeferred<unknown>();
+      const agentB = createDeferred<unknown>();
+      const secondAgentA = createDeferred<unknown>();
+      state.hello = {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+        features: { methods: [method] },
+      };
+      request
+        .mockImplementationOnce(async () => firstAgentA.promise)
+        .mockImplementationOnce(async () => agentB.promise)
+        .mockImplementationOnce(async () => secondAgentA.promise);
 
-    await loadDreamingStatus(state);
+      state.selectedAgentId = "agent-a";
+      const staleA = load(state);
+      state.selectedAgentId = "agent-b";
+      const staleB = load(state);
+      state.selectedAgentId = "agent-a";
+      const latest = load(state);
+      const latestPayload = payload();
 
-    expect(state.dreamingStatus?.enabled).toBe(true);
-    expect(state.dreamingStatus?.phases).toBeUndefined();
-    expect(state.dreamingStatusError).toBeNull();
-  });
+      secondAgentA.resolve(latestPayload);
+      await latest;
+      expect(state[key]).toBe(latestPayload);
 
-  it("loads and normalizes wiki import insights", async () => {
+      firstAgentA.resolve(payload());
+      agentB.resolve(payload());
+      await Promise.all([staleA, staleB]);
+
+      expect(state[key]).toBe(latestPayload);
+      expect(state.resourceRequests[key]).toBeUndefined();
+      expect(request).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it.each(wikiResources)(
+    "invalidates an in-flight $label request when its gateway capability disappears",
+    async ({ key, method, load, payload }) => {
+      const { state, request } = createState();
+      const deferred = createDeferred<unknown>();
+      state.hello = {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+        features: { methods: [method] },
+      };
+      request.mockImplementationOnce(async () => deferred.promise);
+
+      const stale = load(state);
+      state.hello = { ...state.hello, features: { methods: [] } };
+      await load(state);
+      expect(state[key]).toBeNull();
+
+      deferred.resolve(payload());
+      await stale;
+
+      expect(state[key]).toBeNull();
+      expect(state.resourceRequests[key]).toBeUndefined();
+      expect(request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("loads authoritative wiki import insights", async () => {
     const { state, request } = createState();
     state.hello = {
       type: "hello-ok",
@@ -708,56 +779,6 @@ describe("dreaming controller", () => {
     expect(state.wikiOverviewError).toBeNull();
   });
 
-  it("derives legacy wiki wiki overview page counts from clusters", async () => {
-    const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.overview"] },
-    };
-    state.configSnapshot = {
-      hash: "hash-1",
-      config: {
-        plugins: {
-          entries: {
-            "memory-wiki": {
-              enabled: true,
-            },
-          },
-        },
-      },
-    };
-    request.mockResolvedValue({
-      totalItems: 1,
-      totalClaims: 2,
-      totalQuestions: 1,
-      totalContradictions: 0,
-      clusters: [
-        {
-          key: "synthesis",
-          label: "Syntheses",
-          itemCount: 1,
-          claimCount: 2,
-          questionCount: 1,
-          contradictionCount: 0,
-          items: [],
-        },
-      ],
-    });
-
-    await loadWikiOverview(state);
-
-    expect(state.wikiOverview?.totalPages).toBe(1);
-    expect(state.wikiOverview?.pageCounts).toEqual({
-      synthesis: 1,
-      entity: 0,
-      concept: 0,
-      source: 0,
-      report: 0,
-    });
-  });
-
   it("falls back to config gating for wiki wiki overview when methods are not advertised", async () => {
     const { state, request } = createState();
     state.configSnapshot = {
@@ -773,8 +794,10 @@ describe("dreaming controller", () => {
       },
     };
     request.mockResolvedValue({
-      totalItems: 1,
-      totalClaims: 2,
+      totalItems: 0,
+      totalPages: 0,
+      pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+      totalClaims: 0,
       totalQuestions: 0,
       totalContradictions: 0,
       clusters: [],
@@ -783,8 +806,8 @@ describe("dreaming controller", () => {
     await loadWikiOverview(state);
 
     expect(request).toHaveBeenCalledWith("wiki.overview", {});
-    expect(state.wikiOverview?.totalItems).toBe(1);
-    expect(state.wikiOverview?.totalPages).toBe(1);
+    expect(state.wikiOverview?.totalItems).toBe(0);
+    expect(state.wikiOverview?.totalPages).toBe(0);
     expect(state.wikiOverview?.pageCounts).toEqual({
       synthesis: 0,
       entity: 0,
@@ -792,7 +815,7 @@ describe("dreaming controller", () => {
       source: 0,
       report: 0,
     });
-    expect(state.wikiOverview?.totalClaims).toBe(2);
+    expect(state.wikiOverview?.totalClaims).toBe(0);
     expect(state.wikiOverviewError).toBeNull();
     expect(state.wikiOverviewLoading).toBe(false);
   });

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -1,4 +1,9 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import type {
+  DoctorMemoryDreamActionPayload,
+  DoctorMemoryDreamDiaryPayload,
+  DoctorMemoryStatusPayload,
+} from "../../../../../src/gateway/server-methods/doctor.ts";
 import { defaultSlotIdForKey, resolveSlotSelection } from "../../../../../src/plugins/slots.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../../api/gateway.ts";
 import type { ConfigSnapshot } from "../../../api/types.ts";
@@ -8,83 +13,10 @@ import type { RuntimeConfigCapability } from "../../../lib/config/index.ts";
 import { isGatewayMethodAdvertised } from "../../../lib/gateway-methods.ts";
 import { isPluginEnabledInConfigSnapshot } from "../../../lib/plugin-activation.ts";
 
-const DEFAULT_DREAM_DIARY_PATH = "DREAMS.md";
 const MEMORY_WIKI_PLUGIN_ID = "memory-wiki";
 
-type DreamingPhaseStatusBase = {
-  enabled: boolean;
-  cron: string;
-  managedCronPresent: boolean;
-  nextRunAtMs?: number;
-};
-
-type LightDreamingStatus = DreamingPhaseStatusBase & {
-  lookbackDays: number;
-  limit: number;
-};
-
-type DeepDreamingStatus = DreamingPhaseStatusBase & {
-  limit: number;
-  minScore: number;
-  minRecallCount: number;
-  minUniqueQueries: number;
-  recencyHalfLifeDays: number;
-  maxAgeDays?: number;
-  maxPromotedSnippetTokens?: number;
-};
-
-type RemDreamingStatus = DreamingPhaseStatusBase & {
-  lookbackDays: number;
-  limit: number;
-  minPatternStrength: number;
-};
-
-export type DreamingEntry = {
-  key: string;
-  path: string;
-  startLine: number;
-  endLine: number;
-  snippet: string;
-  recallCount: number;
-  dailyCount: number;
-  groundedCount: number;
-  totalSignalCount: number;
-  lightHits: number;
-  remHits: number;
-  phaseHitCount: number;
-  promotedAt?: string;
-  lastRecalledAt?: string;
-};
-
-type DreamingStatus = {
-  enabled: boolean;
-  timezone?: string;
-  verboseLogging: boolean;
-  storageMode: "inline" | "separate" | "both";
-  separateReports: boolean;
-  shortTermCount: number;
-  recallSignalCount: number;
-  dailySignalCount: number;
-  groundedSignalCount: number;
-  totalSignalCount: number;
-  phaseSignalCount: number;
-  lightPhaseHitCount: number;
-  remPhaseHitCount: number;
-  promotedTotal: number;
-  promotedToday: number;
-  storePath?: string;
-  phaseSignalPath?: string;
-  storeError?: string;
-  phaseSignalError?: string;
-  shortTermEntries: DreamingEntry[];
-  signalEntries: DreamingEntry[];
-  promotedEntries: DreamingEntry[];
-  phases?: {
-    light: LightDreamingStatus;
-    deep: DeepDreamingStatus;
-    rem: RemDreamingStatus;
-  };
-};
+type DreamingStatus = NonNullable<DoctorMemoryStatusPayload["dreaming"]>;
+export type DreamingEntry = DreamingStatus["shortTermEntries"][number];
 
 type WikiImportInsightItem = {
   pagePath: string;
@@ -166,48 +98,8 @@ export type WikiOverview = {
   clusters: WikiOverviewCluster[];
 };
 
-type DoctorMemoryStatusPayload = {
-  dreaming?: unknown;
-};
-
-type DoctorMemoryDreamDiaryPayload = {
-  found?: unknown;
-  path?: unknown;
-  content?: unknown;
-};
-
-type DoctorMemoryDreamActionPayload = {
-  action?: unknown;
-  removedEntries?: unknown;
-  dedupedEntries?: unknown;
-  keptEntries?: unknown;
-  written?: unknown;
-  replaced?: unknown;
-  removedShortTermEntries?: unknown;
-  changed?: unknown;
-  archiveDir?: unknown;
-  archivedSessionCorpus?: unknown;
-  archivedSessionIngestion?: unknown;
-  archivedDreamsDiary?: unknown;
-  warnings?: unknown;
-};
-
-type WikiImportInsightsPayload = {
-  sourceType?: unknown;
-  totalItems?: unknown;
-  totalClusters?: unknown;
-  clusters?: unknown;
-};
-
-type WikiOverviewPayload = {
-  totalItems?: unknown;
-  totalPages?: unknown;
-  pageCounts?: unknown;
-  totalClaims?: unknown;
-  totalQuestions?: unknown;
-  totalContradictions?: unknown;
-  clusters?: unknown;
-};
+type DreamingResourceKey = "dreamingStatus" | "dreamDiary" | "wikiImportInsights" | "wikiOverview";
+type DreamingResourceRequest = { agentId: string | null };
 
 export type DreamingState = {
   client: GatewayBrowserClient | null;
@@ -216,17 +108,12 @@ export type DreamingState = {
   configSnapshot: ConfigSnapshot | null;
   applySessionKey: string;
   selectedAgentId: string | null;
-  dreamingStatusRequestAgentId?: string | null;
-  dreamingStatusRequestGeneration?: number;
-  dreamingStatusActiveRequestGeneration?: number | null;
+  resourceRequests: Partial<Record<DreamingResourceKey, DreamingResourceRequest>>;
   dreamingStatusAgentId?: string | null;
   dreamingStatusLoading: boolean;
   dreamingStatusError: string | null;
   dreamingStatus: DreamingStatus | null;
   dreamingModeSaving: boolean;
-  dreamDiaryRequestAgentId?: string | null;
-  dreamDiaryRequestGeneration?: number;
-  dreamDiaryActiveRequestGeneration?: number | null;
   dreamDiaryAgentId?: string | null;
   dreamDiaryLoading: boolean;
   dreamDiaryActionLoading: boolean;
@@ -235,18 +122,10 @@ export type DreamingState = {
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
-  // Agent switches can overlap RPCs; generations keep an old A -> B -> A response
-  // from replacing the current agent's wiki data.
-  wikiImportInsightsRequestAgentId?: string | null;
-  wikiImportInsightsRequestGeneration?: number;
-  wikiImportInsightsActiveRequestGeneration?: number | null;
   wikiImportInsightsAgentId?: string | null;
   wikiImportInsightsLoading: boolean;
   wikiImportInsightsError: string | null;
   wikiImportInsights: WikiImportInsights | null;
-  wikiOverviewRequestAgentId?: string | null;
-  wikiOverviewRequestGeneration?: number;
-  wikiOverviewActiveRequestGeneration?: number | null;
   wikiOverviewAgentId?: string | null;
   wikiOverviewLoading: boolean;
   wikiOverviewError: string | null;
@@ -269,6 +148,7 @@ export function createDreamingState(
     configSnapshot: initial.configSnapshot ?? null,
     applySessionKey: initial.applySessionKey ?? "main",
     selectedAgentId: initial.selectedAgentId ?? null,
+    resourceRequests: {},
     dreamingStatusLoading: false,
     dreamingStatusError: null,
     dreamingStatus: null,
@@ -415,47 +295,6 @@ function buildSelectedAgentPayload(
   return buildSelectedAgentPayloadForAgentId(resolveSelectedAgentId(state));
 }
 
-function normalizeBoolean(value: unknown, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
-function normalizeFiniteInt(value: unknown, fallback = 0): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  return Math.max(0, Math.floor(value));
-}
-
-function normalizeFiniteScore(value: unknown, fallback = 0): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  return Math.max(0, Math.min(1, value));
-}
-
-function normalizeStorageMode(value: unknown): DreamingStatus["storageMode"] {
-  const normalized = normalizeTrimmedString(value)?.toLowerCase();
-  if (normalized === "inline" || normalized === "separate" || normalized === "both") {
-    return normalized;
-  }
-  return "inline";
-}
-
-function normalizeNextRun(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function normalizePhaseStatusBase(record: Record<string, unknown> | null): DreamingPhaseStatusBase {
-  return {
-    enabled: normalizeBoolean(record?.enabled, false),
-    cron: normalizeTrimmedString(record?.cron) ?? "",
-    managedCronPresent: normalizeBoolean(record?.managedCronPresent, false),
-    ...(normalizeNextRun(record?.nextRunAtMs) !== undefined
-      ? { nextRunAtMs: normalizeNextRun(record?.nextRunAtMs) }
-      : {}),
-  };
-}
-
 export function resolveConfiguredDreaming(configValue: Record<string, unknown> | null): {
   pluginId: string;
   enabled: boolean;
@@ -474,608 +313,142 @@ export function resolveConfiguredDreaming(configValue: Record<string, unknown> |
   const overridden = typeof dreaming?.enabled === "boolean";
   return {
     pluginId,
-    enabled: slotSelection.kind === "off" ? false : normalizeBoolean(dreaming?.enabled, true),
+    enabled: slotSelection.kind !== "off" && dreaming?.enabled !== false,
     overridden,
     engineOff: slotSelection.kind === "off",
   };
 }
 
-function normalizeDreamingEntry(raw: unknown): DreamingEntry | null {
-  const record = asRecord(raw);
-  const key = normalizeTrimmedString(record?.key);
-  const path = normalizeTrimmedString(record?.path);
-  const snippet = normalizeTrimmedString(record?.snippet);
-  if (!key || !path || !snippet) {
-    return null;
-  }
-  const promotedAt = normalizeTrimmedString(record?.promotedAt);
-  const lastRecalledAt = normalizeTrimmedString(record?.lastRecalledAt);
-  return {
-    key,
-    path,
-    startLine: Math.max(1, normalizeFiniteInt(record?.startLine, 1)),
-    endLine: Math.max(1, normalizeFiniteInt(record?.endLine, 1)),
-    snippet,
-    recallCount: normalizeFiniteInt(record?.recallCount, 0),
-    dailyCount: normalizeFiniteInt(record?.dailyCount, 0),
-    groundedCount: normalizeFiniteInt(record?.groundedCount, 0),
-    totalSignalCount: normalizeFiniteInt(record?.totalSignalCount, 0),
-    lightHits: normalizeFiniteInt(record?.lightHits, 0),
-    remHits: normalizeFiniteInt(record?.remHits, 0),
-    phaseHitCount: normalizeFiniteInt(record?.phaseHitCount, 0),
-    ...(promotedAt ? { promotedAt } : {}),
-    ...(lastRecalledAt ? { lastRecalledAt } : {}),
-  };
-}
+type DreamingResourcePayloads = {
+  dreamingStatus: DoctorMemoryStatusPayload;
+  dreamDiary: DoctorMemoryDreamDiaryPayload;
+  wikiImportInsights: WikiImportInsights;
+  wikiOverview: WikiOverview;
+};
 
-function normalizeDreamingEntries(raw: unknown): DreamingEntry[] {
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw
-    .map((entry) => normalizeDreamingEntry(entry))
-    .filter((entry): entry is DreamingEntry => entry !== null);
-}
+type DreamingResourceSpec<Key extends DreamingResourceKey> = {
+  method: string;
+  clear: (state: DreamingState) => void;
+  apply: (state: DreamingState, payload: DreamingResourcePayloads[Key]) => void;
+};
 
-function normalizeStringArray(raw: unknown): string[] {
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw.filter(
-    (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
-  );
-}
+const DREAMING_RESOURCE_SPECS: {
+  [Key in DreamingResourceKey]: DreamingResourceSpec<Key>;
+} = {
+  dreamingStatus: {
+    method: "doctor.memory.status",
+    clear: (state) => {
+      state.dreamingStatus = null;
+    },
+    apply: (state, payload) => {
+      state.dreamingStatus = payload.dreaming ?? null;
+    },
+  },
+  dreamDiary: {
+    method: "doctor.memory.dreamDiary",
+    clear: (state) => {
+      state.dreamDiaryPath = null;
+      state.dreamDiaryContent = null;
+    },
+    apply: (state, payload) => {
+      state.dreamDiaryPath = payload.path;
+      state.dreamDiaryContent = payload.found ? (payload.content ?? "") : null;
+    },
+  },
+  wikiImportInsights: {
+    method: "wiki.importInsights",
+    clear: (state) => {
+      state.wikiImportInsights = null;
+    },
+    apply: (state, payload) => {
+      state.wikiImportInsights = payload;
+    },
+  },
+  wikiOverview: {
+    method: "wiki.overview",
+    clear: (state) => {
+      state.wikiOverview = null;
+    },
+    apply: (state, payload) => {
+      state.wikiOverview = payload;
+    },
+  },
+};
 
-function normalizeWikiImportInsightItem(raw: unknown): WikiImportInsightItem | null {
-  const record = asRecord(raw);
-  const pagePath = normalizeTrimmedString(record?.pagePath);
-  const title = normalizeTrimmedString(record?.title);
-  const riskLevel = normalizeTrimmedString(record?.riskLevel);
-  const topicKey = normalizeTrimmedString(record?.topicKey);
-  const topicLabel = normalizeTrimmedString(record?.topicLabel);
-  const digestStatus = normalizeTrimmedString(record?.digestStatus);
-  const summary = normalizeTrimmedString(record?.summary);
+async function loadDreamingResource<Key extends DreamingResourceKey>(
+  state: DreamingState,
+  key: Key,
+  spec: DreamingResourceSpec<Key> = DREAMING_RESOURCE_SPECS[key],
+): Promise<void> {
+  const client = state.client;
+  if (!client || !state.connected) {
+    return;
+  }
+
+  const agentId = resolveSelectedAgentId(state);
+  const loadingKey = `${key}Loading` as const;
+  const errorKey = `${key}Error` as const;
+  const agentKey = `${key}AgentId` as const;
+  if (state[agentKey] !== agentId) {
+    spec.clear(state);
+  }
   if (
-    !pagePath ||
-    !title ||
-    !topicKey ||
-    !topicLabel ||
-    !summary ||
-    (riskLevel !== "low" &&
-      riskLevel !== "medium" &&
-      riskLevel !== "high" &&
-      riskLevel !== "unknown") ||
-    (digestStatus !== "available" && digestStatus !== "withheld")
+    (key === "wikiImportInsights" || key === "wikiOverview") &&
+    !canCallMemoryWikiMethod(state, spec.method)
   ) {
-    return null;
+    delete state.resourceRequests[key];
+    state[loadingKey] = false;
+    state[errorKey] = null;
+    spec.clear(state);
+    return;
   }
-  return {
-    pagePath,
-    title,
-    riskLevel,
-    riskReasons: normalizeStringArray(record?.riskReasons),
-    labels: normalizeStringArray(record?.labels),
-    topicKey,
-    topicLabel,
-    digestStatus,
-    activeBranchMessages: normalizeFiniteInt(record?.activeBranchMessages, 0),
-    userMessageCount: normalizeFiniteInt(record?.userMessageCount, 0),
-    assistantMessageCount: normalizeFiniteInt(record?.assistantMessageCount, 0),
-    ...(normalizeTrimmedString(record?.firstUserLine)
-      ? { firstUserLine: normalizeTrimmedString(record?.firstUserLine) }
-      : {}),
-    ...(normalizeTrimmedString(record?.lastUserLine)
-      ? { lastUserLine: normalizeTrimmedString(record?.lastUserLine) }
-      : {}),
-    ...(normalizeTrimmedString(record?.assistantOpener)
-      ? { assistantOpener: normalizeTrimmedString(record?.assistantOpener) }
-      : {}),
-    summary,
-    candidateSignals: normalizeStringArray(record?.candidateSignals),
-    correctionSignals: normalizeStringArray(record?.correctionSignals),
-    preferenceSignals: normalizeStringArray(record?.preferenceSignals),
-    ...(normalizeTrimmedString(record?.createdAt)
-      ? { createdAt: normalizeTrimmedString(record?.createdAt) }
-      : {}),
-    ...(normalizeTrimmedString(record?.updatedAt)
-      ? { updatedAt: normalizeTrimmedString(record?.updatedAt) }
-      : {}),
-  };
-}
 
-function normalizeWikiImportInsightCluster(raw: unknown): WikiImportInsightCluster | null {
-  const record = asRecord(raw);
-  const key = normalizeTrimmedString(record?.key);
-  const label = normalizeTrimmedString(record?.label);
-  if (!key || !label) {
-    return null;
+  const active = state.resourceRequests[key];
+  if (active?.agentId === agentId && state[loadingKey]) {
+    return;
   }
-  const items = Array.isArray(record?.items)
-    ? record.items
-        .map((entry) => normalizeWikiImportInsightItem(entry))
-        .filter((entry): entry is WikiImportInsightItem => entry !== null)
-    : [];
-  return {
-    key,
-    label,
-    itemCount: normalizeFiniteInt(record?.itemCount, items.length),
-    highRiskCount: normalizeFiniteInt(
-      record?.highRiskCount,
-      items.filter((entry) => entry.riskLevel === "high").length,
-    ),
-    withheldCount: normalizeFiniteInt(
-      record?.withheldCount,
-      items.filter((entry) => entry.digestStatus === "withheld").length,
-    ),
-    preferenceSignalCount: normalizeFiniteInt(
-      record?.preferenceSignalCount,
-      items.reduce((sum, entry) => sum + entry.preferenceSignals.length, 0),
-    ),
-    ...(normalizeTrimmedString(record?.updatedAt)
-      ? { updatedAt: normalizeTrimmedString(record?.updatedAt) }
-      : {}),
-    items,
-  };
-}
 
-function normalizeWikiImportInsights(raw: unknown): WikiImportInsights {
-  const record = asRecord(raw);
-  const clusters = Array.isArray(record?.clusters)
-    ? record.clusters
-        .map((entry) => normalizeWikiImportInsightCluster(entry))
-        .filter((entry): entry is WikiImportInsightCluster => entry !== null)
-    : [];
-  return {
-    sourceType: record?.sourceType === "chatgpt" ? "chatgpt" : "chatgpt",
-    totalItems: normalizeFiniteInt(
-      record?.totalItems,
-      clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0),
-    ),
-    totalClusters: normalizeFiniteInt(record?.totalClusters, clusters.length),
-    clusters,
-  };
-}
-
-function normalizeWikiPageKind(value: unknown): WikiOverviewItem["kind"] | undefined {
-  return value === "entity" ||
-    value === "concept" ||
-    value === "source" ||
-    value === "synthesis" ||
-    value === "report"
-    ? value
-    : undefined;
-}
-
-function createEmptyWikiOverviewPageCounts(): WikiOverviewPageCounts {
-  return {
-    synthesis: 0,
-    entity: 0,
-    concept: 0,
-    source: 0,
-    report: 0,
-  };
-}
-
-function normalizeWikiOverviewPageCounts(
-  raw: unknown,
-  fallback: WikiOverviewPageCounts,
-): WikiOverviewPageCounts {
-  const record = asRecord(raw);
-  return {
-    synthesis: normalizeFiniteInt(record?.synthesis, fallback.synthesis),
-    entity: normalizeFiniteInt(record?.entity, fallback.entity),
-    concept: normalizeFiniteInt(record?.concept, fallback.concept),
-    source: normalizeFiniteInt(record?.source, fallback.source),
-    report: normalizeFiniteInt(record?.report, fallback.report),
-  };
-}
-
-function sumWikiOverviewPageCounts(pageCounts: WikiOverviewPageCounts): number {
-  return (
-    pageCounts.synthesis +
-    pageCounts.entity +
-    pageCounts.concept +
-    pageCounts.source +
-    pageCounts.report
-  );
-}
-
-function normalizeWikiOverviewItem(raw: unknown): WikiOverviewItem | null {
-  const record = asRecord(raw);
-  const pagePath = normalizeTrimmedString(record?.pagePath);
-  const title = normalizeTrimmedString(record?.title);
-  const kind = normalizeWikiPageKind(record?.kind);
-  if (!pagePath || !title || !kind) {
-    return null;
+  // Request identity, not agent identity, rejects stale A -> B -> A completions.
+  const request: DreamingResourceRequest = { agentId };
+  state.resourceRequests[key] = request;
+  state[loadingKey] = true;
+  state[errorKey] = null;
+  try {
+    const payload = await client.request<DreamingResourcePayloads[Key]>(
+      spec.method,
+      buildSelectedAgentPayloadForAgentId(agentId),
+    );
+    if (state.resourceRequests[key] !== request || resolveSelectedAgentId(state) !== agentId) {
+      return;
+    }
+    spec.apply(state, payload);
+    state[agentKey] = agentId;
+  } catch (error) {
+    if (state.resourceRequests[key] === request && resolveSelectedAgentId(state) === agentId) {
+      state[errorKey] = String(error);
+    }
+  } finally {
+    if (state.resourceRequests[key] === request) {
+      delete state.resourceRequests[key];
+      state[loadingKey] = false;
+    }
   }
-  return {
-    pagePath,
-    title,
-    kind,
-    ...(normalizeTrimmedString(record?.id) ? { id: normalizeTrimmedString(record?.id) } : {}),
-    ...(normalizeTrimmedString(record?.updatedAt)
-      ? { updatedAt: normalizeTrimmedString(record?.updatedAt) }
-      : {}),
-    ...(normalizeTrimmedString(record?.sourceType)
-      ? { sourceType: normalizeTrimmedString(record?.sourceType) }
-      : {}),
-    claimCount: normalizeFiniteInt(record?.claimCount, 0),
-    questionCount: normalizeFiniteInt(record?.questionCount, 0),
-    contradictionCount: normalizeFiniteInt(record?.contradictionCount, 0),
-    claims: normalizeStringArray(record?.claims),
-    questions: normalizeStringArray(record?.questions),
-    contradictions: normalizeStringArray(record?.contradictions),
-    ...(normalizeTrimmedString(record?.snippet)
-      ? { snippet: normalizeTrimmedString(record?.snippet) }
-      : {}),
-  };
-}
-
-function normalizeWikiOverviewCluster(raw: unknown): WikiOverviewCluster | null {
-  const record = asRecord(raw);
-  const key = normalizeWikiPageKind(record?.key);
-  const label = normalizeTrimmedString(record?.label);
-  if (!key || !label) {
-    return null;
-  }
-  const items = Array.isArray(record?.items)
-    ? record.items
-        .map((entry) => normalizeWikiOverviewItem(entry))
-        .filter((entry): entry is WikiOverviewItem => entry !== null)
-    : [];
-  return {
-    key,
-    label,
-    itemCount: normalizeFiniteInt(record?.itemCount, items.length),
-    claimCount: normalizeFiniteInt(
-      record?.claimCount,
-      items.reduce((sum, item) => sum + item.claimCount, 0),
-    ),
-    questionCount: normalizeFiniteInt(
-      record?.questionCount,
-      items.reduce((sum, item) => sum + item.questionCount, 0),
-    ),
-    contradictionCount: normalizeFiniteInt(
-      record?.contradictionCount,
-      items.reduce((sum, item) => sum + item.contradictionCount, 0),
-    ),
-    ...(normalizeTrimmedString(record?.updatedAt)
-      ? { updatedAt: normalizeTrimmedString(record?.updatedAt) }
-      : {}),
-    items,
-  };
-}
-
-function normalizeWikiOverview(raw: unknown): WikiOverview {
-  const record = asRecord(raw);
-  const clusters = Array.isArray(record?.clusters)
-    ? record.clusters
-        .map((entry) => normalizeWikiOverviewCluster(entry))
-        .filter((entry): entry is WikiOverviewCluster => entry !== null)
-    : [];
-  const totalItems = normalizeFiniteInt(
-    record?.totalItems,
-    clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0),
-  );
-  const fallbackPageCounts = createEmptyWikiOverviewPageCounts();
-  for (const cluster of clusters) {
-    fallbackPageCounts[cluster.key] += cluster.itemCount;
-  }
-  const pageCounts = normalizeWikiOverviewPageCounts(record?.pageCounts, fallbackPageCounts);
-  const fallbackTotalPages = sumWikiOverviewPageCounts(pageCounts) || totalItems;
-  return {
-    totalItems,
-    totalPages: normalizeFiniteInt(record?.totalPages, fallbackTotalPages),
-    pageCounts,
-    totalClaims: normalizeFiniteInt(
-      record?.totalClaims,
-      clusters.reduce((sum, cluster) => sum + cluster.claimCount, 0),
-    ),
-    totalQuestions: normalizeFiniteInt(
-      record?.totalQuestions,
-      clusters.reduce((sum, cluster) => sum + cluster.questionCount, 0),
-    ),
-    totalContradictions: normalizeFiniteInt(
-      record?.totalContradictions,
-      clusters.reduce((sum, cluster) => sum + cluster.contradictionCount, 0),
-    ),
-    clusters,
-  };
-}
-
-function normalizeDreamingStatus(raw: unknown): DreamingStatus | null {
-  const record = asRecord(raw);
-  if (!record) {
-    return null;
-  }
-  const phasesRecord = asRecord(record.phases);
-  const lightRecord = asRecord(phasesRecord?.light);
-  const deepRecord = asRecord(phasesRecord?.deep);
-  const remRecord = asRecord(phasesRecord?.rem);
-  const phases =
-    lightRecord && deepRecord && remRecord
-      ? {
-          light: {
-            ...normalizePhaseStatusBase(lightRecord),
-            lookbackDays: normalizeFiniteInt(lightRecord.lookbackDays, 0),
-            limit: normalizeFiniteInt(lightRecord.limit, 0),
-          },
-          deep: {
-            ...normalizePhaseStatusBase(deepRecord),
-            limit: normalizeFiniteInt(deepRecord.limit, 0),
-            minScore: normalizeFiniteScore(deepRecord.minScore, 0),
-            minRecallCount: normalizeFiniteInt(deepRecord.minRecallCount, 0),
-            minUniqueQueries: normalizeFiniteInt(deepRecord.minUniqueQueries, 0),
-            recencyHalfLifeDays: normalizeFiniteInt(deepRecord.recencyHalfLifeDays, 0),
-            ...(typeof deepRecord.maxAgeDays === "number" && Number.isFinite(deepRecord.maxAgeDays)
-              ? { maxAgeDays: normalizeFiniteInt(deepRecord.maxAgeDays, 0) }
-              : {}),
-            ...(typeof deepRecord.maxPromotedSnippetTokens === "number" &&
-            Number.isFinite(deepRecord.maxPromotedSnippetTokens)
-              ? {
-                  maxPromotedSnippetTokens: normalizeFiniteInt(
-                    deepRecord.maxPromotedSnippetTokens,
-                    0,
-                  ),
-                }
-              : {}),
-          },
-          rem: {
-            ...normalizePhaseStatusBase(remRecord),
-            lookbackDays: normalizeFiniteInt(remRecord.lookbackDays, 0),
-            limit: normalizeFiniteInt(remRecord.limit, 0),
-            minPatternStrength: normalizeFiniteScore(remRecord.minPatternStrength, 0),
-          },
-        }
-      : undefined;
-  const timezone = normalizeTrimmedString(record.timezone);
-  const storePath = normalizeTrimmedString(record.storePath);
-  const phaseSignalPath = normalizeTrimmedString(record.phaseSignalPath);
-  const storeError = normalizeTrimmedString(record.storeError);
-  const phaseSignalError = normalizeTrimmedString(record.phaseSignalError);
-
-  return {
-    enabled: normalizeBoolean(record.enabled, false),
-    ...(timezone ? { timezone } : {}),
-    verboseLogging: normalizeBoolean(record.verboseLogging, false),
-    storageMode: normalizeStorageMode(record.storageMode),
-    separateReports: normalizeBoolean(record.separateReports, false),
-    shortTermCount: normalizeFiniteInt(record.shortTermCount, 0),
-    recallSignalCount: normalizeFiniteInt(record.recallSignalCount, 0),
-    dailySignalCount: normalizeFiniteInt(record.dailySignalCount, 0),
-    groundedSignalCount: normalizeFiniteInt(record.groundedSignalCount, 0),
-    totalSignalCount: normalizeFiniteInt(record.totalSignalCount, 0),
-    phaseSignalCount: normalizeFiniteInt(record.phaseSignalCount, 0),
-    lightPhaseHitCount: normalizeFiniteInt(record.lightPhaseHitCount, 0),
-    remPhaseHitCount: normalizeFiniteInt(record.remPhaseHitCount, 0),
-    promotedTotal: normalizeFiniteInt(record.promotedTotal, 0),
-    promotedToday: normalizeFiniteInt(record.promotedToday, 0),
-    ...(storePath ? { storePath } : {}),
-    ...(phaseSignalPath ? { phaseSignalPath } : {}),
-    ...(storeError ? { storeError } : {}),
-    ...(phaseSignalError ? { phaseSignalError } : {}),
-    shortTermEntries: normalizeDreamingEntries(record.shortTermEntries),
-    signalEntries: normalizeDreamingEntries(record.signalEntries),
-    promotedEntries: normalizeDreamingEntries(record.promotedEntries),
-    ...(phases ? { phases } : {}),
-  };
 }
 
 export async function loadDreamingStatus(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  const agentId = resolveSelectedAgentId(state);
-  if (state.dreamingStatusLoading && state.dreamingStatusRequestAgentId === agentId) {
-    return;
-  }
-  if (state.dreamingStatusAgentId !== agentId) {
-    state.dreamingStatus = null;
-  }
-  const requestGeneration = (state.dreamingStatusRequestGeneration ?? 0) + 1;
-  state.dreamingStatusRequestGeneration = requestGeneration;
-  state.dreamingStatusActiveRequestGeneration = requestGeneration;
-  state.dreamingStatusRequestAgentId = agentId;
-  state.dreamingStatusLoading = true;
-  state.dreamingStatusError = null;
-  try {
-    const payload = await state.client.request<DoctorMemoryStatusPayload>(
-      "doctor.memory.status",
-      buildSelectedAgentPayloadForAgentId(agentId),
-    );
-    if (
-      state.dreamingStatusActiveRequestGeneration !== requestGeneration ||
-      state.dreamingStatusRequestAgentId !== agentId ||
-      resolveSelectedAgentId(state) !== agentId
-    ) {
-      return;
-    }
-    state.dreamingStatus = normalizeDreamingStatus(payload?.dreaming);
-    state.dreamingStatusAgentId = agentId;
-  } catch (err) {
-    if (
-      state.dreamingStatusActiveRequestGeneration === requestGeneration &&
-      state.dreamingStatusRequestAgentId === agentId &&
-      resolveSelectedAgentId(state) === agentId
-    ) {
-      state.dreamingStatusError = String(err);
-    }
-  } finally {
-    if (state.dreamingStatusActiveRequestGeneration === requestGeneration) {
-      state.dreamingStatusLoading = false;
-      state.dreamingStatusRequestAgentId = null;
-      state.dreamingStatusActiveRequestGeneration = null;
-    }
-  }
+  await loadDreamingResource(state, "dreamingStatus");
 }
 
 export async function loadDreamDiary(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  const agentId = resolveSelectedAgentId(state);
-  if (state.dreamDiaryLoading && state.dreamDiaryRequestAgentId === agentId) {
-    return;
-  }
-  if (state.dreamDiaryAgentId !== agentId) {
-    state.dreamDiaryPath = null;
-    state.dreamDiaryContent = null;
-  }
-  const requestGeneration = (state.dreamDiaryRequestGeneration ?? 0) + 1;
-  state.dreamDiaryRequestGeneration = requestGeneration;
-  state.dreamDiaryActiveRequestGeneration = requestGeneration;
-  state.dreamDiaryRequestAgentId = agentId;
-  state.dreamDiaryLoading = true;
-  state.dreamDiaryError = null;
-  try {
-    const payload = await state.client.request<DoctorMemoryDreamDiaryPayload>(
-      "doctor.memory.dreamDiary",
-      buildSelectedAgentPayloadForAgentId(agentId),
-    );
-    if (
-      state.dreamDiaryActiveRequestGeneration !== requestGeneration ||
-      state.dreamDiaryRequestAgentId !== agentId ||
-      resolveSelectedAgentId(state) !== agentId
-    ) {
-      return;
-    }
-    const path = normalizeTrimmedString(payload?.path) ?? DEFAULT_DREAM_DIARY_PATH;
-    const found = payload?.found === true;
-    if (found) {
-      state.dreamDiaryPath = path;
-      state.dreamDiaryContent = typeof payload?.content === "string" ? payload.content : "";
-    } else {
-      state.dreamDiaryPath = path;
-      state.dreamDiaryContent = null;
-    }
-    state.dreamDiaryAgentId = agentId;
-  } catch (err) {
-    if (
-      state.dreamDiaryActiveRequestGeneration === requestGeneration &&
-      state.dreamDiaryRequestAgentId === agentId &&
-      resolveSelectedAgentId(state) === agentId
-    ) {
-      state.dreamDiaryError = String(err);
-    }
-  } finally {
-    if (state.dreamDiaryActiveRequestGeneration === requestGeneration) {
-      state.dreamDiaryLoading = false;
-      state.dreamDiaryRequestAgentId = null;
-      state.dreamDiaryActiveRequestGeneration = null;
-    }
-  }
+  await loadDreamingResource(state, "dreamDiary");
 }
 
 export async function loadWikiImportInsights(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  const agentId = resolveSelectedAgentId(state);
-  if (state.wikiImportInsightsLoading && state.wikiImportInsightsRequestAgentId === agentId) {
-    return;
-  }
-  if (state.wikiImportInsightsAgentId !== agentId) {
-    state.wikiImportInsights = null;
-  }
-  if (!canCallMemoryWikiMethod(state, "wiki.importInsights")) {
-    state.wikiImportInsightsActiveRequestGeneration = null;
-    state.wikiImportInsightsRequestAgentId = null;
-    state.wikiImportInsightsLoading = false;
-    state.wikiImportInsights = null;
-    state.wikiImportInsightsError = null;
-    return;
-  }
-  const requestGeneration = (state.wikiImportInsightsRequestGeneration ?? 0) + 1;
-  state.wikiImportInsightsRequestGeneration = requestGeneration;
-  state.wikiImportInsightsActiveRequestGeneration = requestGeneration;
-  state.wikiImportInsightsRequestAgentId = agentId;
-  state.wikiImportInsightsLoading = true;
-  state.wikiImportInsightsError = null;
-  try {
-    const payload = await state.client.request<WikiImportInsightsPayload>(
-      "wiki.importInsights",
-      buildSelectedAgentPayloadForAgentId(agentId),
-    );
-    if (
-      state.wikiImportInsightsActiveRequestGeneration !== requestGeneration ||
-      state.wikiImportInsightsRequestAgentId !== agentId ||
-      resolveSelectedAgentId(state) !== agentId
-    ) {
-      return;
-    }
-    state.wikiImportInsights = normalizeWikiImportInsights(payload);
-    state.wikiImportInsightsAgentId = agentId;
-  } catch (err) {
-    if (
-      state.wikiImportInsightsActiveRequestGeneration === requestGeneration &&
-      state.wikiImportInsightsRequestAgentId === agentId &&
-      resolveSelectedAgentId(state) === agentId
-    ) {
-      state.wikiImportInsightsError = String(err);
-    }
-  } finally {
-    if (state.wikiImportInsightsActiveRequestGeneration === requestGeneration) {
-      state.wikiImportInsightsLoading = false;
-      state.wikiImportInsightsRequestAgentId = null;
-      state.wikiImportInsightsActiveRequestGeneration = null;
-    }
-  }
+  await loadDreamingResource(state, "wikiImportInsights");
 }
 
 export async function loadWikiOverview(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  const agentId = resolveSelectedAgentId(state);
-  if (state.wikiOverviewLoading && state.wikiOverviewRequestAgentId === agentId) {
-    return;
-  }
-  if (state.wikiOverviewAgentId !== agentId) {
-    state.wikiOverview = null;
-  }
-  if (!canCallMemoryWikiMethod(state, "wiki.overview")) {
-    state.wikiOverviewActiveRequestGeneration = null;
-    state.wikiOverviewRequestAgentId = null;
-    state.wikiOverviewLoading = false;
-    state.wikiOverview = null;
-    state.wikiOverviewError = null;
-    return;
-  }
-  const requestGeneration = (state.wikiOverviewRequestGeneration ?? 0) + 1;
-  state.wikiOverviewRequestGeneration = requestGeneration;
-  state.wikiOverviewActiveRequestGeneration = requestGeneration;
-  state.wikiOverviewRequestAgentId = agentId;
-  state.wikiOverviewLoading = true;
-  state.wikiOverviewError = null;
-  try {
-    const payload = await state.client.request<WikiOverviewPayload>(
-      "wiki.overview",
-      buildSelectedAgentPayloadForAgentId(agentId),
-    );
-    if (
-      state.wikiOverviewActiveRequestGeneration !== requestGeneration ||
-      state.wikiOverviewRequestAgentId !== agentId ||
-      resolveSelectedAgentId(state) !== agentId
-    ) {
-      return;
-    }
-    state.wikiOverview = normalizeWikiOverview(payload);
-    state.wikiOverviewAgentId = agentId;
-  } catch (err) {
-    if (
-      state.wikiOverviewActiveRequestGeneration === requestGeneration &&
-      state.wikiOverviewRequestAgentId === agentId &&
-      resolveSelectedAgentId(state) === agentId
-    ) {
-      state.wikiOverviewError = String(err);
-    }
-  } finally {
-    if (state.wikiOverviewActiveRequestGeneration === requestGeneration) {
-      state.wikiOverviewLoading = false;
-      state.wikiOverviewRequestAgentId = null;
-      state.wikiOverviewActiveRequestGeneration = null;
-    }
-  }
+  await loadDreamingResource(state, "wikiOverview");
 }
 
 async function runDreamDiaryAction(
@@ -1309,4 +682,3 @@ export async function updateDreamingEnabled(
   }
   return ok;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -487,3 +487,251 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     expect(page.viewState.wikiPreviewContent).toBe("");
   });
 });
+
+describe.runIf(process.env.OPENCLAW_UI_MEMORY_CHROMIUM_E2E === "1")(
+  "agent memory real Chromium owner proof",
+  () => {
+    let browser: import("playwright").Browser;
+    let server: import("../../../test-helpers/control-ui-e2e.ts").ControlUiE2eServer;
+    let e2e: typeof import("../../../test-helpers/control-ui-e2e.ts");
+
+    beforeAll(async () => {
+      const { chromium } = await import("playwright");
+      e2e = await import("../../../test-helpers/control-ui-e2e.ts");
+      const executablePath = e2e.resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+      if (!e2e.canRunPlaywrightChromium(executablePath)) {
+        throw new Error(`Real Chromium required but unavailable: ${executablePath}`);
+      }
+      server = await e2e.startControlUiE2eServer();
+      browser = await chromium.launch({ executablePath, headless: true });
+    }, 90_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await server?.close();
+    });
+
+    it("preserves both routes, agent ownership, wiki gating, and reconnects", async () => {
+      const status = (agentId: string, promotedToday: number) => ({
+        agentId,
+        provider: "builtin",
+        embedding: { ok: true, checked: true },
+        dreaming: {
+          enabled: true,
+          verboseLogging: false,
+          storageMode: "inline" as const,
+          separateReports: false,
+          shortTermCount: promotedToday,
+          recallSignalCount: 0,
+          dailySignalCount: 0,
+          groundedSignalCount: 0,
+          totalSignalCount: 0,
+          phaseSignalCount: 0,
+          lightPhaseHitCount: 0,
+          remPhaseHitCount: 0,
+          promotedTotal: promotedToday,
+          promotedToday,
+          shortTermEntries: [],
+          signalEntries: [],
+          promotedEntries: [],
+          phases: {
+            light: {
+              enabled: true,
+              cron: "0 * * * *",
+              managedCronPresent: true,
+              lookbackDays: 2,
+              limit: 10,
+            },
+            deep: {
+              enabled: true,
+              cron: "0 3 * * *",
+              managedCronPresent: true,
+              limit: 10,
+              minScore: 0.8,
+              minRecallCount: 2,
+              minUniqueQueries: 2,
+              recencyHalfLifeDays: 14,
+            },
+            rem: {
+              enabled: false,
+              cron: "0 5 * * 0",
+              managedCronPresent: false,
+              lookbackDays: 7,
+              limit: 10,
+              minPatternStrength: 0.75,
+            },
+          },
+        },
+      });
+      const diary = (agentId: string) => ({
+        agentId,
+        found: true,
+        path: "DREAMS.md",
+        content: `# Dream Diary\n\n*April 5, 2026, 3:00 AM*\n\n${agentId} owns this dream.`,
+      });
+      const config = {
+        agents: { entries: { main: { default: true }, support: {} } },
+        plugins: {
+          entries: {
+            "memory-core": { enabled: true, config: { dreaming: { enabled: true } } },
+          },
+        },
+      };
+      const roster = {
+        agents: [
+          { id: "main", name: "Main" },
+          { id: "support", name: "Support" },
+        ],
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+      };
+      const context = await browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 900 },
+      });
+      const page = await context.newPage();
+      const gateway = await e2e.installMockGateway(page, {
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "doctor.memory.status",
+          "doctor.memory.dreamDiary",
+        ],
+        methodResponses: {
+          "agents.list": roster,
+          "config.get": {
+            config,
+            sourceConfig: config,
+            runtimeConfig: config,
+            hash: "memory-proof-1",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+          "plugins.list": {
+            plugins: [
+              {
+                id: "memory-core",
+                name: "OpenClaw Memory",
+                installed: true,
+                enabled: true,
+                state: "enabled",
+                kind: ["memory"],
+              },
+            ],
+            diagnostics: [],
+            mutationAllowed: true,
+          },
+          "doctor.memory.status": {
+            cases: [
+              { match: { agentId: "main" }, response: status("main", 11) },
+              { match: { agentId: "support" }, response: status("support", 22) },
+            ],
+          },
+          "doctor.memory.dreamDiary": {
+            cases: [
+              { match: { agentId: "main" }, response: diary("main") },
+              { match: { agentId: "support" }, response: diary("support") },
+            ],
+          },
+        },
+      });
+      const detail = () => page.locator("openclaw-agent-memory-panel .dreams__status-detail");
+      const requestCount = () =>
+        gateway.getRequests("doctor.memory.status").then((requests) => requests.length);
+      const chooseAgent = async (name: string) => {
+        const picker = page.locator(".memory-page .agent-scope-control openclaw-agent-select");
+        await picker.locator(".agent-select__trigger").click();
+        await picker
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: name })
+          .evaluate((item) => (item as HTMLElement).click());
+      };
+
+      try {
+        expect((await page.goto(`${server.baseUrl}settings/agents/main/memory`))?.status()).toBe(
+          200,
+        );
+        await e2e.waitForControlUiRoute(page, {
+          routeId: "agents",
+          pathname: "/settings/agents/main/memory",
+        });
+        await expect
+          .poll(async () => await detail().textContent(), { timeout: 15_000 })
+          .toContain("11 promoted");
+        expect(await gateway.getRequests("wiki.importInsights")).toHaveLength(0);
+        expect(await gateway.getRequests("wiki.overview")).toHaveLength(0);
+
+        const beforeFirstMain = await requestCount();
+        await gateway.deferNext("doctor.memory.status");
+        await page.evaluate(() => {
+          history.pushState(null, "", "/settings/memory/dreams");
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        });
+        await e2e.waitForControlUiRoute(page, {
+          routeId: "memory",
+          pathname: "/settings/memory/dreams",
+        });
+        await expect.poll(requestCount, { timeout: 15_000 }).toBeGreaterThan(beforeFirstMain);
+
+        const beforeSupport = await requestCount();
+        await gateway.deferNext("doctor.memory.status");
+        await chooseAgent("Support");
+        await expect.poll(requestCount, { timeout: 15_000 }).toBeGreaterThan(beforeSupport);
+        await gateway.setMethodResponse("doctor.memory.status", {
+          cases: [
+            { match: { agentId: "main" }, response: status("main", 33) },
+            { match: { agentId: "support" }, response: status("support", 22) },
+          ],
+        });
+        await chooseAgent("Main");
+        await expect
+          .poll(async () => await detail().textContent(), { timeout: 15_000 })
+          .toContain("33 promoted");
+        await gateway.resolveDeferred("doctor.memory.status", status("main", 11));
+        await gateway.resolveDeferred("doctor.memory.status", status("support", 22));
+        await expect
+          .poll(async () => await detail().textContent(), { timeout: 15_000 })
+          .toContain("33 promoted");
+        expect(await gateway.getRequests("wiki.importInsights")).toHaveLength(0);
+        expect(await gateway.getRequests("wiki.overview")).toHaveLength(0);
+
+        await gateway.setMethodResponse("doctor.memory.status", status("main", 44));
+        const beforeReconnect = await requestCount();
+        const socketCount = await gateway.getSocketCount();
+        await gateway.closeLatest(1001, "proxy idle timeout");
+        await gateway.setOnline(false);
+        await expect
+          .poll(
+            () =>
+              page.evaluate(
+                () =>
+                  (
+                    document.querySelector("openclaw-app") as HTMLElement & {
+                      runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+                    }
+                  ).runtime?.context.gateway.snapshot.phase,
+              ),
+            { timeout: 15_000 },
+          )
+          .toBe("reconnecting");
+        await expect
+          .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
+          .toBeGreaterThan(socketCount);
+        await gateway.setOnline(true);
+        await expect.poll(requestCount, { timeout: 15_000 }).toBeGreaterThan(beforeReconnect);
+        await expect
+          .poll(async () => await detail().textContent(), { timeout: 15_000 })
+          .toContain("44 promoted");
+        await e2e.waitForControlUiRoute(page, {
+          routeId: "memory",
+          pathname: "/settings/memory/dreams",
+        });
+      } finally {
+        await context.close();
+      }
+    }, 120_000);
+  },
+);

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -31,7 +31,12 @@ import {
   type DreamingState,
 } from "./dreaming.ts";
 import { renderDreamingToggleConfirmation } from "./toggle-confirmation.ts";
-import { createDreamingViewState, renderDreaming, type DreamingViewState } from "./view.ts";
+import {
+  createDreamingViewState,
+  renderDreaming,
+  resetWikiPreview,
+  type DreamingViewState,
+} from "./view.ts";
 
 type WikiPagePreview = {
   title: string;
@@ -187,23 +192,10 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
   }
 
   private resetTransientState() {
-    this.resetWikiPreview();
+    resetWikiPreview(this.viewState);
     this.toggleConfirmOpen = false;
     this.toggleConfirmLoading = false;
     this.pendingEnabled = null;
-  }
-
-  private resetWikiPreview() {
-    this.viewState.wikiPreviewRequestId += 1;
-    this.viewState.wikiPreviewOpen = false;
-    this.viewState.wikiPreviewLoading = false;
-    this.viewState.wikiPreviewTitle = "";
-    this.viewState.wikiPreviewPath = "";
-    this.viewState.wikiPreviewUpdatedAt = null;
-    this.viewState.wikiPreviewContent = "";
-    this.viewState.wikiPreviewTotalLines = null;
-    this.viewState.wikiPreviewTruncated = false;
-    this.viewState.wikiPreviewError = null;
   }
 
   private createGatewayState(snapshot = this.context.gateway.snapshot): DreamingState {
@@ -515,8 +507,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         active: dreamingOn,
         selectedAgentId,
         shortTermCount: dreamingStatus?.shortTermCount ?? 0,
-        groundedSignalCount: dreamingStatus?.groundedSignalCount ?? 0,
-        totalSignalCount: dreamingStatus?.totalSignalCount ?? 0,
         promotedCount: dreamingStatus?.promotedToday ?? 0,
         phases: dreamingStatus?.phases ?? undefined,
         shortTermEntries: dreamingStatus?.shortTermEntries ?? [],
@@ -524,7 +514,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         dreamingOf: null,
         nextCycle: resolveDreamingNextCycle(dreamingStatus),
         timezone: dreamingStatus?.timezone ?? null,
-        statusLoading: dreaming.dreamingStatusLoading,
         statusError: dreaming.dreamingStatusError,
         modeSaving: dreaming.dreamingModeSaving,
         dreamDiaryLoading: dreaming.dreamDiaryLoading,
@@ -532,7 +521,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         dreamDiaryActionMessage: dreaming.dreamDiaryActionMessage,
         dreamDiaryActionArchivePath: dreaming.dreamDiaryActionArchivePath,
         dreamDiaryError: dreaming.dreamDiaryError,
-        dreamDiaryPath: dreaming.dreamDiaryPath,
         dreamDiaryContent: dreaming.dreamDiaryContent,
         memoryWikiEnabled: isPluginEnabledInConfigSnapshot(
           configState.configSnapshot,
@@ -545,7 +533,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         wikiOverviewLoading: dreaming.wikiOverviewLoading,
         wikiOverviewError: dreaming.wikiOverviewError,
         wikiOverview: dreaming.wikiOverview,
-        onRefresh: () => void this.loadAll(true),
         onRefreshDiary: () => void this.runDreamingTask(loadDreamDiary),
         onRefreshImports: () => void this.refreshWikiData(loadWikiImportInsights),
         onRefreshWikiOverview: () => void this.refreshWikiData(loadWikiOverview),

--- a/ui/src/pages/agents/memory/view.test.ts
+++ b/ui/src/pages/agents/memory/view.test.ts
@@ -106,8 +106,6 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     active: true,
     selectedAgentId: "main",
     shortTermCount: 47,
-    groundedSignalCount: 9,
-    totalSignalCount: 182,
     promotedCount: 12,
     phases: {
       light: { enabled: true, cron: "0 * * * *", nextRunAtMs: Date.parse("2026-04-05T11:30:00Z") },
@@ -150,7 +148,6 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     dreamingOf: null,
     nextCycle: "4:00 AM",
     timezone: "America/Los_Angeles",
-    statusLoading: false,
     statusError: null,
     modeSaving: false,
     dreamDiaryLoading: false,
@@ -158,7 +155,6 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     dreamDiaryActionMessage: null,
     dreamDiaryActionArchivePath: null,
     dreamDiaryError: null,
-    dreamDiaryPath: "DREAMS.md",
     dreamDiaryContent:
       "# Dream Diary\n\n<!-- openclaw:dreaming:diary:start -->\n\n---\n\n*April 5, 2026, 3:00 AM*\n\nThe repository whispered of forgotten endpoints tonight.\n\n<!-- openclaw:dreaming:diary:end -->",
     memoryWikiEnabled: true,
@@ -275,7 +271,6 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
         },
       ],
     },
-    onRefresh: () => {},
     onRefreshDiary: () => {},
     onRefreshImports: () => {},
     onRefreshWikiOverview: () => {},

--- a/ui/src/pages/agents/memory/view.ts
+++ b/ui/src/pages/agents/memory/view.ts
@@ -103,8 +103,6 @@ type DreamingProps = {
   active: boolean;
   selectedAgentId: string;
   shortTermCount: number;
-  groundedSignalCount: number;
-  totalSignalCount: number;
   promotedCount: number;
   phases?: {
     light: DreamingPhaseInfo;
@@ -116,7 +114,6 @@ type DreamingProps = {
   dreamingOf: string | null;
   nextCycle: string | null;
   timezone: string | null;
-  statusLoading: boolean;
   statusError: string | null;
   modeSaving: boolean;
   dreamDiaryLoading: boolean;
@@ -124,7 +121,6 @@ type DreamingProps = {
   dreamDiaryActionMessage: { kind: "success" | "error"; text: string } | null;
   dreamDiaryActionArchivePath: string | null;
   dreamDiaryError: string | null;
-  dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
   memoryWikiEnabled: boolean;
   wikiImportInsightsLoading: boolean;
@@ -133,7 +129,6 @@ type DreamingProps = {
   wikiOverviewLoading: boolean;
   wikiOverviewError: string | null;
   wikiOverview: WikiOverview | null;
-  onRefresh: () => void;
   onRefreshDiary: () => void;
   onRefreshImports: () => void;
   onRefreshWikiOverview: () => void;
@@ -465,19 +460,7 @@ function basename(value: string): string {
 }
 
 function formatKindLabel(kind: "entity" | "concept" | "source" | "synthesis" | "report"): string {
-  switch (kind) {
-    case "entity":
-      return t("dreaming.wiki.pageTypes.entity");
-    case "concept":
-      return t("dreaming.wiki.pageTypes.concept");
-    case "source":
-      return t("dreaming.wiki.pageTypes.source");
-    case "synthesis":
-      return t("dreaming.wiki.pageTypes.synthesis");
-    case "report":
-      return t("dreaming.wiki.pageTypes.report");
-  }
-  return kind;
+  return t(`dreaming.wiki.pageTypes.${kind}`);
 }
 
 function formatPageCount(count: number): string {
@@ -504,48 +487,20 @@ function formatContradictionCount(count: number): string {
     : t("dreaming.wiki.counts.contradictions", { count: String(count) });
 }
 
-function formatChatCount(count: number): string {
-  return t("dreaming.wiki.counts.chats", { count: String(count) });
-}
-
-function formatSignalCount(count: number): string {
-  return t("dreaming.wiki.counts.signals", { count: String(count) });
-}
-
-function formatMessageCount(count: number): string {
-  return t("dreaming.wiki.counts.messages", { count: String(count) });
-}
-
-const WIKI_OVERVIEW_PAGE_COUNT_ORDER: Array<keyof WikiOverview["pageCounts"]> = [
-  "source",
-  "synthesis",
-  "report",
-  "entity",
-  "concept",
-];
-
-function formatWikiOverviewPageCountLabel(kind: keyof WikiOverview["pageCounts"]): string {
-  switch (kind) {
-    case "source":
-      return t("dreaming.wiki.pageGroups.sources");
-    case "synthesis":
-      return t("dreaming.wiki.pageGroups.syntheses");
-    case "report":
-      return t("dreaming.wiki.pageGroups.reports");
-    case "entity":
-      return t("dreaming.wiki.pageGroups.entities");
-    case "concept":
-      return t("dreaming.wiki.pageGroups.concepts");
-  }
-  return kind;
-}
+const WIKI_OVERVIEW_PAGE_GROUPS = [
+  ["source", "sources"],
+  ["synthesis", "syntheses"],
+  ["report", "reports"],
+  ["entity", "entities"],
+  ["concept", "concepts"],
+] as const;
 
 function formatWikiOverviewPageBreakdown(pageCounts: WikiOverview["pageCounts"]): string {
-  const parts = WIKI_OVERVIEW_PAGE_COUNT_ORDER.map((kind) => {
+  const parts = WIKI_OVERVIEW_PAGE_GROUPS.map(([kind, group]) => {
     const count = pageCounts[kind];
     return count > 0
       ? t("dreaming.wiki.pageGroupSummary", {
-          label: formatWikiOverviewPageCountLabel(kind),
+          label: t(`dreaming.wiki.pageGroups.${group}`),
           count: formatPageCount(count),
         })
       : null;
@@ -585,20 +540,11 @@ function formatImportBadge(item: {
   digestStatus: "available" | "withheld";
   riskLevel: "low" | "medium" | "high" | "unknown";
 }): string {
-  if (item.digestStatus === "withheld") {
-    return t("dreaming.wiki.risk.needsReview");
-  }
-  switch (item.riskLevel) {
-    case "low":
-      return t("dreaming.wiki.risk.low");
-    case "medium":
-      return t("dreaming.wiki.risk.medium");
-    case "high":
-      return t("dreaming.wiki.risk.high");
-    case "unknown":
-      return t("dreaming.wiki.risk.unknown");
-  }
-  return t("dreaming.wiki.risk.unknown");
+  return t(
+    item.digestStatus === "withheld"
+      ? "dreaming.wiki.risk.needsReview"
+      : `dreaming.wiki.risk.${item.riskLevel}`,
+  );
 }
 
 function toggleExpandedCard(bucket: Set<string>, key: string, onChange: () => void): void {
@@ -651,7 +597,7 @@ async function openWikiPreview(lookup: string, props: DreamingProps): Promise<vo
   }
 }
 
-function resetWikiPreview(state: DreamingViewState): void {
+export function resetWikiPreview(state: DreamingViewState): void {
   state.wikiPreviewRequestId += 1;
   state.wikiPreviewOpen = false;
   state.wikiPreviewLoading = false;
@@ -865,43 +811,30 @@ function renderAdvancedSection(props: DreamingProps) {
           <div class="dreams-advanced__summary">${summary}</div>
         </div>
         <div class="dreams-advanced__actions">
-          <button
-            class="btn btn--subtle btn--sm"
-            ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
-            @click=${() => props.onDedupeDreamDiary()}
-          >
-            ${t("dreaming.scene.dedupeDiary")}
-          </button>
-          <button
-            class="btn btn--subtle btn--sm"
-            ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
-            @click=${() => props.onRepairDreamingArtifacts()}
-          >
-            ${t("dreaming.scene.repairCache")}
-          </button>
-          <button
-            class="btn btn--subtle btn--sm"
-            ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
-            @click=${() => props.onBackfillDiary()}
-          >
-            ${props.dreamDiaryActionLoading
-              ? t("dreaming.scene.working")
-              : t("dreaming.scene.backfill")}
-          </button>
-          <button
-            class="btn btn--subtle btn--sm"
-            ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
-            @click=${() => props.onResetDiary()}
-          >
-            ${t("dreaming.scene.reset")}
-          </button>
-          <button
-            class="btn btn--subtle btn--sm"
-            ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
-            @click=${() => props.onResetGroundedShortTerm()}
-          >
-            ${t("dreaming.scene.clearGrounded")}
-          </button>
+          ${[
+            { label: t("dreaming.scene.dedupeDiary"), onClick: props.onDedupeDreamDiary },
+            { label: t("dreaming.scene.repairCache"), onClick: props.onRepairDreamingArtifacts },
+            {
+              label: t(
+                props.dreamDiaryActionLoading
+                  ? "dreaming.scene.working"
+                  : "dreaming.scene.backfill",
+              ),
+              onClick: props.onBackfillDiary,
+            },
+            { label: t("dreaming.scene.reset"), onClick: props.onResetDiary },
+            { label: t("dreaming.scene.clearGrounded"), onClick: props.onResetGroundedShortTerm },
+          ].map(
+            ({ label, onClick }) => html`
+              <button
+                class="btn btn--subtle btn--sm"
+                ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
+                @click=${() => onClick()}
+              >
+                ${label}
+              </button>
+            `,
+          )}
         </div>
       </div>
       ${props.dreamDiaryActionMessage
@@ -1023,264 +956,200 @@ function renderAdvancedSection(props: DreamingProps) {
   `;
 }
 
-function renderDiaryImportsSection(props: DreamingProps) {
+type ImportedInsightItem = WikiImportInsights["clusters"][number]["items"][number];
+type WikiPageItem = WikiOverview["clusters"][number]["items"][number];
+type WikiInsightCard =
+  | { kind: "import"; item: ImportedInsightItem }
+  | { kind: "wiki"; item: WikiPageItem };
+
+function renderInsightList(labelKey: string, entries: string[]) {
+  return entries.length > 0
+    ? html`
+        <div class="dreams-diary__insight-list">
+          <strong>${t(labelKey)}</strong>
+          ${entries.map((entry) => html`<p class="dreams-diary__insight-line">• ${entry}</p>`)}
+        </div>
+      `
+    : nothing;
+}
+
+function renderInsightDetail(labelKey: string, value: string | undefined) {
+  return value
+    ? html`
+        <p class="dreams-diary__insight-line">
+          <strong>${t(labelKey)}</strong>
+          ${value}
+        </p>
+      `
+    : nothing;
+}
+
+function renderWikiInsightBody(card: WikiInsightCard, expanded: boolean) {
+  if (card.kind === "import") {
+    const item = card.item;
+    return html`
+      <p class="dreams-diary__insight-line">${item.summary}</p>
+      ${renderInsightList("dreaming.wiki.candidateSignals", item.candidateSignals)}
+      ${renderInsightList("dreaming.wiki.corrections", item.correctionSignals)}
+      ${expanded
+        ? html`
+            <div class="dreams-diary__insight-list">
+              <strong>${t("dreaming.wiki.importDetails")}</strong>
+              ${renderInsightDetail("dreaming.wiki.startedWith", item.firstUserLine)}
+              ${renderInsightDetail(
+                "dreaming.wiki.endedOn",
+                item.lastUserLine !== item.firstUserLine ? item.lastUserLine : undefined,
+              )}
+              ${renderInsightDetail(
+                "dreaming.wiki.messages",
+                `${t("dreaming.wiki.counts.userMessages", {
+                  count: String(item.userMessageCount),
+                })} · ${t("dreaming.wiki.counts.assistantMessages", {
+                  count: String(item.assistantMessageCount),
+                })}`,
+              )}
+              ${renderInsightDetail("dreaming.wiki.riskReasons", item.riskReasons.join(", "))}
+              ${renderInsightDetail("dreaming.wiki.labels", item.labels.join(", "))}
+            </div>
+          `
+        : nothing}
+      ${item.preferenceSignals.length > 0
+        ? html`
+            <div class="dreams-diary__insight-signals">
+              ${item.preferenceSignals.map(
+                (signal) => html`<span class="dreams-diary__insight-signal">${signal}</span>`,
+              )}
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  const item = card.item;
+  return html`
+    ${item.snippet ? html`<p class="dreams-diary__insight-line">${item.snippet}</p>` : nothing}
+    ${renderInsightList("dreaming.wiki.claims", item.claims)}
+    ${renderInsightList("dreaming.wiki.openQuestions", item.questions)}
+    ${renderInsightList("dreaming.wiki.contradictions", item.contradictions)}
+    ${expanded
+      ? html`
+          <div class="dreams-diary__insight-list">
+            <strong>${t("dreaming.wiki.pageDetails")}</strong>
+            ${renderInsightDetail("dreaming.wiki.wikiPage", item.pagePath)}
+            ${renderInsightDetail("dreaming.wiki.id", item.id)}
+          </div>
+        `
+      : nothing}
+  `;
+}
+
+function renderWikiInsightCard(props: DreamingProps, card: WikiInsightCard) {
   const state = props.viewState;
-  const importInsights = props.wikiImportInsights;
-  const clusters = importInsights?.clusters ?? [];
-
-  if (props.wikiImportInsightsLoading && clusters.length === 0) {
-    return html`
-      <div class="dreams-diary__empty">
-        <div class="dreams-diary__empty-text">${t("dreaming.wiki.loadingInsights")}</div>
-      </div>
-    `;
-  }
-
-  if (clusters.length === 0) {
-    return html`
-      <div class="dreams-diary__empty">
-        <div class="dreams-diary__empty-text">${t("dreaming.wiki.noInsights")}</div>
-        <div class="dreams-diary__empty-hint">${t("dreaming.wiki.noInsightsHint")}</div>
-      </div>
-    `;
-  }
-
-  const clusterIndex = Math.max(0, Math.min(state.diaryPage, clusters.length - 1));
-  const cluster = expectDefined(clusters[clusterIndex], "selected imported insight cluster");
-  const clusterMeta = [
-    formatChatCount(cluster.itemCount),
-    ...(cluster.highRiskCount > 0
-      ? [
-          t("dreaming.wiki.counts.sensitive", {
-            count: String(cluster.highRiskCount),
-          }),
-        ]
-      : []),
-    ...(cluster.preferenceSignalCount > 0
-      ? [formatSignalCount(cluster.preferenceSignalCount)]
-      : []),
-  ];
-  const importSummary = [
-    t("dreaming.wiki.importedClusterSummary", {
-      label: cluster.label.toLowerCase(),
-    }),
-    ...(cluster.withheldCount > 0
-      ? [
-          cluster.withheldCount === 1
-            ? t("dreaming.wiki.withheldDigestOne", {
-                count: String(cluster.withheldCount),
-              })
-            : t("dreaming.wiki.withheldDigests", {
-                count: String(cluster.withheldCount),
-              }),
-        ]
-      : []),
-  ];
+  const item = card.item;
+  const expandedCards =
+    card.kind === "import" ? state.expandedInsightCards : state.expandedWikiCards;
+  const expanded = expandedCards.has(item.pagePath);
+  const badgeClass = card.kind === "import" ? card.item.riskLevel : "wiki";
+  const badgeLabel =
+    card.kind === "import" ? formatImportBadge(card.item) : formatKindLabel(card.item.kind);
+  const metadata =
+    card.kind === "import"
+      ? card.item.activeBranchMessages > 0
+        ? ` · ${t("dreaming.wiki.counts.messages", {
+            count: String(card.item.activeBranchMessages),
+          })}`
+        : ""
+      : ` · ${item.pagePath}`;
 
   return html`
-    <div class="dreams-diary__daychips">
-      ${clusters.map(
-        (entry, index) => html`
-          <button
-            class="dreams-diary__day-chip ${index === clusterIndex
-              ? "dreams-diary__day-chip--active"
-              : ""}"
-            @click=${() => {
-              setDiaryPage(state, index, clusters.length);
-              props.onViewStateChange();
-            }}
-          >
-            ${entry.label}
-          </button>
-        `,
-      )}
-    </div>
-
-    <article class="dreams-diary__entry" key="imports-${cluster.key}">
-      <div class="dreams-diary__accent"></div>
-      <div class="dreams-diary__date">${cluster.label} · ${clusterMeta.join(" · ")}</div>
-      <div class="dreams-diary__prose">
-        <p class="dreams-diary__para">${importSummary.join(" ")}</p>
+    <article
+      class="dreams-diary__insight-card dreams-diary__insight-card--clickable"
+      data-import-page=${card.kind === "import" ? item.pagePath : nothing}
+      data-wiki-page=${card.kind === "wiki" ? item.pagePath : nothing}
+      @click=${() => {
+        if (card.kind === "wiki" && card.item.kind === "report") {
+          void openWikiPreview(item.pagePath, props);
+          return;
+        }
+        toggleExpandedCard(expandedCards, item.pagePath, props.onViewStateChange);
+      }}
+    >
+      <div class="dreams-diary__insight-topline">
+        <div class="dreams-diary__insight-title">${item.title}</div>
+        <span class="dreams-diary__insight-badge dreams-diary__insight-badge--${badgeClass}">
+          ${badgeLabel}
+        </span>
       </div>
-      <div class="dreams-diary__insights">
-        ${cluster.items.map((item) => {
-          const expanded = state.expandedInsightCards.has(item.pagePath);
-          return html`
-            <article
-              class="dreams-diary__insight-card dreams-diary__insight-card--clickable"
-              data-import-page=${item.pagePath}
-              @click=${() =>
-                toggleExpandedCard(
-                  state.expandedInsightCards,
-                  item.pagePath,
-                  props.onViewStateChange,
-                )}
-            >
-              <div class="dreams-diary__insight-topline">
-                <div class="dreams-diary__insight-title">${item.title}</div>
-                <span
-                  class="dreams-diary__insight-badge dreams-diary__insight-badge--${item.riskLevel}"
-                >
-                  ${formatImportBadge(item)}
-                </span>
-              </div>
-              <div class="dreams-diary__insight-meta">
-                ${item.updatedAt ? formatCompactDateTime(item.updatedAt) : basename(item.pagePath)}
-                ${item.activeBranchMessages > 0
-                  ? ` · ${formatMessageCount(item.activeBranchMessages)}`
-                  : ""}
-              </div>
-              <p class="dreams-diary__insight-line">${item.summary}</p>
-              ${item.candidateSignals.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.candidateSignals")}</strong>
-                      ${item.candidateSignals.map(
-                        (signal) => html`<p class="dreams-diary__insight-line">• ${signal}</p>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              ${item.correctionSignals.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.corrections")}</strong>
-                      ${item.correctionSignals.map(
-                        (signal) => html`<p class="dreams-diary__insight-line">• ${signal}</p>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              ${expanded
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.importDetails")}</strong>
-                      ${item.firstUserLine
-                        ? html`
-                            <p class="dreams-diary__insight-line">
-                              <strong>${t("dreaming.wiki.startedWith")}</strong>
-                              ${item.firstUserLine}
-                            </p>
-                          `
-                        : nothing}
-                      ${item.lastUserLine && item.lastUserLine !== item.firstUserLine
-                        ? html`
-                            <p class="dreams-diary__insight-line">
-                              <strong>${t("dreaming.wiki.endedOn")}</strong>
-                              ${item.lastUserLine}
-                            </p>
-                          `
-                        : nothing}
-                      <p class="dreams-diary__insight-line">
-                        <strong>${t("dreaming.wiki.messages")}</strong>
-                        ${t("dreaming.wiki.counts.userMessages", {
-                          count: String(item.userMessageCount),
-                        })}
-                        ·
-                        ${t("dreaming.wiki.counts.assistantMessages", {
-                          count: String(item.assistantMessageCount),
-                        })}
-                      </p>
-                      ${item.riskReasons.length > 0
-                        ? html`
-                            <p class="dreams-diary__insight-line">
-                              <strong>${t("dreaming.wiki.riskReasons")}</strong>
-                              ${item.riskReasons.join(", ")}
-                            </p>
-                          `
-                        : nothing}
-                      ${item.labels.length > 0
-                        ? html`
-                            <p class="dreams-diary__insight-line">
-                              <strong>${t("dreaming.wiki.labels")}</strong>
-                              ${item.labels.join(", ")}
-                            </p>
-                          `
-                        : nothing}
-                    </div>
-                  `
-                : nothing}
-              ${item.preferenceSignals.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-signals">
-                      ${item.preferenceSignals.map(
-                        (signal) =>
-                          html`<span class="dreams-diary__insight-signal">${signal}</span>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              <div class="dreams-diary__insight-actions">
-                <button
-                  class="btn btn--subtle btn--sm"
-                  @click=${(event: Event) => {
-                    event.stopPropagation();
-                    toggleExpandedCard(
-                      state.expandedInsightCards,
-                      item.pagePath,
-                      props.onViewStateChange,
-                    );
-                  }}
-                >
-                  ${expanded ? t("dreaming.wiki.hideDetails") : t("dreaming.wiki.details")}
-                </button>
-                <button
-                  class="btn btn--subtle btn--sm"
-                  @click=${(event: Event) => {
-                    event.stopPropagation();
-                    void openWikiPreview(item.pagePath, props);
-                  }}
-                >
-                  ${t("dreaming.wiki.openSourcePage")}
-                </button>
-              </div>
-            </article>
-          `;
-        })}
+      <div class="dreams-diary__insight-meta">
+        ${item.updatedAt
+          ? formatCompactDateTime(item.updatedAt)
+          : basename(item.pagePath)}${metadata}
+      </div>
+      ${renderWikiInsightBody(card, expanded)}
+      <div class="dreams-diary__insight-actions">
+        <button
+          class="btn btn--subtle btn--sm"
+          @click=${(event: Event) => {
+            event.stopPropagation();
+            toggleExpandedCard(expandedCards, item.pagePath, props.onViewStateChange);
+          }}
+        >
+          ${expanded ? t("dreaming.wiki.hideDetails") : t("dreaming.wiki.details")}
+        </button>
+        <button
+          class="btn btn--subtle btn--sm"
+          @click=${(event: Event) => {
+            event.stopPropagation();
+            void openWikiPreview(item.pagePath, props);
+          }}
+        >
+          ${t(
+            card.kind === "import" ? "dreaming.wiki.openSourcePage" : "dreaming.wiki.openWikiPage",
+          )}
+        </button>
       </div>
     </article>
   `;
 }
 
-function renderWikiOverviewSection(props: DreamingProps) {
-  const state = props.viewState;
-  const overview = props.wikiOverview;
-  const clusters = overview?.clusters ?? [];
-
-  if (props.wikiOverviewLoading && clusters.length === 0) {
-    return html`
-      <div class="dreams-diary__empty">
-        <div class="dreams-diary__empty-text">${t("dreaming.wiki.loadingWiki")}</div>
-      </div>
-    `;
-  }
-
+function renderWikiClusterSection<
+  Cluster extends { key: string; label: string; items: { pagePath: string }[] },
+>(
+  props: DreamingProps,
+  params: {
+    kind: "imports" | "wiki";
+    clusters: Cluster[];
+    loading: boolean;
+    loadingKey: string;
+    emptyKey: string;
+    emptyHintKey: string;
+    date: (cluster: Cluster) => string;
+    prose: (cluster: Cluster) => ReturnType<typeof html>;
+    renderItem: (item: Cluster["items"][number]) => ReturnType<typeof html>;
+  },
+) {
+  const { clusters } = params;
   if (clusters.length === 0) {
     return html`
       <div class="dreams-diary__empty">
-        <div class="dreams-diary__empty-text">${t("dreaming.wiki.emptyWiki")}</div>
-        <div class="dreams-diary__empty-hint">${t("dreaming.wiki.emptyWikiHint")}</div>
+        <div class="dreams-diary__empty-text">
+          ${t(params.loading ? params.loadingKey : params.emptyKey)}
+        </div>
+        ${params.loading
+          ? nothing
+          : html`<div class="dreams-diary__empty-hint">${t(params.emptyHintKey)}</div>`}
       </div>
     `;
   }
 
+  const state = props.viewState;
   const clusterIndex = Math.max(0, Math.min(state.diaryPage, clusters.length - 1));
-  const cluster = expectDefined(clusters[clusterIndex], "selected memory overview cluster");
-  const totalPages = overview?.totalPages ?? overview?.totalItems ?? 0;
-  const totalClaims = overview?.totalClaims ?? 0;
-  const totalQuestions = overview?.totalQuestions ?? 0;
-  const totalContradictions = overview?.totalContradictions ?? 0;
-  const pageBreakdown = overview
-    ? formatWikiOverviewPageBreakdown(overview.pageCounts)
-    : t("dreaming.wiki.noPagesYet");
-  const clusterSummary = formatWikiOverviewClusterSummary(cluster);
-  const vaultMeta = [
-    formatPageCount(totalPages),
-    ...(totalClaims > 0 ? [formatClaimRowCount(totalClaims)] : []),
-    ...(totalQuestions > 0 ? [formatOpenQuestionCount(totalQuestions)] : []),
-    ...(totalContradictions > 0 ? [formatContradictionCount(totalContradictions)] : []),
-  ];
-
+  const cluster = expectDefined(
+    clusters[clusterIndex],
+    params.kind === "imports"
+      ? "selected imported insight cluster"
+      : "selected memory overview cluster",
+  );
   return html`
     <div class="dreams-diary__daychips">
       ${clusters.map(
@@ -1299,130 +1168,98 @@ function renderWikiOverviewSection(props: DreamingProps) {
         `,
       )}
     </div>
-
-    <article class="dreams-diary__entry" key="wiki-${cluster.key}">
+    <article class="dreams-diary__entry" key="${params.kind}-${cluster.key}">
       <div class="dreams-diary__accent"></div>
-      <div class="dreams-diary__date">${t("dreaming.wiki.vault")} · ${vaultMeta.join(" · ")}</div>
-      <div class="dreams-diary__prose">
-        <p class="dreams-diary__para">
-          ${t("dreaming.wiki.fullVaultBreakdown", { breakdown: pageBreakdown })}
-        </p>
-        <p class="dreams-diary__para">
-          ${t("dreaming.wiki.selectedSection", { summary: clusterSummary })}
-          ${cluster.updatedAt
-            ? ` ${t("dreaming.wiki.latestUpdate", {
-                date: formatCompactDateTime(cluster.updatedAt),
-              })}`
-            : ""}
-        </p>
-      </div>
-      <div class="dreams-diary__insights">
-        ${cluster.items.map((item) => {
-          const expanded = state.expandedWikiCards.has(item.pagePath);
-          return html`
-            <article
-              class="dreams-diary__insight-card dreams-diary__insight-card--clickable"
-              data-wiki-page=${item.pagePath}
-              @click=${() => {
-                if (item.kind === "report") {
-                  void openWikiPreview(item.pagePath, props);
-                  return;
-                }
-                toggleExpandedCard(state.expandedWikiCards, item.pagePath, props.onViewStateChange);
-              }}
-            >
-              <div class="dreams-diary__insight-topline">
-                <div class="dreams-diary__insight-title">${item.title}</div>
-                <span class="dreams-diary__insight-badge dreams-diary__insight-badge--wiki">
-                  ${formatKindLabel(item.kind)}
-                </span>
-              </div>
-              <div class="dreams-diary__insight-meta">
-                ${item.updatedAt ? formatCompactDateTime(item.updatedAt) : basename(item.pagePath)}
-                · ${item.pagePath}
-              </div>
-              ${item.snippet
-                ? html`<p class="dreams-diary__insight-line">${item.snippet}</p>`
-                : nothing}
-              ${item.claims.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.claims")}</strong>
-                      ${item.claims.map(
-                        (claim) => html`<p class="dreams-diary__insight-line">• ${claim}</p>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              ${item.questions.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.openQuestions")}</strong>
-                      ${item.questions.map(
-                        (question) => html`<p class="dreams-diary__insight-line">• ${question}</p>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              ${item.contradictions.length > 0
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.contradictions")}</strong>
-                      ${item.contradictions.map(
-                        (entry) => html`<p class="dreams-diary__insight-line">• ${entry}</p>`,
-                      )}
-                    </div>
-                  `
-                : nothing}
-              ${expanded
-                ? html`
-                    <div class="dreams-diary__insight-list">
-                      <strong>${t("dreaming.wiki.pageDetails")}</strong>
-                      <p class="dreams-diary__insight-line">
-                        <strong>${t("dreaming.wiki.wikiPage")}</strong>
-                        ${item.pagePath}
-                      </p>
-                      ${item.id
-                        ? html`
-                            <p class="dreams-diary__insight-line">
-                              <strong>${t("dreaming.wiki.id")}</strong>
-                              ${item.id}
-                            </p>
-                          `
-                        : nothing}
-                    </div>
-                  `
-                : nothing}
-              <div class="dreams-diary__insight-actions">
-                <button
-                  class="btn btn--subtle btn--sm"
-                  @click=${(event: Event) => {
-                    event.stopPropagation();
-                    toggleExpandedCard(
-                      state.expandedWikiCards,
-                      item.pagePath,
-                      props.onViewStateChange,
-                    );
-                  }}
-                >
-                  ${expanded ? t("dreaming.wiki.hideDetails") : t("dreaming.wiki.details")}
-                </button>
-                <button
-                  class="btn btn--subtle btn--sm"
-                  @click=${(event: Event) => {
-                    event.stopPropagation();
-                    void openWikiPreview(item.pagePath, props);
-                  }}
-                >
-                  ${t("dreaming.wiki.openWikiPage")}
-                </button>
-              </div>
-            </article>
-          `;
-        })}
-      </div>
+      <div class="dreams-diary__date">${params.date(cluster)}</div>
+      <div class="dreams-diary__prose">${params.prose(cluster)}</div>
+      <div class="dreams-diary__insights">${cluster.items.map(params.renderItem)}</div>
     </article>
   `;
+}
+
+function renderDiaryImportsSection(props: DreamingProps) {
+  return renderWikiClusterSection(props, {
+    kind: "imports",
+    clusters: props.wikiImportInsights?.clusters ?? [],
+    loading: props.wikiImportInsightsLoading,
+    loadingKey: "dreaming.wiki.loadingInsights",
+    emptyKey: "dreaming.wiki.noInsights",
+    emptyHintKey: "dreaming.wiki.noInsightsHint",
+    date: (cluster) => {
+      const metadata = [
+        t("dreaming.wiki.counts.chats", { count: String(cluster.itemCount) }),
+        ...(cluster.highRiskCount > 0
+          ? [t("dreaming.wiki.counts.sensitive", { count: String(cluster.highRiskCount) })]
+          : []),
+        ...(cluster.preferenceSignalCount > 0
+          ? [t("dreaming.wiki.counts.signals", { count: String(cluster.preferenceSignalCount) })]
+          : []),
+      ];
+      return `${cluster.label} · ${metadata.join(" · ")}`;
+    },
+    prose: (cluster) => {
+      const summary = [
+        t("dreaming.wiki.importedClusterSummary", { label: cluster.label.toLowerCase() }),
+        ...(cluster.withheldCount > 0
+          ? [
+              t(
+                cluster.withheldCount === 1
+                  ? "dreaming.wiki.withheldDigestOne"
+                  : "dreaming.wiki.withheldDigests",
+                { count: String(cluster.withheldCount) },
+              ),
+            ]
+          : []),
+      ];
+      return html`<p class="dreams-diary__para">${summary.join(" ")}</p>`;
+    },
+    renderItem: (item) => renderWikiInsightCard(props, { kind: "import", item }),
+  });
+}
+
+function renderWikiOverviewSection(props: DreamingProps) {
+  const overview = props.wikiOverview;
+  return renderWikiClusterSection(props, {
+    kind: "wiki",
+    clusters: overview?.clusters ?? [],
+    loading: props.wikiOverviewLoading,
+    loadingKey: "dreaming.wiki.loadingWiki",
+    emptyKey: "dreaming.wiki.emptyWiki",
+    emptyHintKey: "dreaming.wiki.emptyWikiHint",
+    date: () => {
+      const metadata = [
+        formatPageCount(overview?.totalPages ?? 0),
+        ...((overview?.totalClaims ?? 0) > 0 ? [formatClaimRowCount(overview!.totalClaims)] : []),
+        ...((overview?.totalQuestions ?? 0) > 0
+          ? [formatOpenQuestionCount(overview!.totalQuestions)]
+          : []),
+        ...((overview?.totalContradictions ?? 0) > 0
+          ? [formatContradictionCount(overview!.totalContradictions)]
+          : []),
+      ];
+      return `${t("dreaming.wiki.vault")} · ${metadata.join(" · ")}`;
+    },
+    prose: (cluster) => html`
+      <p class="dreams-diary__para">
+        ${t("dreaming.wiki.fullVaultBreakdown", {
+          breakdown: overview
+            ? formatWikiOverviewPageBreakdown(overview.pageCounts)
+            : t("dreaming.wiki.noPagesYet"),
+        })}
+      </p>
+      <p class="dreams-diary__para">
+        ${t("dreaming.wiki.selectedSection", {
+          summary: formatWikiOverviewClusterSummary(cluster),
+        })}
+        ${cluster.updatedAt
+          ? ` ${t("dreaming.wiki.latestUpdate", {
+              date: formatCompactDateTime(cluster.updatedAt),
+            })}`
+          : ""}
+      </p>
+    `,
+    renderItem: (item) => renderWikiInsightCard(props, { kind: "wiki", item }),
+  });
 }
 
 function renderDreamDiaryEntries(props: DreamingProps) {


### PR DESCRIPTION
## What Problem This Solves

Dreams in both Settings entry points maintained four independent request lifecycles, rebuilt doctor and wiki payloads that their owners already guarantee, and rendered imported insights and wiki pages through duplicated presenters. This made selected-agent transitions, gateway reconnects, capability changes, and report previews harder to keep consistent.

## Why This Change Was Made

Use the authoritative typed doctor payloads and one identity-token request owner for dreaming status, dream diary, imported insights, and wiki overview. Share the existing card/cluster presentation and wiki-preview reset across both Settings routes while preserving producer-owned privacy redaction, report primary-click previews, config gating, and engine-off behavior.

The change removes **804 handwritten production lines**. The dreaming controller now fits the repository size limit, so its existing suppression and exactly one matching shrink-only baseline entry are removed together.

## User Impact

Operators retain the same Dreams UI, actions, labels, imported-chat privacy, wiki/report previews, and explicit memory-engine-off behavior. Switching A → B → A or reconnecting cannot replace the current agent with an older response, and unavailable wiki methods stay uncalled.

## Evidence

- Blacksmith Testbox `tbx_01kyz348jrm2fjgst6jy2savqf`: **77/77 focused tests passed**, including real Playwright Chromium against both `/settings/agents/main/memory` and `/settings/memory/dreams`.
- Real-browser proof covers A → B → A stale responses, agent picker ownership, unavailable wiki methods, and a same-session gateway reconnect.
- Both wiki resources additionally have table-driven stale-response and in-flight capability-withdrawal regressions; existing coverage proves imported sensitive-content redaction, report primary-click previews, markdown sanitization, and engine-off defaults.
- Supported path-scoped full UI changed gate passed: UI/core-test typechecking, all six changed UI files linted, Control UI localization, dead exports, formatting, and the full-tree max-lines ratchet.
- Independent `node scripts/check-max-lines-ratchet.mjs --base origin/main` passed; the baseline diff deletes exactly one entry.
- Production `pnpm ui:build` passed, including **688 finalized precompressed assets** and Control UI performance budgets.
- Fresh `gpt-5.6-sol` xhigh autoreview: **no actionable findings; patch correct**.