### PR TITLE
fix(tasks): fail closed when gateway task cancellation is unavailable

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  cancelActiveCronTaskRun,
+  registerActiveCronTaskRun,
+} from "../cron/service/active-run-cancellation.js";
 import { saveCronStore } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -22,8 +26,10 @@ import {
   configureTaskFlowRegistryRuntime,
   resetDetachedTaskLifecycleRuntimeForTests,
   resetTaskFlowRegistryForTests,
+  resetTaskRegistryControlRuntimeForTests,
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
+  setTaskRegistryControlRuntimeForTests,
 } from "../tasks/task-runtime.test-helpers.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -126,6 +132,7 @@ function resetTaskCommandRuntime() {
   taskRegistryMaintenance.resetTaskRegistryMaintenanceRuntimeForTests();
   resetConfigRuntimeState();
   resetDetachedTaskLifecycleRuntimeForTests();
+  resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryDeliveryRuntimeForTests();
   resetTaskRegistryForTests({ persist: false });
   resetTaskFlowRegistryForTests({ persist: false });
@@ -322,87 +329,42 @@ describe("tasks commands", () => {
     });
   });
 
-  it("routes cron task cancellation through the live gateway before local fallback", async () => {
-    await withTaskCommandStateDir(async () => {
-      const task = createTaskRecord({
-        runtime: "cron",
-        sourceId: "nightly-gmail-sync",
-        ownerKey: "",
-        scopeKind: "system",
-        runId: "cron:nightly-gmail-sync:123",
-        task: "Nightly Gmail sync",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
+  it.each(["cron", "acp"] as const)(
+    "routes %s task cancellation through its gateway",
+    async (owner) => {
+      await withTaskCommandStateDir(async () => {
+        const cron = owner === "cron";
+        const task = createInspectableTask({
+          runtime: owner,
+          ownerKey: cron ? "" : "agent:jarvis:main",
+          scopeKind: cron ? "system" : "session",
+          ...(cron ? {} : { childSessionKey: "agent:codex:acp:child" }),
+          runId: cron ? "cron:nightly-gmail-sync:123" : "run-acp-cancel",
+        });
+        mocks.callGateway.mockResolvedValueOnce({
+          found: true,
+          cancelled: true,
+          task: { taskId: task.taskId, runtime: owner, runId: task.runId },
+        });
+        const runtime = createRuntime();
+
+        await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+        expect(mocks.callGateway).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "tasks.cancel",
+            params: { taskId: task.taskId },
+            timeoutMs: 5_000,
+          }),
+        );
+        expect(runtime.log).toHaveBeenCalledWith(
+          `Cancelled ${task.taskId} (${owner}) run ${task.runId}.`,
+        );
+        expect(runtime.error).not.toHaveBeenCalled();
+        expect(runtime.exit).not.toHaveBeenCalled();
       });
-      mocks.callGateway.mockResolvedValueOnce({
-        found: true,
-        cancelled: true,
-        task: {
-          taskId: task.taskId,
-          runtime: "cron",
-          runId: task.runId,
-        },
-      });
-      const runtime = createRuntime();
-
-      await tasksCancelCommand({ lookup: task.taskId }, runtime);
-
-      expect(mocks.callGateway).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "tasks.cancel",
-          params: { taskId: task.taskId },
-          timeoutMs: 5_000,
-        }),
-      );
-      expect(runtime.log).toHaveBeenCalledWith(
-        `Cancelled ${task.taskId} (cron) run cron:nightly-gmail-sync:123.`,
-      );
-      expect(runtime.error).not.toHaveBeenCalled();
-      expect(runtime.exit).not.toHaveBeenCalled();
-    });
-  });
-
-  it("routes ACP task cancellation through the live gateway before local fallback", async () => {
-    await withTaskCommandStateDir(async () => {
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
-        childSessionKey: "agent:codex:acp:child",
-        runId: "run-acp-cancel",
-        task: "Cancel ACP child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-      });
-      mocks.callGateway.mockResolvedValueOnce({
-        found: true,
-        cancelled: true,
-        task: {
-          taskId: task.taskId,
-          runtime: "acp",
-          runId: task.runId,
-        },
-      });
-      const runtime = createRuntime();
-
-      await tasksCancelCommand({ lookup: task.taskId }, runtime);
-
-      expect(mocks.callGateway).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "tasks.cancel",
-          params: { taskId: task.taskId },
-          timeoutMs: 5_000,
-        }),
-      );
-      expect(runtime.log).toHaveBeenCalledWith(
-        `Cancelled ${task.taskId} (acp) run run-acp-cancel.`,
-      );
-      expect(runtime.error).not.toHaveBeenCalled();
-      expect(runtime.exit).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it.each(["gateway", "local"] as const)(
     "sanitizes untrusted %s task cancellation output",
@@ -434,6 +396,7 @@ describe("tasks commands", () => {
         );
         expectSafeTaskOutput(runtime);
         if (!gatewayOwned) {
+          expect(mocks.callGateway).not.toHaveBeenCalled();
           expect(getTaskById(task.taskId)).toMatchObject({
             status: "cancelled",
             runId: `run${unsafe}`,
@@ -452,36 +415,52 @@ describe("tasks commands", () => {
     },
   );
 
-  it("fails ACP task cancellation loudly when the live gateway is unavailable", async () => {
+  it.each([
+    { owner: "cron" as const, failure: "gateway unavailable" },
+    { owner: "cron" as const, failure: "gateway timed out" },
+    { owner: "cron" as const, failure: "gateway connection closed" },
+    { owner: "acp" as const, failure: "gateway unavailable" },
+  ])("leaves the live $owner run untouched when $failure", async ({ owner, failure }) => {
     await withTaskCommandStateDir(async () => {
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
-        childSessionKey: "agent:codex:acp:child",
-        runId: "run-acp-cancel-gateway-down",
-        task: "Cancel ACP child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
+      const cron = owner === "cron";
+      const task = createInspectableTask({
+        runtime: owner,
+        ownerKey: cron ? "" : "agent:jarvis:main",
+        scopeKind: cron ? "system" : "session",
+        ...(cron ? {} : { childSessionKey: "agent:codex:acp:child" }),
+        runId: cron ? "cron:nightly-gmail-sync:123" : "run-acp-cancel",
       });
-      mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+      const controller = new AbortController();
+      const unregister = cron
+        ? registerActiveCronTaskRun({ runId: task.runId, controller })
+        : undefined;
+      if (cron) {
+        setTaskRegistryControlRuntimeForTests({
+          cancelActiveCronTaskRun,
+          getAcpSessionManager: () => ({ cancelSession: vi.fn() }),
+          killSubagentRunAdmin: async () => ({ found: false, killed: false }),
+        });
+      }
+      mocks.callGateway.mockRejectedValueOnce(new Error(failure));
       const runtime = createRuntime();
 
-      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+      try {
+        await tasksCancelCommand({ lookup: task.taskId }, runtime);
 
-      expect(mocks.callGateway).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "tasks.cancel",
-          params: { taskId: task.taskId },
-          timeoutMs: 5_000,
-        }),
-      );
-      expect(runtime.error).toHaveBeenCalledWith(
-        "ACP task cancellation requires the live Gateway tasks.cancel path: gateway unavailable",
-      );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(runtime.log).not.toHaveBeenCalled();
+        expect(runtime.error).toHaveBeenCalledWith(
+          `${cron ? "Cron" : "ACP"} task cancellation requires the live Gateway tasks.cancel path: ${failure}`,
+        );
+        expect(mocks.callGateway).toHaveBeenCalledWith(
+          expect.objectContaining({ method: "tasks.cancel", params: { taskId: task.taskId } }),
+        );
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(runtime.log).not.toHaveBeenCalled();
+        expect(controller.signal.aborted).toBe(false);
+        reloadTaskRegistryFromStore();
+        expect(getTaskById(task.taskId)).toMatchObject({ status: "running" });
+      } finally {
+        unregister?.();
+      }
     });
   });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -106,16 +106,14 @@ async function tryCancelGatewayOwnedTaskViaGateway(
       timeoutMs: 5_000,
     });
   } catch (error) {
-    if (task.runtime === "acp") {
-      const detail = error instanceof Error ? error.message : String(error);
-      return {
-        found: true,
-        cancelled: false,
-        reason: `ACP task cancellation requires the live Gateway tasks.cancel path: ${detail}`,
-        task,
-      };
-    }
-    return null;
+    const detail = error instanceof Error ? error.message : String(error);
+    const runtimeLabel = task.runtime === "acp" ? "ACP" : "Cron";
+    return {
+      found: true,
+      cancelled: false,
+      reason: `${runtimeLabel} task cancellation requires the live Gateway tasks.cancel path: ${detail}`,
+      task,
+    };
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators canceling a running cron task were told cancellation succeeded when the live Gateway was unavailable, timed out, or disconnected, while the actual Gateway-owned run could continue.

## Why This Change Was Made

Cron and ACP now share one canonical fail-closed Gateway-owned cancellation path. Local-only task cancellation and the existing ACP contract remain unchanged, and duplicated regression tests were consolidated.

## User Impact

Operators receive an explicit, actionable error instead of false cancellation success. Live cron jobs and durable task status remain unchanged until their owning Gateway accepts cancellation.

## Evidence

Tests-first RED: three unavailable, timeout, and disconnect cases failed against the original behavior. Final GREEN: 28 command-owner tests and 35 real Commander registration tests; the regressions use a genuine registered cron AbortController and reload the real SQLite task record. Production LOC decreased by two; test LOC decreased by 21. Four independent hostile reviews found no issues; genuine gpt-5.6-sol high-reasoning P3 autoreview and native TruffleHog 3.96 both passed.
