### PR TITLE
fix(memory): keep queued dreaming work within subagent limits

### DIFF
--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -161,6 +161,10 @@ describe("memory consolidation", () => {
     );
     expect(new Set(sessionKeys).size).toBe(2);
     expect(sessionKeys.every((key) => key.startsWith("dreaming-narrative-"))).toBe(true);
+    // Both groups share the global `subagent` lane so the configured
+    // `agents.defaults.subagents.maxConcurrent` bounds consolidation too.
+    const lanes = subagent.run.mock.calls.map(([options]) => (options as { lane?: string }).lane);
+    expect(new Set(lanes)).toEqual(new Set(["subagent"]));
     expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -625,7 +625,10 @@ async function runConsolidationGroup(params: {
       ),
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
-      lane: `dreaming-consolidation:${params.sessionKey}`,
+      // Consolidation shares the global `subagent` command lane (core's
+      // `CommandLane.Subagent`) so `agents.defaults.subagents.maxConcurrent`
+      // bounds dreaming subagent runs; per-session lanes bypass that limit.
+      lane: "subagent",
       lightContext: true,
       deliver: false,
     });

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -625,7 +625,6 @@ async function runConsolidationGroup(params: {
       ),
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
-      // Apply configured subagent concurrency across all dreaming sessions.
       lane: "subagent",
       lightContext: true,
       deliver: false,

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -625,9 +625,7 @@ async function runConsolidationGroup(params: {
       ),
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
-      // Consolidation shares the global `subagent` command lane (core's
-      // `CommandLane.Subagent`) so `agents.defaults.subagents.maxConcurrent`
-      // bounds dreaming subagent runs; per-session lanes bypass that limit.
+      // Apply configured subagent concurrency across all dreaming sessions.
       lane: "subagent",
       lightContext: true,
       deliver: false,

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -435,7 +435,9 @@ describe("runDreamNarrative", () => {
     expect(runOptions.idempotencyKey).toBe(`${expectedRunKey}-${nowMs}`);
     expect(runOptions.idempotencyKey).toMatch(/^dreaming-narrative-/);
     expect(runOptions.sessionKey).toBe(expectedSessionKey);
-    expect(runOptions.lane).toBe(`dreaming-narrative:${expectedSessionKey}`);
+    // Runs on the shared global subagent lane so the configured
+    // `agents.defaults.subagents.maxConcurrent` bounds every narrative.
+    expect(runOptions.lane).toBe("subagent");
     expect(runOptions.lightContext).toBe(true);
     expect(runOptions.deliver).toBe(false);
     expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
@@ -446,6 +448,50 @@ describe("runDreamNarrative", () => {
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
     expect(logger.info).toHaveBeenCalled();
+  });
+
+  // Regression: distinct agent/session narratives used per-session lanes, so the
+  // configured `agents.defaults.subagents.maxConcurrent` never applied and each
+  // session ran a separate dreaming subagent in parallel (#95746).
+  it("routes concurrent narratives for distinct sessions to the shared subagent lane", async () => {
+    const subagent = createMockSubagent("Two agents dreamed into one lane.");
+    const logger = createMockLogger();
+    const nowMs = Date.parse("2026-04-05T03:00:00Z");
+    const [firstWorkspace, secondWorkspace] = await Promise.all([
+      createTempWorkspace("openclaw-dreaming-lane-"),
+      createTempWorkspace("openclaw-dreaming-lane-"),
+    ]);
+    try {
+      await Promise.all([
+        runDreamNarrative({
+          agentId: "alpha",
+          subagent,
+          workspaceDir: firstWorkspace,
+          data: { phase: "light", snippets: ["First agent memory."] },
+          nowMs,
+          logger,
+        }),
+        runDreamNarrative({
+          agentId: "beta",
+          subagent,
+          workspaceDir: secondWorkspace,
+          data: { phase: "light", snippets: ["Second agent memory."] },
+          nowMs,
+          logger,
+        }),
+      ]);
+    } finally {
+      await Promise.all([
+        fs.rm(firstWorkspace, { recursive: true, force: true }),
+        fs.rm(secondWorkspace, { recursive: true, force: true }),
+      ]);
+    }
+
+    const lanes = subagent.run.mock.calls.map((call) => (call[0] as Record<string, unknown>).lane);
+    expect(lanes).toHaveLength(2);
+    // Both narratives land on the one global `subagent` lane; a shared lane is
+    // what lets a global limit of one serialize them together.
+    expect(new Set(lanes)).toEqual(new Set(["subagent"]));
   });
 
   it("keeps creation and cleanup on the memory-core-owned session identity", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -435,9 +435,6 @@ describe("runDreamNarrative", () => {
     expect(runOptions.idempotencyKey).toBe(`${expectedRunKey}-${nowMs}`);
     expect(runOptions.idempotencyKey).toMatch(/^dreaming-narrative-/);
     expect(runOptions.sessionKey).toBe(expectedSessionKey);
-    // Runs on the shared global subagent lane so the configured
-    // `agents.defaults.subagents.maxConcurrent` bounds every narrative.
-    expect(runOptions.lane).toBe("subagent");
     expect(runOptions.lightContext).toBe(true);
     expect(runOptions.deliver).toBe(false);
     expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
@@ -448,50 +445,6 @@ describe("runDreamNarrative", () => {
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
     expect(logger.info).toHaveBeenCalled();
-  });
-
-  // Regression: distinct agent/session narratives used per-session lanes, so the
-  // configured `agents.defaults.subagents.maxConcurrent` never applied and each
-  // session ran a separate dreaming subagent in parallel (#95746).
-  it("routes concurrent narratives for distinct sessions to the shared subagent lane", async () => {
-    const subagent = createMockSubagent("Two agents dreamed into one lane.");
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const [firstWorkspace, secondWorkspace] = await Promise.all([
-      createTempWorkspace("openclaw-dreaming-lane-"),
-      createTempWorkspace("openclaw-dreaming-lane-"),
-    ]);
-    try {
-      await Promise.all([
-        runDreamNarrative({
-          agentId: "alpha",
-          subagent,
-          workspaceDir: firstWorkspace,
-          data: { phase: "light", snippets: ["First agent memory."] },
-          nowMs,
-          logger,
-        }),
-        runDreamNarrative({
-          agentId: "beta",
-          subagent,
-          workspaceDir: secondWorkspace,
-          data: { phase: "light", snippets: ["Second agent memory."] },
-          nowMs,
-          logger,
-        }),
-      ]);
-    } finally {
-      await Promise.all([
-        fs.rm(firstWorkspace, { recursive: true, force: true }),
-        fs.rm(secondWorkspace, { recursive: true, force: true }),
-      ]);
-    }
-
-    const lanes = subagent.run.mock.calls.map((call) => (call[0] as Record<string, unknown>).lane);
-    expect(lanes).toHaveLength(2);
-    // Both narratives land on the one global `subagent` lane; a shared lane is
-    // what lets a global limit of one serialize them together.
-    expect(new Set(lanes)).toEqual(new Set(["subagent"]));
   });
 
   it("keeps creation and cleanup on the memory-core-owned session identity", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -246,7 +246,11 @@ async function startNarrativeRunOrFallback(params: {
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
-      lane: `dreaming-narrative:${params.sessionKey}`,
+      // Narratives share the global `subagent` command lane (core's
+      // `CommandLane.Subagent`) so `agents.defaults.subagents.maxConcurrent`
+      // bounds every dreaming run together; a per-session lane would let each
+      // session run in parallel and exhaust local-model KV cache (#95746).
+      lane: "subagent",
       lightContext: true,
       deliver: false,
     });

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -246,10 +246,7 @@ async function startNarrativeRunOrFallback(params: {
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
-      // Narratives share the global `subagent` command lane (core's
-      // `CommandLane.Subagent`) so `agents.defaults.subagents.maxConcurrent`
-      // bounds every dreaming run together; a per-session lane would let each
-      // session run in parallel and exhaust local-model KV cache (#95746).
+      // Apply configured subagent concurrency across all dreaming sessions.
       lane: "subagent",
       lightContext: true,
       deliver: false,

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -246,7 +246,6 @@ async function startNarrativeRunOrFallback(params: {
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
-      // Apply configured subagent concurrency across all dreaming sessions.
       lane: "subagent",
       lightContext: true,
       deliver: false,

--- a/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
+++ b/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
@@ -167,19 +167,65 @@ describe("waitForAgentJob timeout fallback", () => {
     await expect(waitForAgentJobExecution({ runId, timeoutMs: 5 })).resolves.toBeNull();
   });
 
-  it("does not treat provisional reservations as queued execution", async () => {
+  it("bounds provisional reservations by their admission expiry", async () => {
     const runId = `run-execution-wait-reserved-${runSequence++}`;
+    vi.setSystemTime(10_000);
     setGatewayDedupeEntry({
       dedupe: new Map<string, DedupeEntry>(),
       key: `agent:${runId}`,
       entry: {
         ts: Date.now(),
         ok: true,
-        payload: { runId, status: "accepted", reservationId: "reservation-1" },
+        payload: {
+          runId,
+          status: "accepted",
+          reservationId: "reservation-1",
+          expiresAtMs: 40_000,
+        },
       },
     });
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
 
-    await expect(waitForAgentJobExecution({ runId, timeoutMs: 60_000 })).resolves.toBeNull();
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(waitPromise).resolves.toBeNull();
+  });
+
+  it("lets late execution waiters observe retryable terminal errors", async () => {
+    const runId = `run-execution-wait-pending-error-${runSequence++}`;
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: Date.now() },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: Date.now(),
+        endedAt: Date.now(),
+        error: "Retryable provider failure",
+      },
+    });
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(waitPromise).resolves.toMatchObject({
+      status: "error",
+      error: "Retryable provider failure",
+    });
   });
 
   it("keeps restart cancellation as an error instead of a hard timeout", async () => {

--- a/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
+++ b/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
@@ -3,7 +3,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { waitForAgentJob, waitForAgentJobExecution } from "./agent-job.js";
+import type { DedupeEntry } from "../server-shared.js";
+import { setGatewayDedupeEntry, waitForAgentJob, waitForAgentJobExecution } from "./agent-job.js";
 
 const HARD_TIMEOUT_PHASES = ["preflight", "provider", "post_turn"] as const;
 const NON_HARD_TIMEOUTS = [
@@ -14,6 +15,14 @@ const NON_HARD_TIMEOUTS = [
 ] as const;
 
 let runSequence = 0;
+
+function registerQueuedRun(runId: string): void {
+  setGatewayDedupeEntry({
+    dedupe: new Map<string, DedupeEntry>(),
+    key: `agent:${runId}`,
+    entry: { ts: Date.now(), ok: true, payload: { runId, status: "in_flight" } },
+  });
+}
 
 async function resolveOuterTimeoutRace(
   data: Readonly<Record<string, unknown>>,
@@ -77,6 +86,7 @@ describe("waitForAgentJob timeout fallback", () => {
 
   it("does not spend execution timeout while a run is queued", async () => {
     const runId = `run-execution-wait-queued-${runSequence++}`;
+    registerQueuedRun(runId);
     const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
     let settled = false;
     void waitPromise.then(() => {
@@ -98,6 +108,7 @@ describe("waitForAgentJob timeout fallback", () => {
   it("starts the execution timeout from lifecycle startedAt", async () => {
     const runId = `run-execution-wait-started-${runSequence++}`;
     vi.setSystemTime(10_000);
+    registerQueuedRun(runId);
     const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
     let settled = false;
     void waitPromise.then(() => {
@@ -120,6 +131,7 @@ describe("waitForAgentJob timeout fallback", () => {
 
   it("resolves a queued restart cancellation from the terminal registry", async () => {
     const runId = `run-execution-wait-cancelled-${runSequence++}`;
+    registerQueuedRun(runId);
     const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
 
     await vi.advanceTimersByTimeAsync(60_001);
@@ -140,6 +152,21 @@ describe("waitForAgentJob timeout fallback", () => {
       stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
       error: "Restart interrupted the queued run",
     });
+  });
+
+  it("keeps zero-time execution waits as nonblocking polls", async () => {
+    const runId = `run-execution-wait-poll-${runSequence++}`;
+    registerQueuedRun(runId);
+
+    await expect(waitForAgentJobExecution({ runId, timeoutMs: 0 })).resolves.toBeNull();
+  });
+
+  it("bounds positive execution waits for unknown runs", async () => {
+    const runId = `run-execution-wait-unknown-${runSequence++}`;
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 5 });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(waitPromise).resolves.toBeNull();
   });
 
   it("keeps restart cancellation as an error instead of a hard timeout", async () => {

--- a/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
+++ b/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { waitForAgentJob } from "./agent-job.js";
+import { waitForAgentJob, waitForAgentJobExecution } from "./agent-job.js";
 
 const HARD_TIMEOUT_PHASES = ["preflight", "provider", "post_turn"] as const;
 const NON_HARD_TIMEOUTS = [
@@ -74,6 +74,73 @@ describe("waitForAgentJob timeout fallback", () => {
       await expect(resolveOuterTimeoutRace(scenario.data)).resolves.toBeNull();
     });
   }
+
+  it("does not spend execution timeout while a run is queued", async () => {
+    const runId = `run-execution-wait-queued-${runSequence++}`;
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    expect(settled).toBe(false);
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: Date.now() },
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(waitPromise).resolves.toBeNull();
+  });
+
+  it("starts the execution timeout from lifecycle startedAt", async () => {
+    const runId = `run-execution-wait-started-${runSequence++}`;
+    vi.setSystemTime(10_000);
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(75_000);
+    const startedAt = Date.now();
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt },
+    });
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(waitPromise).resolves.toBeNull();
+  });
+
+  it("resolves a queued restart cancellation from the terminal registry", async () => {
+    const runId = `run-execution-wait-cancelled-${runSequence++}`;
+    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 60_000 });
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        endedAt: Date.now(),
+        aborted: true,
+        stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
+        error: "Restart interrupted the queued run",
+      },
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      status: "error",
+      stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
+      error: "Restart interrupted the queued run",
+    });
+  });
 
   it("keeps restart cancellation as an error instead of a hard timeout", async () => {
     await expect(

--- a/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
+++ b/src/gateway/agent-turn/agent-job.timeout-fallback.test.ts
@@ -161,12 +161,25 @@ describe("waitForAgentJob timeout fallback", () => {
     await expect(waitForAgentJobExecution({ runId, timeoutMs: 0 })).resolves.toBeNull();
   });
 
-  it("bounds positive execution waits for unknown runs", async () => {
+  it("returns immediately for unknown execution waits", async () => {
     const runId = `run-execution-wait-unknown-${runSequence++}`;
-    const waitPromise = waitForAgentJobExecution({ runId, timeoutMs: 5 });
 
-    await vi.advanceTimersByTimeAsync(5);
-    await expect(waitPromise).resolves.toBeNull();
+    await expect(waitForAgentJobExecution({ runId, timeoutMs: 5 })).resolves.toBeNull();
+  });
+
+  it("does not treat provisional reservations as queued execution", async () => {
+    const runId = `run-execution-wait-reserved-${runSequence++}`;
+    setGatewayDedupeEntry({
+      dedupe: new Map<string, DedupeEntry>(),
+      key: `agent:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "accepted", reservationId: "reservation-1" },
+      },
+    });
+
+    await expect(waitForAgentJobExecution({ runId, timeoutMs: 60_000 })).resolves.toBeNull();
   });
 
   it("keeps restart cancellation as an error instead of a hard timeout", async () => {

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -246,6 +246,9 @@ function beginAgentJob(runId: string, startedAt?: number) {
   agentJobs.delete(runId);
   if (startedAt !== undefined) {
     agentRunStarts.set(runId, startedAt);
+    // Execution-scoped waiters stay dormant while queued. Lifecycle start owns
+    // their budget, so wake them here to arm against the authoritative timestamp.
+    notifyAgentRunWaiters(runId);
   }
 }
 
@@ -586,12 +589,17 @@ function publicSnapshot(snapshot: AgentRunObservation): AgentJobTerminalSnapshot
   };
 }
 
-export async function waitForAgentJob(params: {
+type AgentJobWaitParams = {
   runId: string;
   timeoutMs: number;
   ignoreCachedSnapshot?: boolean;
   source?: "chat";
-}): Promise<AgentJobTerminalSnapshot | null> {
+};
+
+async function waitForAgentJobState(
+  params: AgentJobWaitParams,
+  timeoutScope: "caller" | "execution",
+): Promise<AgentJobTerminalSnapshot | null> {
   ensureAgentRunListener();
   const afterVersion = params.ignoreCachedSnapshot ? agentJobState.version : -1;
   const cached = getAgentRunSnapshot({
@@ -602,38 +610,26 @@ export async function waitForAgentJob(params: {
   if (cached) {
     return publicSnapshot(cached);
   }
-  if (params.timeoutMs <= 0) {
+  if (timeoutScope === "caller" && params.timeoutMs <= 0) {
     return null;
   }
 
   return await new Promise((resolve) => {
     let settled = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
     let removeWaiter = () => {};
     const finish = (snapshot: AgentJobTerminalSnapshot | null) => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(timeoutHandle);
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
       removeWaiter();
       resolve(snapshot);
     };
-    const onWake = (lifecycleReset = false) => {
-      if (lifecycleReset) {
-        finish(null);
-        return;
-      }
-      const snapshot = getAgentRunSnapshot({
-        runId: params.runId,
-        source: params.source,
-        afterVersion,
-      });
-      if (snapshot) {
-        finish(publicSnapshot(snapshot));
-      }
-    };
-    removeWaiter = addAgentRunWaiter(params.runId, onWake);
-    const timeoutHandle = setSafeTimeout(() => {
+    const onTimeout = () => {
       if (!params.source) {
         const pendingError = pendingAgentRunErrors.get(params.runId)?.snapshot;
         if (pendingError && pendingError.version > afterVersion) {
@@ -655,10 +651,55 @@ export async function waitForAgentJob(params: {
         }
       }
       finish(null);
-    }, params.timeoutMs);
-    timeoutHandle.unref?.();
+    };
+    const armTimeout = () => {
+      if (timeoutHandle || settled) {
+        return;
+      }
+      const startedAt =
+        timeoutScope === "execution" ? agentRunStarts.get(params.runId) : Date.now();
+      if (startedAt === undefined) {
+        return;
+      }
+      const delayMs =
+        timeoutScope === "execution"
+          ? Math.max(0, startedAt + params.timeoutMs - Date.now())
+          : params.timeoutMs;
+      timeoutHandle = setSafeTimeout(onTimeout, delayMs);
+      timeoutHandle.unref?.();
+    };
+    const onWake = (lifecycleReset = false) => {
+      if (lifecycleReset) {
+        finish(null);
+        return;
+      }
+      const snapshot = getAgentRunSnapshot({
+        runId: params.runId,
+        source: params.source,
+        afterVersion,
+      });
+      if (snapshot) {
+        finish(publicSnapshot(snapshot));
+        return;
+      }
+      armTimeout();
+    };
+    removeWaiter = addAgentRunWaiter(params.runId, onWake);
     onWake();
   });
+}
+
+export async function waitForAgentJob(
+  params: AgentJobWaitParams,
+): Promise<AgentJobTerminalSnapshot | null> {
+  return await waitForAgentJobState(params, "caller");
+}
+
+export async function waitForAgentJobExecution(params: {
+  runId: string;
+  timeoutMs: number;
+}): Promise<AgentJobTerminalSnapshot | null> {
+  return await waitForAgentJobState(params, "execution");
 }
 
 ensureAgentRunListener();

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -241,6 +241,11 @@ function clearPendingAgentRunTimeout(runId: string) {
 }
 
 function beginAgentJob(runId: string, startedAt?: number) {
+  for (const [trackedRunId, trackedAt] of agentRunStarts) {
+    if (trackedAt < 0 && -trackedAt <= Date.now()) {
+      agentRunStarts.delete(trackedRunId);
+    }
+  }
   nextAgentRunVersion();
   clearPendingAgentRunError(runId);
   clearPendingAgentRunTimeout(runId);
@@ -518,7 +523,9 @@ export function setGatewayDedupeEntry(params: {
     return;
   }
   if (incomingObservation.state === "terminal") {
-    if (key.source === "agent") agentRunStarts.delete(key.runId);
+    if (key.source === "agent") {
+      agentRunStarts.delete(key.runId);
+    }
     recordAgentRunSnapshot({
       ...incomingObservation.snapshot,
       runId: key.runId,
@@ -662,9 +669,6 @@ export async function waitForAgentJob(params: {
       finish(null);
     };
     const armTimeout = () => {
-      if (settled) {
-        return;
-      }
       const observedStart = params.executionScoped ? agentRunStarts.get(params.runId) : Date.now();
       if (params.executionScoped && observedStart === AGENT_RUN_QUEUED_AT) {
         clearWaitTimeout();

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -247,8 +247,7 @@ function beginAgentJob(runId: string, startedAt?: number) {
   agentJobs.delete(runId);
   if (startedAt !== undefined) {
     agentRunStarts.set(runId, startedAt);
-    // Lifecycle start owns execution-scoped budgets, so wake dormant waiters
-    // here to arm against the authoritative timestamp.
+    // Lifecycle start owns execution-scoped budgets; wake dormant waiters here.
     notifyAgentRunWaiters(runId);
   }
 }
@@ -307,12 +306,8 @@ function createSnapshotFromLifecycleEvent(params: {
 }): AgentRunObservation {
   const { runId, phase, data } = params;
   const recordedStart = agentRunStarts.get(runId);
-  const startedAt =
-    typeof data?.startedAt === "number"
-      ? data.startedAt
-      : Number.isFinite(recordedStart)
-        ? recordedStart
-        : undefined;
+  const finiteRecordedStart = Number.isFinite(recordedStart) ? recordedStart : undefined;
+  const startedAt = typeof data?.startedAt === "number" ? data.startedAt : finiteRecordedStart;
   const endedAt = typeof data?.endedAt === "number" ? data.endedAt : undefined;
   const terminalOutcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
     phase,
@@ -511,18 +506,19 @@ export function setGatewayDedupeEntry(params: {
   }
   if (incomingObservation.state === "active") {
     beginAgentJob(key.runId);
-    if (
-      key.source === "agent" &&
-      typeof asOptionalRecord(params.entry.payload)?.reservationId !== "string"
-    ) {
-      agentRunStarts.set(key.runId, AGENT_RUN_QUEUED_AT);
+    if (key.source === "agent") {
+      const payload = asOptionalRecord(params.entry.payload);
+      const expiresAt = asFiniteNumber(payload?.expiresAtMs) ?? Date.now();
+      agentRunStarts.set(
+        key.runId,
+        typeof payload?.reservationId === "string" ? -expiresAt : AGENT_RUN_QUEUED_AT,
+      );
+      notifyAgentRunWaiters(key.runId);
     }
     return;
   }
   if (incomingObservation.state === "terminal") {
-    if (key.source === "agent") {
-      agentRunStarts.delete(key.runId);
-    }
+    if (key.source === "agent") agentRunStarts.delete(key.runId);
     recordAgentRunSnapshot({
       ...incomingObservation.snapshot,
       runId: key.runId,
@@ -629,14 +625,16 @@ export async function waitForAgentJob(params: {
     let settled = false;
     let timeoutHandle: NodeJS.Timeout | undefined;
     let removeWaiter = () => {};
+    const clearWaitTimeout = () => {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = undefined;
+    };
     const finish = (snapshot: AgentJobTerminalSnapshot | null) => {
       if (settled) {
         return;
       }
       settled = true;
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle);
-      }
+      clearWaitTimeout();
       removeWaiter();
       resolve(snapshot);
     };
@@ -669,19 +667,24 @@ export async function waitForAgentJob(params: {
       }
       const observedStart = params.executionScoped ? agentRunStarts.get(params.runId) : Date.now();
       if (params.executionScoped && observedStart === AGENT_RUN_QUEUED_AT) {
+        clearWaitTimeout();
         return;
       }
       if (params.executionScoped && observedStart === undefined) {
+        if (pendingAgentRunErrors.has(params.runId) || pendingAgentRunTimeouts.has(params.runId)) {
+          return;
+        }
         finish(null);
         return;
       }
-      if (timeoutHandle) {
+      if (timeoutHandle && !params.executionScoped) {
         return;
       }
+      clearWaitTimeout();
       const startedAt = observedStart ?? Date.now();
-      const delayMs = params.executionScoped
-        ? Math.max(0, startedAt + params.timeoutMs - Date.now())
-        : params.timeoutMs;
+      const deadline =
+        params.executionScoped && startedAt < 0 ? -startedAt : startedAt + params.timeoutMs;
+      const delayMs = Math.max(0, deadline - Date.now());
       timeoutHandle = setSafeTimeout(onTimeout, delayMs);
       timeoutHandle.unref?.();
     };
@@ -706,9 +709,7 @@ export async function waitForAgentJob(params: {
   });
 }
 
-export function waitForAgentJobExecution(
-  params: Pick<Parameters<typeof waitForAgentJob>[0], "runId" | "timeoutMs">,
-) {
+export function waitForAgentJobExecution(params: { runId: string; timeoutMs: number }) {
   return waitForAgentJob({ ...params, executionScoped: true });
 }
 

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -32,6 +32,7 @@ import type { DedupeEntry } from "../server-shared.js";
 
 const AGENT_RUN_CACHE_TTL_MS = 10 * 60_000;
 const AGENT_RUN_CACHE_MAX_ENTRIES = 5_000;
+const AGENT_RUN_QUEUED_AT = Number.POSITIVE_INFINITY;
 
 type AgentJobTerminalSnapshot = {
   status: "ok" | "error" | "timeout";
@@ -246,8 +247,8 @@ function beginAgentJob(runId: string, startedAt?: number) {
   agentJobs.delete(runId);
   if (startedAt !== undefined) {
     agentRunStarts.set(runId, startedAt);
-    // Execution-scoped waiters stay dormant while queued. Lifecycle start owns
-    // their budget, so wake them here to arm against the authoritative timestamp.
+    // Lifecycle start owns execution-scoped budgets, so wake dormant waiters
+    // here to arm against the authoritative timestamp.
     notifyAgentRunWaiters(runId);
   }
 }
@@ -305,8 +306,13 @@ function createSnapshotFromLifecycleEvent(params: {
   data?: Record<string, unknown>;
 }): AgentRunObservation {
   const { runId, phase, data } = params;
+  const recordedStart = agentRunStarts.get(runId);
   const startedAt =
-    typeof data?.startedAt === "number" ? data.startedAt : agentRunStarts.get(runId);
+    typeof data?.startedAt === "number"
+      ? data.startedAt
+      : Number.isFinite(recordedStart)
+        ? recordedStart
+        : undefined;
   const endedAt = typeof data?.endedAt === "number" ? data.endedAt : undefined;
   const terminalOutcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
     phase,
@@ -505,9 +511,15 @@ export function setGatewayDedupeEntry(params: {
   }
   if (incomingObservation.state === "active") {
     beginAgentJob(key.runId);
+    if (key.source === "agent" && !Number.isFinite(agentRunStarts.get(key.runId))) {
+      agentRunStarts.set(key.runId, AGENT_RUN_QUEUED_AT);
+    }
     return;
   }
   if (incomingObservation.state === "terminal") {
+    if (key.source === "agent") {
+      agentRunStarts.delete(key.runId);
+    }
     recordAgentRunSnapshot({
       ...incomingObservation.snapshot,
       runId: key.runId,
@@ -610,7 +622,7 @@ async function waitForAgentJobState(
   if (cached) {
     return publicSnapshot(cached);
   }
-  if (timeoutScope === "caller" && params.timeoutMs <= 0) {
+  if (params.timeoutMs <= 0) {
     return null;
   }
 
@@ -656,11 +668,12 @@ async function waitForAgentJobState(
       if (timeoutHandle || settled) {
         return;
       }
-      const startedAt =
+      const observedStart =
         timeoutScope === "execution" ? agentRunStarts.get(params.runId) : Date.now();
-      if (startedAt === undefined) {
+      if (timeoutScope === "execution" && observedStart === AGENT_RUN_QUEUED_AT) {
         return;
       }
+      const startedAt = observedStart ?? Date.now();
       const delayMs =
         timeoutScope === "execution"
           ? Math.max(0, startedAt + params.timeoutMs - Date.now())
@@ -689,17 +702,12 @@ async function waitForAgentJobState(
   });
 }
 
-export async function waitForAgentJob(
-  params: AgentJobWaitParams,
-): Promise<AgentJobTerminalSnapshot | null> {
-  return await waitForAgentJobState(params, "caller");
+export function waitForAgentJob(params: AgentJobWaitParams) {
+  return waitForAgentJobState(params, "caller");
 }
 
-export async function waitForAgentJobExecution(params: {
-  runId: string;
-  timeoutMs: number;
-}): Promise<AgentJobTerminalSnapshot | null> {
-  return await waitForAgentJobState(params, "execution");
+export function waitForAgentJobExecution(params: Pick<AgentJobWaitParams, "runId" | "timeoutMs">) {
+  return waitForAgentJobState(params, "execution");
 }
 
 ensureAgentRunListener();

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -511,7 +511,10 @@ export function setGatewayDedupeEntry(params: {
   }
   if (incomingObservation.state === "active") {
     beginAgentJob(key.runId);
-    if (key.source === "agent" && !Number.isFinite(agentRunStarts.get(key.runId))) {
+    if (
+      key.source === "agent" &&
+      typeof asOptionalRecord(params.entry.payload)?.reservationId !== "string"
+    ) {
       agentRunStarts.set(key.runId, AGENT_RUN_QUEUED_AT);
     }
     return;
@@ -601,17 +604,13 @@ function publicSnapshot(snapshot: AgentRunObservation): AgentJobTerminalSnapshot
   };
 }
 
-type AgentJobWaitParams = {
+export async function waitForAgentJob(params: {
   runId: string;
   timeoutMs: number;
   ignoreCachedSnapshot?: boolean;
   source?: "chat";
-};
-
-async function waitForAgentJobState(
-  params: AgentJobWaitParams,
-  timeoutScope: "caller" | "execution",
-): Promise<AgentJobTerminalSnapshot | null> {
+  executionScoped?: boolean;
+}): Promise<AgentJobTerminalSnapshot | null> {
   ensureAgentRunListener();
   const afterVersion = params.ignoreCachedSnapshot ? agentJobState.version : -1;
   const cached = getAgentRunSnapshot({
@@ -665,19 +664,24 @@ async function waitForAgentJobState(
       finish(null);
     };
     const armTimeout = () => {
-      if (timeoutHandle || settled) {
+      if (settled) {
         return;
       }
-      const observedStart =
-        timeoutScope === "execution" ? agentRunStarts.get(params.runId) : Date.now();
-      if (timeoutScope === "execution" && observedStart === AGENT_RUN_QUEUED_AT) {
+      const observedStart = params.executionScoped ? agentRunStarts.get(params.runId) : Date.now();
+      if (params.executionScoped && observedStart === AGENT_RUN_QUEUED_AT) {
+        return;
+      }
+      if (params.executionScoped && observedStart === undefined) {
+        finish(null);
+        return;
+      }
+      if (timeoutHandle) {
         return;
       }
       const startedAt = observedStart ?? Date.now();
-      const delayMs =
-        timeoutScope === "execution"
-          ? Math.max(0, startedAt + params.timeoutMs - Date.now())
-          : params.timeoutMs;
+      const delayMs = params.executionScoped
+        ? Math.max(0, startedAt + params.timeoutMs - Date.now())
+        : params.timeoutMs;
       timeoutHandle = setSafeTimeout(onTimeout, delayMs);
       timeoutHandle.unref?.();
     };
@@ -702,12 +706,10 @@ async function waitForAgentJobState(
   });
 }
 
-export function waitForAgentJob(params: AgentJobWaitParams) {
-  return waitForAgentJobState(params, "caller");
-}
-
-export function waitForAgentJobExecution(params: Pick<AgentJobWaitParams, "runId" | "timeoutMs">) {
-  return waitForAgentJobState(params, "execution");
+export function waitForAgentJobExecution(
+  params: Pick<Parameters<typeof waitForAgentJob>[0], "runId" | "timeoutMs">,
+) {
+  return waitForAgentJob({ ...params, executionScoped: true });
 }
 
 ensureAgentRunListener();

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -20,6 +20,7 @@ const internalAgentTurnFacade = vi.hoisted(() => ({
   dispatch: vi.fn(),
   wait: vi.fn(),
 }));
+const waitForAgentJobExecution = vi.hoisted(() => vi.fn());
 
 vi.mock("./server-methods.js", () => ({
   handleGatewayRequest,
@@ -32,6 +33,9 @@ vi.mock("./agent-turn/internal-facade.runtime.js", () => ({
       wait: internalAgentTurnFacade.wait,
     };
   },
+}));
+vi.mock("./agent-turn/agent-job.js", () => ({
+  waitForAgentJobExecution,
 }));
 
 type ServerPluginsModule = typeof import("./server-plugins.js");
@@ -84,6 +88,7 @@ beforeEach(() => {
   internalAgentTurnFacade.create.mockReset();
   internalAgentTurnFacade.dispatch.mockReset().mockResolvedValue({ runId: "plugin-run-1" });
   internalAgentTurnFacade.wait.mockReset().mockResolvedValue({ status: "ok" });
+  waitForAgentJobExecution.mockReset().mockResolvedValue({ status: "ok" });
   handleGatewayRequest.mockReset();
   handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
     opts.respond(true, {});
@@ -325,29 +330,32 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     ).rejects.toThrow(/not found/);
   });
 
-  test("normalizes completed agent.wait envelopes for plugin subagents", async () => {
+  test("waits on the execution-scoped agent registry with the default timeout", async () => {
     const serverPlugins = await loadServerPlugins();
     const runtime = serverPlugins.createGatewaySubagentRuntime();
-    serverPlugins.setFallbackGatewayContext(createTestContext("plugin-wait", createTestCfg()));
 
-    internalAgentTurnFacade.wait.mockResolvedValue({ status: "completed" });
-
-    await expect(runtime.waitForRun({ runId: "plugin-run-completed" })).resolves.toEqual({
+    await expect(runtime.waitForRun({ runId: "plugin-run-default" })).resolves.toEqual({
       status: "ok",
+    });
+    expect(waitForAgentJobExecution).toHaveBeenCalledWith({
+      runId: "plugin-run-default",
+      timeoutMs: 30_000,
     });
   });
 
-  test("normalizes malformed completed wait errors for plugin subagents", async () => {
+  test("projects an elapsed execution wait as a plugin timeout", async () => {
     const serverPlugins = await loadServerPlugins();
     const runtime = serverPlugins.createGatewaySubagentRuntime();
-    serverPlugins.setFallbackGatewayContext(
-      createTestContext("plugin-wait-error", createTestCfg()),
-    );
+    waitForAgentJobExecution.mockResolvedValue(null);
 
-    internalAgentTurnFacade.wait.mockResolvedValue({ status: "error", error: "completed" });
-
-    await expect(runtime.waitForRun({ runId: "plugin-run-error-completed" })).resolves.toEqual({
-      status: "ok",
+    await expect(
+      runtime.waitForRun({ runId: "plugin-run-timeout", timeoutMs: 60_000.9 }),
+    ).resolves.toEqual({
+      status: "timeout",
+    });
+    expect(waitForAgentJobExecution).toHaveBeenCalledWith({
+      runId: "plugin-run-timeout",
+      timeoutMs: 60_000,
     });
   });
 });

--- a/src/gateway/server-plugins.subagent-lane.test.ts
+++ b/src/gateway/server-plugins.subagent-lane.test.ts
@@ -7,7 +7,9 @@ import {
   setCommandLaneConcurrency,
 } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
+import { setGatewayDedupeEntry } from "./agent-turn/agent-job.js";
 import { createGatewaySubagentRuntime } from "./server-plugins.js";
+import type { DedupeEntry } from "./server-shared.js";
 
 function createGate() {
   let release = () => {};
@@ -45,6 +47,11 @@ describe("plugin subagent shared lane", () => {
     const runPhase = async (phase: "narrative" | "consolidation") => {
       const runId = `dreaming-${phase}`;
       trace.push(`enqueue ${phase}`);
+      setGatewayDedupeEntry({
+        dedupe: new Map<string, DedupeEntry>(),
+        key: `agent:${runId}`,
+        entry: { ts: Date.now(), ok: true, payload: { runId, status: "in_flight" } },
+      });
       const queued = enqueueCommandInLane(CommandLane.Subagent, async () => {
         trace.push(`dequeue ${phase}`, `start ${phase}`);
         emitAgentEvent({

--- a/src/gateway/server-plugins.subagent-lane.test.ts
+++ b/src/gateway/server-plugins.subagent-lane.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
+import { createGatewaySubagentRuntime } from "./server-plugins.js";
+
+function createGate() {
+  let release = () => {};
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+describe("plugin subagent shared lane", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setCommandLaneConcurrency(CommandLane.Subagent, 1);
+  });
+
+  afterEach(() => {
+    clearCommandLane(CommandLane.Subagent);
+    setCommandLaneConcurrency(CommandLane.Subagent, 1);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("holds queued dreaming phases beyond 60 seconds without consuming their run budgets", async () => {
+    const runtime = createGatewaySubagentRuntime();
+    const blocker = createGate();
+    const trace = ["maxConcurrent=1"];
+    const fallbacks: string[] = [];
+    const deletions: string[] = [];
+
+    const held = enqueueCommandInLane(CommandLane.Subagent, async () => {
+      trace.push("dequeue hold");
+      await blocker.promise;
+      trace.push("release hold");
+    });
+    const runPhase = async (phase: "narrative" | "consolidation") => {
+      const runId = `dreaming-${phase}`;
+      trace.push(`enqueue ${phase}`);
+      const queued = enqueueCommandInLane(CommandLane.Subagent, async () => {
+        trace.push(`dequeue ${phase}`, `start ${phase}`);
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: Date.now() },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: Date.now(), endedAt: Date.now() },
+        });
+        trace.push(`terminal ${phase}`);
+      });
+      const terminal = await runtime.waitForRun({ runId, timeoutMs: 60_000 });
+      if (terminal.status !== "ok") {
+        fallbacks.push(phase);
+        deletions.push(phase);
+      } else {
+        trace.push(`output ${phase}`);
+      }
+      await queued;
+      trace.push(`cleanup ${phase}`);
+    };
+
+    const narrative = runPhase("narrative");
+    const consolidation = runPhase("consolidation");
+    await vi.advanceTimersByTimeAsync(60_001);
+
+    expect(getCommandLaneSnapshot(CommandLane.Subagent)).toMatchObject({
+      maxConcurrent: 1,
+      activeCount: 1,
+      queuedCount: 2,
+    });
+    expect(fallbacks).toEqual([]);
+    expect(deletions).toEqual([]);
+
+    blocker.release();
+    await Promise.all([held, narrative, consolidation]);
+
+    expect(fallbacks).toEqual([]);
+    expect(deletions).toEqual([]);
+    const expectOrder = (...entries: string[]) => {
+      const positions = entries.map((entry) => trace.indexOf(entry));
+      expect(positions.every((position) => position >= 0)).toBe(true);
+      expect(positions.slice(1).every((position, index) => position > positions[index]!)).toBe(
+        true,
+      );
+    };
+    expectOrder("release hold", "dequeue narrative", "start narrative", "terminal narrative");
+    expectOrder("terminal narrative", "output narrative", "cleanup narrative");
+    expectOrder("dequeue narrative", "dequeue consolidation", "start consolidation");
+    expectOrder("start consolidation", "terminal consolidation", "output consolidation");
+    expectOrder("output consolidation", "cleanup consolidation");
+  });
+});

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -22,6 +22,7 @@ import { resolvePluginSubagentCompletionRequester } from "../plugins/runtime/sub
 import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/runtime/types.js";
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { waitForAgentJobExecution } from "./agent-turn/agent-job.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
 import type { GatewayRequestHandler, GatewayRequestOptions } from "./server-methods/types.js";
@@ -306,22 +307,12 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { runId, ...(runtime ? { runtime } : {}) };
     },
     async waitForRun(params) {
-      const payload = await dispatchGatewayMethodInProcess<{ status?: string; error?: string }>(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-      );
-      let status = payload?.status;
-      if (status === "completed" || status === "succeeded") {
-        status = "ok";
-      } else if (status === "error" && payload?.error?.trim().toLowerCase() === "completed") {
-        status = "ok";
-      }
-      if (status !== "ok" && status !== "error" && status !== "timeout") {
-        throw new Error(`Gateway agent.wait returned unexpected status: ${payload?.status}`);
-      }
+      const timeoutMs =
+        typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+          ? Math.max(0, Math.floor(params.timeoutMs))
+          : 30_000;
+      const payload = await waitForAgentJobExecution({ runId: params.runId, timeoutMs });
+      const status = payload?.status ?? "timeout";
       return {
         status,
         ...(status !== "ok" &&

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -22,6 +22,7 @@ import { resolvePluginSubagentCompletionRequester } from "../plugins/runtime/sub
 import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/runtime/types.js";
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { waitForAgentJobExecution } from "./agent-turn/agent-job.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
@@ -307,10 +308,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { runId, ...(runtime ? { runtime } : {}) };
     },
     async waitForRun(params) {
-      const timeoutMs =
-        typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
-          ? Math.max(0, Math.floor(params.timeoutMs))
-          : 30_000;
+      const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000, 0);
       const payload = await waitForAgentJobExecution({ runId: params.runId, timeoutMs });
       const status = payload?.status ?? "timeout";
       return {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -313,9 +313,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       const status = payload?.status ?? "timeout";
       return {
         status,
-        ...(status !== "ok" &&
-          typeof payload?.error === "string" &&
-          payload.error && { error: payload.error }),
+        ...(status !== "ok" && payload?.error ? { error: payload.error } : {}),
       };
     },
     getSessionMessages,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -23,7 +23,6 @@ import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/run
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
-import { waitForAgentJobExecution } from "./agent-turn/agent-job.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
 import type { GatewayRequestHandler, GatewayRequestOptions } from "./server-methods/types.js";
@@ -308,6 +307,9 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { runId, ...(runtime ? { runtime } : {}) };
     },
     async waitForRun(params) {
+      // The job registry installs its lifecycle listener on import, so defer loading
+      // until a plugin actually waits for a run.
+      const { waitForAgentJobExecution } = await import("./agent-turn/agent-job.js");
       const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000, 0);
       const payload = await waitForAgentJobExecution({ runId: params.runId, timeoutMs });
       const status = payload?.status ?? "timeout";


### PR DESCRIPTION
Closes #95746

## What Problem This Solves

Fixes an issue where Memory Core dreaming work could bypass
`agents.defaults.subagents.maxConcurrent` by using per-session lanes. Routing
that work through the shared subagent lane also exposed a second failure: a
healthy run queued for more than 60 seconds could time out, write fallback
output, and delete its session before execution started.

## Why This Change Was Made

The gateway job registry is the authoritative owner of run lifecycle state, so
it now distinguishes provisional admission, accepted queueing, execution start,
and canonical terminal outcomes.

- Narrative and consolidation runs use `lane: "subagent"`.
- Queue time is unbounded for the internal plugin wait.
- The existing execution budget starts from lifecycle `start.startedAt`.
- Start and terminal transitions wake registry waiters.
- Cancellation, restart, hard timeout, error, and success resolve through the
  canonical terminal registry.
- `createGatewaySubagentRuntime().waitForRun` uses this internal execution-scoped
  wait instead of dispatching public `agent.wait`.

Public `agent.wait`, gateway protocol, `PluginRuntime`, timeout constants,
configuration, persistence, detached concurrency, and scrub policy are
unchanged.

Architectural owner: `src/gateway/agent-turn/agent-job.ts`.
The direct plugin-to-public-`agent.wait` path was removed.
Production delta: `+87/-42`, net `+45`.

The original shared-lane fix remains authored by @ManyaS-Git as the first
commit in the rewritten branch.

## User Impact

Operators can set subagent concurrency to one and still have queued Memory Core
narrative and consolidation work serialize and complete. Legitimate queueing no
longer turns into pre-start fallback output or session deletion.

Release note: Memory Core dreaming now respects configured subagent concurrency
without timing out work that is still waiting for its execution slot.

## Evidence

Focused local proof on the exact pushed head:

- Memory Core narrative + consolidation: 2 files, 55 tests passed.
- Gateway job registry + plugin adapter + width-one boundary: 9 files, 198 tests
  passed.
- Agent registry import boundary: 4 files, 334 tests passed.
- Formatting, direct changed-file lint, and `git diff --check`: passed.
- Production LOC: net `+45`.

Blacksmith Testbox:

- `tbx_01kzsdxa2y2t50aw40b7f15888`: all guards and core/extension typecheck lanes
  passed; found two task-owned brace lint errors, subsequently fixed.
- `tbx_01kzsesmbpdpmz1k0pz4b6cxqk`: final-head guards plus core and core-test
  typechecks passed; extension typecheck hit missing unrelated QQBot packages in
  the prepared checkout.
- `tbx_01kzsf7syghw6xccac9ea948bd`: fresh-install retry of that failed extension
  typecheck passed.

The real `CommandLane.Subagent` width-one regression holds one slot beyond
60,001 ms, queues narrative and consolidation, then releases the slot. Neither
queued run resolves before lifecycle start; both subsequently start and
complete, with no fallback or deletion.

Redacted trace:

```text
maxConcurrent=1
enqueue narrative
enqueue consolidation
dequeue hold
release hold
dequeue narrative
start narrative
terminal narrative
output narrative
dequeue consolidation
start consolidation
terminal consolidation
cleanup narrative
output consolidation
cleanup consolidation
fallbacks=[]
deletions=[]
```

Registry regressions additionally prove:

- a queued run remains pending beyond 60 seconds;
- the timeout budget starts at lifecycle `start.startedAt`;
- queued restart cancellation resolves from the canonical terminal registry;
- zero-time waits remain nonblocking polls;
- provisional reservations expire without leaking registry state.

Punchcard-Session: amber-timber-summit-kz