### PR TITLE
perf(agent): trace local startup stages

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -56,6 +56,7 @@ import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import type { MainSessionRecoveryPendingTarget } from "./main-session-recovery-store.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import { createAgentRunRestartAbortError } from "./run-termination.js";
+import { measureAgentStartup } from "./startup-timing.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
@@ -386,53 +387,63 @@ async function agentCommandInternal(
         });
       }
 
-      const embeddedSessionState = await prepareEmbeddedSessionState({
-        cfg,
-        opts,
-        sessionEntry,
-        sessionStore,
-        sessionKey,
-        sessionId,
-        storePath,
-        sessionAgentId,
-        lifecycleGeneration,
-        runId,
-        workspaceDir,
-        isNewSession,
-        isSubagentLaneTurn,
-        suppressVisibleSessionEffects,
-        thinkOnce,
-        thinkOverride,
-        persistedThinking,
-        verboseOverride,
-        persistedVerbose,
-        verboseDefault: agentCfg?.verboseDefault as VerboseLevel | undefined,
-        sessionStateActor,
-      });
+      const embeddedSessionState = await measureAgentStartup(
+        "session-state",
+        () =>
+          prepareEmbeddedSessionState({
+            cfg,
+            opts,
+            sessionEntry,
+            sessionStore,
+            sessionKey,
+            sessionId,
+            storePath,
+            sessionAgentId,
+            lifecycleGeneration,
+            runId,
+            workspaceDir,
+            isNewSession,
+            isSubagentLaneTurn,
+            suppressVisibleSessionEffects,
+            thinkOnce,
+            thinkOverride,
+            persistedThinking,
+            verboseOverride,
+            persistedVerbose,
+            verboseDefault: agentCfg?.verboseDefault as VerboseLevel | undefined,
+            sessionStateActor,
+          }),
+        { config: cfg },
+      );
       sessionEntry = embeddedSessionState.sessionEntry;
       const { requestedThinkLevel, runContext } = embeddedSessionState;
 
-      const modelSelection = await resolveEmbeddedModelSelection({
-        cfg,
-        opts,
-        sessionEntry,
-        sessionStore,
-        sessionKey,
-        sessionId,
-        storePath,
-        sessionAgentId,
-        workspaceDir,
-        pluginsEnabled,
-        manifestMetadataSnapshot,
-        modelManifestContext,
-        configuredThinkingCatalog,
-        requestedThinkLevel,
-        thinkOverride,
-        thinkOnce,
-        isSubagentLane,
-        suppressVisibleSessionEffects,
-        runContext,
-      });
+      const modelSelection = await measureAgentStartup(
+        "model-selection",
+        () =>
+          resolveEmbeddedModelSelection({
+            cfg,
+            opts,
+            sessionEntry,
+            sessionStore,
+            sessionKey,
+            sessionId,
+            storePath,
+            sessionAgentId,
+            workspaceDir,
+            pluginsEnabled,
+            manifestMetadataSnapshot,
+            modelManifestContext,
+            configuredThinkingCatalog,
+            requestedThinkLevel,
+            thinkOverride,
+            thinkOnce,
+            isSubagentLane,
+            suppressVisibleSessionEffects,
+            runContext,
+          }),
+        { config: cfg },
+      );
       sessionEntry = modelSelection.sessionEntry;
       const embeddedAttempt = await runEmbeddedAgentAttempt({
         prepared,
@@ -546,7 +557,9 @@ export async function agentCommand(
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
 ) {
-  const resolvedDeps = await resolveAgentCommandDeps(deps);
+  const resolvedDeps = await measureAgentStartup("command-dependencies", () =>
+    resolveAgentCommandDeps(deps),
+  );
   const lifecycleGeneration =
     opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(opts.runId ?? "");
   return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
@@ -570,7 +583,9 @@ export async function agentCommand(
             allowModelOverride: opts.allowModelOverride ?? true,
           },
           prepare: async (preparedOpts) =>
-            await prepareAgentCommandExecution(preparedOpts, runtime),
+            await measureAgentStartup("command-prepare", () =>
+              prepareAgentCommandExecution(preparedOpts, runtime),
+            ),
           run: async (prepared) =>
             await agentCommandInternal(prepared, prepared.opts, runtime, resolvedDeps),
         }),

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -13,6 +13,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import type { RuntimeEnv } from "../runtime.js";
 import { discoverConfigSecretTargetsByIds } from "../secrets/target-registry.js";
 import { listAgentEntries } from "./agent-scope.js";
+import { measureAgentStartup } from "./startup-timing.js";
 
 /** Loads runtime/source config and resolves command SecretRefs when the agent path needs them. */
 export async function resolveAgentRuntimeConfig(
@@ -36,19 +37,23 @@ export async function resolveAgentRuntimeConfig(
     channel: channelSecretScope?.channel,
   });
   let pluginMetadataSnapshot: PluginMetadataSnapshot | undefined;
-  const sourceConfig = await (async () => {
-    try {
-      const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
-      if (snapshot.valid) {
-        pluginMetadataSnapshot = writeOptions.basePluginMetadataSnapshot;
-        return snapshot.resolved;
+  const sourceConfig = await measureAgentStartup(
+    "config-source",
+    async () => {
+      try {
+        const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+        if (snapshot.valid) {
+          pluginMetadataSnapshot = writeOptions.basePluginMetadataSnapshot;
+          return snapshot.resolved;
+        }
+      } catch {
+        // Fall back to runtime-loaded config when source snapshot is unavailable.
       }
-    } catch {
-      // Fall back to runtime-loaded config when source snapshot is unavailable.
-    }
-    pluginMetadataSnapshot = resolvePluginMetadataSnapshot({ config: loadedRaw });
-    return loadedRaw;
-  })();
+      pluginMetadataSnapshot = resolvePluginMetadataSnapshot({ config: loadedRaw });
+      return loadedRaw;
+    },
+    { config: loadedRaw },
+  );
   const cfg = hasRuntimeSecretRefs
     ? await (async () => {
         const runtimeSecretTargets = resolveAgentRuntimeSecretTargets({
@@ -74,17 +79,26 @@ export async function resolveAgentRuntimeConfig(
         ).resolvedConfig;
       })()
     : loadedRaw;
-  const secretsRuntime = await import("../secrets/runtime.js");
+  const secretsRuntime = await measureAgentStartup(
+    "secrets-runtime-import",
+    () => import("../secrets/runtime.js"),
+    { config: cfg },
+  );
   if (secretsRuntime.getActiveSecretsRuntimeSnapshot()) {
     setRuntimeConfigSnapshot(cfg, sourceConfig);
   } else {
     // Standalone local agent commands have no Gateway-owned snapshot. Materialize
     // auth-profile refs too; resolving only config refs leaves selected credentials unusable.
-    const snapshot = await secretsRuntime.prepareSecretsRuntimeSnapshot({
-      config: sourceConfig,
-      assignmentConfig: cfg,
-      includeConfigRefs: false,
-    });
+    const snapshot = await measureAgentStartup(
+      "secrets-snapshot",
+      () =>
+        secretsRuntime.prepareSecretsRuntimeSnapshot({
+          config: sourceConfig,
+          assignmentConfig: cfg,
+          includeConfigRefs: false,
+        }),
+      { config: cfg },
+    );
     secretsRuntime.activateSecretsRuntimeSnapshot(snapshot);
   }
   return {

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -38,6 +38,7 @@ import {
   resolveAgentRunErrorLifecycleFields,
 } from "../run-termination.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../session-runtime-compat.js";
+import { measureAgentStartup } from "../startup-timing.js";
 import {
   hasResolvedThinkingCatalogEntry,
   normalizeThinkingCatalogProviders,
@@ -195,7 +196,11 @@ export async function runEmbeddedAgentAttempt(params: {
     abortSignal: params.opts.abortSignal,
     state: attemptLifecycleState,
   });
-  const attemptExecutionRuntime = await loadAttemptExecutionRuntime();
+  const attemptExecutionRuntime = await measureAgentStartup(
+    "attempt-runtime-import",
+    () => loadAttemptExecutionRuntime(),
+    { config: cfg },
+  );
   const messageChannel = resolveMessageChannel(
     runContext.messageChannel,
     params.opts.replyChannel ?? params.opts.channel,

--- a/src/agents/startup-timing.test.ts
+++ b/src/agents/startup-timing.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { measureAgentStartup } from "./startup-timing.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("measureAgentStartup", () => {
+  it("records the startup stage without changing the result", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-agent-startup-"));
+    tempDirs.push(dir);
+    const path = join(dir, "timeline.jsonl");
+    const env = {
+      OPENCLAW_DIAGNOSTICS: "timeline",
+      OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: path,
+    } as NodeJS.ProcessEnv;
+
+    await expect(measureAgentStartup("command-import", async () => "ready", { env })).resolves.toBe(
+      "ready",
+    );
+
+    const events = (await readFile(path, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: "span.start",
+      name: "agent.startup",
+      phase: "agent.startup",
+      attributes: { stage: "command-import" },
+    });
+    expect(events[1]).toMatchObject({
+      type: "span.end",
+      name: "agent.startup",
+      phase: "agent.startup",
+      attributes: { stage: "command-import" },
+    });
+  });
+});

--- a/src/agents/startup-timing.ts
+++ b/src/agents/startup-timing.ts
@@ -1,0 +1,21 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
+
+type AgentStartupTimingOptions = {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+};
+
+/** Measures local agent startup work before the canonical provider-preparation spans begin. */
+export function measureAgentStartup<T>(
+  stage: string,
+  run: () => Promise<T> | T,
+  options: AgentStartupTimingOptions = {},
+): Promise<T> {
+  return measureDiagnosticsTimelineSpan("agent.startup", run, {
+    config: options.config,
+    env: options.env,
+    phase: "agent.startup",
+    attributes: { stage },
+  });
+}

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -8,6 +8,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { measureAgentStartup } from "../agents/startup-timing.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -917,7 +918,9 @@ export async function agentCliCommand(
   const signalBridge = createAgentCliSignalBridge(resolveAgentCliProcessLike(deps));
   try {
     if (dispatchOpts.local === true) {
-      const agentCommand = await embeddedAgentCommandLoader.load();
+      const agentCommand = await measureAgentStartup("command-import", () =>
+        embeddedAgentCommandLoader.load(),
+      );
       const result = await agentCommand(
         {
           ...gatewayDispatchOpts,


### PR DESCRIPTION
## What Problem This Solves

Local agent startup time before the existing `agent.prepare` spans could not be
attributed to command loading, config/secrets setup, session state, model
selection, or attempt-runtime loading.

## Why This Change Was Made

Adds opt-in `agent.startup` diagnostics timeline spans around the existing owner
boundaries. The spans reuse the canonical diagnostics timeline, preserve the
original direct execution path when diagnostics are disabled, and do not change
provider, model, config, session, or error policy.

## Maintainer Decision

Land the observability seam separately from any optimization. The exact Kova
evidence shows that most pre-provider time remains outside these new spans, so
combining speculative startup changes with the instrumentation would obscure
the baseline. Follow-up performance work should target the measured owners.

## User Impact

No user-visible runtime change. Maintainers get stage-level data for local agent
startup when diagnostics are explicitly enabled.

## Exact-Head Evidence

- Head: `6ccc8e439da7ace01aa4429190612f0fe7860eb1`.
- Exact Kova/source-performance run:
  https://github.com/openclaw/openclaw/actions/runs/30722860302
- All workflow jobs passed: source probes, 10/10 normal mock records, deep
  profile, and live OpenAI.
- Every intended `agent.startup` stage appeared in 10 normal turn traces:

| Stage | p50 | max |
| --- | ---: | ---: |
| command-prepare | 125.1 ms | 148.9 ms |
| attempt-runtime-import | 48.8 ms | 55.2 ms |
| session-state | 41.5 ms | 58.6 ms |
| config-source | 8.8 ms | 17.9 ms |
| model-selection | 6.3 ms | 7.9 ms |
| secrets-runtime-import | 5.0 ms | 5.3 ms |
| command-import | 3.8 ms | 12.8 ms |
| secrets-snapshot | 2.6 ms | 3.0 ms |
| command-dependencies | 1.1 ms | 8.0 ms |

- Normal Kova:
  - agent RSS median/p95/max: 852/858/859 MB
  - cold/warm agent turn median: 3275/3292 ms
  - pre-provider p95 median: 3175 ms
  - `agent.startup` was the slowest new span at 125-149 ms
  - no open spans or liveness warnings
- Near-contemporaneous control run `30722795395`, without this instrumentation:
  - agent RSS median/p95/max: 837/847/849 MB
  - cold/warm agent turn median: 3267/3304 ms
  - pre-provider p95 median: 3183 ms
  - latency is effectively flat; diagnostics-mode RSS is +15 MB median
    (+1.8%). This is not a strict same-SHA A/B because current `main` advanced
    between runs, but the intervening changes did not touch this agent surface.
- Live OpenAI passed: cold/warm 5847/5582 ms, pre-provider 4345 ms.
- Deep profile reproduced all nine stages. Its agent RSS threshold remained the
  known profiler-overhead diagnostic (1053 MB over 1000 MB); the workflow
  classified it as profiling-only and passed.
- Source readiness passed on the post-#117655 baseline; connected health p50/p95
  was 691/698 ms.

## Local Verification

- `node scripts/run-vitest.mjs src/agents/startup-timing.test.ts src/commands/agent-via-gateway.test.ts src/agents/agent-command.ingress-diagnostics.test.ts`
  - 94 passed, 1 skipped.
- Focused `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- P2-wide autoreview completed clean with no accepted/actionable findings.
- The rebased patch is equivalent to the previously reviewed patch.
- Current `main` at `b2278f3d10591d9eec4c091c82a4077d777143a6`
  has not changed the six touched files, and `git merge-tree --write-tree` is
  clean.

## Findings And Next Work

The new spans explain roughly 230-250 ms of a roughly 3.2-second normal
pre-provider path. The largest remaining bucket is still about 2.9 seconds of
unattributed process/module bootstrap. Repeated plugin metadata scans account
for another roughly 175-190 ms per cold/warm pair. Optimize those owners in
separate PRs using this timeline as the baseline.

## Storage And Compatibility

No persisted state, schema, config, protocol, or public API changes. Timeline
events are written only through the existing opt-in diagnostics contract.
