### PR TITLE
fix(signal): cancel unread body when declared archive length exceeds cap

### DIFF
--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -291,6 +291,25 @@ describe("downloadToFile", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("cancels the response body when the declared length exceeds the download cap", async () => {
+    const response = new Response("archive", {
+      status: 200,
+      headers: { "content-length": "12" },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel").mockRejectedValueOnce(new Error("closed"));
+    fetchWithSsrFGuardMock.mockResolvedValue({ response, release: vi.fn() });
+
+    await withTempFile(async (filePath) => {
+      await expect(
+        downloadToFile("https://example.com/signal-cli.tgz", filePath, 5, 8),
+      ).rejects.toThrow("declared 12");
+
+      await expectPathMissing(filePath);
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("downloads through the SSRF guard with an explicit timeout", async () => {
     const fetchResult = okDownloadResponse("archive");
     fetchWithSsrFGuardMock.mockResolvedValue(fetchResult);

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -194,6 +194,7 @@ export async function downloadToFile(
         ? Number(trimmedLength)
         : Number.NaN;
       if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+        await cancelUnusedResponseBody(response);
         throw new Error(
           `signal-cli archive exceeds the ${maxBytes}-byte download cap (declared ${declaredLength}).`,
         );


### PR DESCRIPTION
## Summary

Cancel the unread response body when a declared signal-cli archive `Content-Length` exceeds the download cap, so the rejected download no longer leaks its connection.

## What Problem This Solves

`extensions/signal/src/install-signal-cli.ts` downloads the signal-cli archive through `fetchWithSsrFGuard`, which hands back `{ response, release }`. The guard's `release()` cleans up the timeout and dispatcher but does **not** consume or cancel an unread response body (`src/infra/net/fetch-guard.ts:509`).

- At `install-signal-cli.ts:196-200`, when the server declares a `Content-Length` above `maxBytes`, `downloadToFile` throws before touching the body.
- The `finally` block only awaited `release()`, so the unread body kept the underlying socket open until process teardown.
- The adjacent `!response.ok` branch (`install-signal-cli.ts:185-188`) already calls `cancelUnusedResponseBody` (added by #109442 for the same bug class); the declared-length cap branch was the remaining unguarded early throw in this function.

**Code evidence**: in `extensions/signal/src/install-signal-cli.ts:196-200`, the over-cap branch threw with the response body unread, and the `finally` at line 220 released the guard without cancelling the stream.

## Root Cause

- Bug introduced by commit `2afff85ca43` ("fix: parse signal archive length strictly", 2026-05-28), which added the declared-length pre-check that throws ahead of body handling.
- Violated invariant: callers of `fetchWithSsrFGuard` must either consume the body or cancel it before `release()`; `release()` alone does not terminate an unread stream.
- Trigger condition: any archive server (or attack/packaging mistake) that declares a `Content-Length` above the 256 MiB cap — exactly the case this branch exists to reject.

## Why This Fix

- Option A (this PR): call the file's existing `cancelUnusedResponseBody(response)` helper before throwing — byte-for-byte the convention this file already uses for the `!response.ok` branch (#109442) and the release-info fetch. This call site runs with `capture: false`, so no debug-capture tee can hold the stream and awaiting the cancel is safe here.
- Option B (rejected): fire-and-forget `void response.body?.cancel()` without the helper — diverges from the two sibling branches in the same file for no behavioral gain.
- Option C (rejected): teach `release()` to cancel unread bodies globally — changes the guard's semantics for every caller; the established convention is caller-side cancellation (#115873, #109442).

## User Impact

- Affected operation: `signal` channel setup / `openclaw channels install` flows that download signal-cli from a server declaring an oversized archive.
- Before: the rejected download left its connection dangling until garbage collection while installation reported the cap error.
- After: the connection is cancelled and closed immediately; the same actionable cap error (`declared N`) is preserved, and the partial destination file is still removed.

## Evidence

- **Before**: on `main`, the real `downloadToFile` rejects a live HTTPS download whose declared length (18070) exceeds the cap with `cancels=0` → FAIL.
- **After**: on this branch, the same run rejects with the identical error and `cancels=1` → PASS.

## Real Behavior Proof

**Real-machine production-path proof.** The proof invokes the exported production `downloadToFile` against a real GitHub HTTPS endpoint that returns `200` with a declared `content-length` of 18070 (raw `openclaw/openclaw` `package.json`), with `maxBytes` lowered to 1024 so the declared-length branch trips. The wrapper below still calls native fetch; its `.mock` marker only bypasses DNS pinning because this host resolves public traffic through a special-use proxy address (same technique as the accepted #109442 proof for this file).

### Before (on main)

```bash
$ node --import tsx proof.mjs
caught: signal-cli archive exceeds the 1024-byte download cap (declared 18070).
cancels=0
FAIL: unread over-cap body left the connection dangling
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
caught: signal-cli archive exceeds the 1024-byte download cap (declared 18070).
cancels=1
PASS: unread over-cap body cancelled before release
```

The same cap error remains observable, while the real response stream is now canceled once.

## Tests and Validation

- Added a regression test in `extensions/signal/src/install-signal-cli.test.ts`: a 200 response declaring `content-length: 12` against a cap of 8 must reject with the `declared 12` error, remove the destination file, and have its body cancel called exactly once (with a rejecting cancel, proving cleanup cannot replace the actionable error). The test fails on `main` and passes with the fix.
- `node scripts/run-vitest.mjs extensions/signal/src/install-signal-cli.test.ts` — 43/43 tests passed.
- `oxfmt --check` and `oxlint` clean on both changed files; `git diff --check` clean.
- Sibling audit: this file's other two `fetchWithSsrFGuard` call sites (the `!response.ok` download branch and the release-info fetch) already cancel through the same helper; the streamed-archive cap path reads through `pipeline`, which destroys the stream on error.
