### PR TITLE
fix(ci): repair release E2E regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway session history migration errors:** return an actionable conflict response for duplicate canonical session rows instead of an opaque internal error, directing operators to `openclaw doctor --fix`.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway session history migration errors:** return an actionable conflict response for duplicate canonical session rows instead of an opaque internal error, directing operators to `openclaw doctor --fix`.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -54,14 +54,16 @@ type MockSubagentRun = {
   task: string;
   cleanup: "keep" | "delete";
   createdAt: number;
-  endedAt?: number;
+  execution: {
+    endedAt?: number;
+    outcome?: {
+      status: "ok" | "timeout" | "error" | "unknown";
+      error?: string;
+    };
+  };
   cleanupCompletedAt?: number;
   label?: string;
   frozenResultText?: string | null;
-  outcome?: {
-    status: "ok" | "timeout" | "error" | "unknown";
-    error?: string;
-  };
 };
 type SessionEntryFixture = Partial<Omit<SessionEntry, "updatedAt">> & {
   updatedAt?: number;
@@ -2474,10 +2476,9 @@ describe("subagent announce formatting", () => {
               label: "child-stale",
               cleanup: "keep",
               createdAt: 1,
-              endedAt: 2,
+              execution: { endedAt: 2, outcome: { status: "ok" } },
               cleanupCompletedAt: 3,
               frozenResultText: "stale result that should be filtered",
-              outcome: { status: "ok" },
             },
           ];
         }
@@ -2491,10 +2492,9 @@ describe("subagent announce formatting", () => {
             label: "child-a",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "result from child a",
-            outcome: { status: "ok" },
           },
           {
             runId: "run-child-b",
@@ -2505,10 +2505,9 @@ describe("subagent announce formatting", () => {
             label: "child-b",
             cleanup: "keep",
             createdAt: 11,
-            endedAt: 21,
+            execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
             frozenResultText: "result from child b",
-            outcome: { status: "ok" },
           },
         ];
       },
@@ -2562,10 +2561,9 @@ describe("subagent announce formatting", () => {
             label: "child-a",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "stale result from child a",
-            outcome: { status: "ok" },
           },
           {
             runId: "run-child-current",
@@ -2576,10 +2574,9 @@ describe("subagent announce formatting", () => {
             label: "child-a",
             cleanup: "keep",
             createdAt: 11,
-            endedAt: 22,
+            execution: { endedAt: 22, outcome: { status: "ok" } },
             cleanupCompletedAt: 23,
             frozenResultText: "current result from child a",
-            outcome: { status: "ok" },
           },
           {
             runId: "run-child-b",
@@ -2590,10 +2587,9 @@ describe("subagent announce formatting", () => {
             label: "child-b",
             cleanup: "keep",
             createdAt: 12,
-            endedAt: 24,
+            execution: { endedAt: 24, outcome: { status: "ok" } },
             cleanupCompletedAt: 25,
             frozenResultText: "result from child b",
-            outcome: { status: "ok" },
           },
         ];
       },
@@ -2638,10 +2634,9 @@ describe("subagent announce formatting", () => {
             label: "shared-child",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "stale old parent result",
-            outcome: { status: "ok" },
           },
         ];
       },
@@ -2660,10 +2655,9 @@ describe("subagent announce formatting", () => {
           label: "shared-child",
           cleanup: "keep",
           createdAt: 11,
-          endedAt: 22,
+          execution: { endedAt: 22, outcome: { status: "ok" } },
           cleanupCompletedAt: 23,
           frozenResultText: "current new parent result",
-          outcome: { status: "ok" },
         };
       },
     );
@@ -2713,10 +2707,9 @@ describe("subagent announce formatting", () => {
             label: "child-a",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "result from child a",
-            outcome: { status: "ok" },
           },
           {
             runId: "run-child-b",
@@ -2727,10 +2720,9 @@ describe("subagent announce formatting", () => {
             label: "child-b",
             cleanup: "keep",
             createdAt: 11,
-            endedAt: 21,
+            execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
             frozenResultText: "result from child b",
-            outcome: { status: "ok" },
           },
         ];
       },
@@ -2793,10 +2785,9 @@ describe("subagent announce formatting", () => {
             label: "child-a",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "result from child a",
-            outcome: { status: "ok" },
           },
         ];
       },
@@ -2849,10 +2840,9 @@ describe("subagent announce formatting", () => {
             label: "grandchild",
             cleanup: "keep",
             createdAt: 10,
-            endedAt: 20,
+            execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
             frozenResultText: "grandchild final output",
-            outcome: { status: "ok" },
           },
         ];
       }
@@ -2867,10 +2857,9 @@ describe("subagent announce formatting", () => {
             label: "child",
             cleanup: "keep",
             createdAt: 11,
-            endedAt: 21,
+            execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
             frozenResultText: "child synthesized output from grandchild",
-            outcome: { status: "ok" },
           },
         ];
       }
@@ -3182,10 +3171,12 @@ describe("subagent announce formatting", () => {
         label: params.label,
         cleanup: "keep" as const,
         createdAt: params.createdAt,
-        endedAt: params.endedAt ?? params.createdAt + 1,
+        execution: {
+          endedAt: params.endedAt ?? params.createdAt + 1,
+          outcome: params.outcome ?? ({ status: "ok" } as const),
+        },
         cleanupCompletedAt: params.cleanupCompletedAt ?? params.createdAt + 2,
         frozenResultText: params.frozenResultText,
-        outcome: params.outcome ?? ({ status: "ok" } as const),
       };
     }
 

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -801,7 +801,7 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
-  test("prefers the freshest duplicate row for direct history reads", async () => {
+  test("rejects duplicate canonical rows with an actionable migration error", async () => {
     testState.sessionConfig = { mainKey: "work" };
     const storePath = await createSessionStoreFile();
     await replaceTranscriptEvents(
@@ -848,9 +848,14 @@ describe("session history HTTP endpoints", () => {
       ],
     });
 
-    await expectSessionHistoryText({
-      sessionKey: "agent:main:work",
-      expectedText: "fresh history",
+    await withGatewayHarness(async (harness) => {
+      const res = await fetchSessionHistory(harness.port, "agent:main:work");
+      expect(res.status).toBe(409);
+      expectErrorResponse(await res.json(), {
+        type: "migration_required",
+        message:
+          "duplicate rows resolve to canonical session key agent:main:work; stop the Gateway and run openclaw doctor --fix",
+      });
     });
   });
 

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -302,14 +302,6 @@ async function readSessionHistoryBody(
   return (await res.json()) as SessionHistoryBody;
 }
 
-async function expectSessionHistoryText(params: { sessionKey: string; expectedText: string }) {
-  await withGatewayHarness(async (harness) => {
-    const body = await readSessionHistoryBody(harness.port, params.sessionKey);
-    expect(body.sessionKey).toBe(params.sessionKey);
-    expect(body.messages?.[0]?.content?.[0]?.text).toBe(params.expectedText);
-  });
-}
-
 async function readSseEvent(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   state: { buffer: string },

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -132,8 +132,24 @@ export async function handleSessionHistoryHttpRequest(
   }
   const { cfg } = authResult;
 
-  const target = resolveGatewaySessionStoreTargetWithStore({ cfg, key: sessionKey });
-  const entry = resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);
+  let target: ReturnType<typeof resolveGatewaySessionStoreTargetWithStore>;
+  let entry: ReturnType<typeof resolveCanonicalSessionEntryFromStoreKeys>;
+  try {
+    target = resolveGatewaySessionStoreTargetWithStore({ cfg, key: sessionKey });
+    entry = resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);
+  } catch (error) {
+    if ((error as { code?: unknown })?.code !== "SESSION_CANONICAL_KEY_MIGRATION_REQUIRED") {
+      throw error;
+    }
+    sendJson(res, 409, {
+      ok: false,
+      error: {
+        type: "migration_required",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return true;
+  }
   if (!entry?.sessionId) {
     sendJson(res, 404, {
       ok: false,


### PR DESCRIPTION
## Summary

- update nested subagent completion E2E fixtures to the canonical `execution` state shape
- return an actionable HTTP 409 when session history encounters duplicate canonical rows that require `openclaw doctor --fix`
- align the stale session-history E2E expectation with the runtime migration contract

## Testing

- `node scripts/run-vitest.mjs src/agents/subagent-announce.format.e2e.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/gateway/sessions-history-http.test.ts --reporter=dot`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin /opt/homebrew/bin/codex`

## Context

Full release validation at exact SHA `77796591370df043cb3228d0e24d0f1077bdf2d6` exposed these deterministic repo E2E failures. The remaining live-provider and Docker failures are being classified separately and are not hidden or weakened by this patch.
