### PR TITLE
fix(ci): isolate performance gateway network checks

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -753,6 +753,8 @@ jobs:
           cat > "$gateway_config" <<EOF
           {
             "browser": { "enabled": false },
+            "models": { "catalogRefresh": { "enabled": false } },
+            "update": { "checkOnStart": false },
             "gateway": {
               "mode": "local",
               "port": ${gateway_port},

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -261,6 +261,13 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
   });
 
+  it("keeps the source performance gateway fixture network-hermetic", () => {
+    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+
+    expect(run).toContain('"models": { "catalogRefresh": { "enabled": false } },');
+    expect(run).toContain('"update": { "checkOnStart": false },');
+  });
+
   it("isolates required publication in a fresh artifact-consuming job", () => {
     const workflow = readWorkflow();
     const publisher = workflow.jobs?.publish;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the source performance workflow's gateway fixture could perform hosted model-catalog and update checks during CLI health measurements. In https://github.com/openclaw/openclaw/actions/runs/30715469061, the catalog request timed out while the first connected health probe stalled, adding external-network noise to a benchmark intended to measure local OpenClaw behavior.

## Why This Change Was Made

The workflow fixture now disables remote model-catalog refresh and startup update checks. Production defaults and runtime behavior are unchanged; only the isolated performance gateway configuration is affected.

## User Impact

Maintainers get more deterministic CLI/gateway performance evidence without hosted-network availability contaminating the measurement. There is no end-user runtime impact.

## Evidence

- Before: run 30715469061 logged a 15-second hosted catalog timeout and a 10.3-second first connected health sample.
- Repeated on exact post-landing main in https://github.com/openclaw/openclaw/actions/runs/30715897767: the first connected health sample took 7.31 seconds, the next four took 676-694 ms, and the gateway again logged a hosted catalog timeout.
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` - 33 passed.
- `actionlint .github/workflows/openclaw-performance.yml` - passed.
- `oxfmt --check` for both changed files - passed.
- `git diff --check` - passed.
- Autoreview: clean, no accepted or actionable findings.

### Exact rebased-head proof

- Reviewed head: `35b331729b9950c3b0fb1f6de525e34cfced9580`, based on `c539192b5cdd8369c16c6be03258cc68deac17ef`.
- Exact workflow: https://github.com/openclaw/openclaw/actions/runs/30718848914 (passed).
- All refreshed-head PR checks completed with no failures.
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` - 33 passed.
- `node scripts/run-vitest.mjs src/model-catalog/remote-refresh.test.ts src/infra/update-startup.test.ts` - 53 passed, preserving the independent remote-path contracts.
- `actionlint`, `oxfmt --check`, `git diff --check`, and a current-main `git merge-tree --write-tree` passed.
- The exact-head `cli-gateway.log` contains zero hosted catalog, refresh, fetch-timeout, or startup update-check traffic.
- Connected-health samples were 8619, 706, 673, 688, and 686 ms. First-device samples were 648, 637, 637, 636, and 642 ms.
- The isolated first connected-health outlier remains a separate follow-up. This PR removes benchmark contamination without hiding or claiming to fix that runtime path.
