### PR TITLE
fix(release): overlay plugin lock generator

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/plugin-npm-release.yml"
       - "extensions/**"
       - "package.json"
+      - "scripts/generate-npm-package-lock.mjs"
       - "scripts/lib/npm-publish-plan.mjs"
       - "scripts/lib/release-version.mjs"
       - "scripts/lib/plugin-npm-package-manifest.mjs"
@@ -335,12 +336,17 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           fetch-depth: 1
-          sparse-checkout: scripts/lib/plugin-npm-package-manifest.mjs
+          sparse-checkout: |
+            scripts/generate-npm-package-lock.mjs
+            scripts/lib/plugin-npm-package-manifest.mjs
           sparse-checkout-cone-mode: false
 
       - name: Overlay trusted packaging helper
         run: |
           set -euo pipefail
+          cp \
+            .release-tooling/scripts/generate-npm-package-lock.mjs \
+            scripts/generate-npm-package-lock.mjs
           cp \
             .release-tooling/scripts/lib/plugin-npm-package-manifest.mjs \
             scripts/lib/plugin-npm-package-manifest.mjs
@@ -1229,6 +1235,9 @@ jobs:
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
         run: |
           set -euo pipefail
+          cp \
+            scripts/generate-npm-package-lock.mjs \
+            .publication-target/scripts/generate-npm-package-lock.mjs
           cp \
             scripts/lib/plugin-npm-package-manifest.mjs \
             .publication-target/scripts/lib/plugin-npm-package-manifest.mjs

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -105,6 +105,33 @@ describe("plugin npm extended-stable workflow", () => {
     }
   });
 
+  it("overlays the complete trusted packaging helper dependency pair", () => {
+    const parsed = workflow();
+    const preflightCheckout = step(
+      parsed.jobs?.preview_plugin_pack,
+      "Checkout trusted packaging helper",
+    );
+    expect(preflightCheckout.with?.["sparse-checkout"]).toContain(
+      "scripts/generate-npm-package-lock.mjs",
+    );
+    expect(preflightCheckout.with?.["sparse-checkout"]).toContain(
+      "scripts/lib/plugin-npm-package-manifest.mjs",
+    );
+
+    const expectedCopies = [
+      "scripts/generate-npm-package-lock.mjs",
+      "scripts/lib/plugin-npm-package-manifest.mjs",
+    ];
+    for (const helperPath of expectedCopies) {
+      expect(
+        step(parsed.jobs?.preview_plugin_pack, "Overlay trusted packaging helper").run,
+      ).toContain(helperPath);
+      expect(
+        step(parsed.jobs?.publish_plugins_npm, "Overlay trusted OIDC packaging helper").run,
+      ).toContain(helperPath);
+    }
+  });
+
   it("trusts only the canonical monthly branch at the exact checked-out SHA", () => {
     const trusted = step(
       workflow().jobs?.preview_plugins_npm,
@@ -404,7 +431,6 @@ describe("plugin npm extended-stable workflow", () => {
     ).toMatchObject({
       ref: "${{ github.workflow_sha }}",
       path: ".release-tooling",
-      "sparse-checkout": "scripts/lib/plugin-npm-package-manifest.mjs",
     });
     expect(
       step(parsed.jobs?.preview_plugin_pack, "Overlay trusted packaging helper").run,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin npm recovery workflows could keep the frozen release checkout's stale lock generator, causing the package-lock step to retain its old 10-minute timeout despite overlaying the retry-aware packaging helper.

Related: https://github.com/openclaw/openclaw/pull/117668

## Why This Change Was Made

The trusted workflow checkout now overlays both files in the packaging dependency pair: `plugin-npm-package-manifest.mjs` and `generate-npm-package-lock.mjs`. The same pair is carried into OIDC publication targets, and the workflow trigger tracks changes to the lock generator.

## User Impact

Plugin npm publication uses the intended bounded timeout and retry behavior against frozen release SHAs instead of silently mixing new orchestration with an old lock generator.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-npm-extended-stable-workflow.test.ts` (11/11 passed)
- `git diff --check`
- `oxfmt --check` on the workflow and focused test
- Live recovery run `30722112871` reproduced the stale overlay boundary before publication and was cancelled after source confirmation.
