### PR TITLE
fix(plugins): loading no longer crashes on malformed build metadata

### DIFF
--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { validatePluginConfig } from "./loader-shared.js";
+import type { PluginCandidate } from "./discovery.js";
+import { createManifestPluginRecord, validatePluginConfig } from "./loader-shared.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 
 const emptyObjectSchema = {
   type: "object",
@@ -10,6 +12,50 @@ const emptyObjectSchema = {
 function withSchemaKeyword(key: "if" | "then" | "else", value: unknown) {
   return { [key]: value };
 }
+
+const manifestRecord = {
+  id: "example",
+  channels: [],
+  providers: [],
+  cliBackends: [],
+  skills: [],
+  hooks: [],
+  origin: "global",
+  rootDir: "/plugins/example",
+  source: "/plugins/example/index.js",
+  manifestPath: "/plugins/example/openclaw.plugin.json",
+} satisfies PluginManifestRecord;
+
+function createRecordWithBuildVersion(openclawVersion: unknown) {
+  const candidate = {
+    idHint: "example",
+    source: manifestRecord.source,
+    rootDir: manifestRecord.rootDir,
+    origin: manifestRecord.origin,
+    packageManifest: {
+      build: { openclawVersion },
+    } as unknown as NonNullable<PluginCandidate["packageManifest"]>,
+  } satisfies PluginCandidate;
+
+  return createManifestPluginRecord({
+    candidate,
+    manifestRecord,
+    enabled: true,
+    activationState: {
+      enabled: true,
+      activated: true,
+      explicitlyEnabled: true,
+      source: "explicit",
+    },
+  });
+}
+
+describe("createManifestPluginRecord", () => {
+  it("ignores malformed package build version metadata", () => {
+    expect(createRecordWithBuildVersion(" 2026.7.2 ").builtWithOpenClawVersion).toBe("2026.7.2");
+    expect(createRecordWithBuildVersion(42).builtWithOpenClawVersion).toBeUndefined();
+  });
+});
 
 describe("validatePluginConfig empty schema classification", () => {
   it("validates pattern properties instead of requiring empty config", () => {

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { activateContextEngineRegistrations } from "../context-engine/registry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -285,7 +288,9 @@ export function createManifestPluginRecord(params: {
     description: manifestRecord.description,
     packageVersion: manifestRecord.packageVersion,
     version: manifestRecord.version,
-    builtWithOpenClawVersion: candidate.packageManifest?.build?.openclawVersion?.trim(),
+    builtWithOpenClawVersion: normalizeOptionalString(
+      candidate.packageManifest?.build?.openclawVersion,
+    ),
     packageName: manifestRecord.packageName,
     format: manifestRecord.format,
     bundleFormat: manifestRecord.bundleFormat,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin loading could crash when a plugin package contained a non-string `openclaw.build.openclawVersion` value.

## Why This Change Was Made

Manifest-backed plugin records now read build provenance through the canonical optional-string normalizer. Valid strings remain trimmed, while empty or malformed values are treated as absent. The shared record builder covers both runtime and CLI plugin loaders without changing the documented package metadata contract.

## User Impact

Malformed third-party plugin build metadata no longer aborts plugin registry construction. The affected metadata is ignored and normal plugin diagnostics can continue.

## Evidence

- Before the fix, a numeric build version reproduces `TypeError: ...openclawVersion?.trim is not a function`.
- Added a focused regression test covering trimmed valid metadata and a malformed numeric value.
- Canonical normalizer proof passes for both cases.
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/loader-shared.ts src/plugins/loader-shared.test.ts`
- `git diff --check upstream/main...HEAD`
- `node scripts/docs-list.js`
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- Focused Vitest was attempted with one worker, but the local macOS runner stalled during startup and ended with `ECANCELED` after the no-output watchdog. The added regression remains for CI execution; no full local suite was run.

### Real loader proof

Executed against the CI-built [`dist-runtime-build` artifact](https://github.com/openclaw/openclaw/actions/runs/30718731055) for exact PR head `6bf72ad9a239155315c11f56dd64f2a4ec5f76cf` (artifact digest `sha256:46323ad6dadd7be00082ba71b0c7a68e39ead4ecd418a83541f6b3e298ece60e`). `$PROOF_ROOT` below is an isolated temporary directory; paths are redacted.

The on-disk plugin fixture contained malformed numeric build provenance:

```console
$ jq '{openclawBuild: .openclaw.build}' "$PROOF_ROOT/fixture/package.json"
{
  "openclawBuild": {
    "openclawVersion": 42
  }
}
```

The CLI metadata loader completed normally and omitted the malformed provenance:

```console
$ env OPENCLAW_STATE_DIR="$PROOF_ROOT/state" OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 JITI_FS_CACHE=false node "$PROOF_ROOT/runtime/dist/entry.js" plugins inspect malformed-build-proof --json | jq '{plugin: {id: .plugin.id, status: .plugin.status, imported: .plugin.imported, builtWithOpenClawVersionPresent: (.plugin | has("builtWithOpenClawVersion"))}, diagnostics}'
{
  "plugin": {
    "id": "malformed-build-proof",
    "status": "loaded",
    "imported": false,
    "builtWithOpenClawVersionPresent": false
  },
  "diagnostics": []
}
```

The runtime loader also imported the plugin and completed normally:

```console
$ env OPENCLAW_STATE_DIR="$PROOF_ROOT/state" OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 JITI_FS_CACHE=false node "$PROOF_ROOT/runtime/dist/entry.js" plugins inspect malformed-build-proof --runtime --json | jq '{plugin: {id: .plugin.id, status: .plugin.status, imported: .plugin.imported, builtWithOpenClawVersionPresent: (.plugin | has("builtWithOpenClawVersion"))}, diagnostics}'
{
  "plugin": {
    "id": "malformed-build-proof",
    "status": "loaded",
    "imported": true,
    "builtWithOpenClawVersionPresent": false
  },
  "diagnostics": []
}
```

Both commands exited `0`. This exercises the public `plugins inspect` command through both loader modes: the malformed metadata no longer crashes registry construction, and the plugin reaches the normal loaded state.

## AI Assistance

AI-assisted with Codex. I reviewed the implementation and understand the change.
