### PR TITLE
fix(ui): refresh automation alerts on cron events

### DIFF
--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -193,6 +193,7 @@ describe("sidebar attention refresh ownership", () => {
         password: "",
       },
       subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
     } as unknown as ApplicationGateway;
     const overlays = {
       snapshot: { approvalQueue: [] },
@@ -239,6 +240,59 @@ describe("sidebar attention refresh ownership", () => {
     expect(element.modelAuthStatus).toBe(currentAuth);
     expect(element.loadedAtMs).toBe(200_000);
     expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).not.toBeNull();
+  });
+
+  it("clears a stale failure alert when the gateway reports an automation change", async () => {
+    const responses = {
+      "cron.list": [{ jobs: [cronJob("failed")] }, { jobs: [] }],
+      "models.authStatus": [{ ts: 1, providers: [] }],
+    };
+    const request = vi.fn((method: keyof typeof responses) => {
+      const response = responses[method].shift();
+      if (!response) {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return Promise.resolve(response);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      client,
+      phase: "connected",
+      hello: null,
+      assistantAgentId: "main",
+      sessionKey: "agent:main:main",
+      lastError: null,
+      lastErrorCode: null,
+    };
+    let eventListener: Parameters<ApplicationGateway["subscribeEvents"]>[0] | undefined;
+    const gateway = {
+      snapshot,
+      connection: {
+        gatewayUrl: "ws://gateway.test",
+        token: "",
+        bootstrapToken: "",
+        password: "",
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: (listener: NonNullable<typeof eventListener>) => {
+        eventListener = listener;
+        return () => undefined;
+      },
+    } as unknown as ApplicationGateway;
+    const overlays = {
+      snapshot: { approvalQueue: [] },
+      subscribe: () => () => undefined,
+    } as unknown as ApplicationContext["overlays"];
+    vi.stubGlobal("localStorage", createTestStorageMock());
+
+    const provider = createApplicationContextProvider({ gateway, overlays } as ApplicationContext);
+    const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
+    provider.append(element);
+    document.body.append(provider);
+    await waitForFast(() => expect(element.textContent).toContain("1 automation(s) failed"));
+
+    eventListener?.({ type: "event", event: "cron", payload: {} });
+    await waitForFast(() => expect(element.textContent).not.toContain("automation(s) failed"));
   });
 });
 

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -58,26 +58,35 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     autoRun: false,
     // Gateway identity matters when a replacement source reuses the same client object.
     args: () =>
-      [null as ApplicationContext["gateway"] | null, null as GatewayBrowserClient | null] as const,
-    task: async ([gateway, client], { signal }) => {
+      [
+        null as ApplicationContext["gateway"] | null,
+        null as GatewayBrowserClient | null,
+        true as boolean,
+      ] as const,
+    task: async ([gateway, client, refreshModelAuth], { signal }) => {
       if (!gateway || !client) {
         return initialState;
       }
       const cron = createInitialCronState({ client, connected: true });
-      await Promise.allSettled([
+      const loads: Promise<unknown>[] = [
         loadCronJobsPage(cron).then(() => {
           if (!signal.aborted) {
             this.cronJobs = cron.cronJobs;
           }
         }),
-        loadModelAuthStatus(client, { signal })
-          .catch(() => null)
-          .then((modelAuthStatus) => {
-            if (!signal.aborted) {
-              this.modelAuthStatus = modelAuthStatus;
-            }
-          }),
-      ]);
+      ];
+      if (refreshModelAuth) {
+        loads.push(
+          loadModelAuthStatus(client, { signal })
+            .catch(() => null)
+            .then((modelAuthStatus) => {
+              if (!signal.aborted) {
+                this.modelAuthStatus = modelAuthStatus;
+              }
+            }),
+        );
+      }
+      await Promise.allSettled(loads);
       return true;
     },
     onComplete: () => {
@@ -93,6 +102,19 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
         this.synchronize(gateway);
         return gateway.subscribe(() => this.synchronize(gateway));
       },
+    )
+    .effect(
+      () => this.context?.gateway,
+      (gateway) =>
+        gateway.subscribeEvents((event) => {
+          if (this.context?.gateway !== gateway || event.event !== "cron") {
+            return;
+          }
+          // The Automations page refreshes from the same event. Refresh this
+          // independent snapshot too so its ambient alert cannot contradict it.
+          this.loadedClient = null;
+          this.synchronize(gateway, { refreshModelAuth: false });
+        }),
     )
     .watch(
       () => this.context?.overlays,
@@ -136,13 +158,16 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       this.idleRefreshTimer = null;
     }
     this.subscriptions.clear();
-    void this.loadTask.run([null, null]);
+    void this.loadTask.run([null, null, false]);
     this.loadedClient = null;
     this.loadedGateway = null;
     super.disconnectedCallback();
   }
 
-  private synchronize(gateway: ApplicationContext["gateway"]) {
+  private synchronize(
+    gateway: ApplicationContext["gateway"],
+    options: { refreshModelAuth?: boolean } = {},
+  ) {
     const snapshot = gateway.snapshot;
     const gatewayUrl = gateway.connection.gatewayUrl;
     if (gatewayUrl && gatewayUrl !== this.dismissedScope) {
@@ -150,7 +175,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       this.dismissed = loadDismissals(gatewayUrl);
     }
     if (snapshot.phase !== "connected" || !snapshot.client) {
-      void this.loadTask.run([null, null]);
+      void this.loadTask.run([null, null, false]);
       this.loadedClient = null;
       this.loadedGateway = null;
       this.cronJobs = [];
@@ -162,7 +187,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     }
     this.loadedGateway = gateway;
     this.loadedClient = snapshot.client;
-    void this.loadTask.run([gateway, snapshot.client]);
+    void this.loadTask.run([gateway, snapshot.client, options.refreshModelAuth !== false]);
   }
 
   // Re-arm stale snoozes only right after this tab's own data refresh: fresh


### PR DESCRIPTION
## Summary

- refresh the sidebar automation alert snapshot when the Gateway emits an automation change
- keep model-auth refreshes on their existing lifecycle instead of repeating them for automation events
- cover stale failure-alert removal with a component regression test

The visible wording is already `automation(s)` on current `main` via #114853; this fixes the separate stale-alert mismatch where the Automations page showed zero while the sidebar retained an older failure.

## Validation

- `pnpm test ui/src/components/sidebar-attention.test.ts` — 11 passed on Blacksmith Testbox
- `pnpm check:changed` — passed formatting, i18n, typecheck, lint, and guards on Blacksmith Testbox
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no actionable findings
- rebased onto current `origin/main`; range-diff confirmed the patch was unchanged

## Real browser proof

- Proof source head: `61bb840a1454c9b8638bf28fec4c117140a15dc9`
- Current prepared head: `dadbb6d39bc` (same UI patch plus current `main`, including #117647 for the unrelated CI mock collision)
- Immutable bundle: [`dist-runtime-build` from CI run 30719501315](https://github.com/openclaw/openclaw/actions/runs/30719501315)
- Setup: CI-built Control UI bundle served in the Codex app browser with the repo mock WebSocket Gateway
- Before: `cron.list` returned 3 automations with 1 failed; both the Automations page and sidebar showed the failure
- Transition: the Gateway changed `cron.list` to empty and emitted the existing `cron` event
- After: without reload or manual refresh, the page showed 0 automations / 0 failing and the sidebar failure alert disappeared

[Before the Gateway event](https://github.com/user-attachments/assets/5bafbcd7-0685-4f55-a02f-a5de0e8fdb55)

[After the Gateway event](https://github.com/user-attachments/assets/91931b61-4291-4596-b7db-174b7bb505e8)