### PR TITLE
refactor(ios): deduplicate node invoke test fixtures

### DIFF
--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -375,8 +375,257 @@ private func makeProjectedWatchChatRawMessage(
     return try JSONDecoder().decode(AnyCodable.self, from: data)
 }
 
-private func makePendingExecApprovalJSON(_ approvalID: String) -> String {
-    #"{"approval":{"id":"\#(approvalID)","status":"pending","urlPath":"/approve/\#(approvalID)","createdAtMs":100,"expiresAtMs":4000000000000,"presentation":{"kind":"exec","commandText":"echo held","commandPreview":"echo held","warningText":null,"host":"gateway","nodeId":null,"agentId":"main","allowedDecisions":["allow-once","deny"]}}}"#
+private func encodedFixtureJSON(_ value: some Encodable) -> String {
+    guard let data = try? JSONEncoder().encode(value) else {
+        preconditionFailure("Could not encode test fixture")
+    }
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func execApprovalPresentation(
+    commandText: String,
+    commandPreview: String? = nil,
+    warningText: String? = nil,
+    agentID: String? = "main",
+    allowedDecisions: [ApprovalDecision] = [.allowOnce, .deny]) -> ApprovalPresentation
+{
+    .exec(ExecApprovalPresentation(
+        kind: ApprovalKind.exec.rawValue,
+        commandtext: commandText,
+        commandpreview: AnyCodable(commandPreview ?? commandText),
+        warningtext: warningText.map(AnyCodable.init) ?? AnyCodable(NSNull()),
+        host: AnyCodable("gateway"),
+        nodeid: AnyCodable(NSNull()),
+        agentid: agentID.map(AnyCodable.init) ?? AnyCodable(NSNull()),
+        alloweddecisions: allowedDecisions))
+}
+
+private func pluginApprovalPresentation(
+    title: String,
+    description: String) -> ApprovalPresentation
+{
+    .plugin(PluginApprovalPresentation(
+        kind: ApprovalKind.plugin.rawValue,
+        title: title,
+        description: description,
+        severity: .warning,
+        pluginid: AnyCodable("example"),
+        toolname: AnyCodable("guarded"),
+        agentid: AnyCodable("main"),
+        alloweddecisions: [.allowOnce, .deny]))
+}
+
+private func makePendingApprovalJSON(
+    id: String,
+    presentation: ApprovalPresentation,
+    createdAtMs: Int = 100,
+    expiresAtMs: Int = 4_000_000_000_000) -> String
+{
+    encodedFixtureJSON(ApprovalGetResult(approval: .pending(PendingApprovalSnapshot(
+        id: id,
+        urlpath: "/approve/\(id)",
+        createdatms: createdAtMs,
+        expiresatms: expiresAtMs,
+        presentation: presentation,
+        status: "pending"))))
+}
+
+private func makePendingExecApprovalJSON(
+    _ approvalID: String,
+    commandText: String = "echo held",
+    commandPreview: String? = nil,
+    warningText: String? = nil,
+    agentID: String? = "main",
+    allowedDecisions: [ApprovalDecision] = [.allowOnce, .deny]) -> String
+{
+    makePendingApprovalJSON(
+        id: approvalID,
+        presentation: execApprovalPresentation(
+            commandText: commandText,
+            commandPreview: commandPreview,
+            warningText: warningText,
+            agentID: agentID,
+            allowedDecisions: allowedDecisions))
+}
+
+private func makeDeniedExecApprovalJSON(
+    _ approvalID: String,
+    commandText: String,
+    commandPreview: String? = nil,
+    warningText: String? = nil,
+    allowedDecisions: [ApprovalDecision] = [.allowOnce, .deny],
+    expiresAtMs: Int = 200,
+    applied: Bool? = nil) -> String
+{
+    let approval = DeniedApprovalSnapshot(
+        id: approvalID,
+        urlpath: "/approve/\(approvalID)",
+        createdatms: 100,
+        expiresatms: expiresAtMs,
+        presentation: execApprovalPresentation(
+            commandText: commandText,
+            commandPreview: commandPreview,
+            warningText: warningText,
+            allowedDecisions: allowedDecisions),
+        resolvedatms: 150,
+        status: "denied",
+        decision: ApprovalDecision.deny.rawValue,
+        reason: .user)
+    if let applied {
+        return encodedFixtureJSON(ApprovalResolveResult(applied: applied, approval: .denied(approval)))
+    }
+    return encodedFixtureJSON(ApprovalGetResult(approval: .denied(approval)))
+}
+
+private func makeDeniedPluginApprovalJSON(_ approvalID: String, applied: Bool) -> String {
+    let approval = DeniedApprovalSnapshot(
+        id: approvalID,
+        urlpath: "/approve/\(approvalID)",
+        createdatms: 100,
+        expiresatms: 200,
+        presentation: pluginApprovalPresentation(title: "Plugin approval", description: "Review"),
+        resolvedatms: 150,
+        status: "denied",
+        decision: ApprovalDecision.deny.rawValue,
+        reason: .user)
+    return encodedFixtureJSON(ApprovalResolveResult(applied: applied, approval: .denied(approval)))
+}
+
+private func makeAllowedExecApprovalJSON(
+    _ approvalID: String,
+    commandText: String,
+    decision: ApprovalAllowDecision,
+    applied: Bool) -> String
+{
+    let approval = AllowedApprovalSnapshot(
+        id: approvalID,
+        urlpath: "/approve/\(approvalID)",
+        createdatms: 100,
+        expiresatms: 4_000_000_000_000,
+        presentation: execApprovalPresentation(commandText: commandText),
+        resolvedatms: 150,
+        status: "allowed",
+        decision: decision,
+        reason: .user)
+    return encodedFixtureJSON(ApprovalResolveResult(applied: applied, approval: .allowed(approval)))
+}
+
+private func makeGatewayPair(
+    firstURL: URL,
+    firstStableID: String = "gateway-a",
+    firstToken: String = "token-a",
+    secondURL: URL,
+    secondStableID: String = "gateway-b",
+    secondToken: String = "token-b") throws -> (GatewayConnectConfig, GatewayConnectConfig)
+{
+    let options = GatewayConnectOptions(
+        role: "node",
+        scopes: [],
+        caps: [],
+        commands: [],
+        permissions: [:],
+        clientId: "ios",
+        clientMode: "node",
+        clientDisplayName: "Phone")
+    return try (
+        GatewayConnectConfig(
+            url: firstURL,
+            stableID: firstStableID,
+            tls: nil,
+            token: firstToken,
+            bootstrapToken: nil,
+            password: nil,
+            nodeOptions: options),
+        GatewayConnectConfig(
+            url: secondURL,
+            stableID: secondStableID,
+            tls: nil,
+            token: secondToken,
+            bootstrapToken: nil,
+            password: nil,
+            nodeOptions: options))
+}
+
+@MainActor
+private func makeWatchModel() -> (MockWatchMessagingService, NodeAppModel) {
+    let watchService = MockWatchMessagingService()
+    return (watchService, NodeAppModel(watchMessagingService: watchService))
+}
+
+@MainActor
+private func makeWatchModel(
+    notificationCenter: NotificationCentering) -> (MockWatchMessagingService, NodeAppModel)
+{
+    let watchService = MockWatchMessagingService()
+    return (watchService, NodeAppModel(
+        notificationCenter: notificationCenter,
+        watchMessagingService: watchService))
+}
+
+@MainActor
+private func makeTalkModel() -> (TalkModeManager, NodeAppModel) {
+    let talkMode = TalkModeManager(allowSimulatorCapture: true)
+    return (talkMode, NodeAppModel(talkMode: talkMode))
+}
+
+@MainActor
+private func makeNodeModelWithMockServices() -> NodeAppModel {
+    NodeAppModel(
+        notificationCenter: MockBootstrapNotificationCenter(),
+        watchMessagingService: MockWatchMessagingService())
+}
+
+@MainActor
+private func makeNotificationModel(
+    status: NotificationAuthorizationStatus) -> (MockBootstrapNotificationCenter, NodeAppModel)
+{
+    let center = MockBootstrapNotificationCenter()
+    center.status = status
+    return (center, NodeAppModel(notificationCenter: center))
+}
+
+private func makeInvokeRequest(
+    id: String,
+    command: String,
+    params: some Encodable) throws -> BridgeInvokeRequest
+{
+    let data = try JSONEncoder().encode(params)
+    return BridgeInvokeRequest(id: id, command: command, paramsJSON: String(decoding: data, as: UTF8.self))
+}
+
+private func makeWatchApprovalSnapshotRequest(
+    _ id: String,
+    gateway: String? = "test-gateway",
+    held: [WatchExecApprovalSnapshotRequestItem] = [],
+    sentAt: Int64) -> WatchExecApprovalSnapshotRequestEvent
+{
+    .init(
+        requestId: id,
+        gatewayStableID: gateway,
+        heldApprovals: held,
+        sentAtMs: sentAt,
+        transport: "sendMessage")
+}
+
+private func makeWatchAppCommand(
+    _ id: String,
+    _ command: OpenClawWatchAppCommand,
+    session: String? = "main",
+    gateway: String? = nil,
+    text: String? = nil,
+    sentAt: Int64,
+    transport: String = "sendMessage",
+    kind: WatchMessageKind? = nil) -> WatchAppCommandEvent
+{
+    .init(
+        commandId: id,
+        command: command,
+        sessionKey: session,
+        gatewayStableID: gateway,
+        text: text,
+        sentAtMs: sentAt,
+        transport: transport,
+        messageKind: kind)
 }
 
 private func makeExpiredExecApprovalJSON(_ approvalID: String) -> String {
@@ -967,36 +1216,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `explicit notification tap replaces visible approval after canonical fetch`() async throws {
         let fetchGate = WatchSnapshotSendGate()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         appModel._test_setConnectedGatewayID("test-gateway")
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-visible-a",
                 commandText: "echo visible-a",
                 expiresAtMs: 4_000_000_000_000)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-tapped-b",
-            "status": "pending",
-            "urlPath": "/approve/approval-tapped-b",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo tapped-b",
-              "commandPreview": "echo tapped-b",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#, beforeResponse: { await fetchGate.wait() })
+        appModel._test_setUnifiedExecApprovalGetResponse(
+            makePendingExecApprovalJSON("approval-tapped-b", commandText: "echo tapped-b"),
+            beforeResponse: { await fetchGate.wait() })
 
         let fetching = Task { @MainActor in
             await appModel._test_presentExecApprovalNotificationPrompt(ExecApprovalNotificationPrompt(
@@ -1110,32 +1339,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `plugin notification prompt resolves with plugin kind`() async throws {
-        let pluginJSON = #"""
-        {
-          "approval": {
-            "id": "approval-plugin",
-            "status": "pending",
-            "urlPath": "/approve/approval-plugin",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "plugin",
-              "title": "Allow guarded plugin tool?",
-              "description": "The plugin wants to perform a guarded action.",
-              "severity": "warning",
-              "pluginId": "example",
-              "toolName": "guarded",
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
+        let pluginJSON = makePendingApprovalJSON(
+            id: "approval-plugin",
+            presentation: pluginApprovalPresentation(
+                title: "Allow guarded plugin tool?",
+                description: "The plugin wants to perform a guarded action."))
         let capture = ApprovalResolutionCapture()
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         appModel._test_setUnifiedExecApprovalGetResponse(pluginJSON)
         appModel._test_setExecApprovalResolutionSuccessHandler { _, kind, _, _ in
@@ -1293,10 +1504,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 approvalID: "approval-race") == nil)
         }
 
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-race",
@@ -1343,31 +1552,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(ownWinnerModel._test_pendingExecApprovalInboxItems().isEmpty)
         #expect(ownWinnerService.lastSentExecApprovalResolved?.source == "iphone")
 
-        let pluginResponseJSON = #"""
-        {
-          "applied": false,
-          "approval": {
-            "id": "approval-race",
-            "status": "denied",
-            "urlPath": "/approve/approval-race",
-            "createdAtMs": 100,
-            "expiresAtMs": 200,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "plugin",
-              "title": "Plugin approval",
-              "description": "Review",
-              "severity": "warning",
-              "pluginId": "example",
-              "toolName": "guarded",
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
+        let pluginResponseJSON = makeDeniedPluginApprovalJSON("approval-race", applied: false)
         let decodedPluginResult = try NodeAppModel._test_decodeUnifiedExecApprovalResolution(
             pluginResponseJSON,
             approvalID: "approval-race")
@@ -1378,10 +1563,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `legacy approval resolve acknowledgment uses neutral gateway attribution`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-legacy-ack",
@@ -1401,34 +1584,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `canonical denial keeps destructive terminal tone`() async throws {
-        let responseJSON = #"""
-        {
-          "applied": false,
-          "approval": {
-            "id": "approval-denied-elsewhere",
-            "status": "denied",
-            "urlPath": "/approve/approval-denied-elsewhere",
-            "createdAtMs": 100,
-            "expiresAtMs": 200,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "rm -rf build",
-              "commandPreview": "rm build",
-              "warningText": "Deletes build output",
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let responseJSON = makeDeniedExecApprovalJSON(
+            "approval-denied-elsewhere",
+            commandText: "rm -rf build",
+            commandPreview: "rm build",
+            warningText: "Deletes build output",
+            applied: false)
+        let appModel = makeNodeModelWithMockServices()
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-denied-elsewhere",
@@ -1474,31 +1636,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             notificationCenter: notificationCenter,
             watchMessagingService: watchService)
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "gateway-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "gateway-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")))
 
         appModel.applyGatewayConnectConfig(gatewayA)
         try appModel._test_presentExecApprovalPrompt(#require(
@@ -1561,9 +1701,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `uncertain approval survives dismiss and restart until canonical readback`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         let approvalID = "approval-uncertain-dismissible"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -1585,9 +1723,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(appModel._test_pendingExecApprovalState().resolving)
         #expect(appModel._test_pendingExecApprovalState().error == uncertainMessage)
 
-        let restoredModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let restoredModel = makeNodeModelWithMockServices()
         restoredModel._test_presentExecApprovalPrompt(prompt)
         #expect(restoredModel._test_pendingExecApprovalState().resolving)
         #expect(restoredModel._test_pendingExecApprovalState().error == uncertainMessage)
@@ -1771,35 +1907,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `gateway switch during uncertain resolve keeps owner frozen after switching back`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "gateway-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "gateway-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")))
         let approvalID = "approval-switch-mid-uncertain"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -1839,9 +1951,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(appModel._test_pendingExecApprovalState().resolving)
         #expect(appModel._test_pendingExecApprovalState().error == "simulated approval write failure")
 
-        let restoredModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let restoredModel = makeNodeModelWithMockServices()
         restoredModel._test_presentExecApprovalPrompt(prompt)
         #expect(restoredModel._test_pendingExecApprovalState().resolving)
         #expect(restoredModel._test_pendingExecApprovalState().error == "simulated approval write failure")
@@ -1850,35 +1960,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `gateway switch during in flight resolve keeps the owner write fence`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "gateway-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "gateway-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")))
         let approvalID = "approval-switch-mid-write"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -1925,35 +2011,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `gateway switch during unknown ack readback keeps re-presented card resolving`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "gateway-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "gateway-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")))
         let approvalID = "approval-switch-mid-readback"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -2005,9 +2067,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch pending retry after unknown ack unlocks the phone card`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         let approvalID = "approval-watch-unknown-ack-retry"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -2057,35 +2117,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `gateway switch during uncertain watch resolve records owner uncertainty`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "gateway-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "gateway-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")))
         let approvalID = "approval-watch-switch-mid-uncertain"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: approvalID,
@@ -2140,35 +2176,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(composedGatewayID == decomposedGatewayID)
         #expect(GatewayStableIdentifier.key(composedGatewayID) !=
             GatewayStableIdentifier.key(decomposedGatewayID))
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let switchModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let switchModel = makeNodeModelWithMockServices()
         defer { switchModel.disconnectGateway() }
-        let composedGateway = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: composedGatewayID,
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let decomposedGateway = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: decomposedGatewayID,
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (composedGateway, decomposedGateway) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            firstStableID: composedGatewayID,
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")),
+            secondStableID: decomposedGatewayID)
 
         switchModel.applyGatewayConnectConfig(composedGateway)
         try switchModel._test_presentExecApprovalPrompt(#require(
@@ -2263,8 +2277,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `failed PTT start restores voice wake suspension`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         appModel.voiceWake.isEnabled = true
         appModel.voiceWake.isListening = true
         appModel.voiceWake.statusText = "Listening"
@@ -2301,8 +2314,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `cancelled queued PTT start never acquires preparation`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
@@ -2335,8 +2347,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `PTT cancel invalidates suspended preparation without waiting`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
@@ -2362,8 +2373,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `PTT start after cancel uses the new command epoch`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
@@ -2393,8 +2403,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `chat focus switch invalidates reserved and queued PTT starts`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         talkMode._test_setPTTReservedHandler { await barrier.suspendFirstPreparation() }
@@ -2426,8 +2435,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `same-session route replacement invalidates reserved and queued PTT starts`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         talkMode._test_setPTTReservedHandler { await barrier.suspendFirstPreparation() }
@@ -2459,8 +2467,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `same-route reconnect preserves routing restore before Talk admission`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         let stableID = "talk-routing-restore-\(UUID().uuidString)"
         let databaseDirectoryURL = try #require(NodeAppModel.chatDatabaseDirectoryURL())
@@ -2587,8 +2594,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `gateway main key refresh preserves focused Talk session`() {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         appModel.focusChatSession("agent:focused:thread")
         let epoch = appModel._test_talkPttCommandEpoch()
 
@@ -2600,8 +2606,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `gateway replacement waits for final Talk session before admission`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         appModel.focusChatSession("agent:old:thread")
         let epoch = appModel._test_talkPttCommandEpoch()
         let stableID = "talk-session-replacement-\(UUID().uuidString)"
@@ -2633,8 +2638,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `cancelled PTT start after capture activation cleans up the capture`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCaptureStartedHandler { await barrier.suspendFirstPreparation() }
@@ -2658,8 +2662,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `session switch cannot return a cancelled PTT capture id`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCaptureStartedHandler { await barrier.suspendFirstPreparation() }
@@ -2684,8 +2687,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `session switch cannot strand a one shot PTT waiter`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         talkMode._test_setPTTOnceStartedHandler { await barrier.suspendFirstPreparation() }
@@ -2710,8 +2712,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `node route invalidation cancels active and preparing PTT`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         defer {
@@ -2745,8 +2746,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `cancelled stale interrupt cannot stop a newer PTT capture`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         defer {
@@ -2831,8 +2831,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `PTT stop and cancel interrupt active one-shot capture`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         defer { appModel.voiceWake.stop() }
 
@@ -2973,8 +2972,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `enabling unified voice requests a missing Talk scope upgrade`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let config = try GatewayConnectConfig(
             url: #require(URL(string: "wss://127.0.0.1:1")),
             stableID: "manual|gateway.example.com|443",
@@ -3040,8 +3038,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `chat dictation returns transcript and releases audio ownership`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let transcription = Task { @MainActor in
             try await appModel.transcribeChatDraft()
         }
@@ -3061,8 +3058,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `cancelling chat dictation clears capture and voice wake lease`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let transcription = Task { @MainActor in
             try await appModel.transcribeChatDraft()
         }
@@ -3083,8 +3079,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `remote PTT cannot adopt or interrupt chat dictation`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         let transcription = Task { @MainActor in
             try await appModel.transcribeChatDraft()
@@ -3120,8 +3115,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `chat dictation refuses a capture it did not reserve`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let existing = try await talkMode.beginPushToTalkOnce(
             maxDurationSeconds: 30,
             transcriptionOnly: true)
@@ -3137,8 +3131,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `gateway disconnect preserves local chat dictation`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         let transcription = Task { @MainActor in
             try await appModel.transcribeChatDraft()
@@ -3160,8 +3153,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `gateway replacement preserves local chat dictation`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let initialGateway = GatewayNodeSession()
         let replacementGateway = GatewayNodeSession()
         talkMode.attachGateway(initialGateway)
@@ -3185,8 +3177,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `route and remote PTT invalidation preserve dictation preparation`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
         defer {
@@ -3218,8 +3209,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `backgrounding invalidates dictation preparation`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
         defer {
@@ -3246,8 +3236,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `cancelling invalidates dictation preparation before capture reservation`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
         defer {
@@ -3277,8 +3266,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `backgrounding cancels chat dictation and preserves audio admission`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         defer { appModel.setScenePhase(.active) }
         let transcription = Task { @MainActor in
             try await appModel.transcribeChatDraft()
@@ -3550,8 +3538,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `backgrounding completes PTT once and releases its voice wake lease`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         defer { appModel.voiceWake.stop() }
 
@@ -3572,8 +3559,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `background PTT teardown cannot restart Voice Wake`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         appModel.voiceWake.isEnabled = true
         appModel.voiceWake.isListening = true
@@ -3608,8 +3594,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             }
         }
 
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         defer {
             appModel.setScenePhase(.active)
@@ -3678,8 +3663,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `late finalizer release cannot restart Voice Wake in background`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         talkMode._test_setPTTFinalizerHandler { await barrier.suspendFirstPreparation() }
@@ -3718,8 +3702,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `idle background blocks a later Talk enable`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         defer {
             appModel.setScenePhase(.active)
@@ -3740,8 +3723,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `background to inactive keeps PTT admission closed`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
         defer {
             appModel.setScenePhase(.active)
@@ -3776,8 +3758,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `stale foreground resume cannot reopen Talk after rebackgrounding`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         var startResumed = false
         talkMode.updateGatewayConnected(true)
@@ -3830,8 +3811,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `gateway disconnect cancels manual PTT and releases its lease`() async throws {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
 
         let response = await appModel._test_handleInvoke(
@@ -3847,8 +3827,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `background invalidates active and queued PTT preparation`() async {
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode)
+        let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
         appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
@@ -4185,31 +4164,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
         let appModel = NodeAppModel(watchMessagingService: watchService)
         defer { appModel.disconnectGateway() }
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone")
-        let gatewayA = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "watch-route-a",
-            tls: nil,
-            token: "token-a",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
-        let gatewayB = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:2")),
-            stableID: "watch-route-b",
-            tls: nil,
-            token: "token-b",
-            bootstrapToken: nil,
-            password: nil,
-            nodeOptions: options)
+        let (gatewayA, gatewayB) = try makeGatewayPair(
+            firstURL: #require(URL(string: "wss://127.0.0.1:1")),
+            firstStableID: "watch-route-a",
+            secondURL: #require(URL(string: "wss://127.0.0.1:2")),
+            secondStableID: "watch-route-b")
 
         appModel.applyGatewayConnectConfig(gatewayA)
         try appModel._test_presentExecApprovalPrompt(#require(
@@ -4267,8 +4226,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `presenting exec approval prompt syncs watch prompt`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let prompt = try #require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-sync",
@@ -4295,8 +4253,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch exec approval snapshot request publishes cached approvals in background`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let futureExpiryMs = Int64(Date().timeIntervalSince1970 * 1000) + 60000
         try appModel._test_presentExecApprovalPrompt(
             #require(
@@ -4305,27 +4262,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     commandText: "echo from watch",
                     agentId: nil,
                     expiresAtMs: futureExpiryMs)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-snapshot",
-            "status": "pending",
-            "urlPath": "/approve/approval-watch-snapshot",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo from watch",
-              "commandPreview": "echo from watch",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": null,
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-watch-snapshot",
+            commandText: "echo from watch",
+            agentID: nil))
         let initialSnapshotPublished = await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.contains { snapshot in
                 snapshot.requestId == nil &&
@@ -4337,11 +4277,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.setScenePhase(.background)
         let snapshotCount = watchService.sentExecApprovalSnapshots.count
         watchService.emitExecApprovalSnapshotRequest(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-1",
-                gatewayStableID: "test-gateway",
-                sentAtMs: 111,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest("snapshot-1", sentAt: 111))
         let correlatedSnapshotPublished = await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.dropFirst(snapshotCount).contains { snapshot in
                 snapshot.requestId == "snapshot-1" &&
@@ -4361,8 +4297,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `foreground watch snapshot acknowledgment requires canonical readback`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let futureExpiryMs = Int64(Date().timeIntervalSince1970 * 1000) + 60000
         try appModel._test_presentExecApprovalPrompt(
             #require(
@@ -4371,27 +4306,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     commandText: "echo foreground",
                     agentId: nil,
                     expiresAtMs: futureExpiryMs)))
-        let canonicalResponse = #"""
-        {
-          "approval": {
-            "id": "approval-watch-foreground",
-            "status": "pending",
-            "urlPath": "/approve/approval-watch-foreground",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo foreground",
-              "commandPreview": "echo foreground",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": null,
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
+        let canonicalResponse = makePendingExecApprovalJSON(
+            "approval-watch-foreground",
+            commandText: "echo foreground",
+            agentID: nil)
         let initialSnapshotPublished = await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.contains { snapshot in
                 snapshot.requestId == nil &&
@@ -4404,20 +4322,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         appModel._test_setExecApprovalPromptFetchFailure("gateway unavailable")
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-foreground-failed",
-                gatewayStableID: "test-gateway",
-                sentAtMs: 221,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest("snapshot-foreground-failed", sentAt: 221))
         #expect(watchService.sentExecApprovalSnapshots.count == snapshotCountBeforeMatchingRequest)
 
         appModel._test_setUnifiedExecApprovalGetResponse(canonicalResponse)
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-foreground",
-                gatewayStableID: "test-gateway",
-                sentAtMs: 222,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest("snapshot-foreground", sentAt: 222))
         let matchingSnapshotPublished = await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.dropFirst(snapshotCountBeforeMatchingRequest).contains { snapshot in
                 snapshot.requestId == "snapshot-foreground" &&
@@ -4438,11 +4348,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         watchService.lastSentExecApprovalSnapshot = nil
         let snapshotCountBeforeWrongOwnerRequest = watchService.sentExecApprovalSnapshots.count
         watchService.emitExecApprovalSnapshotRequest(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-wrong-owner",
-                gatewayStableID: "other-gateway",
-                sentAtMs: 223,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-wrong-owner",
+                gateway: "other-gateway",
+                sentAt: 223))
         let uncorrelatedSnapshotPublished = await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.dropFirst(snapshotCountBeforeWrongOwnerRequest)
                 .contains { snapshot in
@@ -4460,24 +4369,20 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `unknown held attempt stays frozen after pending readback`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         let approvalID = "approval-held-pending"
         let resolutionAttemptID = "attempt-e\u{0301}-\u{0085}"
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(approvalID))
 
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-held-pending",
-                gatewayStableID: "test-gateway",
-                heldApprovals: [WatchExecApprovalSnapshotRequestItem(
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-held-pending",
+                held: [WatchExecApprovalSnapshotRequestItem(
                     approvalId: approvalID,
                     activeResolutionAttemptId: resolutionAttemptID)],
-                sentAtMs: 225,
-                transport: "sendMessage"))
+                sentAt: 225))
 
         let snapshot = try #require(watchService.lastSentExecApprovalSnapshot)
         #expect(snapshot.requestId == "snapshot-held-pending")
@@ -4490,23 +4395,19 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `failed held approval readback sends no request snapshot`() async {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         appModel._test_setUnifiedExecApprovalGetResponse(#"{"invalid":true}"#)
         let snapshotCount = watchService.sentExecApprovalSnapshots.count
 
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-readback-failed",
-                gatewayStableID: "test-gateway",
-                heldApprovals: [WatchExecApprovalSnapshotRequestItem(
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-readback-failed",
+                held: [WatchExecApprovalSnapshotRequestItem(
                     approvalId: "approval-watch-readback-failure",
                     activeResolutionAttemptId: nil)],
-                sentAtMs: 225,
-                transport: "sendMessage"))
+                sentAt: 225))
 
         #expect(watchService.sentExecApprovalSnapshots.count == snapshotCount)
     }
@@ -4514,10 +4415,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch refresh classifies every held approval before acknowledging`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         let approvalIDs = ["approval-held-b", "approval-held-a"]
         appModel._test_setUnifiedExecApprovalGetResponses(approvalIDs.map {
@@ -4525,16 +4424,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         })
 
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-held-all",
-                gatewayStableID: "test-gateway",
-                heldApprovals: approvalIDs.map {
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-held-all",
+                held: approvalIDs.map {
                     WatchExecApprovalSnapshotRequestItem(
                         approvalId: $0,
                         activeResolutionAttemptId: nil)
                 },
-                sentAtMs: 226,
-                transport: "sendMessage"))
+                sentAt: 226))
 
         let snapshot = try #require(watchService.lastSentExecApprovalSnapshot)
         #expect(snapshot.requestId == "snapshot-held-all")
@@ -4555,10 +4452,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
           }]
         }
         """#)
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
@@ -4581,14 +4476,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             })
 
         await appModel._test_refreshWatchExecApprovalSnapshotOnDemand(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-canonical-owner-order",
-                gatewayStableID: "test-gateway",
-                heldApprovals: [WatchExecApprovalSnapshotRequestItem(
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-canonical-owner-order",
+                held: [WatchExecApprovalSnapshotRequestItem(
                     approvalId: "approval-held-owner",
                     activeResolutionAttemptId: nil)],
-                sentAtMs: 226,
-                transport: "sendMessage"))
+                sentAt: 226))
 
         #expect(await probe.snapshot() == expectedApprovalIDs)
         let snapshot = try #require(watchService.sentExecApprovalSnapshots.first {
@@ -4608,8 +4501,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(composedGatewayID == decomposedGatewayID)
         #expect(GatewayStableIdentifier.key(composedGatewayID) !=
             GatewayStableIdentifier.key(decomposedGatewayID))
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID(composedGatewayID)
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
@@ -4617,36 +4509,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 gatewayStableID: composedGatewayID,
                 commandText: "echo exact owner",
                 expiresAtMs: 4_000_000_000_000)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-exact-owner",
-            "status": "pending",
-            "urlPath": "/approve/approval-watch-exact-owner",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo exact owner",
-              "commandPreview": "echo exact owner",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-watch-exact-owner",
+            commandText: "echo exact owner"))
         await waitForMainActorWork { watchService.lastSentExecApprovalSnapshot != nil }
         let snapshotCount = watchService.sentExecApprovalSnapshots.count
 
         watchService.emitExecApprovalSnapshotRequest(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-byte-distinct-owner",
-                gatewayStableID: decomposedGatewayID,
-                sentAtMs: 227,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest(
+                "snapshot-byte-distinct-owner",
+                gateway: decomposedGatewayID,
+                sentAt: 227))
         await waitForMainActorWork {
             watchService.sentExecApprovalSnapshots.count > snapshotCount
         }
@@ -4661,10 +4534,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `not found canonical watch refresh acknowledges request`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
@@ -4675,11 +4546,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await waitForMainActorWork { watchService.lastSentExecApprovalSnapshot != nil }
 
         watchService.emitExecApprovalSnapshotRequest(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-not-found",
-                gatewayStableID: "test-gateway",
-                sentAtMs: 226,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest("snapshot-not-found", sentAt: 226))
         await waitForMainActorWork {
             watchService.lastSentExecApprovalSnapshot?.requestId == "snapshot-not-found"
         }
@@ -4692,48 +4559,22 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `foreground watch snapshot acknowledgment follows canonical readback`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-stale-cache",
                 commandText: "echo stale",
                 expiresAtMs: 4_000_000_000_000)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-stale-cache",
-            "status": "denied",
-            "urlPath": "/approve/approval-watch-stale-cache",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo stale",
-              "commandPreview": "echo stale",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makeDeniedExecApprovalJSON(
+            "approval-watch-stale-cache",
+            commandText: "echo stale",
+            expiresAtMs: 4_000_000_000_000))
         watchService.lastSentExecApprovalSnapshot = nil
 
         watchService.emitExecApprovalSnapshotRequest(
-            WatchExecApprovalSnapshotRequestEvent(
-                requestId: "snapshot-canonical",
-                gatewayStableID: "test-gateway",
-                sentAtMs: 224,
-                transport: "sendMessage"))
+            makeWatchApprovalSnapshotRequest("snapshot-canonical", sentAt: 224))
         await waitForMainActorWork {
             watchService.lastSentExecApprovalSnapshot?.requestId == "snapshot-canonical"
         }
@@ -4746,35 +4587,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch approval cache miss reports canonical terminal readback`() async {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-terminal-readback",
-            "status": "denied",
-            "urlPath": "/approve/approval-watch-terminal-readback",
-            "createdAtMs": 100,
-            "expiresAtMs": 200,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo guarded",
-              "commandPreview": "echo guarded",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makeDeniedExecApprovalJSON(
+            "approval-watch-terminal-readback",
+            commandText: "echo guarded"))
 
         let handled = await appModel._test_handleWatchExecApprovalResolve(
             WatchExecApprovalResolveEvent(
@@ -4796,32 +4614,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch approval cache miss reports canonical pending readback`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         appModel._test_setConnectedGatewayID("test-gateway")
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-pending-readback",
-            "status": "pending",
-            "urlPath": "/approve/approval-watch-pending-readback",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo guarded",
-              "commandPreview": "echo guarded",
-              "warningText": "Review this command",
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-watch-pending-readback",
+            commandText: "echo guarded",
+            warningText: "Review this command",
+            allowedDecisions: [.deny]))
 
         let handled = await appModel._test_handleWatchExecApprovalResolve(
             WatchExecApprovalResolveEvent(
@@ -4844,39 +4644,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let fetchGate = WatchSnapshotSendGate()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
         appModel._test_setConnectedGatewayID("test-gateway")
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-visible-b",
                 commandText: "echo visible-b",
                 expiresAtMs: 4_000_000_000_000)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-terminal-a",
-            "status": "denied",
-            "urlPath": "/approve/approval-terminal-a",
-            "createdAtMs": 100,
-            "expiresAtMs": 200,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo terminal-a",
-              "commandPreview": "echo terminal-a",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#, beforeResponse: { await fetchGate.wait() })
+        appModel._test_setUnifiedExecApprovalGetResponse(
+            makeDeniedExecApprovalJSON("approval-terminal-a", commandText: "echo terminal-a"),
+            beforeResponse: { await fetchGate.wait() })
 
         let fetching = Task { @MainActor in
             await appModel._test_presentExecApprovalGatewayEventPrompt("approval-terminal-a")
@@ -4901,27 +4678,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let fetchGate = WatchSnapshotSendGate()
         let appModel = NodeAppModel(watchMessagingService: MockWatchMessagingService())
         appModel._test_setConnectedGatewayID("test-gateway")
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-delayed-a",
-            "status": "pending",
-            "urlPath": "/approve/approval-delayed-a",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo delayed-a",
-              "commandPreview": "echo delayed-a",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#, beforeResponse: { await fetchGate.wait() })
+        appModel._test_setUnifiedExecApprovalGetResponse(
+            makePendingExecApprovalJSON("approval-delayed-a", commandText: "echo delayed-a"),
+            beforeResponse: { await fetchGate.wait() })
         let fetching = Task { @MainActor in
             await appModel._test_presentExecApprovalGatewayEventPrompt("approval-delayed-a")
         }
@@ -4945,8 +4704,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let fetchGate = WatchSnapshotSendGate()
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("test-gateway")
         let approvalID = "approval-terminal-interleave"
         try appModel._test_presentExecApprovalPrompt(#require(
@@ -4969,31 +4727,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             await Task.yield()
         }
 
-        let terminalJSON = #"""
-        {
-          "applied": true,
-          "approval": {
-            "id": "approval-terminal-interleave",
-            "status": "allowed",
-            "urlPath": "/approve/approval-terminal-interleave",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "allow-once",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo guarded",
-              "commandPreview": "echo guarded",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
+        let terminalJSON = makeAllowedExecApprovalJSON(
+            "approval-terminal-interleave",
+            commandText: "echo guarded",
+            decision: .allowOnce,
+            applied: true)
         #expect(try await appModel._test_applyUnifiedExecApprovalResolveResult(
             terminalJSON,
             approvalID: approvalID,
@@ -5011,8 +4749,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `operator reconnect preserves dismissed approval in reopenable inbox`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("test-gateway")
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: "approval-reconnect-restore",
@@ -5022,27 +4759,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel._test_presentExecApprovalPrompt(prompt)
         appModel.dismissPendingExecApprovalPrompt()
         #expect(appModel._test_pendingExecApprovalPrompt() == nil)
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-reconnect-restore",
-            "status": "pending",
-            "urlPath": "/approve/approval-reconnect-restore",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo restore",
-              "commandPreview": "echo restore",
-              "warningText": "Review after reconnect",
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-reconnect-restore",
+            commandText: "echo restore",
+            warningText: "Review after reconnect"))
 
         await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
@@ -5060,10 +4780,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch reconciliation does not reopen dismissed phone presentation`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel(
+            notificationCenter: MockBootstrapNotificationCenter())
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-reconcile",
@@ -5072,27 +4790,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await waitForMainActorWork { watchService.lastSentExecApprovalPrompt != nil }
         appModel._test_dismissPendingExecApprovalPrompt()
         watchService.lastSentExecApprovalPrompt = nil
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-watch-reconcile",
-            "status": "pending",
-            "urlPath": "/approve/approval-watch-reconcile",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo reconcile",
-              "commandPreview": "echo reconcile",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-watch-reconcile",
+            commandText: "echo reconcile"))
 
         await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
@@ -5113,27 +4813,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 id: approvalID,
                 commandText: "echo race",
                 expiresAtMs: 4_000_000_000_000)))
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-phone-write-race",
-            "status": "pending",
-            "urlPath": "/approve/approval-phone-write-race",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo race",
-              "commandPreview": "echo race",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-phone-write-race",
+            commandText: "echo race"))
         let writeGate = ExecApprovalResolutionGate()
         appModel._test_setExecApprovalResolutionFailureHandler { _, _, _ in
             await writeGate.waitForFirstCall()
@@ -5168,8 +4850,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `phone and watch decisions share one exact owner write lease`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let approvalID = "approval-phone-watch-lease"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
@@ -5229,30 +4910,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     commandText: "echo cached \(approvalID)",
                     expiresAtMs: 4_000_000_000_000)))
         }
-        let responseTemplate = #"""
-        {
-          "approval": {
-            "id": "__ID__",
-            "status": "pending",
-            "urlPath": "/approve/__ID__",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "canonical __ID__",
-              "commandPreview": "canonical __ID__",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#
         let responses: [(approvalID: String, json: String)] = [
-            ("approval-a", responseTemplate.replacingOccurrences(of: "__ID__", with: "approval-a")),
-            ("approval-b", responseTemplate.replacingOccurrences(of: "__ID__", with: "approval-b")),
+            (
+                "approval-a",
+                makePendingExecApprovalJSON("approval-a", commandText: "canonical approval-a")),
+            (
+                "approval-b",
+                makePendingExecApprovalJSON("approval-b", commandText: "canonical approval-b")),
         ]
         appModel._test_setUnifiedExecApprovalGetResponses(responses)
 
@@ -5293,8 +4957,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch app snapshot request publishes current dashboard state`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let gatewayStableID = " gateway-watch-snapshot "
         appModel._test_setGatewayConnected(true)
         appModel._test_setOperatorConnected(true)
@@ -5329,8 +4992,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch gateway problem keeps localization semantics`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_applyOperatorGatewayConnectionProblem(GatewayConnectionProblem(
             kind: .pairingRequired,
             owner: .gateway,
@@ -5361,8 +5023,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot publishes offline when operator disconnects`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setGatewayConnected(true)
         appModel._test_setOperatorConnected(true)
         appModel.gatewayStatusText = "Connected"
@@ -5393,8 +5054,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot preserves gateway connection progress`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.setGatewayConnectionProgress(reconnecting: false)
 
         watchService.emitAppSnapshotRequest(
@@ -5416,8 +5076,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot preserves talk failures`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.talkMode._test_markSpeechErrorStatusPendingRestart("Speech error: denied")
 
         watchService.emitAppSnapshotRequest(
@@ -5439,8 +5098,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot preserves one shot push to talk phase`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.talkMode.isEnabled = false
         appModel.talkMode.isPushToTalkActive = true
         appModel.talkMode._test_handleRealtimeRelayStatus("Thinking")
@@ -5461,8 +5119,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot preserves terminal push to talk failure`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.talkMode._test_handleRealtimeRelayStatus("Backend rejected realtime request")
 
         watchService.emitAppSnapshotRequest(
@@ -5484,8 +5141,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot publishes online when operator reconnects`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setGatewayConnected(true)
         appModel.gatewayStatusText = "Connected"
 
@@ -5515,8 +5171,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app snapshot uses configured agent avatar`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.gatewayDefaultAgentId = "main"
         appModel.gatewayAgents = [
             AgentSummary(
@@ -5547,8 +5202,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch app snapshot includes pending approval count`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
 
         try appModel._test_presentExecApprovalPrompt(
             #require(
@@ -5571,28 +5225,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(watchMessagingService: watchService, talkMode: talkMode)
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-start-talk",
-                command: .startTalk,
-                sessionKey: "main",
-                gatewayStableID: nil,
-                text: nil,
-                sentAtMs: 123,
-                transport: "sendMessage"))
+            makeWatchAppCommand("watch-start-talk", .startTalk, sentAt: 123))
         await Task.yield()
 
         #expect(appModel.talkMode.isEnabled == true)
         #expect(watchService.lastSentAppSnapshot?.talkEnabled == true)
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-stop-talk",
-                command: .stopTalk,
-                sessionKey: "main",
-                gatewayStableID: nil,
-                text: nil,
-                sentAtMs: 124,
-                transport: "sendMessage"))
+            makeWatchAppCommand("watch-stop-talk", .stopTalk, sentAt: 124))
         await Task.yield()
 
         #expect(appModel.talkMode.isEnabled == false)
@@ -5600,18 +5240,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app command opens chat session on phone model`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-open-chat",
-                command: .openChat,
-                sessionKey: "incident-42",
-                gatewayStableID: nil,
-                text: nil,
-                sentAtMs: 125,
-                transport: "sendMessage"))
+            makeWatchAppCommand(
+                "watch-open-chat",
+                .openChat,
+                session: "incident-42",
+                sentAt: 125))
         await Task.yield()
 
         #expect(appModel.chatSessionKey == "incident-42")
@@ -5627,13 +5263,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         for command in [OpenClawWatchAppCommand.openChat, .startTalk] {
             watchService.emitAppCommand(
-                WatchAppCommandEvent(
-                    commandId: "watch-stale-\(command.rawValue)",
-                    command: command,
-                    sessionKey: "stale-session",
-                    gatewayStableID: "gateway-stale",
-                    text: nil,
-                    sentAtMs: 125,
+                makeWatchAppCommand(
+                    "watch-stale-\(command.rawValue)",
+                    command,
+                    session: "stale-session",
+                    gateway: "gateway-stale",
+                    sentAt: 125,
                     transport: "transferUserInfo"))
             await Task.yield()
         }
@@ -5643,13 +5278,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         appModel.setTalkEnabled(true)
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-stale-stop-talk",
-                command: .stopTalk,
-                sessionKey: "stale-session",
-                gatewayStableID: "gateway-stale",
-                text: nil,
-                sentAtMs: 126,
+            makeWatchAppCommand(
+                "watch-stale-stop-talk",
+                .stopTalk,
+                session: "stale-session",
+                gateway: "gateway-stale",
+                sentAt: 126,
                 transport: "transferUserInfo"))
         await Task.yield()
 
@@ -5657,19 +5291,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch app command sends chat message through phone model`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.enterAppleReviewDemoMode()
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: AppleReviewDemoMode.gatewayID,
+            makeWatchAppCommand(
+                "watch-send-chat",
+                .sendChat,
+                gateway: AppleReviewDemoMode.gatewayID,
                 text: "Watch says hello",
-                sentAtMs: 126,
-                transport: "sendMessage"))
+                sentAt: 126))
         for _ in 0..<20 {
             if watchService.lastSentChatCompletion?.commandId == "watch-send-chat",
                watchService.lastSentAppSnapshot?.chatItems?.contains(where: { item in
@@ -5922,33 +5553,28 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch app command queues chat message when operator offline`() async {
         NodeAppModel._test_resetPersistedWatchChatQueueState()
         defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let gatewayID = "gateway-watch-chat-offline"
         appModel._test_setConnectedGatewayID(gatewayID)
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-offline",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: gatewayID,
+            makeWatchAppCommand(
+                "watch-send-chat-offline",
+                .sendChat,
+                gateway: gatewayID,
                 text: "Queue this from watch",
-                sentAtMs: 127,
-                transport: "sendMessage"))
+                sentAt: 127))
         await Task.yield()
 
         #expect(appModel._test_queuedWatchChatCommandCount() == 1)
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-offline",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: gatewayID,
+            makeWatchAppCommand(
+                "watch-send-chat-offline",
+                .sendChat,
+                gateway: gatewayID,
                 text: "Queue this from watch",
-                sentAtMs: 128,
-                transport: "sendMessage"))
+                sentAt: 128))
         await Task.yield()
 
         #expect(appModel._test_queuedWatchChatCommandCount() == 1)
@@ -5957,17 +5583,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch app command queues until cold launch restores its gateway`() async {
         NodeAppModel._test_resetPersistedWatchChatQueueState()
         defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-before-route",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: "gateway-cold-launch",
+            makeWatchAppCommand(
+                "watch-send-chat-before-route",
+                .sendChat,
+                gateway: "gateway-cold-launch",
                 text: "Keep this until startup restores the route",
-                sentAtMs: 127,
+                sentAt: 127,
                 transport: "transferUserInfo"))
         await waitForMainActorWork { appModel._test_queuedWatchChatCommandCount() == 1 }
 
@@ -5978,18 +5602,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch app command drops chat message for stale gateway snapshot`() async {
         NodeAppModel._test_resetPersistedWatchChatQueueState()
         defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("gateway-current")
 
         watchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-stale-gateway",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: "gateway-from-old-snapshot",
+            makeWatchAppCommand(
+                "watch-send-chat-stale-gateway",
+                .sendChat,
+                gateway: "gateway-from-old-snapshot",
                 text: "Do not send to the new gateway",
-                sentAtMs: 128,
+                sentAt: 128,
                 transport: "transferUserInfo"))
         await Task.yield()
 
@@ -6005,14 +5627,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let firstAppModel = NodeAppModel(watchMessagingService: firstWatchService)
         firstAppModel._test_setConnectedGatewayID(gatewayID)
         firstWatchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-restore",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: gatewayID,
+            makeWatchAppCommand(
+                "watch-send-chat-restore",
+                .sendChat,
+                gateway: gatewayID,
                 text: "Keep this through restart",
-                sentAtMs: 129,
-                transport: "sendMessage"))
+                sentAt: 129))
         await Task.yield()
 
         #expect(firstAppModel._test_queuedWatchChatCommandIds() == ["watch-send-chat-restore"])
@@ -6024,13 +5644,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(secondAppModel._test_queuedWatchChatCommandIds() == ["watch-send-chat-restore"])
 
         secondWatchService.emitAppCommand(
-            WatchAppCommandEvent(
-                commandId: "watch-send-chat-restore",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: gatewayID,
+            makeWatchAppCommand(
+                "watch-send-chat-restore",
+                .sendChat,
+                gateway: gatewayID,
                 text: "Keep this through restart",
-                sentAtMs: 130,
+                sentAt: 130,
                 transport: "transferUserInfo"))
         await Task.yield()
 
@@ -6046,22 +5665,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let coordinator = WatchMessageOutbox(defaults: defaults)
-        let first = WatchAppCommandEvent(
-            commandId: "watch-send-chat-gateway-a-1",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+        let first = makeWatchAppCommand(
+            "watch-send-chat-gateway-a-1",
+            .sendChat,
+            gateway: "gateway-a",
             text: "First for gateway A",
-            sentAtMs: 131,
-            transport: "sendMessage")
-        let second = WatchAppCommandEvent(
-            commandId: "watch-send-chat-gateway-a-2",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+            sentAt: 131)
+        let second = makeWatchAppCommand(
+            "watch-send-chat-gateway-a-2",
+            .sendChat,
+            gateway: "gateway-a",
             text: "Second for gateway A",
-            sentAtMs: 132,
-            transport: "sendMessage")
+            sentAt: 132)
 
         if case .queue = coordinator.ingest(first, isAvailable: false, gatewayStableID: "gateway-a") {
         } else {
@@ -6101,14 +5716,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let coordinator = WatchMessageOutbox(defaults: defaults)
-        let event = WatchAppCommandEvent(
-            commandId: "watch-send-chat-retry-gateway-a",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+        let event = makeWatchAppCommand(
+            "watch-send-chat-retry-gateway-a",
+            .sendChat,
+            gateway: "gateway-a",
             text: "Retry for gateway A",
-            sentAtMs: 133,
-            transport: "sendMessage")
+            sentAt: 133)
 
         coordinator.requeueFront(event, gatewayStableID: event.gatewayStableID)
 
@@ -6141,23 +5754,22 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let outbox = WatchMessageOutbox(defaults: defaults)
-        let chat = WatchAppCommandEvent(
-            commandId: "queued-chat",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+        let chat = makeWatchAppCommand(
+            "queued-chat",
+            .sendChat,
+            gateway: "gateway-a",
             text: "Chat first",
-            sentAtMs: 1,
+            sentAt: 1,
             transport: "transferUserInfo")
-        let reply = WatchAppCommandEvent(
-            commandId: "queued-reply",
-            command: .sendChat,
-            sessionKey: nil,
-            gatewayStableID: "gateway-a",
+        let reply = makeWatchAppCommand(
+            "queued-reply",
+            .sendChat,
+            session: nil,
+            gateway: "gateway-a",
             text: "Reply second",
-            sentAtMs: 2,
+            sentAt: 2,
             transport: "transferUserInfo",
-            messageKind: .quickReply)
+            kind: .quickReply)
 
         _ = outbox.ingest(chat, isAvailable: false, gatewayStableID: "gateway-a")
         _ = outbox.ingest(reply, isAvailable: false, gatewayStableID: "gateway-a")
@@ -6221,14 +5833,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         let coordinator = WatchMessageOutbox(defaults: defaults)
         for index in 0..<140 {
-            let event = WatchAppCommandEvent(
-                commandId: "watch-forward-\(index)",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: nil,
+            let event = makeWatchAppCommand(
+                "watch-forward-\(index)",
+                .sendChat,
                 text: "Message \(index)",
-                sentAtMs: Int64(index),
-                transport: "sendMessage")
+                sentAt: Int64(index))
             if case .forward = coordinator.ingest(
                 event,
                 isAvailable: true,
@@ -6242,14 +5851,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             }
         }
 
-        let oldestEvent = WatchAppCommandEvent(
-            commandId: "watch-forward-0",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: nil,
+        let oldestEvent = makeWatchAppCommand(
+            "watch-forward-0",
+            .sendChat,
             text: "Message 0 again",
-            sentAtMs: 999,
-            transport: "sendMessage")
+            sentAt: 999)
         if case .forward = coordinator.ingest(
             oldestEvent,
             isAvailable: true,
@@ -6259,14 +5865,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             Issue.record("expected oldest forwarded command to age out of dedupe")
         }
 
-        let recentEvent = WatchAppCommandEvent(
-            commandId: "watch-forward-139",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: nil,
+        let recentEvent = makeWatchAppCommand(
+            "watch-forward-139",
+            .sendChat,
             text: "Message 139 again",
-            sentAtMs: 1000,
-            transport: "sendMessage")
+            sentAt: 1000)
         if case .deduped = coordinator.ingest(
             recentEvent,
             isAvailable: true,
@@ -6287,13 +5890,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         let coordinator = WatchMessageOutbox(defaults: defaults)
         for index in 0..<140 {
-            let event = WatchAppCommandEvent(
-                commandId: "watch-queued-\(index)",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: nil,
+            let event = makeWatchAppCommand(
+                "watch-queued-\(index)",
+                .sendChat,
                 text: "Queued \(index)",
-                sentAtMs: Int64(index),
+                sentAt: Int64(index),
                 transport: "transferUserInfo")
             if case .queue = coordinator.ingest(
                 event,
@@ -6309,13 +5910,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             messageID: "watch-queued-0",
             gatewayStableID: "gateway-a")
 
-        let duplicateDeliveredEvent = WatchAppCommandEvent(
-            commandId: "watch-queued-0",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: nil,
+        let duplicateDeliveredEvent = makeWatchAppCommand(
+            "watch-queued-0",
+            .sendChat,
             text: "Duplicate after delivery",
-            sentAtMs: 999,
+            sentAt: 999,
             transport: "transferUserInfo")
         if case .deduped = coordinator.ingest(
             duplicateDeliveredEvent,
@@ -6434,9 +6033,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
           }]
         }
         """#)
-        let appModel = NodeAppModel(
-            notificationCenter: MockBootstrapNotificationCenter(),
-            watchMessagingService: MockWatchMessagingService())
+        let appModel = makeNodeModelWithMockServices()
 
         #expect(appModel._test_watchExecApprovalCacheIDs().isEmpty)
         var readbacks = appModel._test_pendingPersistedExecApprovalReadbacks()
@@ -6444,27 +6041,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(readbacks.first?.approvalId == "approval-shipped-cache")
         #expect(readbacks.first?.gatewayStableID == "gateway-a")
 
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-shipped-cache",
-            "status": "pending",
-            "urlPath": "/approve/approval-shipped-cache",
-            "createdAtMs": 100,
-            "expiresAtMs": 4000000000000,
-            "presentation": {
-              "kind": "exec",
-              "commandText": "canonical command",
-              "commandPreview": "canonical command",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
+            "approval-shipped-cache",
+            commandText: "canonical command"))
         appModel._test_setConnectedGatewayID("gateway-b")
         await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         #expect(appModel._test_watchExecApprovalCacheIDs().isEmpty)
@@ -6684,8 +6263,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let composedID = "approval-\u{00E9}"
         let decomposedID = "approval-e\u{0301}"
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("test-gateway")
 
         for approvalID in [composedID, decomposedID] {
@@ -6759,9 +6337,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `operator gateway requested event shows notification guidance when notifications off`() async throws {
-        let center = MockBootstrapNotificationCenter()
-        center.status = .notDetermined
-        let appModel = NodeAppModel(notificationCenter: center)
+        let (center, appModel) = makeNotificationModel(status: .notDetermined)
         appModel._test_resetExecApprovalNotificationGuidanceSuppression()
         defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
 
@@ -6840,9 +6416,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `suppressed operator gateway requested event does not show notification guidance`() async {
-        let center = MockBootstrapNotificationCenter()
-        center.status = .denied
-        let appModel = NodeAppModel(notificationCenter: center)
+        let (center, appModel) = makeNotificationModel(status: .denied)
         appModel._test_resetExecApprovalNotificationGuidanceSuppression()
         defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
         appModel.dismissNotificationPermissionGuidancePrompt(suppressFuture: true)
@@ -6858,9 +6432,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `canonical resolved readback clears notification guidance prompt`() async throws {
-        let center = MockBootstrapNotificationCenter()
-        center.status = .denied
-        let appModel = NodeAppModel(notificationCenter: center)
+        let (center, appModel) = makeNotificationModel(status: .denied)
         appModel._test_resetExecApprovalNotificationGuidanceSuppression()
         defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
 
@@ -6872,30 +6444,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             stateversion: nil))
         _ = try #require(appModel._test_pendingNotificationPermissionGuidancePrompt())
         appModel._test_setConnectedGatewayID("test-gateway")
-        appModel._test_setUnifiedExecApprovalGetResponse(#"""
-        {
-          "approval": {
-            "id": "approval-guidance-resolved",
-            "status": "denied",
-            "urlPath": "/approve/approval-guidance-resolved",
-            "createdAtMs": 100,
-            "expiresAtMs": 200,
-            "resolvedAtMs": 150,
-            "reason": "user",
-            "decision": "deny",
-            "presentation": {
-              "kind": "exec",
-              "commandText": "echo guarded",
-              "commandPreview": "echo guarded",
-              "warningText": null,
-              "host": "gateway",
-              "nodeId": null,
-              "agentId": "main",
-              "allowedDecisions": ["allow-once", "deny"]
-            }
-          }
-        }
-        """#)
+        appModel._test_setUnifiedExecApprovalGetResponse(makeDeniedExecApprovalJSON(
+            "approval-guidance-resolved",
+            commandText: "echo guarded"))
 
         await appModel._test_handleExecApprovalResolvedForCurrentGateway(
             approvalId: "approval-guidance-resolved",
@@ -7009,15 +6560,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `system notify returns unavailable when notifications off`() async throws {
-        let center = MockBootstrapNotificationCenter()
-        center.status = .notDetermined
-        let appModel = NodeAppModel(notificationCenter: center)
-        let params = OpenClawSystemNotifyParams(title: "Approval", body: "Review request")
-        let paramsData = try JSONEncoder().encode(params)
-        let req = BridgeInvokeRequest(
+        let (center, appModel) = makeNotificationModel(status: .notDetermined)
+        let req = try makeInvokeRequest(
             id: "notify-off",
             command: OpenClawSystemCommand.notify.rawValue,
-            paramsJSON: String(decoding: paramsData, as: UTF8.self))
+            params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
         let res = await appModel._test_handleInvoke(req)
 
@@ -7030,15 +6577,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `system notify schedules when notifications are already allowed`() async throws {
         let restorePreference = overrideNotificationServingPreference(true)
         defer { restorePreference() }
-        let center = MockBootstrapNotificationCenter()
-        center.status = .authorized
-        let appModel = NodeAppModel(notificationCenter: center)
-        let params = OpenClawSystemNotifyParams(title: "Approval", body: "Review request")
-        let paramsData = try JSONEncoder().encode(params)
-        let req = BridgeInvokeRequest(
+        let (center, appModel) = makeNotificationModel(status: .authorized)
+        let req = try makeInvokeRequest(
             id: "notify-on",
             command: OpenClawSystemCommand.notify.rawValue,
-            paramsJSON: String(decoding: paramsData, as: UTF8.self))
+            params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
         let res = await appModel._test_handleInvoke(req)
 
@@ -7049,15 +6592,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `system notify respects app notification opt out`() async throws {
         let restorePreference = overrideNotificationServingPreference(false)
         defer { restorePreference() }
-        let center = MockBootstrapNotificationCenter()
-        center.status = .authorized
-        let appModel = NodeAppModel(notificationCenter: center)
-        let params = OpenClawSystemNotifyParams(title: "Approval", body: "Review request")
-        let paramsData = try JSONEncoder().encode(params)
-        let req = BridgeInvokeRequest(
+        let (center, appModel) = makeNotificationModel(status: .authorized)
+        let req = try makeInvokeRequest(
             id: "notify-disabled",
             command: OpenClawSystemCommand.notify.rawValue,
-            paramsJSON: String(decoding: paramsData, as: UTF8.self))
+            params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
         let res = await appModel._test_handleInvoke(req)
 
@@ -7070,9 +6609,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `apns registration requires notification authorization and relay disclosure`() async {
         let restorePreference = overrideNotificationServingPreference(true)
         defer { restorePreference() }
-        let center = MockBootstrapNotificationCenter()
-        center.status = .authorized
-        let appModel = NodeAppModel(notificationCenter: center)
+        let (center, appModel) = makeNotificationModel(status: .authorized)
         PushEnrollmentConsent.reset()
         defer { PushEnrollmentConsent.reset() }
 
@@ -7091,15 +6628,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `chat push without speech returns unavailable when notifications off`() async throws {
-        let center = MockBootstrapNotificationCenter()
-        center.status = .notDetermined
-        let appModel = NodeAppModel(notificationCenter: center)
-        let params = OpenClawChatPushParams(text: "Build finished", speak: false)
-        let paramsData = try JSONEncoder().encode(params)
-        let req = BridgeInvokeRequest(
+        let (center, appModel) = makeNotificationModel(status: .notDetermined)
+        let req = try makeInvokeRequest(
             id: "chat-push-off",
             command: OpenClawChatCommand.push.rawValue,
-            paramsJSON: String(decoding: paramsData, as: UTF8.self))
+            params: OpenClawChatPushParams(text: "Build finished", speak: false))
 
         let res = await appModel._test_handleInvoke(req)
 
@@ -7112,15 +6645,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `chat push schedules when notifications are already allowed`() async throws {
         let restorePreference = overrideNotificationServingPreference(true)
         defer { restorePreference() }
-        let center = MockBootstrapNotificationCenter()
-        center.status = .authorized
-        let appModel = NodeAppModel(notificationCenter: center)
-        let params = OpenClawChatPushParams(text: "Build finished", speak: false)
-        let paramsData = try JSONEncoder().encode(params)
-        let req = BridgeInvokeRequest(
+        let (center, appModel) = makeNotificationModel(status: .authorized)
+        let req = try makeInvokeRequest(
             id: "chat-push-on",
             command: OpenClawChatCommand.push.rawValue,
-            paramsJSON: String(decoding: paramsData, as: UTF8.self))
+            params: OpenClawChatPushParams(text: "Build finished", speak: false))
 
         let res = await appModel._test_handleInvoke(req)
 
@@ -7157,24 +6686,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(appModel.screen.urlString.isEmpty)
 
         // Loopback URLs are rejected (they are not meaningful for a remote gateway).
-        let navigateParams = OpenClawCanvasNavigateParams(url: "http://example.com/")
-        let navData = try JSONEncoder().encode(navigateParams)
-        let navJSON = String(decoding: navData, as: UTF8.self)
-        let navigate = BridgeInvokeRequest(
+        let navigate = try makeInvokeRequest(
             id: "nav",
             command: OpenClawCanvasCommand.navigate.rawValue,
-            paramsJSON: navJSON)
+            params: OpenClawCanvasNavigateParams(url: "http://example.com/"))
         let navRes = await appModel._test_handleInvoke(navigate)
         #expect(navRes.ok == true)
         #expect(appModel.screen.urlString == "http://example.com/")
 
-        let evalParams = OpenClawCanvasEvalParams(javaScript: "1+1")
-        let evalData = try JSONEncoder().encode(evalParams)
-        let evalJSON = String(decoding: evalData, as: UTF8.self)
-        let eval = BridgeInvokeRequest(
+        let eval = try makeInvokeRequest(
             id: "eval",
             command: OpenClawCanvasCommand.evalJS.rawValue,
-            paramsJSON: evalJSON)
+            params: OpenClawCanvasEvalParams(javaScript: "1+1"))
         var evalRes = await appModel._test_handleInvoke(eval)
         let deadline = ContinuousClock().now.advanced(by: .seconds(3))
         while evalRes.ok != true, ContinuousClock().now < deadline {
@@ -7189,9 +6712,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `pending foreground actions replay canvas navigate`() async throws {
         let appModel = NodeAppModel()
-        let navigateParams = OpenClawCanvasNavigateParams(url: "http://example.com/")
-        let navData = try JSONEncoder().encode(navigateParams)
-        let navJSON = String(decoding: navData, as: UTF8.self)
+        let navJSON = try String(
+            decoding: JSONEncoder().encode(OpenClawCanvasNavigateParams(url: "http://example.com/")),
+            as: UTF8.self)
 
         await appModel._test_applyPendingForegroundNodeActions([
             (
@@ -7206,9 +6729,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `pending foreground actions do not apply while backgrounded`() async throws {
         let appModel = NodeAppModel()
         appModel.setScenePhase(.background)
-        let navigateParams = OpenClawCanvasNavigateParams(url: "http://example.com/")
-        let navData = try JSONEncoder().encode(navigateParams)
-        let navJSON = String(decoding: navData, as: UTF8.self)
+        let navJSON = try String(
+            decoding: JSONEncoder().encode(OpenClawCanvasNavigateParams(url: "http://example.com/")),
+            as: UTF8.self)
 
         await appModel._test_applyPendingForegroundNodeActions([
             (
@@ -7229,13 +6752,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(resetRes.error?.message.contains("A2UI_HOST_UNAVAILABLE") == true)
 
         let jsonl = "{\"beginRendering\":{}}"
-        let pushParams = OpenClawCanvasA2UIPushJSONLParams(jsonl: jsonl)
-        let pushData = try JSONEncoder().encode(pushParams)
-        let pushJSON = String(decoding: pushData, as: UTF8.self)
-        let push = BridgeInvokeRequest(
+        let push = try makeInvokeRequest(
             id: "push",
             command: OpenClawCanvasA2UICommand.pushJSONL.rawValue,
-            paramsJSON: pushJSON)
+            params: OpenClawCanvasA2UIPushJSONLParams(jsonl: jsonl))
         let pushRes = await appModel._test_handleInvoke(push)
         #expect(pushRes.ok == false)
         #expect(pushRes.error?.message.contains("A2UI_HOST_UNAVAILABLE") == true)
@@ -7287,8 +6807,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch status callback publishes reachability changes`() async {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let status = WatchMessagingStatus(
             supported: true,
             paired: true,
@@ -7314,12 +6833,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             title: "OpenClaw",
             body: "Meeting with Peter is at 4pm",
             priority: .timeSensitive)
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req, gatewayStableID: "gateway-a")
         #expect(res.ok == true)
@@ -7626,15 +7143,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `handle invoke watch notify rejects empty message`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let params = OpenClawWatchNotifyParams(title: "   ", body: "\n")
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify-empty",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req)
         #expect(res.ok == false)
@@ -7643,19 +7157,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `handle invoke watch notify adds default actions for prompt`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let params = OpenClawWatchNotifyParams(
             title: "Task",
             body: "Action needed",
             priority: .passive,
             promptId: "prompt-123")
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify-default-actions",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req)
         #expect(res.ok == true)
@@ -7665,18 +7176,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `legacy watch reply binds to latest prompt owner`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("gateway-a")
         let params = OpenClawWatchNotifyParams(
             title: "Task",
             body: "Action needed",
             promptId: "prompt-legacy")
-        let paramsJSON = try String(decoding: JSONEncoder().encode(params), as: UTF8.self)
-        let request = BridgeInvokeRequest(
+        let request = try makeInvokeRequest(
             id: "watch-notify-legacy-owner",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
         #expect(await appModel._test_handleInvoke(request, gatewayStableID: "gateway-a").ok)
 
         watchService.emitReply(WatchQuickReplyEvent(
@@ -7695,19 +7204,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `handle invoke watch notify adds approval defaults`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let params = OpenClawWatchNotifyParams(
             title: "Approval",
             body: "Allow command?",
             promptId: "prompt-approval",
             kind: "approval")
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify-approval-defaults",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req)
         #expect(res.ok == true)
@@ -7717,8 +7223,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `handle invoke watch notify derives priority from risk and caps actions`() async throws {
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         let params = OpenClawWatchNotifyParams(
             title: "Urgent",
             body: "Check now",
@@ -7730,12 +7235,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 OpenClawWatchAction(id: "a4", label: "A4"),
                 OpenClawWatchAction(id: "a5", label: "A5"),
             ])
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify-derive-priority",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req)
         #expect(res.ok == true)
@@ -7753,12 +7256,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             userInfo: [NSLocalizedDescriptionKey: "WATCH_UNAVAILABLE: no paired Apple Watch"])
         let appModel = NodeAppModel(watchMessagingService: watchService)
         let params = OpenClawWatchNotifyParams(title: "OpenClaw", body: "Delivery check")
-        let paramsData = try JSONEncoder().encode(params)
-        let paramsJSON = String(decoding: paramsData, as: UTF8.self)
-        let req = BridgeInvokeRequest(
+        let req = try makeInvokeRequest(
             id: "watch-notify-fail",
             command: OpenClawWatchCommand.notify.rawValue,
-            paramsJSON: paramsJSON)
+            params: params)
 
         let res = await appModel._test_handleInvoke(req)
         #expect(res.ok == false)
@@ -7769,8 +7270,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch reply queues when gateway offline`() async {
         NodeAppModel._test_resetPersistedWatchReplyQueueState()
         defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("gateway-watch-reply")
         watchService.emitReply(
             WatchQuickReplyEvent(
@@ -7791,18 +7291,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchChatQueueState()
         defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
         let gatewayID = " gateway-boundary "
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID(gatewayID)
 
-        watchService.emitAppCommand(WatchAppCommandEvent(
-            commandId: "watch-boundary-chat",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: gatewayID,
+        watchService.emitAppCommand(makeWatchAppCommand(
+            "watch-boundary-chat",
+            .sendChat,
+            gateway: gatewayID,
             text: "Keep exact owner",
-            sentAtMs: 1,
-            transport: "sendMessage"))
+            sentAt: 1))
         watchService.emitReply(WatchQuickReplyEvent(
             replyId: "watch-boundary-reply",
             promptId: "watch-boundary-prompt",
@@ -7818,14 +7315,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(appModel._test_queuedWatchChatCommandIds() == ["watch-boundary-chat"])
         #expect(appModel._test_queuedWatchReplyCount() == 1)
 
-        watchService.emitAppCommand(WatchAppCommandEvent(
-            commandId: "watch-trimmed-owner-chat",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-boundary",
+        watchService.emitAppCommand(makeWatchAppCommand(
+            "watch-trimmed-owner-chat",
+            .sendChat,
+            gateway: "gateway-boundary",
             text: "Wrong owner",
-            sentAtMs: 3,
-            transport: "sendMessage"))
+            sentAt: 3))
         await Task.yield()
         #expect(appModel._test_queuedWatchChatCommandIds() == ["watch-boundary-chat"])
     }
@@ -7838,15 +7333,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        let event = WatchAppCommandEvent(
-            commandId: "reply-restore-1",
-            command: .sendChat,
-            sessionKey: "ios",
-            gatewayStableID: "gateway-a",
+        let event = makeWatchAppCommand(
+            "reply-restore-1",
+            .sendChat,
+            session: "ios",
+            gateway: "gateway-a",
             text: "Watch reply: Approve",
-            sentAtMs: 1235,
+            sentAt: 1235,
             transport: "transferUserInfo",
-            messageKind: .quickReply)
+            kind: .quickReply)
         let firstOutbox = WatchMessageOutbox(defaults: defaults)
         if case .queue = firstOutbox.ingest(event, isAvailable: false, gatewayStableID: "gateway-a") {
         } else {
@@ -7868,27 +7363,24 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let event = WatchAppCommandEvent(
-            commandId: "delivered-reply",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+        let event = makeWatchAppCommand(
+            "delivered-reply",
+            .sendChat,
+            gateway: "gateway-a",
             text: "Delivered reply",
-            sentAtMs: 1,
-            transport: "sendMessage",
-            messageKind: .quickReply)
+            sentAt: 1,
+            kind: .quickReply)
         let firstOutbox = WatchMessageOutbox(defaults: defaults)
         firstOutbox.recordPromptRoute(promptID: "prompt-a", gatewayStableID: "gateway-a")
         _ = firstOutbox.ingest(event, isAvailable: true, gatewayStableID: "gateway-a")
         firstOutbox.removeQueuedMessage(messageID: event.commandId, gatewayStableID: "gateway-a")
         for index in 0..<140 {
-            let pending = WatchAppCommandEvent(
-                commandId: "pending-\(index)",
-                command: .sendChat,
-                sessionKey: "main",
-                gatewayStableID: "gateway-a",
+            let pending = makeWatchAppCommand(
+                "pending-\(index)",
+                .sendChat,
+                gateway: "gateway-a",
                 text: "Pending \(index)",
-                sentAtMs: Int64(index + 2),
+                sentAt: Int64(index + 2),
                 transport: "transferUserInfo")
             _ = firstOutbox.ingest(pending, isAvailable: false, gatewayStableID: "gateway-a")
         }
@@ -7910,15 +7402,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let event = WatchAppCommandEvent(
-            commandId: "delivered-before-crash",
-            command: .sendChat,
-            sessionKey: "main",
-            gatewayStableID: "gateway-a",
+        let event = makeWatchAppCommand(
+            "delivered-before-crash",
+            .sendChat,
+            gateway: "gateway-a",
             text: "Delivered reply",
-            sentAtMs: 1,
-            transport: "sendMessage",
-            messageKind: .quickReply)
+            sentAt: 1,
+            kind: .quickReply)
         let firstOutbox = WatchMessageOutbox(defaults: defaults)
         _ = firstOutbox.ingest(event, isAvailable: true, gatewayStableID: "gateway-a")
         let staleQueue = try #require(defaults.data(forKey: "watch.chat.command.queue.v1"))
@@ -7943,8 +7433,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch reply drops stale gateway target`() async {
         NodeAppModel._test_resetPersistedWatchReplyQueueState()
         defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel._test_setConnectedGatewayID("gateway-current")
 
         watchService.emitReply(
@@ -7967,8 +7456,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch reply uses idempotent chat outbox`() async {
         NodeAppModel._test_resetPersistedWatchReplyQueueState()
         defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.enterAppleReviewDemoMode()
         appModel._test_recordWatchPromptRoute(
             promptID: "prompt-idempotent",
@@ -7997,8 +7485,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch reply rejects legacy prompt without a gateway owner`() async {
         NodeAppModel._test_resetPersistedWatchReplyQueueState()
         defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
-        let watchService = MockWatchMessagingService()
-        let appModel = NodeAppModel(watchMessagingService: watchService)
+        let (watchService, appModel) = makeWatchModel()
         appModel.enterAppleReviewDemoMode()
         let initialOpenChatRequestID = appModel.openChatRequestID
         let event = WatchQuickReplyEvent(


### PR DESCRIPTION
## What Problem This Solves

NodeAppModelInvokeTests repeated large approval payloads, gateway setup, and fresh model/watch/talk construction across lifecycle tests. That duplication made the suite harder to audit and left 513 avoidable lines in a high-risk test surface.

## Why This Change Was Made

This test-only refactor introduces same-file private typed fixture constructors for canonical approval responses, gateway pairs, fresh dependency/model pairs, invoke requests, and Watch events. Every test still owns fresh mutable instances; UserDefaults cleanup, persistence resets, tasks, cancellation, continuations, gateway switching, and wait/release barriers remain in their original order. Malformed, migration, legacy, and wire-contract JSON remains raw, and typed approval fixtures preserve the original explicit JSON null fields.

Architectural owner: the iOS NodeAppModel test suite. Canonical fix: centralize only repeated valid fixtures while retaining test-local lifecycle orchestration and raw contract cases.

Removed paths: 1,175 repeated test-fixture/setup lines replaced by 662 helper/call-site lines. Production LOC delta: 0. Test LOC delta: -513.

## User Impact

No runtime or user-visible behavior changes. Developers get a materially smaller, more consistent suite while preserving the existing behavioral coverage.

## Evidence

- Structural comparison against the base: 242 ordered test declarations unchanged; 959 ordered #expect expressions unchanged; 172 ordered #require expressions unchanged; 12 Issue.record calls unchanged; @Suite(.serialized) retained.
- 221 existing @MainActor test/helper declarations retained.
- SwiftFormat write and lint: clean.
- swiftc -frontend -parse apps/ios/Tests/NodeAppModelInvokeTests.swift: clean.
- git diff --check: clean.
- Independent gpt-5.6-sol xhigh review covered approval JSON, gateway/model freshness, Watch defaults, lifecycle sequencing, persistence cleanup, raw fixtures, and refactor quality. One explicit-null coverage finding was repaired and re-reviewed clean; aggregate verdict: no blockers or remaining findings.
- Isolated xhigh autoreview: no accepted/actionable findings.
- Hosted macOS/Xcode iOS build and focused NodeAppModelInvokeTests proof is expected from this ready PR.