### PR TITLE
fix(whatsapp): align QA message extraction with Baileys envelopes

### DIFF
--- a/extensions/whatsapp/src/qa-driver.runtime.test.ts
+++ b/extensions/whatsapp/src/qa-driver.runtime.test.ts
@@ -462,6 +462,100 @@ describe("startWhatsAppQaDriverSession", () => {
     await session.close();
   });
 
+  it.each([
+    ...[
+      { name: "captionless video note", message: { ptvMessage: {} } },
+      {
+        name: "ephemeral captionless video note",
+        message: { ephemeralMessage: { message: { ptvMessage: {} } } },
+      },
+      {
+        name: "edited captionless video note",
+        message: { editedMessage: { message: { ptvMessage: {} } } },
+      },
+    ].map(({ name, message }) => ({
+      name,
+      message,
+      expected: { kind: "media", mediaType: "video/mp4", text: "" },
+    })),
+    ...[
+      "pollCreationMessage",
+      "pollCreationMessageV2",
+      "pollCreationMessageV3",
+      "pollCreationMessageV5",
+    ].flatMap((pollKey) => {
+      const poll = {
+        [pollKey]: {
+          name: "Choose a time",
+          options: [{ optionName: "Morning" }, { optionName: "Afternoon" }],
+        },
+      };
+      const expected = {
+        kind: "poll",
+        poll: { question: "Choose a time", options: ["Morning", "Afternoon"] },
+      };
+      return [
+        { name: pollKey, message: poll, expected },
+        {
+          name: `ephemeral ${pollKey}`,
+          message: { ephemeralMessage: { message: poll } },
+          expected,
+        },
+      ];
+    }),
+    ...["pollCreationMessageV3", "pollCreationMessageV5"].flatMap((pollKey) => {
+      const poll = {
+        [pollKey]: {
+          name: "Choose a time",
+          options: [{ optionName: "Morning" }, { optionName: "Afternoon" }],
+        },
+      };
+      const wrappedPoll = { pollCreationMessageV4: { message: poll } };
+      const expected = {
+        kind: "poll",
+        poll: { question: "Choose a time", options: ["Morning", "Afternoon"] },
+      };
+      return [
+        { name: `future-proof version-4 ${pollKey}`, message: wrappedPoll, expected },
+        {
+          name: `ephemeral future-proof version-4 ${pollKey}`,
+          message: { ephemeralMessage: { message: wrappedPoll } },
+          expected,
+        },
+        { name: `edited ${pollKey}`, message: { editedMessage: { message: poll } }, expected },
+      ];
+    }),
+  ])("resolves live ingress waiters for $name", async ({ message, expected }) => {
+    const sock = createMockSocket();
+    mocks.createWaSocket.mockResolvedValue(sock);
+    mocks.waitForWaConnection.mockResolvedValue(undefined);
+    mocks.jidToE164.mockReturnValue("+15551234567");
+
+    const session = await startWhatsAppQaDriverSession({
+      authDir: "/tmp/openclaw-whatsapp-auth",
+    });
+
+    try {
+      const observed = session.waitForMessage({
+        timeoutMs: 150,
+        match: (candidate) => candidate.kind === expected.kind,
+      });
+      sock.ev.emit("messages.upsert", {
+        messages: [
+          {
+            key: { fromMe: false, id: "observed-message", remoteJid: "12345@lid" },
+            message,
+          } as WAMessage,
+        ],
+      });
+
+      await expect(observed).resolves.toMatchObject(expected);
+      expect(session.getObservedMessages()).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
   it("uses canonical WhatsApp media MIME defaults when Baileys omits MIME", async () => {
     const sock = createMockSocket();
     mocks.createWaSocket.mockResolvedValue(sock);

--- a/extensions/whatsapp/src/qa-driver.runtime.ts
+++ b/extensions/whatsapp/src/qa-driver.runtime.ts
@@ -1,5 +1,5 @@
 // Whatsapp plugin module implements qa driver behavior.
-import type { ConnectionState, proto, WAMessage } from "baileys";
+import { getContentType, type ConnectionState, type proto, type WAMessage } from "baileys";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import {
   describeReplyContext,
@@ -180,19 +180,10 @@ function findMessageSection(
     if (current.depth >= 4) {
       continue;
     }
-    for (const wrapperName of [
-      "botInvokeMessage",
-      "documentWithCaptionMessage",
-      "ephemeralMessage",
-      "groupMentionedMessage",
-      "viewOnceMessage",
-      "viewOnceMessageV2",
-      "viewOnceMessageV2Extension",
-    ]) {
-      const wrapper = current.value[wrapperName];
-      if (isRecord(wrapper) && isRecord(wrapper.message)) {
-        queue.push({ depth: current.depth + 1, value: wrapper.message });
-      }
+    const contentType = getContentType(current.value as proto.IMessage);
+    const wrapper = contentType ? current.value[contentType] : undefined;
+    if (isRecord(wrapper) && isRecord(wrapper.message)) {
+      queue.push({ depth: current.depth + 1, value: wrapper.message });
     }
   }
   return undefined;
@@ -218,6 +209,7 @@ function readPoll(message: unknown): WhatsAppQaDriverObservedPoll | undefined {
     "pollCreationMessage",
     "pollCreationMessageV2",
     "pollCreationMessageV3",
+    "pollCreationMessageV5",
   ]);
   if (!poll) {
     return undefined;
@@ -244,6 +236,7 @@ function readMedia(message: unknown):
   const mediaSections = [
     "imageMessage",
     "videoMessage",
+    "ptvMessage",
     "audioMessage",
     "documentMessage",
     "stickerMessage",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WhatsApp QA users waiting for native polls or video notes would time out even though WhatsApp delivered the message, including V5 polls, V4-wrapped polls, edited polls, and captionless video notes.

## Why This Change Was Made

Restore three independently evidenced owner invariants: recognize native PTV video notes, recognize V5 native polls, and replace the incomplete seven-wrapper allowlist with Baileys’ canonical active-message FutureProof traversal. Preserve the existing depth bound and media MIME owner while removing seven net production lines.

## User Impact

WhatsApp QA scenarios now observe direct, ephemeral, edited, and FutureProof-wrapped polls and video notes through the existing message waiter. Normal WhatsApp transport, authentication, configuration, storage, and public APIs are unchanged.

## Evidence

- Before: real messages.upsert → waitForMessage regressions reproduced 11 failures while six existing V1/V2/V3 controls passed.
- After: all 36 WhatsApp QA owner tests pass, including direct/ephemeral V1, V2, V3, and V5 polls; genuine V4 FutureProof → V3/V5 polls; edited polls; and direct/ephemeral/edited PTV video notes.
- Extension production and test typechecks, configured extension lint, formatting, deprecated-API checks, and plugin-boundary CI all pass.
- Exact candidate owner blobs verified against current main in [hosted GitHub Actions](https://github.com/openclaw/openclaw/actions/runs/30713379677).
- Six independent source reviews and formal gpt-5.6-sol high-reasoning P0–P3 review report no findings; genuine native TruffleHog 3.96.0 credential scanning is clean.
