### PR TITLE
fix(doctor): preserve surviving checks in overlapping selectors

### DIFF
--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -85,6 +85,81 @@ describe("runDoctorLintChecks", () => {
     },
   );
 
+  it.each(["array", "set"] as const)(
+    "runs surviving selected checks when selectors only partially overlap (%s)",
+    async (selectorShape) => {
+      const skippedId = "plugin/example/skipped";
+      const selectedId = "plugin/example/selected";
+      const detections: string[] = [];
+      const ids = [skippedId, selectedId];
+      const result = await runDoctorLintChecks(ctx, {
+        checks: ids.map((id) =>
+          check(id, async () => {
+            detections.push(id);
+            return [];
+          }),
+        ),
+        onlyIds: selectorShape === "set" ? new Set(ids) : ids,
+        skipIds: selectorShape === "set" ? new Set([skippedId]) : [skippedId],
+      });
+
+      expect(result).toEqual({ findings: [], checksRun: 1, checksSkipped: 1 });
+      expect(detections).toEqual([selectedId]);
+      expect(exitCodeFromFindings(result.findings)).toBe(0);
+    },
+  );
+
+  it("retains every overlap diagnostic when exclusion removes all selected checks", async () => {
+    const ids = ["plugin/example/first", "plugin/example/second"];
+    const result = await runDoctorLintChecks(ctx, {
+      checks: ids.map((id) => check(id, async () => [])),
+      onlyIds: ids,
+      skipIds: ids,
+    });
+
+    expect(result.checksRun).toBe(0);
+    expect(result.checksSkipped).toBe(2);
+    expect(result.findings).toEqual(
+      ids.map((id) => ({
+        checkId: "core/doctor/lint-selection",
+        severity: "error",
+        message: `Health check ${id} cannot be selected by --only and excluded by --skip.`,
+        path: id,
+      })),
+    );
+    expect(exitCodeFromFindings(result.findings)).toBe(1);
+  });
+
+  it("keeps unknown-only diagnostics without treating partial overlap as an error", async () => {
+    const skippedId = "plugin/example/skipped";
+    const selectedId = "plugin/example/selected";
+    const unknownId = "plugin/future/not-loaded";
+    const detections: string[] = [];
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [skippedId, selectedId].map((id) =>
+        check(id, async () => {
+          detections.push(id);
+          return [];
+        }),
+      ),
+      onlyIds: [skippedId, unknownId, selectedId],
+      skipIds: [skippedId, "plugin/future/ignored"],
+    });
+
+    expect(result.checksRun).toBe(1);
+    expect(result.checksSkipped).toBe(1);
+    expect(detections).toEqual([selectedId]);
+    expect(result.findings).toEqual([
+      {
+        checkId: "core/doctor/lint-selection",
+        severity: "error",
+        message: `Unknown health check id selected by --only: ${unknownId}.`,
+        path: unknownId,
+      },
+    ]);
+    expect(exitCodeFromFindings(result.findings)).toBe(1);
+  });
+
   it("keeps non-conflicting selection and exclusion filters independent", async () => {
     let selectedDetections = 0;
     let skippedDetections = 0;

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -53,7 +53,7 @@ export async function runDoctorLintChecks(
     let message: string;
     if (!allIds.has(id)) {
       message = `Unknown health check id selected by --only: ${id}.`;
-    } else if (skip.has(id)) {
+    } else if (selected.length === 0 && skip.has(id)) {
       message = `Health check ${id} cannot be selected by --only and excluded by --skip.`;
     } else {
       continue;


### PR DESCRIPTION
## What Problem This Solves

The freshly landed doctor-lint selector validation rejected a valid repeated selector combination: `--only A --only B --skip A` still runs `B` but incorrectly emitted an overlap error and exited `1`. This broke normal CI/operator workflows that combine allowlists and exclusions.

## Why This Change Was Made

Keep selection ownership in the existing doctor lint runner: report a contradictory known `--only`/`--skip` overlap only when exclusions leave **no effective selected checks**. Preserve independent unknown-check diagnostics, existing full-overlap errors, registry order, arrays/Sets, disabled defaults, and forward-compatible skips.

## User Impact

Valid partial overlaps now execute surviving selected checks and exit cleanly. Fully overlapped selections still fail visibly, including one diagnostic per excluded known check; unknown `--only` IDs still fail; unknown `--skip` IDs remain harmless; output, flags, configuration, storage, and permissions remain unchanged. Production code changes by one net-zero line.

## Evidence

- Exact frozen commit `6522b5c66054ae5d26586b4146e3b7538a25aa3a`, tree `f4fadc8d8f051435a8ac2a6bbca1fb2bfb7e4578`, parent `a14ada134f91c92f76d2bc886ae75b7c7dc0cc0d`; only `src/flows/doctor-lint-flow.ts` and its existing direct test.
- Tests-first owner baseline: three genuine partial-overlap failures (Array, Set, and unknown-plus-survivor). Candidate passes all `61/61` tests across owner (`16`), production registered Commander (`32`), and downstream doctor CLI (`13`).
- **Actual production registered Commander, actual doctor lint execution, synthetic registered plugin checks, real isolated config/state, true process exits:**

```text
[landed-main-before-hotfix; partial overlap]
$ openclaw doctor --lint --only plugin/qa/selector-a --only plugin/qa/selector-b --skip plugin/qa/selector-a --json
stdout: {"ok":false,"checksRun":1,"checksSkipped":57,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Health check plugin/qa/selector-a cannot be selected by --only and excluded by --skip.","path":"plugin/qa/selector-a"}]}
stderr: <empty>
exit: 1

[hotfix-candidate; partial overlap]
$ openclaw doctor --lint --only plugin/qa/selector-a --only plugin/qa/selector-b --skip plugin/qa/selector-a --json
stdout: {"ok":true,"checksRun":1,"checksSkipped":57,"findings":[]}
stderr: <empty>
exit: 0

[hotfix-candidate; partial overlap with reversed only order]
$ openclaw doctor --lint --only plugin/qa/selector-b --only plugin/qa/selector-a --skip plugin/qa/selector-a --json
stdout: {"ok":true,"checksRun":1,"checksSkipped":57,"findings":[]}
stderr: <empty>
exit: 0

[hotfix-candidate; fully overlapped single selector]
$ openclaw doctor --lint --only plugin/qa/selector-a --skip plugin/qa/selector-a --json
stdout: {"ok":false,"checksRun":0,"checksSkipped":58,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Health check plugin/qa/selector-a cannot be selected by --only and excluded by --skip.","path":"plugin/qa/selector-a"}]}
stderr: <empty>
exit: 1

[hotfix-candidate; fully overlapped multiple selectors]
$ openclaw doctor --lint --only plugin/qa/selector-a --only plugin/qa/selector-b --skip plugin/qa/selector-a --skip plugin/qa/selector-b --json
stdout: {"ok":false,"checksRun":0,"checksSkipped":58,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Health check plugin/qa/selector-a cannot be selected by --only and excluded by --skip.","path":"plugin/qa/selector-a"},{"checkId":"core/doctor/lint-selection","severity":"error","message":"Health check plugin/qa/selector-b cannot be selected by --only and excluded by --skip.","path":"plugin/qa/selector-b"}]}
stderr: <empty>
exit: 1

[hotfix-candidate; unknown only remains an error]
$ openclaw doctor --lint --only plugin/qa/not-registered --json
stdout: {"ok":false,"checksRun":0,"checksSkipped":58,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Unknown health check id selected by --only: plugin/qa/not-registered.","path":"plugin/qa/not-registered"}]}
stderr: <empty>
exit: 1

[hotfix-candidate; unknown only plus partial overlap reports only the unknown]
$ openclaw doctor --lint --only plugin/qa/selector-a --only plugin/qa/not-registered --only plugin/qa/selector-b --skip plugin/qa/selector-a --json
stdout: {"ok":false,"checksRun":1,"checksSkipped":57,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Unknown health check id selected by --only: plugin/qa/not-registered.","path":"plugin/qa/not-registered"}]}
stderr: <empty>
exit: 1

[hotfix-candidate; disjoint only and skip]
$ openclaw doctor --lint --only plugin/qa/selector-b --skip plugin/qa/selector-a --json
stdout: {"ok":true,"checksRun":1,"checksSkipped":57,"findings":[]}
stderr: <empty>
exit: 0

[hotfix-candidate; forward-compatible unknown skip]
$ openclaw doctor --lint --only plugin/qa/selector-b --skip plugin/qa/not-registered --json
stdout: {"ok":true,"checksRun":1,"checksSkipped":57,"findings":[]}
stderr: <empty>
exit: 0

```

- Configured exact-two-file type-aware oxlint, formatting, and `git diff --check` pass. Six wholly fresh independent hostile source reviews, including the original regression finder, report zero P0/P1/P2/P3 findings. The single ROOT-authorized genuine `gpt-5.6-sol` HIGH max-P3 review returned CLEAN (`0.98` confidence, zero findings, one complete pass), and real TruffleHog `3.96` returned CLEAN.
