### PR TITLE
refactor(policy): centralize doctor health-check descriptors

### DIFF
--- a/extensions/policy/src/doctor/check-factory.test.ts
+++ b/extensions/policy/src/doctor/check-factory.test.ts
@@ -1,0 +1,111 @@
+import type {
+  HealthCheckContext,
+  HealthFinding,
+  HealthRepairContext,
+  HealthRepairResult,
+} from "openclaw/plugin-sdk/health";
+import { describe, expect, it, vi } from "vitest";
+import { createPolicyScopedChecks } from "./check-factory.js";
+import { CHECK_IDS } from "./check-ids.js";
+import type { PolicyEvaluation } from "./types.js";
+
+describe("policy scoped health checks", () => {
+  const evaluation = {} as PolicyEvaluation;
+  const context = {} as HealthCheckContext;
+
+  it("preserves registration order, descriptions, metadata, and repair capability", () => {
+    const repair = vi.fn(async (): Promise<HealthRepairResult> => ({ changes: [] }));
+    const checks = createPolicyScopedChecks(
+      {
+        evaluatePolicy: vi.fn(async () => evaluation),
+        findingsForCheck: vi.fn(() => []),
+      },
+      [
+        [CHECK_IDS.policyMissingFile, "The policy file exists."],
+        [CHECK_IDS.policyDeniedChannelProvider, "Channels satisfy policy.", repair],
+      ],
+    );
+
+    expect(
+      checks.map(({ id, description, kind, source }) => ({ id, description, kind, source })),
+    ).toEqual([
+      {
+        id: CHECK_IDS.policyMissingFile,
+        description: "The policy file exists.",
+        kind: "plugin",
+        source: "policy",
+      },
+      {
+        id: CHECK_IDS.policyDeniedChannelProvider,
+        description: "Channels satisfy policy.",
+        kind: "plugin",
+        source: "policy",
+      },
+    ]);
+    expect(Object.hasOwn(checks[0]!, "repair")).toBe(false);
+    expect(Object.hasOwn(checks[1]!, "repair")).toBe(true);
+    expect(checks[1]).toMatchObject({ repair });
+  });
+
+  it("awaits the policy evaluation before selecting findings for the same check", async () => {
+    const findings: HealthFinding[] = [
+      { checkId: CHECK_IDS.policyMissingFile, severity: "error", message: "Missing policy." },
+    ];
+    let releaseEvaluation!: () => void;
+    const evaluationGate = new Promise<void>((resolve) => {
+      releaseEvaluation = resolve;
+    });
+    const evaluatePolicy = vi.fn(async (received: HealthCheckContext) => {
+      expect(received).toBe(context);
+      await evaluationGate;
+      return evaluation;
+    });
+    const findingsForCheck = vi.fn(() => findings);
+    const [check] = createPolicyScopedChecks({ evaluatePolicy, findingsForCheck }, [
+      [CHECK_IDS.policyMissingFile, "The policy file exists."],
+    ]);
+
+    const result = check!.detect(context);
+    expect(evaluatePolicy).toHaveBeenCalledOnce();
+    expect(findingsForCheck).not.toHaveBeenCalled();
+
+    releaseEvaluation();
+    await expect(result).resolves.toBe(findings);
+    expect(findingsForCheck).toHaveBeenCalledExactlyOnceWith(
+      evaluation,
+      CHECK_IDS.policyMissingFile,
+    );
+  });
+
+  it("propagates evaluation failures without selecting findings", async () => {
+    const failure = new Error("policy evaluation failed");
+    const evaluatePolicy = vi.fn(async () => {
+      throw failure;
+    });
+    const findingsForCheck = vi.fn(() => []);
+    const [check] = createPolicyScopedChecks({ evaluatePolicy, findingsForCheck }, [
+      [CHECK_IDS.policyMissingFile, "The policy file exists."],
+    ]);
+
+    await expect(check!.detect(context)).rejects.toBe(failure);
+    expect(findingsForCheck).not.toHaveBeenCalled();
+  });
+
+  it("retains the original repair callback and its exact result promise", () => {
+    const repairContext = {} as HealthRepairContext;
+    const findings: HealthFinding[] = [];
+    const pendingRepair = Promise.resolve<HealthRepairResult>({ changes: ["repaired"] });
+    const repair = vi.fn(() => pendingRepair);
+    const [check] = createPolicyScopedChecks(
+      {
+        evaluatePolicy: vi.fn(async () => evaluation),
+        findingsForCheck: vi.fn(() => []),
+      },
+      [[CHECK_IDS.policyDeniedChannelProvider, "Channels satisfy policy.", repair]],
+    );
+
+    expect(check).toMatchObject({ repair });
+    expect(check!.repair!(repairContext, findings)).toBe(pendingRepair);
+    expect(repair).toHaveBeenCalledExactlyOnceWith(repairContext, findings);
+  });
+});

--- a/extensions/policy/src/doctor/check-factory.ts
+++ b/extensions/policy/src/doctor/check-factory.ts
@@ -1,0 +1,26 @@
+import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import type { POLICY_CHECK_IDS } from "./check-ids.js";
+import type { PolicyDoctorCheckDeps } from "./types.js";
+
+type PolicyDoctorCheckDefinition = readonly [
+  id: (typeof POLICY_CHECK_IDS)[number],
+  description: string,
+  repair?: NonNullable<HealthCheck["repair"]>,
+];
+
+export function createPolicyScopedChecks(
+  deps: Pick<PolicyDoctorCheckDeps, "evaluatePolicy" | "findingsForCheck">,
+  definitions: readonly PolicyDoctorCheckDefinition[],
+): readonly HealthCheck[] {
+  const { evaluatePolicy, findingsForCheck } = deps;
+  return definitions.map(([id, description, repair]) => ({
+    id,
+    kind: "plugin",
+    description,
+    source: "policy",
+    async detect(ctx) {
+      return findingsForCheck(await evaluatePolicy(ctx), id);
+    },
+    ...(repair ? { repair } : {}),
+  }));
+}

--- a/extensions/policy/src/doctor/scopes/channels.ts
+++ b/extensions/policy/src/doctor/scopes/channels.ts
@@ -1,6 +1,7 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
@@ -10,109 +11,66 @@ export function createPolicyChannelProviderChecks(
   const {
     channelIdsFromFindings,
     disableChannels,
-    evaluatePolicy,
-    findingsForCheck,
     workspaceRepairsDisabledResult,
     workspaceRepairsEnabled,
   } = deps;
 
-  const policyChannelsDeniedProviderCheck: HealthCheck = {
-    id: CHECK_IDS.policyDeniedChannelProvider,
-    kind: "plugin",
-    description: "Configured channels satisfy policy deny rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedChannelProvider);
-    },
-    async repair(ctx, findings) {
-      if (!workspaceRepairsEnabled(ctx)) {
-        return workspaceRepairsDisabledResult("channel config");
-      }
-      const channelIds = channelIdsFromFindings(findings);
-      if (channelIds.length === 0) {
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyDeniedChannelProvider,
+      "Configured channels satisfy policy deny rules.",
+      async (ctx, findings) => {
+        if (!workspaceRepairsEnabled(ctx)) {
+          return workspaceRepairsDisabledResult("channel config");
+        }
+        const channelIds = channelIdsFromFindings(findings);
+        if (channelIds.length === 0) {
+          return {
+            status: "skipped",
+            reason: "no channel findings matched a configurable channel",
+            changes: [],
+          };
+        }
+        const next = disableChannels(ctx.cfg, channelIds);
+        if (next.changed.length === 0) {
+          return {
+            status: "skipped",
+            reason: "matching channels were already disabled or missing",
+            changes: [],
+          };
+        }
         return {
-          status: "skipped",
-          reason: "no channel findings matched a configurable channel",
-          changes: [],
+          config: next.config,
+          changes: next.changed.map(
+            (id) => `Disabled channels.${id}.enabled for policy conformance.`,
+          ),
         };
-      }
-      const next = disableChannels(ctx.cfg, channelIds);
-      if (next.changed.length === 0) {
-        return {
-          status: "skipped",
-          reason: "matching channels were already disabled or missing",
-          changes: [],
-        };
-      }
-      return {
-        config: next.config,
-        changes: next.changed.map(
-          (id) => `Disabled channels.${id}.enabled for policy conformance.`,
-        ),
-      };
-    },
-  };
-
-  return [policyChannelsDeniedProviderCheck];
+      },
+    ],
+  ]);
 }
 
 export function createPolicyIngressChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyIngressDmPolicyUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyIngressDmPolicyUnapproved,
-    kind: "plugin",
-    description: "Channel direct-message access policy matches ingress requirements.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyIngressDmPolicyUnapproved);
-    },
-  };
-  const policyIngressDmScopeUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyIngressDmScopeUnapproved,
-    kind: "plugin",
-    description: "Direct-message sessions use the policy-required isolation scope.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyIngressDmScopeUnapproved);
-    },
-  };
-  const policyIngressOpenGroupsDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policyIngressOpenGroupsDenied,
-    kind: "plugin",
-    description: "Channel group access does not use open group policy when denied.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyIngressOpenGroupsDenied);
-    },
-    async repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyIngressOpenGroupsDenied);
-    },
-  };
-  const policyIngressGroupMentionRequiredCheck: HealthCheck = {
-    id: CHECK_IDS.policyIngressGroupMentionRequired,
-    kind: "plugin",
-    description: "Channel group access keeps mention gates enabled when required.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyIngressGroupMentionRequired,
-      );
-    },
-    async repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(
-        ctx,
-        findings,
-        CHECK_IDS.policyIngressGroupMentionRequired,
-      );
-    },
-  };
-
-  return [
-    policyIngressDmPolicyUnapprovedCheck,
-    policyIngressDmScopeUnapprovedCheck,
-    policyIngressOpenGroupsDeniedCheck,
-    policyIngressGroupMentionRequiredCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyIngressDmPolicyUnapproved,
+      "Channel direct-message access policy matches ingress requirements.",
+    ],
+    [
+      CHECK_IDS.policyIngressDmScopeUnapproved,
+      "Direct-message sessions use the policy-required isolation scope.",
+    ],
+    [
+      CHECK_IDS.policyIngressOpenGroupsDenied,
+      "Channel group access does not use open group policy when denied.",
+      async (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyIngressOpenGroupsDenied),
+    ],
+    [
+      CHECK_IDS.policyIngressGroupMentionRequired,
+      "Channel group access keeps mention gates enabled when required.",
+      async (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyIngressGroupMentionRequired),
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/core.ts
+++ b/extensions/policy/src/doctor/scopes/core.ts
@@ -1,52 +1,17 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyCoreChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyMissingFileCheck: HealthCheck = {
-    id: CHECK_IDS.policyMissingFile,
-    kind: "plugin",
-    description: "The enabled Policy plugin has a policy file to verify.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingFile);
-    },
-  };
-  const policyHashMismatchCheck: HealthCheck = {
-    id: CHECK_IDS.policyHashMismatch,
-    kind: "plugin",
-    description: "The policy file matches the configured expected hash.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyHashMismatch);
-    },
-  };
-  const policyAttestationMismatchCheck: HealthCheck = {
-    id: CHECK_IDS.policyAttestationMismatch,
-    kind: "plugin",
-    description: "The current policy check matches the accepted attestation.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAttestationMismatch);
-    },
-  };
-  const policyInvalidFileCheck: HealthCheck = {
-    id: CHECK_IDS.policyInvalidFile,
-    kind: "plugin",
-    description: "The enabled policy file parses before policy checks run.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyInvalidFile);
-    },
-  };
-
-  return [
-    policyMissingFileCheck,
-    policyInvalidFileCheck,
-    policyHashMismatchCheck,
-    policyAttestationMismatchCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [CHECK_IDS.policyMissingFile, "The enabled Policy plugin has a policy file to verify."],
+    [CHECK_IDS.policyInvalidFile, "The enabled policy file parses before policy checks run."],
+    [CHECK_IDS.policyHashMismatch, "The policy file matches the configured expected hash."],
+    [
+      CHECK_IDS.policyAttestationMismatch,
+      "The current policy check matches the accepted attestation.",
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/data-auth.ts
+++ b/extensions/policy/src/doctor/scopes/data-auth.ts
@@ -1,118 +1,49 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyDataAuthChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyDataHandlingTelemetryContentCaptureCheck: HealthCheck = {
-    id: CHECK_IDS.policyDataHandlingTelemetryContentCapture,
-    kind: "plugin",
-    description: "Telemetry content capture remains disabled when policy denies it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyDataHandlingTelemetryContentCapture,
-      );
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(
-        ctx,
-        findings,
-        CHECK_IDS.policyDataHandlingTelemetryContentCapture,
-      );
-    },
-  };
-  const policyDataHandlingSessionRetentionNotEnforcedCheck: HealthCheck = {
-    id: CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
-    kind: "plugin",
-    description: "Session retention maintenance is enforced when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
-      );
-    },
-  };
-  const policyDataHandlingSessionTranscriptMemoryCheck: HealthCheck = {
-    id: CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
-    kind: "plugin",
-    description: "Session transcript memory indexing remains disabled when policy denies it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
-      );
-    },
-  };
-  const policySecretsUnmanagedProviderCheck: HealthCheck = {
-    id: CHECK_IDS.policySecretsUnmanagedProvider,
-    kind: "plugin",
-    description:
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+      "Telemetry content capture remains disabled when policy denies it.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(
+          ctx,
+          findings,
+          CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+        ),
+    ],
+    [
+      CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
+      "Session retention maintenance is enforced when policy requires it.",
+    ],
+    [
+      CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
+      "Session transcript memory indexing remains disabled when policy denies it.",
+    ],
+    [
+      CHECK_IDS.policySecretsUnmanagedProvider,
       "OpenClaw config SecretRefs use configured secret providers when policy requires managed providers.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsUnmanagedProvider);
-    },
-  };
-  const policySecretsDeniedProviderSourceCheck: HealthCheck = {
-    id: CHECK_IDS.policySecretsDeniedProviderSource,
-    kind: "plugin",
-    description:
+    ],
+    [
+      CHECK_IDS.policySecretsDeniedProviderSource,
       "OpenClaw config secret providers and SecretRefs do not use sources denied by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySecretsDeniedProviderSource,
-      );
-    },
-  };
-  const policySecretsInsecureProviderCheck: HealthCheck = {
-    id: CHECK_IDS.policySecretsInsecureProvider,
-    kind: "plugin",
-    description:
+    ],
+    [
+      CHECK_IDS.policySecretsInsecureProvider,
       "Configured secret providers do not opt into insecure posture unless policy allows it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsInsecureProvider);
-    },
-  };
-  const policyAuthProfileInvalidMetadataCheck: HealthCheck = {
-    id: CHECK_IDS.policyAuthProfileInvalidMetadata,
-    kind: "plugin",
-    description: "OpenClaw config auth profiles declare required provider and mode metadata.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyAuthProfileInvalidMetadata,
-      );
-    },
-  };
-  const policyAuthProfileUnapprovedModeCheck: HealthCheck = {
-    id: CHECK_IDS.policyAuthProfileUnapprovedMode,
-    kind: "plugin",
-    description: "OpenClaw config auth profile modes stay within the policy allowlist.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAuthProfileUnapprovedMode);
-    },
-  };
-
-  return [
-    policyDataHandlingTelemetryContentCaptureCheck,
-    policyDataHandlingSessionRetentionNotEnforcedCheck,
-    policyDataHandlingSessionTranscriptMemoryCheck,
-    policySecretsUnmanagedProviderCheck,
-    policySecretsDeniedProviderSourceCheck,
-    policySecretsInsecureProviderCheck,
-    policyAuthProfileInvalidMetadataCheck,
-    policyAuthProfileUnapprovedModeCheck,
-  ];
+    ],
+    [
+      CHECK_IDS.policyAuthProfileInvalidMetadata,
+      "OpenClaw config auth profiles declare required provider and mode metadata.",
+    ],
+    [
+      CHECK_IDS.policyAuthProfileUnapprovedMode,
+      "OpenClaw config auth profile modes stay within the policy allowlist.",
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/exec-approvals.ts
+++ b/extensions/policy/src/doctor/scopes/exec-approvals.ts
@@ -1,100 +1,40 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyExecApprovalChecks(
   deps: PolicyDoctorCheckDeps,
 ): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyExecApprovalsMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsMissing,
-    kind: "plugin",
-    description: "Required exec approvals artifact is present for policy conformance.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyExecApprovalsMissing);
-    },
-  };
-  const policyExecApprovalsInvalidCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsInvalid,
-    kind: "plugin",
-    description: "Exec approvals artifact parses before policy checks run.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyExecApprovalsInvalid);
-    },
-  };
-  const policyExecApprovalsDefaultSecurityUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsDefaultSecurityUnapproved,
-    kind: "plugin",
-    description: "Exec approval defaults use a policy-approved security mode.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyExecApprovalsDefaultSecurityUnapproved,
-      );
-    },
-  };
-  const policyExecApprovalsAgentSecurityUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsAgentSecurityUnapproved,
-    kind: "plugin",
-    description: "Per-agent exec approval settings use policy-approved security modes.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyExecApprovalsAgentSecurityUnapproved,
-      );
-    },
-  };
-  const policyExecApprovalsAutoAllowSkillsEnabledCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsAutoAllowSkillsEnabled,
-    kind: "plugin",
-    description:
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyExecApprovalsMissing,
+      "Required exec approvals artifact is present for policy conformance.",
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsInvalid,
+      "Exec approvals artifact parses before policy checks run.",
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsDefaultSecurityUnapproved,
+      "Exec approval defaults use a policy-approved security mode.",
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsAgentSecurityUnapproved,
+      "Per-agent exec approval settings use policy-approved security modes.",
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsAutoAllowSkillsEnabled,
       "Exec approval agents do not implicitly auto-allow skill CLIs unless policy allows it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyExecApprovalsAutoAllowSkillsEnabled,
-      );
-    },
-  };
-  const policyExecApprovalsAllowlistMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsAllowlistMissing,
-    kind: "plugin",
-    description: "Exec approval allowlists include every pattern required by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyExecApprovalsAllowlistMissing,
-      );
-    },
-  };
-  const policyExecApprovalsAllowlistUnexpectedCheck: HealthCheck = {
-    id: CHECK_IDS.policyExecApprovalsAllowlistUnexpected,
-    kind: "plugin",
-    description: "Exec approval allowlists do not contain patterns outside policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyExecApprovalsAllowlistUnexpected,
-      );
-    },
-  };
-
-  return [
-    policyExecApprovalsMissingCheck,
-    policyExecApprovalsInvalidCheck,
-    policyExecApprovalsDefaultSecurityUnapprovedCheck,
-    policyExecApprovalsAgentSecurityUnapprovedCheck,
-    policyExecApprovalsAutoAllowSkillsEnabledCheck,
-    policyExecApprovalsAllowlistMissingCheck,
-    policyExecApprovalsAllowlistUnexpectedCheck,
-  ];
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsAllowlistMissing,
+      "Exec approval allowlists include every pattern required by policy.",
+    ],
+    [
+      CHECK_IDS.policyExecApprovalsAllowlistUnexpected,
+      "Exec approval allowlists do not contain patterns outside policy.",
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/gateway.ts
+++ b/extensions/policy/src/doctor/scopes/gateway.ts
@@ -3,140 +3,58 @@ import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import type { PolicyEvidence } from "../../policy-state.js";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import { previewPolicyReviewRequiredRepair } from "../review-required-repairs.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 import { readPolicyBoolean, readStringList } from "../utils.js";
 
 export function createPolicyGatewayChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyGatewayNonLoopbackBindCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayNonLoopbackBind,
-    kind: "plugin",
-    description: "Gateway bind posture matches policy exposure requirements.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayNonLoopbackBind);
-    },
-    repair(ctx, findings) {
-      return previewPolicyReviewRequiredRepair(
-        ctx,
-        findings,
-        CHECK_IDS.policyGatewayNonLoopbackBind,
-      );
-    },
-  };
-  const policyGatewayAuthDisabledCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayAuthDisabled,
-    kind: "plugin",
-    description: "Gateway authentication remains enabled when required by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayAuthDisabled);
-    },
-  };
-  const policyGatewayRateLimitMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayRateLimitMissing,
-    kind: "plugin",
-    description: "Gateway authentication rate-limit posture is explicit when required by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayRateLimitMissing);
-    },
-  };
-  const policyGatewayControlUiInsecureCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayControlUiInsecure,
-    kind: "plugin",
-    description: "Gateway Control UI insecure exposure toggles remain disabled by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayControlUiInsecure);
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyGatewayControlUiInsecure);
-    },
-  };
-  const policyGatewayTailscaleFunnelCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayTailscaleFunnel,
-    kind: "plugin",
-    description: "Gateway Tailscale Funnel exposure matches policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayTailscaleFunnel);
-    },
-  };
-  const policyGatewayRemoteEnabledCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayRemoteEnabled,
-    kind: "plugin",
-    description: "Remote gateway mode matches policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayRemoteEnabled);
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyGatewayRemoteEnabled);
-    },
-  };
-  const policyGatewayHttpEndpointEnabledCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayHttpEndpointEnabled,
-    kind: "plugin",
-    description: "Gateway HTTP API endpoints match policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyGatewayHttpEndpointEnabled,
-      );
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(
-        ctx,
-        findings,
-        CHECK_IDS.policyGatewayHttpEndpointEnabled,
-      );
-    },
-  };
-  const policyGatewayHttpUrlFetchUnrestrictedCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
-    kind: "plugin",
-    description: "Gateway HTTP URL-fetch inputs have allowlists when required by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
-      );
-    },
-  };
-  const policyGatewayNodeCommandDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policyGatewayNodeCommandDenied,
-    kind: "plugin",
-    description: "Gateway node command allowlists match policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayNodeCommandDenied);
-    },
-    repair(ctx, findings) {
-      return previewPolicyReviewRequiredRepair(
-        ctx,
-        findings,
-        CHECK_IDS.policyGatewayNodeCommandDenied,
-      );
-    },
-  };
-
-  return [
-    policyGatewayNonLoopbackBindCheck,
-    policyGatewayAuthDisabledCheck,
-    policyGatewayRateLimitMissingCheck,
-    policyGatewayControlUiInsecureCheck,
-    policyGatewayTailscaleFunnelCheck,
-    policyGatewayRemoteEnabledCheck,
-    policyGatewayHttpEndpointEnabledCheck,
-    policyGatewayHttpUrlFetchUnrestrictedCheck,
-    policyGatewayNodeCommandDeniedCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyGatewayNonLoopbackBind,
+      "Gateway bind posture matches policy exposure requirements.",
+      (ctx, findings) =>
+        previewPolicyReviewRequiredRepair(ctx, findings, CHECK_IDS.policyGatewayNonLoopbackBind),
+    ],
+    [
+      CHECK_IDS.policyGatewayAuthDisabled,
+      "Gateway authentication remains enabled when required by policy.",
+    ],
+    [
+      CHECK_IDS.policyGatewayRateLimitMissing,
+      "Gateway authentication rate-limit posture is explicit when required by policy.",
+    ],
+    [
+      CHECK_IDS.policyGatewayControlUiInsecure,
+      "Gateway Control UI insecure exposure toggles remain disabled by policy.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyGatewayControlUiInsecure),
+    ],
+    [CHECK_IDS.policyGatewayTailscaleFunnel, "Gateway Tailscale Funnel exposure matches policy."],
+    [
+      CHECK_IDS.policyGatewayRemoteEnabled,
+      "Remote gateway mode matches policy.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyGatewayRemoteEnabled),
+    ],
+    [
+      CHECK_IDS.policyGatewayHttpEndpointEnabled,
+      "Gateway HTTP API endpoints match policy.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyGatewayHttpEndpointEnabled),
+    ],
+    [
+      CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
+      "Gateway HTTP URL-fetch inputs have allowlists when required by policy.",
+    ],
+    [
+      CHECK_IDS.policyGatewayNodeCommandDenied,
+      "Gateway node command allowlists match policy.",
+      (ctx, findings) =>
+        previewPolicyReviewRequiredRepair(ctx, findings, CHECK_IDS.policyGatewayNodeCommandDenied),
+    ],
+  ]);
 }
 
 export function gatewayExposureFindings(

--- a/extensions/policy/src/doctor/scopes/model-network.ts
+++ b/extensions/policy/src/doctor/scopes/model-network.ts
@@ -2,6 +2,7 @@
 import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import type { PolicyEvidence } from "../../policy-state.js";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 import { readPolicyBoolean, readStringList } from "../utils.js";
@@ -9,61 +10,25 @@ import { readPolicyBoolean, readStringList } from "../utils.js";
 export function createPolicyModelNetworkChecks(
   deps: PolicyDoctorCheckDeps,
 ): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyMcpDeniedServerCheck: HealthCheck = {
-    id: CHECK_IDS.policyDeniedMcpServer,
-    kind: "plugin",
-    description: "Configured MCP servers do not match policy deny rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedMcpServer);
-    },
-  };
-  const policyMcpUnapprovedServerCheck: HealthCheck = {
-    id: CHECK_IDS.policyUnapprovedMcpServer,
-    kind: "plugin",
-    description: "Configured MCP servers do not match policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnapprovedMcpServer);
-    },
-  };
-  const policyModelsDeniedProviderCheck: HealthCheck = {
-    id: CHECK_IDS.policyDeniedModelProvider,
-    kind: "plugin",
-    description: "Configured model providers do not match policy deny rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedModelProvider);
-    },
-  };
-  const policyModelsUnapprovedProviderCheck: HealthCheck = {
-    id: CHECK_IDS.policyUnapprovedModelProvider,
-    kind: "plugin",
-    description: "Configured model providers do not match policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnapprovedModelProvider);
-    },
-  };
-  const policyNetworkPrivateAccessCheck: HealthCheck = {
-    id: CHECK_IDS.policyPrivateNetworkAccess,
-    kind: "plugin",
-    description: "Network SSRF policy settings match private-network requirements.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyPrivateNetworkAccess);
-    },
-  };
-
-  return [
-    policyMcpDeniedServerCheck,
-    policyMcpUnapprovedServerCheck,
-    policyModelsDeniedProviderCheck,
-    policyModelsUnapprovedProviderCheck,
-    policyNetworkPrivateAccessCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [CHECK_IDS.policyDeniedMcpServer, "Configured MCP servers do not match policy deny rules."],
+    [
+      CHECK_IDS.policyUnapprovedMcpServer,
+      "Configured MCP servers do not match policy allow rules.",
+    ],
+    [
+      CHECK_IDS.policyDeniedModelProvider,
+      "Configured model providers do not match policy deny rules.",
+    ],
+    [
+      CHECK_IDS.policyUnapprovedModelProvider,
+      "Configured model providers do not match policy allow rules.",
+    ],
+    [
+      CHECK_IDS.policyPrivateNetworkAccess,
+      "Network SSRF policy settings match private-network requirements.",
+    ],
+  ]);
 }
 
 export function mcpServerFindings(

--- a/extensions/policy/src/doctor/scopes/routing.ts
+++ b/extensions/policy/src/doctor/scopes/routing.ts
@@ -1,51 +1,25 @@
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyRoutingChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-  return [
-    {
-      id: CHECK_IDS.policyRoutingBindingsRequired,
-      kind: "plugin",
-      description: "Routing policy has at least one channel route binding when required.",
-      source: "policy",
-      async detect(ctx) {
-        return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyRoutingBindingsRequired);
-      },
-    },
-    {
-      id: CHECK_IDS.policyRoutingBindingChannelUnconfigured,
-      kind: "plugin",
-      description: "Route bindings name channels present in configuration.",
-      source: "policy",
-      async detect(ctx) {
-        return findingsForCheck(
-          await evaluatePolicy(ctx),
-          CHECK_IDS.policyRoutingBindingChannelUnconfigured,
-        );
-      },
-    },
-    {
-      id: CHECK_IDS.policyRoutingAgentMismatch,
-      kind: "plugin",
-      description: "Authored routing probes resolve to their expected agents.",
-      source: "policy",
-      async detect(ctx) {
-        return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyRoutingAgentMismatch);
-      },
-    },
-    {
-      id: CHECK_IDS.policyRoutingMatchKindMismatch,
-      kind: "plugin",
-      description: "Authored routing probes match at their expected specificity.",
-      source: "policy",
-      async detect(ctx) {
-        return findingsForCheck(
-          await evaluatePolicy(ctx),
-          CHECK_IDS.policyRoutingMatchKindMismatch,
-        );
-      },
-    },
-  ];
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyRoutingBindingsRequired,
+      "Routing policy has at least one channel route binding when required.",
+    ],
+    [
+      CHECK_IDS.policyRoutingBindingChannelUnconfigured,
+      "Route bindings name channels present in configuration.",
+    ],
+    [
+      CHECK_IDS.policyRoutingAgentMismatch,
+      "Authored routing probes resolve to their expected agents.",
+    ],
+    [
+      CHECK_IDS.policyRoutingMatchKindMismatch,
+      "Authored routing probes match at their expected specificity.",
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/sandbox.ts
+++ b/extensions/policy/src/doctor/scopes/sandbox.ts
@@ -1,123 +1,43 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicySandboxChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policySandboxModeUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxModeUnapproved,
-    kind: "plugin",
-    description: "Sandbox mode config satisfies policy requirements.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySandboxModeUnapproved);
-    },
-  };
-  const policySandboxBackendUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxBackendUnapproved,
-    kind: "plugin",
-    description: "Sandbox backend config satisfies policy requirements.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySandboxBackendUnapproved);
-    },
-  };
-  const policySandboxContainerPostureUnobservableCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerPostureUnobservable,
-    kind: "plugin",
-    description: "Sandbox container posture policy only targets observable container backends.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerPostureUnobservable,
-      );
-    },
-  };
-  const policySandboxContainerHostNetworkDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerHostNetworkDenied,
-    kind: "plugin",
-    description: "Sandbox container config avoids host network mode.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerHostNetworkDenied,
-      );
-    },
-  };
-  const policySandboxContainerNamespaceJoinDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerNamespaceJoinDenied,
-    kind: "plugin",
-    description: "Sandbox container config avoids joining another container network namespace.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerNamespaceJoinDenied,
-      );
-    },
-  };
-  const policySandboxContainerMountModeRequiredCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerMountModeRequired,
-    kind: "plugin",
-    description: "Sandbox container mounts are read-only when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerMountModeRequired,
-      );
-    },
-  };
-  const policySandboxContainerRuntimeSocketMountCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerRuntimeSocketMount,
-    kind: "plugin",
-    description: "Sandbox container mounts avoid host container runtime sockets.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerRuntimeSocketMount,
-      );
-    },
-  };
-  const policySandboxContainerUnconfinedProfileCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxContainerUnconfinedProfile,
-    kind: "plugin",
-    description: "Sandbox container profile config avoids unconfined profiles.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxContainerUnconfinedProfile,
-      );
-    },
-  };
-  const policySandboxBrowserCdpSourceRangeMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policySandboxBrowserCdpSourceRangeMissing,
-    kind: "plugin",
-    description: "Sandbox browser CDP config includes a source range when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policySandboxBrowserCdpSourceRangeMissing,
-      );
-    },
-  };
-
-  return [
-    policySandboxModeUnapprovedCheck,
-    policySandboxBackendUnapprovedCheck,
-    policySandboxContainerPostureUnobservableCheck,
-    policySandboxContainerHostNetworkDeniedCheck,
-    policySandboxContainerNamespaceJoinDeniedCheck,
-    policySandboxContainerMountModeRequiredCheck,
-    policySandboxContainerRuntimeSocketMountCheck,
-    policySandboxContainerUnconfinedProfileCheck,
-    policySandboxBrowserCdpSourceRangeMissingCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [CHECK_IDS.policySandboxModeUnapproved, "Sandbox mode config satisfies policy requirements."],
+    [
+      CHECK_IDS.policySandboxBackendUnapproved,
+      "Sandbox backend config satisfies policy requirements.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerPostureUnobservable,
+      "Sandbox container posture policy only targets observable container backends.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerHostNetworkDenied,
+      "Sandbox container config avoids host network mode.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerNamespaceJoinDenied,
+      "Sandbox container config avoids joining another container network namespace.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerMountModeRequired,
+      "Sandbox container mounts are read-only when policy requires it.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerRuntimeSocketMount,
+      "Sandbox container mounts avoid host container runtime sockets.",
+    ],
+    [
+      CHECK_IDS.policySandboxContainerUnconfinedProfile,
+      "Sandbox container profile config avoids unconfined profiles.",
+    ],
+    [
+      CHECK_IDS.policySandboxBrowserCdpSourceRangeMissing,
+      "Sandbox browser CDP config includes a source range when policy requires it.",
+    ],
+  ]);
 }

--- a/extensions/policy/src/doctor/scopes/tools.ts
+++ b/extensions/policy/src/doctor/scopes/tools.ts
@@ -1,211 +1,77 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
+import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyAgentsWorkspaceAccessDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
-    kind: "plugin",
-    description: "Agent sandbox workspace access matches policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyAgentsWorkspaceAccessDenied,
-      );
-    },
-  };
-  const policyAgentsToolNotDeniedCheck: HealthCheck = {
-    id: CHECK_IDS.policyAgentsToolNotDenied,
-    kind: "plugin",
-    description: "Agent workspace mutation/runtime tools are denied when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAgentsToolNotDenied);
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyAgentsToolNotDenied);
-    },
-  };
-  const policyToolsProfileUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsProfileUnapproved,
-    kind: "plugin",
-    description: "Configured tool profiles match policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsProfileUnapproved);
-    },
-  };
-  const policyToolsFsWorkspaceOnlyRequiredCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
-    kind: "plugin",
-    description: "Filesystem tools use workspace-only posture when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
-      );
-    },
-  };
-  const policyToolsExecSecurityUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsExecSecurityUnapproved,
-    kind: "plugin",
-    description: "Exec tool security mode matches policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(
-        await evaluatePolicy(ctx),
-        CHECK_IDS.policyToolsExecSecurityUnapproved,
-      );
-    },
-  };
-  const policyToolsExecAskUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsExecAskUnapproved,
-    kind: "plugin",
-    description: "Exec tool ask mode matches policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsExecAskUnapproved);
-    },
-  };
-  const policyToolsExecHostUnapprovedCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsExecHostUnapproved,
-    kind: "plugin",
-    description: "Exec tool host routing matches policy allow rules.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsExecHostUnapproved);
-    },
-  };
-  const policyToolsElevatedEnabledCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsElevatedEnabled,
-    kind: "plugin",
-    description: "Elevated tool mode remains disabled when policy requires it.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsElevatedEnabled);
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyToolsElevatedEnabled);
-    },
-  };
-  const policyToolsAlsoAllowMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsAlsoAllowMissing,
-    kind: "plugin",
-    description: "Configured tools.alsoAllow entries include policy expected lists.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsAlsoAllowMissing);
-    },
-  };
-  const policyToolsAlsoAllowUnexpectedCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsAlsoAllowUnexpected,
-    kind: "plugin",
-    description: "Configured tools.alsoAllow entries match policy expected lists.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsAlsoAllowUnexpected);
-    },
-  };
-  const policyToolsRequiredDenyMissingCheck: HealthCheck = {
-    id: CHECK_IDS.policyToolsRequiredDenyMissing,
-    kind: "plugin",
-    description: "Configured tool deny lists include tools required by policy.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsRequiredDenyMissing);
-    },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyToolsRequiredDenyMissing);
-    },
-  };
-
-  return [
-    policyAgentsWorkspaceAccessDeniedCheck,
-    policyAgentsToolNotDeniedCheck,
-    policyToolsProfileUnapprovedCheck,
-    policyToolsFsWorkspaceOnlyRequiredCheck,
-    policyToolsExecSecurityUnapprovedCheck,
-    policyToolsExecAskUnapprovedCheck,
-    policyToolsExecHostUnapprovedCheck,
-    policyToolsElevatedEnabledCheck,
-    policyToolsAlsoAllowMissingCheck,
-    policyToolsAlsoAllowUnexpectedCheck,
-    policyToolsRequiredDenyMissingCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [CHECK_IDS.policyAgentsWorkspaceAccessDenied, "Agent sandbox workspace access matches policy."],
+    [
+      CHECK_IDS.policyAgentsToolNotDenied,
+      "Agent workspace mutation/runtime tools are denied when policy requires it.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyAgentsToolNotDenied),
+    ],
+    [CHECK_IDS.policyToolsProfileUnapproved, "Configured tool profiles match policy allow rules."],
+    [
+      CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
+      "Filesystem tools use workspace-only posture when policy requires it.",
+    ],
+    [
+      CHECK_IDS.policyToolsExecSecurityUnapproved,
+      "Exec tool security mode matches policy allow rules.",
+    ],
+    [CHECK_IDS.policyToolsExecAskUnapproved, "Exec tool ask mode matches policy allow rules."],
+    [CHECK_IDS.policyToolsExecHostUnapproved, "Exec tool host routing matches policy allow rules."],
+    [
+      CHECK_IDS.policyToolsElevatedEnabled,
+      "Elevated tool mode remains disabled when policy requires it.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyToolsElevatedEnabled),
+    ],
+    [
+      CHECK_IDS.policyToolsAlsoAllowMissing,
+      "Configured tools.alsoAllow entries include policy expected lists.",
+    ],
+    [
+      CHECK_IDS.policyToolsAlsoAllowUnexpected,
+      "Configured tools.alsoAllow entries match policy expected lists.",
+    ],
+    [
+      CHECK_IDS.policyToolsRequiredDenyMissing,
+      "Configured tool deny lists include tools required by policy.",
+      (ctx, findings) =>
+        repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyToolsRequiredDenyMissing),
+    ],
+  ]);
 }
 
 export function createPolicyToolMetadataChecks(
   deps: PolicyDoctorCheckDeps,
 ): readonly HealthCheck[] {
-  const { evaluatePolicy, findingsForCheck } = deps;
-
-  const policyUnmigratedToolsFileCheck: HealthCheck = {
-    id: CHECK_IDS.policyUnmigratedToolsFile,
-    kind: "plugin",
-    description: "Governed tool declarations have been migrated from TOOLS.md into AGENTS.md.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnmigratedToolsFile);
-    },
-  };
-  const policyToolsMissingRiskCheck: HealthCheck = {
-    id: CHECK_IDS.policyMissingToolRisk,
-    kind: "plugin",
-    description: "AGENTS.md tool policy entries declare explicit risk levels.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolRisk);
-    },
-  };
-  const policyToolsUnknownRiskCheck: HealthCheck = {
-    id: CHECK_IDS.policyUnknownToolRisk,
-    kind: "plugin",
-    description: "AGENTS.md tool policy entries use known risk levels.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnknownToolRisk);
-    },
-  };
-  const policyToolsMissingSensitivityCheck: HealthCheck = {
-    id: CHECK_IDS.policyMissingToolSensitivity,
-    kind: "plugin",
-    description: "AGENTS.md tool policy entries declare default artifact sensitivity.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolSensitivity);
-    },
-  };
-  const policyToolsUnknownSensitivityCheck: HealthCheck = {
-    id: CHECK_IDS.policyUnknownToolSensitivity,
-    kind: "plugin",
-    description: "AGENTS.md tool policy entries use known sensitivity levels.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnknownToolSensitivity);
-    },
-  };
-  const policyToolsMissingOwnerCheck: HealthCheck = {
-    id: CHECK_IDS.policyMissingToolOwner,
-    kind: "plugin",
-    description: "AGENTS.md tool policy entries declare an accountable owner.",
-    source: "policy",
-    async detect(ctx) {
-      return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolOwner);
-    },
-  };
-
-  return [
-    policyUnmigratedToolsFileCheck,
-    policyToolsMissingRiskCheck,
-    policyToolsUnknownRiskCheck,
-    policyToolsMissingSensitivityCheck,
-    policyToolsMissingOwnerCheck,
-    policyToolsUnknownSensitivityCheck,
-  ];
+  return createPolicyScopedChecks(deps, [
+    [
+      CHECK_IDS.policyUnmigratedToolsFile,
+      "Governed tool declarations have been migrated from TOOLS.md into AGENTS.md.",
+    ],
+    [
+      CHECK_IDS.policyMissingToolRisk,
+      "AGENTS.md tool policy entries declare explicit risk levels.",
+    ],
+    [CHECK_IDS.policyUnknownToolRisk, "AGENTS.md tool policy entries use known risk levels."],
+    [
+      CHECK_IDS.policyMissingToolSensitivity,
+      "AGENTS.md tool policy entries declare default artifact sensitivity.",
+    ],
+    [
+      CHECK_IDS.policyMissingToolOwner,
+      "AGENTS.md tool policy entries declare an accountable owner.",
+    ],
+    [
+      CHECK_IDS.policyUnknownToolSensitivity,
+      "AGENTS.md tool policy entries use known sensitivity levels.",
+    ],
+  ]);
 }


### PR DESCRIPTION
## What Problem This Solves

The Policy plugin duplicates the same HealthCheck adapter in every one of its 68 doctor checks, spreading identical source, kind, evaluation, finding-selection, and optional-repair behavior across nine owner scopes.

## Why This Change Was Made

A private policy-owned descriptor factory makes that adapter canonical while retaining each existing check identifier, registration order, description, asynchronous detect behavior, and original repair callback. This removes 537 handwritten production lines without changing the public Plugin SDK, configuration, dependencies, storage, or plugin ownership.

## User Impact

Policy checks, doctor findings, and optional repairs behave exactly as before. All 68 shipped check descriptors and all 12 existing repair implementations remain intact.

## Evidence

- Compared the current and tagged v2026.7.1 HealthCheck contracts directly and mechanically verified exact parity for all 68 check IDs, descriptions, order, and all 12 repair callback bodies, including their synchronous or asynchronous declarations.
- Blacksmith Testbox full Policy plugin suite: pnpm test extensions/policy; 12 files and 385 tests passed.
- Full remote pnpm check:changed for all 11 changed paths passed extension production/test typechecks, extension lint, public Plugin SDK manifest, dead-export scan, plugin-boundary checks, SQLite guards, and runtime import-cycle checks.
- Full remote pnpm build passed.
- Real packaged operator proof in an isolated state directory: enabled the policy plugin, verified runtime inspection reported the loaded policy CLI, and proved policy check --json plus doctor --lint --json --only policy/policy-jsonc-missing both emit the expected identical missing-policy finding; doctor ran exactly one check.
- Fresh independent gpt-5.6-sol xhigh autoreview: no actionable findings; patch judged correct with 0.99 confidence.
- Production: +343/-880, net -537 lines. Tests: +111/-0. Overall: +454/-880, net -426 lines.
- AI-assisted implementation; source, shipped contracts, tests, and live operator behavior reviewed.