### PR TITLE
fix(openai): keep native embedding cache identity stable across upgrades

### DIFF
--- a/extensions/openai/memory-embedding-adapter.test.ts
+++ b/extensions/openai/memory-embedding-adapter.test.ts
@@ -1,6 +1,10 @@
 // Openai tests cover memory embedding adapter plugin behavior.
-import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveRemoteEmbeddingBearerClient,
+  type MemoryEmbeddingProvider,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createOpenAiEmbeddingProvider: vi.fn(),
@@ -27,6 +31,10 @@ const provider: MemoryEmbeddingProvider = {
 };
 
 describe("OpenAI memory embedding adapter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     mocks.createOpenAiEmbeddingProvider.mockReset();
     mocks.runOpenAiEmbeddingBatches.mockClear();
@@ -41,6 +49,105 @@ describe("OpenAI memory embedding adapter", () => {
         outputDimensionality: 512,
       },
     });
+  });
+
+  it("keeps native OpenAI embedding cache identity stable across OpenClaw versions", async () => {
+    const createForVersion = async (version: string) => {
+      vi.stubEnv("OPENCLAW_VERSION", version);
+      const client = await resolveRemoteEmbeddingBearerClient({
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        options: {
+          config: { models: {} } as never,
+          model: "text-embedding-3-small",
+          remote: { apiKey: "fixture-secret" },
+        },
+      });
+      mocks.createOpenAiEmbeddingProvider.mockResolvedValueOnce({
+        provider,
+        client: { ...client, model: "text-embedding-3-small" },
+      });
+      const result = await openAiMemoryEmbeddingProviderAdapter.create({
+        config: {} as never,
+        provider: "openai",
+        model: "text-embedding-3-small",
+        fallback: "none",
+      });
+      return { headers: client.headers, cacheKeyData: result.runtime?.cacheKeyData };
+    };
+
+    const previous = await createForVersion("2026.7.1");
+    const current = await createForVersion("2026.7.2");
+
+    expect(previous.headers).toMatchObject({
+      Authorization: "Bearer fixture-secret",
+      version: "2026.7.1",
+      "User-Agent": "openclaw/2026.7.1",
+    });
+    expect(current.headers).toMatchObject({
+      Authorization: "Bearer fixture-secret",
+      version: "2026.7.2",
+      "User-Agent": "openclaw/2026.7.2",
+    });
+    expect(current.cacheKeyData).toEqual(previous.cacheKeyData);
+    expect(hashText(JSON.stringify(current.cacheKeyData))).toBe(
+      hashText(JSON.stringify(previous.cacheKeyData)),
+    );
+    expect(current.cacheKeyData).toMatchObject({
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      model: "text-embedding-3-small",
+      headers: [
+        ["Content-Type", "application/json"],
+        ["originator", "openclaw"],
+      ],
+    });
+    expect(JSON.stringify(current.cacheKeyData)).not.toContain("fixture-secret");
+  });
+
+  it("preserves custom endpoint tenant and version-like cache identity headers", async () => {
+    const createForTenant = async (tenant: string) => {
+      const client = await resolveRemoteEmbeddingBearerClient({
+        provider: "bailian-embedding",
+        defaultBaseUrl: "https://embeddings.example/v1",
+        options: {
+          config: { models: {} } as never,
+          model: "text-embedding-v3",
+          remote: {
+            apiKey: "fixture-secret",
+            headers: {
+              "X-Tenant": tenant,
+              version: "tenant-api-v2",
+              "User-Agent": "tenant-client/2",
+            },
+          },
+        },
+      });
+      mocks.createOpenAiEmbeddingProvider.mockResolvedValueOnce({
+        provider,
+        client: { ...client, model: "text-embedding-v3" },
+      });
+      return await openAiMemoryEmbeddingProviderAdapter.create({
+        config: {} as never,
+        provider: "bailian-embedding",
+        model: "text-embedding-v3",
+        fallback: "none",
+      });
+    };
+
+    const first = await createForTenant("tenant-a");
+    const second = await createForTenant("tenant-b");
+    const headers = first.runtime?.cacheKeyData?.headers;
+
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        ["X-Tenant", "tenant-a"],
+        ["version", "tenant-api-v2"],
+        ["User-Agent", "tenant-client/2"],
+      ]),
+    );
+    expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-secret");
   });
 
   it("sends document input_type in OpenAI batch embedding requests", async () => {

--- a/extensions/openai/memory-embedding-adapter.ts
+++ b/extensions/openai/memory-embedding-adapter.ts
@@ -11,6 +11,23 @@ import {
   DEFAULT_OPENAI_EMBEDDING_MODEL,
 } from "./embedding-provider.js";
 
+function resolveEmbeddingCacheExcludedHeaders(providerId: string, baseUrl: string): string[] {
+  const excludedHeaders = ["authorization"];
+  if (providerId !== "openai") {
+    return excludedHeaders;
+  }
+  try {
+    if (new URL(baseUrl).hostname.toLowerCase().replace(/\.+$/, "") === "api.openai.com") {
+      // Native attribution changes on every upgrade; cache identity must describe embeddings,
+      // not the OpenClaw build that requested them.
+      excludedHeaders.push("version", "user-agent");
+    }
+  } catch {
+    // Invalid URLs are handled by the embedding client; keep existing custom-header identity.
+  }
+  return excludedHeaders;
+}
+
 export const openAiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: "openai",
   defaultModel: DEFAULT_OPENAI_EMBEDDING_MODEL,
@@ -37,7 +54,10 @@ export const openAiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
           model: client.model,
           outputDimensionality: client.outputDimensionality,
           documentInputType: client.documentInputType ?? client.inputType,
-          headers: sanitizeEmbeddingCacheHeaders(client.headers, ["authorization"]),
+          headers: sanitizeEmbeddingCacheHeaders(
+            client.headers,
+            resolveEmbeddingCacheExcludedHeaders(resolvedProvider, client.baseUrl),
+          ),
         },
         batchEmbed: async (batch) => {
           const inputType = client.documentInputType ?? client.inputType;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using native OpenAI embeddings would rebuild their entire memory index after upgrading OpenClaw because version-specific request attribution changed the durable embedding identity.

## Why This Change Was Made

Exclude generated `version` and `User-Agent` attribution only from the native OpenAI embedding-cache identity. Keep the actual outbound headers, endpoint/model partitioning, credential exclusion, and custom-provider tenant or version headers unchanged.

## User Impact

OpenClaw upgrades no longer trigger unnecessary OpenAI memory reindexing or duplicate embedding requests. Existing custom endpoints and tenant-specific model behavior remain isolated.

## Evidence

- Regression reproduced before the fix: one failing owner test with real attribution headers generated for two OpenClaw versions.
- Focused owner suite: 5/5 passing; provider, shared-header, SQLite cache, and reindex suites: 27/27 passing.
- Scoped remote validation passed production and test typechecking, formatting, plugin-boundary checks, and type-aware lint.
- Five independent hostile source reviews: zero P0–P3 findings.
- Formal `gpt-5.6-sol` autoreview at high reasoning through P3: zero findings; TruffleHog 3.96 secret scan clean.
