### PR TITLE
refactor(ui): unify Usage presentation category owners

### DIFF
--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -73,6 +73,9 @@ function mount(
     stale?: boolean;
     onRetryTimeSeries?: () => void;
     onRetrySessionLogs?: () => void;
+    contextWeight?: UsageSessionEntry["contextWeight"];
+    contextExpanded?: boolean;
+    onToggleContextExpanded?: () => void;
   } = {},
 ) {
   const status = (error?: string): PanelRefreshStatus => ({
@@ -83,7 +86,7 @@ function mount(
   const container = document.createElement("div");
   render(
     renderSessionDetailPanel(
-      session(),
+      { ...session(), contextWeight: errors.contextWeight },
       { points },
       false,
       status(errors.timeSeries),
@@ -111,8 +114,8 @@ function mount(
       vi.fn(),
       vi.fn(),
       vi.fn(),
-      false,
-      vi.fn(),
+      errors.contextExpanded ?? false,
+      errors.onToggleContextExpanded ?? vi.fn(),
       vi.fn(),
     ),
     container,
@@ -334,5 +337,86 @@ describe("renderSessionDetailPanel filtered usage", () => {
     expect(container.querySelector(".timeseries-svg")).not.toBeNull();
     expect(container.textContent).toContain("retained message");
     expect(container.textContent).toContain("Showing stale data");
+  });
+
+  it("preserves context-category order, sorted cards, expansion, and callbacks", () => {
+    const contextWeight: NonNullable<UsageSessionEntry["contextWeight"]> = {
+      source: "run",
+      generatedAt: 0,
+      systemPrompt: { chars: 80, projectContextChars: 20, nonProjectContextChars: 60 },
+      skills: {
+        promptChars: 100,
+        entries: Array.from({ length: 5 }, (_, index) => ({
+          name: `skill-${index}`,
+          blockChars: (index + 1) * 10,
+        })),
+      },
+      tools: {
+        listChars: 20,
+        schemaChars: 30,
+        entries: [
+          { name: "smaller-tool", summaryChars: 4, schemaChars: 6 },
+          { name: "larger-tool", summaryChars: 8, schemaChars: 12 },
+        ],
+      },
+      injectedWorkspaceFiles: [
+        {
+          name: "small.md",
+          path: "/small.md",
+          missing: false,
+          rawChars: 10,
+          injectedChars: 10,
+          truncated: false,
+        },
+        {
+          name: "large.md",
+          path: "/large.md",
+          missing: false,
+          rawChars: 30,
+          injectedChars: 30,
+          truncated: false,
+        },
+      ],
+    };
+    const onToggleContextExpanded = vi.fn();
+    const container = mount(
+      [],
+      null,
+      null,
+      "total",
+      {},
+      { contextWeight, onToggleContextExpanded },
+    );
+    const categories = ["system", "skills", "tools", "files"];
+
+    expect(
+      [...container.querySelectorAll(".context-stacked-bar .context-segment")].map((segment) =>
+        categories.find((category) => segment.classList.contains(category)),
+      ),
+    ).toEqual(categories);
+    const cards = [...container.querySelectorAll(".context-breakdown-card")];
+    expect(
+      cards.map((card) => card.querySelector(".context-breakdown-title")?.textContent?.trim()),
+    ).toEqual(["Skills (5)", "Tools (2)", "Files (2)"]);
+    expect(
+      [...(cards[0]?.querySelectorAll(".context-breakdown-item .mono") ?? [])].map(
+        (entry) => entry.textContent,
+      ),
+    ).toEqual(["skill-4", "skill-3", "skill-2", "skill-1"]);
+    expect(cards[1]?.querySelector(".context-breakdown-item .mono")?.textContent).toBe(
+      "larger-tool",
+    );
+    expect(cards[2]?.querySelector(".context-breakdown-item .mono")?.textContent).toBe("large.md");
+    expect(cards[0]?.querySelector(".context-breakdown-more")?.textContent).toContain("1 more");
+    container.querySelector<HTMLButtonElement>(".context-breakdown-header button")?.click();
+    expect(onToggleContextExpanded).toHaveBeenCalledOnce();
+
+    const expanded = mount([], null, null, "total", {}, { contextWeight, contextExpanded: true });
+    expect(
+      expanded
+        .querySelectorAll(".context-breakdown-card")[0]
+        ?.querySelectorAll(".context-breakdown-item"),
+    ).toHaveLength(5);
+    expect(expanded.querySelector(".context-breakdown-more")).toBeNull();
   });
 });

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -19,7 +19,7 @@ import type {
   TimeSeriesPoint,
   UsageSessionEntry,
 } from "./types.ts";
-import { renderInsightList } from "./view-overview.ts";
+import { renderInsightList, renderUsageToggle, USAGE_TOKEN_CATEGORIES } from "./view-overview.ts";
 
 // Chart constants
 const CHART_BAR_WIDTH_RATIO = 0.75; // Fraction of slot used for bar (rest is gap)
@@ -30,10 +30,7 @@ const HANDLE_HEIGHT = 12; // Height of drag handle
 const HANDLE_GRIP_OFFSET = 0.7; // Offset of grip lines inside handle
 
 function pct(part: number, total: number): number {
-  if (!total || total <= 0) {
-    return 0;
-  }
-  return (part / total) * 100;
+  return total > 0 ? (part / total) * 100 : 0;
 }
 
 /** Normalize a log timestamp to milliseconds (handles seconds vs ms). */
@@ -74,6 +71,25 @@ function filterLogsByRange(
   });
 }
 
+function renderUsageRefreshStatus(
+  status: PanelRefreshStatus,
+  onRetry: () => void,
+  detailKey: string,
+  kind: "timeline" | "conversation",
+) {
+  return renderPanelRefreshStatus({
+    status,
+    errorMessage: status.error
+      ? t("usage.details.loadFailed", {
+          detail: normalizeLowercaseStringOrEmpty(t(detailKey)),
+          error: status.error,
+        })
+      : undefined,
+    onRetry,
+    className: `usage-callout usage-detail-error--${kind}`,
+  });
+}
+
 function renderSessionSummary(
   session: UsageSessionEntry,
   filteredUsage?: UsageSessionEntry["usage"],
@@ -86,57 +102,67 @@ function renderSessionSummary(
 
   const formatTs = (ts?: number): string => (ts ? formatMs(ts) : t("usage.common.emptyValue"));
 
-  const badges: string[] = [];
-  if (session.channel) {
-    badges.push(`channel:${session.channel}`);
-  }
-  if (session.agentId) {
-    badges.push(`agent:${session.agentId}`);
-  }
-  if (session.modelProvider || session.providerOverride) {
-    badges.push(`provider:${session.modelProvider ?? session.providerOverride}`);
-  }
-  if (session.model) {
-    badges.push(`model:${session.model}`);
-  }
+  const badges = [
+    session.channel && `channel:${session.channel}`,
+    session.agentId && `agent:${session.agentId}`,
+    (session.modelProvider || session.providerOverride) &&
+      `provider:${session.modelProvider ?? session.providerOverride}`,
+    session.model && `model:${session.model}`,
+  ].filter(Boolean);
 
   // Always use the full tool list for stable layout; update counts when filtering
   const baseTools = usage.toolUsage?.tools.slice(0, 6) ?? [];
-  let toolCallCount: number;
-  let uniqueToolCount: number;
-  let toolItems: Array<{ label: string; value: string; sub: string }>;
-
+  let toolCounts: Map<string, number> | undefined;
   if (filteredLogs) {
-    const toolCounts = new Map<string, number>();
+    toolCounts = new Map();
     for (const log of filteredLogs) {
       const { tools } = parseToolSummary(log.content);
       for (const [name] of tools) {
         toolCounts.set(name, (toolCounts.get(name) || 0) + 1);
       }
     }
-    // Keep the same tool order as the full session, just update counts
-    toolItems = baseTools.map((tool) => ({
-      label: tool.name,
-      value: `${toolCounts.get(tool.name) ?? 0}`,
-      sub: t("usage.overview.calls"),
-    }));
-    toolCallCount = [...toolCounts.values()].reduce((sum, c) => sum + c, 0);
-    uniqueToolCount = toolCounts.size;
-  } else {
-    toolItems = baseTools.map((tool) => ({
-      label: tool.name,
-      value: `${tool.count}`,
-      sub: t("usage.overview.calls"),
-    }));
-    toolCallCount = usage.toolUsage?.totalCalls ?? 0;
-    uniqueToolCount = usage.toolUsage?.uniqueTools ?? 0;
   }
+  const toolItems = baseTools.map((tool) => ({
+    label: tool.name,
+    value: `${toolCounts ? (toolCounts.get(tool.name) ?? 0) : tool.count}`,
+    sub: t("usage.overview.calls"),
+  }));
+  const toolCallCount = toolCounts
+    ? [...toolCounts.values()].reduce((sum, count) => sum + count, 0)
+    : (usage.toolUsage?.totalCalls ?? 0);
+  const uniqueToolCount = toolCounts ? toolCounts.size : (usage.toolUsage?.uniqueTools ?? 0);
   const modelItems =
     usage.modelUsage?.slice(0, 6).map((entry) => ({
       label: entry.model ?? t("usage.common.unknown"),
       value: formatCost(entry.totals.totalCost),
       sub: formatTokens(entry.totals.totalTokens),
     })) ?? [];
+  const cards = [
+    {
+      labelKey: "usage.overview.messages",
+      value: usage.messageCounts?.total ?? 0,
+      meta: html`${usage.messageCounts?.user ?? 0}
+      ${normalizeLowercaseStringOrEmpty(t("usage.overview.user"))} ·
+      ${usage.messageCounts?.assistant ?? 0}
+      ${normalizeLowercaseStringOrEmpty(t("usage.overview.assistant"))}`,
+    },
+    {
+      labelKey: "usage.overview.toolCalls",
+      value: toolCallCount,
+      meta: html`${uniqueToolCount} ${t("usage.overview.toolsUsed")}`,
+    },
+    {
+      labelKey: "usage.overview.errors",
+      value: usage.messageCounts?.errors ?? 0,
+      meta: html`${usage.messageCounts?.toolResults ?? 0} ${t("usage.overview.toolResults")}`,
+    },
+    {
+      labelKey: "usage.details.duration",
+      value:
+        formatDurationCompact(usage.durationMs, { spaced: true }) ?? t("usage.common.emptyValue"),
+      meta: html`${formatTs(usage.firstActivity)} → ${formatTs(usage.lastActivity)}`,
+    },
+  ];
 
   return html`
     ${badges.length > 0
@@ -145,38 +171,15 @@ function renderSessionSummary(
         </div>`
       : nothing}
     <div class="session-summary-grid">
-      <div class="stat session-summary-card">
-        <div class="session-summary-title">${t("usage.overview.messages")}</div>
-        <div class="stat-value session-summary-value">${usage.messageCounts?.total ?? 0}</div>
-        <div class="session-summary-meta">
-          ${usage.messageCounts?.user ?? 0}
-          ${normalizeLowercaseStringOrEmpty(t("usage.overview.user"))} ·
-          ${usage.messageCounts?.assistant ?? 0}
-          ${normalizeLowercaseStringOrEmpty(t("usage.overview.assistant"))}
-        </div>
-      </div>
-      <div class="stat session-summary-card">
-        <div class="session-summary-title">${t("usage.overview.toolCalls")}</div>
-        <div class="stat-value session-summary-value">${toolCallCount}</div>
-        <div class="session-summary-meta">${uniqueToolCount} ${t("usage.overview.toolsUsed")}</div>
-      </div>
-      <div class="stat session-summary-card">
-        <div class="session-summary-title">${t("usage.overview.errors")}</div>
-        <div class="stat-value session-summary-value">${usage.messageCounts?.errors ?? 0}</div>
-        <div class="session-summary-meta">
-          ${usage.messageCounts?.toolResults ?? 0} ${t("usage.overview.toolResults")}
-        </div>
-      </div>
-      <div class="stat session-summary-card">
-        <div class="session-summary-title">${t("usage.details.duration")}</div>
-        <div class="stat-value session-summary-value">
-          ${formatDurationCompact(usage.durationMs, { spaced: true }) ??
-          t("usage.common.emptyValue")}
-        </div>
-        <div class="session-summary-meta">
-          ${formatTs(usage.firstActivity)} → ${formatTs(usage.lastActivity)}
-        </div>
-      </div>
+      ${cards.map(
+        ({ labelKey, value, meta }) => html`
+          <div class="stat session-summary-card">
+            <div class="session-summary-title">${t(labelKey)}</div>
+            <div class="stat-value session-summary-value">${value}</div>
+            <div class="session-summary-meta">${meta}</div>
+          </div>
+        `,
+      )}
     </div>
     <div class="usage-insights-grid usage-insights-grid--tight">
       ${renderInsightList(t("usage.overview.topTools"), toolItems, t("usage.overview.noToolCalls"))}
@@ -203,36 +206,25 @@ function computeFilteredUsage(
   let totalCost = 0;
   let userMessages = 0;
   let assistantMessages = 0;
-  let totalInput = 0;
-  let totalOutput = 0;
-  let totalCacheRead = 0;
-  let totalCacheWrite = 0;
+  const tokenTotals = { output: 0, input: 0, cacheWrite: 0, cacheRead: 0 };
 
   for (const p of filtered) {
     totalTokens += p.totalTokens || 0;
     totalCost += p.cost || 0;
-    totalInput += p.input || 0;
-    totalOutput += p.output || 0;
-    totalCacheRead += p.cacheRead || 0;
-    totalCacheWrite += p.cacheWrite || 0;
-    if (p.output > 0) {
-      assistantMessages++;
+    for (const { key } of USAGE_TOKEN_CATEGORIES) {
+      tokenTotals[key] += p[key] || 0;
     }
-    if (p.input > 0) {
-      userMessages++;
-    }
+    assistantMessages += p.output > 0 ? 1 : 0;
+    userMessages += p.input > 0 ? 1 : 0;
   }
   const first = expectDefined(filtered[0], "filtered usage first point");
   const last = expectDefined(filtered.at(-1), "filtered usage last point");
 
   return {
     ...baseUsage,
+    ...tokenTotals,
     totalTokens,
     totalCost,
-    input: totalInput,
-    output: totalOutput,
-    cacheRead: totalCacheRead,
-    cacheWrite: totalCacheWrite,
     durationMs: last.timestamp - first.timestamp,
     firstActivity: first.timestamp,
     lastActivity: last.timestamp,
@@ -422,17 +414,12 @@ function renderTimeSeriesCompact(
       </div>
     `;
   }
-  const refreshStatus = renderPanelRefreshStatus({
+  const refreshStatus = renderUsageRefreshStatus(
     status,
-    errorMessage: status.error
-      ? t("usage.details.loadFailed", {
-          detail: normalizeLowercaseStringOrEmpty(t("usage.details.usageOverTime")),
-          error: status.error,
-        })
-      : undefined,
     onRetry,
-    className: "usage-callout usage-detail-error--timeline",
-  });
+    "usage.details.usageOverTime",
+    "timeline",
+  );
   if (status.error && !status.hasLoaded) {
     return html`
       <div class="session-timeseries-compact">
@@ -476,17 +463,9 @@ function renderTimeSeriesCompact(
   }
   let cumTokens = 0,
     cumCost = 0;
-  let sumOutput = 0;
-  let sumInput = 0;
-  let sumCacheRead = 0;
-  let sumCacheWrite = 0;
   points = points.map((p) => {
     cumTokens += p.totalTokens;
     cumCost += p.cost;
-    sumOutput += p.output;
-    sumInput += p.input;
-    sumCacheRead += p.cacheRead;
-    sumCacheWrite += p.cacheWrite;
     return { ...p, cumulativeTokens: cumTokens, cumulativeCost: cumCost };
   });
 
@@ -508,15 +487,11 @@ function renderTimeSeriesCompact(
   }
 
   const filteredPoints = hasSelection ? points.slice(rangeStartIdx, rangeEndIdx) : points;
-  let filteredOutput = 0,
-    filteredInput = 0,
-    filteredCacheRead = 0,
-    filteredCacheWrite = 0;
+  const filteredTokens = { output: 0, input: 0, cacheRead: 0, cacheWrite: 0 };
   for (const p of filteredPoints) {
-    filteredOutput += p.output;
-    filteredInput += p.input;
-    filteredCacheRead += p.cacheRead;
-    filteredCacheWrite += p.cacheWrite;
+    for (const { key } of USAGE_TOKEN_CATEGORIES) {
+      filteredTokens[key] += p[key];
+    }
   }
 
   const width = 400,
@@ -528,7 +503,10 @@ function renderTimeSeriesCompact(
   const breakdownByType = mode === "per-turn" && breakdownMode === "by-type";
   const timeZoneOptions: Intl.DateTimeFormatOptions = timeZone === "utc" ? { timeZone: "UTC" } : {};
 
-  const totalTypeTokens = filteredOutput + filteredInput + filteredCacheRead + filteredCacheWrite;
+  const totalTypeTokens = Object.values(filteredTokens).reduce(
+    (total, tokens) => total + tokens,
+    0,
+  );
   const barTotals = points.map((p) =>
     isCumulative
       ? p.cumulativeTokens
@@ -566,76 +544,40 @@ function renderTimeSeriesCompact(
                 </div>
               `
             : nothing}
-          <div class="chart-toggle small">
-            <button
-              class="btn btn--sm toggle-btn ${!isCumulative ? "active" : ""}"
-              @click=${() => onModeChange("per-turn")}
-            >
-              ${t("usage.details.perTurn")}
-            </button>
-            <button
-              class="btn btn--sm toggle-btn ${isCumulative ? "active" : ""}"
-              @click=${() => onModeChange("cumulative")}
-            >
-              ${t("usage.details.cumulative")}
-            </button>
-          </div>
+          ${renderUsageToggle(mode, onModeChange, [
+            { value: "per-turn", labelKey: "usage.details.perTurn" },
+            { value: "cumulative", labelKey: "usage.details.cumulative" },
+          ])}
           ${!isCumulative
-            ? html`
-                <div class="chart-toggle small">
-                  <button
-                    class="btn btn--sm toggle-btn ${breakdownMode === "total" ? "active" : ""}"
-                    @click=${() => onBreakdownChange("total")}
-                  >
-                    ${t("usage.daily.total")}
-                  </button>
-                  <button
-                    class="btn btn--sm toggle-btn ${breakdownMode === "by-type" ? "active" : ""}"
-                    @click=${() => onBreakdownChange("by-type")}
-                  >
-                    ${t("usage.daily.byType")}
-                  </button>
-                </div>
-              `
+            ? renderUsageToggle(breakdownMode, onBreakdownChange, [
+                { value: "total", labelKey: "usage.daily.total" },
+                { value: "by-type", labelKey: "usage.daily.byType" },
+              ])
             : nothing}
         </div>
       </div>
       ${refreshStatus}
       <div class="timeseries-chart-wrapper">
         <svg viewBox="0 0 ${width} ${height + 18}" class="timeseries-svg">
-          <!-- Y axis -->
-          <line
-            x1="${padding.left}"
-            y1="${padding.top}"
-            x2="${padding.left}"
-            y2="${padding.top + chartHeight}"
-            stroke="var(--border)"
-          />
-          <!-- X axis -->
-          <line
-            x1="${padding.left}"
-            y1="${padding.top + chartHeight}"
-            x2="${width - padding.right}"
-            y2="${padding.top + chartHeight}"
-            stroke="var(--border)"
-          />
-          <!-- Y axis labels -->
-          <text
-            x="${padding.left - 4}"
-            y="${padding.top + 5}"
-            text-anchor="end"
-            class="ts-axis-label"
-          >
-            ${formatTokens(maxValue)}
-          </text>
-          <text
-            x="${padding.left - 4}"
-            y="${padding.top + chartHeight}"
-            text-anchor="end"
-            class="ts-axis-label"
-          >
-            0
-          </text>
+          ${[
+            { x1: padding.left, y1: padding.top, x2: padding.left, y2: padding.top + chartHeight },
+            {
+              x1: padding.left,
+              y1: padding.top + chartHeight,
+              x2: width - padding.right,
+              y2: padding.top + chartHeight,
+            },
+          ].map(
+            ({ x1, y1, x2, y2 }) =>
+              svg`<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="var(--border)" />`,
+          )}
+          ${[
+            { y: padding.top + 5, text: formatTokens(maxValue) },
+            { y: padding.top + chartHeight, text: "0" },
+          ].map(
+            ({ y, text }) =>
+              svg`<text x="${padding.left - 4}" y="${y}" text-anchor="end" class="ts-axis-label">${text}</text>`,
+          )}
           <!-- X axis labels (first and last) -->
           ${points.length > 0
             ? svg`
@@ -664,10 +606,11 @@ function renderTimeSeriesCompact(
               `${formatTokens(val)} ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}`,
             ];
             if (breakdownByType) {
-              tooltipLines.push(`Out ${formatTokens(p.output)}`);
-              tooltipLines.push(`In ${formatTokens(p.input)}`);
-              tooltipLines.push(`CW ${formatTokens(p.cacheWrite)}`);
-              tooltipLines.push(`CR ${formatTokens(p.cacheRead)}`);
+              tooltipLines.push(
+                ...USAGE_TOKEN_CATEGORIES.map(
+                  ({ key, short }) => `${short} ${formatTokens(p[key])}`,
+                ),
+              );
             }
             const tooltip = tooltipLines.join(" · ");
             const isOutside = hasSelection && (i < rangeStartIdx || i >= rangeEndIdx);
@@ -675,22 +618,17 @@ function renderTimeSeriesCompact(
             if (!breakdownByType) {
               return svg`<rect x="${x}" y="${y}" width="${barWidth}" height="${bh}" class="ts-bar${isOutside ? " dimmed" : ""}" rx="1"><title>${tooltip}</title></rect>`;
             }
-            const segments = [
-              { value: p.output, cls: "output" },
-              { value: p.input, cls: "input" },
-              { value: p.cacheWrite, cls: "cache-write" },
-              { value: p.cacheRead, cls: "cache-read" },
-            ];
             let yC = padding.top + chartHeight;
             const dim = isOutside ? " dimmed" : "";
             return svg`
-              ${segments.map((seg) => {
-                if (seg.value <= 0 || val <= 0) {
+              ${USAGE_TOKEN_CATEGORIES.map(({ key, className }) => {
+                const value = p[key];
+                if (value <= 0 || val <= 0) {
                   return nothing;
                 }
-                const sh = bh * (seg.value / val);
+                const sh = bh * (value / val);
                 yC -= sh;
-                return svg`<rect x="${x}" y="${yC}" width="${barWidth}" height="${sh}" class="ts-bar ${seg.cls}${dim}" rx="1"><title>${tooltip}</title></rect>`;
+                return svg`<rect x="${x}" y="${yC}" width="${barWidth}" height="${sh}" class="ts-bar ${className}${dim}" rx="1"><title>${tooltip}</title></rect>`;
               })}
             `;
           })}
@@ -706,26 +644,19 @@ function renderTimeSeriesCompact(
               pointer-events="none"
             />
           `}
-          <!-- Left cursor line + handle -->
-          ${svg`
-            <line x1="${leftHandleX}" y1="${padding.top}" x2="${leftHandleX}" y2="${padding.top + chartHeight}" stroke="var(--accent)" stroke-width="0.8" opacity="0.7" />
-            <rect x="${leftHandleX - HANDLE_WIDTH / 2}" y="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 2}" width="${HANDLE_WIDTH}" height="${HANDLE_HEIGHT}" rx="1.5" fill="var(--accent)" class="cursor-handle" />
-            <line x1="${leftHandleX - HANDLE_GRIP_OFFSET}" y1="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 5}" x2="${leftHandleX - HANDLE_GRIP_OFFSET}" y2="${padding.top + chartHeight / 2 + HANDLE_HEIGHT / 5}" stroke="var(--bg)" stroke-width="0.4" pointer-events="none" />
-            <line x1="${leftHandleX + HANDLE_GRIP_OFFSET}" y1="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 5}" x2="${leftHandleX + HANDLE_GRIP_OFFSET}" y2="${padding.top + chartHeight / 2 + HANDLE_HEIGHT / 5}" stroke="var(--bg)" stroke-width="0.4" pointer-events="none" />
-          `}
-          <!-- Right cursor line + handle -->
-          ${svg`
-            <line x1="${rightHandleX}" y1="${padding.top}" x2="${rightHandleX}" y2="${padding.top + chartHeight}" stroke="var(--accent)" stroke-width="0.8" opacity="0.7" />
-            <rect x="${rightHandleX - HANDLE_WIDTH / 2}" y="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 2}" width="${HANDLE_WIDTH}" height="${HANDLE_HEIGHT}" rx="1.5" fill="var(--accent)" class="cursor-handle" />
-            <line x1="${rightHandleX - HANDLE_GRIP_OFFSET}" y1="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 5}" x2="${rightHandleX - HANDLE_GRIP_OFFSET}" y2="${padding.top + chartHeight / 2 + HANDLE_HEIGHT / 5}" stroke="var(--bg)" stroke-width="0.4" pointer-events="none" />
-            <line x1="${rightHandleX + HANDLE_GRIP_OFFSET}" y1="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 5}" x2="${rightHandleX + HANDLE_GRIP_OFFSET}" y2="${padding.top + chartHeight / 2 + HANDLE_HEIGHT / 5}" stroke="var(--bg)" stroke-width="0.4" pointer-events="none" />
-          `}
+          ${[leftHandleX, rightHandleX].map(
+            (handleX) => svg`
+              <line x1="${handleX}" y1="${padding.top}" x2="${handleX}" y2="${padding.top + chartHeight}" stroke="var(--accent)" stroke-width="0.8" opacity="0.7" />
+              <rect x="${handleX - HANDLE_WIDTH / 2}" y="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 2}" width="${HANDLE_WIDTH}" height="${HANDLE_HEIGHT}" rx="1.5" fill="var(--accent)" class="cursor-handle" />
+              ${[-HANDLE_GRIP_OFFSET, HANDLE_GRIP_OFFSET].map(
+                (offset) =>
+                  svg`<line x1="${handleX + offset}" y1="${padding.top + chartHeight / 2 - HANDLE_HEIGHT / 5}" x2="${handleX + offset}" y2="${padding.top + chartHeight / 2 + HANDLE_HEIGHT / 5}" stroke="var(--bg)" stroke-width="0.4" pointer-events="none" />`,
+              )}
+            `,
+          )}
         </svg>
         <!-- Handle drag zones (only on handles, not full chart) -->
         ${(() => {
-          const leftHandlePos = `${((leftHandleX / width) * 100).toFixed(1)}%`;
-          const rightHandlePos = `${((rightHandleX / width) * 100).toFixed(1)}%`;
-
           const makeDragHandler = (side: "left" | "right") => (e: MouseEvent) => {
             if (!onCursorRangeChange) {
               return;
@@ -764,19 +695,17 @@ function renderTimeSeriesCompact(
               if (!pt) {
                 return;
               }
-              if (side === "left") {
-                const endTs =
-                  cursorEnd ??
-                  expectDefined(points.at(-1), "time series right cursor point").timestamp;
-                // Don't let left go past right
-                onCursorRangeChange(Math.min(pt.timestamp, endTs), endTs);
-              } else {
-                const startTs =
-                  cursorStart ??
-                  expectDefined(points[0], "time series left cursor point").timestamp;
-                // Don't let right go past left
-                onCursorRangeChange(startTs, Math.max(pt.timestamp, startTs));
-              }
+              const left = side === "left";
+              const boundary = left
+                ? (cursorEnd ??
+                  expectDefined(points.at(-1), "time series right cursor point").timestamp)
+                : (cursorStart ??
+                  expectDefined(points[0], "time series left cursor point").timestamp);
+              // Clamp the dragged handle against its fixed sibling to preserve range ordering.
+              onCursorRangeChange(
+                left ? Math.min(pt.timestamp, boundary) : boundary,
+                left ? boundary : Math.max(pt.timestamp, boundary),
+              );
             };
 
             const handleUp = () => {
@@ -790,16 +719,14 @@ function renderTimeSeriesCompact(
           };
 
           return html`
-            <div
-              class="chart-handle-zone chart-handle-left"
-              style="left: ${leftHandlePos};"
-              @mousedown=${makeDragHandler("left")}
-            ></div>
-            <div
-              class="chart-handle-zone chart-handle-right"
-              style="left: ${rightHandlePos};"
-              @mousedown=${makeDragHandler("right")}
-            ></div>
+            ${(["left", "right"] as const).map((side) => {
+              const x = side === "left" ? leftHandleX : rightHandleX;
+              return html`<div
+                class="chart-handle-zone chart-handle-${side}"
+                style="left: ${((x / width) * 100).toFixed(1)}%;"
+                @mousedown=${makeDragHandler(side)}
+              ></div>`;
+            })}
           `;
         })()}
       </div>
@@ -823,11 +750,8 @@ function renderTimeSeriesCompact(
                 { hour: "2-digit", minute: "2-digit", ...timeZoneOptions },
                 "",
               )}
-              ·
-              ${formatTokens(
-                filteredOutput + filteredInput + filteredCacheRead + filteredCacheWrite,
-              )}
-              · ${formatCost(filteredPoints.reduce((s, p) => s + (p.cost || 0), 0))}
+              · ${formatTokens(totalTypeTokens)} ·
+              ${formatCost(filteredPoints.reduce((s, p) => s + (p.cost || 0), 0))}
             `
           : html`${points.length} ${t("usage.overview.messagesAbbrev")} · ${formatTokens(cumTokens)}
             · ${formatCost(cumCost)}`}
@@ -837,40 +761,24 @@ function renderTimeSeriesCompact(
             <div class="timeseries-breakdown">
               <div class="card-title usage-section-title">${t("usage.breakdown.tokensByType")}</div>
               <div class="cost-breakdown-bar cost-breakdown-bar--compact">
-                <div
-                  class="cost-segment output"
-                  style="width: ${pct(filteredOutput, totalTypeTokens).toFixed(1)}%"
-                ></div>
-                <div
-                  class="cost-segment input"
-                  style="width: ${pct(filteredInput, totalTypeTokens).toFixed(1)}%"
-                ></div>
-                <div
-                  class="cost-segment cache-write"
-                  style="width: ${pct(filteredCacheWrite, totalTypeTokens).toFixed(1)}%"
-                ></div>
-                <div
-                  class="cost-segment cache-read"
-                  style="width: ${pct(filteredCacheRead, totalTypeTokens).toFixed(1)}%"
-                ></div>
+                ${USAGE_TOKEN_CATEGORIES.map(
+                  ({ key, className }) => html`
+                    <div
+                      class="cost-segment ${className}"
+                      style="width: ${pct(filteredTokens[key], totalTypeTokens).toFixed(1)}%"
+                    ></div>
+                  `,
+                )}
               </div>
               <div class="cost-breakdown-legend">
-                <div class="legend-item" title=${t("usage.details.assistantOutputTokens")}>
-                  <span class="legend-dot output"></span>${t("usage.breakdown.output")}
-                  ${formatTokens(filteredOutput)}
-                </div>
-                <div class="legend-item" title=${t("usage.details.userToolInputTokens")}>
-                  <span class="legend-dot input"></span>${t("usage.breakdown.input")}
-                  ${formatTokens(filteredInput)}
-                </div>
-                <div class="legend-item" title=${t("usage.details.tokensWrittenToCache")}>
-                  <span class="legend-dot cache-write"></span>${t("usage.breakdown.cacheWrite")}
-                  ${formatTokens(filteredCacheWrite)}
-                </div>
-                <div class="legend-item" title=${t("usage.details.tokensReadFromCache")}>
-                  <span class="legend-dot cache-read"></span>${t("usage.breakdown.cacheRead")}
-                  ${formatTokens(filteredCacheRead)}
-                </div>
+                ${USAGE_TOKEN_CATEGORIES.map(
+                  ({ key, className, labelKey, hintKey }) => html`
+                    <div class="legend-item" title=${t(hintKey)}>
+                      <span class="legend-dot ${className}"></span>${t(labelKey)}
+                      ${formatTokens(filteredTokens[key])}
+                    </div>
+                  `,
+                )}
               </div>
               <div class="cost-breakdown-total">
                 ${t("usage.breakdown.total")}: ${formatTokens(totalTypeTokens)}
@@ -895,40 +803,58 @@ function renderContextPanel(
       </div>
     `;
   }
-  const systemTokens = charsToTokens(contextWeight.systemPrompt.chars);
-  const skillsTokens = charsToTokens(contextWeight.skills.promptChars);
-  const toolsTokens = charsToTokens(
-    contextWeight.tools.listChars + contextWeight.tools.schemaChars,
-  );
-  const filesTokens = charsToTokens(
-    contextWeight.injectedWorkspaceFiles.reduce((sum, f) => sum + f.injectedChars, 0),
-  );
-  const totalContextTokens = systemTokens + skillsTokens + toolsTokens + filesTokens;
-
-  let contextPct = "";
-  if (usage && usage.totalTokens > 0) {
-    const inputTokens = usage.input + usage.cacheRead;
-    if (inputTokens > 0) {
-      contextPct = `~${Math.min((totalContextTokens / inputTokens) * 100, 100).toFixed(0)}% ${t("usage.details.ofInput")}`;
-    }
-  }
-
-  const skillsList = contextWeight.skills.entries.toSorted((a, b) => b.blockChars - a.blockChars);
-  const toolsList = contextWeight.tools.entries.toSorted(
-    (a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars),
-  );
-  const filesList = contextWeight.injectedWorkspaceFiles.toSorted(
-    (a, b) => b.injectedChars - a.injectedChars,
-  );
+  const groups = [
+    {
+      className: "skills",
+      labelKey: "usage.details.skills",
+      tokens: charsToTokens(contextWeight.skills.promptChars),
+      entries: contextWeight.skills.entries.map(({ name, blockChars }) => ({
+        name,
+        chars: blockChars,
+      })),
+    },
+    {
+      className: "tools",
+      labelKey: "usage.details.tools",
+      tokens: charsToTokens(contextWeight.tools.listChars + contextWeight.tools.schemaChars),
+      entries: contextWeight.tools.entries.map(({ name, summaryChars, schemaChars }) => ({
+        name,
+        chars: summaryChars + schemaChars,
+      })),
+    },
+    {
+      className: "files",
+      labelKey: "usage.details.files",
+      tokens: charsToTokens(
+        contextWeight.injectedWorkspaceFiles.reduce((sum, file) => sum + file.injectedChars, 0),
+      ),
+      entries: contextWeight.injectedWorkspaceFiles.map(({ name, injectedChars }) => ({
+        name,
+        chars: injectedChars,
+      })),
+    },
+  ].map(({ className, labelKey, tokens, entries }) => ({
+    className,
+    labelKey,
+    tokens,
+    entries: entries.toSorted((left, right) => right.chars - left.chars),
+  }));
+  const categories = [
+    {
+      className: "system",
+      labelKey: "usage.details.system",
+      tokens: charsToTokens(contextWeight.systemPrompt.chars),
+    },
+    ...groups,
+  ];
+  const totalContextTokens = categories.reduce((sum, { tokens }) => sum + tokens, 0);
+  const inputTokens = usage && usage.totalTokens > 0 ? usage.input + usage.cacheRead : 0;
+  const contextDescription =
+    inputTokens > 0
+      ? `~${Math.min((totalContextTokens / inputTokens) * 100, 100).toFixed(0)}% ${t("usage.details.ofInput")}`
+      : t("usage.details.baseContextPerMessage");
   const defaultLimit = 4;
-  const showAll = expanded;
-  const skillsTop = showAll ? skillsList : skillsList.slice(0, defaultLimit);
-  const toolsTop = showAll ? toolsList : toolsList.slice(0, defaultLimit);
-  const filesTop = showAll ? filesList : filesList.slice(0, defaultLimit);
-  const hasMore =
-    skillsList.length > defaultLimit ||
-    toolsList.length > defaultLimit ||
-    filesList.length > defaultLimit;
+  const hasMore = groups.some(({ entries }) => entries.length > defaultLimit);
 
   return html`
     <div class="context-details-panel">
@@ -938,148 +864,66 @@ function renderContextPanel(
         </div>
         ${hasMore
           ? html`<button class="btn btn--sm" @click=${onToggleExpanded}>
-              ${showAll ? t("usage.details.collapse") : t("usage.details.expandAll")}
+              ${expanded ? t("usage.details.collapse") : t("usage.details.expandAll")}
             </button>`
           : nothing}
       </div>
-      <p class="context-weight-desc">${contextPct || t("usage.details.baseContextPerMessage")}</p>
+      <p class="context-weight-desc">${contextDescription}</p>
       <div class="context-stacked-bar">
-        <div
-          class="context-segment system"
-          style="width: ${pct(systemTokens, totalContextTokens).toFixed(1)}%"
-          title="${t("usage.details.system")}: ~${formatTokens(systemTokens)}"
-        ></div>
-        <div
-          class="context-segment skills"
-          style="width: ${pct(skillsTokens, totalContextTokens).toFixed(1)}%"
-          title="${t("usage.details.skills")}: ~${formatTokens(skillsTokens)}"
-        ></div>
-        <div
-          class="context-segment tools"
-          style="width: ${pct(toolsTokens, totalContextTokens).toFixed(1)}%"
-          title="${t("usage.details.tools")}: ~${formatTokens(toolsTokens)}"
-        ></div>
-        <div
-          class="context-segment files"
-          style="width: ${pct(filesTokens, totalContextTokens).toFixed(1)}%"
-          title="${t("usage.details.files")}: ~${formatTokens(filesTokens)}"
-        ></div>
+        ${categories.map(
+          ({ className, labelKey, tokens }) => html`
+            <div
+              class="context-segment ${className}"
+              style="width: ${pct(tokens, totalContextTokens).toFixed(1)}%"
+              title="${t(labelKey)}: ~${formatTokens(tokens)}"
+            ></div>
+          `,
+        )}
       </div>
       <div class="context-legend">
-        <span class="legend-item"
-          ><span class="legend-dot system"></span>${t("usage.details.systemShort")}
-          ~${formatTokens(systemTokens)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot skills"></span>${t("usage.details.skills")}
-          ~${formatTokens(skillsTokens)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot tools"></span>${t("usage.details.tools")}
-          ~${formatTokens(toolsTokens)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot files"></span>${t("usage.details.files")}
-          ~${formatTokens(filesTokens)}</span
-        >
+        ${categories.map(
+          ({ className, labelKey, tokens }) => html`
+            <span class="legend-item"
+              ><span class="legend-dot ${className}"></span>${t(
+                className === "system" ? "usage.details.systemShort" : labelKey,
+              )}
+              ~${formatTokens(tokens)}</span
+            >
+          `,
+        )}
       </div>
       <div class="context-total">
         ${t("usage.breakdown.total")}: ~${formatTokens(totalContextTokens)}
       </div>
       <div class="context-breakdown-grid">
-        ${skillsList.length > 0
-          ? (() => {
-              const more = skillsList.length - skillsTop.length;
-              return html`
-                <div class="context-breakdown-card">
-                  <div class="context-breakdown-title">
-                    ${t("usage.details.skills")} (${skillsList.length})
-                  </div>
-                  <div class="context-breakdown-list">
-                    ${skillsTop.map(
-                      (s) => html`
-                        <div class="context-breakdown-item">
-                          <span class="mono" title=${s.name}>${s.name}</span>
-                          <span class="muted">~${formatTokens(charsToTokens(s.blockChars))}</span>
-                        </div>
-                      `,
-                    )}
-                  </div>
-                  ${more > 0
-                    ? html`
-                        <div class="context-breakdown-more">
-                          ${t("usage.sessions.more", { count: String(more) })}
-                        </div>
-                      `
-                    : nothing}
+        ${groups
+          .filter(({ entries }) => entries.length > 0)
+          .map(({ labelKey, entries }) => {
+            const visible = expanded ? entries : entries.slice(0, defaultLimit);
+            const more = entries.length - visible.length;
+            return html`
+              <div class="context-breakdown-card">
+                <div class="context-breakdown-title">${t(labelKey)} (${entries.length})</div>
+                <div class="context-breakdown-list">
+                  ${visible.map(
+                    ({ name, chars }) => html`
+                      <div class="context-breakdown-item">
+                        <span class="mono" title=${name}>${name}</span>
+                        <span class="muted">~${formatTokens(charsToTokens(chars))}</span>
+                      </div>
+                    `,
+                  )}
                 </div>
-              `;
-            })()
-          : nothing}
-        ${toolsList.length > 0
-          ? (() => {
-              const more = toolsList.length - toolsTop.length;
-              return html`
-                <div class="context-breakdown-card">
-                  <div class="context-breakdown-title">
-                    ${t("usage.details.tools")} (${toolsList.length})
-                  </div>
-                  <div class="context-breakdown-list">
-                    ${toolsTop.map(
-                      (tLocal) => html`
-                        <div class="context-breakdown-item">
-                          <span class="mono" title=${tLocal.name}>${tLocal.name}</span>
-                          <span class="muted"
-                            >~${formatTokens(
-                              charsToTokens(tLocal.summaryChars + tLocal.schemaChars),
-                            )}</span
-                          >
-                        </div>
-                      `,
-                    )}
-                  </div>
-                  ${more > 0
-                    ? html`
-                        <div class="context-breakdown-more">
-                          ${t("usage.sessions.more", { count: String(more) })}
-                        </div>
-                      `
-                    : nothing}
-                </div>
-              `;
-            })()
-          : nothing}
-        ${filesList.length > 0
-          ? (() => {
-              const more = filesList.length - filesTop.length;
-              return html`
-                <div class="context-breakdown-card">
-                  <div class="context-breakdown-title">
-                    ${t("usage.details.files")} (${filesList.length})
-                  </div>
-                  <div class="context-breakdown-list">
-                    ${filesTop.map(
-                      (f) => html`
-                        <div class="context-breakdown-item">
-                          <span class="mono" title=${f.name}>${f.name}</span>
-                          <span class="muted"
-                            >~${formatTokens(charsToTokens(f.injectedChars))}</span
-                          >
-                        </div>
-                      `,
-                    )}
-                  </div>
-                  ${more > 0
-                    ? html`
-                        <div class="context-breakdown-more">
-                          ${t("usage.sessions.more", { count: String(more) })}
-                        </div>
-                      `
-                    : nothing}
-                </div>
-              `;
-            })()
-          : nothing}
+                ${more > 0
+                  ? html`
+                      <div class="context-breakdown-more">
+                        ${t("usage.sessions.more", { count: String(more) })}
+                      </div>
+                    `
+                  : nothing}
+              </div>
+            `;
+          })}
       </div>
     </div>
   `;
@@ -1114,17 +958,12 @@ function renderSessionLogsCompact(
       </div>
     `;
   }
-  const refreshStatus = renderPanelRefreshStatus({
+  const refreshStatus = renderUsageRefreshStatus(
     status,
-    errorMessage: status.error
-      ? t("usage.details.loadFailed", {
-          detail: normalizeLowercaseStringOrEmpty(t("usage.details.conversation")),
-          error: status.error,
-        })
-      : undefined,
     onRetry,
-    className: "usage-callout usage-detail-error--conversation",
-  });
+    "usage.details.conversation",
+    "conversation",
+  );
   if (status.error && !status.hasLoaded) {
     return html`
       <div class="session-logs-compact">
@@ -1152,42 +991,28 @@ function renderSessionLogsCompact(
   const toolOptions = Array.from(
     new Set(entries.flatMap((entry) => entry.toolInfo.tools.map(([name]) => name))),
   ).toSorted((a, b) => a.localeCompare(b));
+  const hasCursorFilter = cursorStart != null && cursorEnd != null;
+  const cursorMin = hasCursorFilter ? Math.min(cursorStart, cursorEnd) : 0;
+  const cursorMax = hasCursorFilter ? Math.max(cursorStart, cursorEnd) : Infinity;
   const filteredEntries = entries.filter((entry) => {
     // Filter by cursor timeline range (only if logs cover the range)
-    if (cursorStart != null && cursorEnd != null) {
-      const ts = entry.log.timestamp;
-      if (ts > 0) {
-        const lo = Math.min(cursorStart, cursorEnd);
-        const hi = Math.max(cursorStart, cursorEnd);
-        const normalizedTs = normalizeLogTimestamp(ts);
-        if (normalizedTs < lo || normalizedTs > hi) {
-          return false;
-        }
-      }
-    }
-    if (filters.roles.length > 0 && !filters.roles.includes(entry.log.role)) {
-      return false;
-    }
-    if (filters.hasTools && entry.toolInfo.tools.length === 0) {
-      return false;
-    }
-    if (filters.tools.length > 0) {
-      const matchesTool = entry.toolInfo.tools.some(([name]) => filters.tools.includes(name));
-      if (!matchesTool) {
+    if (hasCursorFilter && entry.log.timestamp > 0) {
+      const timestamp = normalizeLogTimestamp(entry.log.timestamp);
+      if (timestamp < cursorMin || timestamp > cursorMax) {
         return false;
       }
     }
-    if (normalizedQuery) {
-      const haystack = normalizeLowercaseStringOrEmpty(entry.cleanContent);
-      if (!haystack.includes(normalizedQuery)) {
-        return false;
-      }
-    }
-    return true;
+    return (
+      (filters.roles.length === 0 || filters.roles.includes(entry.log.role)) &&
+      (!filters.hasTools || entry.toolInfo.tools.length > 0) &&
+      (filters.tools.length === 0 ||
+        entry.toolInfo.tools.some(([name]) => filters.tools.includes(name))) &&
+      (!normalizedQuery ||
+        normalizeLowercaseStringOrEmpty(entry.cleanContent).includes(normalizedQuery))
+    );
   });
   const hasActiveFilters =
     filters.roles.length > 0 || filters.tools.length > 0 || filters.hasTools || normalizedQuery;
-  const hasCursorFilter = cursorStart != null && cursorEnd != null;
   const displayedCount =
     hasActiveFilters || hasCursorFilter
       ? `${filteredEntries.length} ${t("usage.details.of")} ${logs.length}${hasCursorFilter ? ` (${t("usage.details.timelineFiltered")})` : ""}`
@@ -1222,18 +1047,19 @@ function renderSessionLogsCompact(
               ),
             )}
         >
-          <option value="user" ?selected=${roleSelected.has("user")}>
-            ${t("usage.overview.user")}
-          </option>
-          <option value="assistant" ?selected=${roleSelected.has("assistant")}>
-            ${t("usage.overview.assistant")}
-          </option>
-          <option value="tool" ?selected=${roleSelected.has("tool")}>
-            ${t("usage.details.tool")}
-          </option>
-          <option value="toolResult" ?selected=${roleSelected.has("toolResult")}>
-            ${t("usage.details.toolResult")}
-          </option>
+          ${(
+            [
+              ["user", "usage.overview.user"],
+              ["assistant", "usage.overview.assistant"],
+              ["tool", "usage.details.tool"],
+              ["toolResult", "usage.details.toolResult"],
+            ] as const
+          ).map(
+            ([role, labelKey]) =>
+              html`<option value=${role} ?selected=${roleSelected.has(role)}>
+                ${t(labelKey)}
+              </option>`,
+          )}
         </select>
         <select
           multiple

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -7,7 +7,9 @@ import type { CostDailyEntry, UsageAggregates, UsageSessionEntry, UsageTotals } 
 import { renderUsageHeatmap } from "./view-heatmap.ts";
 import {
   renderDailyChartCompact,
+  renderCostBreakdownCompact,
   renderCostWindowComparison,
+  renderFilterChips,
   renderSessionsCard,
   renderUsageInsights,
 } from "./view-overview.ts";
@@ -298,6 +300,74 @@ describe("renderUsageHeatmap", () => {
   });
 });
 
+describe("usage overview presentation owners", () => {
+  it.each(["tokens", "cost"] as const)("preserves ordered %s breakdown categories", (mode) => {
+    const container = document.createElement("div");
+    render(
+      renderCostBreakdownCompact(
+        {
+          ...totals,
+          totalCost: 1,
+          outputCost: 0.2,
+          inputCost: 0.1,
+          cacheWriteCost: 0.3,
+          cacheReadCost: 0.4,
+        },
+        mode,
+      ),
+      container,
+    );
+
+    const categories = ["output", "input", "cache-write", "cache-read"];
+    expect(
+      [...container.querySelectorAll(".cost-breakdown-bar .cost-segment")].map((segment) =>
+        categories.find((category) => segment.classList.contains(category)),
+      ),
+    ).toEqual(categories);
+    expect(
+      [...container.querySelectorAll(".cost-breakdown-legend .legend-item")].map((entry) =>
+        entry.textContent?.replaceAll(/\s+/g, " ").trim(),
+      ),
+    ).toEqual(
+      mode === "tokens"
+        ? ["Output 40", "Input 100", "Cache Write 600", "Cache Read 300"]
+        : ["Output $0.20", "Input $0.10", "Cache Write $0.30", "Cache Read $0.40"],
+    );
+  });
+
+  it("preserves filter-chip order, session-only title, labels, and clear callbacks", () => {
+    const container = document.createElement("div");
+    const onClearDays = vi.fn();
+    const onClearHours = vi.fn();
+    const onClearSessions = vi.fn();
+    render(
+      renderFilterChips(
+        ["2026-08-01"],
+        [8],
+        ["agent:main:usage"],
+        [{ key: "agent:main:usage", label: "Usage thread" } as UsageSessionEntry],
+        onClearDays,
+        onClearHours,
+        onClearSessions,
+        vi.fn(),
+      ),
+      container,
+    );
+
+    const chips = [...container.querySelectorAll<HTMLElement>(".filter-chip")];
+    expect(chips.map((chip) => chip.querySelector("button")?.getAttribute("aria-label"))).toEqual([
+      "Remove days filter",
+      "Remove hours filter",
+      "Remove session filter",
+    ]);
+    expect(chips.map((chip) => chip.getAttribute("title"))).toEqual([null, null, "Usage thread"]);
+    chips.forEach((chip) => chip.querySelector<HTMLButtonElement>("button")?.click());
+    expect(onClearDays).toHaveBeenCalledOnce();
+    expect(onClearHours).toHaveBeenCalledOnce();
+    expect(onClearSessions).toHaveBeenCalledOnce();
+  });
+});
+
 describe("renderDailyChartCompact", () => {
   it("keeps day selection operable with mouse and keyboard", () => {
     const { bars, onSelectDay } = renderDailyChart([dailyEntry("2026-05-04", 500, 0.2)]);
@@ -335,8 +405,8 @@ describe("renderDailyChartCompact", () => {
     );
 
     expect(
-      Array.from(container.querySelectorAll(".daily-chart-scale span")).map((entry) =>
-        entry.textContent?.trim(),
+      Array.from(container.querySelectorAll(".daily-chart-scale span")).map(
+        (entry) => entry.textContent,
       ),
     ).toEqual(["$2.00", "$1.00", "$0.00"]);
     expect(container.querySelector(".daily-chart-scale-badge")).toBeNull();

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI view renders usage render overview screen content.
 import { html, nothing } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { copyToClipboard } from "../../lib/clipboard.ts";
@@ -26,6 +27,27 @@ import type {
   CostDailyEntry,
 } from "./types.ts";
 
+function tokenCategory<Key extends "output" | "input" | "cacheWrite" | "cacheRead">(
+  key: Key,
+  hintKey: string,
+  short: string,
+) {
+  return {
+    key,
+    className: key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`),
+    labelKey: `usage.breakdown.${key}`,
+    hintKey,
+    short,
+  };
+}
+
+const USAGE_TOKEN_CATEGORIES = [
+  tokenCategory("output", "usage.details.assistantOutputTokens", "Out"),
+  tokenCategory("input", "usage.details.userToolInputTokens", "In"),
+  tokenCategory("cacheWrite", "usage.details.tokensWrittenToCache", "CW"),
+  tokenCategory("cacheRead", "usage.details.tokensReadFromCache", "CR"),
+] as const;
+
 function pct(part: number, total: number): number {
   return total === 0 ? 0 : (part / total) * 100;
 }
@@ -49,33 +71,26 @@ function handleDailyBarKeydown(
   onSelectDay(day, event.shiftKey);
 }
 
-function getCostBreakdown(totals: UsageTotals) {
-  // Use actual costs from API data (already aggregated in backend)
-  const totalCost = totals.totalCost || 0;
-
-  return {
-    input: {
-      tokens: totals.input,
-      cost: totals.inputCost || 0,
-      pct: pct(totals.inputCost || 0, totalCost),
-    },
-    output: {
-      tokens: totals.output,
-      cost: totals.outputCost || 0,
-      pct: pct(totals.outputCost || 0, totalCost),
-    },
-    cacheRead: {
-      tokens: totals.cacheRead,
-      cost: totals.cacheReadCost || 0,
-      pct: pct(totals.cacheReadCost || 0, totalCost),
-    },
-    cacheWrite: {
-      tokens: totals.cacheWrite,
-      cost: totals.cacheWriteCost || 0,
-      pct: pct(totals.cacheWriteCost || 0, totalCost),
-    },
-    totalCost,
-  };
+function renderUsageToggle<Value extends string>(
+  current: Value,
+  onChange: (value: Value) => void,
+  options: ReadonlyArray<{ value: Value; labelKey: string }>,
+  className = "chart-toggle small",
+) {
+  return html`
+    <div class=${className}>
+      ${options.map(
+        ({ value, labelKey }) => html`
+          <button
+            class="btn btn--sm toggle-btn ${current === value ? "active" : ""}"
+            @click=${() => onChange(value)}
+          >
+            ${t(labelKey)}
+          </button>
+        `,
+      )}
+    </div>
+  `;
 }
 
 function renderFilterChips(
@@ -117,57 +132,47 @@ function renderFilterChips(
     selectedHours.length === 1
       ? `${selectedHours[0]}:00`
       : t("usage.filters.hoursCount", { count: String(selectedHours.length) });
+  const chips = [
+    {
+      active: selectedDays.length > 0,
+      labelKey: "usage.filters.days",
+      value: daysLabel,
+      removeKey: "usage.filters.removeDays",
+      onClear: onClearDays,
+    },
+    {
+      active: selectedHours.length > 0,
+      labelKey: "usage.filters.hours",
+      value: hoursLabel,
+      removeKey: "usage.filters.removeHours",
+      onClear: onClearHours,
+    },
+    {
+      active: selectedSessions.length > 0,
+      labelKey: "usage.filters.session",
+      value: sessionsLabel,
+      removeKey: "usage.filters.removeSession",
+      onClear: onClearSessions,
+      title: sessionsFullName,
+    },
+  ];
 
   return html`
     <div class="active-filters">
-      ${selectedDays.length > 0
-        ? html`
-            <div class="filter-chip">
-              <span class="filter-chip-label">${t("usage.filters.days")}: ${daysLabel}</span>
+      ${chips
+        .filter(({ active }) => active)
+        .map(
+          ({ labelKey, value, removeKey, onClear, title }) => html`
+            <div class="filter-chip" title=${ifDefined(title)}>
+              <span class="filter-chip-label">${t(labelKey)}: ${value}</span>
               <openclaw-tooltip .content=${t("usage.filters.remove")}>
-                <button
-                  class="filter-chip-remove"
-                  @click=${onClearDays}
-                  aria-label=${t("usage.filters.removeDays")}
-                >
+                <button class="filter-chip-remove" @click=${onClear} aria-label=${t(removeKey)}>
                   ×
                 </button>
               </openclaw-tooltip>
             </div>
-          `
-        : nothing}
-      ${selectedHours.length > 0
-        ? html`
-            <div class="filter-chip">
-              <span class="filter-chip-label">${t("usage.filters.hours")}: ${hoursLabel}</span>
-              <openclaw-tooltip .content=${t("usage.filters.remove")}>
-                <button
-                  class="filter-chip-remove"
-                  @click=${onClearHours}
-                  aria-label=${t("usage.filters.removeHours")}
-                >
-                  ×
-                </button>
-              </openclaw-tooltip>
-            </div>
-          `
-        : nothing}
-      ${selectedSessions.length > 0
-        ? html`
-            <div class="filter-chip" title="${sessionsFullName}">
-              <span class="filter-chip-label">${t("usage.filters.session")}: ${sessionsLabel}</span>
-              <openclaw-tooltip .content=${t("usage.filters.remove")}>
-                <button
-                  class="filter-chip-remove"
-                  @click=${onClearSessions}
-                  aria-label=${t("usage.filters.removeSession")}
-                >
-                  ×
-                </button>
-              </openclaw-tooltip>
-            </div>
-          `
-        : nothing}
+          `,
+        )}
       ${(selectedDays.length > 0 || selectedHours.length > 0) && selectedSessions.length > 0
         ? html`
             <button class="btn btn--sm" @click=${onClearFilters}>
@@ -287,20 +292,15 @@ function renderDailyChartCompact(
   return html`
     <div class="daily-chart-compact">
       <div class="daily-chart-header">
-        <div class="chart-toggle small sessions-toggle">
-          <button
-            class="btn btn--sm toggle-btn ${dailyChartMode === "total" ? "active" : ""}"
-            @click=${() => onDailyChartModeChange("total")}
-          >
-            ${t("usage.daily.total")}
-          </button>
-          <button
-            class="btn btn--sm toggle-btn ${dailyChartMode === "by-type" ? "active" : ""}"
-            @click=${() => onDailyChartModeChange("by-type")}
-          >
-            ${t("usage.daily.byType")}
-          </button>
-        </div>
+        ${renderUsageToggle(
+          dailyChartMode,
+          onDailyChartModeChange,
+          [
+            { value: "total", labelKey: "usage.daily.total" },
+            { value: "by-type", labelKey: "usage.daily.byType" },
+          ],
+          "chart-toggle small sessions-toggle",
+        )}
         <div class="card-title">
           ${isTokenMode ? t("usage.daily.tokensTitle") : t("usage.daily.costTitle")}
           ${usesCompressedScale
@@ -316,23 +316,19 @@ function renderDailyChartCompact(
       <div class="daily-chart">
         <div class="daily-chart-plot">
           <div class="daily-chart-scale" aria-hidden="true">
-            ${scaleMaximum > 0
-              ? html`
-                  <span
-                    >${isTokenMode
-                      ? formatTokens(scaleMaximum)
-                      : formatAnalysisCost(scaleMaximum)}</span
-                  >
-                  <span
-                    >${isTokenMode
-                      ? formatTokens(usesCompressedScale ? scaleMaximum / 4 : scaleMaximum / 2)
-                      : formatAnalysisCost(
-                          usesCompressedScale ? scaleMaximum / 4 : scaleMaximum / 2,
-                        )}</span
-                  >
-                  <span>${isTokenMode ? formatTokens(0) : formatCost(0)}</span>
-                `
-              : html`<span>${isTokenMode ? formatTokens(0) : formatCost(0)}</span>`}
+            ${(scaleMaximum > 0
+              ? [scaleMaximum, scaleMaximum / (usesCompressedScale ? 4 : 2), 0]
+              : [0]
+            ).map(
+              (value) =>
+                html`<span
+                  >${isTokenMode
+                    ? formatTokens(value)
+                    : value === 0
+                      ? formatCost(0)
+                      : formatAnalysisCost(value)}</span
+                >`,
+            )}
           </div>
           <div class="daily-chart-bars" style="--bar-max-width: ${barMaxWidth}px">
             ${daily.map((d, idx) => {
@@ -346,62 +342,35 @@ function renderDailyChartCompact(
                 daily.length > 20 ? "daily-bar-label daily-bar-label--compact" : "daily-bar-label";
               const segments =
                 dailyChartMode === "by-type"
-                  ? isTokenMode
-                    ? [
-                        { value: d.output, class: "output" },
-                        { value: d.input, class: "input" },
-                        { value: d.cacheWrite, class: "cache-write" },
-                        { value: d.cacheRead, class: "cache-read" },
-                      ]
-                    : [
-                        { value: d.outputCost ?? 0, class: "output" },
-                        { value: d.inputCost ?? 0, class: "input" },
-                        { value: d.cacheWriteCost ?? 0, class: "cache-write" },
-                        { value: d.cacheReadCost ?? 0, class: "cache-read" },
-                      ]
+                  ? USAGE_TOKEN_CATEGORIES.map(({ key, className, labelKey }) => ({
+                      value: isTokenMode ? d[key] : (d[`${key}Cost`] ?? 0),
+                      className,
+                      labelKey,
+                    }))
                   : [];
-              const breakdownLines =
-                dailyChartMode === "by-type"
-                  ? isTokenMode
-                    ? [
-                        `${t("usage.breakdown.output")} ${formatTokens(d.output)}`,
-                        `${t("usage.breakdown.input")} ${formatTokens(d.input)}`,
-                        `${t("usage.breakdown.cacheWrite")} ${formatTokens(d.cacheWrite)}`,
-                        `${t("usage.breakdown.cacheRead")} ${formatTokens(d.cacheRead)}`,
-                      ]
-                    : [
-                        `${t("usage.breakdown.output")} ${formatAnalysisCost(d.outputCost ?? 0)}`,
-                        `${t("usage.breakdown.input")} ${formatAnalysisCost(d.inputCost ?? 0)}`,
-                        `${t("usage.breakdown.cacheWrite")} ${formatAnalysisCost(d.cacheWriteCost ?? 0)}`,
-                        `${t("usage.breakdown.cacheRead")} ${formatAnalysisCost(d.cacheReadCost ?? 0)}`,
-                      ]
-                  : [];
+              const breakdownLines = segments.map(
+                ({ value, labelKey }) =>
+                  `${t(labelKey)} ${isTokenMode ? formatTokens(value) : formatAnalysisCost(value)}`,
+              );
               const totalLabel = isTokenMode
                 ? formatTokens(d.totalTokens)
                 : formatAnalysisCost(d.totalCost);
-              const tooltipContent = {
-                dateLabel: formatFullDate(d.date),
-                tokensLabel: `${formatTokens(d.totalTokens)} ${normalizeLowercaseStringOrEmpty(
-                  t("usage.metrics.tokens"),
-                )}`.trim(),
-                costLabel: formatAnalysisCost(d.totalCost),
-                breakdownLines,
-              };
+              const dateLabel = formatFullDate(d.date);
+              const tokensLabel = `${formatTokens(d.totalTokens)} ${normalizeLowercaseStringOrEmpty(
+                t("usage.metrics.tokens"),
+              )}`.trim();
+              const costLabel = formatAnalysisCost(d.totalCost);
+              const segmentTotal = segments.reduce((sum, segment) => sum + segment.value, 0) || 1;
               return html`
                 <openclaw-tooltip
-                  .content=${[
-                    tooltipContent.dateLabel,
-                    tooltipContent.tokensLabel,
-                    tooltipContent.costLabel,
-                    ...tooltipContent.breakdownLines,
-                  ].join("\n")}
+                  .content=${[dateLabel, tokensLabel, costLabel, ...breakdownLines].join("\n")}
                 >
                   <div
                     class="daily-bar-wrapper ${isSelected ? "selected" : ""}"
                     role="button"
                     tabindex="0"
                     aria-pressed=${isSelected ? "true" : "false"}
-                    aria-label=${`${tooltipContent.dateLabel}: ${tooltipContent.tokensLabel}, ${tooltipContent.costLabel}`}
+                    aria-label=${`${dateLabel}: ${tokensLabel}, ${costLabel}`}
                     @keydown=${(e: KeyboardEvent) => handleDailyBarKeydown(e, d.date, onSelectDay)}
                     @click=${(e: MouseEvent) => onSelectDay(d.date, e.shiftKey)}
                   >
@@ -411,17 +380,14 @@ function renderDailyChartCompact(
                             class="daily-bar daily-bar--stacked"
                             style="height: ${heightPx.toFixed(0)}px;"
                           >
-                            ${(() => {
-                              const total = segments.reduce((sum, seg) => sum + seg.value, 0) || 1;
-                              return segments.map(
-                                (seg) => html`
-                                  <div
-                                    class="cost-segment ${seg.class}"
-                                    style="height: ${(seg.value / total) * 100}%"
-                                  ></div>
-                                `,
-                              );
-                            })()}
+                            ${segments.map(
+                              ({ className, value }) => html`
+                                <div
+                                  class="cost-segment ${className}"
+                                  style="height: ${(value / segmentTotal) * 100}%"
+                                ></div>
+                              `,
+                            )}
                           </div>
                         `
                       : html`
@@ -446,15 +412,17 @@ function renderDailyChartCompact(
 }
 
 function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost") {
-  const breakdown = getCostBreakdown(totals);
   const isTokenMode = mode === "tokens";
-  const totalTokens = totals.totalTokens || 1;
-  const tokenPcts = {
-    output: pct(totals.output, totalTokens),
-    input: pct(totals.input, totalTokens),
-    cacheWrite: pct(totals.cacheWrite, totalTokens),
-    cacheRead: pct(totals.cacheRead, totalTokens),
-  };
+  const total = isTokenMode ? totals.totalTokens || 1 : totals.totalCost || 0;
+  const categories = USAGE_TOKEN_CATEGORIES.map(({ key, className, labelKey }) => {
+    const value = isTokenMode ? totals[key] : totals[`${key}Cost`] || 0;
+    return {
+      className,
+      labelKey,
+      percentage: pct(value, total),
+      formatted: isTokenMode ? formatTokens(value) : formatAnalysisCost(value),
+    };
+  });
 
   return html`
     <div class="cost-breakdown cost-breakdown-compact">
@@ -462,64 +430,24 @@ function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost"
         ${isTokenMode ? t("usage.breakdown.tokensByType") : t("usage.breakdown.costByType")}
       </div>
       <div class="cost-breakdown-bar">
-        <div
-          class="cost-segment output"
-          style="width: ${(isTokenMode ? tokenPcts.output : breakdown.output.pct).toFixed(1)}%"
-          title="${t("usage.breakdown.output")}: ${isTokenMode
-            ? formatTokens(totals.output)
-            : formatAnalysisCost(breakdown.output.cost)}"
-        ></div>
-        <div
-          class="cost-segment input"
-          style="width: ${(isTokenMode ? tokenPcts.input : breakdown.input.pct).toFixed(1)}%"
-          title="${t("usage.breakdown.input")}: ${isTokenMode
-            ? formatTokens(totals.input)
-            : formatAnalysisCost(breakdown.input.cost)}"
-        ></div>
-        <div
-          class="cost-segment cache-write"
-          style="width: ${(isTokenMode ? tokenPcts.cacheWrite : breakdown.cacheWrite.pct).toFixed(
-            1,
-          )}%"
-          title="${t("usage.breakdown.cacheWrite")}: ${isTokenMode
-            ? formatTokens(totals.cacheWrite)
-            : formatAnalysisCost(breakdown.cacheWrite.cost)}"
-        ></div>
-        <div
-          class="cost-segment cache-read"
-          style="width: ${(isTokenMode ? tokenPcts.cacheRead : breakdown.cacheRead.pct).toFixed(
-            1,
-          )}%"
-          title="${t("usage.breakdown.cacheRead")}: ${isTokenMode
-            ? formatTokens(totals.cacheRead)
-            : formatAnalysisCost(breakdown.cacheRead.cost)}"
-        ></div>
+        ${categories.map(
+          ({ className, labelKey, percentage, formatted }) => html`
+            <div
+              class="cost-segment ${className}"
+              style="width: ${percentage.toFixed(1)}%"
+              title="${t(labelKey)}: ${formatted}"
+            ></div>
+          `,
+        )}
       </div>
       <div class="cost-breakdown-legend">
-        <span class="legend-item"
-          ><span class="legend-dot output"></span>${t("usage.breakdown.output")}
-          ${isTokenMode
-            ? formatTokens(totals.output)
-            : formatAnalysisCost(breakdown.output.cost)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot input"></span>${t("usage.breakdown.input")}
-          ${isTokenMode
-            ? formatTokens(totals.input)
-            : formatAnalysisCost(breakdown.input.cost)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot cache-write"></span>${t("usage.breakdown.cacheWrite")}
-          ${isTokenMode
-            ? formatTokens(totals.cacheWrite)
-            : formatAnalysisCost(breakdown.cacheWrite.cost)}</span
-        >
-        <span class="legend-item"
-          ><span class="legend-dot cache-read"></span>${t("usage.breakdown.cacheRead")}
-          ${isTokenMode
-            ? formatTokens(totals.cacheRead)
-            : formatAnalysisCost(breakdown.cacheRead.cost)}</span
-        >
+        ${categories.map(
+          ({ className, labelKey, formatted }) => html`
+            <span class="legend-item"
+              ><span class="legend-dot ${className}"></span>${t(labelKey)} ${formatted}</span
+            >
+          `,
+        )}
       </div>
       <div class="cost-breakdown-total">
         ${t("usage.breakdown.total")}:
@@ -533,42 +461,16 @@ function renderInsightList(
   title: string,
   items: Array<{ label: string; value: string; sub?: string }>,
   emptyLabel: string,
-) {
-  return html`
-    <div class="usage-insight-card">
-      <div class="usage-insight-title">${title}</div>
-      ${items.length === 0
-        ? html`<div class="muted">${emptyLabel}</div>`
-        : html`
-            <div class="usage-list">
-              ${items.map(
-                (item) => html`
-                  <div class="usage-list-item">
-                    <span>${item.label}</span>
-                    <span class="usage-list-value">
-                      <span>${item.value}</span>
-                      ${item.sub ? html`<span class="usage-list-sub">${item.sub}</span>` : nothing}
-                    </span>
-                  </div>
-                `,
-              )}
-            </div>
-          `}
-    </div>
-  `;
-}
-
-function renderPeakErrorList(
-  title: string,
-  items: Array<{ label: string; value: string; sub?: string }>,
-  emptyLabel: string,
   options?: {
     className?: string;
     listClassName?: string;
+    error?: boolean;
   },
 ) {
   const cardClass = ["usage-insight-card", options?.className].filter(Boolean).join(" ");
-  const listClass = ["usage-error-list", options?.listClassName].filter(Boolean).join(" ");
+  const listClass = [options?.error ? "usage-error-list" : "usage-list", options?.listClassName]
+    .filter(Boolean)
+    .join(" ");
   return html`
     <div class=${cardClass}>
       <div class="usage-insight-title">${title}</div>
@@ -576,14 +478,26 @@ function renderPeakErrorList(
         ? html`<div class="muted">${emptyLabel}</div>`
         : html`
             <div class=${listClass}>
-              ${items.map(
-                (item) => html`
-                  <div class="usage-error-row">
-                    <div class="usage-error-date">${item.label}</div>
-                    <div class="usage-error-rate">${item.value}</div>
-                    ${item.sub ? html`<div class="usage-error-sub">${item.sub}</div>` : nothing}
-                  </div>
-                `,
+              ${items.map((item) =>
+                options?.error
+                  ? html`
+                      <div class="usage-error-row">
+                        <div class="usage-error-date">${item.label}</div>
+                        <div class="usage-error-rate">${item.value}</div>
+                        ${item.sub ? html`<div class="usage-error-sub">${item.sub}</div>` : nothing}
+                      </div>
+                    `
+                  : html`
+                      <div class="usage-list-item">
+                        <span>${item.label}</span>
+                        <span class="usage-list-value">
+                          <span>${item.value}</span>
+                          ${item.sub
+                            ? html`<span class="usage-list-sub">${item.sub}</span>`
+                            : nothing}
+                        </span>
+                      </div>
+                    `,
               )}
             </div>
           `}
@@ -688,14 +602,6 @@ function renderUsageInsights(
       ? (formatDurationCompact(stats.avgDurationMs, { spaced: true }) ??
         t("usage.common.emptyValue"))
       : t("usage.common.emptyValue");
-  const cacheHint = t("usage.overview.cacheHint");
-  const errorHint = t("usage.overview.errorHint");
-  const throughputHint = t("usage.overview.throughputHint");
-  const tokensHint = t("usage.overview.avgTokensHint");
-  const costHint = showCostHint
-    ? t("usage.overview.avgCostHintMissing")
-    : t("usage.overview.avgCostHint");
-
   const errorDays = aggregates.daily
     .filter((day) => day.messages > 0 && day.errors > 0)
     .map((day) => {
@@ -749,6 +655,13 @@ function renderUsageInsights(
     value: formatAnalysisCost(entry.totals.totalCost),
     sub: costAttributionSub(entry.totals.totalCost, entry.totals.totalTokens),
   }));
+  const insightLists = [
+    ["usage.overview.topModels", topModels, "usage.overview.noModelData"],
+    ["usage.overview.topProviders", topProviders, "usage.overview.noProviderData"],
+    ["usage.overview.topTools", topTools, "usage.overview.noToolCalls"],
+    ["usage.overview.topAgents", topAgents, "usage.overview.noAgentData"],
+    ["usage.overview.topChannels", topChannels, "usage.overview.noChannelData"],
+  ] as const;
 
   return renderSettingsSection(
     { title: t("usage.overview.title") },
@@ -767,7 +680,7 @@ function renderUsageInsights(
             ${renderSummaryStat({
               hintId: "throughput",
               title: t("usage.overview.throughput"),
-              hint: throughputHint,
+              hint: t("usage.overview.throughputHint"),
               value: throughputLabel,
               sub: throughputCostLabel,
               className: "usage-summary-card--hero usage-summary-card--throughput",
@@ -784,7 +697,7 @@ function renderUsageInsights(
             ${renderSummaryStat({
               hintId: "average-tokens",
               title: t("usage.overview.avgTokens"),
-              hint: tokensHint,
+              hint: t("usage.overview.avgTokensHint"),
               value: formatTokens(avgTokens),
               sub: t("usage.overview.acrossMessages", {
                 count: String(aggregates.messages.total || 0),
@@ -794,7 +707,7 @@ function renderUsageInsights(
             ${renderSummaryStat({
               hintId: "cache-hit-rate",
               title: t("usage.overview.cacheHitRate"),
-              hint: cacheHint,
+              hint: t("usage.overview.cacheHint"),
               value: cacheHitLabel,
               sub: `${formatTokens(totals.cacheRead)} ${t("usage.overview.cached")} · ${formatTokens(cacheBase)} ${t("usage.overview.prompt")}`,
               tone: cacheHitRate > 0.6 ? "good" : cacheHitRate > 0.3 ? "warn" : "bad",
@@ -803,7 +716,7 @@ function renderUsageInsights(
             ${renderSummaryStat({
               hintId: "error-rate",
               title: t("usage.overview.errorRate"),
-              hint: errorHint,
+              hint: t("usage.overview.errorHint"),
               value: `${errorRatePct.toFixed(2)}%`,
               sub: `${aggregates.messages.errors} ${normalizeLowercaseStringOrEmpty(t("usage.overview.errors"))} · ${avgDurationLabel} ${t("usage.overview.avgSession")}`,
               tone: errorRatePct > 5 ? "bad" : errorRatePct > 1 ? "warn" : "good",
@@ -812,7 +725,9 @@ function renderUsageInsights(
             ${renderSummaryStat({
               hintId: "average-cost",
               title: t("usage.overview.avgCost"),
-              hint: costHint,
+              hint: t(
+                showCostHint ? "usage.overview.avgCostHintMissing" : "usage.overview.avgCostHint",
+              ),
               value: formatAnalysisCost(avgCost),
               sub: `${formatAnalysisCost(totals.totalCost)} ${normalizeLowercaseStringOrEmpty(t("usage.breakdown.total"))}`,
               className: "usage-summary-card--compact",
@@ -835,41 +750,21 @@ function renderUsageInsights(
             })}
           </div>
           <div class="usage-insights-grid">
-            ${renderInsightList(
-              t("usage.overview.topModels"),
-              topModels,
-              t("usage.overview.noModelData"),
+            ${insightLists.map(([titleKey, items, emptyKey]) =>
+              renderInsightList(t(titleKey), items, t(emptyKey)),
             )}
             ${renderInsightList(
-              t("usage.overview.topProviders"),
-              topProviders,
-              t("usage.overview.noProviderData"),
-            )}
-            ${renderInsightList(
-              t("usage.overview.topTools"),
-              topTools,
-              t("usage.overview.noToolCalls"),
-            )}
-            ${renderInsightList(
-              t("usage.overview.topAgents"),
-              topAgents,
-              t("usage.overview.noAgentData"),
-            )}
-            ${renderInsightList(
-              t("usage.overview.topChannels"),
-              topChannels,
-              t("usage.overview.noChannelData"),
-            )}
-            ${renderPeakErrorList(
               t("usage.overview.peakErrorDays"),
               errorDays,
               t("usage.overview.noErrorData"),
+              { error: true },
             )}
-            ${renderPeakErrorList(
+            ${renderInsightList(
               t("usage.overview.peakErrorHours"),
               errorHours,
               t("usage.overview.noErrorData"),
               {
+                error: true,
                 className: "usage-insight-card--wide",
                 listClassName: "usage-error-list--hours",
               },
@@ -907,39 +802,27 @@ function renderSessionsCard(
     }
     return raw;
   };
-  const copySessionName = async (s: UsageSessionEntry) => {
-    const text = formatSessionListLabel(s);
-    await copyToClipboard(text);
-  };
-
-  const buildSessionMeta = (s: UsageSessionEntry): string[] => {
-    const parts: string[] = [];
-    if (showColumn("channel") && s.channel) {
-      parts.push(`channel:${s.channel}`);
-    }
-    if (showColumn("agent") && s.agentId) {
-      parts.push(`agent:${s.agentId}`);
-    }
-    if (showColumn("provider") && (s.modelProvider || s.providerOverride)) {
-      parts.push(`provider:${s.modelProvider ?? s.providerOverride}`);
-    }
-    if (showColumn("model") && s.model) {
-      parts.push(`model:${s.model}`);
-    }
-    if (showColumn("messages") && s.usage?.messageCounts) {
-      parts.push(`msgs:${s.usage.messageCounts.total}`);
-    }
-    if (showColumn("tools") && s.usage?.toolUsage) {
-      parts.push(`tools:${s.usage.toolUsage.totalCalls}`);
-    }
-    if (showColumn("errors") && s.usage?.messageCounts) {
-      parts.push(`errors:${s.usage.messageCounts.errors}`);
-    }
-    if (showColumn("duration") && s.usage?.durationMs) {
-      parts.push(`dur:${formatDurationCompact(s.usage.durationMs, { spaced: true }) ?? "—"}`);
-    }
-    return parts;
-  };
+  const buildSessionMeta = (session: UsageSessionEntry): string[] =>
+    [
+      showColumn("channel") && session.channel && `channel:${session.channel}`,
+      showColumn("agent") && session.agentId && `agent:${session.agentId}`,
+      showColumn("provider") &&
+        (session.modelProvider || session.providerOverride) &&
+        `provider:${session.modelProvider ?? session.providerOverride}`,
+      showColumn("model") && session.model && `model:${session.model}`,
+      showColumn("messages") &&
+        session.usage?.messageCounts &&
+        `msgs:${session.usage.messageCounts.total}`,
+      showColumn("tools") &&
+        session.usage?.toolUsage &&
+        `tools:${session.usage.toolUsage.totalCalls}`,
+      showColumn("errors") &&
+        session.usage?.messageCounts &&
+        `errors:${session.usage.messageCounts.errors}`,
+      showColumn("duration") &&
+        session.usage?.durationMs &&
+        `dur:${formatDurationCompact(session.usage.durationMs, { spaced: true }) ?? "—"}`,
+    ].filter((part): part is string => typeof part === "string" && part.length > 0);
 
   const selectedDaySet = new Set(selectedDays);
 
@@ -1037,7 +920,7 @@ function renderSessionsCard(
             class="btn btn--sm btn--ghost"
             @click=${(e: MouseEvent) => {
               e.stopPropagation();
-              void copySessionName(s);
+              void copyToClipboard(formatSessionListLabel(s));
             }}
           >
             ${t("usage.sessions.copy")}
@@ -1080,20 +963,10 @@ function renderSessionsCard(
               >${totalErrors} ${normalizeLowercaseStringOrEmpty(t("usage.overview.errors"))}</span
             >
           </div>
-          <div class="chart-toggle small">
-            <button
-              class="btn btn--sm toggle-btn ${sessionsTab === "all" ? "active" : ""}"
-              @click=${() => onSessionsTabChange("all")}
-            >
-              ${t("usage.sessions.all")}
-            </button>
-            <button
-              class="btn btn--sm toggle-btn ${sessionsTab === "recent" ? "active" : ""}"
-              @click=${() => onSessionsTabChange("recent")}
-            >
-              ${t("usage.sessions.recent")}
-            </button>
-          </div>
+          ${renderUsageToggle(sessionsTab, onSessionsTabChange, [
+            { value: "all", labelKey: "usage.sessions.all" },
+            { value: "recent", labelKey: "usage.sessions.recent" },
+          ])}
           <label class="sessions-sort">
             <span>${t("usage.sessions.sort")}</span>
             <select
@@ -1101,21 +974,18 @@ function renderSessionsCard(
               @change=${(e: Event) =>
                 onSessionSortChange((e.target as HTMLSelectElement).value as typeof sessionSort)}
             >
-              <option value="cost" ?selected=${sessionSort === "cost"}>
-                ${t("usage.metrics.cost")}
-              </option>
-              <option value="errors" ?selected=${sessionSort === "errors"}>
-                ${t("usage.overview.errors")}
-              </option>
-              <option value="messages" ?selected=${sessionSort === "messages"}>
-                ${t("usage.overview.messages")}
-              </option>
-              <option value="recent" ?selected=${sessionSort === "recent"}>
-                ${t("usage.sessions.recentShort")}
-              </option>
-              <option value="tokens" ?selected=${sessionSort === "tokens"}>
-                ${t("usage.metrics.tokens")}
-              </option>
+              ${Object.entries({
+                cost: "usage.metrics.cost",
+                errors: "usage.overview.errors",
+                messages: "usage.overview.messages",
+                recent: "usage.sessions.recentShort",
+                tokens: "usage.metrics.tokens",
+              }).map(
+                ([value, labelKey]) =>
+                  html`<option value=${value} ?selected=${sessionSort === value}>
+                    ${t(labelKey)}
+                  </option>`,
+              )}
             </select>
           </label>
           <openclaw-tooltip
@@ -1190,5 +1060,7 @@ export {
   renderInsightList,
   renderSessionsCard,
   renderUsageInsights,
+  renderUsageToggle,
+  USAGE_TOKEN_CATEGORIES,
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## Summary
- Root cause: Usage overview and detail owners independently repeated token/category colors, translated labels, totals, chart segments and tooltips, context panels, toggles, insight wrappers, filters, and session controls, creating drift-prone parallel presentation paths.
- Canonical fix: share typed token-category/toggle descriptors across the two existing owner modules and derive charts, legends, context cards, filters, insights, and sort options from their owner-local descriptors.
- Preserve chart math and exact scale text nodes, DOM order/CSS/ARIA, localization catalogs/raw-copy, callbacks, date behavior, selection lifecycle, Unicode truncation, category colors, and clipboard behavior. No locale artifact; no Usage lifecycle/reconnect files touched.
- Production: **-302 LOC** (537 added / 839 removed); tests: **+154 LOC** (159 added / 5 removed); total: **-148 LOC**, exactly four files.

## Independent review
- Fresh independent xhigh architectural review: **CLEAN**, no actionable P0–P2, confidence 0.97; checked Lit 3.3.3 source/contracts, SVG namespace/order, DOM text, locale keys, callbacks, Unicode, clipboard, and sibling/open-PR ownership.

## Validation
- Remote full changed gate: `CI=1 pnpm check:changed` — PASS; all three Knip scans report zero, UI and core-test TypeScript lanes pass, typed lint has zero warnings/errors, formatting/guards and i18n baseline pass.
- Remote full production build: `CI=1 pnpm build` — PASS; 3,020 Vite modules, 692 precompressed Control UI assets, startup JS 298.5 KiB gzip versus 317.0 KiB budget.
- Remote focused owner/sibling tests: `pnpm test ui/src/pages/usage/view-details.test.ts ui/src/pages/usage/view-overview.test.ts ui/src/pages/usage/view.test.ts ui/src/pages/usage/usage-page.test.ts ui/src/pages/usage/metrics.test.ts` — **67 passed / 5 files**.
- Remote actual Chromium + real Control UI dev server + mocked Gateway behavior: `CI=1 pnpm test:ui:e2e ui/src/e2e/usage-cost-analysis.e2e.test.ts ui/src/e2e/usage-session-unicode.e2e.test.ts` — **4 passed / 2 files**:

```text
✓ usage-cost-analysis.e2e.test.ts (1 test)
  ✓ renders cost analysis from Gateway usage data
✓ usage-session-unicode.e2e.test.ts (3 tests)
  ✓ preserves surrogate pair at the truncation boundary after a selected Gateway session disappears
  ✓ preserves surrogate pair within the truncation boundary after a selected Gateway session disappears
  ✓ preserves ordinary ASCII session key after a selected Gateway session disappears

Test Files  2 passed (2)
     Tests  4 passed (4)
```
