### PR TITLE
fix(cli): preserve gateway startup policy with parent options

### DIFF
--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -123,11 +123,21 @@ describe("command-execution-startup", () => {
     ).toBe(true);
   });
 
-  it("uses the resolved action command path for protocol startup policy", () => {
+  it("uses the resolved action command path for every execution startup decision", () => {
+    const context = mod.resolveCliExecutionStartupContext({
+      argv: ["node", "openclaw", "gateway", "--token", "secret", "call", "health"],
+      commandPath: ["gateway", "call"],
+      jsonOutputMode: false,
+      env: {},
+    });
+
+    expect(context.invocation.commandPath).toEqual(["gateway", "secret"]);
+    expect(context.commandPath).toEqual(["gateway", "call"]);
+
     expect(
       mod.resolveCliExecutionStartupContext({
         argv: ["node", "openclaw", "acp", "--token", "-secret"],
-        protocolCommandPath: ["acp"],
+        commandPath: ["acp"],
         jsonOutputMode: false,
         env: {},
       }).startupPolicy.suppressDoctorStdout,
@@ -135,7 +145,7 @@ describe("command-execution-startup", () => {
     expect(
       mod.resolveCliExecutionStartupContext({
         argv: ["node", "openclaw", "acp", "--verbose", "client"],
-        protocolCommandPath: ["acp", "client"],
+        commandPath: ["acp", "client"],
         jsonOutputMode: false,
         env: {},
       }).startupPolicy.suppressDoctorStdout,

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -16,21 +16,21 @@ const hasVersionFlag = (argv: readonly string[]) =>
 
 export function resolveCliExecutionStartupContext(params: {
   argv: string[];
-  protocolCommandPath?: string[];
+  commandPath?: string[];
   jsonOutputMode: boolean;
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  // Resolve argv once so startup policy, routing, and bootstrap share the same command path.
   const invocation = resolveCliArgvInvocation(params.argv);
-  const { commandPath } = invocation;
+  // Commander owns the action path after parsing option values. Route-first
+  // callers omit it and keep using raw argv discovery.
+  const commandPath = params.commandPath ?? invocation.commandPath;
   return {
     invocation,
     commandPath,
     startupPolicy: resolveCliStartupPolicy({
       argv: params.argv,
       commandPath,
-      protocolCommandPath: params.protocolCommandPath,
       jsonOutputMode: params.jsonOutputMode,
       env: params.env,
       routeMode: params.routeMode,

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -28,19 +28,13 @@ function shouldLoadPlugins(params: {
 export function resolveCliStartupPolicy(params: {
   argv?: string[];
   commandPath: string[];
-  protocolCommandPath?: string[];
   jsonOutputMode: boolean;
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
   const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
-  // Commander resolves required option values before selecting the action command, so this path
-  // remains authoritative when a protocol option value itself begins with "-".
-  const ownsProtocolStdout = params.protocolCommandPath
-    ? resolveCliCommandPathPolicy(params.protocolCommandPath).ownsProtocolStdout
-    : commandPolicy.ownsProtocolStdout;
   // Protocol commands own stdout from process startup, before their action installs later routing.
-  const suppressDoctorStdout = params.jsonOutputMode || ownsProtocolStdout;
+  const suppressDoctorStdout = params.jsonOutputMode || commandPolicy.ownsProtocolStdout;
   const env = params.env ?? process.env;
   return {
     suppressDoctorStdout,

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { repoInstallSpec } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../../logging/state.js";
+import { shouldMigrateStateFromPath } from "../argv.js";
 import { isConfigSetJsonParseOnly } from "../config-output-mode.js";
 import { setCommandJsonMode } from "./json-mode.js";
 import { applyParentDefaultHelpAction } from "./parent-default-help.js";
@@ -149,7 +150,7 @@ describe("registerPreActionHooks", () => {
     | null = null;
 
   function buildProgram() {
-    const programLocal = new Command().name("openclaw");
+    const programLocal = new Command().name("openclaw").enablePositionalOptions();
     const agent = programLocal
       .command("agent")
       .argument("[note]")
@@ -181,6 +182,8 @@ describe("registerPreActionHooks", () => {
       .action(() => {});
     const gateway = programLocal
       .command("gateway")
+      .option("--port <port>")
+      .option("--token <token>")
       .option("--allow-unconfigured")
       .option("--force")
       .option("--reset")
@@ -190,6 +193,15 @@ describe("registerPreActionHooks", () => {
       .option("--allow-unconfigured")
       .option("--force")
       .option("--reset")
+      .action(() => {});
+    gateway
+      .command("call")
+      .argument("<method>")
+      .option("--json")
+      .action(() => {});
+    gateway
+      .command("health")
+      .option("--json")
       .action(() => {});
     programLocal
       .command("backup")
@@ -888,6 +900,45 @@ describe("registerPreActionHooks", () => {
       commandPath: ["mcp", "serve"],
       suppressDoctorStdout: true,
     });
+  });
+
+  it.each([
+    {
+      name: "keeps a remote call migration-free",
+      argv: [
+        "node",
+        "openclaw",
+        "gateway",
+        "--token",
+        "secret",
+        "call",
+        "health",
+        "--json",
+      ],
+      expectedPath: ["gateway", "call"],
+      expectedMigration: false,
+    },
+    {
+      name: "keeps health on the invalid-config allowlist",
+      argv: ["node", "openclaw", "gateway", "--port", "19083", "health", "--json"],
+      expectedPath: ["gateway", "health"],
+      expectedMigration: true,
+    },
+  ])("uses the Commander path past parent option values and $name", async (testCase) => {
+    const parseProgram = buildProgram();
+    process.argv = testCase.argv;
+
+    await parseProgram.parseAsync(process.argv);
+
+    const bootstrap = ensureConfigReadyMock.mock.calls.at(-1)?.[0];
+    expect(bootstrap).toEqual({
+      runtime: runtimeMock,
+      commandPath: testCase.expectedPath,
+      suppressDoctorStdout: true,
+    });
+    expect(shouldMigrateStateFromPath(bootstrap?.commandPath ?? [])).toBe(
+      testCase.expectedMigration,
+    );
   });
 
   it("does not preload plugins for agents list JSON output", async () => {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -905,16 +905,7 @@ describe("registerPreActionHooks", () => {
   it.each([
     {
       name: "keeps a remote call migration-free",
-      argv: [
-        "node",
-        "openclaw",
-        "gateway",
-        "--token",
-        "secret",
-        "call",
-        "health",
-        "--json",
-      ],
+      argv: ["node", "openclaw", "gateway", "--token", "secret", "call", "health", "--json"],
       expectedPath: ["gateway", "call"],
       expectedMigration: false,
     },

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -121,7 +121,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     applyResolvedCommandOutputMode(jsonOutputMode);
     const { commandPath, startupPolicy } = resolveCliExecutionStartupContext({
       argv,
-      protocolCommandPath: getCommanderCommandPath(actionCommand),
+      commandPath: getCommanderCommandPath(actionCommand),
       jsonOutputMode,
       env: process.env,
     });


### PR DESCRIPTION
Closes #117674

## What Problem This Solves

Fixes an issue where nested Gateway commands with parent options before the subcommand could run startup under the option value instead of the command the operator selected. A remote `gateway call` could consequently observe or migrate local state, and `gateway health` could lose its invalid-config allowance.

## Why This Change Was Made

The full-Commander pre-action path now uses Commander's resolved action path for every startup, config-guard, migration, plugin-loading, and protocol-output decision. The redundant protocol-only path override is removed; the earlier route-first path intentionally keeps raw-argv discovery because it runs before Commander and already rejects ambiguous shapes.

## User Impact

Operators can place Gateway parent options such as `--token` or `--port` before nested commands without those values changing startup behavior. Remote calls remain migration-free, health keeps its recovery behavior, and machine-readable output stays clean.

## Evidence

- Current-main reproduction at `08ea9cc31d8e17a1101fde0f366fc5050eef0c03`: raw argv discovery turns `gateway --token secret call health` into `gateway secret`, while Commander resolves the action as `gateway call`.
- Blacksmith Testbox `tbx_01kyzr6r4xgk5gedyw8w4c6b6x`, run [30722044061](https://github.com/openclaw/openclaw/actions/runs/30722044061): 246/246 focused CLI assertions passed across argv, startup-context, pre-action, and config-guard suites.
- Fresh final-head Codex autoreview `019fbf8d-8222-7343-afcb-fa2695e01e65`: TruffleHog clean, zero findings, patch correct at 0.99 confidence.
- Independent source review found no blockers, verified route-first, protocol stdout, JSON, config guard, migration, plugin policy, aliases, and ordinary command behavior, and judged this the cleanest bounded owner-level fix.
- `git diff --check` passed. Production is `+6/-12` (net `-6`); tests are `+56/-4`.

Release-note context: CLI startup now preserves the parsed Gateway subcommand when parent options appear before it.

AI-assisted: yes. The implementation, full startup decision surface, route-first sibling, Commander behavior, history, and focused proof were independently reviewed.
