### PR TITLE
fix(release): retry plugin lock generation

### DIFF
--- a/scripts/generate-npm-package-lock.d.mts
+++ b/scripts/generate-npm-package-lock.d.mts
@@ -52,6 +52,7 @@ export function createNpmPackageLockInstallStrategyArgs(options?: {
 export function generateNpmPackageLock(
   packageDir: string,
   options?: {
+    env?: NodeJS.ProcessEnv;
     installStrategy?: "hoisted" | "nested" | "shallow" | "linked" | "" | null;
   },
 ): string;

--- a/scripts/generate-npm-package-lock.mjs
+++ b/scripts/generate-npm-package-lock.mjs
@@ -559,9 +559,9 @@ export function createNpmLockExecOptions(invocation, cwd, env = process.env) {
   };
 }
 
-function runNpm(args, cwd) {
-  const npm = createNpmLockCommand(args);
-  execFileSync(npm.command, npm.args, createNpmLockExecOptions(npm, cwd));
+function runNpm(args, cwd, env = process.env) {
+  const npm = createNpmLockCommand(args, { env });
+  execFileSync(npm.command, npm.args, createNpmLockExecOptions(npm, cwd, env));
 }
 
 function packageExtensionAppliesToDependency(selector, dependencyName) {
@@ -764,7 +764,7 @@ function describeOverrideViolations(violations) {
     .join("; ");
 }
 
-function normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs) {
+function normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs, env) {
   const npmLockPath = path.join(tempDir, "package-lock.json");
   const overrideRules = exactOverrideRulesFromOverrides(npmLockOverrides);
   if (Object.keys(overrideRules).length === 0) {
@@ -787,7 +787,7 @@ function normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs) {
   // shrinkwraps as inactive, drop their cached subtree, then ask npm to recalculate this
   // package's authoritative lock with registry integrity hashes.
   writeFileSync(npmLockPath, `${JSON.stringify(npmLock, null, 2)}\n`);
-  runNpm(npmInstallArgs, tempDir);
+  runNpm(npmInstallArgs, tempDir, env);
 
   const normalized = JSON.parse(readFileSync(npmLockPath, "utf8"));
   const remaining = collectOverrideViolations(normalized, overrideRules);
@@ -832,6 +832,7 @@ export function createNpmPackageLockInstallStrategyArgs(options = {}) {
 export function generateNpmPackageLock(packageDir, options = {}) {
   const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-npm-lock-"));
   try {
+    const env = options.env ?? process.env;
     const packageJson = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
     const npmLockOverrides = readNpmLockOverrides();
     const peerResolutionArgs = shouldUseLegacyPeerDepsForNpmLock(packageJson)
@@ -851,8 +852,8 @@ export function generateNpmPackageLock(packageDir, options = {}) {
       `${JSON.stringify(packageJsonForNpmLock(packageJson, npmLockOverrides), null, 2)}\n`,
     );
     copyLocalFileDependencies(packageJson, packageDir, tempDir);
-    runNpm(npmInstallArgs, tempDir);
-    normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs);
+    runNpm(npmInstallArgs, tempDir, env);
+    normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs, env);
     const generated = normalizeNpmVersionDrift(
       applyPackageExtensionPeerMetadata(
         JSON.parse(readFileSync(path.join(tempDir, "package-lock.json"), "utf8")),

--- a/scripts/lib/plugin-npm-package-manifest.d.mts
+++ b/scripts/lib/plugin-npm-package-manifest.d.mts
@@ -15,6 +15,15 @@ export function runPluginNpmCiWithRetry(
   options: Record<string, unknown>,
   params?: Record<string, unknown>,
 ): unknown;
+/** Generate a plugin package lock with bounded retries for registry timeouts. */
+export function generatePluginNpmPackageLockWithRetry(
+  packageDir: string,
+  options?: {
+    env?: NodeJS.ProcessEnv;
+    installStrategy?: "hoisted" | "nested" | "shallow" | "linked" | "" | null;
+  },
+  params?: Record<string, unknown>,
+): string;
 /** Build the package.json that should be used while packaging a plugin for npm. */
 export function resolveAugmentedPluginNpmPackageJson(params: unknown):
   | {

--- a/scripts/lib/plugin-npm-package-manifest.mjs
+++ b/scripts/lib/plugin-npm-package-manifest.mjs
@@ -259,6 +259,33 @@ export function runPluginNpmCiWithRetry(args, options, params = {}) {
   return result;
 }
 
+/** @internal Directly tested release-script implementation detail. */
+export function generatePluginNpmPackageLockWithRetry(packageDir, options = {}, params = {}) {
+  const attempts = params.attempts ?? 3;
+  const timeoutMs = params.timeoutMs ?? 180_000;
+  const generate = params.generate ?? generateNpmPackageLock;
+  const pluginDir = params.pluginDir ?? "plugin";
+  const env = {
+    ...(options.env ?? process.env),
+    OPENCLAW_NPM_LOCK_COMMAND_TIMEOUT_MS: String(timeoutMs),
+  };
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return generate(packageDir, { ...options, env });
+    } catch (error) {
+      if (error?.code !== "ETIMEDOUT" || attempt === attempts) {
+        throw error;
+      }
+      console.error(
+        `[plugin-npm-publish] package-lock generation timed out for ${pluginDir} ` +
+          `(attempt ${attempt}/${attempts}); retrying`,
+      );
+    }
+  }
+  throw new Error(`package-lock generation retry loop exhausted for ${pluginDir}`);
+}
+
 function resolveInstalledPackageDir(packageDir, packageName) {
   return path.join(packageDir, "node_modules", ...packageName.split("/"));
 }
@@ -460,7 +487,11 @@ function installPackageLocalBundledDependencies(params) {
   try {
     fs.writeFileSync(
       packageLockPath,
-      generateNpmPackageLock(params.packageDir, { installStrategy: "shallow" }),
+      generatePluginNpmPackageLockWithRetry(
+        params.packageDir,
+        { installStrategy: "shallow" },
+        { pluginDir: params.pluginDir },
+      ),
       "utf8",
     );
     const result = runPluginNpmCiWithRetry(

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { dirname, join, win32 } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  generatePluginNpmPackageLockWithRetry,
   resolveAugmentedPluginNpmPackageJson,
   resolveAugmentedPluginNpmManifest,
   resolvePluginNpmCommand,
@@ -280,6 +281,53 @@ describe("plugin npm package manifest staging", () => {
     ) as { status: number | null };
 
     expect(secondResult.status).toBe(0);
+  });
+
+  it("retries timed-out package-lock generation with a bounded command timeout", () => {
+    const timeoutError = Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+    const generateOptions: Array<Record<string, unknown>> = [];
+    let generateCalls = 0;
+
+    const lock = generatePluginNpmPackageLockWithRetry(
+      "/tmp/plugin",
+      { installStrategy: "shallow" },
+      {
+        generate: (_packageDir: string, options: Record<string, unknown>) => {
+          generateCalls += 1;
+          generateOptions.push(options);
+          if (generateCalls === 1) {
+            throw timeoutError;
+          }
+          return '{"lockfileVersion":3}\n';
+        },
+        pluginDir: "whatsapp",
+      },
+    );
+
+    expect(lock).toBe('{"lockfileVersion":3}\n');
+    expect(generateOptions).toHaveLength(2);
+    expect(generateOptions[0]).toMatchObject({
+      env: { OPENCLAW_NPM_LOCK_COMMAND_TIMEOUT_MS: "180000" },
+      installStrategy: "shallow",
+    });
+    expect(generateOptions[1]).toEqual(generateOptions[0]);
+  });
+
+  it("does not retry ordinary package-lock generation failures", () => {
+    let generateCalls = 0;
+    expect(() =>
+      generatePluginNpmPackageLockWithRetry(
+        "/tmp/plugin",
+        { installStrategy: "shallow" },
+        {
+          generate: () => {
+            generateCalls += 1;
+            throw new Error("invalid dependency");
+          },
+        },
+      ),
+    ).toThrow("invalid dependency");
+    expect(generateCalls).toBe(1);
   });
 
   it("overlays generated channel configs while packing and restores source manifest", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release publication failure where plugins with bundled dependencies could spend ten minutes generating `package-lock.json`, then abort the entire plugin npm release on a transient registry timeout.

## Why This Change Was Made

Plugin package-lock generation now uses the same bounded retry policy as the subsequent package-local install: three 180-second attempts, retrying only `ETIMEDOUT`. The timeout is threaded into the existing lock generator without changing frozen release package inputs.

## User Impact

Release operators can complete all-publishable plugin npm releases despite transient npm registry stalls. Ordinary dependency and lock validation failures still fail immediately.

## Evidence

- `node scripts/run-vitest.mjs test/plugin-npm-package-manifest.test.ts test/scripts/generate-npm-package-lock.test.ts` - 49 tests passed.
- `node scripts/check-script-declarations.mjs` - 249 declaration contracts match.
- `git diff --check` - passed.
- The broader local script/test type lanes remain blocked by pre-existing `main` errors in `packages/terminal-core/src/ansi.ts` and missing sparse UI/QA/Android artifacts; hosted exact-head CI is required.
- Live failure evidence: plugin npm run `30720863740` timed out during `npm install --package-lock-only` before reaching the already-retried `npm ci` phase.

AI-assisted: yes.
