### PR TITLE
fix(plugins): explain filtered installed plugins without unsafe recovery

### DIFF
--- a/src/cli/plugins-list-command.test.ts
+++ b/src/cli/plugins-list-command.test.ts
@@ -1,5 +1,6 @@
 // Plugins list command tests cover plugin list command execution and output.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OutputRuntimeEnv } from "../runtime.js";
 
 function createJsonRuntime(writes: unknown[]): OutputRuntimeEnv {
@@ -14,6 +15,65 @@ function createJsonRuntime(writes: unknown[]): OutputRuntimeEnv {
   };
 }
 
+type SnapshotPlugin = {
+  id: string;
+  enabled: boolean;
+  commands?: string[];
+  agentHarnessIds?: string[];
+};
+
+function mockPluginListSnapshot(plugins: SnapshotPlugin[], config: OpenClawConfig = {}): void {
+  vi.doMock("../config/config.js", () => ({
+    getRuntimeConfig: () => config,
+  }));
+  vi.doMock("../plugins/status-snapshot.js", () => ({
+    buildPluginRegistrySnapshotReport: () => ({
+      workspaceDir: "/workspace",
+      registrySource: "config",
+      registryDiagnostics: [],
+      plugins,
+      diagnostics: [],
+    }),
+  }));
+}
+
+function mockHumanListModules(importedModules: string[] = []): void {
+  vi.doMock("../plugins/source-display.js", () => {
+    importedModules.push("source-display");
+    return {
+      formatPluginSourceForTable: vi.fn(),
+      resolvePluginSourceRoots: vi.fn(),
+    };
+  });
+  vi.doMock("../../packages/terminal-core/src/table.js", () => {
+    importedModules.push("table");
+    return {
+      getTerminalTableWidth: vi.fn(),
+      renderTable: vi.fn(),
+    };
+  });
+  vi.doMock("../../packages/terminal-core/src/theme.js", () => {
+    importedModules.push("theme");
+    return {
+      theme: {
+        muted: (value: string) => value,
+      },
+    };
+  });
+  vi.doMock("./command-format.js", () => {
+    importedModules.push("command-format");
+    return {
+      formatCliCommand: (value: string) => `formatted(${value})`,
+    };
+  });
+  vi.doMock("./plugins-list-format.js", () => {
+    importedModules.push("plugins-list-format");
+    return {
+      formatPluginLine: vi.fn(),
+    };
+  });
+}
+
 describe("runPluginsListCommand", () => {
   afterEach(() => {
     vi.doUnmock("../config/config.js");
@@ -22,6 +82,8 @@ describe("runPluginsListCommand", () => {
     vi.doUnmock("../plugins/source-display.js");
     vi.doUnmock("../terminal/table.js");
     vi.doUnmock("../terminal/theme.js");
+    vi.doUnmock("../../packages/terminal-core/src/table.js");
+    vi.doUnmock("../../packages/terminal-core/src/theme.js");
     vi.doUnmock("./command-format.js");
     vi.doUnmock("./plugins-list-format.js");
     vi.resetModules();
@@ -110,6 +172,95 @@ describe("runPluginsListCommand", () => {
           diagnostics: [],
         },
         plugins: [{ id: "demo", enabled: true, commands: ["demo"] }],
+        diagnostics: [],
+      },
+    ]);
+  });
+
+  it.each([
+    { label: "normal", options: { enabled: true } },
+    { label: "verbose", options: { enabled: true, verbose: true } },
+  ])(
+    "explains an empty enabled-only $label list when plugins are installed",
+    async ({ options }) => {
+      mockPluginListSnapshot([{ id: "disabled-plugin", enabled: false }]);
+      mockHumanListModules();
+      const { runPluginsListCommand } = await import("./plugins-list-command.js");
+      const writes: unknown[] = [];
+
+      await runPluginsListCommand(options, createJsonRuntime(writes));
+
+      expect(writes).toEqual([
+        "No enabled plugins found. Run formatted(openclaw plugins list) to inspect installed plugins.",
+      ]);
+    },
+  );
+
+  it.each([
+    { label: "normal", options: { enabled: true } },
+    { label: "verbose", options: { enabled: true, verbose: true } },
+  ])("explains a globally disabled $label plugin inventory", async ({ options }) => {
+    mockPluginListSnapshot([{ id: "disabled-plugin", enabled: false }], {
+      plugins: { enabled: false },
+    });
+    mockHumanListModules();
+    const { runPluginsListCommand } = await import("./plugins-list-command.js");
+    const writes: unknown[] = [];
+
+    await runPluginsListCommand(options, createJsonRuntime(writes));
+
+    expect(writes).toEqual([
+      "No enabled plugins found. Plugins are globally disabled. Run formatted(openclaw plugins list) to inspect installed plugins.",
+    ]);
+  });
+
+  it.each([
+    { label: "denylist", config: { plugins: { deny: ["disabled-plugin"] } } },
+    {
+      label: "allowlist",
+      config: { plugins: { allow: ["allowed-plugin"] } },
+    },
+  ])("does not suggest a blocked mutation for a $label", async ({ config }) => {
+    mockPluginListSnapshot([{ id: "disabled-plugin", enabled: false }], config);
+    mockHumanListModules();
+    const { runPluginsListCommand } = await import("./plugins-list-command.js");
+    const writes: unknown[] = [];
+
+    await runPluginsListCommand({ enabled: true }, createJsonRuntime(writes));
+
+    expect(writes).toEqual([
+      "No enabled plugins found. Run formatted(openclaw plugins list) to inspect installed plugins.",
+    ]);
+  });
+
+  it("keeps install guidance when an enabled-only list has no installed plugins", async () => {
+    mockPluginListSnapshot([]);
+    mockHumanListModules();
+    const { runPluginsListCommand } = await import("./plugins-list-command.js");
+    const writes: unknown[] = [];
+
+    await runPluginsListCommand({ enabled: true }, createJsonRuntime(writes));
+
+    expect(writes).toEqual([
+      "No plugins found. Run formatted(openclaw plugins install <plugin>) to add one, or formatted(openclaw plugins list --json) to inspect raw discovery state.",
+    ]);
+  });
+
+  it("keeps empty enabled-only JSON lazy when every installed plugin is disabled", async () => {
+    const importedHumanModules: string[] = [];
+    mockPluginListSnapshot([{ id: "disabled-plugin", enabled: false }]);
+    mockHumanListModules(importedHumanModules);
+    const { runPluginsListCommand } = await import("./plugins-list-command.js");
+    const writes: unknown[] = [];
+
+    await runPluginsListCommand({ enabled: true, json: true }, createJsonRuntime(writes));
+
+    expect(importedHumanModules).toEqual([]);
+    expect(writes).toEqual([
+      {
+        workspaceDir: "/workspace",
+        registry: { source: "config", diagnostics: [] },
+        plugins: [],
         diagnostics: [],
       },
     ]);

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -76,11 +76,15 @@ export async function runPluginsListCommand(
   } = await loadHumanListModules();
 
   if (list.length === 0) {
-    runtime.log(
-      theme.muted(
-        `No plugins found. Run ${formatCliCommand("openclaw plugins install <plugin>")} to add one, or ${formatCliCommand("openclaw plugins list --json")} to inspect raw discovery state.`,
-      ),
-    );
+    const message =
+      opts.enabled && report.plugins.length > 0
+        ? `${
+            cfg.plugins?.enabled === false
+              ? "No enabled plugins found. Plugins are globally disabled."
+              : "No enabled plugins found."
+          } Run ${formatCliCommand("openclaw plugins list")} to inspect installed plugins.`
+        : `No plugins found. Run ${formatCliCommand("openclaw plugins install <plugin>")} to add one, or ${formatCliCommand("openclaw plugins list --json")} to inspect raw discovery state.`;
+    runtime.log(theme.muted(message));
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins list --enabled` currently reports that no plugins exist when plugins are installed but all disabled. With globally disabled plugins, the resulting install recommendation is misleading and cannot recover the installed inventory.

## Why This Change Was Made

Keep the distinction at the plugin-list owner: a filtered empty result with installed plugins now explains that no plugins are enabled, explicitly identifies global disablement, and suggests the existing read-only inventory command. A genuinely empty installation retains its existing install guidance. JSON output remains unchanged.

## User Impact

Operators receive actionable, profile-aware guidance under global disablement, restrictive allow/deny policies, and immutable Nix configurations. `openclaw --profile qa403 plugins list --enabled` now responds:

```
No enabled plugins found. Plugins are globally disabled. Run openclaw --profile qa403 plugins list to inspect installed plugins.
```

Running the suggested same-profile recovery command displays `Plugins (0/151 enabled)` for an isolated fixture containing 151 installed plugins.

## Evidence

- Earlier tests-first reproduction against the previous base produced six failures and three passing controls; the new current-main parent has the identical production baseline blob, and the exact new candidate passes all nine focused regressions.
- Type-aware focused lint, formatting, and `git diff --check` pass on the exact two touched files.
- Actual root profile parsing/environment application and production plugin-command registration run the parent and candidate filtered/recovery commands, plus candidate JSON inventory; all five processes exit 0 with empty stderr.
- Direct parent incorrectly recommends installation; the candidate identifies global disablement and its exact suggested profile-qualified recovery successfully lists all 151 installed, disabled plugins. JSON inventory confirms 151 installed and zero enabled.
- An additional exact-head named-profile run with `OPENCLAW_NIX_MODE=1` exits successfully, returns the same safe inventory guidance, and preserves configuration plus all logical user-state rows.
- Isolated config SHA and every logical plugin/config/user-state row are unchanged. The shared SQLite file itself changes on both parent and candidate solely because existing state-database initialization refreshes `schema_meta.updated_at` on every CLI process; this baseline side effect is not introduced by the change.
- Four wholly fresh SHA-specific independent source reviews and a fresh exclusive `gpt-5.6-sol` high-reasoning formal autoreview found no actionable P0–P3 issues; formal confidence is 0.97, and TruffleHog 3.96.0 passes. Exact-head GitHub CI remains required before landing.
