### PR TITLE
fix(reply): preserve streamed partials on run failure

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -1,3 +1,4 @@
+import { dispatchReplyWithBufferedBlockDispatcher as dispatchReplyWithBufferedBlockDispatcherRuntime } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { expect, it, vi } from "vitest";
 import {
   describeTelegramDispatch,
@@ -78,18 +79,18 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     );
   });
 
-  it("finalizes a streamed answer draft with the terminal error payload", async () => {
+  it("finalizes the default streamed draft in place after an unexpected reply failure", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onPartialReply?.({ text: "partial answer" });
-        await dispatcherOptions.deliver(
-          { text: "Something went wrong after partial output", isError: true },
-          { kind: "final" },
-        );
-        return { queuedFinal: true };
-      },
-    );
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) => {
+      expect(params.replyOptions?.disableBlockStreaming).toBe(true);
+      return await dispatchReplyWithBufferedBlockDispatcherRuntime({
+        ...params,
+        replyResolver: async (_ctx, opts) => {
+          await opts?.onPartialReply?.({ text: "partial answer" });
+          throw new Error("unexpected model failure");
+        },
+      });
+    });
 
     await dispatchWithContext({
       context: createContext({
@@ -100,8 +101,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "partial answer");
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(2);
     expect(answerDraftStream.update).toHaveBeenLastCalledWith(
-      "partial answer\n\nSomething went wrong after partial output",
+      expect.stringMatching(
+        /^partial answer\n\n.*Something went wrong while processing your request\. Please try again, or use \/new to start a fresh session\.$/,
+      ),
     );
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -78,6 +78,35 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     );
   });
 
+  it("finalizes a streamed answer draft with the terminal error payload", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "partial answer" });
+        await dispatcherOptions.deliver(
+          { text: "Something went wrong after partial output", isError: true },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "partial answer");
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      "partial answer\n\nSomething went wrong after partial output",
+    );
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("returns retryable when dispatch fails after partial output and the fallback is not delivered", async () => {
     deliverReplies.mockResolvedValueOnce({ delivered: true });
     deliverReplies.mockResolvedValueOnce({ delivered: false });

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -79,37 +79,48 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     );
   });
 
-  it("finalizes the default streamed draft in place after an unexpected reply failure", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) => {
-      expect(params.replyOptions?.disableBlockStreaming).toBe(true);
-      return await dispatchReplyWithBufferedBlockDispatcherRuntime({
-        ...params,
-        replyResolver: async (_ctx, opts) => {
-          await opts?.onPartialReply?.({ text: "partial answer" });
-          throw new Error("unexpected model failure");
-        },
-      });
-    });
-
-    await dispatchWithContext({
-      context: createContext({
-        ctxPayload: createDirectSessionPayload(),
+  it.each([
+    { label: "direct chat", createSessionPayload: createDirectSessionPayload },
+    {
+      label: "group chat",
+      createSessionPayload: () => ({
+        ...createDirectSessionPayload(),
+        SessionKey: "agent:test:telegram:group:-100123",
+        ChatType: "group" as const,
       }),
-      streamMode: "partial",
-      telegramCfg: { streaming: { mode: "partial" } },
-    });
+    },
+  ])(
+    "finalizes the default streamed draft in place after an unexpected reply failure in a $label",
+    async ({ createSessionPayload }) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) => {
+        expect(params.replyOptions?.disableBlockStreaming).toBe(true);
+        return await dispatchReplyWithBufferedBlockDispatcherRuntime({
+          ...params,
+          replyResolver: async (_ctx, opts) => {
+            await opts?.onPartialReply?.({ text: "partial answer" });
+            throw new Error("unexpected model failure");
+          },
+        });
+      });
 
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "partial answer");
-    expect(answerDraftStream.update).toHaveBeenCalledTimes(2);
-    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
-      expect.stringMatching(
-        /^partial answer\n\n.*Something went wrong while processing your request\. Please try again, or use \/new to start a fresh session\.$/,
-      ),
-    );
-    expect(answerDraftStream.clear).not.toHaveBeenCalled();
-    expect(deliverReplies).not.toHaveBeenCalled();
-  });
+      await dispatchWithContext({
+        context: createContext({ ctxPayload: createSessionPayload() }),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+
+      expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "partial answer");
+      expect(answerDraftStream.update).toHaveBeenCalledTimes(2);
+      expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+        expect.stringMatching(
+          /^partial answer\n\n.*Something went wrong while processing your request\. Please try again, or use \/new to start a fresh session\.$/,
+        ),
+      );
+      expect(answerDraftStream.clear).not.toHaveBeenCalled();
+      expect(deliverReplies).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns retryable when dispatch fails after partial output and the fallback is not delivered", async () => {
     deliverReplies.mockResolvedValueOnce({ delivered: true });

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -275,9 +275,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     buttons: TelegramInlineButtons | undefined,
     promptContextSequence: TelegramPromptContextProjectionSequence,
     followedByDurablePayload = false,
+    allowErrorPayload = false,
   ): Promise<LaneDeliveryResult | undefined> => {
     const stream = lane.stream;
-    if (!stream || text.length === 0 || payload.isError) {
+    if (!stream || text.length === 0 || (payload.isError && !allowErrorPayload)) {
       return undefined;
     }
     rotateFinalizedStream(lane);
@@ -390,17 +391,40 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     const isDurableFinal = infoKind === "final";
     const finalizePreview = requestedFinalizePreview ?? isDurableFinal;
     const durable = requestedDurable ?? isDurableFinal;
+    const streamedErrorDraftText =
+      isDurableFinal &&
+      payload.isError === true &&
+      laneName === "answer" &&
+      lane.stream &&
+      lane.hasStreamedMessage &&
+      !lane.finalized &&
+      !reply.hasMedia &&
+      text.trim()
+        ? (() => {
+            const existing = (
+              lane.lastPartialText ||
+              lane.stream?.lastDeliveredText?.() ||
+              ""
+            ).trimEnd();
+            const notice = text.trim();
+            return existing && !existing.endsWith(notice)
+              ? `${existing}\n\n${notice}`
+              : existing || notice;
+          })()
+        : undefined;
     const streamed =
       allowStream && !reply.hasMedia
         ? await streamText(
             laneName,
             lane,
-            text,
+            streamedErrorDraftText ?? text,
             payload,
             isDurableFinal,
             finalizePreview,
             buttons,
             promptContextSequence,
+            false,
+            streamedErrorDraftText !== undefined,
           )
         : undefined;
     if (streamed) {

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -450,7 +450,11 @@ export async function handleReplyAgentRunError(
   if (!isHeartbeat && didDeliverVisibleReply && !replyOperation.abortSignal.aborted) {
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(
-      buildTerminalAgentRunFailureReplyPayload({ sessionCtx, cfg }),
+      buildTerminalAgentRunFailureReplyPayload({
+        visibleReplyDelivered: true,
+        sessionCtx,
+        cfg,
+      }),
     );
   }
   replyOperation.fail("run_failed", error);

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -369,6 +369,7 @@ export async function handleReplyAgentRunError(
   context: {
     cfg: OpenClawConfig;
     blockReplyPipeline: BlockReplyPipeline | null;
+    didDeliverVisiblePartialReply: () => boolean;
     isHeartbeat: boolean;
     isRestartRecoveryArmed: () => boolean;
     replyOperation: ReplyOperation;
@@ -380,6 +381,7 @@ export async function handleReplyAgentRunError(
   const {
     cfg,
     blockReplyPipeline,
+    didDeliverVisiblePartialReply,
     isHeartbeat,
     isRestartRecoveryArmed,
     replyOperation,
@@ -442,11 +444,10 @@ export async function handleReplyAgentRunError(
       );
     }
   }
-  if (
-    !isHeartbeat &&
-    blockReplyPipeline?.didStreamTerminalReply?.() === true &&
-    !blockReplyPipeline.isAborted()
-  ) {
+  const didDeliverVisibleReply =
+    (blockReplyPipeline?.didStreamTerminalReply?.() === true && !blockReplyPipeline.isAborted()) ||
+    didDeliverVisiblePartialReply();
+  if (!isHeartbeat && didDeliverVisibleReply && !replyOperation.abortSignal.aborted) {
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(
       buildTerminalAgentRunFailureReplyPayload({ sessionCtx, cfg }),

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -30,7 +30,10 @@ import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
+import {
+  buildKnownAgentRunFailureReplyPayload,
+  buildTerminalAgentRunFailureReplyPayload,
+} from "./agent-runner-failure-reply.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
@@ -365,6 +368,8 @@ export async function handleReplyAgentRunError(
   error: unknown,
   context: {
     cfg: OpenClawConfig;
+    blockReplyPipeline: BlockReplyPipeline | null;
+    isHeartbeat: boolean;
     isRestartRecoveryArmed: () => boolean;
     replyOperation: ReplyOperation;
     resolvedVerboseLevel: VerboseLevel;
@@ -374,6 +379,8 @@ export async function handleReplyAgentRunError(
 ): Promise<ReplyPayload | undefined> {
   const {
     cfg,
+    blockReplyPipeline,
+    isHeartbeat,
     isRestartRecoveryArmed,
     replyOperation,
     resolvedVerboseLevel,
@@ -425,6 +432,21 @@ export async function handleReplyAgentRunError(
   if (knownFailurePayload) {
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(knownFailurePayload);
+  }
+  if (blockReplyPipeline) {
+    try {
+      await blockReplyPipeline.flush({ force: true });
+    } catch (flushError) {
+      logVerbose(
+        `failed to flush streamed reply blocks before surfacing run failure: ${String(flushError)}`,
+      );
+    }
+  }
+  if (!isHeartbeat && blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted()) {
+    replyOperation.fail("run_failed", error);
+    return returnWithQueuedFollowupDrain(
+      buildTerminalAgentRunFailureReplyPayload({ sessionCtx, cfg }),
+    );
   }
   replyOperation.fail("run_failed", error);
   // Keep the followup queue moving even when an unexpected exception escapes

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -442,7 +442,11 @@ export async function handleReplyAgentRunError(
       );
     }
   }
-  if (!isHeartbeat && blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted()) {
+  if (
+    !isHeartbeat &&
+    blockReplyPipeline?.didStreamTerminalReply?.() === true &&
+    !blockReplyPipeline.isAborted()
+  ) {
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(
       buildTerminalAgentRunFailureReplyPayload({ sessionCtx, cfg }),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -446,6 +446,7 @@ async function executeAgentTurnInternalWithRetryState(
   const terminalFailurePayload = terminalRunFailed
     ? buildTerminalAgentRunFailureReplyPayload({
         isHeartbeat: params.isHeartbeat,
+        visibleReplyDelivered: false,
         sessionCtx: params.sessionCtx,
         cfg: params.followupRun.run.config,
       })

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -471,18 +471,24 @@ export function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload:
 
 export function buildTerminalAgentRunFailureReplyPayload(params: {
   isHeartbeat?: boolean;
+  visibleReplyDelivered: boolean;
   sessionCtx: ExternalFailureConversationContext;
   cfg?: OpenClawConfig;
 }): ReplyPayload {
+  const text = params.isHeartbeat
+    ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+    : GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
+  // Once output is visible, hiding its terminal failure leaves a misleading partial reply.
+  // Keep normal group silence only for failures that produced no visible output.
   return markAgentRunFailureReplyPayload({
-    text: resolveExternalRunFailureTextForConversation({
-      text: params.isHeartbeat
-        ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
-        : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-      sessionCtx: params.sessionCtx,
-      isGenericRunnerFailure: true,
-      cfg: params.cfg,
-    }),
+    text: params.visibleReplyDelivered
+      ? text
+      : resolveExternalRunFailureTextForConversation({
+          text,
+          sessionCtx: params.sessionCtx,
+          isGenericRunnerFailure: true,
+          cfg: params.cfg,
+        }),
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -10,6 +10,7 @@ import { hasRestartRecoverySourceClaim } from "../../config/sessions/restart-rec
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import { hasOutboundReplyContent } from "../../plugin-sdk/reply-payload.js";
 import {
   buildHandledBeforeAgentReplyPayloads,
   runBeforeAgentReplyForTurn,
@@ -111,6 +112,18 @@ export async function runReplyAgent(
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
 
   const isHeartbeat = opts?.isHeartbeat === true;
+  let didDeliverVisiblePartialReply = false;
+  const runOpts = opts?.onPartialReply
+    ? {
+        ...opts,
+        onPartialReply: async (payload: Parameters<NonNullable<typeof opts.onPartialReply>>[0]) => {
+          await opts.onPartialReply?.(payload);
+          if (hasOutboundReplyContent(payload, { trimText: true })) {
+            didDeliverVisiblePartialReply = true;
+          }
+        },
+      }
+    : opts;
   const replyOperationRunState = resolveReplyOperationRunState(opts);
   const traceAttributes = {
     provider: followupRun.run.provider,
@@ -654,7 +667,7 @@ export async function runReplyAgent(
       getActiveSessionEntry: () => activeSessionEntry,
       isHeartbeat,
       isRestartRecoveryArmed,
-      opts,
+      opts: runOpts,
       pendingToolTasks,
       performSessionReset: resetSession,
       queueKey,
@@ -696,6 +709,7 @@ export async function runReplyAgent(
     return await handleReplyAgentRunError(error, {
       blockReplyPipeline,
       cfg,
+      didDeliverVisiblePartialReply: () => didDeliverVisiblePartialReply,
       isHeartbeat,
       isRestartRecoveryArmed,
       replyOperation,

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -694,7 +694,9 @@ export async function runReplyAgent(
     });
   } catch (error) {
     return await handleReplyAgentRunError(error, {
+      blockReplyPipeline,
       cfg,
+      isHeartbeat,
       isRestartRecoveryArmed,
       replyOperation,
       resolvedVerboseLevel,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1163,6 +1163,46 @@ describe("runReplyAgent heartbeat followup guard", () => {
       persistSpy.mockRestore();
     }
   });
+
+  it.each(["reasoning", "commentary"] as const)(
+    "rethrows after %s-only block streaming",
+    async (lane) => {
+      const accounting = await import("./session-run-accounting.js");
+      const persistSpy = vi
+        .spyOn(accounting, "persistRunSessionUsage")
+        .mockRejectedValueOnce(new Error("persist exploded"));
+      const onBlockReply = vi.fn();
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+        await params.onBlockReply?.({
+          text: `internal ${lane}`,
+          ...(lane === "reasoning" ? { isReasoning: true } : { isCommentary: true }),
+        });
+        return {
+          payloads: [{ text: "final answer" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      try {
+        const { run } = createMinimalRun({
+          blockStreamingEnabled: true,
+          opts: {
+            onBlockReply,
+            reasoningPayloadsEnabled: lane === "reasoning",
+            commentaryPayloadsEnabled: lane === "commentary",
+          },
+        });
+
+        await expect(run()).rejects.toThrow("persist exploded");
+        expect(onBlockReply).toHaveBeenCalledWith(
+          expect.objectContaining({ text: `internal ${lane}` }),
+          expect.any(Object),
+        );
+      } finally {
+        persistSpy.mockRestore();
+      }
+    },
+  );
 });
 
 describe("runReplyAgent pending final delivery capture", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1129,37 +1129,53 @@ describe("runReplyAgent heartbeat followup guard", () => {
     }
   });
 
-  it("returns a terminal failure after a delivered partial with block streaming disabled", async () => {
-    const accounting = await import("./session-run-accounting.js");
-    const persistSpy = vi
-      .spyOn(accounting, "persistRunSessionUsage")
-      .mockRejectedValueOnce(new Error("persist exploded"));
-    const onPartialReply = vi.fn();
-    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
-      await params.onPartialReply?.({ text: "partial answer" });
-      return {
-        payloads: [{ text: "final answer" }],
-        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
-      };
-    });
-
-    try {
-      const { run } = createMinimalRun({
-        blockStreamingEnabled: false,
-        opts: { onPartialReply },
+  it.each([
+    { label: "direct chat", sessionCtx: {} },
+    {
+      label: "group chat",
+      sessionCtx: {
+        ChatType: "group" as const,
+        SessionKey: "agent:test:telegram:group:-100123",
+      },
+    },
+  ])(
+    "returns a terminal failure in a $label after a delivered partial with block streaming disabled",
+    async ({ sessionCtx }) => {
+      const accounting = await import("./session-run-accounting.js");
+      const persistSpy = vi
+        .spyOn(accounting, "persistRunSessionUsage")
+        .mockRejectedValueOnce(new Error("persist exploded"));
+      const onPartialReply = vi.fn();
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+        await params.onPartialReply?.({ text: "partial answer" });
+        return {
+          payloads: [{ text: "final answer" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
       });
-      const result = await run();
-      const payload = Array.isArray(result) ? result[0] : result;
 
-      expect(onPartialReply).toHaveBeenCalledWith({ text: "partial answer", mediaUrls: undefined });
-      expect(payload).toMatchObject({
-        text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-        isError: true,
-      });
-    } finally {
-      persistSpy.mockRestore();
-    }
-  });
+      try {
+        const { run } = createMinimalRun({
+          blockStreamingEnabled: false,
+          opts: { onPartialReply },
+          sessionCtx,
+        });
+        const result = await run();
+        const payload = Array.isArray(result) ? result[0] : result;
+
+        expect(onPartialReply).toHaveBeenCalledWith({
+          text: "partial answer",
+          mediaUrls: undefined,
+        });
+        expect(payload).toMatchObject({
+          text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+          isError: true,
+        });
+      } finally {
+        persistSpy.mockRestore();
+      }
+    },
+  );
 
   it("rethrows after a delivered partial without visible content", async () => {
     const accounting = await import("./session-run-accounting.js");

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1129,14 +1129,14 @@ describe("runReplyAgent heartbeat followup guard", () => {
     }
   });
 
-  it("returns a terminal failure after visible block streaming", async () => {
+  it("returns a terminal failure after a delivered partial with block streaming disabled", async () => {
     const accounting = await import("./session-run-accounting.js");
     const persistSpy = vi
       .spyOn(accounting, "persistRunSessionUsage")
       .mockRejectedValueOnce(new Error("persist exploded"));
-    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
-      await params.onBlockReply?.({ text: "partial answer" });
+      await params.onPartialReply?.({ text: "partial answer" });
       return {
         payloads: [{ text: "final answer" }],
         meta: { agentMeta: { usage: { input: 1, output: 1 } } },
@@ -1145,16 +1145,13 @@ describe("runReplyAgent heartbeat followup guard", () => {
 
     try {
       const { run } = createMinimalRun({
-        blockStreamingEnabled: true,
-        opts: { onBlockReply },
+        blockStreamingEnabled: false,
+        opts: { onPartialReply },
       });
       const result = await run();
       const payload = Array.isArray(result) ? result[0] : result;
 
-      expect(onBlockReply).toHaveBeenCalledWith(
-        expect.objectContaining({ text: "partial answer" }),
-        expect.any(Object),
-      );
+      expect(onPartialReply).toHaveBeenCalledWith({ text: "partial answer", mediaUrls: undefined });
       expect(payload).toMatchObject({
         text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
         isError: true,
@@ -1162,6 +1159,81 @@ describe("runReplyAgent heartbeat followup guard", () => {
     } finally {
       persistSpy.mockRestore();
     }
+  });
+
+  it("rethrows after a delivered partial without visible content", async () => {
+    const accounting = await import("./session-run-accounting.js");
+    const persistSpy = vi
+      .spyOn(accounting, "persistRunSessionUsage")
+      .mockRejectedValueOnce(new Error("persist exploded"));
+    const onPartialReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onPartialReply?.({ text: "   " });
+      return {
+        payloads: [{ text: "final answer" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        blockStreamingEnabled: false,
+        opts: { onPartialReply },
+      });
+
+      await expect(run()).rejects.toThrow("persist exploded");
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
+
+  it("rethrows heartbeat failures after a delivered partial", async () => {
+    const accounting = await import("./session-run-accounting.js");
+    const persistSpy = vi
+      .spyOn(accounting, "persistRunSessionUsage")
+      .mockRejectedValueOnce(new Error("persist exploded"));
+    const onPartialReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onPartialReply?.({ text: "heartbeat detail" });
+      return {
+        payloads: [{ text: "HEARTBEAT_OK" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        blockStreamingEnabled: false,
+        opts: { isHeartbeat: true, onPartialReply },
+      });
+
+      await expect(run()).rejects.toThrow("persist exploded");
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
+
+  it("keeps user aborts silent after a delivered partial", async () => {
+    const replyOperation = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    const onPartialReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onPartialReply?.({ text: "partial answer" });
+      replyOperation.abortByUser();
+      throw new Error("run stopped");
+    });
+
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: false,
+      opts: { onPartialReply },
+      replyOperation,
+    });
+    const result = await run();
+
+    expect(result).toEqual({ text: "NO_REPLY" });
   });
 
   it.each(["reasoning", "commentary"] as const)(

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1128,6 +1128,41 @@ describe("runReplyAgent heartbeat followup guard", () => {
       persistSpy.mockRestore();
     }
   });
+
+  it("returns a terminal failure after visible block streaming", async () => {
+    const accounting = await import("./session-run-accounting.js");
+    const persistSpy = vi
+      .spyOn(accounting, "persistRunSessionUsage")
+      .mockRejectedValueOnce(new Error("persist exploded"));
+    const onBlockReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.({ text: "partial answer" });
+      return {
+        payloads: [{ text: "final answer" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        blockStreamingEnabled: true,
+        opts: { onBlockReply },
+      });
+      const result = await run();
+      const payload = Array.isArray(result) ? result[0] : result;
+
+      expect(onBlockReply).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "partial answer" }),
+        expect.any(Object),
+      );
+      expect(payload).toMatchObject({
+        text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+        isError: true,
+      });
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
 });
 
 describe("runReplyAgent pending final delivery capture", () => {

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -32,6 +32,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     ctx,
     deliveryChannel,
     dispatcher,
+    failDispatchReplyOperation,
     flushPendingCommentaryProgress,
     getDispatchAbortOperation,
     getDispatchAbortSignal,
@@ -507,6 +508,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     ) {
       throw error;
     }
+    failDispatchReplyOperation(error);
     return buildTerminalAgentRunFailureReplyPayload({
       visibleReplyDelivered: true,
       sessionCtx: ctx,

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -12,6 +12,7 @@ import {
   isReplyPayloadStatusNotice,
   type ReplyPayload,
 } from "../reply-payload.js";
+import { buildTerminalAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 import { takeCommandSessionMetadataChanges } from "./command-session-metadata.js";
 import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
 import {
@@ -64,6 +65,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     wrapProgressCallback,
   } = state;
   let deliberateSilentTerminalReply = false;
+  let didDeliverVisiblePartialReply = false;
   const replyResult = await runWithDispatchLifecycleAdmission(
     async () =>
       await runWithDispatchAbortSignal(
@@ -89,7 +91,13 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                 shouldSuppressToolErrorWarnings: state.shouldSuppressToolErrorWarnings,
                 typingPolicy: typing.typingPolicy,
                 suppressTyping: typing.suppressTyping,
-                onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
+                onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply, {
+                  onVisible: (payload) => {
+                    if (hasOutboundReplyContent(payload, { trimText: true })) {
+                      didDeliverVisiblePartialReply = true;
+                    }
+                  },
+                }),
                 onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
                 streamReasoningInNonStreamModes:
                   params.replyOptions?.streamReasoningInNonStreamModes,
@@ -491,7 +499,16 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
           ),
         trackDispatchLifecycleWork,
       ),
-  );
+  ).catch((error) => {
+    if (
+      params.replyOptions?.isHeartbeat === true ||
+      !didDeliverVisiblePartialReply ||
+      isDispatchOperationAborted()
+    ) {
+      throw error;
+    }
+    return buildTerminalAgentRunFailureReplyPayload({ sessionCtx: ctx, cfg: replyConfig });
+  });
   const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
   notifySessionMetadataChanges(sessionMetadataChanges);
   const finalDispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -507,7 +507,11 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     ) {
       throw error;
     }
-    return buildTerminalAgentRunFailureReplyPayload({ sessionCtx: ctx, cfg: replyConfig });
+    return buildTerminalAgentRunFailureReplyPayload({
+      visibleReplyDelivered: true,
+      sessionCtx: ctx,
+      cfg: replyConfig,
+    });
   });
   const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
   notifySessionMetadataChanges(sessionMetadataChanges);

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -499,7 +499,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
           ),
         trackDispatchLifecycleWork,
       ),
-  ).catch((error) => {
+  ).catch((error: unknown) => {
     if (
       params.replyOptions?.isHeartbeat === true ||
       !didDeliverVisiblePartialReply ||

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -97,4 +97,44 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
+
+  it("records a failed reply operation when recovering a visible partial", async () => {
+    const resolverError = new Error("provider failed after partial");
+    let replyOperation: ReturnType<typeof createReplyOperation> | undefined;
+    const replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]> = async (
+      _ctx,
+      options,
+    ) => {
+      if (!options) {
+        throw new Error("reply options required for partial recovery");
+      }
+      replyOperation = options.replyOperation;
+      await options.onPartialReply?.({ text: "partial telegram reply" });
+      throw resolverError;
+    };
+    const dispatchParams = {
+      ...createVisibleDispatchParams(replyResolver),
+      replyOptions: {
+        onPartialReply: vi.fn(async () => undefined),
+      },
+    };
+
+    const result = await dispatchReplyFromConfig(dispatchParams);
+
+    expect(replyOperation?.result).toEqual({
+      kind: "failed",
+      code: "run_failed",
+      cause: resolverError,
+    });
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(dispatchParams.replyOptions.onPartialReply).toHaveBeenCalledWith({
+      text: "partial telegram reply",
+    });
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("Something went wrong") }),
+    );
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #108586.

Telegram's default answer-draft path disables block streaming, so visible partial text is delivered through `onPartialReply`. If the model run then failed unexpectedly, the canonical runner did not know that Telegram had already shown output and the draft was cleared during cleanup.

## What Changed

- Track a visible partial only after the channel's awaited `onPartialReply` callback succeeds.
- Recover an unexpected non-heartbeat failure when either a terminal block or a visible partial was genuinely delivered.
- Keep user aborts silent and retain the existing heartbeat, reasoning-only, commentary-only, and no-visible-output behavior.
- Add a reply-owner backstop for custom resolvers that throw after an awaited visible partial.
- Finalize Telegram's active answer draft in place by appending the existing sanitized terminal notice, without clearing it or sending a duplicate durable message.

## Maintainer Follow-up

This head covers the exact default path called out in review:

1. Telegram resolves `disableBlockStreaming: true` for the default answer draft.
2. The partial reaches the draft through `onPartialReply`.
3. Delivery is recorded only after the queued draft update resolves.
4. A subsequent unexpected resolver failure produces the canonical terminal error payload.
5. Telegram performs exactly two edits: the visible partial, then the in-place finalized partial plus notice.

The composed Telegram ingress regression invokes the real buffered dispatch runtime. It no longer injects a final error payload directly.

## Evidence

- Runner E2E changed cases: **3 passed**, 127 skipped, including direct-chat and group-chat recovery.
- Core failure/accounting focused suites: **24 passed**.
- Core and extension production/test typechecks: passed.
- Exact-head lifecycle recovery regression on `ab609f08e16`: **2 passed**; asserts `run_failed` while the terminal reply remains deliverable.\n- Telegram composed draft + lane-delivery suites rerun on `ab609f08e16`: **58 passed**.\n- Focused oxfmt, oxlint, `git diff --check`, and full build: passed.

### Real Telegram transport proof

Run on rebased head `6a67980be3a1cb4003bc76e21abe0e925801efeb` with a real Telegram QA user through TDLib, the real SUT bot, a temporary Gateway, and a mock Responses provider. The provider streamed `OPENCLAW_PARTIAL_117603`, waited six seconds, and completed successfully. A proof-only, uncommitted fault hook then threw from the same post-run usage-accounting boundary used by the red regression.

The redacted TDLib recording completed with exactly one SUT message. Its final text retained the streamed partial and appended the terminal notice. It recorded no clear, deletion, or second SUT message.

```json
{
  "scenario": "telegram-group-partial-then-post-run-failure",
  "head": "6a67980be3a1cb4003bc76e21abe0e925801efeb",
  "transport": "real Telegram Bot API + TDLib",
  "faultBoundary": "post-run usage accounting",
  "recordingComplete": true,
  "sutMessageCount": 1,
  "finalText": "OPENCLAW_PARTIAL_117603\n\n⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
  "draftCleared": false,
  "duplicateMessage": false,
  "verdict": "pass"
}
```

Commands:

```text
node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "terminal failure in a .* chat after a delivered partial with block streaming disabled"
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts extensions/telegram/src/lane-delivery.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
pnpm build
```
