### PR TITLE
refactor(ui): consolidate Cron form control rendering

### DIFF
--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -602,19 +602,38 @@ describe("cron view editor", () => {
     expect(onClosePanel).toHaveBeenCalledTimes(1);
   });
 
-  it("wires form changes from prompt and name inputs", () => {
+  it("wires shared text and select controls without changing their field ownership", () => {
     const onFormChange = vi.fn();
-    const container = renderView({ createOpen: true, onFormChange });
+    const container = renderView({
+      createOpen: true,
+      channels: ["telegram"],
+      channelMeta: [{ id: "telegram", label: "", detailLabel: "Telegram" }],
+      channelLabels: { telegram: "Telegram fallback" },
+      form: { ...DEFAULT_CRON_FORM, scheduleKind: "cron", failureAlertMode: "custom" },
+      onFormChange,
+    });
 
     const prompt = getElement(container, "#cron-payload-text", HTMLTextAreaElement);
     prompt.value = "do the thing";
     prompt.dispatchEvent(new Event("input", { bubbles: true }));
     expect(onFormChange).toHaveBeenCalledWith({ payloadText: "do the thing" });
 
-    const name = getElement(container, "#cron-name", HTMLInputElement);
-    name.value = "Thing";
-    name.dispatchEvent(new Event("input", { bubbles: true }));
-    expect(onFormChange).toHaveBeenCalledWith({ name: "Thing" });
+    for (const field of ["name", "sessionKey", "deliveryAccountId", "payloadModel"] as const) {
+      const id = `cron-${field.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`;
+      const input = getElement(container, `#${id}`, HTMLInputElement);
+      if (field === "sessionKey" || field === "deliveryAccountId") {
+        expect(input.placeholder).toBe(field === "sessionKey" ? "agent:main:main" : "default");
+      }
+      input.value = field;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      expect(onFormChange).toHaveBeenLastCalledWith({ [field]: field });
+    }
+
+    const channel = getElement(container, "#cron-failure-alert-channel", HTMLSelectElement);
+    channel.value = "telegram";
+    expect(channel.selectedOptions[0]?.textContent).toBe("Telegram fallback");
+    channel.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onFormChange).toHaveBeenLastCalledWith({ failureAlertChannel: "telegram" });
   });
 
   it("switches schedule inputs by segmented kind and wires kind changes", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -133,40 +133,24 @@ type CronProps = {
 // ── Shared option helpers ──
 
 function buildChannelOptions(props: CronProps): string[] {
-  const options = ["last", ...props.channels.filter(Boolean)];
   const current = props.form.deliveryChannel?.trim();
-  if (current && !options.includes(current)) {
-    options.push(current);
-  }
-  const seen = new Set<string>();
-  return options.filter((value) => {
-    if (seen.has(value)) {
-      return false;
-    }
-    seen.add(value);
-    return true;
-  });
+  return uniqueStrings(["last", ...props.channels.filter(Boolean), ...(current ? [current] : [])]);
 }
 
 function resolveChannelLabel(props: CronProps, channel: string): string {
-  if (channel === "last") {
-    return "last";
-  }
-  const meta = props.channelMeta?.find((entry) => entry.id === channel);
-  if (meta?.label) {
-    return meta.label;
-  }
-  return props.channelLabels?.[channel] ?? channel;
+  return channel === "last"
+    ? channel
+    : props.channelMeta?.find((entry) => entry.id === channel)?.label ||
+        (props.channelLabels?.[channel] ?? channel);
 }
 
 function renderSuggestionList(id: string, options: string[]) {
   const clean = uniqueStrings(normalizeStringEntries(options));
-  if (clean.length === 0) {
-    return nothing;
-  }
-  return html`<datalist id=${id}>
-    ${clean.map((value) => html`<option value=${value}></option> `)}
-  </datalist>`;
+  return clean.length === 0
+    ? nothing
+    : html`<datalist id=${id}>
+        ${clean.map((value) => html`<option value=${value}></option> `)}
+      </datalist>`;
 }
 
 // ── Validation summary helpers ──
@@ -178,45 +162,27 @@ type BlockingField = {
   inputId: string;
 };
 
+const CRON_FIELD_LABEL_KEYS: Record<CronFieldKey, string> = {
+  name: "cron.form.fieldName",
+  scheduleAt: "cron.form.runAt",
+  everyAmount: "cron.form.every",
+  cronExpr: "cron.form.expression",
+  staggerAmount: "cron.form.staggerWindow",
+  payloadText: "cron.form.assistantTaskPrompt",
+  payloadModel: "cron.form.model",
+  payloadThinking: "cron.form.thinking",
+  timeoutSeconds: "cron.form.timeoutSeconds",
+  deliveryTo: "cron.form.to",
+  failureAlertAfter: "cron.form.failureAlertAfter",
+  failureAlertCooldownSeconds: "cron.form.failureAlertCooldown",
+};
+
 function errorIdForField(key: CronFieldKey) {
   return `cron-error-${key}`;
 }
 
-function inputIdForField(key: CronFieldKey) {
-  if (key === "name") {
-    return "cron-name";
-  }
-  if (key === "scheduleAt") {
-    return "cron-schedule-at";
-  }
-  if (key === "everyAmount") {
-    return "cron-every-amount";
-  }
-  if (key === "cronExpr") {
-    return "cron-cron-expr";
-  }
-  if (key === "staggerAmount") {
-    return "cron-stagger-amount";
-  }
-  if (key === "payloadText") {
-    return "cron-payload-text";
-  }
-  if (key === "payloadModel") {
-    return "cron-payload-model";
-  }
-  if (key === "payloadThinking") {
-    return "cron-payload-thinking";
-  }
-  if (key === "timeoutSeconds") {
-    return "cron-timeout-seconds";
-  }
-  if (key === "failureAlertAfter") {
-    return "cron-failure-alert-after";
-  }
-  if (key === "failureAlertCooldownSeconds") {
-    return "cron-failure-alert-cooldown-seconds";
-  }
-  return "cron-delivery-to";
+function inputIdForField(key: string) {
+  return `cron-${key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`;
 }
 
 function fieldLabelForKey(
@@ -224,29 +190,13 @@ function fieldLabelForKey(
   form: CronFormState,
   deliveryMode: CronFormState["deliveryMode"],
 ) {
-  if (key === "payloadText") {
-    return form.payloadKind === "systemEvent"
-      ? t("cron.form.mainTimelineMessage")
-      : t("cron.form.assistantTaskPrompt");
+  if (key === "payloadText" && form.payloadKind === "systemEvent") {
+    return t("cron.form.mainTimelineMessage");
   }
-  if (key === "deliveryTo") {
-    return deliveryMode === "webhook" ? t("cron.form.webhookUrl") : t("cron.form.to");
+  if (key === "deliveryTo" && deliveryMode === "webhook") {
+    return t("cron.form.webhookUrl");
   }
-  const labels: Record<CronFieldKey, string> = {
-    name: t("cron.form.fieldName"),
-    scheduleAt: t("cron.form.runAt"),
-    everyAmount: t("cron.form.every"),
-    cronExpr: t("cron.form.expression"),
-    staggerAmount: t("cron.form.staggerWindow"),
-    payloadText: t("cron.form.assistantTaskPrompt"),
-    payloadModel: t("cron.form.model"),
-    payloadThinking: t("cron.form.thinking"),
-    timeoutSeconds: t("cron.form.timeoutSeconds"),
-    deliveryTo: t("cron.form.to"),
-    failureAlertAfter: t("cron.form.failureAlertAfter"),
-    failureAlertCooldownSeconds: t("cron.form.failureAlertCooldown"),
-  };
-  return labels[key];
+  return t(CRON_FIELD_LABEL_KEYS[key]);
 }
 
 function collectBlockingFields(
@@ -254,34 +204,19 @@ function collectBlockingFields(
   form: CronFormState,
   deliveryMode: CronFormState["deliveryMode"],
 ): BlockingField[] {
-  const orderedKeys: CronFieldKey[] = [
-    "name",
-    "scheduleAt",
-    "everyAmount",
-    "cronExpr",
-    "staggerAmount",
-    "payloadText",
-    "payloadModel",
-    "payloadThinking",
-    "timeoutSeconds",
-    "deliveryTo",
-    "failureAlertAfter",
-    "failureAlertCooldownSeconds",
-  ];
-  const fields: BlockingField[] = [];
-  for (const key of orderedKeys) {
+  return (Object.keys(CRON_FIELD_LABEL_KEYS) as CronFieldKey[]).flatMap((key) => {
     const message = errors[key];
-    if (!message) {
-      continue;
-    }
-    fields.push({
-      key,
-      label: fieldLabelForKey(key, form, deliveryMode),
-      message,
-      inputId: inputIdForField(key),
-    });
-  }
-  return fields;
+    return message
+      ? [
+          {
+            key,
+            label: fieldLabelForKey(key, form, deliveryMode),
+            message,
+            inputId: inputIdForField(key),
+          },
+        ]
+      : [];
+  });
 }
 
 function focusFormField(id: string) {
@@ -347,19 +282,122 @@ function renderFieldRow(params: {
   `;
 }
 
-function renderToggleRow(params: {
+type CronStringFormField = {
+  [Field in keyof CronFormState]: CronFormState[Field] extends string ? Field : never;
+}[keyof CronFormState];
+
+type CronBooleanFormField = {
+  [Field in keyof CronFormState]: CronFormState[Field] extends boolean ? Field : never;
+}[keyof CronFormState];
+
+type CronInputOptions = {
   label: string;
-  checked: boolean;
   help?: string;
+  placeholder?: string;
+  list?: string;
+  type?: string;
+  required?: boolean;
   disabled?: boolean;
-  onChange: (checked: boolean) => void;
-}) {
+  mono?: boolean;
+  errorKey?: CronFieldKey;
+  describeError?: boolean;
+};
+
+function renderCronInput(props: CronProps, field: CronStringFormField, options: CronInputOptions) {
+  const error = options.errorKey ? props.fieldErrors[options.errorKey] : undefined;
+  const describedBy =
+    error && options.errorKey && options.describeError !== false
+      ? errorIdForField(options.errorKey)
+      : undefined;
+  return html`
+    <input
+      id=${inputIdForField(field)}
+      class=${options.mono ? "settings-input mono" : "settings-input"}
+      type=${ifDefined(options.type)}
+      aria-required=${ifDefined(options.required ? "true" : undefined)}
+      .value=${props.form[field]}
+      list=${ifDefined(options.list)}
+      ?disabled=${options.disabled ?? false}
+      aria-invalid=${ifDefined(options.errorKey ? (error ? "true" : "false") : undefined)}
+      aria-describedby=${ifDefined(describedBy)}
+      placeholder=${ifDefined(options.placeholder)}
+      @input=${(event: Event) =>
+        props.onFormChange({ [field]: (event.currentTarget as HTMLInputElement).value })}
+    />
+  `;
+}
+
+function renderCronInputField(
+  props: CronProps,
+  field: CronStringFormField,
+  options: CronInputOptions,
+) {
+  const errorKey = options.errorKey;
+  return renderFieldRow({
+    label: options.label,
+    controlId: inputIdForField(field),
+    required: options.required,
+    help: options.help,
+    error: errorKey ? props.fieldErrors[errorKey] : undefined,
+    errorId: errorKey ? errorIdForField(errorKey) : undefined,
+    control: renderCronInput(props, field, options),
+  });
+}
+
+type CronSelectOption = { value: string; label: string };
+
+type CronSelectOptions = {
+  label: string;
+  options: readonly CronSelectOption[];
+  help?: string;
+  value?: string;
+  disabled?: boolean;
+  standalone?: boolean;
+};
+
+function renderCronSelect(
+  props: CronProps,
+  field: CronStringFormField,
+  options: CronSelectOptions,
+) {
+  return html`
+    <select
+      id=${ifDefined(options.standalone ? undefined : inputIdForField(field))}
+      class="settings-select"
+      .value=${options.value ?? props.form[field]}
+      aria-label=${ifDefined(options.standalone ? options.label : undefined)}
+      ?disabled=${options.disabled ?? false}
+      @change=${(event: Event) =>
+        props.onFormChange({ [field]: (event.currentTarget as HTMLSelectElement).value })}
+    >
+      ${options.options.map(({ value, label }) => html`<option value=${value}>${label}</option>`)}
+    </select>
+  `;
+}
+
+function renderCronSelectField(
+  props: CronProps,
+  field: CronStringFormField,
+  options: CronSelectOptions,
+) {
+  return renderFieldRow({
+    label: options.label,
+    controlId: inputIdForField(field),
+    help: options.help,
+    control: renderCronSelect(props, field, options),
+  });
+}
+
+function renderToggleRow(
+  props: CronProps,
+  field: CronBooleanFormField,
+  params: { label: string; help?: string },
+) {
   return renderSettingsToggleRow({
     title: params.label,
     description: params.help,
-    checked: params.checked,
-    disabled: params.disabled,
-    onChange: params.onChange,
+    checked: props.form[field],
+    onChange: (checked) => props.onFormChange({ [field]: checked }),
   });
 }
 
@@ -517,6 +555,32 @@ function renderToolbar(props: CronProps, hasAdvancedJobsFilters: boolean) {
   `;
 }
 
+function renderJobsFilter(
+  props: CronProps,
+  field: keyof Parameters<CronProps["onJobsFiltersChange"]>[0],
+  params: {
+    label: string;
+    value: string;
+    options: readonly CronSelectOption[];
+    testId?: string;
+  },
+) {
+  return html`
+    <label class="field">
+      <span>${params.label}</span>
+      <select
+        class="settings-select"
+        data-test-id=${ifDefined(params.testId)}
+        .value=${params.value}
+        @change=${(event: Event) =>
+          props.onJobsFiltersChange({ [field]: (event.currentTarget as HTMLSelectElement).value })}
+      >
+        ${params.options.map(({ value, label }) => html`<option value=${value}>${label}</option>`)}
+      </select>
+    </label>
+  `;
+}
+
 function renderJobsFilterPopover(props: CronProps, active: boolean) {
   return html`
     <button
@@ -549,72 +613,46 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
       }}
     >
       <div class="cron-filter-popover__panel">
-        <label class="field">
-          <span>${t("cron.jobs.schedule")}</span>
-          <select
-            class="settings-select"
-            data-test-id="cron-jobs-schedule-filter"
-            .value=${props.jobsScheduleKindFilter}
-            @change=${(e: Event) =>
-              props.onJobsFiltersChange({
-                cronJobsScheduleKindFilter: (e.target as HTMLSelectElement)
-                  .value as CronJobsScheduleKindFilter,
-              })}
-          >
-            <option value="all">${t("cron.jobs.all")}</option>
-            <option value="at">${t("cron.form.at")}</option>
-            <option value="every">${t("cron.form.every")}</option>
-            <option value="cron">${t("cron.form.cronOption")}</option>
-          </select>
-        </label>
-        <label class="field">
-          <span>${t("cron.jobs.lastRun")}</span>
-          <select
-            class="settings-select"
-            data-test-id="cron-jobs-last-status-filter"
-            .value=${props.jobsLastStatusFilter}
-            @change=${(e: Event) =>
-              props.onJobsFiltersChange({
-                cronJobsLastStatusFilter: (e.target as HTMLSelectElement)
-                  .value as CronJobsLastStatusFilter,
-              })}
-          >
-            <option value="all">${t("cron.jobs.all")}</option>
-            <option value="ok">${t("cron.runs.runStatusOk")}</option>
-            <option value="error">${t("cron.runs.runStatusError")}</option>
-            <option value="skipped">${t("cron.runs.runStatusSkipped")}</option>
-            <option value="unknown">${t("cron.runs.runStatusUnknown")}</option>
-          </select>
-        </label>
-        <label class="field">
-          <span>${t("cron.jobs.sort")}</span>
-          <select
-            class="settings-select"
-            .value=${props.jobsSortBy}
-            @change=${(e: Event) =>
-              props.onJobsFiltersChange({
-                cronJobsSortBy: (e.target as HTMLSelectElement).value as CronJobsSortBy,
-              })}
-          >
-            <option value="nextRunAtMs">${t("cron.jobs.nextRun")}</option>
-            <option value="updatedAtMs">${t("cron.jobs.recentlyUpdated")}</option>
-            <option value="name">${t("cron.jobs.name")}</option>
-          </select>
-        </label>
-        <label class="field">
-          <span>${t("cron.jobs.direction")}</span>
-          <select
-            class="settings-select"
-            .value=${props.jobsSortDir}
-            @change=${(e: Event) =>
-              props.onJobsFiltersChange({
-                cronJobsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
-              })}
-          >
-            <option value="asc">${t("cron.jobs.ascending")}</option>
-            <option value="desc">${t("cron.jobs.descending")}</option>
-          </select>
-        </label>
+        ${renderJobsFilter(props, "cronJobsScheduleKindFilter", {
+          label: t("cron.jobs.schedule"),
+          value: props.jobsScheduleKindFilter,
+          testId: "cron-jobs-schedule-filter",
+          options: [
+            { value: "all", label: t("cron.jobs.all") },
+            { value: "at", label: t("cron.form.at") },
+            { value: "every", label: t("cron.form.every") },
+            { value: "cron", label: t("cron.form.cronOption") },
+          ],
+        })}
+        ${renderJobsFilter(props, "cronJobsLastStatusFilter", {
+          label: t("cron.jobs.lastRun"),
+          value: props.jobsLastStatusFilter,
+          testId: "cron-jobs-last-status-filter",
+          options: [
+            { value: "all", label: t("cron.jobs.all") },
+            { value: "ok", label: t("cron.runs.runStatusOk") },
+            { value: "error", label: t("cron.runs.runStatusError") },
+            { value: "skipped", label: t("cron.runs.runStatusSkipped") },
+            { value: "unknown", label: t("cron.runs.runStatusUnknown") },
+          ],
+        })}
+        ${renderJobsFilter(props, "cronJobsSortBy", {
+          label: t("cron.jobs.sort"),
+          value: props.jobsSortBy,
+          options: [
+            { value: "nextRunAtMs", label: t("cron.jobs.nextRun") },
+            { value: "updatedAtMs", label: t("cron.jobs.recentlyUpdated") },
+            { value: "name", label: t("cron.jobs.name") },
+          ],
+        })}
+        ${renderJobsFilter(props, "cronJobsSortDir", {
+          label: t("cron.jobs.direction"),
+          value: props.jobsSortDir,
+          options: [
+            { value: "asc", label: t("cron.jobs.ascending") },
+            { value: "desc", label: t("cron.jobs.descending") },
+          ],
+        })}
         <button
           class="btn btn--sm"
           data-test-id="cron-jobs-filters-reset"
@@ -1152,72 +1190,44 @@ function renderPromptSection(
           ></textarea>
         `,
   });
-  const actionRow = renderFieldRow({
-    label: t("cron.form.action"),
-    controlId: "cron-payload-kind",
-    control: ctx.payloadLocked
-      ? html`
+  const actionLabel = t("cron.form.action");
+  const actionRow = ctx.payloadLocked
+    ? renderFieldRow({
+        label: actionLabel,
+        controlId: inputIdForField("payloadKind"),
+        control: html`
           <input
-            id="cron-payload-kind"
+            id=${inputIdForField("payloadKind")}
             class="settings-input"
             .value=${lockedPayloadLabel}
             readonly
           />
-        `
-      : html`
-          <select
-            id="cron-payload-kind"
-            class="settings-select"
-            .value=${props.form.payloadKind}
-            @change=${(e: Event) =>
-              props.onFormChange({
-                payloadKind: (e.target as HTMLSelectElement).value as CronFormState["payloadKind"],
-              })}
-          >
-            <option value="systemEvent">${t("cron.form.systemEvent")}</option>
-            <option value="agentTurn">${t("cron.form.agentTurn")}</option>
-          </select>
         `,
-  });
+      })
+    : renderCronSelectField(props, "payloadKind", {
+        label: actionLabel,
+        options: [
+          { value: "systemEvent", label: t("cron.form.systemEvent") },
+          { value: "agentTurn", label: t("cron.form.agentTurn") },
+        ],
+      });
   const agentTurnRows = ctx.isAgentTurn
     ? html`
-        ${renderFieldRow({
+        ${renderCronInputField(props, "payloadModel", {
           label: t("cron.form.model"),
-          controlId: "cron-payload-model",
           help: t("cron.form.modelHelp"),
-          error: props.fieldErrors.payloadModel,
-          errorId: errorIdForField("payloadModel"),
-          control: html`
-            <input
-              id="cron-payload-model"
-              class="settings-input"
-              .value=${props.form.payloadModel}
-              list="cron-model-suggestions"
-              placeholder=${t("cron.form.modelPlaceholder")}
-              aria-invalid=${props.fieldErrors.payloadModel ? "true" : "false"}
-              @input=${(e: Event) =>
-                props.onFormChange({ payloadModel: (e.target as HTMLInputElement).value })}
-            />
-          `,
+          errorKey: "payloadModel",
+          describeError: false,
+          list: "cron-model-suggestions",
+          placeholder: t("cron.form.modelPlaceholder"),
         })}
-        ${renderFieldRow({
+        ${renderCronInputField(props, "payloadThinking", {
           label: t("cron.form.thinking"),
-          controlId: "cron-payload-thinking",
           help: t("cron.form.thinkingHelp"),
-          error: props.fieldErrors.payloadThinking,
-          errorId: errorIdForField("payloadThinking"),
-          control: html`
-            <input
-              id="cron-payload-thinking"
-              class="settings-input"
-              .value=${props.form.payloadThinking}
-              list="cron-thinking-suggestions"
-              placeholder=${t("cron.form.thinkingPlaceholder")}
-              aria-invalid=${props.fieldErrors.payloadThinking ? "true" : "false"}
-              @input=${(e: Event) =>
-                props.onFormChange({ payloadThinking: (e.target as HTMLInputElement).value })}
-            />
-          `,
+          errorKey: "payloadThinking",
+          describeError: false,
+          list: "cron-thinking-suggestions",
+          placeholder: t("cron.form.thinkingPlaceholder"),
         })}
       `
     : nothing;
@@ -1230,67 +1240,27 @@ function renderGeneralSection(props: CronProps) {
   return renderSettingsSection(
     { title: t("cron.detail.generalSection") },
     html`
-      ${renderFieldRow({
+      ${renderCronInputField(props, "name", {
         label: t("cron.form.fieldName"),
-        controlId: "cron-name",
         required: true,
-        error: props.fieldErrors.name,
-        errorId: errorIdForField("name"),
-        control: html`
-          <input
-            id="cron-name"
-            class="settings-input"
-            aria-required="true"
-            .value=${props.form.name}
-            placeholder=${t("cron.form.namePlaceholder")}
-            aria-invalid=${props.fieldErrors.name ? "true" : "false"}
-            aria-describedby=${ifDefined(
-              props.fieldErrors.name ? errorIdForField("name") : undefined,
-            )}
-            @input=${(e: Event) =>
-              props.onFormChange({ name: (e.target as HTMLInputElement).value })}
-          />
-        `,
+        errorKey: "name",
+        placeholder: t("cron.form.namePlaceholder"),
       })}
-      ${renderFieldRow({
+      ${renderCronInputField(props, "agentId", {
         label: t("cron.form.agentId"),
-        controlId: "cron-agent-id",
         help: t("cron.form.agentHelp"),
-        control: html`
-          <input
-            id="cron-agent-id"
-            class="settings-input"
-            .value=${props.form.agentId}
-            list="cron-agent-suggestions"
-            ?disabled=${props.form.clearAgent}
-            placeholder=${t("cron.form.agentPlaceholder")}
-            @input=${(e: Event) =>
-              props.onFormChange({ agentId: (e.target as HTMLInputElement).value })}
-          />
-        `,
+        list: "cron-agent-suggestions",
+        disabled: props.form.clearAgent,
+        placeholder: t("cron.form.agentPlaceholder"),
       })}
-      ${renderFieldRow({
+      ${renderCronSelectField(props, "sessionTarget", {
         label: t("cron.form.runsIn"),
-        controlId: "cron-session-target",
         help: t("cron.form.sessionHelp"),
-        control: html`
-          <select
-            id="cron-session-target"
-            class="settings-select"
-            .value=${sessionTarget}
-            @change=${(e: Event) =>
-              props.onFormChange({
-                sessionTarget: (e.target as HTMLSelectElement)
-                  .value as CronFormState["sessionTarget"],
-              })}
-          >
-            <option value="main">${t("cron.form.mainSession")}</option>
-            <option value="isolated">${t("cron.form.isolatedSession")}</option>
-            ${knownSessionTarget
-              ? nothing
-              : html`<option value=${sessionTarget}>${sessionTarget}</option>`}
-          </select>
-        `,
+        options: [
+          { value: "main", label: t("cron.form.mainSession") },
+          { value: "isolated", label: t("cron.form.isolatedSession") },
+          ...(knownSessionTarget ? [] : [{ value: sessionTarget, label: sessionTarget }]),
+        ],
       })}
     `,
   );
@@ -1348,24 +1318,14 @@ function renderScheduleSection(props: CronProps) {
   const isStream = form.scheduleKind === "stream";
   // Process-backed schedules stay selectable only while current: jobs can
   // convert to an editable schedule, but never synthesize a command in the UI.
+  const processSchedule = isOnExit
+    ? { value: "on-exit" as const, label: t("cron.form.repeatOnExit") }
+    : isStream
+      ? { value: "stream" as const, label: t("cron.form.repeatStream") }
+      : null;
   const kinds: Array<{ value: CronFormState["scheduleKind"]; label: string; testId: string }> = [
-    ...(isOnExit
-      ? [
-          {
-            value: "on-exit" as const,
-            label: t("cron.form.repeatOnExit"),
-            testId: "cron-schedule-kind-on-exit",
-          },
-        ]
-      : []),
-    ...(isStream
-      ? [
-          {
-            value: "stream" as const,
-            label: t("cron.form.repeatStream"),
-            testId: "cron-schedule-kind-stream",
-          },
-        ]
+    ...(processSchedule
+      ? [{ ...processSchedule, testId: `cron-schedule-kind-${processSchedule.value}` }]
       : []),
     { value: "every", label: t("cron.form.repeatInterval"), testId: "cron-schedule-kind-every" },
     { value: "at", label: t("cron.form.repeatOnce"), testId: "cron-schedule-kind-at" },
@@ -1395,27 +1355,11 @@ function renderScheduleSection(props: CronProps) {
         }),
       })}
       ${form.scheduleKind === "at"
-        ? renderFieldRow({
+        ? renderCronInputField(props, "scheduleAt", {
             label: t("cron.form.runAt"),
-            controlId: "cron-schedule-at",
             required: true,
-            error: props.fieldErrors.scheduleAt,
-            errorId: errorIdForField("scheduleAt"),
-            control: html`
-              <input
-                id="cron-schedule-at"
-                class="settings-input"
-                type="datetime-local"
-                aria-required="true"
-                .value=${form.scheduleAt}
-                aria-invalid=${props.fieldErrors.scheduleAt ? "true" : "false"}
-                aria-describedby=${ifDefined(
-                  props.fieldErrors.scheduleAt ? errorIdForField("scheduleAt") : undefined,
-                )}
-                @input=${(e: Event) =>
-                  props.onFormChange({ scheduleAt: (e.target as HTMLInputElement).value })}
-              />
-            `,
+            errorKey: "scheduleAt",
+            type: "datetime-local",
           })
         : nothing}
       ${form.scheduleKind === "every"
@@ -1427,77 +1371,40 @@ function renderScheduleSection(props: CronProps) {
             errorId: errorIdForField("everyAmount"),
             control: html`
               <div class="cron-inline-controls">
-                <input
-                  id="cron-every-amount"
-                  class="settings-input"
-                  aria-required="true"
-                  .value=${form.everyAmount}
-                  aria-invalid=${props.fieldErrors.everyAmount ? "true" : "false"}
-                  aria-describedby=${ifDefined(
-                    props.fieldErrors.everyAmount ? errorIdForField("everyAmount") : undefined,
-                  )}
-                  placeholder=${t("cron.form.everyAmountPlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ everyAmount: (e.target as HTMLInputElement).value })}
-                />
-                <select
-                  class="settings-select"
-                  .value=${form.everyUnit}
-                  aria-label=${t("cron.form.unit")}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      everyUnit: (e.target as HTMLSelectElement)
-                        .value as CronFormState["everyUnit"],
-                    })}
-                >
-                  <option value="seconds">${t("cron.form.seconds")}</option>
-                  <option value="minutes">${t("cron.form.minutes")}</option>
-                  <option value="hours">${t("cron.form.hours")}</option>
-                  <option value="days">${t("cron.form.days")}</option>
-                </select>
+                ${renderCronInput(props, "everyAmount", {
+                  label: t("cron.form.every"),
+                  required: true,
+                  errorKey: "everyAmount",
+                  placeholder: t("cron.form.everyAmountPlaceholder"),
+                })}
+                ${renderCronSelect(props, "everyUnit", {
+                  label: t("cron.form.unit"),
+                  standalone: true,
+                  options: [
+                    { value: "seconds", label: t("cron.form.seconds") },
+                    { value: "minutes", label: t("cron.form.minutes") },
+                    { value: "hours", label: t("cron.form.hours") },
+                    { value: "days", label: t("cron.form.days") },
+                  ],
+                })}
               </div>
             `,
           })
         : nothing}
       ${form.scheduleKind === "cron"
         ? html`
-            ${renderFieldRow({
+            ${renderCronInputField(props, "cronExpr", {
               label: t("cron.form.expression"),
-              controlId: "cron-cron-expr",
               required: true,
-              error: props.fieldErrors.cronExpr,
-              errorId: errorIdForField("cronExpr"),
-              control: html`
-                <input
-                  id="cron-cron-expr"
-                  class="settings-input mono"
-                  aria-required="true"
-                  .value=${form.cronExpr}
-                  aria-invalid=${props.fieldErrors.cronExpr ? "true" : "false"}
-                  aria-describedby=${ifDefined(
-                    props.fieldErrors.cronExpr ? errorIdForField("cronExpr") : undefined,
-                  )}
-                  placeholder=${t("cron.form.expressionPlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ cronExpr: (e.target as HTMLInputElement).value })}
-                />
-              `,
+              errorKey: "cronExpr",
+              mono: true,
+              placeholder: t("cron.form.expressionPlaceholder"),
             })}
-            ${renderFieldRow({
+            ${renderCronInputField(props, "cronTz", {
               label: t("cron.form.timezoneOptional"),
-              controlId: "cron-cron-tz",
               help: t("cron.form.timezoneHelp"),
-              control: html`
-                <input
-                  id="cron-cron-tz"
-                  class="settings-input"
-                  .value=${form.cronTz}
-                  list="cron-tz-suggestions"
-                  placeholder=${t("cron.form.timezonePlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ cronTz: (e.target as HTMLInputElement).value })}
-                />
-              `,
+              list: "cron-tz-suggestions",
+              placeholder: t("cron.form.timezonePlaceholder"),
             })}
           `
         : nothing}
@@ -1519,94 +1426,45 @@ function renderDeliverySection(
   return renderSettingsSection(
     { title: t("cron.detail.deliverySection") },
     html`
-      ${renderFieldRow({
+      ${renderCronSelectField(props, "deliveryMode", {
         label: t("cron.form.deliveryModeLabel"),
-        controlId: "cron-delivery-mode",
         help: t("cron.form.deliveryHelp"),
-        control: html`
-          <select
-            id="cron-delivery-mode"
-            class="settings-select"
-            .value=${ctx.selectedDeliveryMode}
-            @change=${(e: Event) =>
-              props.onFormChange({
-                deliveryMode: (e.target as HTMLSelectElement)
-                  .value as CronFormState["deliveryMode"],
-              })}
-          >
-            ${ctx.supportsAnnounce
-              ? html`<option value="announce">${t("cron.form.announceDefault")}</option>`
-              : nothing}
-            <option value="webhook">${t("cron.form.webhookPost")}</option>
-            <option value="none">${t("cron.form.noneInternal")}</option>
-          </select>
-        `,
+        value: ctx.selectedDeliveryMode,
+        options: [
+          ...(ctx.supportsAnnounce
+            ? [{ value: "announce", label: t("cron.form.announceDefault") }]
+            : []),
+          { value: "webhook", label: t("cron.form.webhookPost") },
+          { value: "none", label: t("cron.form.noneInternal") },
+        ],
       })}
       ${ctx.selectedDeliveryMode === "announce"
         ? html`
-            ${renderFieldRow({
+            ${renderCronSelectField(props, "deliveryChannel", {
               label: t("cron.form.channel"),
-              controlId: "cron-delivery-channel",
               help: t("cron.form.channelHelp"),
-              control: html`
-                <select
-                  id="cron-delivery-channel"
-                  class="settings-select"
-                  .value=${props.form.deliveryChannel || "last"}
-                  @change=${(e: Event) =>
-                    props.onFormChange({ deliveryChannel: (e.target as HTMLSelectElement).value })}
-                >
-                  ${channelOptions.map(
-                    (channel) =>
-                      html`<option value=${channel}>
-                        ${resolveChannelLabel(props, channel)}
-                      </option>`,
-                  )}
-                </select>
-              `,
+              value: props.form.deliveryChannel || "last",
+              options: channelOptions.map((channel) => ({
+                value: channel,
+                label: resolveChannelLabel(props, channel),
+              })),
             })}
-            ${renderFieldRow({
+            ${renderCronInputField(props, "deliveryTo", {
               label: t("cron.form.to"),
-              controlId: "cron-delivery-to",
               help: t("cron.form.toHelp"),
-              control: html`
-                <input
-                  id="cron-delivery-to"
-                  class="settings-input"
-                  .value=${props.form.deliveryTo}
-                  list="cron-delivery-to-suggestions"
-                  placeholder=${t("cron.form.toPlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ deliveryTo: (e.target as HTMLInputElement).value })}
-                />
-              `,
+              list: "cron-delivery-to-suggestions",
+              placeholder: t("cron.form.toPlaceholder"),
             })}
           `
         : nothing}
       ${ctx.selectedDeliveryMode === "webhook"
-        ? renderFieldRow({
+        ? renderCronInputField(props, "deliveryTo", {
             label: t("cron.form.webhookUrl"),
-            controlId: "cron-delivery-to",
             required: true,
             help: t("cron.form.webhookHelp"),
-            error: props.fieldErrors.deliveryTo,
-            errorId: errorIdForField("deliveryTo"),
-            control: html`
-              <input
-                id="cron-delivery-to"
-                class="settings-input"
-                aria-required="true"
-                .value=${props.form.deliveryTo}
-                list="cron-delivery-to-suggestions"
-                aria-invalid=${props.fieldErrors.deliveryTo ? "true" : "false"}
-                aria-describedby=${ifDefined(
-                  props.fieldErrors.deliveryTo ? errorIdForField("deliveryTo") : undefined,
-                )}
-                placeholder=${t("cron.form.webhookPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onFormChange({ deliveryTo: (e.target as HTMLInputElement).value })}
-              />
-            `,
+            errorKey: "deliveryTo",
+            list: "cron-delivery-to-suggestions",
+            placeholder: t("cron.form.webhookPlaceholder"),
           })
         : nothing}
     `,
@@ -1633,84 +1491,40 @@ function renderAdvanced(
         </summary>
         <p class="settings-section__desc">${t("cron.form.advancedHelp")}</p>
         <div class="settings-group">
-          ${renderFieldRow({
+          ${renderCronInputField(props, "description", {
             label: t("cron.form.description"),
-            controlId: "cron-description",
-            control: html`
-              <input
-                id="cron-description"
-                class="settings-input"
-                .value=${props.form.description}
-                placeholder=${t("cron.form.descriptionPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onFormChange({ description: (e.target as HTMLInputElement).value })}
-              />
-            `,
+            placeholder: t("cron.form.descriptionPlaceholder"),
           })}
           ${ctx.mode === "create"
-            ? renderToggleRow({
+            ? renderToggleRow(props, "enabled", {
                 label: t("cron.form.startEnabled"),
-                checked: props.form.enabled,
-                onChange: (checked) => props.onFormChange({ enabled: checked }),
               })
             : nothing}
-          ${renderFieldRow({
+          ${renderCronSelectField(props, "wakeMode", {
             label: t("cron.form.wakeMode"),
-            controlId: "cron-wake-mode",
             help: t("cron.form.wakeModeHelp"),
-            control: html`
-              <select
-                id="cron-wake-mode"
-                class="settings-select"
-                .value=${props.form.wakeMode}
-                @change=${(e: Event) =>
-                  props.onFormChange({
-                    wakeMode: (e.target as HTMLSelectElement).value as CronFormState["wakeMode"],
-                  })}
-              >
-                <option value="now">${t("cron.form.now")}</option>
-                <option value="next-heartbeat">${t("cron.form.nextHeartbeat")}</option>
-              </select>
-            `,
+            options: [
+              { value: "now", label: t("cron.form.now") },
+              { value: "next-heartbeat", label: t("cron.form.nextHeartbeat") },
+            ],
           })}
           ${ctx.isAgentTurn
-            ? renderFieldRow({
+            ? renderCronInputField(props, "timeoutSeconds", {
                 label: t("cron.form.timeoutSeconds"),
-                controlId: "cron-timeout-seconds",
                 help: t("cron.form.timeoutHelp"),
-                error: props.fieldErrors.timeoutSeconds,
-                errorId: errorIdForField("timeoutSeconds"),
-                control: html`
-                  <input
-                    id="cron-timeout-seconds"
-                    class="settings-input"
-                    .value=${props.form.timeoutSeconds}
-                    placeholder=${t("cron.form.timeoutPlaceholder")}
-                    aria-invalid=${props.fieldErrors.timeoutSeconds ? "true" : "false"}
-                    aria-describedby=${ifDefined(
-                      props.fieldErrors.timeoutSeconds
-                        ? errorIdForField("timeoutSeconds")
-                        : undefined,
-                    )}
-                    @input=${(e: Event) =>
-                      props.onFormChange({ timeoutSeconds: (e.target as HTMLInputElement).value })}
-                  />
-                `,
+                errorKey: "timeoutSeconds",
+                placeholder: t("cron.form.timeoutPlaceholder"),
               })
             : nothing}
           ${props.form.scheduleKind === "at" || props.form.scheduleKind === "on-exit"
-            ? renderToggleRow({
+            ? renderToggleRow(props, "deleteAfterRun", {
                 label: t("cron.form.deleteAfterRun"),
-                checked: props.form.deleteAfterRun,
                 help: t("cron.form.deleteAfterRunHelp"),
-                onChange: (checked) => props.onFormChange({ deleteAfterRun: checked }),
               })
             : nothing}
-          ${renderToggleRow({
+          ${renderToggleRow(props, "clearAgent", {
             label: t("cron.form.clearAgentOverride"),
-            checked: props.form.clearAgent,
             help: t("cron.form.clearAgentHelp"),
-            onChange: (checked) => props.onFormChange({ clearAgent: checked }),
           })}
           ${renderFieldRow({
             label: t("cron.form.sessionKey"),
@@ -1729,11 +1543,9 @@ function renderAdvanced(
           })}
           ${isCronSchedule
             ? html`
-                ${renderToggleRow({
+                ${renderToggleRow(props, "scheduleExact", {
                   label: t("cron.form.exactTiming"),
-                  checked: props.form.scheduleExact,
                   help: t("cron.form.exactTimingHelp"),
-                  onChange: (checked) => props.onFormChange({ scheduleExact: checked }),
                 })}
                 ${renderFieldRow({
                   label: t("cron.form.staggerWindow"),
@@ -1742,37 +1554,21 @@ function renderAdvanced(
                   errorId: errorIdForField("staggerAmount"),
                   control: html`
                     <div class="cron-inline-controls">
-                      <input
-                        id="cron-stagger-amount"
-                        class="settings-input"
-                        .value=${props.form.staggerAmount}
-                        ?disabled=${props.form.scheduleExact}
-                        aria-invalid=${props.fieldErrors.staggerAmount ? "true" : "false"}
-                        aria-describedby=${ifDefined(
-                          props.fieldErrors.staggerAmount
-                            ? errorIdForField("staggerAmount")
-                            : undefined,
-                        )}
-                        placeholder=${t("cron.form.staggerPlaceholder")}
-                        @input=${(e: Event) =>
-                          props.onFormChange({
-                            staggerAmount: (e.target as HTMLInputElement).value,
-                          })}
-                      />
-                      <select
-                        class="settings-select"
-                        .value=${props.form.staggerUnit}
-                        ?disabled=${props.form.scheduleExact}
-                        aria-label=${t("cron.form.staggerUnit")}
-                        @change=${(e: Event) =>
-                          props.onFormChange({
-                            staggerUnit: (e.target as HTMLSelectElement)
-                              .value as CronFormState["staggerUnit"],
-                          })}
-                      >
-                        <option value="seconds">${t("cron.form.seconds")}</option>
-                        <option value="minutes">${t("cron.form.minutes")}</option>
-                      </select>
+                      ${renderCronInput(props, "staggerAmount", {
+                        label: t("cron.form.staggerWindow"),
+                        disabled: props.form.scheduleExact,
+                        errorKey: "staggerAmount",
+                        placeholder: t("cron.form.staggerPlaceholder"),
+                      })}
+                      ${renderCronSelect(props, "staggerUnit", {
+                        label: t("cron.form.staggerUnit"),
+                        standalone: true,
+                        disabled: props.form.scheduleExact,
+                        options: [
+                          { value: "seconds", label: t("cron.form.seconds") },
+                          { value: "minutes", label: t("cron.form.minutes") },
+                        ],
+                      })}
                     </div>
                   `,
                 })}
@@ -1799,21 +1595,17 @@ function renderAdvanced(
                     />
                   `,
                 })}
-                ${renderToggleRow({
+                ${renderToggleRow(props, "payloadLightContext", {
                   label: t("cron.form.lightContext"),
-                  checked: props.form.payloadLightContext,
                   help: t("cron.form.lightContextHelp"),
-                  onChange: (checked) => props.onFormChange({ payloadLightContext: checked }),
                 })}
                 ${renderFailureAlertRows(props, channelOptions)}
               `
             : nothing}
           ${ctx.selectedDeliveryMode !== "none"
-            ? renderToggleRow({
+            ? renderToggleRow(props, "deliveryBestEffort", {
                 label: t("cron.form.bestEffortDelivery"),
-                checked: props.form.deliveryBestEffort,
                 help: t("cron.form.bestEffortHelp"),
-                onChange: (checked) => props.onFormChange({ deliveryBestEffort: checked }),
               })
             : nothing}
         </div>
@@ -1824,147 +1616,54 @@ function renderAdvanced(
 
 function renderFailureAlertRows(props: CronProps, channelOptions: string[]) {
   return html`
-    ${renderFieldRow({
+    ${renderCronSelectField(props, "failureAlertMode", {
       label: t("cron.form.failureAlerts"),
-      controlId: "cron-failure-alert-mode",
       help: t("cron.form.failureAlertsHelp"),
-      control: html`
-        <select
-          id="cron-failure-alert-mode"
-          class="settings-select"
-          .value=${props.form.failureAlertMode}
-          @change=${(e: Event) =>
-            props.onFormChange({
-              failureAlertMode: (e.target as HTMLSelectElement)
-                .value as CronFormState["failureAlertMode"],
-            })}
-        >
-          <option value="inherit">${t("cron.form.failureAlertInherit")}</option>
-          <option value="disabled">${t("cron.form.failureAlertDisabled")}</option>
-          <option value="custom">${t("cron.form.failureAlertCustom")}</option>
-        </select>
-      `,
+      options: [
+        { value: "inherit", label: t("cron.form.failureAlertInherit") },
+        { value: "disabled", label: t("cron.form.failureAlertDisabled") },
+        { value: "custom", label: t("cron.form.failureAlertCustom") },
+      ],
     })}
     ${props.form.failureAlertMode === "custom"
       ? html`
-          ${renderFieldRow({
+          ${renderCronInputField(props, "failureAlertAfter", {
             label: t("cron.form.failureAlertAfter"),
-            controlId: "cron-failure-alert-after",
             help: t("cron.form.failureAlertAfterHelp"),
-            error: props.fieldErrors.failureAlertAfter,
-            errorId: errorIdForField("failureAlertAfter"),
-            control: html`
-              <input
-                id="cron-failure-alert-after"
-                class="settings-input"
-                .value=${props.form.failureAlertAfter}
-                aria-invalid=${props.fieldErrors.failureAlertAfter ? "true" : "false"}
-                aria-describedby=${ifDefined(
-                  props.fieldErrors.failureAlertAfter
-                    ? errorIdForField("failureAlertAfter")
-                    : undefined,
-                )}
-                placeholder="2"
-                @input=${(e: Event) =>
-                  props.onFormChange({ failureAlertAfter: (e.target as HTMLInputElement).value })}
-              />
-            `,
+            errorKey: "failureAlertAfter",
+            placeholder: "2",
           })}
-          ${renderFieldRow({
+          ${renderCronInputField(props, "failureAlertCooldownSeconds", {
             label: t("cron.form.failureAlertCooldown"),
-            controlId: "cron-failure-alert-cooldown-seconds",
             help: t("cron.form.failureAlertCooldownHelp"),
-            error: props.fieldErrors.failureAlertCooldownSeconds,
-            errorId: errorIdForField("failureAlertCooldownSeconds"),
-            control: html`
-              <input
-                id="cron-failure-alert-cooldown-seconds"
-                class="settings-input"
-                .value=${props.form.failureAlertCooldownSeconds}
-                aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds ? "true" : "false"}
-                aria-describedby=${ifDefined(
-                  props.fieldErrors.failureAlertCooldownSeconds
-                    ? errorIdForField("failureAlertCooldownSeconds")
-                    : undefined,
-                )}
-                placeholder="3600"
-                @input=${(e: Event) =>
-                  props.onFormChange({
-                    failureAlertCooldownSeconds: (e.target as HTMLInputElement).value,
-                  })}
-              />
-            `,
+            errorKey: "failureAlertCooldownSeconds",
+            placeholder: "3600",
           })}
-          ${renderFieldRow({
+          ${renderCronSelectField(props, "failureAlertChannel", {
             label: t("cron.form.failureAlertChannel"),
-            controlId: "cron-failure-alert-channel",
-            control: html`
-              <select
-                id="cron-failure-alert-channel"
-                class="settings-select"
-                .value=${props.form.failureAlertChannel || "last"}
-                @change=${(e: Event) =>
-                  props.onFormChange({
-                    failureAlertChannel: (e.target as HTMLSelectElement).value,
-                  })}
-              >
-                ${channelOptions.map(
-                  (channel) =>
-                    html`<option value=${channel}>${resolveChannelLabel(props, channel)}</option>`,
-                )}
-              </select>
-            `,
+            value: props.form.failureAlertChannel || "last",
+            options: channelOptions.map((channel) => ({
+              value: channel,
+              label: resolveChannelLabel(props, channel),
+            })),
           })}
-          ${renderFieldRow({
+          ${renderCronInputField(props, "failureAlertTo", {
             label: t("cron.form.failureAlertTo"),
-            controlId: "cron-failure-alert-to",
             help: t("cron.form.failureAlertToHelp"),
-            control: html`
-              <input
-                id="cron-failure-alert-to"
-                class="settings-input"
-                .value=${props.form.failureAlertTo}
-                list="cron-delivery-to-suggestions"
-                placeholder=${t("cron.form.failureAlertToPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onFormChange({ failureAlertTo: (e.target as HTMLInputElement).value })}
-              />
-            `,
+            list: "cron-delivery-to-suggestions",
+            placeholder: t("cron.form.failureAlertToPlaceholder"),
           })}
-          ${renderFieldRow({
+          ${renderCronSelectField(props, "failureAlertDeliveryMode", {
             label: t("cron.form.failureAlertMode"),
-            controlId: "cron-failure-alert-delivery-mode",
-            control: html`
-              <select
-                id="cron-failure-alert-delivery-mode"
-                class="settings-select"
-                .value=${props.form.failureAlertDeliveryMode || "announce"}
-                @change=${(e: Event) =>
-                  props.onFormChange({
-                    failureAlertDeliveryMode: (e.target as HTMLSelectElement)
-                      .value as CronFormState["failureAlertDeliveryMode"],
-                  })}
-              >
-                <option value="announce">${t("cron.form.failureAlertAnnounce")}</option>
-                <option value="webhook">${t("cron.form.failureAlertWebhook")}</option>
-              </select>
-            `,
+            value: props.form.failureAlertDeliveryMode || "announce",
+            options: [
+              { value: "announce", label: t("cron.form.failureAlertAnnounce") },
+              { value: "webhook", label: t("cron.form.failureAlertWebhook") },
+            ],
           })}
-          ${renderFieldRow({
+          ${renderCronInputField(props, "failureAlertAccountId", {
             label: t("cron.form.failureAlertAccountId"),
-            controlId: "cron-failure-alert-account-id",
-            control: html`
-              <input
-                id="cron-failure-alert-account-id"
-                class="settings-input"
-                .value=${props.form.failureAlertAccountId}
-                placeholder=${t("cron.form.failureAlertAccountPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onFormChange({
-                    failureAlertAccountId: (e.target as HTMLInputElement).value,
-                  })}
-              />
-            `,
+            placeholder: t("cron.form.failureAlertAccountPlaceholder"),
           })}
         `
       : nothing}


### PR DESCRIPTION
## Summary
- consolidate Cron form input, select, toggle, validation, stable DOM IDs, and advanced filter rendering under the existing page owner
- preserve exact accessibility/error wiring, literals/localization inventory, Gateway payloads, channel labels, schedule visibility, and browser behavior
- remove 301 handwritten production lines; add 19 focused regression-test lines (282 fewer lines overall)

## Root cause and repair
The Cron page reimplemented field IDs, options, values, DOM event patches, validation, and filters across each field, duplicating the ownership contract and allowing sibling controls to drift. One typed page-owned control flow now derives the canonical field behavior; the two intentionally raw literal placeholders retain their original Lit template classification. Existing first-seen channel deduplication now uses the canonical normalization helper, and empty channel metadata labels still fall back exactly as before.

## Direct after-fix browser behavior artifact
Exact reviewed commit: `92db5032b0e2fe2b95bf15c40c54bc04779a72f9`. This is captured terminal output from an actual Linux Chromium browser loading the actual Control UI server and communicating with the existing mock Gateway RPC harness; no claim of a live external provider or live channel is intended. The browser fills and submits real DOM controls and the harness asserts actual `cron.list`/mutation request payloads.

```text
$ pnpm test:ui:e2e ui/src/e2e/cron-filters.e2e.test.ts
[ui-e2e] Using system Chromium at /usr/bin/chromium-browser.

 RUN  v4.1.10 /home/runner/_work/openclaw/openclaw

 ✓ ui-e2e ui/src/e2e/cron-filters.e2e.test.ts (10 tests) 11262ms
   ✓ suggests browser-supported timezones without restricting free-form input
   ✓ sends cron job table filters through the Gateway and renders the filtered page
   ✓ keeps read-only operators on Cron browse and history surfaces
   ✓ keeps the newest visible overview when an older history search resolves last
   ✓ keeps selected task history when a deferred overview refresh resolves last
   ✓ saves and displays agent-turn model overrides
   ✓ creates and edits agent-turn jobs with an explicit zero timeout
   ✓ defaults recurring jobs converted to one-time cleanup
   ✓ shows why a requested run was not started
   ✓ supports skip navigation and keyboard tab activation

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Independent hosted exact-head browser proof also passed across all four Chromium shards: [1/4](https://github.com/openclaw/openclaw/actions/runs/30713850109/job/91406942490), [2/4](https://github.com/openclaw/openclaw/actions/runs/30713850109/job/91406942351), [3/4](https://github.com/openclaw/openclaw/actions/runs/30713850109/job/91406942573), [4/4](https://github.com/openclaw/openclaw/actions/runs/30713850109/job/91406942651).

## Validation
- independent maintainer source review: clean, including stable IDs, Lit attribute presence/removal, validation accessibility, channel label truthiness, and unchanged localization inventory
- `pnpm check:changed` on Blacksmith Testbox: passed, including UI/core-test TypeScript, typed lint, production/full-tree/script unused-export scans, localization baseline, formatting, and guards
- `pnpm build` on Blacksmith Testbox: passed, including optimized Control UI production build, 692 compressed sidecars, and startup performance budgets
- `pnpm test ui/src/pages/cron/view.test.ts ui/src/pages/cron/cron-page.test.ts ui/src/lib/cron/index.test.ts`: 160 passed
- `pnpm test:ui:e2e ui/src/e2e/cron-filters.e2e.test.ts`: 10 real Chromium/mock-Gateway scenarios passed; direct terminal evidence above
- `pnpm ui:i18n:verify`: passed with unchanged raw-copy baseline and no localization artifact changes

## ClawSweeper rank-up moves
1. Attach direct after-fix browser/terminal evidence: satisfied by the unredacted non-sensitive Chromium terminal artifact and exact-head hosted browser-job links above.
2. Confirm latest rank-up moves with a maintainer: latest review and both moves were read; independent maintainer source review completed before publication.