### PR TITLE
fix(skills): bound evaluator text without splitting surrogate pairs

### DIFF
--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -759,6 +759,61 @@ describe("Skill Workshop proposal evaluation", () => {
     });
   });
 
+  it("does not split surrogate pairs when bounding evaluator text", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-evaluation-surrogate-");
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      agentId: "main",
+      name: "Surrogate Bounds",
+      description: "Bound evaluator text without splitting surrogates",
+      content: "# Surrogate Bounds\n",
+    });
+    hookMocks.evaluate.mockResolvedValue([
+      {
+        evaluatorId: "emoji-bounds",
+        pluginId: "evaluation-tests",
+        status: "completed",
+        result: {
+          summary: `${"s".repeat(7_999)}🙂`,
+          decisionReason: `${"r".repeat(1_999)}🙂`,
+          metrics: { note: `${"m".repeat(3_999)}🙂` },
+        },
+      },
+      {
+        evaluatorId: "emoji-error",
+        pluginId: "evaluation-tests",
+        status: "error",
+        error: `${"e".repeat(1_999)}🙂`,
+      },
+    ]);
+
+    const evaluated = await evaluateSkillProposal({
+      workspaceDir,
+      agentId: "main",
+      proposalId: proposal.record.id,
+      expectedRevisionHash: proposal.revisionHash,
+    });
+
+    expect(evaluated.evaluation.outcomes).toEqual([
+      {
+        evaluatorId: "emoji-bounds",
+        pluginId: "evaluation-tests",
+        status: "completed",
+        result: {
+          summary: "s".repeat(7_999),
+          decisionReason: "r".repeat(1_999),
+          metrics: { note: "m".repeat(3_999) },
+        },
+      },
+      {
+        evaluatorId: "emoji-error",
+        pluginId: "evaluation-tests",
+        status: "error",
+        error: "e".repeat(1_999),
+      },
+    ]);
+  });
+
   it("rejects evaluator results that exceed the aggregate persistence budget", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-evaluation-size-budget-");
     const proposal = await proposeCreateSkill({

--- a/src/skills/workshop/service-evaluation.ts
+++ b/src/skills/workshop/service-evaluation.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   PluginHookSkillEvaluationFinding,
   PluginHookSkillProposalEvaluateResult,
@@ -346,18 +347,19 @@ function normalizeMetrics(
     ) {
       return undefined;
     }
-    normalized[key] = typeof value === "string" ? value.slice(0, 4_000) : value;
+    normalized[key] = typeof value === "string" ? truncateUtf16Safe(value, 4_000) : value;
   }
   return normalized;
 }
 
 function boundedRequired(value: string, maxLength: number, fallback: string): string {
   const normalized = normalizeOptionalString(value) ?? fallback;
-  return normalized.slice(0, maxLength);
+  return truncateUtf16Safe(normalized, maxLength);
 }
 
 function boundedOptional(value: string | undefined, maxLength: number): string | undefined {
-  return normalizeOptionalString(value)?.slice(0, maxLength);
+  const normalized = normalizeOptionalString(value);
+  return normalized === undefined ? undefined : truncateUtf16Safe(normalized, maxLength);
 }
 
 function storeOptions(env?: NodeJS.ProcessEnv) {


### PR DESCRIPTION
## Summary

Bound evaluator-produced text in the Skill Workshop evaluation pipeline with `truncateUtf16Safe` instead of UTF-16 code-unit `slice`, so emoji/CJK characters straddling a cap are no longer persisted to the proposal store as a lone surrogate (tofu).

## What Problem This Solves

`src/skills/workshop/service-evaluation.ts` normalizes third-party evaluator output before persisting it. Four user-visible text paths are bounded by raw code-unit slicing:

- `boundedRequired` (`service-evaluation.ts:355-357`) — used for the evaluator `error` message (2000) and attribution ids.
- `boundedOptional` (`service-evaluation.ts:360-361`) — used for `summary` (8000), `decisionReason` (2000), `evaluatorVersion`, `mode`, and finding `file`.
- `normalizeMetrics` (`service-evaluation.ts:350`) — string metric values (`value.slice(0, 4_000)`).

Any character outside the Basic Multilingual Plane (emoji, CJK ext-B) occupies **two** UTF-16 code units. When such a character straddles a cap, `slice` keeps only the leading **high surrogate**, and that lone surrogate is written into the durable proposal store (SQLite) — surfacing later as tofu/invalid glyphs wherever the evaluation summary, decision reason, error, or metric is displayed.

**Code evidence**: `service-evaluation.ts:350`, `:356`, `:360` bounded evaluator-controlled text with `slice(0, n)` on UTF-16 code units.

## Root Cause

- Introduced by commit `14940edf15f` ("feat(skills): add Skill Workshop lifecycle hooks", 2026-07-29, #115606), which added the evaluation normalization helpers with code-unit slicing.
- Violated invariant: "bound to N characters" only holds for BMP text when implemented as `slice(0, N)`; astral characters occupy two UTF-16 units, so the cut can persist half a character.
- Trigger: an evaluator plugin returns a summary/decisionReason/error/metric whose character at the cap boundary is an emoji (e.g. 7999 ASCII chars + 🙂 at the 8000-unit summary cap) — a normal occurrence for LLM-backed evaluators that decorate output with emoji.

## Why This Fix

- Use `truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` — the repo's established convention for this bug class (`src/skills/lifecycle/install-output.ts`, `src/skills/loading/workspace.ts`, ACP control plane, and #117062 all use it).
- Drop-in replacement with the same length contract (`length <= n` unchanged; oversized input truncated to `n` units) except a dangling surrogate at the cut is dropped instead of persisted.
- Alternative considered: rejecting over-cap text containing surrogates — changes the evaluator contract and can turn benign emoji output into hard failures; clean truncation preserves the existing non-fatal bounding behavior.

## User Impact

- Affected operations: Skill Workshop proposal evaluations whose evaluator output is clipped at a boundary falling inside an emoji — the persisted summary / decision reason / error / metric values end with a broken glyph in the workshop UI, event log, and any downstream consumer of the store.
- Before: store holds e.g. `"ssss…\uD83D"` — a dangling high surrogate.
- After: store holds the same text clipped cleanly before the emoji.

## Evidence

- **Before**: on `main`, a real evaluator hook registered through the real global hook runner returns text with 🙂 straddling each cap; the record re-read from the real store ends `summary`/`decisionReason`/`metrics.note` with `U+D83D` (lone high surrogate) → FAIL.
- **After**: on this branch, the same run persists all three fields with clean tails (`U+0073`/`U+0072`/`U+006D`) → PASS.

## Real Behavior Proof

The proof registers a real `skill_proposal_evaluate` hook through the real `initializeGlobalHookRunner` (exactly the dispatch path a third-party evaluator plugin uses), then runs the real `proposeCreateSkill` → `evaluateSkillProposal` pipeline and re-reads the persisted record from the real SQLite store via `inspectSkillProposal`.

### Before (on main)

```bash
$ node --import tsx proof.mjs
summary_units=8000 tail=U+73 U+d83d lone_surrogate=true
decisionReason_units=2000 tail=U+72 U+d83d lone_surrogate=true
metrics.note_units=4000 tail=U+6d U+d83d lone_surrogate=true
FAIL: store persists evaluator text ending in a lone UTF-16 surrogate (tofu)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
summary_units=7999 tail=U+73 U+73 lone_surrogate=false
decisionReason_units=1999 tail=U+72 U+72 lone_surrogate=false
metrics.note_units=3999 tail=U+6d U+6d lone_surrogate=false
PASS: evaluator text bounded without splitting surrogate pairs
```

## Tests and Validation

- Added a regression test in `src/skills/workshop/service-evaluation.test.ts`: a completed outcome (summary/decisionReason/metric with 🙂 straddling the 8000/2000/4000 caps) and an error outcome (error with 🙂 straddling the 2000 cap) must persist with each emoji dropped whole. The test fails on `main` and passes with the fix; the other 20 tests are unchanged.
- `node scripts/run-vitest.mjs src/skills/workshop/service-evaluation.test.ts` — 21/21 tests passed.
- `oxfmt --check` and `oxlint` clean on both changed files; `git diff --check` clean.
- Sibling audit: all bounded-text paths in this file funnel through the three helpers changed here (attribution ids, evaluatorVersion/mode, finding file/ruleId, metrics); no other code-unit `slice` remains in the evaluation normalization path. The same `truncateUtf16Safe` convention was applied to the beam mirror in a companion PR.
