### PR TITLE
fix(ui): gateway logs truncate complete persisted messages

### DIFF
--- a/ui/src/pages/logs/data.test.ts
+++ b/ui/src/pages/logs/data.test.ts
@@ -4,6 +4,55 @@ import { describe, expect, it } from "vitest";
 import { parseLogLine } from "./log-lines.ts";
 
 describe("parseLogLine", () => {
+  it.each([
+    {
+      name: "uses the complete persisted message for subsystem records",
+      record: {
+        "0": '{"subsystem":"gateway"}',
+        "1": "request failed",
+        "2": "retry later",
+        message: "request failed retry later",
+        time: "2026-08-01T15:00:00.000Z",
+        _meta: { logLevelName: "ERROR" },
+      },
+      message: "request failed retry later",
+      subsystem: "gateway",
+      level: "error",
+      time: "2026-08-01T15:00:00.000Z",
+    },
+    {
+      name: "preserves positional-only legacy records",
+      record: {
+        "0": '{"subsystem":"gateway"}',
+        "1": "legacy request failed",
+      },
+      message: "legacy request failed",
+      subsystem: "gateway",
+      level: null,
+      time: null,
+    },
+    {
+      name: "uses the complete persisted message for generic positional records",
+      record: {
+        "0": "worker",
+        "1": "request failed",
+        "2": "retry later",
+        message: "request failed retry later",
+      },
+      message: "request failed retry later",
+      subsystem: "worker",
+      level: null,
+      time: null,
+    },
+  ])("$name", ({ record, message, subsystem, level, time }) => {
+    const parsed = parseLogLine(JSON.stringify(record));
+
+    expect(parsed.message).toBe(message);
+    expect(parsed.subsystem).toBe(subsystem);
+    expect(parsed.level).toBe(level);
+    expect(parsed.time).toBe(time);
+  });
+
   it("strips ANSI escape sequences from rendered log fields", () => {
     const parsed = parseLogLine(
       JSON.stringify({

--- a/ui/src/pages/logs/log-lines.ts
+++ b/ui/src/pages/logs/log-lines.ts
@@ -75,14 +75,14 @@ export function parseLogLine(line: string): LogEntry {
     }
 
     const message =
-      typeof obj["1"] === "string"
-        ? obj["1"]
-        : typeof obj["2"] === "string"
-          ? obj["2"]
-          : !contextObj && typeof obj["0"] === "string"
-            ? obj["0"]
-            : typeof obj.message === "string"
-              ? obj.message
+      typeof obj.message === "string"
+        ? obj.message
+        : typeof obj["1"] === "string"
+          ? obj["1"]
+          : typeof obj["2"] === "string"
+            ? obj["2"]
+            : !contextObj && typeof obj["0"] === "string"
+              ? obj["0"]
               : line;
 
     return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Gateway Logs in the Control UI would see only the first positional log fragment when a persisted record already contains the complete flattened message.

## Why This Change Was Made

The logger already produces the authoritative, complete top-level `message`. The Control UI now reads that canonical field before positional fragments while retaining the existing positional-only fallback for older records and preserving subsystem, timestamp, level, and ANSI handling.

## User Impact

Operators now see complete gateway diagnostics in the Logs dashboard, including trailing context that previously disappeared. Existing older log records continue to display normally.

## Evidence

- Regression-first proof against unchanged production: **2 failing, 4 passing**; both failures showed `request failed` instead of `request failed retry later`.
- Focused regression suite after the fix: **6 passing** across subsystem records, generic positional records, older positional-only records, timestamps, levels, and ANSI handling.
- Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/logs/data.test.ts`.
- Four independent hostile source-only reviews: **CLEAN** (`google`, `ws_reconnect_events`, `agents_lifecycle`, `feishu_delivery`).
- Official structured autoreview: `gpt-5.6-sol`, high reasoning, P0–P3, **zero findings**, confidence **0.99**; native TruffleHog **3.96.0** clean.
- Reviewed immutable commit: `c614538e46448ae736ea9e2330bcd62e125425f8`; two files; production delta **+8/-8 (net zero)**.
- AI-assisted implementation and review; no logging, redaction, transport, or credential-handling behavior changed.
- Real served Control UI Logs dashboard proof on the exact frozen head `c614538e46448ae736ea9e2330bcd62e125425f8`: **1/1 passed** using actual Google Chrome `150.0.7871.187`, the real Vite-served Logs page, and a mocked Gateway WebSocket serving canonical persisted JSONL via the actual `logs.tail` request.
- Persisted canonical multi-part log record exercised through the real UI: `{"0":"{\"subsystem\":\"gateway\"}","1":"request failed","2":"retry later","message":"request failed retry later","time":"2026-08-01T15:00:00.000Z","_meta":{"logLevelName":"ERROR"}}`. The actual visible Logs row preserved the entire authoritative `message` as `request failed retry later`; a generic multi-part worker record preserved `artifact conversion failed retry tomorrow`, and an unchanged positional-only legacy record remained visible.
- Actual dashboard search for `retry later` returned exactly the full visible message `request failed retry later`, proving the previously lost trailing context is both rendered and searchable; time, level, and subsystem columns remained intact, with no Gateway or unknown-agent error.
- Focused browser command: `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/qa400-logs-fidelity-proof.e2e.test.ts` (the isolated temporary proof spec was removed after the run; the frozen reviewed tree remained unchanged).
- Genuine redacted dashboard screenshots: `logs-complete-persisted-messages.png` and `logs-searches-preserved-trailing-context.png` under `/private/tmp/openclaw-qa400-logs-fidelity-c614-browser-artifacts/`; structured persisted-record/rendered-row/search evidence is in `logs-fidelity-proof.json` in the same directory.
- Authoritative clean exact-head browser-test terminal log: `/private/tmp/openclaw-qa400-logs-fidelity-c614-browser-proof.log` (`Test Files 1 passed`; `Tests 1 passed`; duration `16.18s`).
