### PR TITLE
fix(nodes): preserve operator rename during reapproval

### DIFF
--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -36,11 +36,12 @@ async function seedNodeDevice(baseDir: string, nodeId: string): Promise<void> {
   await approveDevicePairing(request.request.requestId, { callerScopes: [] }, baseDir);
 }
 
-async function setupPairedNode(baseDir: string): Promise<void> {
+async function setupPairedNode(baseDir: string, displayName?: string): Promise<void> {
   await seedNodeDevice(baseDir, "node-1");
   const request = await requestNodePairing(
     {
       nodeId: "node-1",
+      displayName,
       platform: "darwin",
       commands: ["system.run"],
     },
@@ -783,17 +784,50 @@ describe("node surface approvals", () => {
     });
   });
 
-  test("renames the operator-facing node name without touching approval state", async () => {
+  test("keeps the operator-facing node name through capability reapproval", async () => {
     await withNodePairingDir(async (baseDir) => {
-      await setupPairedNode(baseDir);
+      await setupPairedNode(baseDir, "Reported iPad");
+      const initialGeneration = resolveNodePairingGeneration(
+        await getPairedDevice("node-1", baseDir),
+      );
+      if (!initialGeneration) {
+        throw new Error("expected initial node pairing generation");
+      }
+      const upgrade = await requestNodePairing(
+        {
+          nodeId: "node-1",
+          displayName: "Reported iPad (updated)",
+          platform: "darwin",
+          commands: ["system.run", "canvas.snapshot"],
+        },
+        baseDir,
+      );
+      expect(upgrade.request.displayName).toBe("Reported iPad (updated)");
 
       const renamed = await renamePairedNode("node-1", "Living Room iPad", baseDir);
       expect(renamed?.displayName).toBe("Living Room iPad");
       await expect(renamePairedNode("missing", "Nope", baseDir)).resolves.toBeNull();
 
+      await expect(
+        approveNodePairing(
+          upgrade.request.requestId,
+          { callerScopes: ["operator.pairing", "operator.admin", "operator.write"] },
+          baseDir,
+        ),
+      ).resolves.toMatchObject({
+        node: {
+          displayName: "Living Room iPad",
+          commands: ["system.run", "canvas.snapshot"],
+        },
+      });
+
       const pairedNode = await findPairedNode("node-1", baseDir);
       expect(pairedNode?.displayName).toBe("Living Room iPad");
-      expect(pairedNode?.commands).toEqual(["system.run"]);
+      expect(pairedNode?.commands).toEqual(["system.run", "canvas.snapshot"]);
+      expect((await listNodePairing(baseDir)).pending).toEqual([]);
+      expect(resolveNodePairingGeneration(await getPairedDevice("node-1", baseDir))?.key).not.toBe(
+        initialGeneration.key,
+      );
     });
   });
 });

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -569,7 +569,8 @@ export async function approveNodePairing(
     const previousPairingGeneration = resolveNodePairingGeneration(device);
     const now = Math.max(Date.now(), (device.nodeSurface?.approvedAtMs ?? -1) + 1);
     device.nodeSurface = {
-      displayName: pending.displayName,
+      // Reapproval refreshes the node-declared surface without replacing the operator-owned name.
+      displayName: device.nodeSurface?.displayName ?? pending.displayName,
       version: pending.version,
       coreVersion: pending.coreVersion,
       uiVersion: pending.uiVersion,


### PR DESCRIPTION
Closes #117607

## What Problem This Solves

Fixes an issue where operators who renamed a paired node would lose that stable label when approving a later capability or command-surface change from the same node.

## Why This Change Was Made

Node reapproval now refreshes the node-declared capability surface while retaining the existing approved display name. The pending client-reported name remains the fallback for first approval, so initial pairing behavior is unchanged.

## User Impact

Names assigned with `openclaw nodes rename` now survive node capability reapproval. Operators can keep stable inventory labels even when a client reports a different machine name during an upgrade or reconnect.

## Evidence

- Current-main source reproduction: `node.rename` writes the approved `nodeSurface.displayName`, but `approveNodePairing` previously replaced the whole surface with `pending.displayName` on every reapproval.
- Exact-head real behavior proof on `d352beed78690bfac4eadb22960bb4d602f6111d`: an isolated Gateway and real headless node used separate temporary state and port `21467` (never the operator Gateway or port `18789`). The node was first approved as `Reported iPad`, renamed through `openclaw nodes rename` to `Living Room iPad`, then reconnected as `Reported iPad (updated)` with installed-app sharing enabled to force a capability reapproval. Before approval, `nodes pending --json` showed the new `device.apps` command while `nodes status --json` retained `Living Room iPad` with `pending-reapproval`. After `nodes approve`, status still showed `Living Room iPad`, included `device.apps`, reported `approvalState: approved`, and `nodes pending --json` returned `[]`. The owned node and Gateway then shut down cleanly and the isolated port closed.
- Focused Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30715621692 passed 18/18 node-pairing cases, including the operator rename, capability refresh, pending cleanup, and pairing-generation rotation. The workflow reports cancelled only because the externally stopped kept Testbox cancels its keepalive job after the remote command exits.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/30715914147 completed successfully, including `openclaw/ci-gate`.
- Targeted formatting, oxlint, and `git diff --check` passed.
- Final post-rebase P1 Codex autoreview and TruffleHog were clean with no accepted/actionable findings at 0.94 confidence. A fresh current-main Codex autoreview after the real lifecycle proof was also clean with no findings at 0.99 confidence.
- Production delta: `+2/-1`; tests: `+38/-4`.

Release-note context: paired node rename overrides now remain stable across capability reapproval.

AI-assisted: yes. The state ownership and public node-rename contract were independently reviewed, and the final branch was remotely tested, exercised through the real CLI/Gateway/node lifecycle, and autoreviewed.
