### PR TITLE
fix(gateway): bound service reads in status

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -675,7 +675,10 @@ describe("gatherDaemonStatus", () => {
     expect(serviceIsLoaded).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 100 }));
     expect(serviceReadRuntime).toHaveBeenCalledWith(expect.any(Object), { timeoutMs: 100 });
     expect(status.service.loaded).toBe(false);
-    expect(status.service.runtime).toBeUndefined();
+    expect(status.service.runtime).toEqual({
+      status: "unknown",
+      detail: "Error: systemctl show timed out",
+    });
 
     const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
     try {
@@ -688,10 +691,25 @@ describe("gatherDaemonStatus", () => {
       expect(JSON.parse(serialized)).toMatchObject({
         service: {
           loaded: false,
+          runtime: {
+            status: "unknown",
+            detail: "Error: systemctl show timed out",
+          },
         },
       });
     } finally {
       writeJson.mockRestore();
+    }
+
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const error = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    try {
+      printDaemonStatus(status, { json: false, deep: true });
+      const output = log.mock.calls.flat().join("\n");
+      expect(output).toContain("Runtime: unknown (Error: systemctl show timed out)");
+    } finally {
+      log.mockRestore();
+      error.mockRestore();
     }
   }, 1_000);
 

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -7,10 +7,12 @@ import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
 import type { PortListener, PortUsageStatus } from "../../infra/ports.js";
 import type { GatewayRestartHandoff } from "../../infra/restart-handoff.js";
+import { defaultRuntime } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { VERSION } from "../../version.js";
 import type { GatewayRestartSnapshot } from "./restart-health.js";
 import { gatherDaemonStatus } from "./status.gather.js";
+import { printDaemonStatus } from "./status.print.js";
 
 type PortConnections = Awaited<
   ReturnType<typeof import("../../infra/ports.js").inspectPortConnections>
@@ -103,10 +105,15 @@ const inspectWindowsGatewayFirewall = vi.fn<(opts?: unknown) => Promise<unknown>
   details: [],
 }));
 const auditGatewayServiceConfig = vi.fn(async (_opts?: unknown) => undefined);
-const serviceIsLoaded = vi.fn(async (_opts?: unknown) => true);
+const serviceIsLoaded = vi.fn<
+  (opts?: { env?: NodeJS.ProcessEnv; timeoutMs?: number }) => Promise<boolean>
+>(async (_opts?: { env?: NodeJS.ProcessEnv; timeoutMs?: number }) => true);
 const serviceReadRuntime = vi.fn<
-  (_env?: NodeJS.ProcessEnv) => Promise<{ status: string; detail?: string }>
->(async (_env?: NodeJS.ProcessEnv) => ({ status: "running" }));
+  (
+    _env?: NodeJS.ProcessEnv,
+    _opts?: { timeoutMs?: number },
+  ) => Promise<{ status: string; detail?: string }>
+>(async (_env?: NodeJS.ProcessEnv, _opts?: { timeoutMs?: number }) => ({ status: "running" }));
 const inspectGatewayRestart = vi.fn<(opts?: unknown) => Promise<GatewayRestartSnapshot>>(
   async (_opts?: unknown) => ({
     runtime: { status: "running", pid: 1234 },
@@ -210,7 +217,8 @@ vi.mock("../../daemon/inspect.js", () => ({
   findExtraGatewayServices: (env: unknown, opts?: unknown) => findExtraGatewayServices(env, opts),
 }));
 
-vi.mock("../../daemon/launchd.js", () => ({
+vi.mock("../../daemon/launchd.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../daemon/launchd.js")>()),
   findStaleOpenClawUpdateLaunchdJobs: (env?: NodeJS.ProcessEnv) =>
     findStaleOpenClawUpdateLaunchdJobs(env),
 }));
@@ -219,7 +227,8 @@ vi.mock("../../daemon/service-audit.js", () => ({
   auditGatewayServiceConfig: (opts: unknown) => auditGatewayServiceConfig(opts),
 }));
 
-vi.mock("../../daemon/service.js", () => ({
+vi.mock("../../daemon/service.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../daemon/service.js")>()),
   resolveGatewayService: () =>
     createMockGatewayService({
       isLoaded: serviceIsLoaded,
@@ -374,6 +383,9 @@ describe("gatherDaemonStatus", () => {
     readLastGatewayErrorLine.mockReset();
     readLastGatewayErrorLine.mockResolvedValue(null);
     readGatewayRestartHandoffSync.mockClear();
+    serviceIsLoaded.mockClear();
+    serviceReadCommand.mockClear();
+    serviceReadRuntime.mockClear();
     readConfigFileSnapshotCalls.mockClear();
     loadConfigCalls.mockClear();
     daemonConfigWarnings = [];
@@ -639,6 +651,49 @@ describe("gatherDaemonStatus", () => {
     expect(status.service.runtime?.status).toBe("running");
     expect((status.service.runtime as { detail?: string }).detail).toBe("19001");
   });
+
+  it("bounds both service-manager reads and still emits JSON after they time out", async () => {
+    serviceIsLoaded.mockImplementationOnce(async (args?: { timeoutMs?: number }) => {
+      if (args?.timeoutMs === undefined) {
+        return await new Promise<boolean>(() => {});
+      }
+      throw new Error("systemctl is-enabled timed out");
+    });
+    serviceReadRuntime.mockImplementationOnce(async (_env, opts) => {
+      if (opts?.timeoutMs === undefined) {
+        return await new Promise<{ status: string }>(() => {});
+      }
+      throw new Error("systemctl show timed out");
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: { timeout: "100", json: true },
+      probe: false,
+      deep: true,
+    });
+
+    expect(serviceIsLoaded).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 100 }));
+    expect(serviceReadRuntime).toHaveBeenCalledWith(expect.any(Object), { timeoutMs: 100 });
+    expect(status.service.loaded).toBe(false);
+    expect(status.service.runtime).toBeUndefined();
+
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    try {
+      printDaemonStatus(status, { json: true, deep: true });
+      expect(writeJson).toHaveBeenCalledOnce();
+      const serialized = JSON.stringify(writeJson.mock.calls[0]?.[0]);
+      if (!serialized) {
+        throw new Error("expected terminal JSON output");
+      }
+      expect(JSON.parse(serialized)).toMatchObject({
+        service: {
+          loaded: false,
+        },
+      });
+    } finally {
+      writeJson.mockRestore();
+    }
+  }, 1_000);
 
   it("keeps gateway status read-only when service management is unsupported", async () => {
     serviceReadCommand.mockResolvedValueOnce(null);

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -21,7 +21,7 @@ import type { ExtraGatewayService, FindExtraGatewayServicesOptions } from "../..
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
-import { resolveGatewayService } from "../../daemon/service.js";
+import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
@@ -578,20 +578,13 @@ export async function gatherDaemonStatus(
     allowExecSecretRefs?: boolean;
   } & FindExtraGatewayServicesOptions,
 ): Promise<DaemonStatus> {
+  const timeoutMs = parseStrictPositiveInteger(opts.rpc.timeout ?? undefined) ?? 10_000;
   const service = resolveGatewayService();
-  const command = await service.readCommand(process.env).catch(() => null);
-  const serviceEnv = command?.environment
-    ? ({
-        ...process.env,
-        ...command.environment,
-      } satisfies NodeJS.ProcessEnv)
-    : process.env;
-  const [loaded, runtime] = await Promise.all([
-    service.isLoaded({ env: serviceEnv }).catch(() => false),
-    service
-      .readRuntime(serviceEnv)
-      .catch((err: unknown) => ({ status: "unknown", detail: String(err) })),
-  ]);
+  const serviceState = await readGatewayServiceState(service, {
+    env: process.env,
+    timeoutMs,
+  });
+  const { command, env: serviceEnv, loaded, runtime } = serviceState;
   const restartHandoff = opts.deep ? readGatewayRestartHandoffSync(serviceEnv) : null;
   const configAudit: ServiceConfigAudit = command
     ? await loadServiceAuditModule().then(({ auditGatewayServiceConfig }) =>
@@ -654,8 +647,6 @@ export async function gatherDaemonStatus(
           )
           .catch(() => [])
       : [];
-
-  const timeoutMs = parseStrictPositiveInteger(opts.rpc.timeout ?? undefined) ?? 10_000;
 
   const tlsEnabled = daemonCfg.gateway?.tls?.enabled === true;
   const shouldUseLocalTlsRuntime = opts.probe && !probeUrlOverride && tlsEnabled;

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -186,6 +186,23 @@ describe("readGatewayServiceState", () => {
     );
   });
 
+  it("preserves runtime probe failures as an explicit unknown state", async () => {
+    const service = createService({
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => {
+        throw new Error("systemctl show timed out");
+      }),
+    });
+
+    const state = await readGatewayServiceState(service, { timeoutMs: 100 });
+
+    expect(state.running).toBe(false);
+    expect(state.runtime).toEqual({
+      status: "unknown",
+      detail: "Error: systemctl show timed out",
+    });
+  });
+
   it("validates merged service env before native status probes", async () => {
     const isLoaded = vi.fn(async () => true);
     const readRuntime = vi.fn(async () => ({ status: "running" as const }));

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -196,7 +196,13 @@ export async function readGatewayServiceState(
   // bound; isLoaded/readRuntime can spawn service-manager subprocesses.
   const [loaded, runtime] = await Promise.all([
     service.isLoaded({ env, timeoutMs: args.timeoutMs }).catch(() => false),
-    service.readRuntime(env, { timeoutMs: args.timeoutMs }).catch(() => undefined),
+    service.readRuntime(env, { timeoutMs: args.timeoutMs }).catch(
+      (error: unknown) =>
+        ({
+          status: "unknown",
+          detail: String(error),
+        }) satisfies GatewayServiceRuntime,
+    ),
   ]);
   return {
     installed: command !== null,


### PR DESCRIPTION
Closes #117622

## What Problem This Solves

Fixes an issue where `openclaw gateway status --deep --timeout <ms> --json` could hang indefinitely without printing JSON when the native service manager stopped responding.

## Why This Change Was Made

The command now resolves its effective timeout before service inspection and reuses the existing canonical bounded service-state reader. That single owner applies the same deadline to both service-manager probes and preserves a rejected runtime probe as an explicit `unknown` result with its diagnostic detail. The RPC deadline, default timeout, JSON shape, service-selection policy, and platform adapters are unchanged.

## User Impact

Operators and health automation now get a bounded, parseable status response even when `systemctl` or another service-manager probe is wedged. The explicit `--timeout` value applies to the service checks that run before the Gateway RPC instead of taking effect only after those checks finish.

## Evidence

- Current-main reproduction: both service-manager reads are fault-injected to never settle unless they receive the requested bound; before this repair `gatherDaemonStatus` calls them without a timeout and cannot reach the JSON renderer.
- Exact-current Blacksmith Testbox `tbx_01kyzghwny5vjt31xrk5xb9xfp`, run https://github.com/openclaw/openclaw/actions/runs/30717274312: 37 focused cases passed with one Darwin-only skip, then the full changed gate passed, including production/test type checks, formatting, lint, dead-code, import-cycle, architecture, environment, and database/runtime guards.
- The regression verifies `100` ms reaches both `isLoaded` and `readRuntime`, that both timeout failures degrade safely, and that the final deep JSON output remains parseable.
- Source-blind exact-built Linux CLI proof on Testbox `tbx_01kyzhnasvn48vkgxynbfzgf9g`, run https://github.com/openclaw/openclaw/actions/runs/30717963677: an isolated unique user unit and nonterminating PATH-first `systemctl` received both `--user status` and `--user is-enabled`; `gateway status --deep --timeout 100 --json` exited 0 in 1,064 ms with parseable JSON, `service.loaded=false`, `runtime.status=unknown`, a degraded RPC result, and zero stderr bytes. The isolated validator workspace was removed.
- Two prior source-blind attempts (runs `30717604274` and `30717758464`) were rejected as fixture failures because their generic unit selection never reached the hanging shim; they made no product claim and no production-code change. The unique-unit retry supplied the missing anti-cheat evidence.
- Existing systemd process tests cover the underlying timeout and `SIGKILL` propagation to every relevant `systemctl` call.
- ClawSweeper correctly found that the first head dropped the previous explicit runtime failure record. The accepted repair now preserves that fact in the canonical shared service-state owner; focused coverage asserts both deep JSON and rendered text retain `Runtime: unknown (<reason>)`.
- Final accepted-finding Testbox `tbx_01kyzjzv7zwg4kdng599dg1s9a`, run https://github.com/openclaw/openclaw/actions/runs/30718802554: service tests passed 24/24, status tests passed 37 with one Darwin-only skip, and the complete changed gate passed. An earlier gate attempt caught only an oxlint shape in the new assertion; it was corrected without changing behavior.
- Exact-head hosted CI run https://github.com/openclaw/openclaw/actions/runs/30719106686 completed successfully, including `openclaw/ci-gate`. The first head's sole compact-shard failure was an unrelated non-isolated plugin mock; current-main run `30718629424` and the repaired exact-head rerun passed that same shard unchanged.
- Fresh final whole-branch Codex autoreview against `origin/main`: TruffleHog clean, zero findings, patch correct at 0.99 confidence (thread `019fbf37-2a70-7cb2-99e6-761fb4edebf4`).
- `git diff --check` passed. Production delta is `+14/-17` (net `-3`); tests are `+95/-5`.

Release-note context: Gateway status deadlines now include native service-manager inspection, preventing wedged `systemctl` calls from hanging JSON diagnostics.

AI-assisted: yes. The command entry point, canonical service-state owner, Linux adapter, sibling status path, tests, and current-main history were independently reviewed. No agent transcript is attached.
