### PR TITLE
fix(gateway): active turns are interrupted on SIGTERM

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -531,7 +531,7 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("drains active work without a timeout before closing on SIGTERM", async () => {
+  it("drains active work before the SIGTERM shutdown deadline", async () => {
     vi.clearAllMocks();
     getActiveTaskCount.mockReturnValueOnce(1);
     getActiveEmbeddedRunCount.mockReturnValueOnce(1);
@@ -574,9 +574,10 @@ describe("runGatewayLoop", () => {
         );
 
         expect(markGatewayDraining).toHaveBeenCalledOnce();
-        expect(waitForActiveTasks).toHaveBeenCalledWith(undefined);
-        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
-        expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(undefined);
+        expect(waitForActiveTasks).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
+        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(15_000);
         expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
         expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
         expect(close).not.toHaveBeenCalled();
@@ -596,6 +597,49 @@ describe("runGatewayLoop", () => {
         releaseRuns?.();
         releaseRoot?.();
         await exited;
+        waitForActiveTasks.mockReset();
+        waitForActiveTasks.mockResolvedValue({ drained: true });
+        waitForActiveEmbeddedRuns.mockReset();
+        waitForActiveEmbeddedRuns.mockResolvedValue({ drained: true });
+        waitForActiveGatewayRootWork.mockReset();
+        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
+      }
+    });
+  });
+
+  it("continues SIGTERM shutdown when the active-work drain deadline expires", async () => {
+    vi.clearAllMocks();
+    getActiveTaskCount.mockReturnValueOnce(1);
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1);
+    waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+    waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: false });
+    waitForActiveGatewayRootWork.mockResolvedValueOnce({ drained: false, active: 2 });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime, exited } = await createSignaledLoopHarness();
+
+      try {
+        captureSignal("SIGTERM")();
+
+        await expect(exited).resolves.toBe(0);
+        expect(waitForActiveTasks).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
+        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(15_000);
+        expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
+        expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
+        expect(gatewayLog.warn).toHaveBeenCalledWith(
+          "drain timeout reached; proceeding with shutdown",
+        );
+        expect(gatewayLog.warn).toHaveBeenCalledWith(
+          "gateway root transaction drain timeout reached with 2 root(s) still active; proceeding with shutdown",
+        );
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway stopping",
+          restartExpectedMs: null,
+        });
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+      } finally {
         waitForActiveTasks.mockReset();
         waitForActiveTasks.mockResolvedValue({ drained: true });
         waitForActiveEmbeddedRuns.mockReset();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -531,9 +531,82 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it.each(["SIGTERM", "SIGINT"] as const)(
-    "drains admitted root work before closing on %s",
-    async (signal) => {
+  it("drains active work without a timeout before closing on SIGTERM", async () => {
+    vi.clearAllMocks();
+    getActiveTaskCount.mockReturnValueOnce(1);
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1);
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime, exited } = await createSignaledLoopHarness();
+      let releaseTasks: (() => void) | undefined;
+      let releaseRuns: (() => void) | undefined;
+      let releaseRoot: (() => void) | undefined;
+      const pendingTasks = new Promise<void>((resolve) => {
+        releaseTasks = resolve;
+      });
+      const pendingRuns = new Promise<void>((resolve) => {
+        releaseRuns = resolve;
+      });
+      const pendingRoot = new Promise<void>((resolve) => {
+        releaseRoot = resolve;
+      });
+      waitForActiveTasks.mockImplementationOnce(async () => {
+        await pendingTasks;
+        return { drained: true };
+      });
+      waitForActiveEmbeddedRuns.mockImplementationOnce(async () => {
+        await pendingRuns;
+        return { drained: true };
+      });
+      waitForActiveGatewayRootWork.mockImplementationOnce(async () => {
+        await pendingRoot;
+        return { drained: true, active: 0 };
+      });
+
+      try {
+        captureSignal("SIGTERM")();
+        await waitForLoopCondition(
+          () =>
+            waitForActiveTasks.mock.calls.length === 1 &&
+            waitForActiveEmbeddedRuns.mock.calls.length === 1 &&
+            waitForActiveGatewayRootWork.mock.calls.length === 1,
+          "expected SIGTERM to begin draining active gateway work",
+        );
+
+        expect(markGatewayDraining).toHaveBeenCalledOnce();
+        expect(waitForActiveTasks).toHaveBeenCalledWith(undefined);
+        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
+        expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(undefined);
+        expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
+        expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
+        expect(close).not.toHaveBeenCalled();
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        releaseTasks?.();
+        releaseRuns?.();
+        releaseRoot?.();
+
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway stopping",
+          restartExpectedMs: null,
+        });
+      } finally {
+        releaseTasks?.();
+        releaseRuns?.();
+        releaseRoot?.();
+        await exited;
+        waitForActiveTasks.mockReset();
+        waitForActiveTasks.mockResolvedValue({ drained: true });
+        waitForActiveEmbeddedRuns.mockReset();
+        waitForActiveEmbeddedRuns.mockResolvedValue({ drained: true });
+        waitForActiveGatewayRootWork.mockReset();
+        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
+      }
+    });
+  });
+
+  it("drains admitted root work before closing on SIGINT", async () => {
       vi.clearAllMocks();
 
       await withIsolatedSignals(async ({ captureSignal }) => {
@@ -548,10 +621,10 @@ describe("runGatewayLoop", () => {
         });
 
         try {
-          captureSignal(signal)();
+          captureSignal("SIGINT")();
           await waitForLoopCondition(
             () => waitForActiveGatewayRootWork.mock.calls.length === 1,
-            `expected ${signal} to drain admitted gateway root work`,
+            "expected SIGINT to drain admitted gateway root work",
           );
 
           expect(markGatewayDraining).toHaveBeenCalledOnce();
@@ -576,8 +649,7 @@ describe("runGatewayLoop", () => {
           waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
         }
       });
-    },
-  );
+  });
 
   it("continues direct shutdown when the bounded root-work drain times out", async () => {
     vi.clearAllMocks();
@@ -587,7 +659,7 @@ describe("runGatewayLoop", () => {
       const { close, runtime, exited } = await createSignaledLoopHarness();
 
       try {
-        captureSignal("SIGTERM")();
+        captureSignal("SIGINT")();
 
         await expect(exited).resolves.toBe(0);
         expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
@@ -614,7 +686,7 @@ describe("runGatewayLoop", () => {
       const { close, runtime, exited } = await createSignaledLoopHarness();
 
       try {
-        captureSignal("SIGTERM")();
+        captureSignal("SIGINT")();
 
         await expect(exited).resolves.toBe(0);
         expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -607,48 +607,48 @@ describe("runGatewayLoop", () => {
   });
 
   it("drains admitted root work before closing on SIGINT", async () => {
-      vi.clearAllMocks();
+    vi.clearAllMocks();
 
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        const { close, runtime, exited } = await createSignaledLoopHarness();
-        let releaseDrain: (() => void) | undefined;
-        const pendingDrain = new Promise<void>((resolve) => {
-          releaseDrain = resolve;
-        });
-        waitForActiveGatewayRootWork.mockImplementationOnce(async () => {
-          await pendingDrain;
-          return { drained: true, active: 0 };
-        });
-
-        try {
-          captureSignal("SIGINT")();
-          await waitForLoopCondition(
-            () => waitForActiveGatewayRootWork.mock.calls.length === 1,
-            "expected SIGINT to drain admitted gateway root work",
-          );
-
-          expect(markGatewayDraining).toHaveBeenCalledOnce();
-          expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
-            waitForActiveGatewayRootWork.mock.invocationCallOrder[0] ?? 0,
-          );
-          expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
-          expect(close).not.toHaveBeenCalled();
-          expect(runtime.exit).not.toHaveBeenCalled();
-
-          releaseDrain?.();
-
-          await expect(exited).resolves.toBe(0);
-          expect(close).toHaveBeenCalledWith({
-            reason: "gateway stopping",
-            restartExpectedMs: null,
-          });
-        } finally {
-          releaseDrain?.();
-          await exited;
-          waitForActiveGatewayRootWork.mockReset();
-          waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
-        }
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime, exited } = await createSignaledLoopHarness();
+      let releaseDrain: (() => void) | undefined;
+      const pendingDrain = new Promise<void>((resolve) => {
+        releaseDrain = resolve;
       });
+      waitForActiveGatewayRootWork.mockImplementationOnce(async () => {
+        await pendingDrain;
+        return { drained: true, active: 0 };
+      });
+
+      try {
+        captureSignal("SIGINT")();
+        await waitForLoopCondition(
+          () => waitForActiveGatewayRootWork.mock.calls.length === 1,
+          "expected SIGINT to drain admitted gateway root work",
+        );
+
+        expect(markGatewayDraining).toHaveBeenCalledOnce();
+        expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
+          waitForActiveGatewayRootWork.mock.invocationCallOrder[0] ?? 0,
+        );
+        expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
+        expect(close).not.toHaveBeenCalled();
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        releaseDrain?.();
+
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway stopping",
+          restartExpectedMs: null,
+        });
+      } finally {
+        releaseDrain?.();
+        await exited;
+        waitForActiveGatewayRootWork.mockReset();
+        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
+      }
+    });
   });
 
   it("continues direct shutdown when the bounded root-work drain times out", async () => {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -574,10 +574,10 @@ describe("runGatewayLoop", () => {
         );
 
         expect(markGatewayDraining).toHaveBeenCalledOnce();
-        expect(waitForActiveTasks).toHaveBeenCalledWith(15_000);
-        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveTasks).toHaveBeenCalledWith(50_000);
+        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(50_000);
         expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
-        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(15_000);
+        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(50_000);
         expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
         expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
         expect(close).not.toHaveBeenCalled();
@@ -622,10 +622,10 @@ describe("runGatewayLoop", () => {
         captureSignal("SIGTERM")();
 
         await expect(exited).resolves.toBe(0);
-        expect(waitForActiveTasks).toHaveBeenCalledWith(15_000);
-        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(15_000);
+        expect(waitForActiveTasks).toHaveBeenCalledWith(50_000);
+        expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(50_000);
         expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
-        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(15_000);
+        expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(50_000);
         expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
         expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
         expect(gatewayLog.warn).toHaveBeenCalledWith(

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -453,10 +453,9 @@ export async function runGatewayLoop(params: {
 
   const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
-  const STOP_ACTIVE_WORK_DRAIN_TIMEOUT_MS = Math.max(
-    0,
-    SHUTDOWN_TIMEOUT_MS - CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS,
-  );
+  const SIGTERM_SHUTDOWN_TIMEOUT_MS = 60_000;
+  const STOP_ACTIVE_WORK_DRAIN_TIMEOUT_MS =
+    SIGTERM_SHUTDOWN_TIMEOUT_MS - CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS;
   const clearPendingStartupForceExitTimer = () => {
     if (!pendingStartupForceExitTimer) {
       return;
@@ -568,7 +567,7 @@ export async function runGatewayLoop(params: {
           ? Date.now() + activeWorkDrainTimeoutMs
           : undefined;
       if (!isRestart) {
-        armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+        armForceExitTimer(isGracefulStop ? SIGTERM_SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS);
       } else if (activeWorkDrainTimeoutMs !== undefined) {
         // Allow extra time for draining active turns on explicitly capped restarts.
         armForceExitTimer(activeWorkDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -31,7 +31,7 @@ const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
 const DEFAULT_RESTART_DRAIN_TIMEOUT_MS = 300_000;
 const RESTART_DRAIN_STILL_PENDING_WARN_MS = 30_000;
-const RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
+const CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 const LOG_FLUSH_EXIT_TIMEOUT_MS = 4_000;
@@ -453,6 +453,10 @@ export async function runGatewayLoop(params: {
 
   const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
+  const STOP_ACTIVE_WORK_DRAIN_TIMEOUT_MS = Math.max(
+    0,
+    SHUTDOWN_TIMEOUT_MS - CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS,
+  );
   const clearPendingStartupForceExitTimer = () => {
     if (!pendingStartupForceExitTimer) {
       return;
@@ -557,13 +561,13 @@ export async function runGatewayLoop(params: {
       const activeWorkDrainTimeoutMs = isRestart
         ? await resolveRestartDrainTimeoutMs(restartIntent)
         : isGracefulStop
-          ? undefined
+          ? STOP_ACTIVE_WORK_DRAIN_TIMEOUT_MS
           : 0;
       const activeWorkDrainDeadlineAt =
         shouldDrainActiveWork && activeWorkDrainTimeoutMs !== undefined
           ? Date.now() + activeWorkDrainTimeoutMs
           : undefined;
-      if (!shouldDrainActiveWork) {
+      if (!isRestart) {
         armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
       } else if (activeWorkDrainTimeoutMs !== undefined) {
         // Allow extra time for draining active turns on explicitly capped restarts.
@@ -574,8 +578,8 @@ export async function runGatewayLoop(params: {
         activeWorkDrainTimeoutMs === undefined
           ? "without a timeout"
           : `with timeout ${activeWorkDrainTimeoutMs}ms`;
-      const armCloseForceExitTimerAfterUnboundedDrain = () => {
-        if (shouldDrainActiveWork && activeWorkDrainTimeoutMs === undefined) {
+      const armCloseForceExitTimerForIndefiniteRestart = () => {
+        if (isRestart && activeWorkDrainTimeoutMs === undefined) {
           armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
         }
       };
@@ -584,7 +588,7 @@ export async function runGatewayLoop(params: {
           return null;
         }
         if (activeWorkDrainTimeoutMs === undefined) {
-          return Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
+          return Math.max(0, SHUTDOWN_TIMEOUT_MS - CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
         }
         return Math.max(0, (activeWorkDrainDeadlineAt ?? Date.now()) - Date.now());
       };
@@ -776,7 +780,7 @@ export async function runGatewayLoop(params: {
           // reserve that server teardown and the supervisor watchdog need.
           try {
             const rootDrain = await eagerLifecycleRuntime.waitForActiveGatewayRootWork(
-              Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
+              Math.max(0, SHUTDOWN_TIMEOUT_MS - CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
             );
             if (!rootDrain.drained) {
               gatewayLog.warn(
@@ -790,7 +794,7 @@ export async function runGatewayLoop(params: {
           }
         }
 
-        armCloseForceExitTimerAfterUnboundedDrain();
+        armCloseForceExitTimerForIndefiniteRestart();
         const closeDrainTimeoutMs = resolveRestartCloseDrainTimeoutMs();
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -677,9 +677,10 @@ export async function runGatewayLoop(params: {
                 activeWorkDrainDeadlineAt === undefined
                   ? undefined
                   : Math.max(0, activeWorkDrainDeadlineAt - Date.now());
-              const rootDrainPromise = isRestart && restartIntent?.force
-                ? Promise.resolve({ drained: true, active: 0 })
-                : waitForActiveGatewayRootWork(rootDrainTimeoutMs);
+              const rootDrainPromise =
+                isRestart && restartIntent?.force
+                  ? Promise.resolve({ drained: true, active: 0 })
+                  : waitForActiveGatewayRootWork(rootDrainTimeoutMs);
               const activeTasks = getActiveTaskCount();
               const activeRuns = getActiveEmbeddedRunCount();
               activeTasksAtDrainStart = activeTasks;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -510,6 +510,8 @@ export async function runGatewayLoop(params: {
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
     const { action, restartIntent } = acceptedRequest;
     const isRestart = action === "restart";
+    const isGracefulStop = action === "stop" && acceptedRequest.signal === "SIGTERM";
+    const shouldDrainActiveWork = isRestart || isGracefulStop;
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
     }
@@ -552,26 +554,28 @@ export async function runGatewayLoop(params: {
     }
 
     void (async () => {
-      const restartDrainTimeoutMs = isRestart
+      const activeWorkDrainTimeoutMs = isRestart
         ? await resolveRestartDrainTimeoutMs(restartIntent)
-        : 0;
-      const restartDrainDeadlineAt =
-        isRestart && restartDrainTimeoutMs !== undefined
-          ? Date.now() + restartDrainTimeoutMs
+        : isGracefulStop
+          ? undefined
+          : 0;
+      const activeWorkDrainDeadlineAt =
+        shouldDrainActiveWork && activeWorkDrainTimeoutMs !== undefined
+          ? Date.now() + activeWorkDrainTimeoutMs
           : undefined;
-      if (!isRestart) {
+      if (!shouldDrainActiveWork) {
         armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
-      } else if (restartDrainTimeoutMs !== undefined) {
+      } else if (activeWorkDrainTimeoutMs !== undefined) {
         // Allow extra time for draining active turns on explicitly capped restarts.
-        armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
+        armForceExitTimer(activeWorkDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
       }
 
-      const formatRestartDrainBudget = () =>
-        restartDrainTimeoutMs === undefined
+      const formatDrainBudget = () =>
+        activeWorkDrainTimeoutMs === undefined
           ? "without a timeout"
-          : `with timeout ${restartDrainTimeoutMs}ms`;
-      const armCloseForceExitTimerForIndefiniteRestart = () => {
-        if (isRestart && restartDrainTimeoutMs === undefined) {
+          : `with timeout ${activeWorkDrainTimeoutMs}ms`;
+      const armCloseForceExitTimerAfterUnboundedDrain = () => {
+        if (shouldDrainActiveWork && activeWorkDrainTimeoutMs === undefined) {
           armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
         }
       };
@@ -579,21 +583,21 @@ export async function runGatewayLoop(params: {
         if (!isRestart) {
           return null;
         }
-        if (restartDrainTimeoutMs === undefined) {
+        if (activeWorkDrainTimeoutMs === undefined) {
           return Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
         }
-        return Math.max(0, (restartDrainDeadlineAt ?? Date.now()) - Date.now());
+        return Math.max(0, (activeWorkDrainDeadlineAt ?? Date.now()) - Date.now());
       };
 
       try {
-        // On restart, wait for in-flight agent turns to finish before
-        // tearing down the server so buffered messages are delivered.
-        if (isRestart) {
+        // SIGTERM is a graceful stop request. Fence new work, then let in-flight
+        // turns and their delivery finish before tearing down the server.
+        if (shouldDrainActiveWork) {
           let activeTasksAtDrainStart = 0;
           let activeRunsAtDrainStart = 0;
           let drainTimedOut = false;
           await measureGatewayRestartTrace(
-            "restart.drain",
+            isRestart ? "restart.drain" : "stop.drain",
             async () => {
               const {
                 abortEmbeddedAgentRun,
@@ -662,7 +666,7 @@ export async function runGatewayLoop(params: {
               const createStillPendingDrainLogger = () =>
                 setInterval(() => {
                   gatewayLog.warn(
-                    `still draining ${getActiveTaskCount()} active task(s) and ${getActiveEmbeddedRunCount()} active embedded run(s) before restart`,
+                    `still draining ${getActiveTaskCount()} active task(s) and ${getActiveEmbeddedRunCount()} active embedded run(s) before ${isRestart ? "restart" : "shutdown"}`,
                   );
                 }, RESTART_DRAIN_STILL_PENDING_WARN_MS);
 
@@ -670,10 +674,10 @@ export async function runGatewayLoop(params: {
               // sessions get an explicit restart error instead of silent task loss.
               markRestartDraining();
               const rootDrainTimeoutMs =
-                restartDrainDeadlineAt === undefined
+                activeWorkDrainDeadlineAt === undefined
                   ? undefined
-                  : Math.max(0, restartDrainDeadlineAt - Date.now());
-              const rootDrainPromise = restartIntent?.force
+                  : Math.max(0, activeWorkDrainDeadlineAt - Date.now());
+              const rootDrainPromise = isRestart && restartIntent?.force
                 ? Promise.resolve({ drained: true, active: 0 })
                 : waitForActiveGatewayRootWork(rootDrainTimeoutMs);
               const activeTasks = getActiveTaskCount();
@@ -685,7 +689,7 @@ export async function runGatewayLoop(params: {
 
               // Best-effort abort for compacting runs so long compaction operations
               // don't hold session write locks across restart boundaries.
-              if (activeRuns > 0) {
+              if (isRestart && activeRuns > 0) {
                 await markActiveMainSessionsForRestart("gateway restart drain");
                 abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" });
               }
@@ -693,14 +697,14 @@ export async function runGatewayLoop(params: {
               if (activeTasks > 0 || activeRuns > 0) {
                 const taskBlockers = formatTaskBlockers();
                 gatewayLog.info(
-                  `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart ${formatRestartDrainBudget()}`,
+                  `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before ${isRestart ? "restart" : "shutdown"} ${formatDrainBudget()}`,
                 );
                 if (taskBlockers) {
                   gatewayLog.warn(
-                    `restart blocked by active background task run(s): ${taskBlockers}`,
+                    `${isRestart ? "restart" : "shutdown"} blocked by active background task run(s): ${taskBlockers}`,
                   );
                 }
-                if (restartIntent?.force) {
+                if (isRestart && restartIntent?.force) {
                   gatewayLog.warn("forced restart requested; skipping active work drain");
                   await markActiveMainSessionsForRestart(
                     restartIntent.reason ?? "forced gateway restart",
@@ -714,13 +718,13 @@ export async function runGatewayLoop(params: {
                   try {
                     const tasksDrainPromise =
                       activeTasks > 0
-                        ? waitForActiveTasks(restartDrainTimeoutMs)
+                        ? waitForActiveTasks(activeWorkDrainTimeoutMs)
                         : Promise.resolve({ drained: true });
                     runsDrain =
                       activeRuns > 0
-                        ? await waitForActiveEmbeddedRuns(restartDrainTimeoutMs)
+                        ? await waitForActiveEmbeddedRuns(activeWorkDrainTimeoutMs)
                         : { drained: true };
-                    if (!runsDrain.drained && activeRuns > 0) {
+                    if (isRestart && !runsDrain.drained && activeRuns > 0) {
                       gatewayLog.warn(
                         "active embedded run drain timeout reached; aborting active run(s) before restart",
                       );
@@ -735,12 +739,16 @@ export async function runGatewayLoop(params: {
                     gatewayLog.info("all active work drained");
                   } else {
                     drainTimedOut = true;
-                    gatewayLog.warn("drain timeout reached; proceeding with restart");
-                    await markActiveMainSessionsForRestart("gateway restart drain timeout");
-                    // Final best-effort abort to avoid carrying active runs into the
-                    // next lifecycle when drain time budget is exhausted.
-                    if (!abortedAfterRunTimeout) {
-                      abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
+                    gatewayLog.warn(
+                      `drain timeout reached; proceeding with ${isRestart ? "restart" : "shutdown"}`,
+                    );
+                    if (isRestart) {
+                      await markActiveMainSessionsForRestart("gateway restart drain timeout");
+                      // Final best-effort abort to avoid carrying active runs into the
+                      // next lifecycle when drain time budget is exhausted.
+                      if (!abortedAfterRunTimeout) {
+                        abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
+                      }
                     }
                   }
                 }
@@ -749,7 +757,7 @@ export async function runGatewayLoop(params: {
               if (!rootDrain.drained) {
                 drainTimedOut = true;
                 gatewayLog.warn(
-                  `gateway root transaction drain timeout reached with ${rootDrain.active} root(s) still active; proceeding with restart`,
+                  `gateway root transaction drain timeout reached with ${rootDrain.active} root(s) still active; proceeding with ${isRestart ? "restart" : "shutdown"}`,
                 );
               }
             },
@@ -762,7 +770,7 @@ export async function runGatewayLoop(params: {
           );
         }
 
-        if (!isRestart) {
+        if (!shouldDrainActiveWork) {
           // Keep reset-started finalizers alive without spending the shutdown
           // reserve that server teardown and the supervisor watchdog need.
           try {
@@ -781,7 +789,7 @@ export async function runGatewayLoop(params: {
           }
         }
 
-        armCloseForceExitTimerForIndefiniteRestart();
+        armCloseForceExitTimerAfterUnboundedDrain();
         const closeDrainTimeoutMs = resolveRestartCloseDrainTimeoutMs();
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -18,6 +18,7 @@ const WAIT_OPTIONS = { timeout: 10_000, interval: 25 } as const;
 type AgentEventPayload = {
   runId?: string;
   state?: string;
+  [key: string]: unknown;
 };
 
 type DelayedModelServer = {
@@ -82,11 +83,19 @@ describe("Gateway agent shutdown", () => {
           idempotencyKey: runId,
         });
         expect(started).toMatchObject({ runId, status: "accepted" });
-        await waitForProofStep(
-          modelServer.requestStarted,
+        const providerStart = await waitForProofStep(
+          Promise.race([
+            modelServer.requestStarted.then(() => ({ kind: "request" as const })),
+            finalEvent.then((payload) => ({ kind: "final" as const, payload })),
+          ]),
           30_000,
           () => `model request did not start\n${instance.logs()}`,
         );
+        if (providerStart.kind === "final") {
+          throw new Error(
+            `agent finished before the model request started: ${JSON.stringify(providerStart.payload)}\n${instance.logs()}`,
+          );
+        }
 
         const child = instance.child;
         if (!child) {

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -1,0 +1,275 @@
+// E2E: a real Gateway process must finish an active agent turn before SIGTERM exit.
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const MODEL_REF = "sigterm-drain/sigterm-drain";
+const SESSION_KEY = "agent:main:main";
+const TEST_TIMEOUT_MS = 180_000;
+const WAIT_OPTIONS = { timeout: 10_000, interval: 25 } as const;
+
+type AgentEventPayload = {
+  runId?: string;
+  state?: string;
+};
+
+type DelayedModelServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+  releaseResponse: () => void;
+  requestStarted: Promise<void>;
+};
+
+const instances: OpenClawTestInstance[] = [];
+const modelServers: DelayedModelServer[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
+  await Promise.allSettled(modelServers.splice(0).map((server) => server.close()));
+});
+
+describe("Gateway agent shutdown", () => {
+  it(
+    "delivers an active turn before exiting after an operating-system SIGTERM",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startDelayedModelServer();
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "agent-sigterm-drain",
+        config: createTestConfig(modelServer.baseUrl),
+        env: { OPENCLAW_SKIP_PROVIDERS: undefined },
+        stopTimeoutMs: 30_000,
+      });
+      instances.push(instance);
+      await instance.startGateway();
+
+      const runId = randomUUID();
+      let resolveFinalEvent: ((payload: AgentEventPayload) => void) | undefined;
+      const finalEvent = new Promise<AgentEventPayload>((resolve) => {
+        resolveFinalEvent = resolve;
+      });
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        onEvent: (event) => {
+          if (event.event !== "agent" || !event.payload || typeof event.payload !== "object") {
+            return;
+          }
+          const payload = event.payload as AgentEventPayload;
+          if (payload.runId === runId && payload.state === "final") {
+            resolveFinalEvent?.(payload);
+          }
+        },
+      });
+
+      try {
+        const started = await client.request<{ runId?: string; status?: string }>("agent", {
+          sessionKey: SESSION_KEY,
+          message: "finish this turn during SIGTERM drain",
+          deliver: false,
+          idempotencyKey: runId,
+        });
+        expect(started).toMatchObject({ runId, status: "accepted" });
+        await modelServer.requestStarted;
+
+        const child = instance.child;
+        if (!child) {
+          throw new Error("Gateway process exited before SIGTERM proof started");
+        }
+        let exitedEarly = false;
+        const exited = once(child, "exit") as Promise<
+          [code: number | null, signal: NodeJS.Signals | null]
+        >;
+        void exited.then(() => {
+          exitedEarly = true;
+        });
+        expect(child.kill("SIGTERM")).toBe(true);
+
+        await vi.waitFor(() => {
+          expect(instance.logs()).toContain("before shutdown with timeout 15000ms");
+        }, WAIT_OPTIONS);
+        await new Promise<void>((resolve) => setTimeout(resolve, 250));
+        expect(exitedEarly, instance.logs()).toBe(false);
+
+        modelServer.releaseResponse();
+
+        await expect(finalEvent).resolves.toMatchObject({ runId, state: "final" });
+        await expect(exited).resolves.toEqual([0, null]);
+        expect(instance.logs()).toContain("all active work drained");
+      } finally {
+        modelServer.releaseResponse();
+        await disconnectGatewayClient(client).catch(() => undefined);
+      }
+    },
+  );
+});
+
+function createTestConfig(baseUrl: string): OpenClawConfig {
+  return {
+    plugins: { slots: { memory: "none" } },
+    agents: {
+      defaults: {
+        heartbeat: { every: "0m" },
+        model: { primary: MODEL_REF },
+        models: { [MODEL_REF]: { agentRuntime: { id: "openclaw" } } },
+        skipBootstrap: true,
+        skills: [],
+      },
+    },
+    tools: { profile: "minimal" },
+    models: {
+      mode: "replace",
+      providers: {
+        "sigterm-drain": {
+          baseUrl: `${baseUrl}/v1`,
+          apiKey: "test-token-placeholder",
+          api: "openai-responses",
+          request: { allowPrivateNetwork: true },
+          models: [
+            {
+              id: "sigterm-drain",
+              name: "sigterm-drain",
+              api: "openai-responses",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128_000,
+              maxTokens: 4_096,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+async function startDelayedModelServer(): Promise<DelayedModelServer> {
+  let markRequestStarted: (() => void) | undefined;
+  const requestStarted = new Promise<void>((resolve) => {
+    markRequestStarted = resolve;
+  });
+  let releaseResponse: (() => void) | undefined;
+  const responseReleased = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  const server = createServer((request, response) => {
+    void handleModelRequest(request, response, {
+      markRequestStarted: () => markRequestStarted?.(),
+      responseReleased,
+    }).catch((error) => {
+      if (response.headersSent) {
+        response.destroy(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: String(error) } }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("SIGTERM drain model server did not bind");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requestStarted,
+    releaseResponse: () => releaseResponse?.(),
+    close: async () => {
+      releaseResponse?.();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+async function handleModelRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  controls: { markRequestStarted: () => void; responseReleased: Promise<void> },
+): Promise<void> {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  if (request.method === "GET" && url.pathname === "/v1/models") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ data: [{ id: "sigterm-drain", object: "model" }] }));
+    return;
+  }
+  if (request.method !== "POST" || url.pathname !== "/v1/responses") {
+    response.writeHead(404).end();
+    return;
+  }
+  await drainRequest(request);
+  controls.markRequestStarted();
+  await controls.responseReleased;
+  writeModelResponse(response);
+}
+
+async function drainRequest(request: IncomingMessage): Promise<void> {
+  for await (const chunk of request) {
+    void chunk;
+  }
+}
+
+function writeModelResponse(response: ServerResponse): void {
+  const text = "SIGTERM drain completed";
+  const message = {
+    type: "message",
+    id: "sigterm-drain-message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  const events = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: "sigterm-drain-response",
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ];
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  response.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
+}

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -15,7 +15,7 @@ const SESSION_KEY = "agent:main:main";
 const TEST_TIMEOUT_MS = 180_000;
 const WAIT_OPTIONS = { timeout: 10_000, interval: 25 } as const;
 
-type AgentEventPayload = {
+type ChatEventPayload = {
   runId?: string;
   state?: string;
   [key: string]: unknown;
@@ -53,8 +53,8 @@ describe("Gateway agent shutdown", () => {
       await instance.startGateway();
 
       const runId = randomUUID();
-      let resolveFinalEvent: ((payload: AgentEventPayload) => void) | undefined;
-      const finalEvent = new Promise<AgentEventPayload>((resolve) => {
+      let resolveFinalEvent: ((payload: ChatEventPayload) => void) | undefined;
+      const finalEvent = new Promise<ChatEventPayload>((resolve) => {
         resolveFinalEvent = resolve;
       });
       const client = await connectGatewayClient({
@@ -63,10 +63,10 @@ describe("Gateway agent shutdown", () => {
         role: "operator",
         scopes: ["operator.admin", "operator.read", "operator.write"],
         onEvent: (event) => {
-          if (event.event !== "agent" || !event.payload || typeof event.payload !== "object") {
+          if (event.event !== "chat" || !event.payload || typeof event.payload !== "object") {
             return;
           }
-          const payload = event.payload as AgentEventPayload;
+          const payload = event.payload as ChatEventPayload;
           if (payload.runId === runId && payload.state === "final") {
             resolveFinalEvent?.(payload);
           }

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -109,7 +109,7 @@ describe("Gateway agent shutdown", () => {
         expect(child.kill("SIGTERM")).toBe(true);
 
         await vi.waitFor(() => {
-          expect(instance.logs()).toContain("before shutdown with timeout 15000ms");
+          expect(instance.logs()).toContain("before shutdown with timeout 50000ms");
         }, WAIT_OPTIONS);
         await new Promise<void>((resolve) => setTimeout(resolve, 250));
         expect(exitedEarly, instance.logs()).toBe(false);

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -45,6 +45,8 @@ describe("Gateway agent shutdown", () => {
       const instance = await createOpenClawTestInstance({
         name: "agent-sigterm-drain",
         config: createTestConfig(modelServer.baseUrl),
+        nodeExecutable: process.execPath,
+        entrypointArgs: ["--import", "tsx", "src/entry.ts"],
         env: { OPENCLAW_SKIP_PROVIDERS: undefined },
         stopTimeoutMs: 30_000,
       });

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -46,8 +46,6 @@ describe("Gateway agent shutdown", () => {
       const instance = await createOpenClawTestInstance({
         name: "agent-sigterm-drain",
         config: createTestConfig(modelServer.baseUrl),
-        nodeExecutable: process.execPath,
-        entrypointArgs: ["--import", "tsx", "src/entry.ts"],
         env: { OPENCLAW_SKIP_PROVIDERS: undefined },
         stopTimeoutMs: 30_000,
       });

--- a/test/gateway-agent-shutdown.e2e.test.ts
+++ b/test/gateway-agent-shutdown.e2e.test.ts
@@ -82,7 +82,11 @@ describe("Gateway agent shutdown", () => {
           idempotencyKey: runId,
         });
         expect(started).toMatchObject({ runId, status: "accepted" });
-        await modelServer.requestStarted;
+        await waitForProofStep(
+          modelServer.requestStarted,
+          30_000,
+          () => `model request did not start\n${instance.logs()}`,
+        );
 
         const child = instance.child;
         if (!child) {
@@ -105,8 +109,20 @@ describe("Gateway agent shutdown", () => {
 
         modelServer.releaseResponse();
 
-        await expect(finalEvent).resolves.toMatchObject({ runId, state: "final" });
-        await expect(exited).resolves.toEqual([0, null]);
+        await expect(
+          waitForProofStep(
+            finalEvent,
+            30_000,
+            () => `agent did not emit a final event after model completion\n${instance.logs()}`,
+          ),
+        ).resolves.toMatchObject({ runId, state: "final" });
+        await expect(
+          waitForProofStep(
+            exited,
+            30_000,
+            () => `gateway did not exit after its active turn completed\n${instance.logs()}`,
+          ),
+        ).resolves.toEqual([0, null]);
         expect(instance.logs()).toContain("all active work drained");
       } finally {
         modelServer.releaseResponse();
@@ -115,6 +131,26 @@ describe("Gateway agent shutdown", () => {
     },
   );
 });
+
+async function waitForProofStep<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: () => string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(timeoutMessage())), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 function createTestConfig(baseUrl: string): OpenClawConfig {
   return {

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -20,8 +20,6 @@ type OpenClawTestStateOptions = NonNullable<Parameters<typeof createOpenClawTest
 type OpenClawTestInstanceOptions = {
   name: string;
   cwd?: string;
-  nodeExecutable?: string;
-  entrypointArgs?: string[];
   port?: number;
   gatewayToken?: string;
   hookToken?: string;
@@ -327,11 +325,6 @@ export async function createOpenClawTestInstance(
   options: OpenClawTestInstanceOptions,
 ): Promise<OpenClawTestInstance> {
   const cwd = options.cwd ?? process.cwd();
-  const nodeExecutable = options.nodeExecutable ?? "node";
-  const resolveEntrypoint = () =>
-    options.entrypointArgs
-      ? Promise.resolve(options.entrypointArgs)
-      : resolveGatewayEntrypoint(cwd);
   const port = options.port ?? (await getFreePort());
   const gatewayToken = options.gatewayToken ?? `gateway-${options.name}-${randomUUID()}`;
   const hookToken = options.hookToken ?? `token-${options.name}-${randomUUID()}`;
@@ -381,11 +374,11 @@ export async function createOpenClawTestInstance(
       return child;
     },
     env,
-    entrypoint: resolveEntrypoint,
+    entrypoint: () => resolveGatewayEntrypoint(cwd),
     cli: async (args, commandOptions = {}) => {
-      const entrypoint = await resolveEntrypoint();
+      const entrypoint = await resolveGatewayEntrypoint(cwd);
       return await runCommand({
-        args: [nodeExecutable, ...entrypoint, ...args],
+        args: ["node", ...entrypoint, ...args],
         cwd,
         env,
         timeoutMs: commandOptions.timeoutMs ?? COMMAND_TIMEOUT_MS,
@@ -395,9 +388,9 @@ export async function createOpenClawTestInstance(
       if (child && !hasChildExited(child) && !child.killed) {
         return;
       }
-      const entrypoint = await resolveEntrypoint();
+      const entrypoint = await resolveGatewayEntrypoint(cwd);
       child = spawn(
-        nodeExecutable,
+        "node",
         [
           ...entrypoint,
           "gateway",

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -20,6 +20,8 @@ type OpenClawTestStateOptions = NonNullable<Parameters<typeof createOpenClawTest
 type OpenClawTestInstanceOptions = {
   name: string;
   cwd?: string;
+  nodeExecutable?: string;
+  entrypointArgs?: string[];
   port?: number;
   gatewayToken?: string;
   hookToken?: string;
@@ -325,6 +327,9 @@ export async function createOpenClawTestInstance(
   options: OpenClawTestInstanceOptions,
 ): Promise<OpenClawTestInstance> {
   const cwd = options.cwd ?? process.cwd();
+  const nodeExecutable = options.nodeExecutable ?? "node";
+  const resolveEntrypoint = () =>
+    options.entrypointArgs ? Promise.resolve(options.entrypointArgs) : resolveGatewayEntrypoint(cwd);
   const port = options.port ?? (await getFreePort());
   const gatewayToken = options.gatewayToken ?? `gateway-${options.name}-${randomUUID()}`;
   const hookToken = options.hookToken ?? `token-${options.name}-${randomUUID()}`;
@@ -374,11 +379,11 @@ export async function createOpenClawTestInstance(
       return child;
     },
     env,
-    entrypoint: () => resolveGatewayEntrypoint(cwd),
+    entrypoint: resolveEntrypoint,
     cli: async (args, commandOptions = {}) => {
-      const entrypoint = await resolveGatewayEntrypoint(cwd);
+      const entrypoint = await resolveEntrypoint();
       return await runCommand({
-        args: ["node", ...entrypoint, ...args],
+        args: [nodeExecutable, ...entrypoint, ...args],
         cwd,
         env,
         timeoutMs: commandOptions.timeoutMs ?? COMMAND_TIMEOUT_MS,
@@ -388,9 +393,9 @@ export async function createOpenClawTestInstance(
       if (child && !hasChildExited(child) && !child.killed) {
         return;
       }
-      const entrypoint = await resolveGatewayEntrypoint(cwd);
+      const entrypoint = await resolveEntrypoint();
       child = spawn(
-        "node",
+        nodeExecutable,
         [
           ...entrypoint,
           "gateway",

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -329,7 +329,9 @@ export async function createOpenClawTestInstance(
   const cwd = options.cwd ?? process.cwd();
   const nodeExecutable = options.nodeExecutable ?? "node";
   const resolveEntrypoint = () =>
-    options.entrypointArgs ? Promise.resolve(options.entrypointArgs) : resolveGatewayEntrypoint(cwd);
+    options.entrypointArgs
+      ? Promise.resolve(options.entrypointArgs)
+      : resolveGatewayEntrypoint(cwd);
   const port = options.port ?? (await getFreePort());
   const gatewayToken = options.gatewayToken ?? `gateway-${options.name}-${randomUUID()}`;
   const hookToken = options.hookToken ?? `token-${options.name}-${randomUUID()}`;


### PR DESCRIPTION
## What Problem This Solves

A process supervisor sends SIGTERM when it replaces or stops a gateway process. OpenClaw previously entered normal teardown immediately, so an in-progress agent turn could be cut off before its model response and terminal chat event completed.

## Why This Change Was Made

SIGTERM now enters the admission fence and active-work drain used by planned restarts before server teardown. It waits for active tasks, embedded runs, and admitted root continuations for up to 50 seconds. The total SIGTERM watchdog is 60 seconds, leaving a 10-second reserve for server teardown after active-work draining.

The change does not alter interactive SIGINT semantics. Restart-only behavior, including forced aborts and restart-recovery markers, remains limited to actual restart requests; a SIGTERM timeout proceeds with ordinary shutdown instead of converting the turn into restart recovery.

## User Impact

An in-flight turn can finish and deliver its terminal chat event when a supervisor sends SIGTERM. New work is rejected once draining begins. If active work does not finish within 50 seconds, shutdown continues so the process still respects its bounded 60-second termination contract.

## Evidence

AI-assisted: yes. I understand the drain, timeout, and shutdown paths changed here.

| Validation | Result |
| --- | --- |
| Real gateway child, delayed local OpenAI Responses server, operating-system SIGTERM during the model request | Passed before the budget-only adjustment: the process remained alive, returned the model response, emitted the final chat event, logged all active work drained, and exited with code 0 |
| Current-head focused unit suite: node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts | 55 tests passed |
| oxfmt on all changed TypeScript files and git diff --check | Passed |

The focused unit cases cover the 50-second SIGTERM active-work deadline, 60-second total watchdog, timeout fallthrough, no restart-specific abort or recovery on SIGTERM, unchanged SIGINT handling, and existing restart behavior.