### PR TITLE
fix(tasks): expose failures and sanitize persisted terminal output

### DIFF
--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -4,6 +4,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { createRunningTaskRun as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
+import { markTaskLostById, markTaskTerminalById } from "../tasks/task-registry.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import {
   resetTaskFlowRegistryForTests,
@@ -279,6 +280,237 @@ describe("flows commands", () => {
         "Linked tasks:",
         `- ${task.taskId} running run-child-2 Collect logs`,
       ]);
+    });
+  });
+
+  it.each(["failed", "timed_out", "lost"] as const)(
+    "shows the persisted failure reason for linked %s tasks",
+    async (status) => {
+      await withTaskFlowCommandStateDir(async () => {
+        const flow = createManagedTaskFlow({
+          ownerKey: "agent:main:main",
+          controllerId: "tests/flows-command-failure-detail",
+          goal: "Inspect child task failures",
+          status: "running",
+        });
+        const task = createRunningTaskRun({
+          runtime: "subagent",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          parentFlowId: flow.flowId,
+          childSessionKey: `agent:main:flow-child-${status}`,
+          runId: `run-flow-child-${status}`,
+          label: "Inspect linked child",
+          task: "Inspect linked child",
+          notifyPolicy: "silent",
+          startedAt: Date.now(),
+          progressSummary: "Outdated child progress",
+        });
+        const error = `${status}: linked provider credentials need attention`;
+        const endedAt = Date.now();
+
+        if (status === "lost") {
+          markTaskLostById({ taskId: task.taskId, endedAt, error });
+        } else {
+          markTaskTerminalById({
+            taskId: task.taskId,
+            status,
+            endedAt,
+            error,
+            terminalSummary: "Generic child completion summary",
+          });
+        }
+
+        const runtime = createRuntime();
+        await flowsShowCommand({ lookup: flow.flowId }, runtime);
+
+        const lines = vi.mocked(runtime.log).mock.calls.map(([line]) => String(line));
+        const linkedTaskLine = lines.find((line) => line.startsWith(`- ${task.taskId} `));
+        expect(linkedTaskLine).toContain("Inspect linked child");
+        expect(linkedTaskLine).toContain(error);
+        expect(linkedTaskLine).not.toContain("Outdated child progress");
+        expect(linkedTaskLine).not.toContain("Generic child completion summary");
+
+        const jsonRuntime = createRuntime();
+        await flowsShowCommand({ lookup: flow.flowId, json: true }, jsonRuntime);
+        expect(vi.mocked(jsonRuntime.writeJson).mock.calls[0]?.[0]).toMatchObject({
+          tasks: [expect.objectContaining({ status, error })],
+        });
+      });
+    },
+  );
+
+  it("includes running progress and terminal completion summaries for linked tasks", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command-task-progress",
+        goal: "Inspect child task updates",
+        status: "running",
+      });
+      const running = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:flow-child-running",
+        runId: "run-flow-child-running",
+        label: "Inspect running child",
+        task: "Inspect running child",
+        notifyPolicy: "silent",
+        startedAt: Date.now(),
+        progressSummary: "Downloading provider metadata",
+      });
+      const completed = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:flow-child-completed",
+        runId: "run-flow-child-completed",
+        label: "Inspect completed child",
+        task: "Inspect completed child",
+        notifyPolicy: "silent",
+        startedAt: Date.now(),
+      });
+      markTaskTerminalById({
+        taskId: completed.taskId,
+        status: "succeeded",
+        endedAt: Date.now(),
+        terminalSummary: "Provider metadata refreshed",
+      });
+
+      const runtime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId }, runtime);
+
+      const lines = vi.mocked(runtime.log).mock.calls.map(([line]) => String(line));
+      expect(lines.find((line) => line.startsWith(`- ${running.taskId} `))).toContain(
+        "Downloading provider metadata",
+      );
+      expect(lines.find((line) => line.startsWith(`- ${completed.taskId} `))).toContain(
+        "Provider metadata refreshed",
+      );
+    });
+  });
+
+  it("sanitizes linked task failure reasons before terminal display", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command-task-safety",
+        goal: "Inspect unsafe child error",
+        status: "running",
+      });
+      const task = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:flow-child-safety",
+        runId: "run-flow-child-safety",
+        label: "Inspect child safely",
+        task: "Inspect child safely",
+        notifyPolicy: "silent",
+        startedAt: Date.now(),
+      });
+      markTaskTerminalById({
+        taskId: task.taskId,
+        status: "failed",
+        endedAt: Date.now(),
+        error: "Provider \u001b[31mrejected\nforged: yes",
+      });
+
+      const runtime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId }, runtime);
+
+      const lines = vi.mocked(runtime.log).mock.calls.map(([line]) => String(line));
+      const linkedTaskLine = lines.find((line) => line.startsWith(`- ${task.taskId} `));
+      expect(linkedTaskLine).toContain("Provider rejected forged: yes");
+      expect(linkedTaskLine).not.toContain("\u001b");
+      expect(linkedTaskLine).not.toContain("\n");
+    });
+  });
+
+  it("sanitizes persisted linked task identifiers while preserving raw flow JSON", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const unsafe = "\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes";
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: `controller${unsafe}`,
+        goal: `goal${unsafe}`,
+        currentStep: `step${unsafe}`,
+        status: "running",
+      });
+      const task = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: `agent:main:child${unsafe}`,
+        runId: `run${unsafe}`,
+        label: `label${unsafe}`,
+        task: `prompt${unsafe}`,
+        notifyPolicy: "silent",
+        startedAt: Date.now(),
+      });
+      markTaskTerminalById({
+        taskId: task.taskId,
+        status: "failed",
+        endedAt: Date.now(),
+        error: `error${unsafe}`,
+      });
+
+      const humanRuntime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId }, humanRuntime);
+
+      const lines = vi.mocked(humanRuntime.log).mock.calls.map(([line]) => String(line));
+      const linkedTaskLine = lines.find((line) => line.startsWith(`- ${task.taskId} `));
+      expect(linkedTaskLine).toContain("label");
+      expect(linkedTaskLine).toContain("error");
+      for (const line of lines) {
+        expect(line).not.toContain("\u001b");
+        expect(line).not.toContain("\u0007");
+        expect(line).not.toContain("\n");
+      }
+
+      const jsonRuntime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId, json: true }, jsonRuntime);
+      expect(vi.mocked(jsonRuntime.writeJson).mock.calls[0]?.[0]).toMatchObject({
+        goal: `goal${unsafe}`,
+        currentStep: `step${unsafe}`,
+        tasks: [
+          expect.objectContaining({
+            childSessionKey: `agent:main:child${unsafe}`,
+            runId: `run${unsafe}`,
+            label: `label${unsafe}`,
+            task: `prompt${unsafe}`,
+            error: `error${unsafe}`,
+          }),
+        ],
+      });
+    });
+  });
+
+  it("sanitizes untrusted TaskFlow filters and lookup errors", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const unsafe = "\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes";
+      const filterRuntime = createRuntime();
+      await flowsListCommand({ status: `running${unsafe}` }, filterRuntime);
+
+      const lookupRuntime = createRuntime();
+      await flowsShowCommand({ lookup: `missing${unsafe}` }, lookupRuntime);
+
+      const lines = [
+        ...vi.mocked(filterRuntime.log).mock.calls.map(([line]) => String(line)),
+        ...vi.mocked(lookupRuntime.error).mock.calls.map(([line]) => String(line)),
+      ];
+      expect(lines.some((line) => line.includes("Status filter: running"))).toBe(true);
+      expect(lines.some((line) => line.includes("TaskFlow not found: missing"))).toBe(true);
+      for (const line of lines) {
+        expect(line).not.toContain("\u001b");
+        expect(line).not.toContain("\u0007");
+        expect(line).not.toContain("\n");
+      }
     });
   });
 

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -17,6 +17,7 @@ import {
   listTaskFlowRecords,
   resolveTaskFlowForLookupToken,
 } from "../tasks/task-flow-runtime-internal.js";
+import { formatTaskStatusDetail } from "../tasks/task-status.js";
 
 const ID_PAD = 10;
 const STATUS_PAD = 10;
@@ -25,7 +26,7 @@ const REV_PAD = 6;
 const CTRL_PAD = 20;
 
 function formatFlowLookupMiss(lookup: string): string {
-  return `TaskFlow not found: ${lookup}. Run ${formatCliCommand("openclaw tasks flow list")} to see recent flow ids.`;
+  return `TaskFlow not found: ${sanitizeTerminalText(lookup)}. Run ${formatCliCommand("openclaw tasks flow list")} to see recent flow ids.`;
 }
 
 function truncate(value: string, maxChars: number) {
@@ -47,11 +48,7 @@ function safeFlowDisplayText(value: string | undefined, maxChars?: number): stri
 }
 
 function shortToken(value: string | undefined, maxChars = ID_PAD): string {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return "n/a";
-  }
-  return truncate(trimmed, maxChars);
+  return safeFlowDisplayText(normalizeOptionalString(value), maxChars);
 }
 
 function formatFlowTimestamp(value: number | undefined | null): string {
@@ -178,7 +175,7 @@ export async function flowsListCommand(
   runtime.log(info(`TaskFlows: ${flows.length}`));
   runtime.log(info(`TaskFlow pressure: ${formatFlowListSummary(flows)}`));
   if (statusFilter) {
-    runtime.log(info(`Status filter: ${statusFilter}`));
+    runtime.log(info(`Status filter: ${sanitizeTerminalText(statusFilter)}`));
   }
   if (flows.length === 0) {
     runtime.log(
@@ -234,7 +231,7 @@ export async function flowsShowCommand(
     `tasks: ${taskSummary.total} total · ${taskSummary.active} active · ${taskSummary.failures} issues`,
   ];
   for (const line of lines) {
-    runtime.log(line);
+    runtime.log(sanitizeTerminalText(line));
   }
   if (tasks.length === 0) {
     runtime.log("Linked tasks: none");
@@ -243,7 +240,13 @@ export async function flowsShowCommand(
   runtime.log("Linked tasks:");
   for (const task of tasks) {
     const safeLabel = safeFlowDisplayText(task.label ?? task.task);
-    runtime.log(`- ${task.taskId} ${task.status} ${task.runId ?? "n/a"} ${safeLabel}`);
+    const detail = formatTaskStatusDetail(task);
+    const safeDetail = detail ? ` · ${safeFlowDisplayText(detail)}` : "";
+    runtime.log(
+      sanitizeTerminalText(
+        `- ${task.taskId} ${task.status} ${safeFlowDisplayText(task.runId)} ${safeLabel}${safeDetail}`,
+      ),
+    );
   }
 }
 
@@ -260,15 +263,21 @@ export async function flowsCancelCommand(opts: { lookup: string }, runtime: Runt
     flowId: flow.flowId,
   });
   if (!result.found) {
-    runtime.error(result.reason ?? formatFlowLookupMiss(opts.lookup));
+    runtime.error(sanitizeTerminalText(result.reason ?? formatFlowLookupMiss(opts.lookup)));
     runtime.exit(1);
     return;
   }
   if (!result.cancelled) {
-    runtime.error(result.reason ?? `Could not cancel TaskFlow: ${opts.lookup}`);
+    runtime.error(
+      sanitizeTerminalText(result.reason ?? `Could not cancel TaskFlow: ${opts.lookup}`),
+    );
     runtime.exit(1);
     return;
   }
   const updated = getTaskFlowById(flow.flowId) ?? result.flow ?? flow;
-  runtime.log(`Cancelled ${updated.flowId} (${updated.syncMode}) with status ${updated.status}.`);
+  runtime.log(
+    sanitizeTerminalText(
+      `Cancelled ${updated.flowId} (${updated.syncMode}) with status ${updated.status}.`,
+    ),
+  );
 }

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -12,6 +12,8 @@ import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import {
   createTaskRecord as createTaskRecordOrNull,
   getTaskById,
+  markTaskLostById,
+  markTaskTerminalById,
   reloadTaskRegistryFromStore,
 } from "../tasks/task-registry.js";
 import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
@@ -79,6 +81,28 @@ function jsonRoundTrip<T>(value: T): T {
   return JSON.parse(serialized) as T;
 }
 
+const UNSAFE_TASK_TERMINAL_TEXT = "\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes";
+
+function createInspectableTask(params: Partial<Parameters<typeof createTaskRecord>[0]> = {}) {
+  return createTaskRecord({
+    runtime: "cli",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    status: "running",
+    notifyPolicy: "silent",
+    task: "Inspect a background task",
+    ...params,
+  });
+}
+
+function expectSafeTaskOutput(runtime: RuntimeEnv, channel: "log" | "error" = "log") {
+  for (const [line] of vi.mocked(runtime[channel]).mock.calls) {
+    for (const control of ["\u001b", "\u0007", "\n", "\r"]) {
+      expect(String(line)).not.toContain(control);
+    }
+  }
+}
+
 const zeroTaskAuditCounts = {
   delivery_failed: 0,
   inconsistent_timestamps: 0,
@@ -97,31 +121,28 @@ async function writeSessionEntries(
   }
 }
 
+function resetTaskCommandRuntime() {
+  taskRegistryMaintenance.stopTaskRegistryMaintenance();
+  taskRegistryMaintenance.resetTaskRegistryMaintenanceRuntimeForTests();
+  resetConfigRuntimeState();
+  resetDetachedTaskLifecycleRuntimeForTests();
+  resetTaskRegistryDeliveryRuntimeForTests();
+  resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests({ persist: false });
+  closeOpenClawAgentDatabasesForTest();
+}
+
 async function withTaskCommandStateDir(
   run: (state: OpenClawTestState) => Promise<void>,
 ): Promise<void> {
   await withOpenClawTestState(
     { layout: "state-only", prefix: "openclaw-tasks-command-" },
     async (state) => {
-      taskRegistryMaintenance.stopTaskRegistryMaintenance();
-      taskRegistryMaintenance.resetTaskRegistryMaintenanceRuntimeForTests();
-      resetConfigRuntimeState();
-      resetDetachedTaskLifecycleRuntimeForTests();
-      resetTaskRegistryDeliveryRuntimeForTests();
-      resetTaskRegistryForTests({ persist: false });
-      resetTaskFlowRegistryForTests({ persist: false });
-      closeOpenClawAgentDatabasesForTest();
+      resetTaskCommandRuntime();
       try {
         await run(state);
       } finally {
-        taskRegistryMaintenance.stopTaskRegistryMaintenance();
-        taskRegistryMaintenance.resetTaskRegistryMaintenanceRuntimeForTests();
-        resetConfigRuntimeState();
-        resetDetachedTaskLifecycleRuntimeForTests();
-        resetTaskRegistryDeliveryRuntimeForTests();
-        resetTaskRegistryForTests({ persist: false });
-        resetTaskFlowRegistryForTests({ persist: false });
-        closeOpenClawAgentDatabasesForTest();
+        resetTaskCommandRuntime();
       }
     },
   );
@@ -134,14 +155,7 @@ describe("tasks commands", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    taskRegistryMaintenance.stopTaskRegistryMaintenance();
-    taskRegistryMaintenance.resetTaskRegistryMaintenanceRuntimeForTests();
-    resetConfigRuntimeState();
-    resetDetachedTaskLifecycleRuntimeForTests();
-    resetTaskRegistryDeliveryRuntimeForTests();
-    resetTaskRegistryForTests({ persist: false });
-    resetTaskFlowRegistryForTests({ persist: false });
-    closeOpenClawAgentDatabasesForTest();
+    resetTaskCommandRuntime();
     mocks.callGateway.mockReset();
   });
 
@@ -389,6 +403,54 @@ describe("tasks commands", () => {
       expect(runtime.exit).not.toHaveBeenCalled();
     });
   });
+
+  it.each(["gateway", "local"] as const)(
+    "sanitizes untrusted %s task cancellation output",
+    async (owner) => {
+      await withTaskCommandStateDir(async () => {
+        const unsafe = UNSAFE_TASK_TERMINAL_TEXT;
+        const gatewayOwned = owner === "gateway";
+        const task = createInspectableTask({
+          runtime: gatewayOwned ? "cron" : "cli",
+          ownerKey: gatewayOwned ? "" : "agent:main:main",
+          scopeKind: gatewayOwned ? "system" : "session",
+          runId: `run${unsafe}`,
+        });
+        if (gatewayOwned) {
+          mocks.callGateway.mockResolvedValueOnce({
+            found: true,
+            cancelled: true,
+            task: {
+              taskId: `${task.taskId}${unsafe}`,
+              runtime: `cron${unsafe}`,
+              runId: task.runId,
+            },
+          });
+        }
+        const runtime = createRuntime();
+        await tasksCancelCommand({ lookup: task.taskId }, runtime);
+        expect(runtime.log).toHaveBeenCalledWith(
+          expect.stringContaining(`Cancelled ${task.taskId}`),
+        );
+        expectSafeTaskOutput(runtime);
+        if (!gatewayOwned) {
+          expect(getTaskById(task.taskId)).toMatchObject({
+            status: "cancelled",
+            runId: `run${unsafe}`,
+          });
+          return;
+        }
+        mocks.callGateway.mockResolvedValueOnce({
+          found: true,
+          cancelled: false,
+          reason: `gateway refused${unsafe}`,
+        });
+        const failureRuntime = createRuntime();
+        await tasksCancelCommand({ lookup: task.taskId }, failureRuntime);
+        expectSafeTaskOutput(failureRuntime, "error");
+      });
+    },
+  );
 
   it("fails ACP task cancellation loudly when the live gateway is unavailable", async () => {
     await withTaskCommandStateDir(async () => {
@@ -680,6 +742,110 @@ describe("tasks commands", () => {
     });
   });
 
+  it("sanitizes every persisted task surface while preserving raw task JSON", async () => {
+    await withTaskCommandStateDir(async () => {
+      const unsafe = UNSAFE_TASK_TERMINAL_TEXT;
+      const task = createInspectableTask({
+        sourceId: `source${unsafe}`,
+        childSessionKey: `agent:main:child${unsafe}`,
+        parentTaskId: `parent${unsafe}`,
+        agentId: `worker${unsafe}`,
+        runId: `run${unsafe}`,
+        label: `label${unsafe}`,
+        task: `prompt${unsafe}`,
+        progressSummary: `progress${unsafe}`,
+        terminalSummary: `summary${unsafe}`,
+      });
+      markTaskLostById({ taskId: task.taskId, endedAt: Date.now(), error: `error${unsafe}` });
+      const showRuntime = createRuntime();
+      const listRuntime = createRuntime();
+      const auditRuntime = createRuntime();
+      await tasksShowCommand({ lookup: task.taskId }, showRuntime);
+      await tasksListCommand({}, listRuntime);
+      await tasksAuditCommand({}, auditRuntime);
+      for (const runtime of [showRuntime, listRuntime, auditRuntime]) {
+        expectSafeTaskOutput(runtime);
+      }
+      const shown = vi
+        .mocked(showRuntime.log)
+        .mock.calls.map(([line]) => String(line))
+        .join("|");
+      for (const field of [
+        "sourceId",
+        "childSessionKey",
+        "parentTaskId",
+        "agentId",
+        "runId",
+        "label",
+        "task",
+        "error",
+        "progressSummary",
+        "terminalSummary",
+      ]) {
+        expect(shown).toContain(`${field}:`);
+      }
+      expect(vi.mocked(listRuntime.log).mock.calls.flat().join("|")).toContain("error");
+      expect(vi.mocked(auditRuntime.log).mock.calls.flat().join("|")).toContain("error");
+      const jsonRuntime = createRuntime();
+      await tasksShowCommand({ lookup: task.taskId, json: true }, jsonRuntime);
+      expect(readFirstJsonLog(jsonRuntime)).toEqual(jsonRoundTrip(getTaskById(task.taskId)));
+      expect(getTaskById(task.taskId)).toMatchObject({
+        runId: `run${unsafe}`,
+        error: `error${unsafe}`,
+      });
+      const filteredListRuntime = createRuntime();
+      await tasksListCommand(
+        { runtime: `cron${unsafe}`, status: `running${unsafe}` },
+        filteredListRuntime,
+      );
+      const filteredAuditRuntime = createRuntime();
+      await tasksAuditCommand(
+        {
+          severity: `warn${unsafe}` as TaskSystemAuditSeverity,
+          code: `lost${unsafe}` as TaskSystemAuditCode,
+        },
+        filteredAuditRuntime,
+      );
+      for (const runtime of [filteredListRuntime, filteredAuditRuntime]) {
+        expectSafeTaskOutput(runtime);
+      }
+      const lookupRuntime = createRuntime();
+      await tasksShowCommand({ lookup: `missing${unsafe}` }, lookupRuntime);
+      expectSafeTaskOutput(lookupRuntime, "error");
+    });
+  });
+
+  it.each(["failed", "timed_out", "lost"] as const)(
+    "shows the persisted failure reason for %s tasks in list summaries",
+    async (status) => {
+      await withTaskCommandStateDir(async () => {
+        const task = createInspectableTask({
+          runId: `task-list-${status}`,
+          label: "Original task title",
+          progressSummary: "Outdated running progress",
+          terminalSummary: "Generic terminal summary",
+        });
+        const error = `${status}: upstream credentials need attention`;
+        const terminal = { taskId: task.taskId, endedAt: Date.now(), error };
+        if (status === "lost") {
+          markTaskLostById(terminal);
+        } else {
+          markTaskTerminalById({
+            ...terminal,
+            status,
+            terminalSummary: "Generic terminal summary",
+          });
+        }
+        const runtime = createRuntime();
+        await tasksListCommand({}, runtime);
+        const output = vi.mocked(runtime.log).mock.calls.flat().join("|");
+        expect(output).toContain(error);
+        expect(output).not.toContain("Outdated running progress");
+        expect(output).not.toContain("Generic terminal summary");
+      });
+    },
+  );
+
   it("keeps task list summaries within their UTF-16 column limit", async () => {
     await withTaskCommandStateDir(async () => {
       createTaskRecord({
@@ -691,6 +857,8 @@ describe("tasks commands", () => {
         task: "Inspect task summary",
         terminalSummary: `${"y".repeat(78)}🚀xx`,
       });
+      createInspectableTask({ progressSummary: "Fetching provider credentials" });
+      createInspectableTask({ status: "succeeded", label: "Human-readable task title" });
       const runtime = createRuntime();
 
       await tasksListCommand({}, runtime);
@@ -701,6 +869,8 @@ describe("tasks commands", () => {
         .join("\n");
       expect(output).toContain(`${"y".repeat(78)}…`);
       expect(output).not.toContain("🚀");
+      expect(output).toContain("Fetching provider credentials");
+      expect(output).toContain("Human-readable task title");
     });
   });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -4,6 +4,7 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatLookupMiss } from "../cli/error-format.js";
@@ -42,6 +43,7 @@ import {
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
 import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import { formatTaskStatusDetail } from "../tasks/task-status.js";
 import {
   buildTaskSystemAuditJsonPayload,
   buildTaskSystemAuditFindings,
@@ -62,7 +64,7 @@ const info = theme.info;
 function formatTaskLookupMiss(lookup: string): string {
   return formatLookupMiss({
     noun: "Task",
-    value: lookup,
+    value: sanitizeTerminalText(lookup),
     listCommand: "openclaw tasks list",
     valueLabel: "task id",
   });
@@ -208,11 +210,11 @@ function truncate(value: string, maxChars: number) {
 }
 
 function shortToken(value: string | undefined, maxChars = ID_PAD): string {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
+  const sanitized = sanitizeTerminalText(normalizeOptionalString(value) ?? "").trim();
+  if (!sanitized) {
     return "n/a";
   }
-  return truncate(trimmed, maxChars);
+  return truncate(sanitized, maxChars);
 }
 
 function formatTaskStatusCell(status: string, rich: boolean) {
@@ -245,10 +247,9 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
   const lines = [rich ? theme.heading(header) : header];
   for (const task of tasks) {
     const summary = truncate(
-      normalizeOptionalString(task.terminalSummary) ||
-        normalizeOptionalString(task.progressSummary) ||
-        normalizeOptionalString(task.label) ||
-        task.task.trim(),
+      sanitizeTerminalText(
+        formatTaskStatusDetail(task) || normalizeOptionalString(task.label) || task.task.trim(),
+      ),
       80,
     );
     const line = [
@@ -257,7 +258,7 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
       formatTaskStatusCell(task.status, rich),
       task.deliveryStatus.padEnd(DELIVERY_PAD),
       shortToken(task.runId, RUN_PAD).padEnd(RUN_PAD),
-      truncate(normalizeOptionalString(task.childSessionKey) || "n/a", 36).padEnd(36),
+      shortToken(task.childSessionKey, 36).padEnd(36),
       summary,
     ].join(" ");
     lines.push(line.trimEnd());
@@ -318,7 +319,7 @@ function formatAuditRows(findings: TaskSystemAuditFinding[], rich: boolean) {
         shortToken(finding.token).padEnd(ID_PAD),
         status,
         formatAgeMs(finding.ageMs).padEnd(8),
-        truncate(finding.detail, 88),
+        truncate(sanitizeTerminalText(finding.detail), 88),
       ]
         .join(" ")
         .trimEnd(),
@@ -372,10 +373,10 @@ export async function tasksListCommand(
   runtime.log(info(`Background tasks: ${tasks.length}`));
   runtime.log(info(`Task pressure: ${formatTaskListSummary(tasks)}`));
   if (runtimeFilter) {
-    runtime.log(info(`Runtime filter: ${runtimeFilter}`));
+    runtime.log(info(`Runtime filter: ${sanitizeTerminalText(runtimeFilter)}`));
   }
   if (statusFilter) {
-    runtime.log(info(`Status filter: ${statusFilter}`));
+    runtime.log(info(`Status filter: ${sanitizeTerminalText(statusFilter)}`));
   }
   if (tasks.length === 0) {
     runtime.log(
@@ -432,7 +433,7 @@ export async function tasksShowCommand(
     ...(task.terminalSummary ? [`terminalSummary: ${task.terminalSummary}`] : []),
   ];
   for (const line of lines) {
-    runtime.log(line);
+    runtime.log(sanitizeTerminalText(line));
   }
 }
 
@@ -456,7 +457,9 @@ export async function tasksNotifyCommand(
     runtime.exit(1);
     return;
   }
-  runtime.log(`Updated ${updated.taskId} notify policy to ${updated.notifyPolicy}.`);
+  runtime.log(
+    sanitizeTerminalText(`Updated ${updated.taskId} notify policy to ${updated.notifyPolicy}.`),
+  );
 }
 
 /** Cancels a detached task run by lookup token. */
@@ -470,18 +473,24 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
   const gatewayResult = await tryCancelGatewayOwnedTaskViaGateway(task);
   if (gatewayResult) {
     if (!gatewayResult.found) {
-      runtime.error(gatewayResult.reason ?? formatTaskLookupMiss(opts.lookup));
+      runtime.error(
+        sanitizeTerminalText(gatewayResult.reason ?? formatTaskLookupMiss(opts.lookup)),
+      );
       runtime.exit(1);
       return;
     }
     if (!gatewayResult.cancelled) {
-      runtime.error(gatewayResult.reason ?? `Could not cancel task: ${opts.lookup}`);
+      runtime.error(
+        sanitizeTerminalText(gatewayResult.reason ?? `Could not cancel task: ${opts.lookup}`),
+      );
       runtime.exit(1);
       return;
     }
     const updated = gatewayResult.task;
     runtime.log(
-      `Cancelled ${updated?.taskId ?? updated?.id ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
+      sanitizeTerminalText(
+        `Cancelled ${updated?.taskId ?? updated?.id ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
+      ),
     );
     return;
   }
@@ -490,18 +499,20 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     taskId: task.taskId,
   });
   if (!result.found) {
-    runtime.error(result.reason ?? formatTaskLookupMiss(opts.lookup));
+    runtime.error(sanitizeTerminalText(result.reason ?? formatTaskLookupMiss(opts.lookup)));
     runtime.exit(1);
     return;
   }
   if (!result.cancelled) {
-    runtime.error(result.reason ?? `Could not cancel task: ${opts.lookup}`);
+    runtime.error(sanitizeTerminalText(result.reason ?? `Could not cancel task: ${opts.lookup}`));
     runtime.exit(1);
     return;
   }
   const updated = getTaskById(task.taskId);
   runtime.log(
-    `Cancelled ${updated?.taskId ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
+    sanitizeTerminalText(
+      `Cancelled ${updated?.taskId ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
+    ),
   );
 }
 
@@ -549,10 +560,10 @@ export async function tasksAuditCommand(
     runtime.log(info(`Showing ${filteredFindings.length} matching findings.`));
   }
   if (severityFilter) {
-    runtime.log(info(`Severity filter: ${severityFilter}`));
+    runtime.log(info(`Severity filter: ${sanitizeTerminalText(severityFilter)}`));
   }
   if (codeFilter) {
-    runtime.log(info(`Code filter: ${codeFilter}`));
+    runtime.log(info(`Code filter: ${sanitizeTerminalText(codeFilter)}`));
   }
   if (limit) {
     runtime.log(info(`Limit: ${limit}`));


### PR DESCRIPTION
## What Problem This Solves

Human `openclaw tasks list` and linked TaskFlow output silently hid persisted
failure reasons for failed, timed-out, and lost background work. A full
same-owner audit also reproduced OSC52/BEL/newline terminal injection across
task details, task lists, task audits, linked TaskFlows, and successful task
cancellation.

## Why This Change Was Made

Both human surfaces now reuse the canonical task-status detail owner. Task and
TaskFlow command owners sanitize every untrusted human-output boundary using the
existing shared terminal formatter before bounded UTF-16 truncation. Intentional
rich theme styling survives because only untrusted values, not styled table
rows, are sanitized.

## User Impact

Operators immediately see failed, timed-out, and lost task failure reasons;
running progress and successful summaries remain useful. Human show/list/audit,
TaskFlow details, notification, filters, lookup errors, and both gateway/local
cancellation reject terminal control injection. Raw machine-readable JSON and
persisted SQLite records remain unchanged. No schema, config, API, or migration
changes.

## Verification

- Frozen immutable `726e4409e913c8761a3cd296d575fd686467b288`, tree
  `5de964ac8824d77737de2deaf1ab6a11909d1034`, parent
  `fd343ca8cc956d4af650a35c2957a8a8e700651c`; zero relevant drift on current
  canonical main.
- Regression-first same-owner suites reproduced **8 hostile failures**; final
  frozen exact-four task/TaskFlow suites: **40 passed**.
- Actual registered Commander commands against isolated real SQLite confirmed
  all three failure classes and all five malicious human surfaces; raw JSON and
  stored run IDs remain unchanged.
- Exact configured type-aware lint, formatting, and patch checks pass.
- Genuine native TruffleHog 3.96 scanned all four changed files: **0 verified /
  0 unverified secrets**.
- Five fresh independent hostile source reviews reported zero P1/P2; formal
  autoreview and full exact-head hosted CI remain required before landing.
