### PR TITLE
fix(tlon): preserve provider-native group message ids

### DIFF
--- a/extensions/tlon/src/urbit/send.test.ts
+++ b/extensions/tlon/src/urbit/send.test.ts
@@ -38,11 +38,83 @@ describe("sendDm", () => {
     expect(result.receipt.primaryPlatformMessageId).toBe("~zod/mocked-ud");
   });
 
+  it.each([
+    { kind: "text" as const, story: [{ inline: ["group post"] }] },
+    {
+      kind: "media" as const,
+      story: [
+        {
+          block: { image: { src: "https://example.com/image.png", height: 0, width: 0, alt: "" } },
+        },
+      ],
+    },
+  ])(
+    "returns the provider-native $kind group post ID in its delivery receipt",
+    async ({ kind, story }) => {
+      const { sendGroupMessageWithStory } = await import("./send.js");
+      const aura = await import("@urbit/aura");
+      const sentAt = 1_700_000_000_000;
+      const groupPostId = "170.141.184.507.123";
+      vi.spyOn(Date, "now").mockReturnValue(sentAt);
+      vi.mocked(aura.scot).mockReturnValue(groupPostId);
+      const poke = vi.fn(async () => ({}));
+
+      const result = await sendGroupMessageWithStory({
+        api: { poke },
+        fromShip: "~zod",
+        hostShip: "~nec",
+        channelName: "general",
+        story,
+        kind,
+      });
+
+      expect(aura.da.fromUnix).toHaveBeenCalledWith(sentAt);
+      expect(aura.scot).toHaveBeenCalledWith("ud", 123n);
+      expect(result.messageId).toBe(groupPostId);
+      expect(result.receipt.primaryPlatformMessageId).toBe(groupPostId);
+      expect(result.receipt.platformMessageIds).toEqual([groupPostId]);
+      expect(result.receipt.parts[0]?.kind).toBe(kind);
+    },
+  );
+
+  it("reuses a sent group post ID as the provider-native thread reply target", async () => {
+    const { sendGroupMessage } = await import("./send.js");
+    const aura = await import("@urbit/aura");
+    const groupPostId = "170.141.184.507.123";
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.mocked(aura.scot).mockReturnValue(groupPostId);
+    const poke = vi.fn(async () => ({}));
+    const shared = {
+      api: { poke },
+      fromShip: "~zod",
+      hostShip: "~nec",
+      channelName: "general",
+    };
+
+    const root = await sendGroupMessage({ ...shared, text: "root" });
+    await sendGroupMessage({ ...shared, text: "reply", replyToId: root.messageId });
+
+    expect(poke).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        json: expect.objectContaining({
+          channel: expect.objectContaining({
+            action: expect.objectContaining({
+              post: expect.objectContaining({
+                reply: expect.objectContaining({ id: groupPostId }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
   it("passes numeric group reply ids through aura formatting", async () => {
     const { sendGroupMessage } = await import("./send.js");
     const aura = await import("@urbit/aura");
     const scot = vi.mocked(aura.scot);
-    scot.mockReturnValueOnce("~2024.1.1");
+    scot.mockReturnValueOnce("1.700.000.000.000");
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const poke = vi.fn(async () => ({}));
 
@@ -65,7 +137,7 @@ describe("sendDm", () => {
           action: {
             post: {
               reply: {
-                id: "~2024.1.1",
+                id: "1.700.000.000.000",
                 action: {
                   add: {
                     content: [{ inline: ["threaded"] }],

--- a/extensions/tlon/src/urbit/send.ts
+++ b/extensions/tlon/src/urbit/send.ts
@@ -25,6 +25,10 @@ type SendStoryParams = {
   kind?: MessageReceiptPartKind;
 };
 
+function formatTlonPostId(sentAt: number): string {
+  return scot("ud", da.fromUnix(sentAt));
+}
+
 function createTlonSendReceipt(params: {
   messageId: string;
   conversationId: string;
@@ -56,8 +60,7 @@ export async function sendDmWithStory({
   kind = "unknown",
 }: SendStoryParams) {
   const sentAt = Date.now();
-  const idUd = scot("ud", da.fromUnix(sentAt));
-  const id = `${fromShip}/${idUd}`;
+  const id = `${fromShip}/${formatTlonPostId(sentAt)}`;
 
   const delta = {
     add: {
@@ -192,7 +195,7 @@ export async function sendGroupMessageWithStory({
     json: action,
   });
 
-  const messageId = `${fromShip}/${sentAt}`;
+  const messageId = formatTlonPostId(sentAt);
   return {
     channel: "tlon",
     messageId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Tlon group sends returned a fabricated `~ship/<unix-ms>` message ID instead of the provider-native dotted `@ud`. Reusing that delivery receipt for a reply targeted the wrong group post. Direct messages use a separate `~ship/<@ud>` contract and are unaffected.

## Why This Change Was Made

The Tlon send owner now formats timestamps once with `scot("ud", da.fromUnix(sentAt))`. Group sends return that bare provider-native ID, while direct messages continue to prepend the sending ship. This repairs the producer boundary instead of rewriting IDs later in receipt or reply routing.

## User Impact

Agents and operators can reuse a sent Tlon group message receipt as the reply target, preserving native thread routing for both text and media sends. Direct-message IDs and existing numeric reply-ID formatting remain unchanged.

## Evidence

- Before the repair: 3 of 8 focused send-owner tests failed, covering group text/media receipts and root-to-reply target reuse.
- After the repair: focused Tlon send-owner tests pass 8/8; the full Tlon suite previously passed 285/285.
- Fresh publication check: `node scripts/run-vitest.mjs extensions/tlon/src/urbit/send.test.ts` passes 8/8, and `git diff --check` is clean.
- Extension type, lint, format, package-boundary, and architecture checks passed during validation.
- Direct dependency proof: `@urbit/aura` 3.0.0 declarations and implementation show `da.fromUnix(number): bigint`; `scot("ud", bigint)` renders decimal digits grouped with dots.
- Scope: exactly `extensions/tlon/src/urbit/send.ts` and `extensions/tlon/src/urbit/send.test.ts`. Production `+6/-3` (net +3); tests `+74/-2`.
- Exact-head CI is terminal green, including `openclaw/ci-gate`.
- AI-assisted; the patch was inspected and validated. No agent transcript is included.

**Review required: live Tlon group root-to-reply roundtrip unavailable; do not merge until supplied.** No authorized live Tlon ship and disposable group channel were available. The deterministic poke-boundary test verifies the exact outgoing reply target, but it is not a live external-provider roundtrip.
