### PR TITLE
fix(perf): fail connected health probes on transport errors

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -807,7 +807,7 @@ jobs:
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
             node --import tsx scripts/bench-cli-startup.ts \
-            --case gatewayHealthJson \
+            --case gatewayHealthJsonConnected \
             --case gatewayHealthJsonFirstDevice \
             --case configGetGatewayPort \
             --runs "$source_runs" \

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -447,12 +447,17 @@ const COMMAND_CASES: readonly CommandCase[] = [
     expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
   {
+    id: "gatewayHealthJsonConnected",
+    name: "gateway health --json (connected)",
+    args: ["gateway", "health", "--json"],
+    presets: [],
+    stateScope: "case",
+  },
+  {
     id: "gatewayHealthJsonFirstDevice",
     name: "gateway health --json (first device)",
     args: ["gateway", "health", "--json"],
     presets: [],
-    expectedExitCodes: [0, 1],
-    expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
   {
     id: "configGetGatewayPort",
@@ -659,6 +664,7 @@ function buildConfigFixture(commandCase: CommandCase): Record<string, unknown> |
   if (
     commandCase.id !== "configGetGatewayPort" &&
     commandCase.id !== "gatewayHealthJson" &&
+    commandCase.id !== "gatewayHealthJsonConnected" &&
     commandCase.id !== "gatewayHealthJsonFirstDevice" &&
     commandCase.id !== "health" &&
     commandCase.id !== "healthJson"

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -463,6 +463,12 @@ describe("bench-cli-startup", () => {
         presets: ["real"],
       },
       {
+        id: "gatewayHealthJsonConnected",
+        name: "gateway health --json (connected)",
+        args: ["gateway", "health", "--json"],
+        presets: [],
+      },
+      {
         id: "gatewayHealthJsonFirstDevice",
         name: "gateway health --json (first device)",
         args: ["gateway", "health", "--json"],
@@ -491,7 +497,11 @@ describe("bench-cli-startup", () => {
     expect(testing.parseGatewayPortEnv("::1")).toBe(32123);
     expect(testing.parseGatewayPortEnv("[::1]")).toBe(32123);
 
-    for (const id of ["gatewayHealthJson", "gatewayHealthJsonFirstDevice"]) {
+    for (const id of [
+      "gatewayHealthJson",
+      "gatewayHealthJsonConnected",
+      "gatewayHealthJsonFirstDevice",
+    ]) {
       expect(
         withEnv({ OPENCLAW_GATEWAY_PORT: "45678" }, () =>
           testing.buildConfigFixture({

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -78,7 +78,7 @@ describe("CLI startup benchmark script spawners", () => {
         return fs.readFileSync(homeLogPath, "utf8").trim().split("\n");
       };
 
-      const warmedHomes = runCase("gatewayHealthJson");
+      const warmedHomes = runCase("gatewayHealthJsonConnected");
       expect(warmedHomes).toHaveLength(3);
       expect(new Set(warmedHomes).size).toBe(1);
       expect(warmedHomes.every((home) => !fs.existsSync(home))).toBe(true);
@@ -87,6 +87,49 @@ describe("CLI startup benchmark script spawners", () => {
       expect(firstDeviceHomes).toHaveLength(3);
       expect(new Set(firstDeviceHomes).size).toBe(3);
       expect(firstDeviceHomes.every((home) => !fs.existsSync(home))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires connected gateway health probes to exit successfully", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-connected-test-"));
+    try {
+      const fixturePath = path.join(tmpDir, "transport-error.mjs");
+      fs.writeFileSync(
+        fixturePath,
+        [
+          'console.log(\'{"ok":false,"gateway_transport_error":"closed"}\');',
+          "process.exitCode = 1;",
+          "",
+        ].join("\n"),
+      );
+
+      const runCase = (caseId: string) =>
+        spawnSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-cli-startup.ts",
+            "--entry",
+            fixturePath,
+            "--case",
+            caseId,
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+          ],
+          { cwd: process.cwd(), encoding: "utf8" },
+        );
+
+      expect(runCase("gatewayHealthJson").status).toBe(0);
+      for (const caseId of ["gatewayHealthJsonConnected", "gatewayHealthJsonFirstDevice"]) {
+        const result = runCase(caseId);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(`${caseId} sample 1: exited with code 1`);
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -257,7 +257,7 @@ describe("OpenClaw performance workflow", () => {
   it("measures warmed and first-device gateway health separately", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
 
-    expect(run).toContain("--case gatewayHealthJson \\");
+    expect(run).toContain("--case gatewayHealthJsonConnected \\");
     expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
   });
 


### PR DESCRIPTION
Related: #117525

## What Problem This Solves

Fixes an issue where the source performance workflow could treat `gateway health --json` transport failures as valid samples even though that workflow had already booted and health-checked a local Gateway.

## Why This Change Was Made

The benchmark now has a source-only connected warmed-health case that requires exit code 0. The source-only first-device case also requires success. The generic `real` preset remains tolerant of clean offline transport errors, preserving its existing standalone contract.

## User Impact

Performance CI now fails visibly when either connected Gateway-health measurement cannot complete its WebSocket/RPC path, instead of publishing a timing for an expected transport error.

## Evidence

- Stacked on #117525 so it reuses the separate warmed and first-device state lifecycles.
- Exact #117525 source artifacts showed every connected health sample exiting code 0, proving the stricter contract matches the intended workflow.
- 60 focused tests passed across the CLI benchmark, spawner, and performance-workflow contract suites.
- Black-box coverage proves the generic health case still accepts the documented clean offline error while both connected cases reject exit code 1.
- Targeted `oxfmt`, direct `oxlint`, `actionlint`, `git diff --check`, and P1 autoreview passed.
- The repo oxlint wrapper could not complete in the sparse GWT because an unrelated `packages/terminal-core` declaration build failed; direct targeted oxlint passed.
