### PR TITLE
fix(gateway): finish cleanup after sidecar failures

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -312,11 +312,6 @@ describe("createGatewayCloseHandler", () => {
         events.push("reload:stopped");
       }),
     };
-    const postReadySidecar = {
-      stop: vi.fn(async () => {
-        events.push("sidecar:stopped");
-      }),
-    };
     const pluginServices = {
       stop: vi.fn(async () => {
         events.push("plugins:stopped");
@@ -329,7 +324,6 @@ describe("createGatewayCloseHandler", () => {
       createGatewayCloseTestDeps({
         channelIds: ["discord"],
         configReloader,
-        postReadySidecars: [postReadySidecar],
         pluginServices: pluginServices as never,
         stopChannel,
       }),
@@ -339,7 +333,6 @@ describe("createGatewayCloseHandler", () => {
     await vi.waitFor(() => {
       expect(events).toEqual(["session-suspension-timers", "reload:stopping"]);
     });
-    expect(postReadySidecar.stop).not.toHaveBeenCalled();
     expect(pluginServices.stop).not.toHaveBeenCalled();
     expect(stopChannel).not.toHaveBeenCalled();
 
@@ -350,7 +343,6 @@ describe("createGatewayCloseHandler", () => {
       "session-suspension-timers",
       "reload:stopping",
       "reload:stopped",
-      "sidecar:stopped",
       "plugins:stopped",
       "channel:stopped",
     ]);
@@ -420,58 +412,12 @@ describe("createGatewayCloseHandler", () => {
     expect(result.warnings).toContain("channel/telegram");
   });
 
-  it("awaits post-ready sidecars before plugin services and channels", async () => {
-    const events: string[] = [];
-    let releaseSidecar!: () => void;
-    const sidecarReleased = new Promise<void>((resolve) => {
-      releaseSidecar = resolve;
-    });
-    const postReadySidecar = {
-      stop: vi.fn(async () => {
-        events.push("sidecar:start");
-        await sidecarReleased;
-        events.push("sidecar:end");
-      }),
-    };
-    const pluginServices = {
-      stop: vi.fn(async () => {
-        events.push("plugin-services");
-      }),
-    };
-    const stopChannel = vi.fn(async (channelId: string) => {
-      events.push(`channel:${channelId}`);
-    });
-    const close = createGatewayCloseHandler(
-      createGatewayCloseTestDeps({
-        channelIds: ["discord"],
-        postReadySidecars: [postReadySidecar],
-        pluginServices: pluginServices as never,
-        stopChannel,
-      }),
-    );
-
-    const closePromise = close({ reason: "test" });
-    await vi.waitFor(() => {
-      expect(events).toEqual(["sidecar:start"]);
-    });
-    releaseSidecar();
-    await closePromise;
-
-    expect(events).toEqual(["sidecar:start", "sidecar:end", "plugin-services", "channel:discord"]);
-    expect(postReadySidecar.stop).toHaveBeenCalledTimes(1);
-  });
-
-  it("clears session suspension timers before sidecars, plugin services, and channels stop", async () => {
+  it("clears session suspension timers before plugin services and channels stop", async () => {
     const events: string[] = [];
     mocks.clearSessionSuspensionTimers.mockImplementation(() => {
       events.push("session-suspension-timers");
       return 1;
     });
-    const postReadySidecar = {
-      stop: vi.fn(async () => {
-        events.push("sidecar");
-      }),
-    };
     const pluginServices = {
       stop: vi.fn(async () => {
         events.push("plugin-services");
@@ -483,7 +429,6 @@ describe("createGatewayCloseHandler", () => {
     const close = createGatewayCloseHandler(
       createGatewayCloseTestDeps({
         channelIds: ["discord"],
-        postReadySidecars: [postReadySidecar],
         pluginServices: pluginServices as never,
         stopChannel,
       }),
@@ -492,12 +437,7 @@ describe("createGatewayCloseHandler", () => {
     await close({ reason: "test shutdown" });
 
     expect(mocks.clearSessionSuspensionTimers).toHaveBeenCalledOnce();
-    expect(events).toEqual([
-      "session-suspension-timers",
-      "sidecar",
-      "plugin-services",
-      "channel:discord",
-    ]);
+    expect(events).toEqual(["session-suspension-timers", "plugin-services", "channel:discord"]);
   });
 
   it("emits gateway shutdown and pre-restart hooks", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -36,7 +36,6 @@ import {
 } from "./server-chat-state.js";
 import type { MediaCleanupStopResult } from "./server-media-cleanup-lifecycle.js";
 import { clearSessionTypingState } from "./server-methods/session-typing-state.js";
-import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
 const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;
@@ -680,7 +679,6 @@ export function createGatewayCloseHandler(
     channelIds?: readonly ChannelId[];
     stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
     pluginServices: PluginServicesHandle | null;
-    postReadySidecars?: readonly GatewayPostReadySidecarHandle[];
     disposeSessionMcpRuntimes?: () => Promise<void>;
     disposeBundleLspRuntimes?: () => Promise<void>;
     cron: { stop: () => void; stopAndDrain?: () => Promise<void> };
@@ -847,13 +845,6 @@ export function createGatewayCloseHandler(
       }
       if (params.tailscaleCleanup) {
         await shutdownStep("tailscale", () => params.tailscaleCleanup!(), warnings);
-      }
-      if (params.postReadySidecars?.length) {
-        await measureCloseStep("post-ready-sidecars", async () => {
-          for (const [index, sidecar] of params.postReadySidecars!.entries()) {
-            await shutdownStep(`post-ready-sidecar/${index}`, () => sidecar.stop(), warnings);
-          }
-        });
       }
       if (params.pluginServices) {
         await measureCloseStep("plugin-services", () =>

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -135,13 +135,24 @@ describe("gateway startup import boundaries", () => {
   it("fences config reload before gateway teardown and gateway_stop hooks", () => {
     const serverImpl = readServerImplementation();
     const closeStart = /close:\s*async\s*\([^)]*\)\s*=>/u.exec(serverImpl)?.index ?? -1;
-    const hookStart = serverImpl.indexOf("runGlobalGatewayStopSafely", closeStart);
-    const reloadStopStart = serverImpl.indexOf("await beginClosePrelude();", closeStart);
-    const terminalStopStart = serverImpl.indexOf("terminalSessions.disposeAll();", closeStart);
+    const hookStart = serverImpl.indexOf('["gateway stop hook", runGatewayStopHook]', closeStart);
+    const reloadStopStart = serverImpl.indexOf(
+      '["gateway close prelude fence", beginClosePrelude]',
+      closeStart,
+    );
+    const terminalStopStart = serverImpl.indexOf(
+      '["terminal sessions", () => terminalSessions.disposeAll()]',
+      closeStart,
+    );
     const markHelperStart = serverImpl.indexOf("const markClosePreludeStarted = () => {");
     const markHelperEnd = serverImpl.indexOf("};", markHelperStart);
     const beginHelperStart = serverImpl.indexOf("const beginClosePrelude = async () => {");
     const beginHelperEnd = serverImpl.indexOf("};", beginHelperStart);
+    const postFenceHelperStart = serverImpl.indexOf(
+      "const runClosePreludeAfterFence = async () => {",
+    );
+    const postFenceHelperEnd = serverImpl.indexOf("};", postFenceHelperStart);
+    const postFenceHelper = serverImpl.slice(postFenceHelperStart, postFenceHelperEnd);
     const postReadyStart = serverImpl.indexOf("scheduleGatewayPostReadyMaintenance({");
     const postReadyEnd = serverImpl.indexOf("});", postReadyStart);
     const postReadyBlock = serverImpl.slice(postReadyStart, postReadyEnd);
@@ -169,6 +180,18 @@ describe("gateway startup import boundaries", () => {
     );
     expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
       "stopOutboundDeliveryRecoveryForClose(),",
+    );
+    expect(postFenceHelperStart).toBeGreaterThan(-1);
+    expect(postFenceHelper).not.toContain("beginClosePrelude");
+    expect(postFenceHelper).toContain("disposeNodeConnectionNotifications(nodeRegistry);");
+    expect(postFenceHelper).toContain("watchNodeHttpRuntime.close();");
+    expect(postFenceHelper).toContain("clearPluginMetadataLifecycleCaches();");
+    expect(postFenceHelper).toContain("runGatewayClosePrelude");
+    expect(serverImpl).toContain(
+      "stopPostReadySidecars: () => stopRegisteredPostReadySidecars(runtimeState, log),",
+    );
+    expect(serverImpl).not.toContain(
+      "stopPostReadySidecars: () => stopRegisteredGatewaySidecars(runtimeState, log),",
     );
     expect(postReadyStart).toBeGreaterThan(-1);
     expect(postReadyBlock).toContain("isClosing: () => lifecycle.closePreludeStarted");

--- a/src/gateway/server-lifecycle.test.ts
+++ b/src/gateway/server-lifecycle.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runGatewayCleanupSequence,
+  stopRegisteredGatewaySidecars,
+  stopRegisteredPostReadySidecars,
+} from "./server-lifecycle.js";
+
+describe("gateway cleanup sequence", () => {
+  it("runs later cleanup after sidecar failure and rethrows the first error last", async () => {
+    const sidecarFailure = new Error("sidecar stop failed");
+    const laterFailure = new Error("gateway close failed");
+    const order: string[] = [];
+    const log = { warn: vi.fn() };
+
+    await expect(
+      runGatewayCleanupSequence(
+        [
+          [
+            "registered sidecars",
+            async () => {
+              order.push("sidecars");
+              throw sidecarFailure;
+            },
+          ],
+          ["close prelude", () => order.push("prelude")],
+          [
+            "gateway close",
+            async () => {
+              order.push("close");
+              throw laterFailure;
+            },
+          ],
+          ["fallback context", () => order.push("fallback")],
+        ],
+        log,
+      ),
+    ).rejects.toBe(sidecarFailure);
+
+    expect(order).toEqual(["sidecars", "prelude", "close", "fallback"]);
+    expect(log.warn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("gateway registered sidecar cleanup", () => {
+  it("transfers both groups, drains every sidecar, and rethrows the first failure", async () => {
+    const firstFailure = new Error("first lifetime stop failed");
+    const secondFailure = new Error("second lifetime stop failed");
+    const postReadyFailure = new Error("post-ready stop failed");
+    const stopOrder: string[] = [];
+    const runtimeState = {
+      gatewayLifetimeSidecars: [] as Array<{ stop: () => void | Promise<void> }>,
+      postReadySidecars: [] as Array<{ stop: () => void | Promise<void> }>,
+    };
+    runtimeState.gatewayLifetimeSidecars = [
+      {
+        stop: vi.fn(async () => {
+          expect(runtimeState.gatewayLifetimeSidecars).toEqual([]);
+          expect(runtimeState.postReadySidecars).toEqual([]);
+          stopOrder.push("lifetime:first");
+          throw firstFailure;
+        }),
+      },
+      {
+        stop: vi.fn(() => {
+          stopOrder.push("lifetime:second");
+          throw secondFailure;
+        }),
+      },
+    ];
+    runtimeState.postReadySidecars = [
+      {
+        stop: vi.fn(async () => {
+          stopOrder.push("post-ready:first");
+          throw postReadyFailure;
+        }),
+      },
+      {
+        stop: vi.fn(() => {
+          stopOrder.push("post-ready:second");
+        }),
+      },
+    ];
+    const stops = [...runtimeState.gatewayLifetimeSidecars, ...runtimeState.postReadySidecars].map(
+      (sidecar) => sidecar.stop,
+    );
+    const log = { warn: vi.fn() };
+
+    await expect(stopRegisteredGatewaySidecars(runtimeState, log)).rejects.toBe(firstFailure);
+
+    expect(stopOrder).toEqual([
+      "lifetime:first",
+      "lifetime:second",
+      "post-ready:first",
+      "post-ready:second",
+    ]);
+    expect(log.warn).toHaveBeenCalledTimes(3);
+    expect(stops.every((stop) => stop.mock.calls.length === 1)).toBe(true);
+
+    await stopRegisteredGatewaySidecars(runtimeState, log);
+    expect(stops.every((stop) => stop.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("leaves gateway-lifetime sidecars running during Gmail reload cleanup", async () => {
+    const firstFailure = new Error("first post-ready stop failed");
+    const lifetimeStop = vi.fn();
+    const firstPostReadyStop = vi.fn(async () => {
+      throw firstFailure;
+    });
+    const secondPostReadyStop = vi.fn(() => {
+      throw new Error("second post-ready stop failed");
+    });
+    const runtimeState = {
+      gatewayLifetimeSidecars: [{ stop: lifetimeStop }],
+      postReadySidecars: [{ stop: firstPostReadyStop }, { stop: secondPostReadyStop }],
+    };
+    const log = { warn: vi.fn() };
+
+    await expect(stopRegisteredPostReadySidecars(runtimeState, log)).rejects.toBe(firstFailure);
+
+    expect(firstPostReadyStop).toHaveBeenCalledOnce();
+    expect(secondPostReadyStop).toHaveBeenCalledOnce();
+    expect(log.warn).toHaveBeenCalledTimes(2);
+    expect(runtimeState.postReadySidecars).toEqual([]);
+    expect(lifetimeStop).not.toHaveBeenCalled();
+    expect(runtimeState.gatewayLifetimeSidecars).toHaveLength(1);
+  });
+});

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -42,7 +42,60 @@ import { broadcastPresenceSnapshot } from "./server/presence-events.js";
 import { createSessionViewerPresenceDeclarations } from "./session-viewer-presence.js";
 
 type GatewayRuntimePreparation = Awaited<ReturnType<typeof prepareGatewayRuntimeState>>;
+type GatewayRuntimeState = ReturnType<typeof createGatewayServerLiveState>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
+type GatewayCleanupStep = readonly [label: string, run: () => void | Promise<void>];
+
+export async function runGatewayCleanupSequence(
+  steps: readonly GatewayCleanupStep[],
+  log: Pick<GatewayLogger, "warn">,
+): Promise<void> {
+  const errors: unknown[] = [];
+  for (const [label, run] of steps) {
+    try {
+      await run();
+    } catch (error) {
+      log.warn(`${label} failed: ${String(error)}`);
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw errors[0];
+  }
+}
+
+export async function stopRegisteredGatewaySidecars(
+  runtimeState: Pick<GatewayRuntimeState, "gatewayLifetimeSidecars" | "postReadySidecars">,
+  log: Pick<GatewayLogger, "warn">,
+): Promise<void> {
+  const groups = [
+    ["gateway-lifetime", runtimeState.gatewayLifetimeSidecars],
+    ["post-ready", runtimeState.postReadySidecars],
+  ] as const;
+  runtimeState.gatewayLifetimeSidecars = [];
+  runtimeState.postReadySidecars = [];
+
+  const steps = groups.flatMap(([label, sidecars]) =>
+    sidecars.map(
+      (sidecar, index) => [`${label} sidecar ${index} stop`, () => sidecar.stop()] as const,
+    ),
+  );
+  await runGatewayCleanupSequence(steps, log);
+}
+
+export async function stopRegisteredPostReadySidecars(
+  runtimeState: Pick<GatewayRuntimeState, "postReadySidecars">,
+  log: Pick<GatewayLogger, "warn">,
+): Promise<void> {
+  const postReadySidecars = runtimeState.postReadySidecars;
+  runtimeState.postReadySidecars = [];
+  await runGatewayCleanupSequence(
+    postReadySidecars.map(
+      (sidecar, index) => [`post-ready sidecar ${index} stop`, () => sidecar.stop()] as const,
+    ),
+    log,
+  );
+}
 
 export async function prepareGatewayLifecycle(params: {
   runtime: GatewayRuntimePreparation;
@@ -339,8 +392,9 @@ export async function prepareGatewayLifecycle(params: {
       stopConfigReloaderForClose().catch(() => {}),
     ]);
   };
-  const runClosePrelude = async () => {
-    await beginClosePrelude();
+  const runClosePreludeAfterFence = async () => {
+    // The outer cleanup sequence owns the fence join so its failure cannot
+    // strand these independent prelude owners.
     disposeNodeConnectionNotifications(nodeRegistry);
     watchNodeHttpRuntime.close();
     clearPluginMetadataLifecycleCaches();
@@ -380,20 +434,7 @@ export async function prepareGatewayLifecycle(params: {
       getEventLoopHealth: readinessEventLoopHealth.snapshot,
       getConfigReloaderHotReloadStatus: () => runtimeState?.configReloader.hotReloadStatus?.(),
     });
-  const stopRegisteredPostReadySidecars = async () => {
-    const postReadySidecars = runtimeState.postReadySidecars;
-    runtimeState.postReadySidecars = [];
-    for (const postReadySidecar of postReadySidecars) {
-      await postReadySidecar.stop();
-    }
-  };
-  const stopRegisteredGatewayLifetimeSidecars = async () => {
-    const gatewayLifetimeSidecars = runtimeState.gatewayLifetimeSidecars;
-    runtimeState.gatewayLifetimeSidecars = [];
-    for (const gatewayLifetimeSidecar of gatewayLifetimeSidecars) {
-      await gatewayLifetimeSidecar.stop();
-    }
-  };
+  const stopRegisteredSidecars = () => stopRegisteredGatewaySidecars(runtimeState, log);
   const createCloseHandler = () => async (optsValue?: GatewayCloseOptions) => {
     const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
     const { createGatewayCloseHandler, drainActiveSessionsForShutdown } =
@@ -405,7 +446,6 @@ export async function prepareGatewayLifecycle(params: {
       channelIds,
       stopChannel,
       pluginServices: runtimeState.pluginServices,
-      postReadySidecars: runtimeState.postReadySidecars,
       cron: runtimeState.cronState.cron,
       heartbeatRunner: runtimeState.heartbeatRunner,
       updateCheckStop: runtimeState.stopGatewayUpdateCheck,
@@ -462,17 +502,17 @@ export async function prepareGatewayLifecycle(params: {
     })(optsValue);
   };
   let clearFallbackGatewayContextForServer = () => {};
-  const closeOnStartupFailure = async () => {
-    try {
-      await beginClosePrelude();
-      await stopRegisteredGatewayLifetimeSidecars();
-      await stopRegisteredPostReadySidecars();
-      await runClosePrelude();
-      await createCloseHandler()({ reason: "gateway startup failed" });
-    } finally {
-      clearFallbackGatewayContextForServer();
-    }
-  };
+  const closeOnStartupFailure = () =>
+    runGatewayCleanupSequence(
+      [
+        ["gateway close prelude fence", beginClosePrelude],
+        ["registered sidecars", stopRegisteredSidecars],
+        ["gateway close prelude", runClosePreludeAfterFence],
+        ["gateway close", () => createCloseHandler()({ reason: "gateway startup failed" })],
+        ["fallback gateway context", clearFallbackGatewayContextForServer],
+      ],
+      log,
+    );
 
   if (diagnosticsEnabled) {
     // Gateway lifecycle owns both this existing heartbeat timer and the monitor
@@ -523,15 +563,14 @@ export async function prepareGatewayLifecycle(params: {
     postReadyState,
     cronReconciliation,
     beginClosePrelude,
-    runClosePrelude,
+    runClosePreludeAfterFence,
     getRuntimeSnapshot,
     startChannels,
     startChannel,
     stopChannel,
     markChannelLoggedOut,
     refreshGatewayHealthSnapshotWithRuntime,
-    stopRegisteredPostReadySidecars,
-    stopRegisteredGatewayLifetimeSidecars,
+    stopRegisteredSidecars,
     createCloseHandler,
     clearFallbackGatewayContextForServer: {
       get: () => clearFallbackGatewayContextForServer,

--- a/src/gateway/server-start.lifecycle.test.ts
+++ b/src/gateway/server-start.lifecycle.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const log = {
+    child: vi.fn(),
+    warn: vi.fn(),
+  };
+  log.child.mockReturnValue(log);
+  return {
+    startupError: new Error("gateway startup failed"),
+    cleanupError: new Error("gateway cleanup failed"),
+    log,
+    beginClosePrelude: vi.fn(),
+    clearFallbackGatewayContext: vi.fn(),
+    closeHandler: vi.fn(),
+    closeOnStartupFailure: vi.fn(),
+    createCloseHandler: vi.fn(),
+    finishGatewayStartup: vi.fn(),
+    runClosePreludeAfterFence: vi.fn(),
+    runCleanupSequence: vi.fn(),
+    runGlobalGatewayStopSafely: vi.fn(),
+    startGatewayCoreRuntime: vi.fn(),
+    stopRegisteredSidecars: vi.fn(),
+    terminalSessionsDisposeAll: vi.fn(),
+  };
+});
+
+vi.mock("../infra/path-env.js", () => ({ ensureOpenClawCliOnPath: vi.fn() }));
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => hoisted.log),
+  runtimeForLogger: vi.fn(() => ({})),
+}));
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  runGlobalGatewayStopSafely: hoisted.runGlobalGatewayStopSafely,
+}));
+vi.mock("./server-startup-bootstrap.js", () => ({
+  prepareGatewayServerBootstrap: vi.fn(async () => ({ diagnosticsEnabled: false })),
+}));
+vi.mock("./server-runtime-state-prepare.js", () => ({
+  prepareGatewayRuntimeState: vi.fn(async () => ({})),
+}));
+vi.mock("./server-lifecycle.js", () => ({
+  prepareGatewayLifecycle: vi.fn(async () => ({
+    beginClosePrelude: hoisted.beginClosePrelude,
+    clearFallbackGatewayContextForServer: {
+      get: () => hoisted.clearFallbackGatewayContext,
+      set: vi.fn(),
+    },
+    closeOnStartupFailure: hoisted.closeOnStartupFailure,
+    createCloseHandler: hoisted.createCloseHandler,
+    runClosePreludeAfterFence: hoisted.runClosePreludeAfterFence,
+    stopRegisteredSidecars: hoisted.stopRegisteredSidecars,
+    terminalSessions: { disposeAll: hoisted.terminalSessionsDisposeAll },
+  })),
+  runGatewayCleanupSequence: hoisted.runCleanupSequence,
+}));
+vi.mock("./server-core-runtime.js", () => ({
+  startGatewayCoreRuntime: hoisted.startGatewayCoreRuntime,
+}));
+vi.mock("./server-startup-finish.js", () => ({
+  finishGatewayStartup: hoisted.finishGatewayStartup,
+}));
+
+const { startGatewayServer } = await import("./server-start.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.log.child.mockReturnValue(hoisted.log);
+  hoisted.closeOnStartupFailure.mockRejectedValue(hoisted.cleanupError);
+  hoisted.createCloseHandler.mockReturnValue(hoisted.closeHandler);
+  hoisted.finishGatewayStartup.mockResolvedValue(undefined);
+  hoisted.runCleanupSequence.mockImplementation(async (steps) => {
+    let firstError: { value: unknown } | undefined;
+    for (const [, run] of steps) {
+      try {
+        await run();
+      } catch (error) {
+        firstError ??= { value: error };
+      }
+    }
+    if (firstError) {
+      throw firstError.value;
+    }
+  });
+  hoisted.startGatewayCoreRuntime.mockRejectedValue(hoisted.startupError);
+});
+
+describe("gateway startup failure cleanup", () => {
+  it("preserves the initiating startup error when cleanup rejects", async () => {
+    await expect(startGatewayServer()).rejects.toBe(hoisted.startupError);
+
+    expect(hoisted.closeOnStartupFailure).toHaveBeenCalledOnce();
+    expect(hoisted.log.warn).toHaveBeenCalledWith(
+      `gateway startup cleanup failed: ${String(hoisted.cleanupError)}`,
+    );
+  });
+
+  it("runs the full explicit cleanup sequence after a sidecar failure", async () => {
+    const sidecarFailure = new Error("sidecar stop failed");
+    const order: string[] = [];
+    hoisted.startGatewayCoreRuntime.mockResolvedValue({});
+    hoisted.beginClosePrelude.mockImplementation(() => order.push("prelude-fence"));
+    hoisted.terminalSessionsDisposeAll.mockImplementation(() => order.push("terminals"));
+    hoisted.stopRegisteredSidecars.mockImplementation(async () => {
+      order.push("sidecars");
+      throw sidecarFailure;
+    });
+    hoisted.runGlobalGatewayStopSafely.mockImplementation(async () => {
+      order.push("gateway-stop-hook");
+    });
+    hoisted.runClosePreludeAfterFence.mockImplementation(async () => {
+      order.push("close-prelude");
+    });
+    hoisted.closeHandler.mockImplementation(async () => {
+      order.push("close");
+    });
+    hoisted.clearFallbackGatewayContext.mockImplementation(() => {
+      order.push("fallback");
+    });
+
+    const server = await startGatewayServer();
+    await expect(server.close()).rejects.toBe(sidecarFailure);
+
+    expect(order).toEqual([
+      "prelude-fence",
+      "terminals",
+      "sidecars",
+      "gateway-stop-hook",
+      "close-prelude",
+      "close",
+      "fallback",
+    ]);
+  });
+
+  it("runs post-fence prelude cleanup after the fence join rejects", async () => {
+    const fenceFailure = new Error("prelude fence failed");
+    const order: string[] = [];
+    hoisted.startGatewayCoreRuntime.mockResolvedValue({});
+    hoisted.beginClosePrelude.mockImplementation(async () => {
+      order.push("prelude-fence");
+      throw fenceFailure;
+    });
+    hoisted.runClosePreludeAfterFence.mockImplementation(() => {
+      order.push("close-prelude");
+    });
+    hoisted.closeHandler.mockImplementation(() => {
+      order.push("close");
+    });
+    hoisted.clearFallbackGatewayContext.mockImplementation(() => {
+      order.push("fallback");
+    });
+
+    const server = await startGatewayServer();
+    await expect(server.close()).rejects.toBe(fenceFailure);
+
+    expect(order).toEqual(["prelude-fence", "close-prelude", "close", "fallback"]);
+  });
+});

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -3,7 +3,7 @@ import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { startGatewayCoreRuntime } from "./server-core-runtime.js";
-import { prepareGatewayLifecycle } from "./server-lifecycle.js";
+import { prepareGatewayLifecycle, runGatewayCleanupSequence } from "./server-lifecycle.js";
 import type { GatewayServer, GatewayServerOptions } from "./server-public.js";
 import { prepareGatewayRuntimeState } from "./server-runtime-state-prepare.js";
 import { prepareGatewayServerBootstrap } from "./server-startup-bootstrap.js";
@@ -147,9 +147,8 @@ export async function startGatewayServer(
     clearFallbackGatewayContextForServer,
     closeOnStartupFailure,
     createCloseHandler,
-    runClosePrelude,
-    stopRegisteredGatewayLifetimeSidecars,
-    stopRegisteredPostReadySidecars,
+    runClosePreludeAfterFence,
+    stopRegisteredSidecars,
     terminalSessions,
   } = lifecycleRuntime;
   try {
@@ -182,7 +181,9 @@ export async function startGatewayServer(
       waitForPostReadyWork: () => postReadyWorkBarrier,
     });
   } catch (err) {
-    await closeOnStartupFailure();
+    await closeOnStartupFailure().catch((cleanupError: unknown) =>
+      log.warn(`gateway startup cleanup failed: ${String(cleanupError)}`),
+    );
     throw err;
   }
   // The public server is fully initialized now. Leave a short I/O window before
@@ -194,12 +195,7 @@ export async function startGatewayServer(
 
   return {
     close: async (optsLocal) => {
-      try {
-        await beginClosePrelude();
-        // Kill any live operator shells before the socket layer tears down.
-        terminalSessions.disposeAll();
-        await stopRegisteredGatewayLifetimeSidecars();
-        await stopRegisteredPostReadySidecars();
+      const runGatewayStopHook = async () => {
         // Run gateway_stop plugin hook before shutdown
         const { runGlobalGatewayStopSafely } = await import("../plugins/hook-runner-global.js");
         await runGlobalGatewayStopSafely({
@@ -207,11 +203,20 @@ export async function startGatewayServer(
           ctx: { port },
           onError: (err) => log.warn(`gateway_stop hook failed: ${String(err)}`),
         });
-        await runClosePrelude();
-        await close(optsLocal);
-      } finally {
-        clearFallbackGatewayContextForServer.get()();
-      }
+      };
+      // Preserve ordering, but do not let one cleanup owner strand the rest.
+      await runGatewayCleanupSequence(
+        [
+          ["gateway close prelude fence", beginClosePrelude],
+          ["terminal sessions", () => terminalSessions.disposeAll()],
+          ["registered sidecars", stopRegisteredSidecars],
+          ["gateway stop hook", runGatewayStopHook],
+          ["gateway close prelude", runClosePreludeAfterFence],
+          ["gateway close", () => close(optsLocal)],
+          ["fallback gateway context", clearFallbackGatewayContextForServer.get()],
+        ],
+        log,
+      );
     },
   };
 }

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -16,6 +16,7 @@ import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.
 import { collectGatewayProcessMemoryUsageMb, finishGatewayRestartTrace } from "./restart-trace.js";
 import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
 import type { startGatewayCoreRuntime } from "./server-core-runtime.js";
+import { stopRegisteredPostReadySidecars } from "./server-lifecycle.js";
 import {
   attachInitialGatewayLifetimeSidecars,
   publishGatewayLifetimeSidecars,
@@ -189,7 +190,6 @@ export async function finishGatewayStartup(params: {
     resolveSharedGatewaySessionGenerationForConfig,
     reloadAttachedGatewayPlugins,
     readinessEventLoopHealth,
-    stopRegisteredPostReadySidecars,
     clearFallbackGatewayContextForServer,
   } = runtime;
   const unavailableGatewayMethods = new Set<string>(
@@ -480,10 +480,13 @@ export async function finishGatewayStartup(params: {
           },
           onPostReadySidecars: (postReadySidecars) => {
             runtimeState.postReadySidecars = postReadySidecars;
-            stopPostReadySidecarsAfterCloseStarted({
-              postReadySidecars,
-              closeStarted: lifecycle.closePreludeStarted,
-            });
+            stopPostReadySidecarsAfterCloseStarted(
+              {
+                postReadySidecars,
+                closeStarted: lifecycle.closePreludeStarted,
+              },
+              log,
+            );
             if (lifecycle.closePreludeStarted) {
               runtimeState.postReadySidecars = [];
             }
@@ -493,7 +496,8 @@ export async function finishGatewayStartup(params: {
               registered: runtimeState.gatewayLifetimeSidecars,
               published: gatewayLifetimeSidecars,
               closeStarted: lifecycle.closePreludeStarted,
-              stopAfterCloseStarted: stopPostReadySidecarsAfterCloseStarted,
+              stopAfterCloseStarted: (sidecarState) =>
+                stopPostReadySidecarsAfterCloseStarted(sidecarState, log),
             });
           },
           ...(workerPlacementRuntime
@@ -599,7 +603,7 @@ export async function finishGatewayStartup(params: {
     startChannel,
     stopChannel,
     getChannelAutostartSuppression: channelManager.getAutostartSuppression,
-    stopPostReadySidecars: stopRegisteredPostReadySidecars,
+    stopPostReadySidecars: () => stopRegisteredPostReadySidecars(runtimeState, log),
     reloadPlugins: reloadAttachedGatewayPlugins,
     logHooks,
     logChannels,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -315,14 +315,16 @@ async function stopTrackedSidecar(sidecar: SidecarHandle): Promise<void> {
 }
 
 function stopTrackedPostReadySidecarsAfterCloseStarted(
-  params: Parameters<typeof testing.stopPostReadySidecarsAfterCloseStarted>[0],
+  params: Parameters<typeof testing.stopPostReadySidecarsAfterCloseStarted>[0] & {
+    log: { warn: (msg: string) => void };
+  },
 ): void {
   if (params.closeStarted) {
     for (const sidecar of params.postReadySidecars) {
       transferBeforeStop(sidecar);
     }
   }
-  testing.stopPostReadySidecarsAfterCloseStarted(params);
+  testing.stopPostReadySidecarsAfterCloseStarted(params, params.log);
 }
 
 async function cleanupGatewayTestState(): Promise<void> {
@@ -2226,6 +2228,7 @@ describe("startGatewayPostAttachRuntime", () => {
     stopTrackedPostReadySidecarsAfterCloseStarted({
       postReadySidecars: [postReadySidecar],
       closeStarted: true,
+      log: { warn: vi.fn() },
     });
 
     expect(postReadySidecar.stop).toHaveBeenCalledTimes(1);
@@ -2239,10 +2242,46 @@ describe("startGatewayPostAttachRuntime", () => {
     stopTrackedPostReadySidecarsAfterCloseStarted({
       postReadySidecars: [postReadySidecar],
       closeStarted: false,
+      log: { warn: vi.fn() },
     });
 
     expect(postReadySidecar.stop).not.toHaveBeenCalled();
     expect(publishedPostReadySidecars).toContain(postReadySidecar);
+  });
+
+  it("contains synchronous and asynchronous late sidecar stop failures", async () => {
+    const synchronousFailure = new Error("synchronous stop failed");
+    const asynchronousFailure = new Error("asynchronous stop failed");
+    const sidecars = [
+      {
+        stop: vi.fn(() => {
+          throw synchronousFailure;
+        }),
+      },
+      {
+        stop: vi.fn(() => Promise.reject(asynchronousFailure)),
+      },
+      { stop: vi.fn() },
+    ];
+    const log = { warn: vi.fn() };
+    adoptSidecars(publishedPostReadySidecars, sidecars);
+
+    stopTrackedPostReadySidecarsAfterCloseStarted({
+      postReadySidecars: sidecars,
+      closeStarted: true,
+      log,
+    });
+
+    await vi.waitFor(() => expect(log.warn).toHaveBeenCalledTimes(2));
+    expect(sidecars.every((sidecar) => sidecar.stop.mock.calls.length === 1)).toBe(true);
+    expect(log.warn).toHaveBeenNthCalledWith(
+      1,
+      `post-ready sidecar 0 failed to stop after close started: ${String(synchronousFailure)}`,
+    );
+    expect(log.warn).toHaveBeenNthCalledWith(
+      2,
+      `post-ready sidecar 1 failed to stop after close started: ${String(asynchronousFailure)}`,
+    );
   });
 
   it("runs Gmail watcher after sidecars are ready", async () => {
@@ -2419,7 +2458,7 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
-  it("stops already-started Gmail watcher cleanup on close", async () => {
+  it("does not stop already-transferred Gmail cleanup twice", async () => {
     const postReadySidecars = [{ stop: vi.fn() }];
     const stopChannel = vi.fn(async () => {});
     const pluginServices = { stop: vi.fn(async () => {}) };
@@ -2429,7 +2468,6 @@ describe("startGatewayPostAttachRuntime", () => {
       channelIds: [],
       stopChannel,
       pluginServices,
-      postReadySidecars,
       cron: { stop: vi.fn() },
       heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() },
       nodePresenceTimers: new Map(),
@@ -2457,9 +2495,15 @@ describe("startGatewayPostAttachRuntime", () => {
       httpServer: { close: vi.fn((callback: () => void) => callback()) } as never,
     });
 
+    stopTrackedPostReadySidecarsAfterCloseStarted({
+      postReadySidecars,
+      closeStarted: true,
+      log: { warn: vi.fn() },
+    });
+    await vi.waitFor(() => expect(postReadySidecars[0]?.stop).toHaveBeenCalledOnce());
     await close();
 
-    expect(postReadySidecars[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(postReadySidecars[0]?.stop).toHaveBeenCalledOnce();
     expect(pluginServices.stop).toHaveBeenCalledTimes(1);
   });
 
@@ -2637,6 +2681,37 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(workerSidecar.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the startup failure when worker placement cleanup rejects", async () => {
+    const cleanupError = new Error("worker cleanup failed");
+    const workerSidecar = {
+      stop: vi.fn(async () => {
+        throw cleanupError;
+      }),
+    };
+    const startupError = new Error("sidecar startup failed");
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await expect(
+      startGatewayPostAttachRuntime(
+        {
+          ...createPostAttachParams(),
+          log,
+          startWorkerEnvironmentRuntime: vi.fn(() => workerSidecar),
+        },
+        createPostAttachRuntimeDeps({
+          startGatewaySidecars: vi.fn(async () => {
+            throw startupError;
+          }),
+        }),
+      ),
+    ).rejects.toBe(startupError);
+
+    expect(workerSidecar.stop).toHaveBeenCalledOnce();
+    expect(log.warn).toHaveBeenCalledWith(
+      `worker-environment sidecar failed to stop during startup rollback: ${String(cleanupError)}`,
+    );
+  });
+
   it("does not start the worker environment sidecar after close begins", async () => {
     const startWorkerEnvironmentRuntime = vi.fn(() => ({ stop: vi.fn() }));
     const startGatewaySidecarsValue = vi.fn(async () => ({
@@ -2781,6 +2856,7 @@ describe("startGatewayPostAttachRuntime", () => {
     stopTrackedPostReadySidecarsAfterCloseStarted({
       postReadySidecars: result.postReadySidecars,
       closeStarted: true,
+      log: { warn: vi.fn() },
     });
     releasePostReadyWork();
     await vi.advanceTimersByTimeAsync(1_000);

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -81,15 +81,24 @@ const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
 export type GatewayPostReadySidecarHandle = { stop: () => Awaitable<void> };
 
 /** Stop sidecars immediately when shutdown has already started before they are reported. */
-export function stopPostReadySidecarsAfterCloseStarted(params: {
-  postReadySidecars: readonly GatewayPostReadySidecarHandle[];
-  closeStarted: boolean;
-}): void {
+export function stopPostReadySidecarsAfterCloseStarted(
+  params: {
+    postReadySidecars: readonly GatewayPostReadySidecarHandle[];
+    closeStarted: boolean;
+  },
+  log: { warn: (msg: string) => void },
+): void {
   if (!params.closeStarted) {
     return;
   }
-  for (const postReadySidecar of params.postReadySidecars) {
-    void postReadySidecar.stop();
+  const warn = (index: number, error: unknown) =>
+    log.warn(`post-ready sidecar ${index} failed to stop after close started: ${String(error)}`);
+  for (const [index, sidecar] of params.postReadySidecars.entries()) {
+    try {
+      void Promise.resolve(sidecar.stop()).catch((error: unknown) => warn(index, error));
+    } catch (error) {
+      warn(index, error);
+    }
   }
 }
 
@@ -1270,7 +1279,15 @@ export async function startGatewayPostAttachRuntime(
               }),
             );
           } catch (error) {
-            await workerEnvironmentSidecar?.stop();
+            if (workerEnvironmentSidecar) {
+              try {
+                await workerEnvironmentSidecar.stop();
+              } catch (cleanupError) {
+                params.log.warn(
+                  `worker-environment sidecar failed to stop during startup rollback: ${String(cleanupError)}`,
+                );
+              }
+            }
             throw error;
           }
         })();


### PR DESCRIPTION
[AI-assisted]

## Summary

Repair Gateway startup and shutdown cleanup at the lifecycle owner boundary.

- preserve the initiating startup error even when cleanup rejects or throws
- transfer and clear both registered sidecar groups before stopping them
- attempt every sidecar stop and every later Gateway cleanup step
- log every cleanup failure, then throw the first cleanup failure only after explicit close completes
- keep post-fence close-prelude owners running when the initial fence join rejects
- contain synchronous and asynchronous failures from late-published sidecars
- keep Gmail hot reload scoped to post-ready sidecars, preserving gateway-lifetime owners
- remove the duplicate sidecar-stop loop from `server-close.ts`

No new sidecar helper module, retry stack, generation framework, or downstream guard is added.

## What Problem This Solves

Registered sidecars had split cleanup ownership. A sidecar stop rejection could abort the remaining Gateway cleanup contract, while startup teardown could replace the root startup failure with cleanup noise.

The first repair still had two owner-boundary holes:

1. `runClosePrelude` rejoined the memoized close fence after the outer cleanup sequence had already caught its rejection, which could skip node notifications, watch-node HTTP shutdown, metadata cache clearing, and the remaining close prelude.
2. Gmail hot reload was wired to the full registered-sidecar drain, which could stop gateway-lifetime owners during a watcher restart.

The lifecycle owner now separates the fence join from post-fence cleanup and exposes a post-ready-only drain for hot reload. Full close and startup rollback still drain both sidecar classes. Startup reports its initiating error; explicit close reports the first cleanup error only after every cleanup step has been attempted.

## Evidence

Exact base: `b5180b68163a0dec24ac7615b81e7f12aadbd5e2`  
Exact head: `0f2e9064ca10e14bb0920c955c92a73d5654f940`

- lifecycle/start cleanup regressions: 2 files, 6 tests passed
- exact Gmail hot-reload regressions: 1 file, 2 tests passed
- structural owner-boundary regression: 1 test passed
- targeted `oxfmt`: clean
- targeted `oxlint`: clean
- `git diff --check`: clean
- exact-diff autoreview: no actionable findings
- independent full-branch exact-head review: no actionable findings (`0.96`)

Hosted exact-head CI and exact-head ClawSweeper remain the final gates.

## Scope

- production: +126 / -70, net +56
- tests: +394 / -70, net +324

The positive production delta is the lifecycle-owned sequential cleanup contract shared by startup failure and explicit close, sync/async late-stop diagnostics, and the separate post-ready-only reload owner. The connected duplicate close ownership was removed in the same change.

## Credit

The editable contributor branch was rebuilt in place. The signed commit preserves IWhatsskill as author and Peter Steinberger as co-author.

## Punchcard

Punchcard-Session: amber-workshop-workshop-36

PR attestation receipt:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaR1lUMlZYWDRZQ1Q5WlpBRDBUQ1g4NQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMTc2NDYAZGZjNzYwZDFhZmZkYjg5ZGU1Zjc3NmE2NTgxNmFkNjUzNzM3MDg2NTgxNGQ3NTFkMzQyZmRlNTVmMmNiN2ViOABzaWduaW5nLXYxADJTR1hwTUFXS2lsWE9NQVloSVJ1R0xZNDUtQTBqUW9TUHN1Z2VFLXVKNk9HREJCMjJVWFA5ZTFwb3hwWHVuRUZoNVlyakoxS0lCRzB4aUk5SWs1UkJ3ADIwMjYtMDgtMDhUMTU6MTA6MzYuNDEzWgA.fxfOAUlWOOcbEJ22W7TKjJSMMVeSGsHa_CLm_NuLCBjCIoacBFnAjopQ3y-JlLio9G3cGU-W_x49Zs4rWBSuAA`
