### PR TITLE
refactor(feishu): deduplicate Drive tool test fixtures

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -105,7 +105,6 @@ extensions/feishu/src/channel.test.ts
 extensions/feishu/src/channel.ts
 extensions/feishu/src/doctor.ts
 extensions/feishu/src/docx.ts
-extensions/feishu/src/drive.test.ts
 extensions/feishu/src/drive.ts
 extensions/feishu/src/media.ts
 extensions/feishu/src/monitor.comment.ts

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -31,18 +31,24 @@ async function raceWithNextMacrotask<T>(promise: Promise<T>): Promise<T | "pendi
   ]);
 }
 
-function createDriveToolApi(params: {
-  config: OpenClawPluginApi["config"];
-  registerTool: OpenClawPluginApi["registerTool"];
-}): OpenClawPluginApi {
+function createDriveToolApi(registerTool: OpenClawPluginApi["registerTool"]): OpenClawPluginApi {
   return createTestPluginApi({
     id: "feishu-test",
     name: "Feishu Test",
     source: "local",
-    config: params.config,
+    config: {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app_id",
+          appSecret: "app_secret", // pragma: allowlist secret
+          tools: { drive: true },
+        },
+      },
+    },
     runtime: createFeishuToolRuntime(),
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    registerTool: params.registerTool,
+    registerTool,
   });
 }
 
@@ -65,6 +71,13 @@ type FeishuDriveTool = {
   parameters?: unknown;
 };
 
+type FeishuDriveCommentDetails = {
+  comment_id?: string;
+  delivery_mode?: string;
+  reply_id?: string;
+  success?: boolean;
+};
+
 type FeishuDriveToolFactory = (context: {
   agentAccountId?: string;
   deliveryContext?: unknown;
@@ -74,24 +87,12 @@ function firstToolFactory(mock: { mock: { calls: unknown[][] } }): FeishuDriveTo
   return mockCallArg<FeishuDriveToolFactory>(mock, 0, 0);
 }
 
-function buildDriveTool(): FeishuDriveTool {
+function buildDriveTool(
+  context: Parameters<FeishuDriveToolFactory>[0] = { agentAccountId: undefined },
+): FeishuDriveTool {
   const registerTool = vi.fn();
-  registerFeishuDriveTools(
-    createDriveToolApi({
-      config: {
-        channels: {
-          feishu: {
-            enabled: true,
-            appId: "app_id",
-            appSecret: "app_secret", // pragma: allowlist secret
-            tools: { drive: true },
-          },
-        },
-      },
-      registerTool,
-    }),
-  );
-  return firstToolFactory(registerTool)({ agentAccountId: undefined });
+  registerFeishuDriveTools(createDriveToolApi(registerTool));
+  return firstToolFactory(registerTool)(context);
 }
 
 function firstLogMessage(mock: { mock: { calls: unknown[][] } }): string {
@@ -105,6 +106,86 @@ type FeishuDriveRequest = {
   url?: string;
 };
 
+function driveResponse<T>(data: T): { code: 0; data: T } {
+  return { code: 0, data };
+}
+
+function commentMetadataResponse(isWhole = false, commentId = "c1") {
+  return driveResponse({ items: [{ comment_id: commentId, is_whole: isWhole }] });
+}
+
+function commentReply(
+  replyId: string,
+  userId: string,
+  textRun: { text?: string; content?: string },
+) {
+  return {
+    reply_id: replyId,
+    user_id: userId,
+    content: { elements: [{ type: "text_run", text_run: textRun }] },
+  };
+}
+
+function replyCommentInput(content: string, options: { omitFileType?: boolean } = {}) {
+  return {
+    action: "reply_comment",
+    file_token: "doc_1",
+    ...(options.omitFileType ? {} : { file_type: "docx" }),
+    comment_id: "c1",
+    content,
+  };
+}
+
+function ambientCommentContext() {
+  return {
+    channel: "feishu",
+    to: "comment:docx:doc_1:c1",
+    threadId: "reply_ambient_1",
+  };
+}
+
+function commentMetadataRequest(): FeishuDriveRequest {
+  return {
+    method: "POST",
+    url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
+    data: { comment_ids: ["c1"] },
+  };
+}
+
+function newCommentRequest(content: string, blockId?: string): FeishuDriveRequest {
+  return {
+    method: "POST",
+    url: "/open-apis/drive/v1/files/doc_1/new_comments",
+    data: {
+      file_type: "docx",
+      reply_elements: [{ type: "text", text: content }],
+      ...(blockId ? { anchor: { block_id: blockId } } : {}),
+    },
+  };
+}
+
+function replyCommentRequest(content: string): FeishuDriveRequest {
+  return {
+    method: "POST",
+    url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
+    params: { file_type: "docx" },
+    data: { content: { elements: [{ type: "text_run", text_run: { text: content } }] } },
+  };
+}
+
+function replyHttpError(code: number, message: string, logId: string) {
+  return {
+    message: "Request failed with status code 400",
+    code: "ERR_BAD_REQUEST",
+    config: {
+      method: "post",
+      url: "https://open.feishu.cn/open-apis/drive/v1/files/doc_1/comments/c1/replies",
+      params: { file_type: "docx" },
+    },
+    response: { status: 400, data: { code, msg: message, log_id: logId } },
+  };
+}
+
 function requestCall(
   mock: { mock: { calls: unknown[][] } },
   callIndex: number,
@@ -116,14 +197,18 @@ function expectRequestCall(
   mock: { mock: { calls: unknown[][] } },
   callIndex: number,
   expected: FeishuDriveRequest,
+  options: { paramsFirst?: boolean } = {},
 ): void {
   const request = requestCall(mock, callIndex);
   expect(request.method).toBe(expected.method);
   expect(request.url).toBe(expected.url);
+  if (options.paramsFirst && "params" in expected) {
+    expect(request.params).toEqual(expected.params);
+  }
   if ("data" in expected) {
     expect(request.data).toEqual(expected.data);
   }
-  if ("params" in expected) {
+  if (!options.paramsFirst && "params" in expected) {
     expect(request.params).toEqual(expected.params);
   }
 }
@@ -183,30 +268,15 @@ describe("registerFeishuDriveTools", () => {
 
   it("registers feishu_drive and handles comment actions", async () => {
     const registerTool = vi.fn();
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
+    registerFeishuDriveTools(createDriveToolApi(registerTool));
 
     expect(registerTool).toHaveBeenCalledTimes(1);
     const toolFactory = firstToolFactory(registerTool);
     const tool = toolFactory({ agentAccountId: undefined });
     expect(tool?.name).toBe("feishu_drive");
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: {
+    requestMock.mockResolvedValueOnce(
+      driveResponse({
         has_more: false,
         page_token: "0",
         items: [
@@ -215,36 +285,14 @@ describe("registerFeishuDriveTools", () => {
             quote: "quoted text",
             reply_list: {
               replies: [
-                {
-                  reply_id: "r1",
-                  user_id: "ou_author",
-                  content: {
-                    elements: [
-                      {
-                        type: "text_run",
-                        text_run: { text: "root comment" },
-                      },
-                    ],
-                  },
-                },
-                {
-                  reply_id: "r2",
-                  user_id: "ou_reply",
-                  content: {
-                    elements: [
-                      {
-                        type: "text_run",
-                        text_run: { text: "reply text" },
-                      },
-                    ],
-                  },
-                },
+                commentReply("r1", "ou_author", { text: "root comment" }),
+                commentReply("r2", "ou_reply", { text: "reply text" }),
               ],
             },
           },
         ],
-      },
-    });
+      }),
+    );
     const listResult = await tool.execute("call-1", {
       action: "list_comments",
       file_token: "doc_1",
@@ -273,27 +321,13 @@ describe("registerFeishuDriveTools", () => {
     expect(listDetails?.comments?.[0]?.replies?.[0]?.reply_id).toBe("r2");
     expect(listDetails?.comments?.[0]?.replies?.[0]?.text).toBe("reply text");
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: {
+    requestMock.mockResolvedValueOnce(
+      driveResponse({
         has_more: false,
         page_token: "0",
-        items: [
-          {
-            reply_id: "r3",
-            user_id: "ou_reply_2",
-            content: {
-              elements: [
-                {
-                  type: "text_run",
-                  text_run: { content: "reply from api" },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    });
+        items: [commentReply("r3", "ou_reply_2", { content: "reply from api" })],
+      }),
+    );
     const repliesResult = await tool.execute("call-2", {
       action: "list_comment_replies",
       file_token: "doc_1",
@@ -312,10 +346,7 @@ describe("registerFeishuDriveTools", () => {
     expect(repliesDetails?.replies?.[0]?.reply_id).toBe("r3");
     expect(repliesDetails?.replies?.[0]?.text).toBe("reply from api");
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { comment_id: "c2" },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ comment_id: "c2" }));
     const addCommentResult = await tool.execute("call-3", {
       action: "add_comment",
       file_token: "doc_1",
@@ -323,76 +354,18 @@ describe("registerFeishuDriveTools", () => {
       block_id: "blk_1",
       content: "please update this section",
     });
-    const addRequest = mockCallArg<{
-      data?: {
-        anchor?: { block_id?: string };
-        file_type?: string;
-        reply_elements?: Array<{ text?: string; type?: string }>;
-      };
-      method?: string;
-      url?: string;
-    }>(requestMock, 2, 0);
-    expect(addRequest.method).toBe("POST");
-    expect(addRequest.url).toBe("/open-apis/drive/v1/files/doc_1/new_comments");
-    expect(addRequest.data).toEqual({
-      file_type: "docx",
-      reply_elements: [{ type: "text", text: "please update this section" }],
-      anchor: { block_id: "blk_1" },
-    });
+    expectRequestCall(requestMock, 2, newCommentRequest("please update this section", "blk_1"));
     expect((addCommentResult.details as { comment_id?: string; success?: boolean }).success).toBe(
       true,
     );
     expect((addCommentResult.details as { comment_id?: string }).comment_id).toBe("c2");
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: false }],
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { reply_id: "r4" },
-      });
-    const replyCommentResult = await tool.execute("call-4", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "handled",
-    });
-    const batchRequest = mockCallArg<{
-      data?: { comment_ids?: string[] };
-      method?: string;
-      url?: string;
-    }>(requestMock, 3, 0);
-    expect(batchRequest.method).toBe("POST");
-    expect(batchRequest.url).toBe(
-      "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-    );
-    expect(batchRequest.data).toEqual({ comment_ids: ["c1"] });
-    const replyRequest = mockCallArg<{
-      data?: { content?: { elements?: Array<{ text_run?: { text?: string }; type?: string }> } };
-      method?: string;
-      params?: { file_type?: string };
-      url?: string;
-    }>(requestMock, 4, 0);
-    expect(replyRequest.method).toBe("POST");
-    expect(replyRequest.url).toBe("/open-apis/drive/v1/files/doc_1/comments/c1/replies");
-    expect(replyRequest.params).toEqual({ file_type: "docx" });
-    expect(replyRequest.data).toEqual({
-      content: {
-        elements: [
-          {
-            type: "text_run",
-            text_run: {
-              text: "handled",
-            },
-          },
-        ],
-      },
-    });
+      .mockResolvedValueOnce(commentMetadataResponse())
+      .mockResolvedValueOnce(driveResponse({ reply_id: "r4" }));
+    const replyCommentResult = await tool.execute("call-4", replyCommentInput("handled"));
+    expectRequestCall(requestMock, 3, commentMetadataRequest());
+    expectRequestCall(requestMock, 4, replyCommentRequest("handled"), { paramsFirst: true });
     expect((replyCommentResult.details as { reply_id?: string; success?: boolean }).success).toBe(
       true,
     );
@@ -616,31 +589,10 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("defaults add_comment file_type to docx when omitted", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
+    const tool = buildDriveTool();
 
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
-
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { comment_id: "c-default-docx" },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ comment_id: "c-default-docx" }));
 
     const result = await tool.execute("call-default-docx", {
       action: "add_comment",
@@ -648,44 +600,17 @@ describe("registerFeishuDriveTools", () => {
       content: "defaulted file type",
     });
 
-    const request = requestCall(requestMock, 0);
-    expect(request.method).toBe("POST");
-    expect(request.url).toBe("/open-apis/drive/v1/files/doc_1/new_comments");
-    expect(request.data).toEqual({
-      file_type: "docx",
-      reply_elements: [{ type: "text", text: "defaulted file type" }],
-    });
+    expectRequestCall(requestMock, 0, newCommentRequest("defaulted file type"));
     expect(firstLogMessage(infoSpy)).toContain("add_comment missing file_type; defaulting to docx");
     expect((result.details as { comment_id?: string; success?: boolean }).success).toBe(true);
     expect((result.details as { comment_id?: string }).comment_id).toBe("c-default-docx");
   });
 
   it("defaults list_comments file_type to docx when omitted", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
+    const tool = buildDriveTool();
 
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
-
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { has_more: false, items: [] },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ has_more: false, items: [] }));
 
     await tool.execute("call-list-default-docx", {
       action: "list_comments",
@@ -703,31 +628,10 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("defaults list_comment_replies file_type to docx when omitted", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
+    const tool = buildDriveTool();
 
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
-
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { has_more: false, items: [] },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ has_more: false, items: [] }));
 
     await tool.execute("call-replies-default-docx", {
       action: "list_comment_replies",
@@ -746,81 +650,21 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("surfaces reply_comment HTTP errors when the single supported body fails", async () => {
-    const registerTool = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: false }],
-        },
-      })
-      .mockRejectedValueOnce({
-        message: "Request failed with status code 400",
-        code: "ERR_BAD_REQUEST",
-        config: {
-          method: "post",
-          url: "https://open.feishu.cn/open-apis/drive/v1/files/doc_1/comments/c1/replies",
-          params: { file_type: "docx" },
-        },
-        response: {
-          status: 400,
-          data: {
-            code: 99992402,
-            msg: "field validation failed",
-            log_id: "log_legacy_400",
-          },
-        },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse())
+      .mockRejectedValueOnce(replyHttpError(99992402, "field validation failed", "log_legacy_400"));
 
-    const replyCommentResult = await tool.execute("call-throw", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "inserted successfully",
-    });
-
-    const batchRequest = requestCall(requestMock, 0);
-    expect(batchRequest.method).toBe("POST");
-    expect(batchRequest.url).toBe(
-      "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
+    const replyCommentResult = await tool.execute(
+      "call-throw",
+      replyCommentInput("inserted successfully"),
     );
-    expect(batchRequest.data).toEqual({ comment_ids: ["c1"] });
-    const replyRequest = requestCall(requestMock, 1);
-    expect(replyRequest.method).toBe("POST");
-    expect(replyRequest.url).toBe("/open-apis/drive/v1/files/doc_1/comments/c1/replies");
-    expect(replyRequest.params).toEqual({ file_type: "docx" });
-    expect(replyRequest.data).toEqual({
-      content: {
-        elements: [
-          {
-            type: "text_run",
-            text_run: {
-              text: "inserted successfully",
-            },
-          },
-        ],
-      },
+
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, replyCommentRequest("inserted successfully"), {
+      paramsFirst: true,
     });
     expect(firstLogMessage(warnSpy)).toContain("replyComment threw");
     expect((replyCommentResult.details as { error?: string }).error).toBe(
@@ -829,44 +673,14 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("does not wait for ambient typing cleanup before reply_comment sends visible output", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({
+    const tool = buildDriveTool({
       agentAccountId: undefined,
-      deliveryContext: {
-        channel: "feishu",
-        to: "comment:docx:doc_1:c1",
-        threadId: "reply_ambient_1",
-      },
+      deliveryContext: ambientCommentContext(),
     });
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: false }],
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { reply_id: "r6" },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse())
+      .mockResolvedValueOnce(driveResponse({ reply_id: "r6" }));
 
     let resolveCleanup: ((value: boolean) => void) | undefined;
     cleanupAmbientCommentTypingReactionMock.mockImplementationOnce(
@@ -883,27 +697,9 @@ describe("registerFeishuDriveTools", () => {
     const status = await raceWithNextMacrotask(replyCommentPromise.then(() => "done"));
 
     expect(status).toBe("done");
-    const batchRequest = requestCall(requestMock, 0);
-    expect(batchRequest.method).toBe("POST");
-    expect(batchRequest.url).toBe(
-      "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-    );
-    expect(batchRequest.data).toEqual({ comment_ids: ["c1"] });
-    const replyRequest = requestCall(requestMock, 1);
-    expect(replyRequest.method).toBe("POST");
-    expect(replyRequest.url).toBe("/open-apis/drive/v1/files/doc_1/comments/c1/replies");
-    expect(replyRequest.params).toEqual({ file_type: "docx" });
-    expect(replyRequest.data).toEqual({
-      content: {
-        elements: [
-          {
-            type: "text_run",
-            text_run: {
-              text: "ambient success",
-            },
-          },
-        ],
-      },
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, replyCommentRequest("ambient success"), {
+      paramsFirst: true,
     });
     const cleanupRequest = mockCallArg<{
       client?: unknown;
@@ -912,11 +708,7 @@ describe("registerFeishuDriveTools", () => {
     if (!cleanupRequest.client) {
       throw new Error("Expected cleanup request client");
     }
-    expect(cleanupRequest.deliveryContext).toEqual({
-      channel: "feishu",
-      to: "comment:docx:doc_1:c1",
-      threadId: "reply_ambient_1",
-    });
+    expect(cleanupRequest.deliveryContext).toEqual(ambientCommentContext());
     const replyCommentResult = await replyCommentPromise;
     expect((replyCommentResult.details as { reply_id?: string; success?: boolean }).success).toBe(
       true,
@@ -927,37 +719,12 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("does not wait for ambient typing cleanup before add_comment sends visible output", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({
+    const tool = buildDriveTool({
       agentAccountId: undefined,
-      deliveryContext: {
-        channel: "feishu",
-        to: "comment:docx:doc_1:c1",
-        threadId: "reply_ambient_1",
-      },
+      deliveryContext: ambientCommentContext(),
     });
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { comment_id: "c_add" },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ comment_id: "c_add" }));
 
     let resolveCleanup: ((value: boolean) => void) | undefined;
     cleanupAmbientCommentTypingReactionMock.mockImplementationOnce(
@@ -974,13 +741,7 @@ describe("registerFeishuDriveTools", () => {
     const status = await raceWithNextMacrotask(addCommentPromise.then(() => "done"));
 
     expect(status).toBe("done");
-    const request = requestCall(requestMock, 0);
-    expect(request.method).toBe("POST");
-    expect(request.url).toBe("/open-apis/drive/v1/files/doc_1/new_comments");
-    expect(request.data).toEqual({
-      file_type: "docx",
-      reply_elements: [{ type: "text", text: "ambient top-level comment" }],
-    });
+    expectRequestCall(requestMock, 0, newCommentRequest("ambient top-level comment"));
     const cleanupRequest = mockCallArg<{
       client?: unknown;
       deliveryContext?: { channel?: string; threadId?: string; to?: string };
@@ -988,11 +749,7 @@ describe("registerFeishuDriveTools", () => {
     if (!cleanupRequest.client) {
       throw new Error("Expected cleanup request client");
     }
-    expect(cleanupRequest.deliveryContext).toEqual({
-      channel: "feishu",
-      to: "comment:docx:doc_1:c1",
-      threadId: "reply_ambient_1",
-    });
+    expect(cleanupRequest.deliveryContext).toEqual(ambientCommentContext());
     const addCommentResult = await addCommentPromise;
     expect((addCommentResult.details as { comment_id?: string; success?: boolean }).success).toBe(
       true,
@@ -1003,26 +760,8 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("does not inherit non-doc ambient file types for add_comment", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({
+    const tool = buildDriveTool({
       agentAccountId: undefined,
       deliveryContext: {
         channel: "feishu",
@@ -1030,10 +769,7 @@ describe("registerFeishuDriveTools", () => {
       },
     });
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { comment_id: "c-add-docx" },
-    });
+    requestMock.mockResolvedValueOnce(driveResponse({ comment_id: "c-add-docx" }));
 
     const result = await tool.execute("call-add-ignore-sheet-ambient", {
       action: "add_comment",
@@ -1041,81 +777,27 @@ describe("registerFeishuDriveTools", () => {
       content: "default add comment",
     });
 
-    const request = requestCall(requestMock, 0);
-    expect(request.method).toBe("POST");
-    expect(request.url).toBe("/open-apis/drive/v1/files/doc_1/new_comments");
-    expect(request.data).toEqual({
-      file_type: "docx",
-      reply_elements: [{ type: "text", text: "default add comment" }],
-    });
+    expectRequestCall(requestMock, 0, newCommentRequest("default add comment"));
     expect(firstLogMessage(infoSpy)).toContain("add_comment missing file_type; defaulting to docx");
     expect((result.details as { comment_id?: string; success?: boolean }).success).toBe(true);
     expect((result.details as { comment_id?: string }).comment_id).toBe("c-add-docx");
   });
 
   it("defaults reply_comment file_type to docx when omitted", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: false }],
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { reply_id: "r-default-docx" },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse())
+      .mockResolvedValueOnce(driveResponse({ reply_id: "r-default-docx" }));
 
-    const result = await tool.execute("call-reply-default-docx", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      comment_id: "c1",
-      content: "default reply docx",
-    });
+    const result = await tool.execute(
+      "call-reply-default-docx",
+      replyCommentInput("default reply docx", { omitFileType: true }),
+    );
 
-    expectRequestCall(requestMock, 0, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-      data: { comment_ids: ["c1"] },
-    });
-    expectRequestCall(requestMock, 1, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
-      params: { file_type: "docx" },
-      data: {
-        content: {
-          elements: [
-            {
-              type: "text_run",
-              text_run: {
-                text: "default reply docx",
-              },
-            },
-          ],
-        },
-      },
-    });
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, replyCommentRequest("default reply docx"));
     expect(firstLogMessage(infoSpy)).toContain(
       "reply_comment missing file_type; defaulting to docx",
     );
@@ -1124,316 +806,96 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("routes whole-document reply_comment requests through add_comment compatibility", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: true }],
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { comment_id: "c2" },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse(true))
+      .mockResolvedValueOnce(driveResponse({ comment_id: "c2" }));
 
-    const result = await tool.execute("call-whole", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "whole comment follow-up",
-    });
+    const result = await tool.execute("call-whole", replyCommentInput("whole comment follow-up"));
 
-    expectRequestCall(requestMock, 0, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-      data: { comment_ids: ["c1"] },
-    });
-    expectRequestCall(requestMock, 1, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/new_comments",
-      data: {
-        file_type: "docx",
-        reply_elements: [{ type: "text", text: "whole comment follow-up" }],
-      },
-    });
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, newCommentRequest("whole comment follow-up"));
     expect(firstLogMessage(infoSpy)).toContain("whole-comment compatibility path");
-    const details = result.details as {
-      comment_id?: string;
-      delivery_mode?: string;
-      success?: boolean;
-    };
+    const details = result.details as FeishuDriveCommentDetails;
     expect(details.success).toBe(true);
     expect(details.comment_id).toBe("c2");
     expect(details.delivery_mode).toBe("add_comment");
   });
 
   it("continues with reply_comment when comment metadata preflight fails", async () => {
-    const registerTool = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
+    const tool = buildDriveTool();
+
+    requestMock
+      .mockRejectedValueOnce(new Error("preflight unavailable"))
+      .mockResolvedValueOnce(driveResponse({ reply_id: "r-preflight-fallback" }));
+
+    const result = await tool.execute(
+      "call-preflight-fallback",
+      replyCommentInput("preflight fallback reply"),
     );
 
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
-
-    requestMock.mockRejectedValueOnce(new Error("preflight unavailable")).mockResolvedValueOnce({
-      code: 0,
-      data: { reply_id: "r-preflight-fallback" },
-    });
-
-    const result = await tool.execute("call-preflight-fallback", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "preflight fallback reply",
-    });
-
-    expectRequestCall(requestMock, 0, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-      data: { comment_ids: ["c1"] },
-    });
-    expectRequestCall(requestMock, 1, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
-      params: { file_type: "docx" },
-      data: {
-        content: {
-          elements: [
-            {
-              type: "text_run",
-              text_run: {
-                text: "preflight fallback reply",
-              },
-            },
-          ],
-        },
-      },
-    });
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, replyCommentRequest("preflight fallback reply"));
     expect(firstLogMessage(warnSpy)).toContain("comment metadata preflight failed");
-    const details = result.details as {
-      delivery_mode?: string;
-      reply_id?: string;
-      success?: boolean;
-    };
+    const details = result.details as FeishuDriveCommentDetails;
     expect(details.success).toBe(true);
     expect(details.reply_id).toBe("r-preflight-fallback");
     expect(details.delivery_mode).toBe("reply_comment");
   });
 
   it("continues with reply_comment when batch_query returns no exact comment match", async () => {
-    const registerTool = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "different_comment", is_whole: true }],
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { reply_id: "r-no-exact-match" },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse(true, "different_comment"))
+      .mockResolvedValueOnce(driveResponse({ reply_id: "r-no-exact-match" }));
 
-    const result = await tool.execute("call-preflight-no-exact-match", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "fallback on exact match miss",
-    });
+    const result = await tool.execute(
+      "call-preflight-no-exact-match",
+      replyCommentInput("fallback on exact match miss"),
+    );
 
-    expectRequestCall(requestMock, 0, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
-      data: { comment_ids: ["c1"] },
-    });
-    expectRequestCall(requestMock, 1, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
-      params: { file_type: "docx" },
-      data: {
-        content: {
-          elements: [
-            {
-              type: "text_run",
-              text_run: {
-                text: "fallback on exact match miss",
-              },
-            },
-          ],
-        },
-      },
-    });
+    expectRequestCall(requestMock, 0, commentMetadataRequest());
+    expectRequestCall(requestMock, 1, replyCommentRequest("fallback on exact match miss"));
     expect(
       warnSpy.mock.calls.some((call) =>
         String(call[0]).includes("whole-comment compatibility path"),
       ),
     ).toBe(false);
-    const details = result.details as {
-      delivery_mode?: string;
-      reply_id?: string;
-      success?: boolean;
-    };
+    const details = result.details as FeishuDriveCommentDetails;
     expect(details.success).toBe(true);
     expect(details.reply_id).toBe("r-no-exact-match");
     expect(details.delivery_mode).toBe("reply_comment");
   });
 
   it("falls back to add_comment when reply_comment returns compatibility code 1069302 even without is_whole metadata", async () => {
-    const registerTool = vi.fn();
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ comment_id: "c1", is_whole: false }],
-        },
-      })
-      .mockRejectedValueOnce({
-        message: "Request failed with status code 400",
-        code: "ERR_BAD_REQUEST",
-        config: {
-          method: "post",
-          url: "https://open.feishu.cn/open-apis/drive/v1/files/doc_1/comments/c1/replies",
-          params: { file_type: "docx" },
-        },
-        response: {
-          status: 400,
-          data: {
-            code: 1069302,
-            msg: "param error",
-            log_id: "log_reply_forbidden",
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { comment_id: "c3" },
-      });
+      .mockResolvedValueOnce(commentMetadataResponse())
+      .mockRejectedValueOnce(replyHttpError(1069302, "param error", "log_reply_forbidden"))
+      .mockResolvedValueOnce(driveResponse({ comment_id: "c3" }));
 
-    const result = await tool.execute("call-reply-forbidden", {
-      action: "reply_comment",
-      file_token: "doc_1",
-      file_type: "docx",
-      comment_id: "c1",
-      content: "compat follow-up",
-    });
+    const result = await tool.execute(
+      "call-reply-forbidden",
+      replyCommentInput("compat follow-up"),
+    );
 
-    expectRequestCall(requestMock, 2, {
-      method: "POST",
-      url: "/open-apis/drive/v1/files/doc_1/new_comments",
-      data: {
-        file_type: "docx",
-        reply_elements: [{ type: "text", text: "compat follow-up" }],
-      },
-    });
+    expectRequestCall(requestMock, 2, newCommentRequest("compat follow-up"));
     expect(firstLogMessage(infoSpy)).toContain("reply-not-allowed compatibility path");
-    const details = result.details as {
-      comment_id?: string;
-      delivery_mode?: string;
-      success?: boolean;
-    };
+    const details = result.details as FeishuDriveCommentDetails;
     expect(details.success).toBe(true);
     expect(details.comment_id).toBe("c3");
     expect(details.delivery_mode).toBe("add_comment");
   });
 
   it("clamps comment list page sizes to the Feishu API maximum", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
 
     requestMock.mockResolvedValueOnce({ code: 0, data: { has_more: false, items: [] } });
     await tool.execute("call-list", {
@@ -1462,25 +924,7 @@ describe("registerFeishuDriveTools", () => {
   });
 
   it("rejects block-scoped comments for non-docx files", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDriveTools(
-      createDriveToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { drive: true },
-            },
-          },
-        },
-        registerTool,
-      }),
-    );
-
-    const toolFactory = firstToolFactory(registerTool);
-    const tool = toolFactory({ agentAccountId: undefined });
+    const tool = buildDriveTool();
     const result = await tool.execute("call-5", {
       action: "add_comment",
       file_token: "doc_1",
@@ -1493,4 +937,3 @@ describe("registerFeishuDriveTools", () => {
     );
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Feishu Drive tests repeated complete tool registration, client responses, HTTP payloads, and comment fixtures across every case. The oversized suite carried a grandfathered lint exemption, making security-sensitive comment delivery and pagination behavior harder to review.

## Why This Change Was Made

Use one typed private Drive tool setup plus fresh request, response, metadata, and comment fixtures. Preserve every existing case and every actual assertion while removing the obsolete max-lines suppression and its single matching canonical baseline entry.

## User Impact

No production or user-visible behavior changes. Developers get a smaller Feishu Drive test suite with clearer canonical fixtures and one fewer grandfathered lint suppression.

## Evidence

- Exact head: `1024cef9cf0f7de253ade41746748b6a69109c90`.
- LOC: `+210/-768` across exactly two approved files, net **-558 lines**; production LOC delta **0**.
- Drive test: `+210/-767`, net **-557 lines**; canonical max-lines baseline: one matching stale-row deletion.
- Independent in-memory replay runs both baseline and refactored suites against the real `extensions/feishu/src/drive.ts`: all **22 exact registrations**, **24 expanded scenarios**, and **152 ordered matcher invocations** preserve titles, matcher names, negation, actual values, mock histories, expected arguments, and ordering.
- Security/behavior proof preserves metadata preflight before reply, exact-comment-ID matching, doc/docx-only error `1069302` compatibility fallback, unresolved non-blocking ambient cleanup, folder pagination `1..200`, comment pagination maximum `100`, missing-scope root fallback, and shortcut metadata exclusion.
- Directly inspected installed `@larksuiteoapi/node-sdk@1.71.1` request implementation and Drive metadata/file/comment types.
- Blacksmith Testbox `tbx_01kyzmnsmmdwh2db3994g54fwv`: `corepack pnpm test extensions/feishu/src/drive.test.ts extensions/feishu/src/comment-reaction.test.ts extensions/feishu/src/comment-dispatcher.test.ts extensions/feishu/src/comment-handler.test.ts extensions/feishu/src/monitor.comment.test.ts extensions/feishu/src/tool-account-routing.test.ts` — **6 files, 80 tests passed**.
- Same exact-tree Blacksmith Testbox: full `corepack pnpm check:changed` passed, including the max-lines ratchet, extension test typechecking, all **8,139** extension files, all **880** tooling files, plugin boundaries, format, and dead-code checks.
- Fresh independent `gpt-5.6-sol` xhigh review: **CLEAN**, no P0–P2 findings.
- Current-main synthetic merge is clean and contains exactly the approved two-file patch; no open PR overlaps the Drive test, and concurrent baseline changes remove unrelated sorted entries.
- `git diff --check` and targeted `oxfmt --check` pass.
