### PR TITLE
[codex] fix skills prompt canonical locations

### DIFF
--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -334,11 +334,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).toContain("<description>");
   });
 
-  it("budget check uses compacted home-dir paths, not canonical paths", () => {
-    // Skills with home-dir prefix get compacted (e.g. /home/user/... → ~/...).
-    // Budget check must use the compacted length, not the longer canonical path.
-    // If it used canonical paths, it would overestimate and potentially drop
-    // skills that actually fit after compaction.
+  it("budget check uses canonical home-dir paths for executable skill locations", () => {
     const home = os.homedir();
     const skills = Array.from({ length: 30 }, (_, i) =>
       makeSkill(
@@ -347,7 +343,6 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
         `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`,
       ),
     );
-    // Compute compacted lengths (what the prompt will actually contain)
     const compactedSkills = skills.map((s) => ({
       ...s,
       filePath: s.filePath.replace(home, "~"),
@@ -356,23 +351,22 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
       descriptionMaxChars: 0,
     }).length;
     const canonicalCompactLen = formatSkillsCompact(skills, { descriptionMaxChars: 0 }).length;
-    // Sanity: canonical paths are longer than compacted paths
     expect(canonicalCompactLen).toBeGreaterThan(compactedCompactLen);
-    // Set budget between compacted and canonical lengths — only fits if
-    // budget check uses compacted paths (correct) not canonical (wrong).
     const budget =
       Math.floor((compactedCompactLen + canonicalCompactLen) / 2) +
       COMPACT_OMITTED_NOTICE.length +
       1;
     const prompt = buildPrompt(skills, { maxChars: budget });
-    // All 30 skills should be preserved in compact form (tier 2, no dropping)
+
+    expect(prompt.length).toBeLessThanOrEqual(budget);
+    const [included, total] = requireIncludedCounts(prompt);
+    expect(included).toBeLessThan(total);
+    expect(total).toBe(skills.length);
     expect(prompt).toContain("skill-0");
-    expect(prompt).toContain("skill-29");
-    expect(prompt).not.toContain("included");
+    expect(prompt).toContain("included");
     expect(prompt).toContain("compact format");
-    // Verify paths in output are compacted
-    expect(prompt).toContain("~/");
-    expect(prompt).not.toContain(home);
+    expect(prompt).toContain(home);
+    expect(prompt).not.toContain("<location>~/");
   });
 
   it("skills are sorted alphabetically regardless of entry insertion order", () => {
@@ -389,7 +383,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(nameMatches).toEqual(["apple", "banana", "mango", "zoo"]);
   });
 
-  it("resolvedSkills in snapshot keeps canonical paths, not compacted", () => {
+  it("snapshot prompt and resolvedSkills keep canonical paths, not compacted", () => {
     const home = os.homedir();
     const skills = Array.from({ length: 5 }, (_, i) =>
       makeSkill(`skill-${i}`, "A skill", `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`),
@@ -397,9 +391,8 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const snapshot = buildWorkspaceSkillSnapshot("/fake", {
       entries: skills.map(makeEntry),
     });
-    // Prompt should use compacted paths
-    expect(snapshot.prompt).toContain("~/");
-    // resolvedSkills should preserve canonical (absolute) paths
+    expect(snapshot.prompt).toContain(home);
+    expect(snapshot.prompt).not.toContain("<location>~/");
     expect(snapshot.resolvedSkills).toHaveLength(5);
     for (const skill of snapshot.resolvedSkills ?? []) {
       expect(skill.filePath).toContain(home);

--- a/src/skills/loading/compact-skill-paths.test.ts
+++ b/src/skills/loading/compact-skill-paths.test.ts
@@ -7,7 +7,7 @@ import { withEnv } from "../../test-utils/env.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import { testing as workspaceSkillsTesting, buildWorkspaceSkillsPrompt } from "./workspace.js";
 
-describe("compactSkillPaths", () => {
+describe("skill prompt locations", () => {
   function buildPromptForFixtureSkill(params: {
     workspaceRoot: string;
     skillDir: string;
@@ -37,9 +37,10 @@ describe("compactSkillPaths", () => {
     });
   }
 
-  it("replaces home directory prefix with ~ in skill locations", () => {
+  it("keeps home directory prefixes canonical in skill locations", () => {
     const home = os.homedir();
     const skillDir = path.join(home, ".openclaw-test-skills", "test-skill");
+    const skillFile = path.join(skillDir, "SKILL.md");
 
     const prompt = buildPromptForFixtureSkill({
       workspaceRoot: home,
@@ -48,8 +49,8 @@ describe("compactSkillPaths", () => {
       description: "A test skill for path compaction",
     });
 
-    expect(prompt).not.toContain(home + path.sep);
-    expect(prompt).toContain("~/");
+    expect(prompt).toContain(`<location>${skillFile}</location>`);
+    expect(prompt).not.toContain("<location>~/");
     expect(prompt).toContain("test-skill");
     expect(prompt).toContain("A test skill for path compaction");
   });
@@ -108,10 +109,11 @@ describe("compactSkillPaths", () => {
     expect(prompt).not.toContain("~/.openclaw/plugin-skills/calendar-plugin-skill/SKILL.md");
   });
 
-  it("compacts managed skill paths when OS-home tilde reaches the same path", () => {
+  it("keeps managed skill paths canonical when OS-home tilde reaches the same path", () => {
     const home = os.homedir();
     const stateDir = path.join(home, ".openclaw");
     const skillDir = path.join(stateDir, "skills", "home-managed-skill");
+    const skillFile = path.join(skillDir, "SKILL.md");
 
     const prompt = withEnv(
       {
@@ -128,8 +130,10 @@ describe("compactSkillPaths", () => {
         }),
     );
 
-    expect(prompt).toContain("<location>~/.openclaw/skills/home-managed-skill/SKILL.md</location>");
-    expect(prompt).not.toContain(`<location>${path.join(skillDir, "SKILL.md")}</location>`);
+    expect(prompt).toContain(`<location>${skillFile}</location>`);
+    expect(prompt).not.toContain(
+      "<location>~/.openclaw/skills/home-managed-skill/SKILL.md</location>",
+    );
   });
 
   it("normalizes compacted Windows skill locations to forward slashes", () => {
@@ -141,9 +145,10 @@ describe("compactSkillPaths", () => {
     expect(compactedPath).toBe("~/.openclaw-test-skills/win-skill/SKILL.md");
   });
 
-  it("preserves POSIX literal backslashes after home compaction", () => {
+  it("preserves POSIX literal backslashes in canonical skill locations", () => {
     const home = os.homedir();
     const skillDir = path.join(home, ".openclaw-test-skills\\literal-skill");
+    const skillFile = path.join(skillDir, "SKILL.md");
 
     const prompt = buildPromptForFixtureSkill({
       workspaceRoot: home,
@@ -156,7 +161,7 @@ describe("compactSkillPaths", () => {
     if (!locationMatch) {
       throw new Error("expected prompt location tag");
     }
-    expect(locationMatch[1]).toContain("~/");
+    expect(locationMatch[1]).toBe(skillFile);
     expect(locationMatch[1]).toContain("\\literal-skill");
   });
 

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -21,6 +21,47 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toBe("SNAPSHOT");
   });
+
+  it("rebuilds tilde snapshot locations from current entries", () => {
+    const entry: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt:
+          "<available_skills><skill><location>~/.openclaw/skills/demo-skill/SKILL.md</location></skill></available_skills>",
+        skills: [{ name: "demo-skill" }],
+      },
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("<available_skills>");
+    expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
+    expect(prompt).not.toContain("<location>~/");
+  });
+
+  it("fails closed for tilde snapshot locations when entries are unavailable", () => {
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt:
+          "<available_skills><skill><location>~/.openclaw/skills/demo-skill/SKILL.md</location></skill></available_skills>",
+        skills: [{ name: "demo-skill" }],
+      },
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toBe("");
+  });
+
   it("builds prompt from entries when snapshot is missing", () => {
     const entry: SkillEntry = {
       skill: createCanonicalFixtureSkill({

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -64,13 +64,11 @@ const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.
 const MAX_SKILL_SOURCE_ORIGIN_BYTES = 16 * 1024;
 
 /**
- * Replace OS home directory prefixes with `~` in skill file paths to
- * reduce system prompt token usage while matching host file-tool expansion.
+ * Replace OS home directory prefixes with `~` in display-only skill file paths
+ * while preserving executable prompt locations by default at the call site.
  *
  * Example: `/Users/alice/.bun/.../skills/github/SKILL.md`
- * → `~/.bun/.../skills/github/SKILL.md`
- *
- * Saves ~5–6 tokens per skill path × N skills ≈ 400–600 tokens total.
+ * -> `~/.bun/.../skills/github/SKILL.md`
  */
 function resolveUserHomeDir(): string | undefined {
   return resolveOsHomeDir(process.env, os.homedir);
@@ -95,7 +93,13 @@ function resolveCompactHomePrefixes(): string[] {
   return uniqueStrings([...resolvedHomes, ...realHomes]).toSorted((a, b) => b.length - a.length);
 }
 
-function compactSkillPaths(skills: Skill[]): Skill[] {
+function compactSkillPaths(
+  skills: Skill[],
+  opts?: { preserveExecutableLocations?: boolean },
+): Skill[] {
+  if (opts?.preserveExecutableLocations) {
+    return skills;
+  }
   const homes = resolveCompactHomePrefixes();
   if (homes.length === 0) {
     return skills;
@@ -1644,13 +1648,11 @@ function resolveWorkspaceSkillPromptState(
   const promptEntries = filterPromptVisibleSkillEntries(eligible);
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
-  // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.
-  // Budget checks and final render both use this same representation so the
-  // tier decision is based on the exact strings that end up in the prompt.
-  // resolvedSkills keeps canonical paths for snapshot / runtime consumers.
-  const promptSkills = compactSkillPaths(resolvedSkills).toSorted((a, b) =>
-    a.name.localeCompare(b.name, "en"),
-  );
+  // Prompt locations are executable read targets. Keep them canonical so a
+  // persisted prompt cannot rebind `~/...` to a different runtime home.
+  const promptSkills = compactSkillPaths(resolvedSkills, {
+    preserveExecutableLocations: true,
+  }).toSorted((a, b) => a.name.localeCompare(b.name, "en"));
   const prompt = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,
@@ -1670,6 +1672,18 @@ export function resolveSkillsPromptForRun(params: {
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (params.skillsSnapshot && !snapshotPrompt) {
+    return "";
+  }
+  if (snapshotPrompt?.includes("<location>~/")) {
+    if (params.entries && params.entries.length > 0) {
+      const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
+        entries: params.entries,
+        config: params.config,
+        agentId: params.agentId,
+        eligibility: params.eligibility,
+      });
+      return prompt.trim() ? prompt : "";
+    }
     return "";
   }
   const snapshotHasLegacySkillIdentity = params.skillsSnapshot?.skills.some(

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -285,4 +285,31 @@ describe("resolveReusableWorkspaceSkillSnapshot", () => {
     expect(result.shouldRefresh).toBe(true);
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
   });
+
+  it("refreshes snapshots from before canonical skill prompt locations", () => {
+    shouldRefreshSnapshotForVersionMock.mockReturnValue(false);
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt:
+        "<available_skills><skill><location>/Users/alice/.openclaw/skills/demo/SKILL.md</location></skill></available_skills>",
+      skills: [{ name: "demo" }],
+      resolvedSkills: [],
+    });
+
+    const result = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: TEST_WORKSPACE_DIR,
+      config: {},
+      existingSnapshot: {
+        ...strippedSnapshot("demo"),
+        prompt:
+          "<available_skills><skill><location>~/.openclaw/skills/demo/SKILL.md</location></skill></available_skills>",
+      },
+    });
+
+    expect(result.shouldRefresh).toBe(true);
+    expect(result.snapshot.prompt).toContain(
+      "<location>/Users/alice/.openclaw/skills/demo/SKILL.md",
+    );
+    expect(result.snapshot.prompt).not.toContain("<location>~/");
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -63,6 +63,8 @@ export function resolveReusableWorkspaceSkillSnapshot(
   const snapshotVersion = params.snapshotVersion ?? getSkillsSnapshotVersion(params.workspaceDir);
   const promptFormatChanged =
     params.existingSnapshot?.promptFormatVersion !== WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION;
+  const promptHasTildeSkillLocation =
+    params.existingSnapshot?.prompt?.includes("<location>~/") === true;
   const skillVersionChanged = shouldRefreshSnapshotForVersion(
     params.existingSnapshot?.version,
     snapshotVersion,
@@ -75,6 +77,7 @@ export function resolveReusableWorkspaceSkillSnapshot(
     stableStringify(params.skillOverrides);
   const shouldRefresh =
     promptFormatChanged ||
+    promptHasTildeSkillLocation ||
     skillVersionChanged ||
     nodeSkillsEligibilityChanged ||
     !matchesSkillFilter(params.existingSnapshot?.skillFilter, params.skillFilter) ||


### PR DESCRIPTION
## Summary

This fixes skill prompt locations so executable `<location>` values stay canonical absolute paths instead of being compacted to `~/...`.

Root cause: workspace skill prompt rendering compacted prompt-facing skill file paths under the process home directory to `~`. The system prompt tells the model to read the exact `<location>`, and the read tool expands `~` against the runtime `os.homedir()`. When prompt generation, sandbox/container execution, or a persisted snapshot used a different home binding, the same prompt could resolve to the wrong home directory and skill reads could fail or read the wrong path.

## Changes

- Removed home-directory compaction from prompt-facing skill locations.
- Kept canonical `resolvedSkills` and prompt `<location>` values aligned.
- Made `resolveSkillsPromptForRun` reject stale prompt formats: it rebuilds from current entries when possible and otherwise fails closed instead of reusing old prompt text.
- Bumped `WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION` from 3 to 4 so persisted snapshots with `~/...` locations refresh.
- Updated regression tests for canonical home-managed skill paths and stale snapshot handling.

## Validation

Passed:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/skills/loading/prompt-resolution.test.ts src/skills/runtime/session-snapshot.test.ts src/skills/loading/compact-skill-paths.test.ts src/skills/loading/compact-format.test.ts src/skills/loading/workspace-snapshot.test.ts src/agents/embedded-agent-runner/sandbox-skills.test.ts src/agents/agent-tools.read.host-tilde-expansion.test.ts src/auto-reply/reply/commands-system-prompt.test.ts src/agents/code-mode.skills.test.ts`
- Repeated 5x: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/skills/loading/prompt-resolution.test.ts src/skills/runtime/session-snapshot.test.ts src/skills/loading/compact-skill-paths.test.ts src/skills/loading/compact-format.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/skills/runtime/embedded-run-entries.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm exec oxlint src/skills/loading/workspace.ts src/skills/loading/prompt-resolution.test.ts src/skills/runtime/session-snapshot.test.ts src/skills/loading/compact-skill-paths.test.ts src/skills/loading/compact-format.test.ts src/skills/types.ts`
- `git diff --check`
- A local `node --import tsx` repro that verifies a home-managed skill prompt contains the canonical path and a stale `~/...` snapshot rebuilds without `<location>~/`.

Known local validation issue, not introduced by this patch:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/skills/loading` still fails 20 plugin-skill tests around `resolvePluginSkillDirs` / `publishPluginSkills` / Claude bundle command discovery. The same plugin-focused files pass when run individually; the failure is isolated to plugin skill directory state in the whole-directory run and does not exercise the prompt location change.
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.json` OOMs locally even with an 8GB Node heap, so validation used the repo `tsgo` core and core-test checks instead.
