### PR TITLE
fix(commitments): make dismissal atomic and truthful

### DIFF
--- a/docs/cli/commitments.md
+++ b/docs/cli/commitments.md
@@ -86,6 +86,32 @@ and one row per commitment:
 JSON output includes the count, the active status and agent filters, the
 shared SQLite database path, and the full stored records.
 
+### Dismissal output
+
+`dismiss` changes only active `pending` or `snoozed` commitments. Missing,
+already dismissed, sent, and expired commitments remain unchanged. Duplicate
+IDs are ignored after their first occurrence, and results preserve request order.
+
+When every requested commitment is dismissed, `--json` returns:
+
+```json
+{ "dismissed": ["cm_abc123", "cm_def456"] }
+```
+
+When a request includes stale or inactive IDs, the command reports both results
+and exits with status `1`:
+
+```json
+{ "dismissed": ["cm_abc123"], "notDismissed": ["cm_missing", "cm_expired"] }
+```
+
+If no requested commitment can be dismissed, the command still exits with status
+`1`:
+
+```json
+{ "dismissed": [], "notDismissed": ["cm_missing"] }
+```
+
 ## Related
 
 - [Inferred commitments](/concepts/commitments)

--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -70,6 +70,38 @@ describe("commitments command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.listCommitments.mockResolvedValue([commitment()]);
+    mocks.markCommitmentsStatus.mockResolvedValue(["cm_escape"]);
+  });
+
+  it("sanitizes invalid status values before rendering errors", async () => {
+    const { runtime } = createRuntime();
+
+    await commitmentsListCommand(
+      { status: "bad\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes\u001b[31m" },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Unknown commitment status: bad\\nforged: yes. Use one of: pending, sent, dismissed, snoozed, expired.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.listCommitments).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes agent filters and database paths in human-readable output", async () => {
+    const unsafeText = "\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes\u001b[31m";
+    mocks.resolveCommitmentDatabasePath.mockReturnValueOnce(`/tmp/${unsafeText}.sqlite`);
+    mocks.listCommitments.mockResolvedValueOnce([]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({ agent: `main${unsafeText}` }, runtime);
+
+    expect(logs.map(stripAnsi)).toContain("Store: /tmp/\\nforged: yes.sqlite");
+    expect(logs.map(stripAnsi)).toContain("Agent filter: main\\nforged: yes");
+    for (const line of logs) {
+      expect(line).not.toContain("\u0007");
+      expect(line).not.toContain("\n");
+    }
   });
 
   it("sanitizes untrusted commitment fields in table output", async () => {
@@ -240,5 +272,81 @@ describe("commitments command", () => {
       status: "dismissed",
       nowMs: expect.any(Number),
     });
+  });
+
+  it("reports only actually dismissed ids and explains skipped ids", async () => {
+    mocks.markCommitmentsStatus.mockResolvedValueOnce(["cm_valid"]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsDismissCommand(
+      { ids: [" cm_valid ", "cm_missing", "cm_valid", "cm_terminal"] },
+      runtime,
+    );
+
+    expect(mocks.markCommitmentsStatus).toHaveBeenCalledWith({
+      cfg: {},
+      ids: ["cm_valid", "cm_missing", "cm_terminal"],
+      status: "dismissed",
+      nowMs: expect.any(Number),
+    });
+    expect(logs.map(stripAnsi)).toEqual(["Dismissed commitments: cm_valid"]);
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Commitments not found or no longer active: cm_missing, cm_terminal. Run openclaw commitments --all to inspect current state.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects dismissals when no requested commitment is active", async () => {
+    mocks.markCommitmentsStatus.mockResolvedValueOnce([]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsDismissCommand({ ids: ["cm_missing", "cm_terminal"] }, runtime);
+
+    expect(logs).toEqual([]);
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Commitments not found or no longer active: cm_missing, cm_terminal. Run openclaw commitments --all to inspect current state.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps unsuccessful dismissals truthful and machine-readable", async () => {
+    mocks.markCommitmentsStatus.mockResolvedValueOnce([]);
+    const { runtime, logs, stdout } = createRuntime();
+
+    await commitmentsDismissCommand({ ids: ["cm_missing"], json: true }, runtime);
+
+    expect(logs).toEqual([]);
+    expect(stdout).toEqual([
+      JSON.stringify({ dismissed: [], notDismissed: ["cm_missing"] }, null, 2),
+    ]);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("sanitizes dismissed ids in human output while preserving raw JSON", async () => {
+    const unsafeId = "cm_\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes\u001b[31m";
+    mocks.markCommitmentsStatus.mockResolvedValue([unsafeId]);
+    const human = createRuntime();
+    const json = createRuntime();
+
+    await commitmentsDismissCommand({ ids: [unsafeId] }, human.runtime);
+    await commitmentsDismissCommand({ ids: [unsafeId], json: true }, json.runtime);
+
+    expect(human.logs.map(stripAnsi)).toEqual(["Dismissed commitments: cm_\\nforged: yes"]);
+    expect(human.logs[0]).not.toContain("\u0007");
+    expect(human.logs[0]).not.toContain("\n");
+    expect(JSON.parse(json.stdout[0] ?? "{}")).toStrictEqual({ dismissed: [unsafeId] });
+  });
+
+  it("sanitizes skipped dismiss ids in human-readable failure output", async () => {
+    const unsafeId = "cm_\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes\u001b[31m";
+    mocks.markCommitmentsStatus.mockResolvedValueOnce([]);
+    const { runtime } = createRuntime();
+
+    await commitmentsDismissCommand({ ids: [unsafeId] }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Commitments not found or no longer active: cm_\\nforged: yes. Run openclaw commitments --all to inspect current state.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -1,7 +1,7 @@
 // Implements commitment listing and dismissal commands for scheduled follow-up records.
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
@@ -41,7 +41,7 @@ function parseStatus(raw: string | undefined, runtime: RuntimeEnv): CommitmentSt
     return status as CommitmentStatus;
   }
   runtime.error(
-    `Unknown commitment status: ${status}. Use one of: ${Array.from(STATUS_VALUES).join(", ")}.`,
+    `Unknown commitment status: ${safe(status)}. Use one of: ${Array.from(STATUS_VALUES).join(", ")}.`,
   );
   runtime.exit(1);
   return undefined;
@@ -120,12 +120,12 @@ export async function commitmentsListCommand(
   }
 
   runtime.log(info(`Commitments: ${commitments.length}`));
-  runtime.log(info(`Store: ${resolveCommitmentDatabasePath()}`));
+  runtime.log(info(`Store: ${safe(resolveCommitmentDatabasePath())}`));
   if (status) {
     runtime.log(info(`Status filter: ${status}`));
   }
   if (opts.agent) {
-    runtime.log(info(`Agent filter: ${opts.agent}`));
+    runtime.log(info(`Agent filter: ${safe(opts.agent)}`));
   }
   if (commitments.length === 0) {
     runtime.log(
@@ -143,7 +143,7 @@ export async function commitmentsDismissCommand(
   opts: { ids: string[]; json?: boolean },
   runtime: RuntimeEnv,
 ): Promise<void> {
-  const ids = normalizeStringEntries(opts.ids);
+  const ids = normalizeUniqueStringEntries(opts.ids);
   if (ids.length === 0) {
     runtime.error(
       `At least one commitment id is required. Run ${formatCliCommand("openclaw commitments list")} to choose one.`,
@@ -152,15 +152,31 @@ export async function commitmentsDismissCommand(
     return;
   }
   const cfg = getRuntimeConfig();
-  await markCommitmentsStatus({
+  const dismissed = await markCommitmentsStatus({
     cfg,
     ids,
     status: "dismissed",
     nowMs: Date.now(),
   });
+  const dismissedIds = new Set(dismissed);
+  const notDismissed = ids.filter((id) => !dismissedIds.has(id));
   if (opts.json) {
-    writeRuntimeJson(runtime, { dismissed: ids });
+    writeRuntimeJson(runtime, {
+      dismissed,
+      ...(notDismissed.length > 0 ? { notDismissed } : {}),
+    });
+    if (notDismissed.length > 0) {
+      runtime.exit(1);
+    }
     return;
   }
-  runtime.log(info(`Dismissed commitments: ${ids.join(", ")}`));
+  if (dismissed.length > 0) {
+    runtime.log(info(`Dismissed commitments: ${dismissed.map(safe).join(", ")}`));
+  }
+  if (notDismissed.length > 0) {
+    runtime.error(
+      `Commitments not found or no longer active: ${notDismissed.map(safe).join(", ")}. Run ${formatCliCommand("openclaw commitments --all")} to inspect current state.`,
+    );
+    runtime.exit(1);
+  }
 }

--- a/src/commitments/store.test.ts
+++ b/src/commitments/store.test.ts
@@ -289,6 +289,51 @@ describe("commitment SQLite store", () => {
     expect(byId.cm_raceB?.status).toBe("dismissed");
   });
 
+  it("reports only active rows updated in first-seen requested order", async () => {
+    await useTempStateDir();
+    seedCommitmentsForTest([
+      commitment({ id: "cm_first", dedupeKey: "first" }),
+      commitment({ id: "cm_second", dedupeKey: "second", status: "snoozed" }),
+      commitment({
+        id: "cm_terminal",
+        dedupeKey: "terminal",
+        status: "dismissed",
+        dismissedAtMs: nowMs - 60_000,
+      }),
+    ]);
+
+    await expect(
+      markCommitmentsStatus({
+        ids: [" cm_second ", "cm_missing", "cm_first", "cm_second", "cm_terminal"],
+        status: "dismissed",
+        nowMs,
+      }),
+    ).resolves.toStrictEqual(["cm_second", "cm_first"]);
+
+    const byId = Object.fromEntries(readCommitmentsForTest().map((record) => [record.id, record]));
+    expect(byId.cm_first).toMatchObject({ status: "dismissed", dismissedAtMs: nowMs });
+    expect(byId.cm_second).toMatchObject({ status: "dismissed", dismissedAtMs: nowMs });
+    expect(byId.cm_terminal?.dismissedAtMs).toBe(nowMs - 60_000);
+  });
+
+  it("returns an empty update list without opening SQLite for empty ids", async () => {
+    await expect(
+      markCommitmentsStatus({ ids: ["", "   "], status: "dismissed", nowMs }),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("lets only one competing status transition claim the same commitment", async () => {
+    await useTempStateDir();
+    seedCommitmentsForTest([commitment({ id: "cm_race_claim" })]);
+
+    await expect(
+      Promise.all([
+        markCommitmentsStatus({ ids: ["cm_race_claim"], status: "dismissed", nowMs }),
+        markCommitmentsStatus({ ids: ["cm_race_claim"], status: "dismissed", nowMs }),
+      ]),
+    ).resolves.toStrictEqual([["cm_race_claim"], []]);
+  });
+
   it("increments concurrent attempt bumps without losing a write", async () => {
     await useTempStateDir();
     seedCommitmentsForTest([commitment({ id: "cm_race_attempts", attempts: 0 })]);

--- a/src/commitments/store.ts
+++ b/src/commitments/store.ts
@@ -1,6 +1,7 @@
 // Persists commitment records in the canonical shared SQLite database.
 import { randomBytes } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   executeSqliteQuerySync,
@@ -404,23 +405,30 @@ export async function markCommitmentsStatus(params: {
   ids: string[];
   status: Extract<CommitmentStatus, "sent" | "dismissed" | "expired">;
   nowMs?: number;
-}): Promise<void> {
-  const ids = [...new Set(params.ids.map((id) => id.trim()).filter(Boolean))];
+}): Promise<string[]> {
+  const ids = normalizeUniqueStringEntries(params.ids);
   if (ids.length === 0) {
-    return;
+    return [];
   }
   const nowMs = params.nowMs ?? Date.now();
-  runOpenClawStateWriteTransaction(({ db }) => {
+  return runOpenClawStateWriteTransaction(({ db }) => {
     const commitmentsDb = getNodeSqliteKysely<CommitmentsDatabase>(db);
-    const rows = executeSqliteQuerySync(
-      db,
-      commitmentsDb
-        .selectFrom("commitments")
-        .selectAll()
-        .where("id", "in", ids)
-        .where("status", "in", [...ACTIVE_STATUSES]),
-    ).rows;
-    for (const row of rows) {
+    const rowsById = new Map(
+      executeSqliteQuerySync(
+        db,
+        commitmentsDb
+          .selectFrom("commitments")
+          .selectAll()
+          .where("id", "in", ids)
+          .where("status", "in", [...ACTIVE_STATUSES]),
+      ).rows.map((row) => [row.id, row]),
+    );
+    const updatedIds: string[] = [];
+    for (const id of ids) {
+      const row = rowsById.get(id);
+      if (!row) {
+        continue;
+      }
       const record = commitmentRecordFromRow(row);
       updateCommitmentRow(db, {
         ...record,
@@ -430,7 +438,9 @@ export async function markCommitmentsStatus(params: {
         ...(params.status === "dismissed" ? { dismissedAtMs: nowMs } : {}),
         ...(params.status === "expired" ? { expiredAtMs: nowMs } : {}),
       });
+      updatedIds.push(record.id);
     }
+    return updatedIds;
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators dismissing missing or already-terminal follow-up commitments were told every requested dismissal succeeded even when SQLite changed nothing. Commitment filters, database paths, and identifiers could also place terminal control sequences into human-readable CLI output.

## Why This Change Was Made

The existing synchronous SQLite transaction now returns exactly the active commitment IDs it actually transitioned, preserving normalized first-seen request order. The CLI uses that authoritative result for truthful complete and partial outcomes, rejects unsuccessful requests, and sanitizes every affected human-readable value without changing successful JSON output, heartbeat behavior, storage schema, or SQL boundaries.

## User Impact

Operators receive accurate dismissal results, clear explanations and nonzero exits for missing or already-terminal commitments, deterministic duplicate-free batches, and safe terminal output. Concurrent CLI processes cannot both claim ownership of the same dismissal; machine-readable successful responses continue to preserve the original raw IDs.

## Evidence

- 84 focused tests pass across the commitment store, CLI commands, heartbeat delivery and cron-monitor paths, and registered Commander dispatch.
- A registered CLI against an isolated real SQLite database verifies missing, terminal, mixed, duplicate, hostile-control-character, and raw-JSON cases.
- Two independent operating-system processes simultaneously raced for the same SQLite row: exactly one returned a successful dismissal; the other returned a truthful structured failure with exit code 1.
- The production JSON-routing wrapper and registered CLI were exercised with separate real stdout and stderr pseudo-terminals: failure stdout remained valid escape-free JSON while terminal-reset bytes were emitted only on stderr.
- Forced-color terminal proof preserved intentional theme ANSI while removing injected OSC, BEL, CSI, and newline controls.
- Type-aware lint and type checking, formatting validation, and genuine TruffleHog 3.96 scanning passed with zero detected secrets.
- Five independent hostile reviews found no P0–P3 issues, and formal gpt-5.6-sol high-reasoning autoreview returned zero findings with 0.98 confidence.

Directly inspectable production evidence from the registered Commander path, an isolated real SQLite database, and two independent operating-system processes:

```json
{
  "listHumanSanitized": true,
  "listJsonRawPreserved": true,
  "nonexistentDismissTruthful": true,
  "terminalDismissTruthful": true,
  "mixedDismissTruthful": true,
  "dismissHumanSanitized": true,
  "dismissJsonRawPreserved": true,
  "missingDismissJsonTruthful": true,
  "richThemeAnsiPreserved": true,
  "independentProcessRace": [
    { "label": "A", "code": 0, "json": { "dismissed": ["cm_real_os_process_race"] } },
    { "label": "B", "code": 1, "json": { "dismissed": [], "notDismissed": ["cm_real_os_process_race"] } }
  ]
}
```

The production JSON-routing wrapper also passed against independent real stdout/stderr pseudo-terminals: failure stdout contained valid escape-free JSON and terminal reset bytes appeared only on stderr. The complete public evidence is available in https://github.com/openclaw/openclaw/pull/117591#issuecomment-5153077727.
