### PR TITLE
fix(ui): decode artifact previews as UTF-8

### DIFF
--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -62,6 +62,95 @@ describe("custodian panel toggle", () => {
   });
 });
 
+describe("session workspace artifacts", () => {
+  function createArtifactHost(params: { data: string; mimeType: string; title?: string }) {
+    const handleOpenSidebar = vi.fn();
+    const request = vi.fn().mockResolvedValue({
+      artifact: {
+        id: "artifact-1",
+        mimeType: params.mimeType,
+        title: params.title ?? "Unicode artifact",
+      },
+      data: params.data,
+      encoding: "base64",
+    });
+    const state = {
+      client: { request },
+      connected: true,
+      handleOpenSidebar,
+      hello: gatewayHello([]),
+      sessionKey: "agent:main:current",
+      sessions: {},
+    } as unknown as SessionWorkspaceHost;
+    return { handleOpenSidebar, request, state };
+  }
+
+  it.each([
+    {
+      content: "Résumé 東京 🦀",
+      fence: "```",
+      mimeType: "text/plain",
+    },
+    {
+      content: JSON.stringify({ message: "Résumé 東京 🦀" }),
+      fence: "```json",
+      mimeType: "application/json",
+    },
+  ])(
+    "decodes UTF-8 $mimeType artifacts without corrupting visible or raw text",
+    async (testCase) => {
+      const data = btoa(String.fromCharCode(...new TextEncoder().encode(testCase.content)));
+      const { handleOpenSidebar, state } = createArtifactHost({
+        data,
+        mimeType: testCase.mimeType,
+      });
+
+      createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
+
+      await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
+      expect(handleOpenSidebar.mock.calls[0]?.[0]).toEqual({
+        kind: "markdown",
+        content: `# Unicode artifact\n\n${testCase.fence}\n${testCase.content}\n\`\`\``,
+        rawText: testCase.content,
+      });
+    },
+  );
+
+  it("preserves inline image artifacts as their original base64 data URLs", async () => {
+    const data = "iVBORw0KGgo=";
+    const { handleOpenSidebar, state } = createArtifactHost({
+      data,
+      mimeType: "image/png",
+      title: "preview.png",
+    });
+
+    createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
+
+    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
+    expect(handleOpenSidebar.mock.calls[0]?.[0]).toEqual({
+      kind: "image",
+      mimeType: "image/png",
+      rawText: null,
+      src: `data:image/png;base64,${data}`,
+      title: "preview.png",
+    });
+  });
+
+  it("reports malformed base64 artifact data as a visible workspace error", async () => {
+    const { handleOpenSidebar, state } = createArtifactHost({
+      data: "not-base64!",
+      mimeType: "text/plain",
+    });
+
+    createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
+
+    await vi.waitFor(() =>
+      expect(createSessionWorkspaceProps(state).error).toMatch(/InvalidCharacterError|invalid/i),
+    );
+    expect(handleOpenSidebar).not.toHaveBeenCalled();
+  });
+});
+
 describe("openSessionWorkspaceFile", () => {
   it("opens Markdown with a canonical Gateway- and pane-scoped draft identity", async () => {
     const handleOpenSidebar = vi.fn();

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -281,19 +281,17 @@ function artifactSidebarContent(params: {
       rawText: url ?? null,
     };
   }
-  if (encoding === "base64" && data && mimeType === "application/json") {
-    const decoded = globalThis.atob(data);
+  if (
+    encoding === "base64" &&
+    data &&
+    (mimeType === "application/json" || mimeType.startsWith("text/"))
+  ) {
+    const bytes = Uint8Array.from(globalThis.atob(data), (char) => char.charCodeAt(0));
+    const decoded = new TextDecoder().decode(bytes);
+    const language = mimeType === "application/json" ? "json" : "";
     return {
       kind: "markdown",
-      content: `# ${title}\n\n\`\`\`json\n${decoded}\n\`\`\``,
-      rawText: decoded,
-    };
-  }
-  if (encoding === "base64" && data && mimeType.startsWith("text/")) {
-    const decoded = globalThis.atob(data);
-    return {
-      kind: "markdown",
-      content: `# ${title}\n\n\`\`\`\n${decoded}\n\`\`\``,
+      content: `# ${title}\n\n\`\`\`${language}\n${decoded}\n\`\`\``,
       rawText: decoded,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

Control UI workspace previews corrupt UTF-8 text and JSON artifacts. Accented characters, CJK text, and emoji appear as mojibake, and the sidebar's copied raw text is corrupted too.

## Why This Change Was Made

The Gateway delivers inline artifacts as Base64-encoded bytes, but the workspace preview treated the binary string returned by `atob()` as decoded text. One canonical text-artifact path now converts those bytes through `TextDecoder`, matching the existing attachment decoder in `ui/src/pages/chat/components/chat-attachments.ts` and removing duplicated JSON/plain-text branches.

## User Impact

Downloaded `text/plain` and `application/json` artifacts display and copy their original Unicode content correctly. Existing Markdown/JSON code fences, image data URLs, and visible malformed-Base64 errors are preserved. Production code decreases by two lines.

## Evidence

- Focused owner suite: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-session-workspace.test.ts`.
- Before the fix: both real Unicode regressions failed; the other 15 tests passed.
- After the fix: all 17 tests passed, including accented/CJK/emoji JSON and plain text, unchanged image previews, and malformed-Base64 visible errors.
- Four independent blind hostile source reviews returned no P0–P3 findings.
- Official Codex autoreview returned `findings: []`, `patch is correct`, and confidence `0.98`; TruffleHog secret scanning also passed.
- Frozen reviewed commit: `a2893fba094c2aa541613b0013ceacd308d50495`.
- Real served Control UI browser proof on the exact frozen head `a2893fba094c2aa541613b0013ceacd308d50495`: **2/2 passed** using actual Google Chrome `150.0.7871.187`, the real Vite-served Control UI, and a mocked Gateway WebSocket; `artifacts.list` and `artifacts.download` were exercised through the actual workspace artifact rows.
- Focused browser command: `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/qa400-artifact-utf8-proof.e2e.test.ts` (the isolated temporary proof spec was removed after the run; the reviewed Git tree stayed unchanged).
- The actual browser visibly rendered and displayed raw `Résumé 東京 🦀` for both `text/plain` and `application/json`, expanded the JSON preview, clicked each real code-copy button, and confirmed the browser clipboard received the exact original Unicode string; no Gateway or unknown-agent error appeared.
- Redacted real-browser screenshots: `text-plain-rendered.png`, `text-plain-raw.png`, `application-json-rendered.png`, and `application-json-raw.png` under `/private/tmp/openclaw-qa400-ui-artifact-utf8-a289-browser-proof/`. Structured request/clipboard evidence is in `text-plain.json` and `application-json.json` in the same directory.
- Authoritative clean browser-test terminal log: `/private/tmp/openclaw-qa400-ui-artifact-utf8-a289-browser-proof-final.log` (`Test Files 1 passed`; `Tests 2 passed`; duration `10.45s`).
