### PR TITLE
fix(agents): isolate run snapshots by execution handle

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -286,6 +286,7 @@ describe("runEmbeddedAttemptSettledPhase", () => {
             catalogEntries: [],
           },
         }),
+        submission: expect.objectContaining({ queueHandle: fixture.queueHandle }),
       }),
     );
     expect(mocks.completeResult).toHaveBeenCalledWith(

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -254,6 +254,7 @@ export async function runEmbeddedAttemptSettledPhase(
           : {}),
       },
       submission: {
+        queueHandle,
         promptActiveSession,
         sessionPromptState,
         toolResultPromptProjectionState,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-dispatch.test.ts
@@ -55,7 +55,7 @@ function createInput(overrides: Partial<DispatchInput> = {}): DispatchInput {
     execution: {},
     observation: {},
     preflight: {},
-    submission: {},
+    submission: { queueHandle: { kind: "embedded", runId: "run-1" } },
     ...overrides,
   } as unknown as DispatchInput;
 }
@@ -122,6 +122,7 @@ describe("dispatchEmbeddedAttemptPrompt", () => {
       expect.objectContaining({
         images: [expect.objectContaining({ type: "image" })],
         modelPrompt: "model prompt",
+        queueHandle: input.submission.queueHandle,
         runtimeContextMessage: expect.objectContaining({ content: "runtime" }),
         transcriptPrompt: "session prompt",
       }),

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -78,6 +78,7 @@ type PromptErrorCall = {
 
 function createFixture() {
   const order: string[] = [];
+  const queueHandle = { kind: "embedded", runId: "run-1" };
   const state: PromptPhaseState = {
     contextBudgetStatus: undefined,
     preflightRecovery: undefined,
@@ -230,6 +231,7 @@ function createFixture() {
     },
     submission: {
       promptActiveSession: vi.fn(),
+      queueHandle,
       toolResultPromptProjectionState: {},
       trajectoryRecorder: null,
     },
@@ -253,6 +255,7 @@ function createFixture() {
     input,
     markYieldAborted,
     order,
+    queueHandle,
     setFinalPromptText,
     setPrePromptMessageCount,
     setPromptCacheChangesForTurn,
@@ -289,6 +292,7 @@ describe("runEmbeddedAttemptPromptPhase", () => {
         observation: expect.objectContaining({ transcriptLeafId: "leaf-1" }),
         submission: expect.objectContaining({
           leasedSteering: { leaseId: "lease-1", runIds: ["run-1"] },
+          queueHandle: fixture.queueHandle,
           transcriptLeafId: "leaf-1",
         }),
       }),

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -50,6 +50,7 @@ type PromptPreflightPhaseInput = PromptDispatchInput["preflight"] & {
 type PromptSubmissionPhaseInput = Pick<
   PromptDispatchInput["submission"],
   | "promptActiveSession"
+  | "queueHandle"
   | "sessionPromptState"
   | "toolResultPromptProjectionState"
   | "trajectoryRecorder"

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -3,6 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ImageContent } from "../../../llm/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
+  clearActiveEmbeddedRun,
+  getActiveEmbeddedRunSnapshot,
+  setActiveEmbeddedRun,
+  type EmbeddedAgentQueueHandle,
+} from "../runs.js";
+import {
   clearEmbeddedSessionPromptStates,
   getEmbeddedSessionPromptState,
 } from "../session-prompt-state.js";
@@ -10,6 +16,16 @@ import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 
 const sessionId = "attempt-prompt-submit-test";
+
+function createQueueHandle(runId = "shared-run"): EmbeddedAgentQueueHandle {
+  return {
+    runId,
+    queueMessage: async () => {},
+    isStreaming: () => true,
+    isCompacting: () => false,
+    abort: () => {},
+  };
+}
 
 function createSession() {
   const state = {
@@ -37,6 +53,7 @@ function createBaseInput() {
   const sessionPromptState = getEmbeddedSessionPromptState(sessionId);
   return {
     attempt: { sessionId },
+    queueHandle: createQueueHandle(),
     appendContext: "append context",
     contextTokenBudget: 8_000,
     images: [] as ImageContent[],
@@ -61,6 +78,47 @@ afterEach(() => {
 });
 
 describe("submitEmbeddedAttemptPrompt", () => {
+  it("publishes the prepared prompt for the exact active attempt handle", async () => {
+    const { activeSession } = createSession();
+    const input = createBaseInput();
+    setActiveEmbeddedRun(sessionId, input.queueHandle);
+
+    try {
+      await submitEmbeddedAttemptPrompt({
+        ...input,
+        activeSession,
+        promptActiveSession: async () => {},
+      });
+
+      expect(getActiveEmbeddedRunSnapshot(sessionId)).toMatchObject({
+        transcriptLeafId: null,
+        inFlightPrompt: "transcript prompt",
+      });
+    } finally {
+      clearActiveEmbeddedRun(sessionId, input.queueHandle);
+    }
+  });
+
+  it("never publishes a stale attempt when its replacement reuses the same run id", async () => {
+    const { activeSession } = createSession();
+    const input = createBaseInput();
+    const replacement = createQueueHandle(input.queueHandle.runId);
+    setActiveEmbeddedRun(sessionId, input.queueHandle);
+    setActiveEmbeddedRun(sessionId, replacement);
+
+    try {
+      await submitEmbeddedAttemptPrompt({
+        ...input,
+        activeSession,
+        promptActiveSession: async () => {},
+      });
+
+      expect(getActiveEmbeddedRunSnapshot(sessionId)).toBeUndefined();
+    } finally {
+      clearActiveEmbeddedRun(sessionId, replacement);
+    }
+  });
+
   it("submits runtime-only prompts without images and acknowledges steering", async () => {
     const { activeSession, baseStreamFn, originalTransformContext } = createSession();
     const input = createBaseInput();

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -7,7 +7,7 @@ import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtim
 import type { AgentMessage } from "../../runtime/index.js";
 import { ackPendingAgentSteeringItems } from "../../subagent-registry.js";
 import { normalizeAssistantReplayContent } from "../replay-history.js";
-import { updateActiveEmbeddedRunSnapshot } from "../runs.js";
+import { type EmbeddedAgentQueueHandle, updateActiveEmbeddedRunSnapshot } from "../runs.js";
 import type {
   getEmbeddedSessionPromptState,
   ToolResultPromptProjectionState,
@@ -60,6 +60,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
   onSteeringAcknowledged: () => void;
   prependContext?: string;
   promptActiveSession: PromptActiveSession;
+  queueHandle: EmbeddedAgentQueueHandle;
   runtimeContextMessage?: RuntimeContextCustomMessage;
   runtimeOnly: boolean;
   sessionPromptState: ReturnType<typeof getEmbeddedSessionPromptState>;
@@ -118,7 +119,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
     messages: activeSession.messages,
     imagesCount: input.images.length,
   });
-  updateActiveEmbeddedRunSnapshot(attempt.sessionId, {
+  updateActiveEmbeddedRunSnapshot(attempt.sessionId, input.queueHandle, {
     transcriptLeafId: input.transcriptLeafId,
     messages: snapshotRecentMessages(normalizedReplayMessages),
     inFlightPrompt: input.transcriptPrompt,

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -1115,20 +1115,58 @@ describe("embedded-agent runner run registry", () => {
 
   it("tracks and clears per-session transcript snapshots for active runs", () => {
     const handle = createRunHandle();
+    const snapshot = {
+      transcriptLeafId: "assistant-1",
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
+      inFlightPrompt: "keep going",
+    };
 
     setActiveEmbeddedRun("session-snapshot", handle);
-    updateActiveEmbeddedRunSnapshot("session-snapshot", {
-      transcriptLeafId: "assistant-1",
-      messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
-      inFlightPrompt: "keep going",
-    });
-    expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toEqual({
-      transcriptLeafId: "assistant-1",
-      messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
-      inFlightPrompt: "keep going",
-    });
+    updateActiveEmbeddedRunSnapshot("session-snapshot", handle, snapshot);
+    expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toEqual(snapshot);
 
     clearActiveEmbeddedRun("session-snapshot", handle);
     expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toBeUndefined();
+  });
+
+  it("discards the previous attempt snapshot when another handle reuses its run id", () => {
+    const previous = createRunHandle({ runId: "shared-run" });
+    const replacement = createRunHandle({ runId: "shared-run" });
+
+    setActiveEmbeddedRun("snapshot-replaced", previous);
+    updateActiveEmbeddedRunSnapshot("snapshot-replaced", previous, {
+      transcriptLeafId: "previous-leaf",
+      inFlightPrompt: "previous private task",
+    });
+    setActiveEmbeddedRun("snapshot-replaced", replacement);
+
+    expect(getActiveEmbeddedRunSnapshot("snapshot-replaced")).toBeUndefined();
+  });
+
+  it("rejects a superseded attempt sharing its replacement owner's run id", () => {
+    const previous = createRunHandle({ runId: "shared-run" });
+    const replacement = createRunHandle({ runId: "shared-run" });
+    const currentSnapshot = { transcriptLeafId: "current-leaf", inFlightPrompt: "current task" };
+
+    setActiveEmbeddedRun("snapshot-replaced", previous);
+    setActiveEmbeddedRun("snapshot-replaced", replacement);
+    updateActiveEmbeddedRunSnapshot("snapshot-replaced", replacement, currentSnapshot);
+    updateActiveEmbeddedRunSnapshot("snapshot-replaced", previous, {
+      transcriptLeafId: "previous-leaf",
+      inFlightPrompt: "previous private task",
+    });
+
+    expect(getActiveEmbeddedRunSnapshot("snapshot-replaced")).toEqual(currentSnapshot);
+  });
+
+  it("preserves an owned snapshot when its exact run handle is registered again", () => {
+    const handle = createRunHandle({ runId: "shared-run" });
+    const snapshot = { transcriptLeafId: "assistant-1", inFlightPrompt: "keep going" };
+
+    setActiveEmbeddedRun("snapshot-reregistered", handle);
+    updateActiveEmbeddedRunSnapshot("snapshot-reregistered", handle, snapshot);
+    setActiveEmbeddedRun("snapshot-reregistered", handle);
+
+    expect(getActiveEmbeddedRunSnapshot("snapshot-reregistered")).toEqual(snapshot);
   });
 });

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -1017,6 +1017,10 @@ export function setActiveEmbeddedRun(
   const wasActive = previousHandle !== undefined;
   if (previousHandle) {
     clearEmbeddedRunAbortability(previousHandle, { retainFinalizing: true });
+    if (previousHandle !== handle) {
+      // Retry attempts reuse run ids, but snapshots belong to their exact handle.
+      ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
+    }
   }
   clearEmbeddedRunAbandonment({ sessionId, sessionKey, sessionFile });
   ACTIVE_EMBEDDED_RUNS.set(sessionId, handle);
@@ -1042,9 +1046,10 @@ export function setActiveEmbeddedRun(
 
 export function updateActiveEmbeddedRunSnapshot(
   sessionId: string,
+  handle: EmbeddedAgentQueueHandle,
   snapshot: ActiveEmbeddedRunSnapshot,
 ) {
-  if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+  if (ACTIVE_EMBEDDED_RUNS.get(sessionId) !== handle) {
     return;
   }
   ACTIVE_EMBEDDED_RUN_SNAPSHOTS.set(sessionId, snapshot);


### PR DESCRIPTION
## What Problem This Solves

Embedded agent prompt snapshots were associated only with a reusable session or logical run ID. When a run was replaced, `/btw` could read the previous attempt's private prompt, transcript leaf, or message history. Retries reuse the same logical run ID, so checking that ID cannot distinguish a stale attempt from its replacement.

## Why This Change Was Made

The existing per-attempt queue handle is already unique. Carry that exact handle through the established settlement, prompt-phase, dispatcher, and submission boundaries, and let the canonical run registry publish snapshots only while the identical handle still owns the session. Clear the old snapshot when a different handle takes over; preserve it when the same handle is registered again.

## User Impact

Side questions observe only the currently active attempt's context, even when retries share a logical run ID. Normal prompt submission, re-registration, manual compaction, session aliases, abort handling, and cleanup continue working. No public SDK, configuration, storage, or provider contract changes.

## Evidence

- Regression-first proof against unchanged production: **two failing registry cases and one failing real prompt-producer case**, all using distinct handles with the **same run ID**.
- Corrected owner, producer, settlement, prompt-phase, and dispatcher suites: **75/75 tests passed**.
- Dedicated remote verification reconstructed the exact immutable commit and confirmed all nine changed-file hashes before passing complete production and source-test TypeScript graphs, strict type-aware warning-deny lint, and the full focused regression suite.
- Six fresh independent hostile reviews found **no P0–P3 issues**. A genuine **GPT-5.6 Sol / high-reasoning review through P3** returned no findings; the native **TruffleHog 3.96.0** secret scan also passed.
- Remote verification: https://github.com/openclaw/openclaw/actions/runs/30712827450.
