### PR TITLE
fix(beam): clip mirrored session text without splitting surrogate pairs

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -189,6 +189,13 @@ describe("buildBeamMirrorItems", () => {
     const reduced = buildBeamMirrorItems([{ type: "userMessage", text: "x".repeat(10_000) }]);
     expect(reduced.items[0]?.text.length).toBe(6_000);
   });
+
+  it("does not split a surrogate pair when clipping message text", () => {
+    const reduced = buildBeamMirrorItems([
+      { type: "userMessage", text: `${"x".repeat(5_999)}🙂tail` },
+    ]);
+    expect(reduced.items[0]?.text).toBe("x".repeat(5_999));
+  });
 });
 
 describe("fitBeamMirrorUpload", () => {
@@ -246,6 +253,24 @@ describe("createBeamMirrorRunner", () => {
     });
     expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
     expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not split a surrogate pair when clipping the session title", async () => {
+    const sent: SentRequest[] = [];
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t-emoji", name: `${"x".repeat(159)}🙂`, recencyAt: NOW - 60_000 }],
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+    await runner.tick();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.payload.title).toBe("x".repeat(159));
   });
 
   it("keeps successful uploads successful when response cancellation rejects", async () => {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -11,6 +11,7 @@ import {
   type ActiveSessionCatalog,
 } from "openclaw/plugin-sdk/session-catalog-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { BEAM_MAX_BODY_BYTES, BEAM_MAX_ITEM_CHARS, BEAM_MAX_ITEMS } from "./types.js";
 
 const MIRROR_CONFIG_PATH = "plugins.entries.beam.config.mirror";
@@ -134,7 +135,7 @@ export function beamMirrorId(catalogId: string, hostId: string, threadId: string
 }
 
 function clipText(text: string): string {
-  return text.length > BEAM_MAX_ITEM_CHARS ? text.slice(0, BEAM_MAX_ITEM_CHARS) : text;
+  return truncateUtf16Safe(text, BEAM_MAX_ITEM_CHARS);
 }
 
 function droppedSummary(counts: Map<string, number>): string | undefined {
@@ -324,7 +325,7 @@ export function createBeamMirrorRunner(params: {
       version: 1,
       beamId: beamMirrorId(candidate.catalogId, candidate.hostId, candidate.threadId),
       source: candidate.catalogId,
-      title: candidate.title.slice(0, 160),
+      title: truncateUtf16Safe(candidate.title, 160),
       updatedAt: new Date(candidate.recencyAt || now()).toISOString(),
       completed,
       items,


### PR DESCRIPTION
## Summary

Clip beam-mirrored session titles and transcript text with `truncateUtf16Safe` instead of UTF-16 code-unit `slice`, so emoji/CJK characters straddling the clip boundary no longer reach the Beam receiver as a lone surrogate (tofu).

## What Problem This Solves

`extensions/beam/src/mirror.ts` uploads local coding-session metadata to a remote Beam receiver. Two user-visible text fields are bounded by raw UTF-16 code-unit slicing:

- `mirror.ts:137` — `clipText` cuts transcript message text at `BEAM_MAX_ITEM_CHARS` (6000) with `text.slice(0, ...)`.
- `mirror.ts:328` — the upload title is cut at 160 with `candidate.title.slice(0, 160)`. The title comes from the session name, which users control.

Any character outside the Basic Multilingual Plane (emoji, CJK ext-B) occupies **two** UTF-16 code units. When such a character straddles the clip boundary, `slice` keeps only the leading **high surrogate**, producing a lone surrogate that renders as tofu/invalid glyph on the Beam receiver — on every mirrored session row whose name has an emoji at the boundary, and on any clipped long message.

**Code evidence**: `extensions/beam/src/mirror.ts:137` and `mirror.ts:328` both bounded user-controlled text with code-unit `slice(0, n)`.

## Root Cause

- Introduced by commit `7e8afba7032` ("feat(plugins): mirror local coding sessions to a remote Beam receiver", 2026-07-27, #114735), which added both clip sites with code-unit slicing.
- Violated invariant: "clip to N characters" only holds for BMP text when implemented as `slice(0, N)`; astral characters occupy two UTF-16 units, so the cut can keep half a character.
- Trigger: name a session so that code unit 160 falls inside an emoji (e.g. 159 ASCII chars + 🙂), or send a long message whose 6000th code unit is the first half of an emoji, then let the mirror upload it.

## Why This Fix

- Use `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` — the repo's established convention for exactly this bug class (already used in `sessions-cleanup`, signal install, and elsewhere; #117062 introduced it for display-width text).
- `truncateUtf16Safe(text, n)` is a drop-in for the `length > n ? slice(0, n) : text` shape (same length contract) but drops a dangling surrogate at the cut instead of emitting half a character.
- Kept the surrounding logic untouched: same caps (6000 / 160), same truncation flags, no wire-shape changes.
- Alternative considered: `Array.from(text).slice(0, n).join("")` (code-point clip) — changes the cap semantics from UTF-16 units to code points and allocates the whole string; the receiver contract is unit-based, so `truncateUtf16Safe` is the minimal correct fix.

## User Impact

- Affected operations: every mirrored session whose name or message text is clipped at an astral character boundary — the Beam receiver shows tofu in the session list title / transcript excerpt.
- Before: receiver gets `"Fix flow: xxx…\uD83D"` — a dangling surrogate rendered as an invalid glyph.
- After: receiver gets the same text clipped cleanly before the emoji (`"Fix flow: xxx…"`), no broken glyphs.

## Evidence

- **Before**: on `main`, a real loopback Beam receiver captures an upload whose session name places 🙂 across the 160-unit cap — received title is 160 units ending `U+0078 U+D83D` (lone high surrogate) → FAIL.
- **After**: on this branch, the same upload arrives at 159 units ending `U+0078 U+0078` — emoji dropped whole → PASS.

## Real Behavior Proof

The proof runs the real `createBeamMirrorRunner` pipeline (config parse → candidate selection → upload build → real HTTP POST) against a real loopback Beam receiver and inspects the received title's trailing code units. Session name: 159 code units + 🙂 (161 units), so the emoji straddles the 160-unit cap.

### Before (on main)

```bash
$ node --import tsx proof.mjs
session_name_units=161
received_title_units=160 tail_units=U+78 U+d83d
FAIL: beam received a title ending in a lone UTF-16 surrogate (tofu)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
session_name_units=161
received_title_units=159 tail_units=U+78 U+78
PASS: title clipped without splitting the emoji
```

## Tests and Validation

- Added two regression tests in `extensions/beam/src/mirror.test.ts`: `buildBeamMirrorItems` must not split a surrogate pair when clipping message text at the 6000-unit cap, and the runner must upload a session title with no lone surrogate when the emoji straddles the 160-unit cap. Both fail on `main` and pass with the fix; the other 15 tests are unchanged.
- `node scripts/run-vitest.mjs extensions/beam/src/mirror.test.ts` — 17/17 tests passed.
- `oxfmt --check` and `oxlint` clean on both changed files; `git diff --check` clean.
- Sibling audit: these are the only two text-clip sites in the mirror path (`fitBeamMirrorUpload` drops whole items by byte budget and never slices text); the same `truncateUtf16Safe` convention was applied to sessions cleanup in #117459.
