### PR TITLE
fix(memory-core): pass allowTranscriptTurnSnippet at all isContaminatedDreamingSnippet call sites

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -50,6 +50,7 @@ import {
 } from "./short-term-promotion-types.js";
 import {
   isContaminatedDreamingSnippet,
+  isShortTermSessionCorpusPath,
   normalizeSnippet,
   toFiniteNonNegativeInt,
   toFiniteScore,
@@ -298,7 +299,9 @@ export async function applyShortTermPromotions(
       if (options.consolidation && (!latest || !isConsolidationCandidateEligible(candidate))) {
         return false;
       }
-      if (isContaminatedDreamingSnippet(candidate.snippet)) {
+      if (isContaminatedDreamingSnippet(candidate.snippet, {
+        allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(candidate.path),
+      })) {
         return false;
       }
       if (candidate.promotedAt) {
@@ -337,7 +340,9 @@ export async function applyShortTermPromotions(
     if (
       sourceFingerprintBefore === sourceFingerprintAfter &&
       rehydrated &&
-      !isContaminatedDreamingSnippet(rehydrated.snippet)
+      !isContaminatedDreamingSnippet(rehydrated.snippet, {
+        allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(rehydrated.path),
+      })
     ) {
       rehydratedSelected.push(rehydrated);
       plannedSourceFingerprints.set(candidate.key, sourceFingerprintAfter);
@@ -426,7 +431,9 @@ export async function applyShortTermPromotions(
           if (
             wasDirectCandidate &&
             sourceUnchanged &&
-            !isContaminatedDreamingSnippet(candidate.snippet)
+            !isContaminatedDreamingSnippet(candidate.snippet, {
+              allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(candidate.path),
+            })
           ) {
             authoritativeSelected.push(candidate);
           }
@@ -447,7 +454,9 @@ export async function applyShortTermPromotions(
         if (options.consolidation && !isConsolidationCandidateEligible(currentCandidate)) {
           continue;
         }
-        if (!isContaminatedDreamingSnippet(currentCandidate.snippet)) {
+        if (!isContaminatedDreamingSnippet(currentCandidate.snippet, {
+          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(currentCandidate.path),
+        })) {
           authoritativeSelected.push(currentCandidate);
         }
       }

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -375,7 +375,9 @@ export async function recordGroundedShortTermCandidates(params: {
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
         !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet) ||
+        isContaminatedDreamingSnippet(rawSnippet, {
+          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
+        }) ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||


### PR DESCRIPTION
## What Problem This Solves

The dreaming recall store has been empty since installation (0 entries ever). Every dreaming run produces "No notable updates" because the light phase short-circuits before calling the model. The root cause: `isContaminatedDreamingSnippet()` has an `allowTranscriptTurnSnippet` option that was only passed at 3 of 8 call sites. The 5 missing call sites gate session transcript ingestion and promotion. Without the flag, `RAW_TRANSCRIPT_TURN_RE` blocks every session transcript snippet because they all start with `User:` or `Assistant:`.

## Fix

Pass `allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(path)` at every call site that has access to a path. No new code, just wiring up the existing option. The remaining contamination filters still catch the feedback loop from #67580.

Call sites fixed:
- `short-term-promotion-record.ts:378` — ingestion path (the main blocker)
- `short-term-promotion-apply.ts:302` — promotion gate
- `short-term-promotion-apply.ts:343` — rehydrated selection
- `short-term-promotion-apply.ts:434` — direct candidate selection
- `short-term-promotion-apply.ts:457` — authoritative selection

## Evidence

### Patch surface

```
 extensions/memory-core/src/short-term-promotion-apply.ts       | 17 +++++++++++++----
 extensions/memory-core/src/short-term-promotion-record.ts      |  4 +++-
 2 files changed, 16 insertions(+), 5 deletions(-)
```

### Before fix: recall store empty

```
$ openclaw memory status --deep | grep "Recall store"
Recall store: 0 entries · 0 promoted · 0 concept-tagged · 0 spaced
```

Dreaming output before fix (every night since installation):
```
# Light Sleep
- No notable updates.
# Deep Sleep
- Ranked 0 candidate(s) for durable promotion.
- Promoted 0 candidate(s) into MEMORY.md.
```

### After fix: recall store populated

```
$ openclaw memory status --deep | grep "Recall store"
Recall store: 512 entries · 3 promoted · 512 concept-tagged · 67 spaced
```

Dreaming output after fix (first successful run):
```
# Light Sleep
- Candidate: Assistant: Now the key diagnostic. Running the REM harness manually...
  - confidence: 0.58
  - evidence: memory/.dreams/session-corpus/2026-08-01.txt:977-977
  - recalls: 0
  - status: staged
- Candidate: Assistant: Now let me look at what the dreaming model actually sees...
  - confidence: 0.58
  - evidence: memory/.dreams/session-corpus/2026-08-01.txt:976-976
  - recalls: 0
  - status: staged
...

# Deep Sleep
- Repaired recall artifacts: rewrote recall store.
- Ranked 3 candidate(s) for durable promotion.
- Promoted 3 candidate(s) into MEMORY.md.
```

### Promotion evidence (entries that reached MEMORY.md)

```
<!-- openclaw-memory-promotion:memory:memory/2026-08-01.md:1:15 -->
- # 2026-08-01 Memory Flush ## Dreaming Root Cause Found and Patched...
  [score=0.826 recalls=9 avg=0.718 source=memory/2026-08-01.md:1-15]
<!-- openclaw-memory-promotion:memory:memory/2026-08-01.md:10:27 -->
- Subagent spawned (002b948f) to run the Oracle skill against the patch...
  [score=0.811 recalls=10 avg=0.638 source=memory/2026-08-01.md:10-19]
<!-- openclaw-memory-promotion:memory:memory/2026-08-01.md:25:41 -->
- 6 parallel deepseek subagents ran research: config audit, docs, marketplace...
  [score=0.811 recalls=10 avg=0.635 source=memory/2026-08-01.md:25-41]
```

### Contamination filters still intact

The `allowTranscriptTurnSnippet` flag only disables `RAW_TRANSCRIPT_TURN_RE`. All other dreaming-artifact filters remain active regardless of the flag:

```
extensions/memory-core/src/short-term-promotion-utils.ts:
  167: /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||
  168: DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet) ||
  169: RAW_SESSION_METADATA_RE.test(snippet) ||
  170: RAW_CONVERSATION_SUMMARY_RE.test(snippet) ||
  171: (!opts.allowTranscriptTurnSnippet && RAW_TRANSCRIPT_TURN_RE.test(snippet)) ||
  172: MEMORY_FLUSH_PROMPT_RE.test(snippet) ||
  173: PROMOTION_SCORE_METADATA_RE.test(snippet)
```

### All 8 call sites now pass the flag

```
short-term-promotion-record.ts:205   allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath)  [already correct]
short-term-promotion-record.ts:379   allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath)  [FIXED]
short-term-promotion-apply.ts:303    allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(candidate.path)  [FIXED]
short-term-promotion-apply.ts:344    allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(rehydrated.path)  [FIXED]
short-term-promotion-apply.ts:435    allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(candidate.path)   [FIXED]
short-term-promotion-apply.ts:458    allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(currentCandidate.path) [FIXED]
short-term-promotion-utils.ts:350    allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entryPath)        [already correct]
short-term-promotion.ts:131          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entry.path)       [already correct]
```

## Reviews

- Ponytail: SIGNED OFF. Existing mechanism, minimal diff, root cause addressed.
- Plan-forge: SIGNED OFF. All call sites covered, no feedback loop risk.

Fixes #117669
