### PR TITLE
fix(nvidia): recover from unavailable featured model catalogs

### DIFF
--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -321,4 +321,53 @@ describe("nvidia provider hooks", () => {
       catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test")),
     ).resolves.toEqual([]);
   });
+
+  it.each([
+    ["unavailable", { error: "unavailable" }, 503],
+    ["malformed", { error: "missing featured rows" }, 200],
+  ])(
+    "falls back to bundled runtime models when the featured catalog is %s",
+    async (_, body, status) => {
+      mockFeaturedCatalogResponse(body, status);
+      const provider = await registerNvidiaProvider();
+      const context = buildCatalogContext("nvapi-test");
+
+      await expect(provider.catalog?.run(context)).resolves.toBeNull();
+      await expect(provider.staticCatalog?.run(context)).resolves.toMatchObject({
+        provider: {
+          models: expect.arrayContaining([
+            expect.objectContaining({ id: "nvidia/nemotron-3-ultra-550b-a55b" }),
+            expect.objectContaining({ id: "moonshotai/kimi-k2.6" }),
+          ]),
+        },
+      });
+    },
+  );
+
+  it("preserves a genuinely empty successful featured catalog", async () => {
+    mockFeaturedCatalogResponse({ "featured-models": [] });
+    const provider = await registerNvidiaProvider();
+
+    await expect(provider.catalog?.run(buildCatalogContext("nvapi-test"))).resolves.toMatchObject({
+      provider: { apiKey: "nvapi-test", models: [] },
+    });
+  });
+
+  it("keeps a healthy deprecated-only featured catalog genuinely empty", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "moonshotai/kimi-k2.5",
+          "model-name": "Kimi K2.5",
+          context: 262144,
+          "max-output": 32768,
+        },
+      ],
+    });
+    const provider = await registerNvidiaProvider();
+
+    await expect(provider.catalog?.run(buildCatalogContext("nvapi-test"))).resolves.toMatchObject({
+      provider: { apiKey: "nvapi-test", models: [] },
+    });
+  });
 });

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -1,11 +1,12 @@
 // Nvidia plugin entrypoint registers its OpenClaw integration.
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyNvidiaConfig, NVIDIA_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import {
   buildLiveNvidiaProvider,
+  buildSelectableFeaturedNvidiaProvider,
   buildSelectableNvidiaProvider,
-  buildSelectableLiveNvidiaProvider,
 } from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
@@ -36,6 +37,17 @@ async function buildNvidiaCatalogModels(ctx: {
   }));
 }
 
+async function buildNvidiaRuntimeCatalog(ctx: ProviderCatalogContext) {
+  const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+  if (!apiKey) {
+    return null;
+  }
+  const provider = await buildSelectableFeaturedNvidiaProvider();
+  // A null catalog lets runtime discovery use bundled rows without projecting
+  // those static models into the separate live-catalog surface.
+  return provider ? { provider: { ...provider, apiKey } } : null;
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "NVIDIA Provider",
@@ -50,8 +62,8 @@ export default defineSingleProviderPluginEntry({
       applyConfig: applyNvidiaConfig,
     },
     catalog: {
-      buildProvider: buildSelectableLiveNvidiaProvider,
-      buildStaticProvider: buildSelectableNvidiaProvider,
+      run: buildNvidiaRuntimeCatalog,
+      staticRun: async () => ({ provider: buildSelectableNvidiaProvider() }),
     },
     augmentModelCatalog: buildNvidiaCatalogModels,
     wizard: {

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -5,8 +5,8 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 import {
   buildLiveNvidiaProvider,
   buildNvidiaProvider,
+  buildSelectableFeaturedNvidiaProvider,
   buildSelectableNvidiaProvider,
-  buildSelectableLiveNvidiaProvider,
 } from "./provider-catalog.js";
 
 const NVIDIA_FEATURED_MODELS_URL =
@@ -275,9 +275,9 @@ describe("nvidia provider catalog", () => {
       ],
     });
 
-    const provider = await buildSelectableLiveNvidiaProvider();
+    const provider = await buildSelectableFeaturedNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual([
+    expect(provider?.models.map((model) => model.id)).toEqual([
       "z-ai/glm-5.2",
       "nvidia/nemotron-3-super-120b-a12b",
     ]);
@@ -302,10 +302,10 @@ describe("nvidia provider catalog", () => {
     });
 
     const live = await buildLiveNvidiaProvider();
-    const selectableLive = await buildSelectableLiveNvidiaProvider();
+    const selectableLive = await buildSelectableFeaturedNvidiaProvider();
 
     expect(live.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m3"]);
-    expect(selectableLive.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m3"]);
+    expect(selectableLive?.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m3"]);
   });
 
   it("maps current featured feed metadata for MiniMax, DeepSeek, and Qwen", async () => {
@@ -347,12 +347,20 @@ describe("nvidia provider catalog", () => {
     ]);
   });
 
-  it("returns no selectable live rows when the featured catalog is unavailable", async () => {
+  it("returns no featured provider when the featured catalog is unavailable", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
 
-    const provider = await buildSelectableLiveNvidiaProvider();
+    const provider = await buildSelectableFeaturedNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual([]);
+    expect(provider).toBeNull();
+  });
+
+  it("preserves a genuinely empty successful featured catalog", async () => {
+    mockFeaturedCatalogResponse({ "featured-models": [] });
+
+    const provider = await buildSelectableFeaturedNvidiaProvider();
+
+    expect(provider?.models).toEqual([]);
   });
 
   it("ignores malformed featured catalog rows and keeps valid entries", async () => {
@@ -462,6 +470,27 @@ describe("nvidia provider catalog", () => {
       EXPECTED_FEATURED_MODELS.map((model) => model.id),
     );
     expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.2"]);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache genuinely empty featured catalog responses", async () => {
+    mockFeaturedCatalogResponse({ "featured-models": [] });
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "z-ai/glm-5.2",
+          "model-name": "GLM 5.2",
+          context: 202752,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const first = await buildSelectableFeaturedNvidiaProvider();
+    const second = await buildSelectableFeaturedNvidiaProvider();
+
+    expect(first?.models).toEqual([]);
+    expect(second?.models.map((model) => model.id)).toEqual(["z-ai/glm-5.2"]);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -101,14 +101,11 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   };
 }
 
-export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProviderConfig> {
+export async function buildSelectableFeaturedNvidiaProvider(): Promise<ModelProviderConfig | null> {
   const provider = buildSelectableNvidiaProvider();
   const featuredModels = await loadNvidiaFeaturedModels();
-  if (!featuredModels || featuredModels.length === 0) {
-    return {
-      ...provider,
-      models: [],
-    };
+  if (!featuredModels) {
+    return null;
   }
   return {
     ...provider,
@@ -130,13 +127,17 @@ async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | nul
       // the guarded fixed-host fetch on the fast path.
       lookupFn: lookupNvidiaFeaturedModelHostname,
       auditContext: "nvidia-featured-model-catalog",
-      shouldCacheRows: (modelRows) => parseNvidiaFeaturedModels(modelRows) !== null,
+      shouldCacheRows: (modelRows) =>
+        modelRows.length > 0 && parseNvidiaFeaturedModels(modelRows) !== null,
       readRows: (payload) => {
-        if (!payload || typeof payload !== "object") {
-          return [];
+        if (!isRecord(payload)) {
+          throw new Error("Invalid NVIDIA featured model catalog response");
         }
-        const featuredRows = (payload as { "featured-models"?: unknown })["featured-models"];
-        return Array.isArray(featuredRows) ? featuredRows : [];
+        const featuredRows = payload["featured-models"];
+        if (!Array.isArray(featuredRows)) {
+          throw new Error("Missing NVIDIA featured model catalog rows");
+        }
+        return featuredRows;
       },
     });
     return parseNvidiaFeaturedModels(rows);
@@ -146,6 +147,9 @@ async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | nul
 }
 
 function parseNvidiaFeaturedModels(rows: readonly unknown[]): ModelDefinitionConfig[] | null {
+  if (rows.length === 0) {
+    return [];
+  }
   const models = rows
     .slice(0, FEATURED_MODEL_MAX_ROWS)
     .map(parseNvidiaFeaturedModel)


### PR DESCRIPTION
## What Problem This Solves

An authenticated NVIDIA provider silently ended up with zero runnable models whenever NVIDIA's featured catalog was unavailable or malformed, even though a bundled catalog and documented fallback were available. The live catalog returned a successful-looking empty provider, so the existing runtime static fallback never ran.

## Why This Change Was Made

Refactor the NVIDIA-owned catalog boundary to distinguish a failed or unusable featured response from a successful genuinely empty response. Failed responses now return `null`, allowing the existing runtime owner to load the bundled catalog; successful empty and deprecated-only feeds remain empty. Keep static and live catalog provenance separate, preserve existing API-key behavior, avoid caching empty failures, and remove the obsolete helper instead of retaining a compatibility wrapper.

## User Impact

Operators keep their bundled NVIDIA models and configured defaults when the featured feed returns an error or malformed data. Healthy live catalogs retain their current ordering and behavior, genuinely empty feeds remain empty, deprecated models stay filtered, and recovered feeds become visible without waiting for a stale cache entry.

## Evidence

- Reproduced two failing registered-provider cases with actual mocked HTTP 503 and malformed responses, plus a separate failing empty-feed cache-recovery regression; all three now pass.
- All **33 NVIDIA owner and registered-provider tests pass** on the exact reviewed commit.
- Complete hosted changed-file gate passed, including production and test extension typechecks, type-aware lint, formatting, dead exports, plugin/API boundaries, and import cycles: [full hosted validation](https://github.com/openclaw/openclaw/actions/runs/30711969165).
- Six independent commit-bound adversarial reviews reported **zero P0-P3 findings**.
- Final isolated `gpt-5.6-sol` high-reasoning P0-P3 autoreview exited cleanly with **97% confidence**; native TruffleHog 3.96.0 also passed.
