### PR TITLE
test(auto-reply): preserve plugin hook runner lifecycle exports

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
@@ -130,11 +130,15 @@ vi.mock("../agents/auth-profiles/session-override.js", () => ({
     resolveSessionAuthProfileOverrideMock(...args),
 }));
 
-vi.mock("../plugins/hook-runner-global.js", () => ({
-  getGlobalHookRunner: () => undefined,
-  initializeGlobalHookRunner: vi.fn(),
-  resetGlobalHookRunner: vi.fn(),
-}));
+vi.mock("../plugins/hook-runner-global.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/hook-runner-global.js")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => undefined,
+    initializeGlobalHookRunner: vi.fn(),
+    resetGlobalHookRunner: vi.fn(),
+  };
+});
 
 vi.mock("./reply/agent-runner.runtime.js", () => ({
   runReplyAgent: (...args: unknown[]) => runReplyAgentMock(...args),


### PR DESCRIPTION
## What Problem This Solves

The non-isolated core unit-fast CI shard deterministically fails bundled-plugin source-checkout activation after a reply directive test leaks an incomplete global hook-runner module mock.

## Why This Change Was Made

The registry-bundle refactor added `getGlobalPluginRegistry()` to plugin activation, but the existing reply-test support owner replaced the entire hook-runner module with three exports. Reuse the adjacent typed `importOriginal` partial-mock pattern so every real current and future lifecycle export remains available while preserving the three intentional test overrides.

## User Impact

Unrelated OpenClaw pull requests no longer fail the shared core unit-fast CI shard because of this cross-file test mock. Production behavior is unchanged: exactly one existing test-support owner changes, with no production files or new test files.

## Evidence

- Frozen commit: `eefe009a5edc437850dfc57750c3e53cbbed7614`; parent: `c539192b5cdd8369c16c6be03258cc68deac17ef`.
- Exactly one changed owner: `src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts`.
- Authentic owner-first RED: `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/auto-reply/reply.directive.directive-behavior.shows-current-verbose-level-verbose-has-no.test.ts src/plugins/source-checkout-runtime.test.ts --no-isolate --maxWorkers=1 --fileParallelism=false --reporter=verbose`; nine reply tests passed, then the bundled-plugin runtime test failed with `No "getGlobalPluginRegistry" export is defined`, pointing to `src/plugins/loader-shared.ts:349`.
- Authentic owner-first GREEN: `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/auto-reply/reply.directive.directive-behavior.shows-current-verbose-level-verbose-has-no.test.ts src/plugins/source-checkout-runtime.test.ts --no-isolate --maxWorkers=1 --fileParallelism=false --no-cache --reporter=verbose`; the same nine reply tests run first and the bundled-plugin runtime test then passes: **2 files, 10 tests passed**. `--no-cache` prevents Vitest's failed-first result cache from reversing the regression order.
- Four fresh independent hostile immutable-source reviews found no P0–P3 findings.
- Official commit-mode autoreview used `gpt-5.6-sol` with high reasoning and P3 coverage; native TruffleHog 3.96.0 was clean; exit 0, no findings, confidence 0.96.
- Existing targeted formatter check and `git diff --check` passed. No production code changed; no full-suite or remote CI result is claimed.
