### PR TITLE
perf(gateway): separate startup maintenance timing

### DIFF
--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -475,12 +475,20 @@ export async function prepareGatewayServerBootstrap(input: {
         const workerModule = await loadWorkerEnvironmentStartupModule();
         return await workerModule.loadGatewayWorkerEnvironmentStartupState();
       });
-  const { prepareGatewayPluginBootstrap } = await loadStartupPluginsModule();
+  const { prepareGatewayPluginBootstrap, runGatewayStartupMaintenance } =
+    await loadStartupPluginsModule();
+  await startupTrace.measure("startup.maintenance", () =>
+    runGatewayStartupMaintenance({
+      cfgAtStart,
+      startupRuntimeConfig,
+      minimalTestGateway,
+      log,
+    }),
+  );
   const pluginBootstrap = await startupTrace.measure("plugins.bootstrap", () =>
     prepareGatewayPluginBootstrap({
       cfgAtStart,
       activationSourceConfig: startupActivationSourceConfig,
-      startupRuntimeConfig,
       pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot,
       workerProviderIds: workerEnvironmentStartup?.durableProviderIds ?? [],
       minimalTestGateway,

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -108,6 +108,12 @@ const listAmbientOnlyConfiguredChannelIds = vi.hoisted(() =>
   vi.fn((_params: unknown) => [] as string[]),
 );
 const runStartupSessionMigration = vi.hoisted(() => vi.fn(async (_params: unknown) => undefined));
+const migrateLegacyDevicePairingStore = vi.hoisted(() =>
+  vi.fn(async (_params: unknown) => undefined),
+);
+const migrateLegacyNodePairingStore = vi.hoisted(() =>
+  vi.fn(async (_params: unknown) => undefined),
+);
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: () => "/workspace",
   resolveDefaultAgentId: () => "default",
@@ -128,6 +134,14 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
 
 vi.mock("../infra/openclaw-root.js", () => ({
   resolveOpenClawPackageRootSync: (params: unknown) => resolveOpenClawPackageRootSync(params),
+}));
+
+vi.mock("../infra/device-pairing-migration.js", () => ({
+  migrateLegacyDevicePairingStore: (params: unknown) => migrateLegacyDevicePairingStore(params),
+}));
+
+vi.mock("../infra/node-pairing-migration.js", () => ({
+  migrateLegacyNodePairingStore: (params: unknown) => migrateLegacyNodePairingStore(params),
 }));
 
 vi.mock("../plugins/channel-presence-policy.js", () => ({
@@ -222,7 +236,6 @@ async function prepareBootstrapWithRuntimeConfig(
 
   return await prepareGatewayPluginBootstrap({
     cfgAtStart: cfg,
-    startupRuntimeConfig: cfg,
     minimalTestGateway: false,
     log,
     ...options,
@@ -246,6 +259,83 @@ function expectStartupPluginLoad(params: {
   expect(startupInput.suppressPluginInfoLogs).toBe(params.suppressPluginInfoLogs);
 }
 
+describe("runGatewayStartupMaintenance", () => {
+  beforeEach(() => {
+    runChannelPluginStartupMaintenance.mockClear();
+    runStartupSessionMigration.mockClear();
+    migrateLegacyDevicePairingStore.mockClear();
+    migrateLegacyNodePairingStore.mockClear();
+  });
+
+  it("runs channel, session, and ordered pairing maintenance for a normal gateway", async () => {
+    const log = createLog();
+    const { runGatewayStartupMaintenance } = await import("./server-startup-plugins.js");
+
+    await runGatewayStartupMaintenance({
+      cfgAtStart: {},
+      startupRuntimeConfig: {},
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(runChannelPluginStartupMaintenance).toHaveBeenCalledWith({
+      cfg: {},
+      env: process.env,
+      log,
+    });
+    expect(runStartupSessionMigration).toHaveBeenCalledWith({
+      cfg: {},
+      env: process.env,
+      log,
+    });
+    expect(migrateLegacyDevicePairingStore).toHaveBeenCalledWith({ log });
+    expect(migrateLegacyNodePairingStore).toHaveBeenCalledWith({ log });
+    const deviceMigrationOrder = migrateLegacyDevicePairingStore.mock.invocationCallOrder[0];
+    const nodeMigrationOrder = migrateLegacyNodePairingStore.mock.invocationCallOrder[0];
+    expect(deviceMigrationOrder).toBeDefined();
+    expect(nodeMigrationOrder).toBeDefined();
+    expect(deviceMigrationOrder!).toBeLessThan(nodeMigrationOrder!);
+  });
+
+  it("skips maintenance for a minimal gateway without channel config", async () => {
+    const { runGatewayStartupMaintenance } = await import("./server-startup-plugins.js");
+
+    await runGatewayStartupMaintenance({
+      cfgAtStart: {},
+      startupRuntimeConfig: {},
+      minimalTestGateway: true,
+      log: createLog(),
+    });
+
+    expect(runChannelPluginStartupMaintenance).not.toHaveBeenCalled();
+    expect(runStartupSessionMigration).not.toHaveBeenCalled();
+    expect(migrateLegacyDevicePairingStore).not.toHaveBeenCalled();
+    expect(migrateLegacyNodePairingStore).not.toHaveBeenCalled();
+  });
+
+  it("runs only channel maintenance for a minimal gateway with recovered channel config", async () => {
+    const log = createLog();
+    const recoveredConfig = slackConfig();
+    const { runGatewayStartupMaintenance } = await import("./server-startup-plugins.js");
+
+    await runGatewayStartupMaintenance({
+      cfgAtStart: {},
+      startupRuntimeConfig: recoveredConfig,
+      minimalTestGateway: true,
+      log,
+    });
+
+    expect(runChannelPluginStartupMaintenance).toHaveBeenCalledWith({
+      cfg: recoveredConfig,
+      env: process.env,
+      log,
+    });
+    expect(runStartupSessionMigration).not.toHaveBeenCalled();
+    expect(migrateLegacyDevicePairingStore).not.toHaveBeenCalled();
+    expect(migrateLegacyNodePairingStore).not.toHaveBeenCalled();
+  });
+});
+
 describe("prepareGatewayPluginBootstrap startup plugins", () => {
   beforeEach(() => {
     applyPluginAutoEnable.mockClear();
@@ -263,7 +353,18 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
     resolveOpenClawPackageRootSync.mockClear().mockReturnValue("/package");
     runChannelPluginStartupMaintenance.mockClear();
     runStartupSessionMigration.mockClear();
+    migrateLegacyDevicePairingStore.mockClear();
+    migrateLegacyNodePairingStore.mockClear();
   });
+  it("does not run startup maintenance", async () => {
+    await prepareBootstrapWithRuntimeConfig({});
+
+    expect(runChannelPluginStartupMaintenance).not.toHaveBeenCalled();
+    expect(runStartupSessionMigration).not.toHaveBeenCalled();
+    expect(migrateLegacyDevicePairingStore).not.toHaveBeenCalled();
+    expect(migrateLegacyNodePairingStore).not.toHaveBeenCalled();
+  });
+
   it("derives startup activation from source config instead of runtime plugin defaults", async () => {
     const sourceConfig = {
       channels: {
@@ -328,7 +429,6 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
     await prepareGatewayPluginBootstrap({
       cfgAtStart: runtimeConfig,
       activationSourceConfig: sourceConfig,
-      startupRuntimeConfig: runtimeConfig,
       pluginMetadataSnapshot,
       minimalTestGateway: false,
       log,
@@ -435,7 +535,6 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
     const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
     const result = await prepareGatewayPluginBootstrap({
       cfgAtStart: { channels: {} },
-      startupRuntimeConfig: { channels: {} },
       minimalTestGateway: false,
       ambientEnvTriggers: "suppress",
       log,

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -1,5 +1,4 @@
-// Gateway plugin startup bootstrap.
-// Runs startup maintenance, loads plugin runtime, and prepares advertised methods.
+// Gateway plugin startup bootstrap and adjacent startup maintenance.
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
@@ -45,20 +44,13 @@ export function resolveGatewayStartupMaintenanceConfig(params: {
     : params.cfgAtStart;
 }
 
-/** Builds plugin startup state and gateway method lists before the server binds. */
-export async function prepareGatewayPluginBootstrap(params: {
+/** Runs channel, session, and pairing maintenance before plugin bootstrap. */
+export async function runGatewayStartupMaintenance(params: {
   cfgAtStart: OpenClawConfig;
-  activationSourceConfig?: OpenClawConfig;
   startupRuntimeConfig: OpenClawConfig;
-  pluginMetadataSnapshot?: PluginMetadataSnapshot;
-  workerProviderIds?: readonly string[];
   minimalTestGateway: boolean;
   log: GatewayPluginBootstrapLog;
-  loadRuntimePlugins?: boolean;
-  loadSetupRuntimePlugins?: boolean;
-  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
-}) {
-  const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
+}): Promise<void> {
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
     cfgAtStart: params.cfgAtStart,
     startupRuntimeConfig: params.startupRuntimeConfig,
@@ -110,7 +102,21 @@ export async function prepareGatewayPluginBootstrap(params: {
     }
     await Promise.all(startupTasks);
   }
+}
 
+/** Builds plugin startup state and gateway method lists before the server binds. */
+export async function prepareGatewayPluginBootstrap(params: {
+  cfgAtStart: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
+  workerProviderIds?: readonly string[];
+  minimalTestGateway: boolean;
+  log: GatewayPluginBootstrapLog;
+  loadRuntimePlugins?: boolean;
+  loadSetupRuntimePlugins?: boolean;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
+}) {
+  const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
   initSubagentRegistry();
 
   // Activation uses the pre-runtime source so auto-enable policy cannot be skewed by


### PR DESCRIPTION
## What Problem This Solves

The source-performance startup trace reports the full Gateway startup-maintenance interval as `plugins.bootstrap` / `plugins.load`. Session, channel, and pairing maintenance therefore appears to be plugin-loading cost, which sends Kova follow-up work to the wrong owner.

## Why This Change Was Made

Run startup maintenance through its own exported owner and measure it as `startup.maintenance` before the plugin-only `plugins.bootstrap` span. The existing maintenance concurrency, minimal-Gateway behavior, and device-before-node migration order remain unchanged.

## User Impact

No product runtime behavior changes. Maintainers get accurate startup attribution, so future performance work can distinguish migration/maintenance cost from plugin loading.

## Evidence

- Kova hosted startup evidence showed `plugins.bootstrap` at roughly `281-301ms`, while source inspection found the span also contained channel, session, and pairing maintenance.
- Exact-head hosted source-performance run: https://github.com/openclaw/openclaw/actions/runs/30713929982
  - `preparedRuntimeScaleMany`: `startup.maintenance=263.3ms`, plugin-only `plugins.bootstrap=33.8ms`
  - `fiftyStartupLazyPlugins`: `startup.maintenance=141.4ms`, plugin-only `plugins.bootstrap=52.7ms`
  - the source artifact contains both spans independently across the startup scenarios
- `node scripts/run-vitest.mjs src/gateway/server-startup-plugins.test.ts src/gateway/server-startup-bootstrap.test.ts`: 28/28 passed.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.
- The broad changed gate could not acquire a ready Testbox because the local Crabbox client/auth path is unavailable; local fallback was intentionally stopped when pnpm attempted linked-worktree dependency reconciliation. GitHub CI is the broad validation owner for this draft.
