### PR TITLE
fix(channels): preserve filters in offline status output

### DIFF
--- a/src/commands/channels.config-only-status-output.test.ts
+++ b/src/commands/channels.config-only-status-output.test.ts
@@ -11,6 +11,10 @@ vi.mock("../channels/plugins/index.js", () => ({
   listChannelPlugins: () => activeChannelPlugins,
   getLoadedChannelPlugin: (id: string) => activeChannelPlugins.find((plugin) => plugin.id === id),
   getChannelPlugin: (id: string) => activeChannelPlugins.find((plugin) => plugin.id === id),
+  normalizeChannelId: (value: string) => {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "wa" || normalized === "whatsapp" ? "whatsapp" : null;
+  },
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
@@ -25,12 +29,18 @@ async function formatLocalStatusSummary(
   cfg: unknown,
   options?: {
     sourceConfig?: unknown;
+    channel?: string;
   },
 ) {
   const lines = await formatConfigChannelsStatusLines(
     cfg as never,
     { mode: "local" },
-    options?.sourceConfig ? { sourceConfig: options.sourceConfig as never } : undefined,
+    options
+      ? {
+          ...(options.sourceConfig ? { sourceConfig: options.sourceConfig as never } : {}),
+          ...(options.channel !== undefined ? { channel: options.channel } : {}),
+        }
+      : undefined,
   );
   return lines.join("\n");
 }
@@ -193,6 +203,68 @@ function requireReadOnlyPluginListCall(): unknown[] {
 }
 
 describe("config-only channels status output", () => {
+  it.each([
+    {
+      label: "unregistered external channels",
+      channel: "token-only",
+      included: ["TokenOnly"],
+      excluded: ["WhatsApp"],
+    },
+    {
+      label: "case-insensitive external channels",
+      channel: "TOKEN-ONLY",
+      included: ["TokenOnly"],
+      excluded: ["WhatsApp"],
+    },
+    {
+      label: "bundled channel aliases",
+      channel: "wa",
+      included: ["WhatsApp"],
+      excluded: ["TokenOnly"],
+    },
+    {
+      label: "unknown channels",
+      channel: "missing-channel",
+      included: [],
+      excluded: ["TokenOnly", "WhatsApp"],
+    },
+    {
+      label: "no channel filter",
+      channel: undefined,
+      included: ["TokenOnly", "WhatsApp"],
+      excluded: [],
+    },
+    {
+      label: "blank channel filters",
+      channel: "   ",
+      included: ["TokenOnly", "WhatsApp"],
+      excluded: [],
+    },
+  ])(
+    "preserves exact config-only status filtering for $label",
+    async ({ channel, included, excluded }) => {
+      activeChannelPlugins.splice(
+        0,
+        activeChannelPlugins.length,
+        makeUnavailableTokenPlugin(),
+        makeIndeterminateLinkPlugin(),
+      );
+
+      const summary = await formatLocalStatusSummary(
+        { channels: { "token-only": {}, whatsapp: {} } },
+        { channel },
+      );
+
+      expect(summary).toContain("Gateway not reachable; showing config-only status.");
+      for (const label of included) {
+        expect(summary).toContain(label);
+      }
+      for (const label of excluded) {
+        expect(summary).not.toContain(label);
+      }
+    },
+  );
+
   it("uses setup fallback plugins so configured external channels can be shown", async () => {
     registerSingleTestPlugin("token-only", makeUnavailableTokenPlugin());
     listReadOnlyChannelPluginsForConfig.mockClear();

--- a/src/commands/channels/status-config-format.ts
+++ b/src/commands/channels/status-config-format.ts
@@ -1,4 +1,5 @@
 // Config-only channel status formatter used when the gateway is unreachable.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import {
@@ -68,7 +69,9 @@ export async function formatConfigChannelsStatusLines(
     });
 
   const sourceConfig = opts?.sourceConfig ?? cfg;
-  const requestedChannel = opts?.channel ? normalizeChannelId(opts.channel) : null;
+  const requestedChannel = opts?.channel
+    ? (normalizeChannelId(opts.channel) ?? normalizeOptionalLowercaseString(opts.channel))
+    : null;
   const plugins = listReadOnlyChannelPluginsForConfig(cfg, {
     activationSourceConfig: sourceConfig,
     includeSetupFallbackPlugins: true,


### PR DESCRIPTION
## What Problem This Solves

When the Gateway is unreachable, `openclaw channels status --channel <id>` falls back to local configuration. For an external channel absent from the loaded registry, an uppercase external identifier, or an unknown channel, the human-readable fallback accidentally discarded the requested filter and printed every configured channel. The existing JSON fallback already preserved the requested channel correctly.

## Why This Change Was Made

Reuse the JSON fallback's existing channel-identity rule at the human-readable formatter: resolve a registered channel alias first, then preserve the trimmed, lowercase raw identifier. This repairs the owner boundary without changing plugin registration, credentials, provider behavior, storage, or JSON contracts.

## User Impact

- External and case-insensitive channel selections show only the requested configured account.
- Bundled aliases continue resolving to their canonical channel.
- Unknown nonblank selections show no account instead of exposing unrelated channel diagnostics.
- Blank or omitted filters continue showing every configured channel.
- Missing official-plugin repair hints follow the same requested-channel filter.

## Evidence

- Tests-first reproduction on the exact parent produced three genuine failures: external channel, uppercase external channel, and unknown channel. Nine existing, alias, and unfiltered controls passed.
- The frozen candidate passes all 12 focused config-only status tests.
- Existing Gateway alias dispatch and JSON external-channel fallback controls both pass.
- Configured core type-aware lint with type checking, targeted formatting, and `git diff --check` pass.
- Four independent cross-lane hostile source reviews and the lane coordinator reported no actionable P0-P3 findings.
- A fresh exclusive `gpt-5.6-sol` high-reasoning formal autoreview reported zero P0-P3 findings and judged the patch correct with 0.93 confidence.
- Native TruffleHog 3.96.0 found no verified or unknown credentials.
- Exact-head hosted GitHub CI remains required before landing.
