### PR TITLE
fix(qa): staged Matrix voice notes use the correct mock transcript

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3989,7 +3989,7 @@ describe("qa mock openai server", () => {
     });
   });
 
-  it("serves the Matrix voice preflight transcription contract for its explicit fixture", async () => {
+  it("serves the Matrix voice preflight transcription contract after Matrix media staging", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
       port: 0,
@@ -4003,7 +4003,9 @@ describe("qa mock openai server", () => {
       headers: {
         "content-type": "multipart/form-data; boundary=qa",
       },
-      body: '--qa\r\ncontent-disposition: form-data; name="file"; filename="matrix-qa-voice-preflight.wav"\r\n\r\nvoice\r\n--qa--\r\n',
+      body: `--qa\r\ncontent-disposition: form-data; name="file"; filename="matrix-qa-voice-preflight---fixture-id.wav"\r\n\r\n${"voice".repeat(
+        16_000,
+      )}\r\n--qa--\r\n`,
     });
 
     expect(response.status).toBe(200);

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -192,6 +192,10 @@ const QA_GROUP_AUDIO_TRANSCRIPTION_TEXT =
   "openclawqa reply with only this exact marker after group audio preflight: WHATSAPP_QA_GROUP_AUDIO_TRANSCRIPT_OK";
 const QA_GROUP_AUDIO_MIN_MULTIPART_BODY_CHARS = 48_000;
 const QA_MATRIX_VOICE_PREFLIGHT_FILENAME = "matrix-qa-voice-preflight.wav";
+const QA_MATRIX_VOICE_PREFLIGHT_FILENAME_STEM = QA_MATRIX_VOICE_PREFLIGHT_FILENAME.replace(
+  /\.wav$/,
+  "",
+);
 const QA_MATRIX_VOICE_PREFLIGHT_TRANSCRIPTION_TEXT =
   "MATRIX_QA_VOICE_PREFLIGHT_MENTION reply with only this exact marker: MATRIX_QA_VOICE_PREFLIGHT_OK";
 const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
@@ -255,7 +259,9 @@ function writeOpenAiMalformedJsonError(res: ServerResponse, label: string) {
 }
 
 function transcriptionTextForAudioRequest(rawBody: string) {
-  if (rawBody.includes(QA_MATRIX_VOICE_PREFLIGHT_FILENAME)) {
+  // Matrix stages inbound media as <original-stem>---<uuid>.<ext>, so the
+  // original filename is not present verbatim in the OpenAI multipart upload.
+  if (rawBody.includes(QA_MATRIX_VOICE_PREFLIGHT_FILENAME_STEM)) {
     return QA_MATRIX_VOICE_PREFLIGHT_TRANSCRIPTION_TEXT;
   }
   if (rawBody.length >= QA_GROUP_AUDIO_MIN_MULTIPART_BODY_CHARS) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.6.34 release-validation Matrix voice-note lane would time out after Matrix staged the uploaded WAV with its UUID-backed filename. The QA mock then selected the unrelated large-audio response, so the transcript did not contain the configured Matrix mention marker.

## Why This Change Was Made

The mock now recognizes the stable fixture filename stem, which survives Matrix's `<original-stem>---<uuid>.<ext>` media staging. It leaves production Matrix media handling and mention gating unchanged.

## User Impact

Release validation once again verifies that a real Matrix voice-note upload can satisfy group mention gating through transcription. There is no end-user runtime behavior change.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts` (109 tests passed)
- Local disposable Matrix homeserver run, against this branch: `matrix-voice-preflight-mention` and `matrix-approval-exec-metadata-chunked` both passed.
- Fresh autoreview of the uncommitted repair completed with no actionable findings.

AI-assisted implementation; reviewed and validated locally.
