### PR TITLE
perf(gateway): mark recovery before model preparation

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1815,9 +1815,12 @@ describe("startGatewayPostAttachRuntime", () => {
     });
   });
 
-  it("marks startup main-session orphans before channel startup", async () => {
+  it("marks startup main-session orphans before model runtime and channel startup", async () => {
     const events: string[] = [];
     let releaseMarking: (() => void) | undefined;
+    const prewarmPrimaryModel = vi.fn(async () => {
+      events.push("model-runtime");
+    });
     const startChannels = vi.fn(async () => {
       events.push("channels");
     });
@@ -1838,6 +1841,7 @@ describe("startGatewayPostAttachRuntime", () => {
       defaultWorkspaceDir: "/tmp/openclaw-workspace",
       deps: {} as never,
       startChannels,
+      prewarmPrimaryModel,
       log: { warn: vi.fn() },
       logHooks: {
         info: vi.fn(),
@@ -1861,7 +1865,13 @@ describe("startGatewayPostAttachRuntime", () => {
     releaseMarking();
     await sidecars;
 
-    expect(events).toEqual(["main-session-mark:start", "main-session-mark:done", "channels"]);
+    expect(events).toEqual([
+      "main-session-mark:start",
+      "main-session-mark:done",
+      "model-runtime",
+      "channels",
+    ]);
+    expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
     expect(startChannels).toHaveBeenCalledTimes(1);
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -123,8 +123,11 @@ vi.mock("../agents/subagent-registry.js", () => ({
   scheduleSubagentOrphanRecovery: hoisted.scheduleSubagentOrphanRecovery,
 }));
 
-vi.mock("../agents/main-session-restart-recovery.js", () => ({
+vi.mock("../agents/main-session-restart-recovery-marking.js", () => ({
   markStartupOrphanedMainSessionsForRecovery: hoisted.markStartupOrphanedMainSessionsForRecovery,
+}));
+
+vi.mock("../agents/main-session-restart-recovery.js", () => ({
   scheduleRestartAbortedMainSessionRecovery: hoisted.scheduleRestartAbortedMainSessionRecovery,
 }));
 

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1876,6 +1876,43 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).not.toHaveBeenCalled();
   });
 
+  it("marks startup main-session orphans before propagating model runtime failure", async () => {
+    const modelRuntimeError = new Error("model runtime unavailable");
+    const startChannels = vi.fn(async () => {});
+    const prewarmPrimaryModel = vi.fn(async () => {
+      throw modelRuntimeError;
+    });
+    hoisted.markStartupOrphanedMainSessionsForRecovery.mockResolvedValueOnce({
+      marked: 1,
+      skipped: 0,
+    });
+
+    await expect(
+      startGatewaySidecars({
+        cfg: { hooks: { internal: { enabled: false } } } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels,
+        prewarmPrimaryModel,
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+      }),
+    ).rejects.toBe(modelRuntimeError);
+
+    expect(hoisted.markStartupOrphanedMainSessionsForRecovery).toHaveBeenCalledTimes(1);
+    expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
+    expect(startChannels).not.toHaveBeenCalled();
+  });
+
   it("logs startup main-session marker failures and still starts channels", async () => {
     const log = { warn: vi.fn() };
     const startChannels = vi.fn(async () => {});

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -662,6 +662,8 @@ export async function startGatewaySidecars(params: {
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+  // These runs were orphaned by the previous Gateway lifecycle. Record that fact
+  // even if this process later fails model preparation and never starts channels.
   await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
     try {
       const { markStartupOrphanedMainSessionsForRecovery } = await measureStartup(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -55,6 +55,10 @@ type GatewayMemoryStartupPolicy =
 const loadMainSessionRestartRecoveryModule = createLazyRuntimeModule(
   () => import("../agents/main-session-restart-recovery.js"),
 );
+// Startup only needs orphan marking; keep resume and delivery runtime out of the pre-channel path.
+const loadMainSessionRestartRecoveryMarkingModule = createLazyRuntimeModule(
+  () => import("../agents/main-session-restart-recovery-marking.js"),
+);
 
 const loadAgentDefaultsModule = createLazyRuntimeModule(() => import("../agents/defaults.js"));
 
@@ -674,7 +678,7 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
     try {
       const { markStartupOrphanedMainSessionsForRecovery } =
-        await loadMainSessionRestartRecoveryModule();
+        await loadMainSessionRestartRecoveryMarkingModule();
       await markStartupOrphanedMainSessionsForRecovery({ cfg: params.cfg });
     } catch (err) {
       params.log.warn(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -662,6 +662,22 @@ export async function startGatewaySidecars(params: {
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+  await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
+    try {
+      const { markStartupOrphanedMainSessionsForRecovery } = await measureStartup(
+        params.startupTrace,
+        "sidecars.main-session-recovery-load",
+        loadMainSessionRestartRecoveryMarkingModule,
+      );
+      await measureStartup(params.startupTrace, "sidecars.main-session-recovery-scan", () =>
+        markStartupOrphanedMainSessionsForRecovery({ cfg: params.cfg }),
+      );
+    } catch (err) {
+      params.log.warn(
+        `main-session startup orphan marking failed before channel startup: ${String(err)}`,
+      );
+    }
+  });
   // Agent RPC remains available when transports are disabled. Publish configured/static facts before
   // accepting work; live provider catalogs stay advisory and never enter the Gateway lifecycle.
   await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
@@ -675,17 +691,6 @@ export async function startGatewaySidecars(params: {
       params.prewarmPrimaryModel,
     ),
   );
-  await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
-    try {
-      const { markStartupOrphanedMainSessionsForRecovery } =
-        await loadMainSessionRestartRecoveryMarkingModule();
-      await markStartupOrphanedMainSessionsForRecovery({ cfg: params.cfg });
-    } catch (err) {
-      params.log.warn(
-        `main-session startup orphan marking failed before channel startup: ${String(err)}`,
-      );
-    }
-  });
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {


### PR DESCRIPTION
## Status

Exact-head local proof is positive, and the behaviorally identical runtime diff passed the hosted source-performance workflow. Merge remains blocked until the durable exact-head ClawSweeper review clears every finding, owner decision, merge risk, and rank-up item.

## Root Cause

The earlier import-only attempt did not improve `preparedRuntimeScaleMany / sidecars.main-session-recovery`.

Follow-up profiling separated the phase:

- module load: about `1ms`
- recovery scan when run immediately after prepared-model publication: about `1.03s`
- the same 12-agent target resolution in isolation: about `20ms`

The recovery scan does not depend on prepared model state. Running it first removes startup-work contention while preserving the contract that orphan marking completes before channels start.

## Changes

- Import only the recovery marking owner on the startup path; resume and delivery recovery stay lazy.
- Mark startup-orphaned main sessions before prepared model runtime publication.
- Record nested load and scan startup spans so future regressions identify the actual boundary.
- Assert recovery completes before model preparation and channel startup.

## Exact-Head Evidence

Head: `a8ab778b7d85416548f7ad888b480c90a74bd27c`  
Base: `f4253da3e40b6b65560fa4f9aa9d3fce1faceb97`

Before, exact hosted source probe at `3c54e096720545db480985e2054401bc6250761e`:

- 12-agent recovery: `1275.3ms`, `1325.1ms`, `1274.5ms`

After, hosted source probe at runtime-equivalent head `12fe34cac26650fd4c75f48a45fa93561d6ef412`:

- 12-agent recovery: `8.6ms`, `8.6ms`, `9.2ms`
- 12-agent recovery load: `1.0ms`, `1.1ms`, `1.1ms`
- 12-agent recovery scan: `6.2ms`, `6.1ms`, `6.6ms`
- 12-agent completion: `1014.2ms`, `994.6ms`, `1046.7ms`
- one-agent recovery: `4.6ms`, `4.0ms`, `4.1ms`
- one-agent completion: `693.7ms`, `658.6ms`, `696.1ms`

Hosted source-performance run: https://github.com/openclaw/openclaw/actions/runs/30712533160

The current head only rebases onto unrelated latest-main changes and adds the lifecycle contract comment plus failure-path regression test. The measured runtime logic is unchanged.

## Lifecycle Decision

Startup orphan marking records runs abandoned by the previous Gateway lifecycle. That state transition must occur even when the new process later fails model preparation; otherwise a failed restart can leave those prior runs falsely recorded as running. The current head documents this owner contract and tests that marking completes before a model-runtime failure propagates, while channels remain stopped.

## Verification

- Hosted source-performance workflow passed and published the artifact.
- `OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs sourcePerformance`
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`: 62/62 passed
- direct `oxfmt --check`, `oxlint`, and `git diff --check`: passed

The old ClawSweeper finding was based on the disproven import-only head. The current head includes the measured root-cause fix, hosted proof, and explicit model-preparation failure-path contract above.
