### PR TITLE
fix(msteams): cancel unread Graph error response bodies

### DIFF
--- a/extensions/msteams/src/attachments/graph.test.ts
+++ b/extensions/msteams/src/attachments/graph.test.ts
@@ -249,6 +249,54 @@ describe("downloadMSTeamsGraphMedia hosted content $value fallback", () => {
     expect(hugeResponse.bodyUsed).toBe(true);
   });
 
+  it("cancels the unread $value body when the hosted content bytes fetch fails", async () => {
+    const fetchCalls: string[] = [];
+    const failedValueResponse = new Response("server error", { status: 500 });
+
+    mockGraphMediaFetch({
+      messageId: "msg-500",
+      hostedContents: [{ id: "hosted-500", contentType: "image/png" }],
+      valueResponses: {
+        "/hostedContents/hosted-500/$value": failedValueResponse,
+      },
+      fetchCalls,
+    });
+
+    const result = await downloadMSTeamsGraphMedia({
+      messageUrl: "https://graph.microsoft.com/v1.0/chats/c/messages/msg-500",
+      tokenProvider: { getAccessToken: vi.fn(async () => "test-token") },
+      maxBytes: 10 * 1024 * 1024,
+    });
+
+    expect(result.media).toEqual([
+      { kind: "image", contentType: "image/png", sourceId: "hosted-500" },
+    ]);
+    expect(failedValueResponse.bodyUsed).toBe(true);
+  });
+
+  it("cancels the unread message body when the Graph message fetch fails", async () => {
+    const fetchCalls: string[] = [];
+    const failedMessageResponse = new Response("server error", { status: 500 });
+
+    mockGraphMediaFetch({
+      messageId: "msg-err",
+      valueResponses: {
+        "/hostedContents": mockFetchResponse({ value: [] }),
+        "/messages/msg-err": failedMessageResponse,
+      },
+      fetchCalls,
+    });
+
+    const result = await downloadMSTeamsGraphMedia({
+      messageUrl: "https://graph.microsoft.com/v1.0/chats/c/messages/msg-err",
+      tokenProvider: { getAccessToken: vi.fn(async () => "test-token") },
+      maxBytes: 10 * 1024 * 1024,
+    });
+
+    expect(result.media).toEqual([]);
+    expect(failedMessageResponse.bodyUsed).toBe(true);
+  });
+
   it("ignores unexpected inline bytes and still fetches bounded $value", async () => {
     const fetchCalls: string[] = [];
     const base64Png = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");

--- a/extensions/msteams/src/attachments/graph.test.ts
+++ b/extensions/msteams/src/attachments/graph.test.ts
@@ -297,6 +297,56 @@ describe("downloadMSTeamsGraphMedia hosted content $value fallback", () => {
     expect(failedMessageResponse.bodyUsed).toBe(true);
   });
 
+  it("releases a cloned failed collection body without awaiting stalled cancellation", async () => {
+    const failedCollectionResponse = new Response("server error", { status: 500 });
+    const captureClone = failedCollectionResponse.clone();
+    const body = failedCollectionResponse.body;
+    if (!body) {
+      throw new Error("expected a readable collection error body");
+    }
+    const originalCancel = body.cancel.bind(body);
+    let cancellation: Promise<void> | undefined;
+    let cancellationSettled = false;
+    const cancellationStarted = new Promise<void>((resolve) => {
+      vi.spyOn(body, "cancel").mockImplementation((reason) => {
+        cancellation = originalCancel(reason).finally(() => {
+          cancellationSettled = true;
+        });
+        resolve();
+        return cancellation;
+      });
+    });
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockImplementation(async (params: GuardedFetchParams) => {
+      if (params.url.endsWith("/hostedContents")) {
+        return guardedFetchResult(params, failedCollectionResponse, release);
+      }
+      return guardedFetchResult(params, mockFetchResponse({ body: {}, attachments: [] }));
+    });
+
+    const operation = downloadMSTeamsGraphMedia({
+      messageUrl: "https://graph.microsoft.com/v1.0/chats/c/messages/msg-cloned-collection",
+      tokenProvider: { getAccessToken: vi.fn(async () => "test-token") },
+      maxBytes: 10 * 1024 * 1024,
+    });
+
+    try {
+      await cancellationStarted;
+      expect(release).toHaveBeenCalledOnce();
+      expect(failedCollectionResponse.bodyUsed).toBe(true);
+      expect(cancellationSettled).toBe(false);
+      await expect(operation).resolves.toMatchObject({
+        media: [],
+        hostedCount: 0,
+        hostedStatus: 500,
+      });
+    } finally {
+      void captureClone.body?.cancel().catch(() => undefined);
+      await cancellation?.catch(() => undefined);
+      await operation.catch(() => undefined);
+    }
+  });
+
   it("ignores unexpected inline bytes and still fetches bounded $value", async () => {
     const fetchCalls: string[] = [];
     const base64Png = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -229,6 +229,11 @@ async function downloadGraphHostedContent(params: {
           sourceId: item.id,
         });
       } finally {
+        // Guard release does not consume unread bodies. Start cancellation first;
+        // awaiting can deadlock when response capture tees the stream.
+        if (!valRes.bodyUsed) {
+          void valRes.body?.cancel().catch(() => undefined);
+        }
         await release();
       }
     } catch (err) {
@@ -338,6 +343,11 @@ export async function downloadMSTeamsGraphMedia(params: {
         });
       }
     } finally {
+      // Guard release does not consume unread bodies. Start cancellation first;
+      // awaiting can deadlock when response capture tees the stream.
+      if (!msgRes.bodyUsed) {
+        void msgRes.body?.cancel().catch(() => undefined);
+      }
       await release();
     }
   } catch (err) {

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -99,6 +99,13 @@ export function buildMSTeamsGraphMessageUrl(params: {
   return `${GRAPH_ROOT}/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}`;
 }
 
+async function releaseGraphResponse(response: Response, release: () => Promise<void>) {
+  if (!response.bodyUsed) {
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
+  }
+  await release();
+}
+
 async function fetchGraphCollection(params: {
   url: string;
   accessToken: string;
@@ -120,7 +127,6 @@ async function fetchGraphCollection(params: {
   try {
     const status = response.status;
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
       return { status, items: [] };
     }
     try {
@@ -134,7 +140,7 @@ async function fetchGraphCollection(params: {
       return { status, items: [] };
     }
   } finally {
-    await release();
+    await releaseGraphResponse(response, release);
   }
 }
 
@@ -229,12 +235,7 @@ async function downloadGraphHostedContent(params: {
           sourceId: item.id,
         });
       } finally {
-        // Guard release does not consume unread bodies. Start cancellation first;
-        // awaiting can deadlock when response capture tees the stream.
-        if (!valRes.bodyUsed) {
-          void valRes.body?.cancel().catch(() => undefined);
-        }
-        await release();
+        await releaseGraphResponse(valRes, release);
       }
     } catch (err) {
       out.push(createGraphHostedContentFact(item));
@@ -343,12 +344,7 @@ export async function downloadMSTeamsGraphMedia(params: {
         });
       }
     } finally {
-      // Guard release does not consume unread bodies. Start cancellation first;
-      // awaiting can deadlock when response capture tees the stream.
-      if (!msgRes.bodyUsed) {
-        void msgRes.body?.cancel().catch(() => undefined);
-      }
-      await release();
+      await releaseGraphResponse(msgRes, release);
     }
   } catch (err) {
     params.logger?.debug?.("graph media message fetch failed", {


### PR DESCRIPTION
## Summary

Cancel unread Microsoft Teams Graph response bodies before releasing their guarded fetch resources.

The final branch is intentionally narrow:

- message metadata responses
- hosted-content collection responses
- existing hosted-content `$value` responses

The unrelated shared Gateway test-helper changes were removed.

## What Problem This Solves

`fetchWithSsrFGuard()` returns both a `Response` and a `release()` callback. The callback clears guard state and closes its dispatcher, but it does not consume or cancel an unread response body.

The message and `$value` non-ok paths released the guard with unread bodies. The collection path attempted to cancel first, but awaited that cancellation. Awaiting can deadlock when response capture has cloned and teed the stream because cancellation waits for the other tee branch.

Slow, large, or stalled Graph error bodies can therefore retain the pinned connection and dispatcher after the caller has finished handling the failure. Small finite JSON errors may already be buffered, so this PR does not claim every Graph error leaks a connection.

Microsoft Graph defines JSON error response bodies, and Undici requires callers to consume or cancel response bodies:

- https://learn.microsoft.com/en-us/graph/errors
- https://github.com/nodejs/undici#garbage-collection

## Fix

Add one local `releaseGraphResponse()` owner helper that:

1. starts best-effort cancellation when the response body is unread;
2. does not await cancellation, avoiding cloned-stream deadlock;
3. awaits the guarded fetch `release()` callback.

All three guarded Graph response owners use this helper. The shared SSRF guard remains unchanged because streaming consumers have different response-lifecycle contracts.

## Evidence

Exact reviewed head: `c37c2c9206ee995a7cfce583f4c42424731bdd85`

- Sanitized AWS Crabbox, fresh PR checkout, public network, no Tailscale, no instance profile, no hydration:
  - `pnpm test extensions/msteams/src/attachments/graph.test.ts`
  - 1 file passed
  - 20/20 tests passed
  - run `run_2c674c8df4cc`
- Added regressions for:
  - failed message response cancellation
  - failed hosted-content `$value` response cancellation
  - cloned failed collection response where cancellation starts before release without blocking the operation
- Trusted-main pinned-dispatcher fixture:
  - stalled unread 500 + `release()` only: release completed after about 101 ms, while the server-side socket and response remained open after 1 second
  - stalled unread 500 + cancellation before `release()`: release completed in about 1 ms and the socket/response closed in about 5 ms
- `git diff --check` clean
- Autoreview clean, patch correctness `0.98`

## Scope

- Production: `extensions/msteams/src/attachments/graph.ts`, +10/-4, net +6
- Tests: `extensions/msteams/src/attachments/graph.test.ts`, +98
- No config, persistence, SDK, protocol, or user-visible behavior changes
