### PR TITLE
fix(cron): link active tasks to execution transcripts

### DIFF
--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -24,6 +24,7 @@ import {
   tryFinishCronTaskRun,
   tryFinishCronTaskRunWithoutHistory,
 } from "./task-runs.js";
+import { executeJobCoreWithTimeout } from "./timer-job-runner.js";
 
 function createCronServiceState(
   params: Parameters<typeof createCronServiceStateBase>[0],
@@ -113,25 +114,11 @@ describe("cron task run terminal records", () => {
     );
   });
 
-  it("uses the scoped owner for a current-session task run", async () => {
+  it("seeds main transcript links only for system events and clears an unused link", async () => {
     await withOpenClawTestState(
-      { layout: "state-only", prefix: "openclaw-cron-current-task-owner-" },
+      { layout: "state-only", prefix: "openclaw-cron-main-task-session-" },
       async () => {
         resetTaskRegistryForTests();
-        const job = {
-          id: "current-task-owner",
-          name: "current task owner",
-          agentId: "   ",
-          sessionKey: "agent:ops:main",
-          sessionTarget: "current",
-          wakeMode: "next-heartbeat",
-          payload: { kind: "systemEvent", text: "work" },
-          schedule: { kind: "every", everyMs: 60_000 },
-          state: {},
-          createdAtMs: 100,
-          updatedAtMs: 100,
-          enabled: true,
-        } satisfies CronJob;
         const state = createCronServiceState({
           storePath: "/tmp/jobs.json",
           cronEnabled: true,
@@ -140,64 +127,154 @@ describe("cron task run terminal records", () => {
           requestHeartbeat: vi.fn(),
           runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
         });
-
-        expect(tryCreateCronTaskRun({ state, job, startedAt: 1_500 })).toBeTruthy();
-
-        expect(
+        const createMainJob = (id: string, payload: CronJob["payload"]): CronJob => ({
+          id,
+          name: id,
+          agentId: "ops",
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload,
+          schedule: { kind: "every", everyMs: 60_000 },
+          state: {},
+          createdAtMs: 100,
+          updatedAtMs: 100,
+          enabled: true,
+        });
+        const systemEventJob = createMainJob("main-system-event", {
+          kind: "systemEvent",
+          text: "work",
+        });
+        const jobs = [
+          systemEventJob,
+          createMainJob("main-script", { kind: "script", script: "return {}" }),
+          createMainJob("main-heartbeat", { kind: "heartbeat" }),
+        ];
+        const runIds = jobs.map((job) => tryCreateCronTaskRun({ state, job, startedAt: 1_500 }));
+        const childSessionKey = (job: CronJob) =>
           listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
             runtime: "cron",
             sourceId: job.id,
-          }),
-        ).toEqual([
-          expect.objectContaining({
-            agentId: "ops",
-            childSessionKey: "agent:ops:cron:current-task-owner",
-          }),
-        ]);
+          })[0]?.childSessionKey;
+
+        expect(childSessionKey(systemEventJob)).toBe("agent:ops:cron:main-system-event:run:1500");
+        expect(childSessionKey(jobs[1]!)).toBeUndefined();
+        expect(childSessionKey(jobs[2]!)).toBeUndefined();
+
+        tryFinishCronTaskRunWithoutHistory(state, {
+          taskRunId: runIds[0],
+          status: "skipped",
+          endedAt: 1_501,
+        });
+        expect(childSessionKey(systemEventJob)).toBeUndefined();
       },
     );
   });
 
-  it("uses the scoped owner for an isolated task run", async () => {
+  it.each([
+    {
+      label: "current",
+      id: "current-task-owner",
+      agentId: "   ",
+      sessionTarget: "current" as const,
+      timeoutSeconds: 0,
+      initialSessionKey: undefined,
+      executionSessionKey: "agent:ops:cron:current-task-owner:run:session-1",
+    },
+    {
+      label: "isolated with creator source",
+      id: "isolated-task-owner",
+      agentId: "   ",
+      sessionTarget: "isolated" as const,
+      timeoutSeconds: undefined,
+      initialSessionKey: undefined,
+      executionSessionKey: "agent:ops:cron:isolated-task-owner:run:session-1",
+    },
+    {
+      label: "custom session target",
+      id: "custom-task-owner",
+      agentId: "ops",
+      sessionTarget: "session:agent:ops:telegram:group:target" as const,
+      timeoutSeconds: 0,
+      initialSessionKey: undefined,
+      executionSessionKey: "agent:ops:telegram:group:target",
+    },
+  ])("uses the authoritative $label execution transcript", async (testCase) => {
     await withOpenClawTestState(
-      { layout: "state-only", prefix: "openclaw-cron-isolated-scoped-owner-" },
+      { layout: "state-only", prefix: `openclaw-cron-${testCase.id}-` },
       async () => {
         resetTaskRegistryForTests();
-        const job = {
-          id: "isolated-scoped-owner",
-          name: "isolated scoped owner",
-          agentId: "   ",
-          sessionKey: "agent:ops:main",
-          sessionTarget: "isolated",
+        let resolveStarted!: () => void;
+        let resolveRun!: () => void;
+        const started = new Promise<void>((resolve) => {
+          resolveStarted = resolve;
+        });
+        const runPending = new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        });
+        const job: CronJob = {
+          id: testCase.id,
+          name: testCase.label,
+          agentId: testCase.agentId,
+          sessionKey: "agent:ops:telegram:group:creator",
+          sessionTarget: testCase.sessionTarget,
           wakeMode: "next-heartbeat",
-          payload: { kind: "agentTurn", message: "work" },
+          payload: {
+            kind: "agentTurn",
+            message: "work",
+            ...(testCase.timeoutSeconds !== undefined
+              ? { timeoutSeconds: testCase.timeoutSeconds }
+              : {}),
+          },
           schedule: { kind: "every", everyMs: 60_000 },
           state: {},
           createdAtMs: 100,
           updatedAtMs: 100,
           enabled: true,
-        } satisfies CronJob;
+        };
         const state = createCronServiceState({
           storePath: "/tmp/jobs.json",
           cronEnabled: true,
           log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
           enqueueSystemEvent: vi.fn(),
           requestHeartbeat: vi.fn(),
-          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+          runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
+            onExecutionStarted?.({
+              jobId: job.id,
+              agentId: "ops",
+              sessionId: "session-1",
+              sessionKey: testCase.executionSessionKey,
+              phase: "runner_entered",
+            });
+            resolveStarted();
+            await runPending;
+            return {
+              status: "ok" as const,
+              sessionId: "session-1",
+              sessionKey: testCase.executionSessionKey,
+            };
+          }),
         });
 
-        expect(tryCreateCronTaskRun({ state, job, startedAt: 1_500 })).toBeTruthy();
-        expect(
+        const taskRunId = tryCreateCronTaskRun({ state, job, startedAt: 1_500 });
+        expect(taskRunId).toBeTruthy();
+        const taskRecords = () =>
           listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
             runtime: "cron",
             sourceId: job.id,
-          }),
-        ).toEqual([
-          expect.objectContaining({
-            agentId: "ops",
-            childSessionKey: "agent:ops:main",
-          }),
-        ]);
+          });
+        expect(taskRecords()).toHaveLength(1);
+        expect(taskRecords()[0]?.agentId).toBe("ops");
+        expect(taskRecords()[0]?.childSessionKey).toBe(testCase.initialSessionKey);
+
+        const runPromise = executeJobCoreWithTimeout(state, job, { runId: taskRunId });
+        try {
+          await started;
+          expect(taskRecords()[0]?.agentId).toBe("ops");
+          expect(taskRecords()[0]?.childSessionKey).toBe(testCase.executionSessionKey);
+        } finally {
+          resolveRun();
+          await runPromise;
+        }
       },
     );
   });

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -1,11 +1,7 @@
 /** Detached task-ledger integration for cron runs. */
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import {
-  normalizeAgentId,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-} from "../../routing/session-key.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import { isCronTimeoutErrorText } from "../execution-error-constants.js";
 
@@ -25,9 +21,9 @@ import {
   finalizeTaskRunByRunId,
   findTaskByRunId,
   listTaskRecordsUnsorted,
+  recordTaskRunProgressByRunId,
 } from "../../tasks/task-executor.js";
 import type { JsonValue, TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
-import { resolveCronAgentSessionKey } from "../isolated-agent/session-key.js";
 import { createCronExecutionId } from "../run-id.js";
 import type { CronRunLogEntry } from "../run-log-types.js";
 import { cronStoreKey } from "../store/key.js";
@@ -72,36 +68,40 @@ function resolveCronTaskChildSessionKey(params: {
   job: CronJob;
   startedAt: number;
 }): string | undefined {
-  const explicitAgentId = params.job.agentId?.trim() || undefined;
-  if (params.job.sessionTarget === "main") {
+  if (params.job.sessionTarget === "main" && params.job.payload.kind === "systemEvent") {
     return resolveMainSessionCronRunSessionKey(
       params.job,
       params.startedAt,
       resolveCurrentDefaultAgentId(params.state),
     );
   }
-  if (params.job.sessionTarget === "current") {
-    const scopedAgentId = parseAgentSessionKey(params.job.sessionKey)?.agentId;
-    return resolveCronAgentSessionKey({
-      sessionKey: `cron:${params.job.id}`,
-      agentId: requireCronAgentId(
-        explicitAgentId ?? scopedAgentId ?? resolveCurrentDefaultAgentId(params.state),
-      ),
+  // Agent turns publish their exact transcript key after setup. This also
+  // avoids inventing links for headless command/script/heartbeat work.
+  return undefined;
+}
+
+/** Updates an active cron task with the exact transcript identity reported by its runner. */
+export function tryUpdateCronTaskRunSession(
+  state: CronServiceState,
+  taskRunId: string | undefined,
+  sessionKey: string | undefined,
+): void {
+  const childSessionKey = sessionKey?.trim();
+  if (!taskRunId || !childSessionKey) {
+    return;
+  }
+  try {
+    const updated = recordTaskRunProgressByRunId({
+      runId: taskRunId,
+      runtime: "cron",
+      childSessionKey,
     });
+    if (updated.length === 0) {
+      state.deps.log.warn({ runId: taskRunId }, "cron: task ledger session was not updated");
+    }
+  } catch (error) {
+    state.deps.log.warn({ runId: taskRunId, error }, "cron: failed to update task ledger session");
   }
-  const explicitSessionKey = params.job.sessionKey?.trim();
-  if (explicitSessionKey) {
-    // Explicit session bindings must win over generated cron session keys so
-    // task drill-down opens the same transcript the cron run actually used.
-    return explicitSessionKey;
-  }
-  if (params.job.sessionTarget !== "isolated") {
-    return undefined;
-  }
-  return resolveCronAgentSessionKey({
-    sessionKey: `cron:${params.job.id}`,
-    agentId: resolveCronJobEffectiveAgentId(params.job, resolveCurrentDefaultAgentId(params.state)),
-  });
 }
 
 /** Creates a best-effort detached task row keyed to the persisted execution start. */
@@ -287,6 +287,7 @@ export function tryFinishCronTaskRunWithoutHistory(
     endedAt: number;
     summary?: string;
     childSessionKey?: string;
+    sessionKey?: string;
   },
 ): void {
   if (!result.taskRunId) {
@@ -307,7 +308,7 @@ export function tryFinishCronTaskRunWithoutHistory(
       lastEventAt: result.endedAt,
       error,
       terminalSummary: result.summary,
-      childSessionKey: result.childSessionKey,
+      childSessionKey: result.childSessionKey ?? result.sessionKey ?? null,
     });
   } catch (cause) {
     state.deps.log.warn(

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -15,6 +15,7 @@ function requireCronAgentId(agentId: string | undefined): string {
 function resolveCurrentDefaultAgentId(state: CronServiceState): string | undefined {
   return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
 }
+import { CRON_TASK_KIND } from "../../tasks/cron-task-contract.js";
 import {
   createRunningTaskRun,
   finalizeTaskRunById,
@@ -237,6 +238,7 @@ function tryCreateCronTaskRunRecord(params: {
       : undefined;
     const task = createRunningTaskRun({
       runtime: "cron",
+      taskKind: CRON_TASK_KIND,
       sourceId: params.jobId,
       ownerKey: "",
       scopeKind: "system",

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -18,6 +18,7 @@ import {
   timeoutErrorMessage,
 } from "./execution-errors.js";
 import type { CronServiceState } from "./state.js";
+import { tryUpdateCronTaskRunSession } from "./task-runs.js";
 import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 import {
   type IsolatedAgentSetupTimeoutSignal,
@@ -95,6 +96,9 @@ export async function executeJobCoreWithTimeout(
         onCancel: () => resolveOperatorCancellation?.(operatorCancellationMarker),
       })
     : undefined;
+  const recordTaskExecutionStart = (info?: CronAgentExecutionStarted) => {
+    tryUpdateCronTaskRunSession(state, opts?.runId, info?.sessionKey);
+  };
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   try {
     if (typeof jobTimeoutMs !== "number") {
@@ -108,13 +112,17 @@ export async function executeJobCoreWithTimeout(
           activeExecution = { ...activeExecution, ...info };
         }
       };
+      const noteExecutionStarted = (info?: CronAgentExecutionStarted) => {
+        accumulateExecution(info);
+        recordTaskExecutionStart(info);
+      };
       const corePromise = executeJobCore(state, job, runAbortController.signal, {
         activeJobMarker: opts?.activeJobMarker,
         owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
         streamBatch: opts?.streamBatch,
         streamScheduleKey: opts?.streamScheduleKey,
         streamSourceIdentity: opts?.streamSourceIdentity,
-        onExecutionStarted: accumulateExecution,
+        onExecutionStarted: noteExecutionStarted,
         onExecutionPhase: accumulateExecution,
       });
       trackActiveCronTaskRunSettlement(corePromise);
@@ -166,13 +174,17 @@ export async function executeJobCoreWithTimeout(
       }
       watchdog.noteLaneWait();
     };
+    const noteRunnerStarted = (info?: CronAgentExecutionStarted) => {
+      watchdog.noteRunnerStarted(info);
+      recordTaskExecutionStart(info);
+    };
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
       activeJobMarker: opts?.activeJobMarker,
       owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
       streamBatch: opts?.streamBatch,
       streamScheduleKey: opts?.streamScheduleKey,
       streamSourceIdentity: opts?.streamSourceIdentity,
-      onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
+      onExecutionStarted: deferTimeoutUntilExecutionStart ? noteRunnerStarted : undefined,
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
       onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
     });

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import { HEARTBEAT_SKIP_LANES_BUSY, type HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import { CRON_TASK_KIND } from "../../tasks/cron-task-contract.js";
 import { cancelTaskById, listTaskRecords } from "../../tasks/task-registry.js";
 import {
   resetTaskRegistryControlRuntimeForTests,
@@ -751,6 +752,7 @@ describe("cron service timer regressions", () => {
         throw new Error("Expected timed-out cron task row");
       }
       expect(task.status).toBe("running");
+      expect(task.taskKind).toBe(CRON_TASK_KIND);
 
       installCronCancellationControlRuntime();
       const cancelResult = await cancelTaskById({

--- a/src/tasks/cron-task-contract.ts
+++ b/src/tasks/cron-task-contract.ts
@@ -1,0 +1,2 @@
+/** Durable task kind stamped by the current cron task-ledger owner. */
+export const CRON_TASK_KIND = "automation_run";

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -171,6 +171,7 @@ export function recordTaskRunProgressByRunId(params: {
   runId: string;
   runtime?: TaskRuntime;
   sessionKey?: string;
+  childSessionKey?: string | null;
   lastEventAt?: number;
   progressSummary?: string | null;
   eventSummary?: string | null;

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isBackgroundExecTask } from "./background-exec-task-contract.js";
+import { CRON_TASK_KIND } from "./cron-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { isHarnessOwnedSubagentTask } from "./harness-owned-subagent-task.js";
 import { isProvisionalSubagentKillTask } from "./task-cancellation-state.js";
@@ -92,7 +93,7 @@ export async function cancelTaskById(params: {
             reason: params.reason?.trim() || "Cancelled by operator.",
           })
         ) {
-          if (childSessionKey) {
+          if (task.taskKind === CRON_TASK_KIND || childSessionKey) {
             return {
               found: true,
               cancelled: false,
@@ -100,8 +101,8 @@ export async function cancelTaskById(params: {
               task: cloneTaskRecord(task),
             };
           }
-          // Childless cron rows are stale legacy ledger records; with no live
-          // runner handle and no child session to cancel, clear the task row.
+          // Current rows carry taskKind before their runner publishes a child
+          // session. Only an unmarked childless row is legacy cleanup state.
         }
       } else if (!childSessionKey) {
         if (!isHarnessOwnedSubagentTask(task)) {

--- a/src/tasks/task-registry-record-api.ts
+++ b/src/tasks/task-registry-record-api.ts
@@ -466,6 +466,7 @@ export function recordTaskProgressByRunId(params: {
   runId: string;
   runtime?: TaskRuntime;
   sessionKey?: string;
+  childSessionKey?: string | null;
   lastEventAt?: number;
   progressSummary?: string | null;
   eventSummary?: string | null;
@@ -474,6 +475,7 @@ export function recordTaskProgressByRunId(params: {
     runId: params.runId,
     runtime: params.runtime,
     sessionKey: params.sessionKey,
+    childSessionKey: params.childSessionKey,
     lastEventAt: params.lastEventAt,
     progressSummary: params.progressSummary,
     eventSummary: params.eventSummary,

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -26,6 +26,7 @@ import {
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { CRON_TASK_KIND } from "./cron-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { ensureTaskRuntimeStateReady } from "./runtime-internal.js";
 import {
@@ -4775,7 +4776,8 @@ describe("task-registry", () => {
 
   it.each([
     {
-      name: "cancels stale cron tasks without an active runtime abort handle",
+      name: "cancels stale legacy childless cron tasks without an active runtime abort handle",
+      taskKind: undefined,
       childSessionKey: undefined,
       cancelled: true,
       reason: undefined,
@@ -4783,17 +4785,28 @@ describe("task-registry", () => {
       error: "Cancelled by operator.",
     },
     {
+      name: "does not cancel canonical childless cron tasks without an active runtime abort handle",
+      taskKind: CRON_TASK_KIND,
+      childSessionKey: undefined,
+      cancelled: false,
+      reason: "Cron task has no active cancellation handle.",
+      status: "running",
+      error: undefined,
+    },
+    {
       name: "does not mark session-backed cron tasks cancelled without an active runtime abort handle",
+      taskKind: undefined,
       childSessionKey: "agent:main:cron:daily-repost",
       cancelled: false,
       reason: "Cron task has no active cancellation handle.",
       status: "running",
       error: undefined,
     },
-  ])("$name", async ({ childSessionKey, cancelled, reason, status, error }) => {
+  ])("$name", async ({ taskKind, childSessionKey, cancelled, reason, status, error }) => {
     await withTaskRegistryTempDir(async () => {
       const task = createTaskFixture("cron", {
         sourceId: "daily-repost",
+        taskKind,
         ownerKey: "",
         scopeKind: "system",
         childSessionKey,


### PR DESCRIPTION
Closes #117678

## What Problem This Solves

Fixes an issue where an active scheduled task could link to the session that created the job instead of the transcript where the scheduled run was actually executing. Opening the task could therefore show an unrelated conversation or a provisional key that never received the run.

## Why This Change Was Made

Cron task rows now start without an invented transcript link for agent turns and adopt the exact session key reported by the runner when execution begins. Both timeout and no-timeout paths use the same callback; main system events retain their deterministic per-run key, headless jobs stay childless, and terminal outcomes keep their existing authoritative session projection. A durable task-kind marker now distinguishes canonical pre-session rows from unmarked legacy cleanup rows, so cancellation no longer abuses transcript-link presence as a lifecycle sentinel.

## User Impact

Operators opening active automation tasks now land in the real execution transcript for current, isolated, and custom persistent session targets. Script, command, and heartbeat tasks no longer advertise nonexistent conversations.

## Evidence

- Current-main reproduction at `eb8c22ed13f9865e07c0e363706183188e2a8fd1`: custom and isolated jobs can carry both a creator `job.sessionKey` and a different execution target, while the task projection prefers the creator metadata.
- Blacksmith Testbox `tbx_01kyzs0ds7t8df63v96a4d35mg`, run [30722526103](https://github.com/openclaw/openclaw/actions/runs/30722526103): 81/81 focused cron and task assertions passed, covering current, isolated-with-source, custom persistent sessions, timeout/no-timeout callbacks, main system events, and headless work.
- Exact-head CI on the first head caught the hidden cancellation sibling: a childless canonical row could be mistaken for stale legacy state and overwritten during timeout cleanup. The repair adds an explicit task-kind fact instead of restoring a fake transcript link.
- Blacksmith Testbox `tbx_01kyzswphf6sw5ft5584xgxeph`, run [30723047598](https://github.com/openclaw/openclaw/actions/runs/30723047598): the exact failed timer regression and full task-registry suite passed 178/178 after the ownership repair.
- Real isolated Gateway + public CLI proof on Testbox `tbx_01kyzv0jw2s8c6h74fekm8gxrm`, run [30723680725](https://github.com/openclaw/openclaw/actions/runs/30723680725): a cron agent turn remained actively `running`, carried `taskKind: "automation_run"`, and changed from creator session `agent:main:telegram:group:creator-proof` to the runner's exact `agent:main:cron:<job>:run:<session>` key before terminal completion. The full product build passed first; the owned Gateway, mock provider, state directory, and non-default ports were cleaned up.
- Fresh final whole-branch Codex autoreview `019fbfa2-b05e-7ff0-a6f4-be30d1432aa0`: TruffleHog clean, zero findings, patch correct at 0.96 confidence.
- Independent owner/history review found no blocker, confirmed `job.sessionKey` is creator/wake/delivery metadata rather than execution identity, and verified the runner callback is the authoritative transcript boundary.
- Targeted oxfmt and `git diff --check` passed. Production is `+55/-34` (net `+21`); tests are `+141/-49`.

Release-note context: active cron task links now open the transcript where the scheduled run is actually executing.

AI-assisted: yes. The execution owner, task registry projection, timeout siblings, history, and focused proof were independently reviewed.
