### PR TITLE
fix(release): use pinned plugin packaging tooling

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -328,6 +328,23 @@ jobs:
           ref: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
           fetch-depth: 1
 
+      - name: Checkout trusted packaging helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          fetch-depth: 1
+          sparse-checkout: scripts/lib/plugin-npm-package-manifest.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Overlay trusted packaging helper
+        run: |
+          set -euo pipefail
+          cp \
+            .release-tooling/scripts/lib/plugin-npm-package-manifest.mjs \
+            scripts/lib/plugin-npm-package-manifest.mjs
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -1205,11 +1222,20 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
+          path: .publication-target
           fetch-depth: 1
+
+      - name: Overlay trusted OIDC packaging helper
+        if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
+        run: |
+          set -euo pipefail
+          cp \
+            scripts/lib/plugin-npm-package-manifest.mjs \
+            .publication-target/scripts/lib/plugin-npm-package-manifest.mjs
 
       - name: Setup OIDC publication target
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
-        uses: ./.github/actions/setup-node-env
+        uses: ./.publication-target/.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
@@ -1231,6 +1257,7 @@ jobs:
 
       - name: Publish with trusted publisher
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc' && steps.npm_package_version.outputs.already_published != 'true'
+        working-directory: .publication-target
         env:
           OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
           OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1235,7 +1235,7 @@ jobs:
 
       - name: Setup OIDC publication target
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
-        uses: ./.publication-target/.github/actions/setup-node-env
+        uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -425,7 +425,7 @@ describe("plugin npm extended-stable workflow", () => {
       step(parsed.jobs?.publish_plugins_npm, "Overlay trusted OIDC packaging helper").run,
     ).toContain(".publication-target/scripts/lib/plugin-npm-package-manifest.mjs");
     expect(step(parsed.jobs?.publish_plugins_npm, "Setup OIDC publication target").uses).toBe(
-      "./.publication-target/.github/actions/setup-node-env",
+      "./.github/actions/setup-node-env",
     );
     expect(
       step(parsed.jobs?.publish_plugins_npm, "Publish with trusted publisher")["working-directory"],

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -13,6 +13,7 @@ type Step = {
   run?: string;
   uses?: string;
   with?: Record<string, string | number>;
+  "working-directory"?: string;
 };
 type Job = {
   name?: string;
@@ -399,6 +400,16 @@ describe("plugin npm extended-stable workflow", () => {
       step(parsed.jobs?.publish_plugins_npm, "Checkout trusted publication tooling").with?.ref,
     ).toBe("${{ github.workflow_sha }}");
     expect(
+      step(parsed.jobs?.preview_plugin_pack, "Checkout trusted packaging helper").with,
+    ).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      path: ".release-tooling",
+      "sparse-checkout": "scripts/lib/plugin-npm-package-manifest.mjs",
+    });
+    expect(
+      step(parsed.jobs?.preview_plugin_pack, "Overlay trusted packaging helper").run,
+    ).toContain(".release-tooling/scripts/lib/plugin-npm-package-manifest.mjs");
+    expect(
       step(parsed.jobs?.publish_plugins_npm, "Setup trusted publication dependencies").if,
     ).toContain("npm-token-bootstrap");
     expect(
@@ -407,6 +418,18 @@ describe("plugin npm extended-stable workflow", () => {
     expect(step(parsed.jobs?.publish_plugins_npm, "Checkout OIDC publication target").if).toContain(
       "npm-oidc",
     );
+    expect(
+      step(parsed.jobs?.publish_plugins_npm, "Checkout OIDC publication target").with?.path,
+    ).toBe(".publication-target");
+    expect(
+      step(parsed.jobs?.publish_plugins_npm, "Overlay trusted OIDC packaging helper").run,
+    ).toContain(".publication-target/scripts/lib/plugin-npm-package-manifest.mjs");
+    expect(step(parsed.jobs?.publish_plugins_npm, "Setup OIDC publication target").uses).toBe(
+      "./.publication-target/.github/actions/setup-node-env",
+    );
+    expect(
+      step(parsed.jobs?.publish_plugins_npm, "Publish with trusted publisher")["working-directory"],
+    ).toBe(".publication-target");
     expect(parsed.jobs?.reconcile_plugins_npm).toBeUndefined();
     expect(readFileSync(workflowPath, "utf8")).not.toContain(
       'npm dist-tag add "${PACKAGE_NAME}@${PACKAGE_VERSION}" extended-stable',


### PR DESCRIPTION
## Summary

- keep plugin package bytes sourced from the frozen release SHA
- overlay the SHA-pinned packaging helper into artifact preview jobs
- publish OIDC packages from a separate frozen target checkout while retaining trusted workflow tooling

## Why

The beta publish child checked out `v2026.7.2-beta.7` over the workflow checkout, so the release-tooling timeout recovery merged in #117618 never reached plugin matrix jobs. WhatsApp therefore reproduced the old ten-minute `npm ci` timeout.

## Validation

- `node scripts/run-vitest.mjs test/scripts/plugin-npm-extended-stable-workflow.test.ts`
- `./node_modules/.bin/oxfmt --check .github/workflows/plugin-npm-release.yml test/scripts/plugin-npm-extended-stable-workflow.test.ts`
- `git diff --check`

## Release evidence

- failed child: https://github.com/openclaw/openclaw/actions/runs/30718719835
- failed WhatsApp job: https://github.com/openclaw/openclaw/actions/runs/30718719835/job/91418950931
