### PR TITLE
fix(perf): wait for gateway WebSocket readiness

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -744,12 +744,16 @@ jobs:
           done
 
           gateway_home="$(mktemp -d)"
+          gateway_readiness_home="$(mktemp -d)"
           gateway_port="$(node -e "const net=require('node:net'); const s=net.createServer(); s.listen(0,'127.0.0.1',()=>{ console.log(s.address().port); s.close(); });")"
           gateway_state="$gateway_home/.openclaw"
           gateway_config="$gateway_state/openclaw.json"
+          gateway_readiness_state="$gateway_readiness_home/.openclaw"
+          gateway_readiness_config="$gateway_readiness_state/openclaw.json"
           gateway_log="$SOURCE_PERF_DIR/cli-gateway.log"
+          gateway_readiness_log="$SOURCE_PERF_DIR/cli-gateway-readiness.log"
           gateway_pid=""
-          mkdir -p "$gateway_state"
+          mkdir -p "$gateway_state" "$gateway_readiness_state"
           cat > "$gateway_config" <<EOF
           {
             "browser": { "enabled": false },
@@ -769,12 +773,14 @@ jobs:
             }
           }
           EOF
+          cp "$gateway_config" "$gateway_readiness_config"
+          : > "$gateway_readiness_log"
           cleanup_gateway() {
             if [[ -n "${gateway_pid:-}" ]] && kill -0 "$gateway_pid" 2>/dev/null; then
               kill "$gateway_pid" 2>/dev/null || true
               wait "$gateway_pid" 2>/dev/null || true
             fi
-            rm -rf "$gateway_home"
+            rm -rf "$gateway_home" "$gateway_readiness_home"
           }
           trap cleanup_gateway EXIT
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 \
@@ -805,6 +811,30 @@ jobs:
               exit 1
             fi
             sleep 1
+          done
+
+          # Exercise the real WebSocket handshake and health RPC without warming benchmark device state.
+          while true; do
+            gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))
+            if (( gateway_ready_remaining <= 0 )); then
+              cat "$gateway_log" >&2
+              cat "$gateway_readiness_log" >&2
+              echo "Timed out after ${gateway_ready_timeout_seconds}s waiting for gateway WebSocket health." >&2
+              exit 1
+            fi
+            gateway_ready_remaining_ms=$((gateway_ready_remaining * 1000))
+            if OPENCLAW_HOME="$gateway_readiness_home" OPENCLAW_STATE_DIR="$gateway_readiness_state" OPENCLAW_CONFIG_PATH="$gateway_readiness_config" \
+              node dist/entry.js gateway health \
+                --port "$gateway_port" \
+                --timeout "$gateway_ready_remaining_ms" \
+                --json >"$gateway_readiness_log" 2>&1; then
+              break
+            fi
+            if ! kill -0 "$gateway_pid" 2>/dev/null; then
+              cat "$gateway_log" >&2
+              cat "$gateway_readiness_log" >&2
+              exit 1
+            fi
           done
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -835,6 +835,11 @@ jobs:
               cat "$gateway_readiness_log" >&2
               exit 1
             fi
+            # Pace fast transport failures without extending the shared startup deadline.
+            gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))
+            if (( gateway_ready_remaining > 0 )); then
+              sleep 1
+            fi
           done
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -241,6 +241,12 @@ describe("OpenClaw performance workflow", () => {
       'curl -fsS --connect-timeout 2 --max-time "$gateway_probe_timeout" "http://127.0.0.1:${gateway_port}/healthz"';
     const websocketTimeout = "gateway_ready_remaining_ms=$((gateway_ready_remaining * 1000))";
     const websocketProbe = "node dist/entry.js gateway health \\";
+    const websocketRetryDelay = [
+      "  gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))",
+      "  if (( gateway_ready_remaining > 0 )); then",
+      "    sleep 1",
+      "  fi",
+    ].join("\n");
     const benchmark = "node --import tsx scripts/bench-cli-startup.ts \\";
 
     expect(run).toContain("gateway_ready_timeout_seconds=120");
@@ -255,6 +261,7 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain('--port "$gateway_port" \\');
     expect(run).toContain('--timeout "$gateway_ready_remaining_ms" \\');
     expect(run).toContain('--json >"$gateway_readiness_log" 2>&1; then');
+    expect(run).toContain(websocketRetryDelay);
     expect(run).toContain(
       "Timed out after ${gateway_ready_timeout_seconds}s waiting for gateway WebSocket health.",
     );
@@ -265,10 +272,9 @@ describe("OpenClaw performance workflow", () => {
     expect(run.indexOf(probeCap)).toBeLessThan(run.indexOf(boundedProbe));
     expect(run.indexOf(boundedProbe)).toBeLessThan(run.indexOf(websocketTimeout));
     expect(run.indexOf(websocketTimeout)).toBeLessThan(run.indexOf(websocketProbe));
-    expect(run.indexOf(websocketProbe)).toBeLessThan(run.indexOf(benchmark));
-    expect(run.slice(run.indexOf(websocketTimeout), run.indexOf(benchmark))).not.toContain(
-      "sleep ",
-    );
+    const websocketRetryDelayIndex = run.indexOf(websocketRetryDelay, run.indexOf(websocketProbe));
+    expect(websocketRetryDelayIndex).toBeGreaterThan(run.indexOf(websocketProbe));
+    expect(websocketRetryDelayIndex).toBeLessThan(run.indexOf(benchmark));
   });
 
   it("isolates gateway readiness identity from benchmark device state", () => {

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -239,6 +239,9 @@ describe("OpenClaw performance workflow", () => {
     ].join("\n");
     const boundedProbe =
       'curl -fsS --connect-timeout 2 --max-time "$gateway_probe_timeout" "http://127.0.0.1:${gateway_port}/healthz"';
+    const websocketTimeout = "gateway_ready_remaining_ms=$((gateway_ready_remaining * 1000))";
+    const websocketProbe = "node dist/entry.js gateway health \\";
+    const benchmark = "node --import tsx scripts/bench-cli-startup.ts \\";
 
     expect(run).toContain("gateway_ready_timeout_seconds=120");
     expect(run).toContain("gateway_probe_timeout_seconds=5");
@@ -247,11 +250,37 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain(deadlineFailure);
     expect(run).toContain(probeCap);
     expect(run).toContain(boundedProbe);
+    expect(run).toContain(websocketTimeout);
+    expect(run).toContain(websocketProbe);
+    expect(run).toContain('--port "$gateway_port" \\');
+    expect(run).toContain('--timeout "$gateway_ready_remaining_ms" \\');
+    expect(run).toContain('--json >"$gateway_readiness_log" 2>&1; then');
+    expect(run).toContain(
+      "Timed out after ${gateway_ready_timeout_seconds}s waiting for gateway WebSocket health.",
+    );
     expect(run.split("/healthz")).toHaveLength(2);
     expect(run.indexOf(deadline)).toBeLessThan(run.indexOf(remaining));
     expect(run.indexOf(remaining)).toBeLessThan(run.indexOf(deadlineFailure));
     expect(run.indexOf(deadlineFailure)).toBeLessThan(run.indexOf(probeCap));
     expect(run.indexOf(probeCap)).toBeLessThan(run.indexOf(boundedProbe));
+    expect(run.indexOf(boundedProbe)).toBeLessThan(run.indexOf(websocketTimeout));
+    expect(run.indexOf(websocketTimeout)).toBeLessThan(run.indexOf(websocketProbe));
+    expect(run.indexOf(websocketProbe)).toBeLessThan(run.indexOf(benchmark));
+    expect(run.slice(run.indexOf(websocketTimeout), run.indexOf(benchmark))).not.toContain(
+      "sleep ",
+    );
+  });
+
+  it("isolates gateway readiness identity from benchmark device state", () => {
+    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+
+    expect(run).toContain('gateway_readiness_home="$(mktemp -d)"');
+    expect(run).toContain('gateway_readiness_state="$gateway_readiness_home/.openclaw"');
+    expect(run).toContain('gateway_readiness_config="$gateway_readiness_state/openclaw.json"');
+    expect(run).toContain('mkdir -p "$gateway_state" "$gateway_readiness_state"');
+    expect(run).toContain('cp "$gateway_config" "$gateway_readiness_config"');
+    expect(run).toContain(': > "$gateway_readiness_log"');
+    expect(run).toContain('rm -rf "$gateway_home" "$gateway_readiness_home"');
   });
 
   it("measures warmed and first-device gateway health separately", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the source-performance benchmark could start after the HTTP listener was reachable but before the Gateway could complete a real WebSocket health exchange. Under runner load, the first connected-health warmup could time out and leave the following measured sample waiting for the server's preauth timeout.

## Why This Change Was Made

The source-performance fixture now keeps the existing bounded `/healthz` startup check, then requires a successful `gateway health --json` RPC within the same 120-second deadline. The readiness probe uses a separate home and state directory so it does not warm or mutate the benchmark client's connected/first-device state.

## User Impact

No product runtime change. Maintainers get stable source-performance evidence that begins only after the benchmark Gateway can serve the protocol being measured.

## Evidence

- Failure artifact: https://github.com/openclaw/openclaw/actions/runs/30719599205
  - `/healthz` passed and the benchmark started.
  - `gatewayHealthJsonConnected` warmup timed out after 10 seconds.
  - The Gateway closed the stale preauth socket at 20 seconds, immediately before the next sample completed.
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts`
  - 34/34 passed.
- `actionlint .github/workflows/openclaw-performance.yml`
- Focused `oxlint`, `oxfmt --check`, and `git diff --check` passed.
- ClawSweeper finding resolved:
  - Failed WebSocket health probes now wait one second only while shared deadline budget remains.
  - Focused coverage requires the paced retry before benchmark launch.
- Exact-head Kova: https://github.com/openclaw/openclaw/actions/runs/30722210352
  - Tested SHA: `089181fb3e384444bd41ab6a4c4373011e267ef0`.
  - Source-performance, deep-profile workflow execution, and live OpenAI jobs completed successfully.
  - The readiness RPC returned `ok: true` before benchmark sampling.
  - `gatewayHealthJsonConnected`: 5/5 successful, p50 698.7ms, p95 729.9ms.
  - `gatewayHealthJsonFirstDevice`: 5/5 successful, p50 647.9ms, p95 650.1ms.
  - The prior multi-second connected-health tail did not recur.
  - One initial normal-mock sample had a runner RSS outlier (`1111.6MB`); rerunning only that failed lane passed 10/10 with gateway RSS median `933MB` and max `938MB`.
  - Live OpenAI remained healthy: 1/1 scenario passed.
  - Deep profiling retained the known profiler-overhead RSS findings (`942MB` status CLI versus `900MB`; `1049MB` agent versus `1000MB`). This PR changes only workflow readiness and did not alter either runtime path.
- Exact-head hosted gates:
  - CI, Blacksmith Testbox, Blacksmith ARM Testbox, Blacksmith Build Artifacts Testbox, CodeQL, and Workflow Sanity all passed.
- Current-main merge proof:
  - `origin/main`: `eb8c22ed13f9865e07c0e363706183188e2a8fd1`.
  - `git merge-tree --write-tree origin/main HEAD` completed without conflicts.
  - Neither touched file changed on main after this PR's base.

## Maintainer Decision

This is the owner-boundary fix: readiness now checks the WebSocket RPC being measured, within the existing startup deadline, without warming benchmark identity state. The exact-head runner proof resolves the remaining ClawSweeper merge-risk and rank-up items.
