### PR TITLE
perf(gateway): skip empty session reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway empty-agent startup:** skip transcript projection reconciliation when configured agents still have no session SQLite database after legacy import, avoiding empty per-agent database creation and reducing multi-agent startup work.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway empty-agent startup:** skip transcript projection reconciliation when configured agents still have no session SQLite database after legacy import, avoiding empty per-agent database creation and reducing multi-agent startup work.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/src/gateway/server-startup-session-migration.test.ts
+++ b/src/gateway/server-startup-session-migration.test.ts
@@ -1,7 +1,11 @@
 /**
  * Gateway startup session migration tests.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { runStartupSessionMigration } from "./server-startup-session-migration.js";
 
 type StartupMigrationDeps = NonNullable<Parameters<typeof runStartupSessionMigration>[0]["deps"]>;
@@ -14,6 +18,7 @@ type RunDoctorSessionSqlite = NonNullable<StartupMigrationDeps["runDoctorSession
 type ReconcileSessionTranscriptIndexes = NonNullable<
   StartupMigrationDeps["reconcileSessionTranscriptIndexes"]
 >;
+type SessionSqliteDatabaseExists = NonNullable<StartupMigrationDeps["sessionSqliteDatabaseExists"]>;
 
 function makeLog() {
   return {
@@ -50,7 +55,14 @@ function makeDeps(
       .mockResolvedValue(0),
     runDoctorSessionSqlite,
     reconcileSessionTranscriptIndexes,
+    sessionSqliteDatabaseExists: vi.fn<SessionSqliteDatabaseExists>().mockReturnValue(true),
   };
+}
+
+function useDefaultDatabaseExists(deps: ReturnType<typeof makeDeps>): StartupMigrationDeps {
+  const defaultDeps: StartupMigrationDeps = { ...deps };
+  delete defaultDeps.sessionSqliteDatabaseExists;
+  return defaultDeps;
 }
 
 function firstLogMessage(log: ReturnType<typeof vi.fn>, label: string): string {
@@ -229,6 +241,105 @@ describe("runStartupSessionMigration", () => {
     expect(log.info).toHaveBeenCalledWith(
       "session: rebuilt 3 transcript projection(s) before serving history",
     );
+  });
+
+  it("skips transcript reconciliation when configured agents have no SQLite database", async () => {
+    const log = makeLog();
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const reconcile = vi
+      .fn<ReconcileSessionTranscriptIndexes>()
+      .mockResolvedValue({ reconciledSessions: 0 });
+    const deps = makeDeps(migrate, 0, makeSessionSqliteImport(), reconcile);
+    const defaultDeps = useDefaultDatabaseExists(deps);
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-startup-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    try {
+      await runStartupSessionMigration({
+        cfg: {
+          agents: { defaults: {}, list: [{ id: "main" }, { id: "ops" }] },
+          session: {},
+        } as Parameters<typeof runStartupSessionMigration>[0]["cfg"],
+        env,
+        log,
+        deps: defaultDeps,
+      });
+
+      expect(reconcile).not.toHaveBeenCalled();
+      expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId: "main", env }))).toBe(false);
+      expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId: "ops", env }))).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("reconciles configured agents with an existing SQLite database", async () => {
+    const log = makeLog();
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const reconcile = vi
+      .fn<ReconcileSessionTranscriptIndexes>()
+      .mockResolvedValue({ reconciledSessions: 1 });
+    const deps = makeDeps(migrate, 0, makeSessionSqliteImport(), reconcile);
+    const defaultDeps = useDefaultDatabaseExists(deps);
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-startup-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "ops", env });
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    fs.writeFileSync(databasePath, "");
+    try {
+      await runStartupSessionMigration({
+        cfg: {
+          agents: { defaults: {}, list: [{ id: "main" }, { id: "ops" }] },
+          session: {},
+        } as Parameters<typeof runStartupSessionMigration>[0]["cfg"],
+        env,
+        log,
+        deps: defaultDeps,
+      });
+
+      expect(reconcile).toHaveBeenCalledOnce();
+      expect(reconcile).toHaveBeenCalledWith({ agentId: "ops", env });
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("reconciles a SQLite database created by the startup import", async () => {
+    const log = makeLog();
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const events: string[] = [];
+    const importSessionSqlite = makeSessionSqliteImport();
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-startup-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+    const runDoctorSessionSqlite = vi.fn<RunDoctorSessionSqlite>().mockImplementation(async () => {
+      events.push("import");
+      fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+      fs.writeFileSync(databasePath, "");
+      return await importSessionSqlite({
+        allAgents: true,
+        cfg: makeCfg(),
+        env,
+        mode: "import",
+      });
+    });
+    const reconcile = vi
+      .fn<ReconcileSessionTranscriptIndexes>()
+      .mockResolvedValue({ reconciledSessions: 1 });
+    const deps = makeDeps(migrate, 0, runDoctorSessionSqlite, reconcile);
+    const defaultDeps = useDefaultDatabaseExists(deps);
+    const cfg = makeCfg();
+    reconcile.mockImplementation(async () => {
+      events.push("reconcile");
+      return { reconciledSessions: 1 };
+    });
+    try {
+      await runStartupSessionMigration({ cfg, env, log, deps: defaultDeps });
+
+      expect(events).toEqual(["import", "reconcile"]);
+      expect(reconcile).toHaveBeenCalledWith({ agentId: "main", env });
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
   });
 
   it("warns without blocking when hot legacy session SQLite import reports legacy file issues", async () => {

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { listAgentIds } from "../agents/agent-scope.js";
 import {
   isSessionSqliteMigrationWarning,
@@ -10,6 +11,7 @@ import {
   type SessionStartupMigrationLogger,
 } from "../config/sessions/startup-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 
 type SessionSqliteStartupImportRunner = (params: {
   allAgents: true;
@@ -28,10 +30,16 @@ type SessionSqliteStartupFailureReportWriter = (
   params: { reason: string },
 ) => { jsonPath: string; markdownPath: string };
 
+type SessionSqliteDatabaseExists = (params: {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+}) => boolean;
+
 type SessionMigrationDeps = Parameters<typeof runSessionStartupMigration>[0]["deps"] & {
   reconcileSessionTranscriptIndexes?: typeof import("../config/sessions/session-transcript-reconcile.js").reconcileSessionTranscriptIndexes;
   restoreSessionSqliteMigrationRun?: SessionSqliteStartupRestoreRunner;
   runDoctorSessionSqlite?: SessionSqliteStartupImportRunner;
+  sessionSqliteDatabaseExists?: SessionSqliteDatabaseExists;
   writeSessionSqliteMigrationFailureReports?: SessionSqliteStartupFailureReportWriter;
 };
 
@@ -58,12 +66,27 @@ async function reconcileStartupSessionTranscriptIndexes(params: {
   log: SessionStartupMigrationLogger;
   deps?: SessionMigrationDeps;
 }): Promise<void> {
+  const databaseExists =
+    params.deps?.sessionSqliteDatabaseExists ??
+    ((input: Parameters<SessionSqliteDatabaseExists>[0]) =>
+      fs.existsSync(resolveOpenClawAgentSqlitePath(input)));
+  const agentIds = listAgentIds(params.cfg).filter((agentId) =>
+    databaseExists({
+      agentId,
+      ...(params.env ? { env: params.env } : {}),
+    }),
+  );
+  if (agentIds.length === 0) {
+    // No durable session rows can need projection repair when the agent DB is absent.
+    // Avoid creating and schema-registering one empty DB per configured agent at startup.
+    return;
+  }
   const reconcile =
     params.deps?.reconcileSessionTranscriptIndexes ??
     (await import("../config/sessions/session-transcript-reconcile.js"))
       .reconcileSessionTranscriptIndexes;
   let reconciledSessions = 0;
-  for (const agentId of listAgentIds(params.cfg)) {
+  for (const agentId of agentIds) {
     const result = await reconcile({
       agentId,
       ...(params.env ? { env: params.env } : {}),


### PR DESCRIPTION
Related: #117577

## What Problem This Solves

Fixes an issue where gateways with configured agents that had no session state would create and schema-register an empty SQLite database for every agent during startup transcript reconciliation.

## Why This Change Was Made

Startup now checks each configured agent's canonical SQLite path after the legacy import step and reconciles transcript projections only when that database exists. Request-time reconciliation and reconciliation for existing or newly imported databases remain unchanged.

## User Impact

Gateways with many configured but unused agents start faster and no longer create empty per-agent databases solely because the gateway started.

## Evidence

- Safe temp-state probe on Node 24.15.0:
  - current `main`, 1 agent: 123-139 ms, 1 reconcile call, 1 database created
  - this branch, 1 agent: 1.5-1.6 ms, 0 reconcile calls, 0 databases created
  - current `main`, 12 agents: 424-433 ms, 12 reconcile calls, 12 databases created
  - this branch, 12 agents: 45.1-48.8 ms, 0 reconcile calls, 0 databases created
- `node scripts/run-vitest.mjs src/gateway/server-startup-session-migration.test.ts`
  - 15/15 tests passed
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Structured autoreview completed with no accepted or actionable findings.
- The broader oxlint wrapper was attempted but stopped on an unrelated current-main declaration error in `packages/terminal-core/src/ansi.ts`; the touched files pass direct targeted lint.
