### PR TITLE
fix(gateway): reject empty embedding inputs before provider execution

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -434,6 +434,33 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     await expectInvalidEmbeddingRequest(res);
   });
 
+  it.each([
+    { name: "an empty string", input: "" },
+    { name: "an empty batch", input: [] },
+    { name: "an empty batch entry", input: [""] },
+    { name: "a mixed batch with an empty entry", input: ["valid", ""] },
+  ])("rejects $name before creating an embedding provider", async ({ input }) => {
+    const providersCreatedBefore = createEmbeddingProviderMock.mock.calls.length;
+    const res = await postEmbeddings({
+      model: "openclaw/default",
+      input,
+    });
+
+    await expectInvalidEmbeddingRequest(res, "`input` must contain at least one non-empty string.");
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(providersCreatedBefore);
+  });
+
+  it("preserves whitespace-only embedding input", async () => {
+    const input = " \t\n";
+    const res = await postEmbeddings({
+      model: "openclaw/default",
+      input,
+    });
+
+    await expectDefaultEmbeddingResponse(res);
+    expect(embedBatchMock.mock.calls.at(-1)?.[0]).toEqual([input]);
+  });
+
   it("ignores narrower declared scopes for shared-secret bearer auth", async () => {
     const res = await postEmbeddings(
       {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -200,6 +200,9 @@ function encodeEmbeddingBase64(embedding: number[]): string {
 // Keep request limits local to the HTTP bridge; provider adapters may support
 // more, but this endpoint must protect gateway memory and request latency.
 function validateInputTexts(texts: string[]): string | undefined {
+  if (texts.length === 0 || texts.some((text) => text.length === 0)) {
+    return "`input` must contain at least one non-empty string.";
+  }
   if (texts.length > MAX_EMBEDDING_INPUTS) {
     return `Too many inputs (max ${MAX_EMBEDDING_INPUTS}).`;
   }


### PR DESCRIPTION
## What Problem This Solves

The OpenAI-compatible `/v1/embeddings` endpoint accepted empty string inputs, empty batches, and batches containing empty strings. The existing Gateway HTTP suite reproduced all four forms returning HTTP 200, even though the installed official OpenAI SDK explicitly requires non-empty input strings; empty batches could also allocate a provider and return a meaningless empty result.

## Why This Change Was Made

Validate the non-empty-input invariant once in the existing Gateway embeddings request validator, before provider creation. This is a bounded owner-level repair: three production lines, no new abstractions or configuration, and no changes to dimensions, encoding format, authentication, provider routing, or valid whitespace-only input.

## User Impact

Invalid empty embedding requests now receive a clear OpenAI-shaped HTTP 400 `invalid_request_error` instead of a misleading successful response or unnecessary provider work. Valid scalar and batch requests, whitespace-only input, existing request limits, authorization, and provider lifecycle behavior are preserved.

## Evidence

- Authentic baseline against the suite-owned real Gateway HTTP server: four failing cases (`""`, `[]`, `[""]`, and `["valid", ""]`) returned HTTP 200 instead of HTTP 400; the whitespace-only control passed.
- Corrected focused regression: all four invalid cases return HTTP 400 before any provider is created; whitespace input remains valid.
- Complete existing Gateway HTTP owner suite: `PATH=/Users/steipete/.local/bin:$PATH OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-qa-embeddings-empty-vitest-cache OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts src/gateway/embeddings-http.test.ts` — **30 tests passed**.
- Installed official OpenAI SDK source, `node_modules/openai/src/resources/embeddings.ts:129-137`, directly documents that embedding input cannot be an empty string.
- Six fresh independent immutable-commit hostile reviews: zero P0–P3 findings.
- Formal immutable-commit autoreview: Codex `gpt-5.6-sol`, reasoning `high`, maximum priority `P3`; clean with correctness confidence **0.98**. Native TruffleHog 3.96.0 secret scan: clean.
- Two existing files only: **+3 production lines, +27 test lines**; targeted formatting and `git diff --check` pass.

