### PR TITLE
fix(ci): prevent plugin prerelease validation timeouts

### DIFF
--- a/src/plugins/bundled-capability-runtime.test.ts
+++ b/src/plugins/bundled-capability-runtime.test.ts
@@ -60,6 +60,56 @@ function writeArtifactPreferencePlugin(id: string): TempPlugin {
   return plugin;
 }
 
+function writeDistShimCapabilityPlugin(id: string): TempPlugin {
+  return writePlugin({
+    id,
+    filename: "index.ts",
+    body: `import { isVoiceCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
+
+void isVoiceCompatibleAudio;
+
+export default {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    api.registerMediaUnderstandingProvider({ id: ${JSON.stringify(id)} });
+    api.registerWebSearchProvider({ id: ${JSON.stringify(id)} });
+    api.registerMigrationProvider({ id: ${JSON.stringify(id)} });
+  },
+};`,
+  });
+}
+
+function writeChannelCapabilityPlugin(id: string): TempPlugin {
+  const plugin = writePlugin({
+    id,
+    body: `module.exports = {
+      id: ${JSON.stringify(id)},
+      register(api) {
+        if (api.registrationMode === "discovery") {
+          api.registerTranscriptSourceProvider({
+            id: ${JSON.stringify(`${id}-voice`)},
+            name: "Voice transcripts",
+            sourceKinds: ["meeting"],
+          });
+        }
+      },
+    };`,
+  });
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id,
+        channels: [id],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      },
+      null,
+      2,
+    ),
+  );
+  return plugin;
+}
+
 function loadCanonicalFixture(plugin: TempPlugin, discovery: PluginDiscoveryResult) {
   return loadOpenClawPlugins({
     config: {
@@ -147,39 +197,43 @@ describe("loadBundledCapabilityRuntimeRegistry", () => {
   );
 
   it("loads runtime-backed bundled capabilities through the dist SDK shims", () => {
+    const target = writeDistShimCapabilityPlugin("capability-dist-shims");
     const registry = loadBundledCapabilityRuntimeRegistry({
-      pluginIds: ["codex"],
+      pluginIds: [target.id],
       pluginSdkResolution: "dist",
+      discovery: discoveryFor(target),
     });
 
-    const plugin = registry.plugins.find((entry) => entry.id === "codex");
+    const plugin = registry.plugins.find((entry) => entry.id === target.id);
     expect(
       plugin?.status,
       JSON.stringify({ plugin, diagnostics: registry.diagnostics }, null, 2),
     ).toBe("loaded");
     expect(registry.mediaUnderstandingProviders.map((entry) => entry.provider.id)).toEqual([
-      "codex",
+      target.id,
     ]);
-    expect(registry.webSearchProviders.map((entry) => entry.provider.id)).toEqual(["codex"]);
-    expect(registry.migrationProviders.map((entry) => entry.provider.id)).toEqual(["codex"]);
+    expect(registry.webSearchProviders.map((entry) => entry.provider.id)).toEqual([target.id]);
+    expect(registry.migrationProviders.map((entry) => entry.provider.id)).toEqual([target.id]);
   });
 
-  it("registers Discord voice transcript capabilities without full channel activation", () => {
+  it("registers channel capabilities during discovery without replacing the active registry", () => {
+    const target = writeChannelCapabilityPlugin("capability-channel");
     const active = createEmptyPluginRegistry();
-    setActivePluginRegistry(active, "existing-discord-registry");
+    setActivePluginRegistry(active, "existing-channel-registry");
     const registry = loadBundledCapabilityRuntimeRegistry({
-      pluginIds: ["discord"],
+      pluginIds: [target.id],
       pluginSdkResolution: "dist",
+      discovery: discoveryFor(target),
     });
 
-    const plugin = registry.plugins.find((entry) => entry.id === "discord");
+    const plugin = registry.plugins.find((entry) => entry.id === target.id);
     expect(
       plugin?.status,
       JSON.stringify({ plugin, diagnostics: registry.diagnostics }, null, 2),
     ).toBe("loaded");
-    expect(plugin?.transcriptSourceProviderIds).toEqual(["discord-voice"]);
+    expect(plugin?.transcriptSourceProviderIds).toEqual([`${target.id}-voice`]);
     expect(registry.transcriptSourceProviders.map((entry) => entry.provider.id)).toEqual([
-      "discord-voice",
+      `${target.id}-voice`,
     ]);
     expect(registry.typedHooks).toEqual([]);
     expect(getActivePluginRegistry()).toBe(active);

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -108,7 +108,7 @@ describe("manifest model id normalization", () => {
     }
   });
 
-  it("keeps process metadata stable across manifest edits and reflects lifecycle resets", () => {
+  it("reflects manifest edits and state directory changes without a prepared snapshot", () => {
     const stateDirA = makeTempDir();
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");
     writeInstallIndex({ stateDir: stateDirA, pluginDir: pluginDirA });
@@ -122,7 +122,7 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("alpha/demo-model");
 
     writeNormalizerManifest({ pluginDir: pluginDirA, prefix: "bravo-local" });
-    expect(normalizeDemoModel()).toBe("alpha/demo-model");
+    expect(normalizeDemoModel()).toBe("bravo-local/demo-model");
 
     const stateDirB = makeTempDir();
     const pluginDirB = path.join(stateDirB, "extensions", "normalizer");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation could fail the plugin prerelease lane because a unit test loaded the complete Codex and Discord production plugin graphs, exceeding the 120-second per-test limit. It also corrects a stale model-normalization expectation after registry snapshot memoization was removed.

## Why This Change Was Made

The capability loader tests now use bounded bundled fixtures that preserve the same dist-SDK alias, channel discovery, registration, and active-registry invariants without compiling unrelated production graphs. The normalization test now asserts the current no-prepared-snapshot behavior introduced by the registry snapshot refactor.

## User Impact

No runtime behavior changes. Release validation is deterministic and the plugin agentic shard no longer spends several minutes compiling unrelated plugin code.

## Evidence

- Reproduced on the frozen release target `acf28495b1ae8b911c38a9980eea303709f7a64f`: Codex capability test timed out and model normalization returned `bravo-local/demo-model`.
- Focused Testbox: 2 files, 7 tests passed in 1.67s.
- Exact release-only `agentic-plugins` Testbox shard: 222 files passed; 3,298 passed, 1 skipped; 89.37s.
- `oxfmt --check` clean; `git diff --check` clean.
- Autoreview: clean, no accepted/actionable findings; confidence 0.99.
