### PR TITLE
fix(xai): classify failed realtime voice responses before continuation

### DIFF
--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -1,5 +1,5 @@
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX,
   XAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR,
@@ -11,6 +11,21 @@ import { XaiRealtimeVoiceProtocol } from "./realtime-voice-protocol.js";
 
 export class XaiRealtimeMalformedAudioError extends Error {}
 
+function readXaiRealtimeTerminalFailure(event: XaiRealtimeEvent): string | undefined {
+  const status = normalizeOptionalString(event.response?.status)?.toLowerCase();
+  if (status !== "failed" && status !== "incomplete") {
+    return undefined;
+  }
+  const details = isRecord(event.response?.status_details)
+    ? event.response.status_details
+    : undefined;
+  if (status === "failed" && details?.error) {
+    return readXaiRealtimeErrorDetail(details.error);
+  }
+  const reason = normalizeOptionalString(details?.reason);
+  return `xAI realtime voice response ${status}${reason ? `: ${reason}` : ""}`;
+}
+
 export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
   private assistantTranscriptBuffer = "";
   private assistantTranscriptFinalized = false;
@@ -20,16 +35,31 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
   protected abstract onSessionUpdated(connection: XaiRealtimeVoiceConnection): void;
 
   protected handleEvent(event: XaiRealtimeEvent, connection: XaiRealtimeVoiceConnection): void {
-    this.config.onEvent?.({
-      direction: "server",
-      type: event.type,
-      detail: this.describeServerEvent(event),
-      ...(event.item_id ? { itemId: event.item_id } : {}),
-      ...((event.response_id ?? event.response?.id)
-        ? { responseId: event.response_id ?? event.response?.id }
-        : {}),
-    });
+    const terminalFailure =
+      event.type === "response.done" ? readXaiRealtimeTerminalFailure(event) : undefined;
+    if (!terminalFailure) {
+      this.config.onEvent?.({
+        direction: "server",
+        type: event.type,
+        detail: this.describeServerEvent(event),
+        ...(event.item_id ? { itemId: event.item_id } : {}),
+        ...((event.response_id ?? event.response?.id)
+          ? { responseId: event.response_id ?? event.response?.id }
+          : {}),
+      });
+    }
     if (!this.acceptsEvent(connection)) {
+      return;
+    }
+    if (terminalFailure) {
+      // Failed done events must not finish a successful turn or start queued,
+      // billable generation before the meeting receives its terminal error.
+      this.flushAssistantTranscript();
+      this.responseActive = false;
+      this.responseCreateInFlight = false;
+      this.responseCancelInFlight = false;
+      this.responseCreatePending = false;
+      this.config.onError?.(new Error(terminalFailure));
       return;
     }
     switch (event.type) {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -775,6 +775,152 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     });
   });
 
+  it.each([
+    {
+      status: "failed",
+      statusDetails: {
+        type: "failed",
+        error: { code: "server_error", message: "Voice generation failed upstream" },
+      },
+      expectedError: "Voice generation failed upstream",
+    },
+    {
+      status: "incomplete",
+      statusDetails: { type: "incomplete", reason: "content_filter" },
+      expectedError: "xAI realtime voice response incomplete: content_filter",
+    },
+    {
+      status: "incomplete",
+      statusDetails: { type: "incomplete", reason: "max_output_tokens" },
+      expectedError: "xAI realtime voice response incomplete: max_output_tokens",
+    },
+  ])(
+    "surfaces a $status response.done outcome instead of silently completing the turn",
+    async ({ status, statusDetails, expectedError }) => {
+      const callbackOrder: string[] = [];
+      const onTranscript = vi.fn((_role, _text, isFinal) => {
+        if (isFinal) {
+          callbackOrder.push("final-transcript");
+        }
+      });
+      const onEvent = vi.fn((event: { type: string }) => {
+        if (event.type === "response.done") {
+          callbackOrder.push("turn.ended");
+        }
+      });
+      const onError = vi.fn(() => callbackOrder.push("session.error"));
+      const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+        providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onTranscript,
+        onEvent,
+        onError,
+      });
+      const { connecting, socket } = await openRealtimeBridge(bridge);
+      await connecting;
+
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({ type: "response.output_text.delta", delta: "Partial answer" }),
+        ),
+      );
+      bridge.sendUserMessage?.("Queued meeting follow-up");
+
+      expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
+
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.done",
+            response: { id: "resp_failed", status, status_details: statusDetails },
+          }),
+        ),
+      );
+
+      expect(onEvent.mock.calls.some(([event]) => event.type === "response.done")).toBe(false);
+      expect(onTranscript).toHaveBeenLastCalledWith("assistant", "Partial answer", true);
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ message: expectedError }),
+      );
+      expect(callbackOrder).toEqual(["final-transcript", "session.error"]);
+      expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
+    },
+  );
+
+  it("never starts a queued meeting generation after a failed response.done outcome", async () => {
+    const meetingOutcomes: string[] = [];
+    const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onEvent: (event) => {
+        if (event.type === "response.done") {
+          meetingOutcomes.push("turn.ended");
+        }
+      },
+      onError: () => meetingOutcomes.push("session.error"),
+    });
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+    bridge.sendUserMessage?.("Queued meeting follow-up");
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.done",
+          response: {
+            status: "failed",
+            status_details: { type: "failed", error: { message: "Voice generation failed" } },
+          },
+        }),
+      ),
+    );
+
+    expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
+    expect(meetingOutcomes).toEqual(["session.error"]);
+  });
+
+  it.each(["completed", "cancelled"])(
+    "keeps a %s response.done outcome non-failing and starts queued work",
+    async (status) => {
+      const onError = vi.fn();
+      const onEvent = vi.fn();
+      const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+        providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onError,
+        onEvent,
+      });
+      const { connecting, socket } = await openRealtimeBridge(bridge);
+      await connecting;
+
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+      bridge.sendUserMessage?.("Queued meeting follow-up");
+
+      socket.emit(
+        "message",
+        Buffer.from(JSON.stringify({ type: "response.done", response: { status } })),
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onEvent).toHaveBeenCalledWith({
+        direction: "server",
+        type: "response.done",
+        detail: `status=${status}`,
+      });
+      expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([
+        { type: "response.create" },
+      ]);
+    },
+  );
+
   it("buffers assistant transcript deltas and finalizes them when done has no text", async () => {
     const provider = buildXaiRealtimeVoiceProvider();
     const onTranscript = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

xAI realtime voice always sends `response.done` for completed, cancelled, failed, and incomplete responses. The provider treated failed and incomplete responses like successful turns, which could falsely end a meeting turn successfully and start another queued, billable model response before reporting the failure.

## Why This Change Was Made

Classify terminal response status inside the xAI provider before publishing a successful completion or flushing queued generation. Failed and incomplete responses finalize any partial assistant transcript, clear pending generation, and report one visible terminal error; completed and cancelled responses preserve their existing event and continuation behavior.

## User Impact

Voice meeting operators see an explicit error instead of a false successful turn when generation fails or stops incomplete. Partial assistant text is preserved, unintended paid follow-up generation is prevented, and healthy or intentionally cancelled conversations continue to behave as before.

## Evidence

- Reproduced **four failing owner-level regressions** covering failed and incomplete terminal outcomes, false successful meeting completion, and an unintended queued provider response; healthy completed/cancelled controls passed.
- Corrected implementation passes **all 67 xAI provider-owner and lifecycle tests**, including six focused terminal-outcome cases.
- Four independent frozen-commit hostile source reviews found **zero P0, P1, P2, or P3 issues** and agreed on one root cause.
- Genuine exact-commit `gpt-5.6-sol` high-reasoning P0–P3 autoreview completed cleanly with **91% confidence**; native TruffleHog 3.96.0 also passed.
- An additional hosted preflight **did not run its checks** because its remote checkout lacked the frozen local commit. It does not count as passing hosted validation; successful exact-head GitHub pull-request CI is required before landing.
