### PR TITLE
fix(ci): repair plugin prerelease validation

### DIFF
--- a/scripts/lib/state-schema-inline-plugin.d.mts
+++ b/scripts/lib/state-schema-inline-plugin.d.mts
@@ -1,0 +1,9 @@
+export const STATE_SCHEMA_INLINE_PLUGIN_NAME: string;
+
+export function createStateSchemaInlinePlugin(rootDir?: string): {
+  name: string;
+  load(
+    this: { addWatchFile(id: string): void },
+    id: string,
+  ): { code: string; moduleType: "js" } | null;
+};

--- a/scripts/lib/state-schema-inline-plugin.mjs
+++ b/scripts/lib/state-schema-inline-plugin.mjs
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const STATE_SCHEMA_INLINE_PLUGIN_NAME = "openclaw:inline-state-schemas";
+
+const STATE_SCHEMA_MODULES = [
+  {
+    modulePath: "src/state/openclaw-state-schema.ts",
+    schemaPath: "src/state/openclaw-state-schema.sql",
+    exportName: "OPENCLAW_STATE_SCHEMA_SQL",
+  },
+  {
+    modulePath: "src/state/openclaw-agent-schema.ts",
+    schemaPath: "src/state/openclaw-agent-schema.sql",
+    exportName: "OPENCLAW_AGENT_SCHEMA_SQL",
+  },
+];
+
+/** Inline canonical schema bytes so bundled consumers need no SQL asset. */
+export function createStateSchemaInlinePlugin(rootDir = process.cwd()) {
+  const schemasByModulePath = new Map(
+    STATE_SCHEMA_MODULES.map((schema) => [path.resolve(rootDir, schema.modulePath), schema]),
+  );
+
+  return {
+    name: STATE_SCHEMA_INLINE_PLUGIN_NAME,
+    load(id) {
+      const schema = schemasByModulePath.get(path.resolve(id));
+      if (!schema) {
+        return null;
+      }
+      const schemaPath = path.resolve(rootDir, schema.schemaPath);
+      this.addWatchFile(schemaPath);
+      return {
+        code: `export const ${schema.exportName} = ${JSON.stringify(fs.readFileSync(schemaPath, "utf8"))};\n`,
+        moduleType: "js",
+      };
+    },
+  };
+}

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -80,8 +80,8 @@ vi.mock("./manifest-registry.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./plugin-registry.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./plugin-registry.js")>();
+vi.mock("./plugin-registry-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-registry-snapshot.js")>();
   return {
     ...actual,
     loadPluginRegistrySnapshot: mocks.loadPluginRegistrySnapshot,

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -61,7 +61,7 @@ vi.mock("./active-runtime-registry.js", () => ({
   },
 }));
 
-vi.mock("./plugin-registry.js", () => ({
+vi.mock("./plugin-registry-snapshot.js", () => ({
   loadPluginRegistrySnapshot: mocks.loadPluginRegistrySnapshot,
   loadPluginRegistrySnapshotWithMetadata: mocks.loadPluginRegistrySnapshotWithMetadata,
 }));

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -16,8 +16,8 @@ import { resetPluginRuntimeStateForTest } from "./runtime.js";
 const loadPluginRegistrySnapshotWithMetadata = vi.hoisted(() => vi.fn());
 const loadPluginManifestRegistryForInstalledIndex = vi.hoisted(() => vi.fn());
 
-vi.mock("./plugin-registry.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./plugin-registry.js")>();
+vi.mock("./plugin-registry-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-registry-snapshot.js")>();
   return {
     ...actual,
     loadPluginRegistrySnapshotWithMetadata: (params: unknown) =>

--- a/src/plugins/web-fetch-providers.runtime.test.ts
+++ b/src/plugins/web-fetch-providers.runtime.test.ts
@@ -104,9 +104,10 @@ function createRuntimeWebFetchProvider() {
 
 describe("resolvePluginWebFetchProviders", () => {
   beforeAll(async () => {
-    vi.doMock("./plugin-registry.js", async () => {
-      const actual =
-        await vi.importActual<typeof import("./plugin-registry.js")>("./plugin-registry.js");
+    vi.doMock("./plugin-registry-snapshot.js", async () => {
+      const actual = await vi.importActual<typeof import("./plugin-registry-snapshot.js")>(
+        "./plugin-registry-snapshot.js",
+      );
       return {
         ...actual,
         loadPluginRegistrySnapshotWithMetadata: () => ({

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import acpCorePackageJson from "../../packages/acp-core/package.json" with { type: "json" };
 import { pluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mjs";
 import privateLocalOnlyPluginSdkSubpaths from "../../scripts/lib/plugin-sdk-private-local-only-subpaths.json" with { type: "json" };
+import { createStateSchemaInlinePlugin } from "../../scripts/lib/state-schema-inline-plugin.mjs";
 import {
   detectVitestHostInfo as detectVitestHostInfoImpl,
   isCiLikeEnv,
@@ -158,6 +159,7 @@ if (!isCI && localScheduling.throttledBySystem && shouldPrintVitestThrottle(proc
 export const sharedVitestConfig = {
   root: repoRoot,
   envDir: false as const,
+  plugins: [createStateSchemaInlinePlugin(repoRoot)],
   resolve: {
     alias: [
       {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -12,6 +12,10 @@ import {
   productionPluginSdkEntrypoints,
 } from "./scripts/lib/plugin-sdk-entries.mjs";
 import {
+  createStateSchemaInlinePlugin,
+  STATE_SCHEMA_INLINE_PLUGIN_NAME,
+} from "./scripts/lib/state-schema-inline-plugin.mjs";
+import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
   TSDOWN_UNIFIED_CONFIG_GROUP,
   TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
@@ -46,43 +50,7 @@ const env = {
 const OUTPUT_SOURCE_MAPS = process.env.OUTPUT_SOURCE_MAPS === "1";
 const RUN_NODE_SKIP_DTS_BUILD = process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD === "1";
 const TSDOWN_DECLARATIONS = !RUN_NODE_SKIP_DTS_BUILD;
-export const STATE_SCHEMA_INLINE_PLUGIN_NAME = "openclaw:inline-state-schemas";
-
-const STATE_SCHEMA_MODULES = [
-  {
-    modulePath: "src/state/openclaw-state-schema.ts",
-    schemaPath: "src/state/openclaw-state-schema.sql",
-    exportName: "OPENCLAW_STATE_SCHEMA_SQL",
-  },
-  {
-    modulePath: "src/state/openclaw-agent-schema.ts",
-    schemaPath: "src/state/openclaw-agent-schema.sql",
-    exportName: "OPENCLAW_AGENT_SCHEMA_SQL",
-  },
-] as const;
-
-/** Inline canonical schema bytes so packaged database opens need no SQL asset. */
-export function createStateSchemaInlinePlugin(rootDir: string = process.cwd()) {
-  const schemasByModulePath = new Map(
-    STATE_SCHEMA_MODULES.map((schema) => [path.resolve(rootDir, schema.modulePath), schema]),
-  );
-
-  return {
-    name: STATE_SCHEMA_INLINE_PLUGIN_NAME,
-    load(this: { addWatchFile(id: string): void }, id: string) {
-      const schema = schemasByModulePath.get(path.resolve(id));
-      if (!schema) {
-        return null;
-      }
-      const schemaPath = path.resolve(rootDir, schema.schemaPath);
-      this.addWatchFile(schemaPath);
-      return {
-        code: `export const ${schema.exportName} = ${JSON.stringify(fs.readFileSync(schemaPath, "utf8"))};\n`,
-        moduleType: "js" as const,
-      };
-    },
-  };
-}
+export { createStateSchemaInlinePlugin, STATE_SCHEMA_INLINE_PLUGIN_NAME };
 
 const SUPPRESSED_EVAL_WARNING_PATHS = [
   "@protobufjs/inquire/index.js",


### PR DESCRIPTION
## Summary

- update release-only plugin metadata tests to mock the canonical `plugin-registry-snapshot` owner after the loader move
- share the production state-schema inline plugin with Vitest so browser-mode extension tests receive canonical SQL without executing Node source loaders
- preserve the existing packaged build behavior and add the required script declaration contract

## Validation

- `node scripts/run-vitest.mjs src/plugins/capability-provider-runtime.test.ts src/plugins/migration-provider-runtime.test.ts src/plugins/providers.runtime.consult-current-snapshot.test.ts src/plugins/web-fetch-providers.runtime.test.ts extensions/telegram/src/miniapp/page.auth-timeout.test.ts extensions/browser/src/browser/pw-tools-core.extract.test.ts extensions/qa-lab/web/src/app.browser.test.ts src/infra/tsdown-config.test.ts --reporter=dot`
- `node scripts/check-script-declarations.mjs`
- autoreview: clean, confidence 0.86
- Blacksmith Testbox changed-gate: running

## Release evidence

Repairs the failures isolated from frozen full release validation run https://github.com/openclaw/openclaw/actions/runs/30709267571 at `263741b1f076307e8162650b30d88122c96474a3`.
