### PR TITLE
fix(skills): show proposal detail on Skill Workshop approval cards

### DIFF
--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -22,6 +22,10 @@ const NATIVE_TOOL_EXCLUDE = new Set(["read", "write", "edit", "apply_patch", "ex
 
 type CachedScopedTools = {
   agentId: string | undefined;
+  // Tool policy resolves the workspace root (grant value, else the agent's
+  // configured workspace). Hook context must carry the same one the tools were
+  // built with, or before-tool-call policy resolves state against a different root.
+  workspaceDir: string | undefined;
   tools: McpLoopbackTool[];
   toolSchema: McpToolSchemaEntry[];
   configRef: OpenClawConfig;
@@ -67,6 +71,7 @@ function resolveMcpLoopbackTools(
   mode: LoopbackToolsAllowMode,
 ): {
   agentId: string | undefined;
+  workspaceDir?: string;
   tools: McpLoopbackTool[];
 } {
   const excludeToolNames = new Set(NATIVE_TOOL_EXCLUDE);
@@ -91,6 +96,7 @@ function resolveMcpLoopbackTools(
   });
   return {
     agentId: scoped.agentId,
+    workspaceDir: scoped.workspaceDir,
     tools:
       mode === "exact"
         ? applyGrantToolsAllow(scoped.tools, params.toolsAllow)
@@ -101,6 +107,7 @@ function resolveMcpLoopbackTools(
 /** Resolves loopback-visible tools from the exact names carried by a minted grant. */
 export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
   agentId: string | undefined;
+  workspaceDir?: string;
   tools: McpLoopbackTool[];
 } {
   return resolveMcpLoopbackTools(params, "exact");
@@ -238,6 +245,7 @@ export class McpLoopbackToolCache {
     const next = resolveMcpLoopbackScopedTools(params);
     const nextEntry: CachedScopedTools = {
       agentId: next.agentId,
+      workspaceDir: next.workspaceDir,
       tools: next.tools,
       toolSchema: buildMcpToolSchema(next.tools),
       configRef: params.cfg,

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -21,6 +21,7 @@ type MockGatewayTool = {
 
 type MockGatewayScopedTools = {
   agentId: string;
+  workspaceDir?: string;
   tools: MockGatewayTool[];
 };
 
@@ -113,6 +114,7 @@ type BeforeToolCallHookInput = {
     turnSourceTo?: string;
     turnSourceAccountId?: string;
     turnSourceThreadId?: string | number;
+    workspaceDir?: string;
     loopDetection?: unknown;
   };
   signal?: unknown;
@@ -1426,6 +1428,23 @@ describe("mcp loopback server", () => {
       turnSourceThreadId: "bound-thread",
     });
     expect(getBeforeToolCallHookInput(0).ctx).toHaveProperty("loopDetection");
+  });
+
+  it("carries the resolved workspace dir into the before-tool-call hook context", async () => {
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [makeMessageTool()],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    const { runtime } = await startLoopbackServerForTest();
+
+    await callMainSessionTool({
+      token: runtime?.ownerToken,
+      name: "message",
+      args: { body: "hello" },
+    });
+
+    expect(getBeforeToolCallHookInput(0).ctx?.workspaceDir).toBe("/tmp/openclaw-workspace");
   });
 
   it("revalidates a CLI grant after async preparation before tool execution", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -360,6 +360,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
               hookContext: {
                 agentId: scopedTools.agentId,
                 config: cfg,
+                ...(scopedTools.workspaceDir ? { workspaceDir: scopedTools.workspaceDir } : {}),
                 sessionKey: requestContext.sessionKey,
                 sessionId: requestContext.sessionId,
                 runId: requestContext.runId,

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -4,6 +4,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
+import { logDebug } from "../../logger.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
 import { resolvePendingSkillProposal } from "./service.js";
@@ -127,7 +128,12 @@ async function resolveLifecycleApprovalDescription(params: {
       }),
       proposalId: record.id,
     };
-  } catch {
+  } catch (error) {
+    // Approving blind is the failure this record exists to make diagnosable:
+    // the card otherwise looks identical to "there is no more detail".
+    logDebug(
+      `skill-workshop: approval detail unavailable, using generic text: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return { description: params.fallback };
   }
 }


### PR DESCRIPTION
Closes #116490

## What Problem This Solves

Fixes an issue where operators approving a Skill Workshop lifecycle action (`skill_workshop` `apply` / `reject` / `quarantine`) would see only generic text — "Apply a pending workspace skill proposal into live workspace skills." — instead of the proposal id, target skill name, description, support-file count, and body size the approval card is meant to show.

The card looked exactly the same as if there were no further detail to show, so there was no way to tell "detail failed to resolve, approve blind" from "there is nothing more to see". Anyone reviewing these requests — including from a phone via a channel approval card — was approving a write into live workspace skills without knowing which skill it targeted.

## Why This Change Was Made

The approval detail is resolved by looking the proposal up in the workshop store, which needs the workspace root. That root reaches the before-tool-call policy on the hook context.

Every tool call from a Gateway-spawned CLI-backend session goes through the loopback MCP surface, and that surface never put `workspaceDir` on the hook context it built (`src/gateway/mcp-http.ts:360`), even though tool resolution had already computed it 60 lines earlier and returned it. With no workspace root, `resolveLifecycleApprovalDescription` returned the generic fallback before it ever tried the lookup (`src/skills/workshop/policy.ts:109-111`). The apply itself still worked, because the tool executes with its own scope baked in at construction — which is why the card was wrong but the action succeeded.

This is an incomplete prior repair, not a new gap. `f53103de72d` (#100498) added the rich description, made `resolveGatewayScopedTools` return a resolved `workspaceDir`, and threaded it into the `tools.invoke` boundary — but not into the loopback consumer, which drops it in its tool cache.

The fix carries that same resolved value through the loopback tool cache onto the hook context, so the approval policy resolves the proposal against the same workspace root the tools were built with. It deliberately uses the resolved value rather than the raw request field, so a grant that omits the workspace still lands on the agent's configured one instead of silently degrading again.

Second, the resolver's `catch` swallowed every failure with no record at all. Now it logs at debug level, so the remaining legitimate fallbacks (a proposal already applied, a racing lifecycle call) are diagnosable instead of invisible. The fallback text itself is unchanged — that wording is a product surface, and this change does not touch it.

Not changed: the `agentId` scope is intentionally left out of the policy lookup. Store visibility already matches on resolved workspace dir when no agent id is given, so adding it would be scope the bug does not need.

## User Impact

Skill Workshop approval cards again show which proposal is being applied, rejected, or quarantined:

```
Proposal ID: weather-helper-20260801-934722e598
Target skill: Weather Helper
Description: Check the weather provider before answering forecast questions.
Support files: 1
Body size: 0.2 KB
```

Operators can tell what they are approving before they approve it. When detail genuinely cannot be resolved, the card still falls back to the generic wording, but the reason is now in the debug log instead of being discarded.

Other before-tool-call policy and plugin hooks on the loopback surface now also receive `workspaceDir`, matching what the embedded runner and the `tools.invoke` boundary already passed.

## Evidence

Production diff is 3 files, +16/−1; the rest is the regression test.

**Regression test — red on `main`, green with the fix.** New test in `src/gateway/mcp-http.test.ts` drives a real `tools/call` over the real loopback HTTP server and asserts the hook context carries the resolved workspace root.

Before (on unmodified `main`):

```
FAIL  |gateway-server| src/gateway/mcp-http.test.ts > mcp loopback server > carries the resolved workspace dir into the before-tool-call hook context
AssertionError: expected undefined to be '/tmp/openclaw-workspace' // Object.is equality

- Expected:  "/tmp/openclaw-workspace"
+ Received:  undefined

 Test Files  3 failed (3)
      Tests  3 failed | 294 skipped (297)
```

After:

```
node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts src/skills/workshop/policy.test.ts

 Test Files  1 passed (1)      Tests  8 passed (8)      [unit]
 Test Files  1 passed (1)      Tests  99 passed (99)    [gateway]
[test] passed 2 Vitest shards in 98.64s
```

**Real-behavior before/after.** A local harness writes a real pending proposal through the real service into a real state dir, then runs the real production approval resolver twice. The only difference between the runs is the field the loopback boundary was dropping:

```
proposal id: weather-helper-20260801-934722e598

--- BEFORE (loopback hook context without workspaceDir) ---
Apply a pending workspace skill proposal into live workspace skills.

--- AFTER (loopback hook context with workspaceDir) ---
Proposal ID: weather-helper-20260801-934722e598
Target skill: Weather Helper
Description: Check the weather provider before answering forecast questions.
Support files: 1
Body size: 0.2 KB

PASS  BEFORE: approval card shows only the generic fallback
PASS  BEFORE: approval card does not name the proposal
PASS  AFTER: approval card names the proposal id
PASS  AFTER: approval card names the target skill
PASS  AFTER: approval card reports support file count

PROOF PASS — 5/5 checks
```

**Callers checked.** `resolveMcpLoopbackScopedTools` / `resolveMcpLoopbackPolicyTools` are also consumed by `src/agents/cli-runner/prepare.ts` through injected deps whose test doubles are type-checked against the real signature, so the new field is optional and those doubles are untouched.

**Typecheck.** `check-prod-types` and `check-test-types` both pass in CI on this head. Locally, `node scripts/run-tsgo.mjs -p tsconfig.core.json` is clean; the local test-type lane is what caught a real defect in this PR's own test fixture — the new mock set `workspaceDir` on a local mock type that did not declare it (TS2353) — which is fixed here.

**Not verified here.** No Crabbox/Testbox on this machine, so breadth beyond the suites above is left to CI. The end-to-end path was proven in two real-code links — the loopback server supplying the field, and the approval resolver consuming it — rather than one live gateway run with a channel-rendered approval card.

---

🤖 AI-assisted: investigated, implemented, and proven with Claude Code, and reviewed with `codex review`. That review raised one P1 — the mock-type gap noted under Typecheck — which is applied in this branch.
