### PR TITLE
fix: show human names for group sessions

### DIFF
--- a/extensions/buzz/src/inbound.test.ts
+++ b/extensions/buzz/src/inbound.test.ts
@@ -107,9 +107,11 @@ describe("handleBuzzInbound", () => {
     expect(firstDispatch(runtime).ctxPayload).toMatchObject({
       WasMentioned: true,
       SenderId: SENDER_PUBLIC_KEY,
-      GroupChannel: ROOM_ID,
+      ChatId: ROOM_ID,
+      NativeChannelId: ROOM_ID,
       GroupSubject: ROOM_ID,
     });
+    expect(firstDispatch(runtime).ctxPayload.GroupChannel).toBeUndefined();
   });
 
   it("uses current Buzz labels without changing the stable sender identity", async () => {
@@ -171,9 +173,11 @@ describe("handleBuzzInbound", () => {
     expect(firstDispatch(runtime).ctxPayload).toMatchObject({
       SenderId: SENDER_PUBLIC_KEY,
       SenderName: "Alice",
-      GroupChannel: ROOM_ID,
+      ChatId: ROOM_ID,
+      NativeChannelId: ROOM_ID,
       GroupSubject: "Engineering",
     });
+    expect(firstDispatch(runtime).ctxPayload.GroupChannel).toBeUndefined();
   });
 
   it("accepts a configured text mention when no native p tag is present", async () => {

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -126,7 +126,6 @@ export async function handleBuzzInbound(params: {
       mentions: { canDetectMention: true, wasMentioned },
     },
     extra: {
-      GroupChannel: channelId,
       GroupSubject: roomName,
       BuzzEventKind: message.kind,
     },

--- a/extensions/matrix/src/matrix/monitor/handler-context.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-context.ts
@@ -302,7 +302,6 @@ export async function resolveMatrixInboundContext(config: {
     extra: {
       GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
       GroupId: isRoom ? roomId : undefined,
-      GroupChannel: isRoom ? roomId : undefined,
       ...locationPayload?.context,
       CommandSource: "text" as const,
       NativeDirectUserId: isDirectMessage ? senderId : undefined,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1649,7 +1649,7 @@ describe("matrix monitor handler pairing account scope", () => {
     }
   });
 
-  it("uses stable room ids instead of room-declared aliases in group context", async () => {
+  it("keeps stable room ids as routing metadata without using them as the display channel", async () => {
     const { handler, finalizeInboundContext } = createMatrixHandlerTestHarness({
       isDirectMessage: false,
       getRoomInfo: async () => ({
@@ -1677,7 +1677,9 @@ describe("matrix monitor handler pairing account scope", () => {
       lastCallArg(finalizeInboundContext, 0, "finalized context"),
       "finalized context",
     );
-    expect(finalized.GroupChannel).toBe("!room:example.org");
+    expect(finalized.ChatId).toBe("!room:example.org");
+    expect(finalized.NativeChannelId).toBe("!room:example.org");
+    expect(finalized.GroupChannel).toBeUndefined();
     expect(finalized.GroupSubject).toBe("Ops Room");
     expect(finalized.GroupId).toBe("!room:example.org");
   });

--- a/extensions/slack/src/monitor/enterprise-install.test.ts
+++ b/extensions/slack/src/monitor/enterprise-install.test.ts
@@ -56,6 +56,19 @@ describe("resolveSlackInstallationIdentity", () => {
     ).toEqual({ kind: "workspace", teamId: "T123" });
   });
 
+  it("preserves the human workspace name from auth.test", () => {
+    expect(
+      resolveSlackInstallationIdentity({
+        enterpriseOrgInstall: false,
+        auth: {
+          team: "Local Claw",
+          team_id: "T123",
+          is_enterprise_install: false,
+        },
+      }),
+    ).toEqual({ kind: "workspace", teamId: "T123", teamName: "Local Claw" });
+  });
+
   it("accepts an org-wide auth.test response without app_id", () => {
     expect(
       resolveSlackInstallationIdentity({

--- a/extensions/slack/src/monitor/enterprise-install.ts
+++ b/extensions/slack/src/monitor/enterprise-install.ts
@@ -9,6 +9,7 @@ export type SlackInstallationIdentity =
       kind: "workspace";
       apiAppId?: string;
       teamId: string;
+      teamName?: string;
       enterpriseId?: string;
     }
   | {
@@ -33,6 +34,7 @@ export type SlackIdentityHealth =
 
 export type SlackAuthTestIdentity = {
   app_id?: unknown;
+  team?: unknown;
   team_id?: unknown;
   enterprise_id?: unknown;
   is_enterprise_install?: unknown;
@@ -244,9 +246,11 @@ export function resolveSlackInstallationIdentity(params: {
   if (!teamId) {
     throw new Error("Slack workspace auth.test returned no team_id");
   }
+  const teamName = normalizeOptionalString(auth.team);
   return {
     kind: "workspace",
     teamId,
+    ...(teamName ? { teamName } : {}),
     ...(apiAppId ? { apiAppId } : {}),
     ...(enterpriseId ? { enterpriseId } : {}),
   };

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -2311,6 +2311,50 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(channelMetadata).toContain("Do dangerous things");
   });
 
+  it("records a human workspace and channel title for session display", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    slackCtx.teamId = "T0BDK6HMPS7";
+    slackCtx.installationIdentity = {
+      kind: "workspace",
+      teamId: "T0BDK6HMPS7",
+      teamName: "Local Claw",
+    } as SlackMonitorContext["installationIdentity"];
+    slackCtx.resolveChannelName = async () => ({ name: "channel-name", type: "channel" });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({ channel: "C0BDN50FL2Z", channel_type: "channel" }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.GroupSubject).toBe("Local Claw #channel-name");
+  });
+
+  it("records explicit stable Slack ids when channel metadata is unavailable", async () => {
+    const { account, ctx } = createMissingChannelInfoBotCtx();
+    ctx.teamId = "T0BDK6HMPS7";
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "C0BDN50FL2Z",
+        channel_type: "channel",
+        user: "U1",
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.GroupSubject).toBe(
+      "Slack Channel (Workspace ID: T0BDK6HMPS7, Channel ID: C0BDN50FL2Z)",
+    );
+  });
+
   it("classifies D-prefix DMs correctly even when channel_type is wrong", async () => {
     const prepared = await prepareMessageWith(
       createDmScopeMainSlackCtx(),

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -103,6 +103,20 @@ const SLACK_HISTORY_MEDIA_TOTAL_TIMEOUT_MS = 3_000;
 const SLACK_CHANNEL_ACCESS_DOCS_URL =
   "https://docs.openclaw.ai/channels/slack#access-control-and-routing";
 
+function resolveSlackGroupSessionSubject(params: {
+  channelId: string;
+  channelName?: string;
+  workspaceId: string;
+  workspaceName?: string;
+}): string {
+  const channelName = normalizeOptionalString(params.channelName);
+  const workspaceName = normalizeOptionalString(params.workspaceName);
+  if (channelName && workspaceName) {
+    return `${workspaceName} #${channelName}`;
+  }
+  return `Slack Channel (Workspace ID: ${params.workspaceId}, Channel ID: ${params.channelId})`;
+}
+
 function recordString(
   record: Record<string, unknown> | undefined,
   key: string,
@@ -1431,6 +1445,22 @@ export async function prepareSlackMessage(params: {
         : null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
+  const workspaceId = opts.eventScope?.teamId || ctx.teamId;
+  const workspaceName =
+    ctx.installationIdentity?.kind === "workspace" &&
+    ctx.installationIdentity.teamId === workspaceId
+      ? ctx.installationIdentity.teamName
+      : undefined;
+  // Stable Slack ids already own routing. Session presentation uses both human names or an
+  // explicit id-labelled fallback so shared metadata never has to infer Slack identifiers.
+  const groupSessionSubject = isRoomish
+    ? resolveSlackGroupSessionSubject({
+        channelId: message.channel,
+        channelName,
+        workspaceId,
+        workspaceName,
+      })
+    : undefined;
   const senderName = await resolveSenderName();
   const preview = truncateUtf16Safe(bodyForAgent.replace(/\s+/g, " "), 160);
   const inboundLabel = isDirectMessage
@@ -1666,7 +1696,7 @@ export async function prepareSlackMessage(params: {
       groupSystemPrompt,
     },
     extra: {
-      GroupSubject: isRoomish ? roomLabel : undefined,
+      GroupSubject: groupSessionSubject,
       ChannelPromptContext: channelMetadata ? [channelMetadata] : undefined,
       ChannelStructuredContext:
         agentContextEntities.length > 0

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -193,9 +193,13 @@ function deriveGroupSessionPatch(params: {
   };
   if (nextSubject) {
     patch.subject = nextSubject;
+    // These fields are alternate presentations of the same chat. Clear the stale channel title
+    // when ingress now owns a human subject, or an old opaque route id will keep winning in UI.
+    patch.groupChannel = undefined;
   }
   if (nextGroupChannel) {
     patch.groupChannel = nextGroupChannel;
+    patch.subject = undefined;
   }
   if (space) {
     patch.space = space;
@@ -203,8 +207,8 @@ function deriveGroupSessionPatch(params: {
 
   const displayName = buildGroupDisplayName({
     provider: channel,
-    subject: nextSubject ?? params.existing?.subject,
-    groupChannel: nextGroupChannel ?? params.existing?.groupChannel,
+    subject: nextSubject ?? (nextGroupChannel ? undefined : params.existing?.subject),
+    groupChannel: nextGroupChannel ?? (nextSubject ? undefined : params.existing?.groupChannel),
     space: space ?? params.existing?.space,
     id: resolution.id,
     key: params.sessionKey,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -12,6 +12,7 @@ import {
   appendTranscriptMessageSync,
   listSessionChildEntriesReadOnly,
   listSessionEntriesReadOnly,
+  recordInboundSessionMeta,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -1302,6 +1303,123 @@ describe("gateway session utils", () => {
       entry,
     });
     expect(row.displayName).toBe("Engineering");
+  });
+
+  test("refreshes a legacy Buzz UUID title from inbound room metadata", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-buzz-session-title-"));
+    const storePath = path.join(dir, "sessions.json");
+    const roomId = "b25b8e40-eb1a-43a4-b56b-30a4e16df586";
+    const key = `agent:main:buzz:group:${roomId}`;
+    try {
+      await replaceSessionEntry(
+        { sessionKey: key, storePath },
+        {
+          sessionId: "legacy-buzz-room",
+          updatedAt: 1,
+          chatType: "group",
+          groupId: roomId,
+          groupChannel: roomId,
+          displayName: "buzz:g-b25b8e40-eb1a-43a4-b56b-30a4e16df586",
+        },
+      );
+
+      const entry = await recordInboundSessionMeta({
+        storePath,
+        sessionKey: key,
+        ctx: {
+          Provider: "buzz",
+          Surface: "buzz",
+          ChatType: "group",
+          From: `buzz:group:${roomId}`,
+          To: `buzz:${roomId}`,
+          OriginatingTo: `buzz:${roomId}`,
+          NativeChannelId: roomId,
+          GroupSubject: "Engineering",
+        },
+      });
+
+      expect(entry).toMatchObject({
+        groupId: roomId,
+        subject: "Engineering",
+      });
+      expect(entry?.groupChannel).toBeUndefined();
+      const row = buildGatewaySessionRow({
+        cfg: { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig,
+        storePath,
+        store: { [key]: entry as SessionEntry },
+        key,
+        entry: entry as SessionEntry,
+      });
+      expect(row.displayName).toBe("Engineering");
+      expect(row.origin?.nativeChannelId).toBe(roomId);
+    } finally {
+      closeSessionSqliteDatabasesForTest();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    {
+      name: "resolved human names",
+      subject: "Local Claw #channel-name",
+    },
+    {
+      name: "explicit stable-id fallback",
+      subject: "Slack Channel (Workspace ID: T0BDK6HMPS7, Channel ID: C0BDN50FL2Z)",
+    },
+  ])("refreshes a legacy Slack id title with $name", async ({ subject }) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-slack-session-title-"));
+    const storePath = path.join(dir, "sessions.json");
+    const channelId = "C0BDN50FL2Z";
+    const key = `agent:main:slack:channel:${channelId.toLowerCase()}`;
+    try {
+      await replaceSessionEntry(
+        { sessionKey: key, storePath },
+        {
+          sessionId: "legacy-slack-channel",
+          updatedAt: 1,
+          chatType: "channel",
+          groupId: channelId.toLowerCase(),
+          groupChannel: `#${channelId}`,
+          space: "T0BDK6HMPS7",
+          displayName: `slack:#${channelId}`,
+        },
+      );
+
+      const entry = await recordInboundSessionMeta({
+        storePath,
+        sessionKey: key,
+        ctx: {
+          Provider: "slack",
+          Surface: "slack",
+          ChatType: "channel",
+          From: `slack:channel:${channelId}`,
+          To: `channel:${channelId}`,
+          OriginatingTo: `channel:${channelId}`,
+          NativeChannelId: channelId,
+          GroupSubject: subject,
+          GroupSpace: "T0BDK6HMPS7",
+        },
+      });
+
+      expect(entry).toMatchObject({
+        groupId: channelId.toLowerCase(),
+        subject,
+      });
+      expect(entry?.groupChannel).toBeUndefined();
+      const row = buildGatewaySessionRow({
+        cfg: { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig,
+        storePath,
+        store: { [key]: entry as SessionEntry },
+        key,
+        entry: entry as SessionEntry,
+      });
+      expect(row.displayName).toBe(subject);
+      expect(row.origin?.nativeChannelId).toBe(channelId);
+    } finally {
+      closeSessionSqliteDatabasesForTest();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("buildGatewaySessionRow group displayName prefers #channel and falls back to the token", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack, Buzz, and Matrix group sessions could appear in the session list as opaque workspace, channel, or room IDs instead of recognizable human names. Slack installations that cannot resolve channel metadata also lacked an explicit, understandable fallback.

## Why This Change Was Made

Channel ingress now keeps stable provider IDs exclusively as routing identity while supplying display metadata owned by the channel. Slack preserves the human workspace name returned by `auth.test` and emits either `Local Claw #channel-name` or the explicit fallback `Slack Channel (Workspace ID: <workspace-id>, Channel ID: <channel-id>)`. Buzz and Matrix no longer duplicate stable room IDs into `GroupChannel` when a human subject exists.

Shared session metadata clears stale alternate title fields when refreshed, so existing rows self-repair after their next admitted inbound message. Dormant rows are intentionally not backfilled by this change. No SQLite schema, OAuth scope, deployment, or live state changes are included.

## User Impact

Operators see recognizable workspace and room titles in Gateway session rows. Stable Slack channel IDs and Buzz/Matrix room IDs remain available for routing and delivery.

## Evidence

Blacksmith Testbox proof:

- Provider: `blacksmith-testbox`
- Lease: `tbx_01kyzqvh838fdertna7g53d4m7`
- Run: https://github.com/openclaw/openclaw/actions/runs/30721828585
- Focused tests: 488 passed
  - Gateway session metadata/display: 160
  - Slack installation and ingress: 184
  - Buzz ingress: 11
  - Matrix ingress sibling invariant: 133
- Targeted `oxfmt` and Oxlint passed for all 10 changed files.
- `tsgo:core`, `tsgo:core:test`, `tsgo:extensions`, and `tsgo:extensions:test` passed.
- `git diff --check` passed.

The broad `pnpm check:changed` invocation stopped on an unrelated existing max-lines baseline ratchet for `src/infra/windows-gateway-firewall-diagnostics.ts`; the path-scoped formatting, lint, typecheck, and focused test lanes above all passed.

Regression coverage spans channel ingress context, SQLite-backed session metadata refresh, and Gateway session-row display. It proves resolved Slack names, the exact unresolved Slack fallback, Buzz legacy UUID-title refresh, and stable routing IDs after display repair.

### Visual before/after proof

Same fixture-driven Control UI flow on one isolated direct AWS Crabbox lease: baseline `origin/main` versus PR head `c6cede43a93`.

| Before — opaque provider IDs | After — human display metadata |
| --- | --- |
| <img width="800" alt="Before: group sessions display opaque provider IDs" src="https://github.com/user-attachments/assets/334ab3ab-25ec-4b2b-b831-2398fa69405c" /> | <img width="800" alt="After: group sessions display human names and explicit fallback" src="https://github.com/user-attachments/assets/c913d798-c41f-4f9d-b99b-5daeb7464344" /> |

- Slack unresolved: `T0BDK6HMPS7 #C0BDN50FL2Z` → `Slack Channel (Workspace ID: T0BDK6HMPS7, Channel ID: C0BDN50FL2Z)`
- Slack resolved: workspace/channel IDs → `Local Claw #channel-name`
- Buzz legacy title: `#b25b8e40-eb1a-43a4-b56b-30a4e16df586` → `Engineering`
- Stable routing IDs remain unchanged in `NativeChannelId`.

The harness seeds legacy SQLite session rows, refreshes them through `recordInboundSessionMeta`, builds real Gateway rows with `buildGatewaySessionRow`, and renders the actual Control UI Threads page against a mocked Gateway. This is isolated fixture-driven proof; it does not mutate or deploy to the live DGX.

Crabbox: provider `aws`, lease `cbx_26e4951e3331` (stopped), run [`run_074a4b1cb8d5`](https://crabbox.openclaw.ai/portal/runs/run_074a4b1cb8d5).

```json
{
  "verdict": "pass",
  "harness": "mock-gateway-control-ui",
  "baseline": { "ref": "origin/main", "visualTestsPassed": 1 },
  "candidate": { "ref": "c6cede43a93", "visualTestsPassed": 1 },
  "routingIdentityPreserved": true,
  "liveDgxMutated": false,
  "crabbox": { "provider": "aws", "run": "run_074a4b1cb8d5" }
}
```
