### PR TITLE
fix(skills): preserve ClawHub publisher identity

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1301,9 +1301,9 @@
       "kind": "conditional-branch",
       "line": 6384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
-      "source": "ClawHub did not return an installable version for ${skill.slug}.",
+      "source": "ClawHub did not return an installable version for ${skill.reference}.",
       "surface": "android",
-      "id": "native.android.57c31cd4bd7c5146"
+      "id": "native.android.e5b0558c26183ff4"
     },
     {
       "kind": "ui-call",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 120,
+      "line": 125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt",
       "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 232,
+      "line": 237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt",
       "source": "The result for $slug is unknown. Reconnect, refresh Skills, then retry; the Gateway safely joins a matching install that is still running.",
       "surface": "android",
@@ -10979,7 +10979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 606,
+      "line": 607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version $it",
       "surface": "android",
@@ -10987,7 +10987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 615,
+      "line": 617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installing",
       "surface": "android",
@@ -10995,7 +10995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 616,
+      "line": 618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -11003,7 +11003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 676,
+      "line": 678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -11011,7 +11011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 714,
+      "line": 716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -11019,7 +11019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 720,
+      "line": 722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Dismiss",
       "surface": "android",
@@ -11027,7 +11027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Acknowledge Gateway warning and install",
       "surface": "android",
@@ -11035,7 +11035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 746,
+      "line": 748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review ClawHub skill",
       "surface": "android",
@@ -11043,7 +11043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 753,
+      "line": 755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version",
       "surface": "android",
@@ -11051,7 +11051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 754,
+      "line": 756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Publisher",
       "surface": "android",
@@ -11059,7 +11059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 756,
+      "line": 758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "The Gateway will verify this exact release with ClawHub before download. If the release needs explicit risk acknowledgement, Android will show the Gateway warning before retrying.",
       "surface": "android",
@@ -11067,7 +11067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 764,
+      "line": 766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Verify and install",
       "surface": "android",
@@ -11075,7 +11075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 769,
+      "line": 771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -11083,7 +11083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 811,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "All",
       "surface": "android",
@@ -11091,7 +11091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs Setup",
       "surface": "android",
@@ -11099,7 +11099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 832,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -11107,7 +11107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 831,
+      "line": 833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -11115,7 +11115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 832,
+      "line": 834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11123,7 +11123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 845,
+      "line": 847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Disabled",
       "surface": "android",
@@ -11131,7 +11131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 846,
+      "line": 848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Blocked",
       "surface": "android",
@@ -11139,7 +11139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 847,
+      "line": 849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Not available to this agent",
       "surface": "android",
@@ -11147,7 +11147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 849,
+      "line": 851,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs setup",
       "surface": "android",
@@ -11155,7 +11155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 857,
+      "line": 859,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is disabled on the gateway. Enable it here when the current connection has operator.admin.",
       "surface": "android",
@@ -11163,7 +11163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 860,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is blocked by the gateway allowlist. Allowlist changes stay on desktop or CLI.",
       "surface": "android",
@@ -11171,7 +11171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 859,
+      "line": 861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI.",
       "surface": "android",
@@ -11179,7 +11179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 861,
+      "line": 863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not currently eligible to run. Use desktop or CLI for configuration changes.",
       "surface": "android",
@@ -11187,7 +11187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 862,
+      "line": 864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready on this gateway. Android can enable or disable it globally; setup and configuration stay on desktop or CLI.",
       "surface": "android",
@@ -11195,7 +11195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 867,
+      "line": 869,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No missing items",
       "surface": "android",
@@ -11203,7 +11203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 868,
+      "line": 870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "1 missing item",
       "surface": "android",
@@ -11211,7 +11211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 869,
+      "line": 871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "$count missing items",
       "surface": "android",
@@ -11219,7 +11219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 874,
+      "line": 876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs 1 setup item. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -11227,7 +11227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 875,
+      "line": 877,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs $count setup items. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -11235,7 +11235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 880,
+      "line": 882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Built-in",
       "surface": "android",
@@ -11243,7 +11243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 880,
+      "line": 882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Bundled",
       "surface": "android",
@@ -11251,7 +11251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 881,
+      "line": 883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed",
       "surface": "android",
@@ -11259,7 +11259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 882,
+      "line": 884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Workspace",
       "surface": "android",
@@ -11267,7 +11267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 883,
+      "line": 885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Extra",
       "surface": "android",
@@ -11275,7 +11275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 884,
+      "line": 886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill",
       "surface": "android",
@@ -43075,7 +43075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 348,
+      "line": 355,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift",
       "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
       "surface": "apple",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -6362,7 +6362,7 @@ class NodeRuntime private constructor(
     publishGatewayData(gatewayScope) {
       _clawHubSkillSearchState.value =
         _clawHubSkillSearchState.value.copy(
-          reviewingSlug = skill.slug,
+          reviewingSlug = skill.reference,
           installReview = null,
           acknowledgeSlug = null,
           acknowledgeVersion = null,
@@ -6371,7 +6371,7 @@ class NodeRuntime private constructor(
         )
     }
     try {
-      val response = requestGatewayData(gatewayScope, "skills.detail", clawHubDetailParams(skill.slug))
+      val response = requestGatewayData(gatewayScope, "skills.detail", clawHubDetailParams(skill.reference))
       val review = parseClawHubInstallReview(response, skill, json)
       publishGatewayData(gatewayScope) {
         if (clawHubSkillReviewSeq.get() == reviewSeq) {
@@ -6381,7 +6381,7 @@ class NodeRuntime private constructor(
               installReview = review,
               errorText =
                 if (review == null) {
-                  "ClawHub did not return an installable version for ${skill.slug}."
+                  "ClawHub did not return an installable version for ${skill.reference}."
                 } else {
                   null
                 },
@@ -6397,7 +6397,7 @@ class NodeRuntime private constructor(
             _clawHubSkillSearchState.value.copy(
               reviewingSlug = null,
               errorText =
-                nativeString("Could not load ClawHub details for \${skill.slug}.", skill.slug),
+                nativeString("Could not load ClawHub details for \${skill.slug}.", skill.reference),
             )
         }
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
@@ -31,7 +31,11 @@ data class GatewayClawHubSkillSummary(
   val displayName: String,
   val summary: String?,
   val version: String?,
-)
+  val ownerHandle: String? = null,
+) {
+  val reference: String
+    get() = canonicalClawHubSkillReference(slug, ownerHandle) ?: slug
+}
 
 data class GatewayClawHubInstallReview(
   val slug: String,
@@ -60,6 +64,7 @@ internal fun parseClawHubSearchResults(
       val displayName = value.string("displayName") ?: return@mapNotNull null
       GatewayClawHubSkillSummary(
         slug = slug,
+        ownerHandle = value.string("ownerHandle"),
         displayName = displayName,
         summary = value.string("summary"),
         version = value.string("version"),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
@@ -599,15 +599,17 @@ private fun ClawHubSkillSearchPanel(
   if (state.results.isNotEmpty()) {
     ClawListPanel(items = state.results) { skill ->
       val installed =
-        skill.version?.let { version -> isClawHubSkillInstalled(installedSkills, skill.slug, version) }
-          ?: isClawHubSkillInstalled(installedSkills, skill.slug)
+        skill.version?.let { version -> isClawHubSkillInstalled(installedSkills, skill.reference, version) }
+          ?: isClawHubSkillInstalled(installedSkills, skill.reference)
       ClawDetailRow(
         title = skill.displayName,
-        subtitle = listOfNotNull(skill.summary, skill.version?.let { nativeString("Version \$it", it) }).joinToString(" · "),
+        subtitle =
+          listOfNotNull(skill.summary, skill.reference, skill.version?.let { nativeString("Version \$it", it) })
+            .joinToString(" · "),
         leading = { ClawTextBadge(text = skillBadge(skill.displayName)) },
         trailing = {
-          val reviewing = state.reviewingSlug == skill.slug
-          val installing = isClawHubSkillOperationActive(state.installingSlugs, skill.slug)
+          val reviewing = state.reviewingSlug == skill.reference
+          val installing = isClawHubSkillOperationActive(state.installingSlugs, skill.reference)
           ClawSecondaryButton(
             text =
               when {

--- a/apps/android/app/src/test/java/ai/openclaw/app/SkillManagementTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SkillManagementTest.kt
@@ -38,6 +38,26 @@ class SkillManagementTest {
   }
 
   @Test
+  fun searchResultsKeepSameSlugPublishersDistinct() {
+    val results =
+      parseClawHubSearchResults(
+        """{"results":[{"slug":"weather","ownerHandle":"alice","displayName":"Alice Weather"},{"slug":"weather","ownerHandle":"bob","displayName":"Bob Weather"}]}""",
+        json,
+      )
+
+    assertEquals(listOf("@alice/weather", "@bob/weather"), results.map { it.reference })
+    assertEquals(
+      "@alice/weather",
+      json
+        .parseToJsonElement(clawHubDetailParams(results.first().reference))
+        .jsonObject
+        .getValue("slug")
+        .jsonPrimitive
+        .content,
+    )
+  }
+
+  @Test
   fun detailBindsExactVersionAndPublisherIdentity() {
     val review =
       parseClawHubInstallReview(

--- a/apps/ios/Sources/Design/AgentProModels.swift
+++ b/apps/ios/Sources/Design/AgentProModels.swift
@@ -263,9 +263,16 @@ struct ClawHubSearchResponseLite: Decodable {
 
 struct ClawHubSearchResultLite: Decodable {
     let slug: String
+    let ownerHandle: String?
     let displayName: String
     let summary: String?
     let version: String?
+
+    var reference: String {
+        SkillManagementContract.canonicalClawHubReference(
+            slug: self.slug,
+            ownerHandle: self.ownerHandle) ?? self.slug
+    }
 }
 
 struct ClawHubInstallParams: Encodable {

--- a/apps/ios/Sources/Design/AgentProTab+Skills.swift
+++ b/apps/ios/Sources/Design/AgentProTab+Skills.swift
@@ -146,7 +146,7 @@ extension AgentProTab {
                 if !self.clawHubResults.isEmpty {
                     VStack(spacing: 0) {
                         let results = Array(self.clawHubResults.prefix(8))
-                        ForEach(Array(results.enumerated()), id: \.element.slug) { index, result in
+                        ForEach(Array(results.enumerated()), id: \.element.reference) { index, result in
                             self.clawHubResultRow(result)
                             if index < results.count - 1 {
                                 Divider().padding(.leading, 42)
@@ -160,7 +160,7 @@ extension AgentProTab {
     }
 
     func clawHubResultRow(_ result: ClawHubSearchResultLite) -> some View {
-        let installing = clawHubInstallSlug == result.slug
+        let installing = clawHubInstallSlug == result.reference
         return HStack(alignment: .top, spacing: 10) {
             ProIconBadge(systemName: "sparkles", color: OpenClawBrand.accent)
             VStack(alignment: .leading, spacing: 3) {
@@ -741,11 +741,11 @@ extension AgentProTab {
     @MainActor
     func installClawHubSkill(_ result: ClawHubSearchResultLite) async {
         guard liveGatewayConnected else { return }
-        clawHubInstallSlug = result.slug
+        clawHubInstallSlug = result.reference
         clawHubErrorText = nil
         defer { self.clawHubInstallSlug = nil }
         do {
-            let params = ClawHubInstallParams(slug: result.slug)
+            let params = ClawHubInstallParams(slug: result.reference)
             _ = try await self.requestGateway(method: "skills.install", params: params, timeoutSeconds: 125)
             await appModel.refreshGatewayOverviewIfConnected()
             await refreshOverview(force: true)

--- a/apps/ios/Sources/Design/SettingsSkillsDestination.swift
+++ b/apps/ios/Sources/Design/SettingsSkillsDestination.swift
@@ -387,10 +387,10 @@ struct SettingsSkillsDestination: View {
                 ClawHubSkillRow(
                     skill: skill,
                     installed: skill.version.map {
-                        SkillManagementContract.installed(self.installedSkills, slug: skill.slug, version: $0)
-                    } ?? SkillManagementContract.installed(self.installedSkills, slug: skill.slug),
-                    isBusy: self.reviewingSlug == skill.slug || self.installingSlug.map {
-                        SkillManagementContract.sameClawHubSkill($0, skill.slug)
+                        SkillManagementContract.installed(self.installedSkills, slug: skill.reference, version: $0)
+                    } ?? SkillManagementContract.installed(self.installedSkills, slug: skill.reference),
+                    isBusy: self.reviewingSlug == skill.reference || self.installingSlug.map {
+                        SkillManagementContract.sameClawHubSkill($0, skill.reference)
                     } == true,
                     onReview: { Task { await self.review(skill) } })
             }
@@ -523,7 +523,7 @@ struct SettingsSkillsDestination: View {
         let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
         self.reviewID = operationID
-        self.reviewingSlug = skill.slug
+        self.reviewingSlug = skill.reference
         self.notice = nil
         defer {
             if self.reviewID == operationID {
@@ -535,7 +535,7 @@ struct SettingsSkillsDestination: View {
             let route = try await gatewayRoute()
             let data = try await request(
                 method: "skills.detail",
-                params: ClawHubDetailRequest(slug: skill.slug),
+                params: ClawHubDetailRequest(slug: skill.reference),
                 timeoutSeconds: 20,
                 route: route)
             let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
@@ -907,12 +907,12 @@ private struct ClawHubSkillRow: View {
             ProIconBadge(systemName: "shippingbox", color: self.installed ? OpenClawBrand.ok : OpenClawBrand.accent)
             VStack(alignment: .leading, spacing: 4) {
                 Text(self.skill.displayName).font(OpenClawType.subheadSemiBold)
-                Text(self.skill.summary ?? self.skill.slug)
+                Text(self.skill.summary ?? self.skill.reference)
                     .font(OpenClawType.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 6) {
-                    Text(self.skill.slug).font(OpenClawType.monoSmall).foregroundStyle(.secondary)
+                    Text(self.skill.reference).font(OpenClawType.monoSmall).foregroundStyle(.secondary)
                     if let version = self.skill.version {
                         Text(verbatim: version).font(OpenClawType.monoSmall).foregroundStyle(.secondary)
                     }

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -66,13 +66,13 @@ struct ClawHubSkillsBrowser: View {
                                 installed: skill.version.map {
                                     SkillManagementContract.installed(
                                         self.installedSkills,
-                                        slug: skill.slug,
+                                        slug: skill.reference,
                                         version: $0)
                                 } ?? SkillManagementContract.installed(
                                     self.installedSkills,
-                                    slug: skill.slug),
-                                isBusy: self.model.reviewingSlug == skill.slug || self.model.installingSlug.map {
-                                    SkillManagementContract.sameClawHubSkill($0, skill.slug)
+                                    slug: skill.reference),
+                                isBusy: self.model.reviewingSlug == skill.reference || self.model.installingSlug.map {
+                                    SkillManagementContract.sameClawHubSkill($0, skill.reference)
                                 } == true,
                                 showsDivider: index != self.model.results.count - 1)
                             {
@@ -127,7 +127,7 @@ private struct ClawHubSkillResultRow: View {
     var body: some View {
         SettingsCardRow(
             title: .verbatim(self.skill.displayName),
-            subtitle: .verbatim(self.skill.summary ?? self.skill.slug),
+            subtitle: .verbatim(self.skill.summary ?? self.skill.reference),
             showsDivider: self.showsDivider)
         {
             if let version = self.skill.version {
@@ -288,14 +288,14 @@ private final class ClawHubSkillsBrowserModel {
 
     func review(_ skill: ClawHubSkillSummary) async {
         guard self.reviewingSlug == nil else { return }
-        self.reviewingSlug = skill.slug
+        self.reviewingSlug = skill.reference
         self.notice = nil
         defer { self.reviewingSlug = nil }
         do {
             guard let route = await GatewayConnection.shared.captureRoute() else {
                 throw ClawHubSkillsBrowserError.gatewayUnavailable
             }
-            let detail = try await GatewayConnection.shared.skillsDetail(slug: skill.slug, on: route)
+            let detail = try await GatewayConnection.shared.skillsDetail(slug: skill.reference, on: route)
             guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
                 throw ClawHubSkillsBrowserError.missingInstallVersion
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
@@ -220,12 +220,19 @@ public struct ClawHubInstalledSkillLink: Codable, Sendable {
 
 public struct ClawHubSkillSummary: Codable, Identifiable, Hashable, Sendable {
     public let slug: String
+    public let ownerHandle: String?
     public let displayName: String
     public let summary: String?
     public let version: String?
 
     public var id: String {
-        self.slug
+        self.reference
+    }
+
+    public var reference: String {
+        SkillManagementContract.canonicalClawHubReference(
+            slug: self.slug,
+            ownerHandle: self.ownerHandle) ?? self.slug
     }
 }
 
@@ -367,7 +374,7 @@ public enum SkillManagementContract {
         return (String(parts[1]), String(parts[0]).lowercased())
     }
 
-    fileprivate static func canonicalClawHubReference(slug: String, ownerHandle: String?) -> String? {
+    public static func canonicalClawHubReference(slug: String, ownerHandle: String?) -> String? {
         guard let reference = clawHubReference(slug) else { return nil }
         let owner = ownerHandle?
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
@@ -22,6 +22,15 @@ struct SkillManagementTests {
         #expect(review.author == "Molly")
     }
 
+    @Test func `search results keep same slug publishers distinct`() throws {
+        let data = Data(
+            #"{"results":[{"slug":"weather","ownerHandle":"alice","displayName":"Alice Weather"},{"slug":"weather","ownerHandle":"bob","displayName":"Bob Weather"}]}"#.utf8)
+        let results = try JSONDecoder().decode(ClawHubSkillSearchResult.self, from: data).results
+
+        #expect(results.map(\.reference) == ["@alice/weather", "@bob/weather"])
+        #expect(results.map(\.id) == ["@alice/weather", "@bob/weather"])
+    }
+
     @Test func `risk acknowledgement stays bound to reviewed version`() {
         let matching = GatewayResponseError(
             method: "skills.install",

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"48dad42d04caeb62f04f9dbe32b4562ecef695e9f0c97fb891040408400f37bd","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"87139ea5369a9ac01c7c8d6ebe159ec867b1966241c073be7deb5852a5ae1809","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"3d1c84bcc585b57a93054889e16fb3be02ff4d599d7d2a0566df6f463f2254a8","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"ab7edea40eae3b17e30843c13397dabbb6661ff3f413e61567be86a6baf903e9","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"4245891bae7517cf001f637e80d1d813c11385d695eebbd69a61258e83399c4e","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"e605e7d798b86ee279f65cb65822701ca437ec26895e0717ea970a6d2c90d945","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"f719599ed89a658109698bc1ef1309e1709e5ae3385b7ce3f1c583343ea23b33","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"827682e077dc6e56aff154db2ad1b8d9da1460406968c4972d6408cf12af13ce","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"d531b32d0544c42f375f628bd7a6b3d3582a91078db37bc048af7c3f23a9e59f","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"376055c8e98e0c86c9cd6ac3a46a673223218a684c2b1268d7b4d66cb0878263","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"40b25681a1ee102cf1d2d5b23a29f96e2501ea521404deed59303e59c35089ec","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"3a2be771afd25e914dbec5e5cc78c80d52df0a92ced71230ee05b5155a990aad","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"67884fcf5fc91b8b40a3c83e83080e69f54f7750cdd780368af63363f84ddc40","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"f56d1138f44ea313240b901f2a166f613f55a1bc470e7d6a4cd427686231a6fe","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"ab54be164a2b0affece4d6c196ee64ae9259cac072d4ac6c32dd27daf4941565","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"a1210d9461da5a826e15fb4ebc73a13ed6a6237aea667fca9439e38cb89a3e6c","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"21823a6741645b81797b4be6bf16a2d067e7e2a007177fbc5c7a6cab98b08027","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"ee6a1845493b22347fda599f8d7313e1735a42e3f867cf1578d4f315291200f5","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e31574637f3e276338e3e05e4774f7ad79981042c8021e49fb53df7ffe901917","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}
+{"contentHash":"945f60648841f6990973ee5dd5564f53009f99d30ebdfbaa647d1728781339e7","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"80686774b5023519466038e4a20604d9efce462b0cd2915ab5597fb1087ef8af","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"56172b3eb4af27fe3bd3e3ad08f4eef168508860217fdc9bf8fa432f6b525ea0","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9eb227dd27a3d08b868b1144bd64e1ff22da707af353699b9eb0f6438d4d98c1","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"23cc152c55235ffd59d4cc528b94503d0f6a84aeefd289dd5365e6f51e06786d","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"696f33ed5d8f059b82ff4159183b80f7e4af086abb2383bae5c02d909427fe43","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"25be165e0e6e50b996cd8b12ff4f63c69bb0dfa2fc8c15d39930e35130811cc3","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"411769ac67fd1a5b0ea4ada41b45678688e86194d03adc8d8efcad65c5f0c38c","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"64e16b98a2432efeacfd28e797b25549759f8b0e3d3c92e1d48f17433ea942be","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6539e277a49a27344f2844bcce06f609c5e463bb5a9be9eb1532994f9fec6479","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"32089c3aa351c490c35795156d7abdba5b9e8971e79996e22d1685c3649c08be","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"9d1c23c498e989db4592749e735d0a09fc41ffeb86ab66f70b6894a2161e1212","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"a752ff196294c15b8fe2eb02bcd77a549ca2dbeef5a7b23c143473e44cd014a6","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"d0b42cb31d5b2e84acb3a63ca79fdd2bc988bde3505de54dc07dd85bb76fd60c","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"aeb035116ed9ad48e982be74138ef3abbbef7dc05a795559dda4defcfc471c96","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -413,6 +413,7 @@ export const SkillsSearchResultSchema = closedObject({
     closedObject({
       score: Type.Number(),
       slug: NonEmptyString,
+      ownerHandle: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
       displayName: NonEmptyString,
       summary: Type.Optional(Type.String()),
       version: Type.Optional(NonEmptyString),

--- a/src/gateway/server-methods/skills.search-detail.test.ts
+++ b/src/gateway/server-methods/skills.search-detail.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../skills/lifecycle/clawhub.js", () => ({
 }));
 
 vi.mock("../../infra/clawhub-skills.js", () => ({
+  CLAWHUB_SKILLS_SH_TRUST_STATE: "not-scanned-by-clawhub",
   fetchClawHubSkillDetail: (...args: unknown[]) => fetchClawHubSkillDetailMock(...args),
   searchClawHubSkills: vi.fn(),
 }));
@@ -80,6 +81,7 @@ describe("skills.search handler", () => {
       {
         score: 0.95,
         slug: "github",
+        ownerHandle: "openclaw",
         displayName: "GitHub",
         summary: "GitHub integration",
         version: "1.0.0",
@@ -103,6 +105,7 @@ describe("skills.search handler", () => {
         {
           score: 0.95,
           slug: "github",
+          ownerHandle: "openclaw",
           displayName: "GitHub",
           summary: "GitHub integration",
           version: "1.0.0",
@@ -193,6 +196,24 @@ describe("skills.detail handler", () => {
     expect(response).toEqual(detail);
   });
 
+  it("resolves an owner-qualified reference before fetching detail", async () => {
+    fetchClawHubSkillDetailMock.mockResolvedValue({
+      skill: { slug: "weather", displayName: "Alice Weather", createdAt: 1, updatedAt: 1 },
+      owner: { handle: "alice", displayName: "Alice" },
+    });
+
+    const { ok, error } = await callHandler("skills.detail", {
+      slug: "@Alice/weather",
+    });
+
+    expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "alice",
+    });
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+  });
+
   it("returns error when slug is not found", async () => {
     fetchClawHubSkillDetailMock.mockRejectedValue(new Error("not found"));
 
@@ -215,6 +236,17 @@ describe("skills.detail handler", () => {
 
     expect(ok).toBe(false);
     expectErrorField(error, "code", "INVALID_REQUEST");
+    expect(fetchClawHubSkillDetailMock).not.toHaveBeenCalled();
+  });
+
+  it("does not treat source-qualified install references as ClawHub detail refs", async () => {
+    const { ok, error } = await callHandler("skills.detail", {
+      slug: "skills-sh:alice/tools/weather",
+    });
+
+    expect(ok).toBe(false);
+    expectErrorField(error, "code", "INVALID_REQUEST");
+    expectErrorField(error, "message", "skills.detail only supports ClawHub skill references.");
     expect(fetchClawHubSkillDetailMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -34,6 +34,7 @@ import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { updateSkillConfigEntry } from "../../skills/config/mutations.js";
 import { collectSkillBins } from "../../skills/discovery/bins.js";
 import { buildWorkspaceSkillStatus } from "../../skills/discovery/status.js";
+import { parseRequestedClawHubSkillRef } from "../../skills/lifecycle/clawhub-store.js";
 import {
   installSkillFromClawHub,
   readLocalSkillCardContentSync,
@@ -297,9 +298,28 @@ export const skillsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateSkillsDetailParams, "skills.detail", respond)) {
       return;
     }
+    let ref;
+    try {
+      ref = parseRequestedClawHubSkillRef((params as { slug: string }).slug);
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(err)));
+      return;
+    }
+    if (ref.requestedReference) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "skills.detail only supports ClawHub skill references.",
+        ),
+      );
+      return;
+    }
     try {
       const detail = await fetchClawHubSkillDetail({
-        slug: (params as { slug: string }).slug,
+        slug: ref.slug,
+        ...(ref.ownerHandle ? { ownerHandle: ref.ownerHandle } : {}),
       });
       respond(true, detail, undefined);
     } catch (err) {

--- a/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -25,7 +26,79 @@ const ENV_KEYS = [
   "OPENCLAW_TEST_MINIMAL_GATEWAY",
   "OPENCLAW_BUNDLED_PLUGINS_DIR",
   "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_CLAWHUB_URL",
 ] as const;
+
+async function startDuplicatePublisherRegistry(requests: URL[]): Promise<{
+  baseUrl: string;
+  server: Server;
+}> {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    requests.push(url);
+    response.setHeader("content-type", "application/json");
+
+    if (url.pathname === "/api/v1/search") {
+      response.end(
+        JSON.stringify({
+          results: [
+            { score: 1, slug: "weather", ownerHandle: "alice", displayName: "Alice Weather" },
+            { score: 0.9, slug: "weather", ownerHandle: "bob", displayName: "Bob Weather" },
+          ],
+        }),
+      );
+      return;
+    }
+
+    if (url.pathname === "/api/v1/skills/weather") {
+      const ownerHandle = url.searchParams.get("ownerHandle");
+      if (ownerHandle === "alice" || ownerHandle === "bob") {
+        response.end(
+          JSON.stringify({
+            skill: {
+              slug: "weather",
+              displayName: `${ownerHandle === "alice" ? "Alice" : "Bob"} Weather`,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+            latestVersion: { version: "1.0.0", createdAt: 1 },
+            owner: { handle: ownerHandle, displayName: ownerHandle },
+          }),
+        );
+        return;
+      }
+    }
+
+    if (url.pathname === "/api/v1/skills/weather/install") {
+      response.statusCode = 423;
+      response.end(
+        JSON.stringify({
+          ok: false,
+          slug: "weather",
+          reason: "fixture-stop-before-download",
+          message: "Fixture stopped before download.",
+          status: 423,
+        }),
+      );
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("duplicate publisher registry did not bind a TCP port");
+  }
+  return { baseUrl: `http://127.0.0.1:${address.port}`, server };
+}
 
 async function setupTempHome() {
   const env = captureEnv([...ENV_KEYS]);
@@ -78,6 +151,68 @@ async function setupTempHome() {
 }
 
 describe("gateway RPC tool and skill catalogs", () => {
+  it(
+    "keeps the selected publisher through search, detail, and install",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const temp = await setupTempHome();
+      const requests: URL[] = [];
+      const registry = await startDuplicatePublisherRegistry(requests);
+      const token = `rpc-clawhub-publishers-${process.pid}`;
+      let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        setTestEnvValue("OPENCLAW_CLAWHUB_URL", registry.baseUrl);
+        started = await startGatewayWithClient({
+          cfg: {
+            agents: { defaults: { workspace: temp.workspace } },
+            gateway: { auth: { mode: "token", token } },
+          },
+          configPath: temp.configPath,
+          token,
+          clientDisplayName: "rpc-clawhub-publisher-reader",
+        });
+
+        const search = (await started.client.request("skills.search", {
+          query: "weather",
+        })) as { results: Array<{ slug: string; ownerHandle?: string }> };
+        expect(search.results).toEqual([
+          expect.objectContaining({ slug: "weather", ownerHandle: "alice" }),
+          expect.objectContaining({ slug: "weather", ownerHandle: "bob" }),
+        ]);
+
+        const detail = (await started.client.request("skills.detail", {
+          slug: "@alice/weather",
+        })) as { owner?: { handle?: string } };
+        expect(detail.owner?.handle).toBe("alice");
+
+        await expect(
+          started.client.request("skills.install", {
+            source: "clawhub",
+            slug: "@bob/weather",
+          }),
+        ).rejects.toThrow("Fixture stopped before download");
+        expect(
+          requests.some(
+            (request) =>
+              request.pathname === "/api/v1/skills/weather/install" &&
+              request.searchParams.get("ownerHandle") === "bob",
+          ),
+        ).toBe(true);
+      } finally {
+        try {
+          if (started) {
+            await disconnectGatewayClient(started.client).catch(() => undefined);
+            await started.server.close({ reason: "publisher identity proof complete" });
+          }
+          await new Promise<void>((resolve) => registry.server.close(() => resolve()));
+        } finally {
+          temp.env.restore();
+        }
+      }
+    },
+  );
+
   it(
     "returns built-in commands, core tools, and a readable workspace skill card",
     { timeout: TEST_TIMEOUT_MS },

--- a/ui/src/e2e/skills-publisher-identity.e2e.test.ts
+++ b/ui/src/e2e/skills-publisher-identity.e2e.test.ts
@@ -1,0 +1,122 @@
+// Control UI E2E coverage for preserving ClawHub publisher identity from search selection.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI ClawHub publisher identity",
+  trackBrowserContexts: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is required for ClawHub publisher identity proof at ${executablePath}`,
+});
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "skills-publishers");
+
+async function setThemeMode(page: Page, mode: "dark" | "light") {
+  await page.emulateMedia({ colorScheme: mode });
+  await page.evaluate((nextMode) => {
+    const root = document.documentElement;
+    root.dataset.themeMode = nextMode;
+    root.dataset.themeResolved = nextMode;
+    root.classList.toggle("wa-light", nextMode === "light");
+    root.classList.toggle("wa-dark", nextMode === "dark");
+    root.style.colorScheme = nextMode;
+  }, mode);
+  await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe(mode);
+}
+
+suite.define(() => {
+  it("keeps same-slug publishers distinct through detail and install", async () => {
+    if (captureUiProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      colorScheme: "light",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["skills.detail", "skills.install", "skills.search"],
+      methodResponses: {
+        "agents.list": {
+          agents: [{ id: "main", identity: { name: "Main" }, name: "Main" }],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "skills.detail": {
+          skill: { slug: "weather", displayName: "Alice Weather", createdAt: 1, updatedAt: 1 },
+          latestVersion: { version: "1.0.0", createdAt: 1 },
+          owner: { handle: "alice", displayName: "Alice" },
+        },
+        "skills.install": { message: "Installed Bob Weather" },
+        "skills.search": {
+          results: [
+            {
+              score: 1,
+              slug: "weather",
+              ownerHandle: "alice",
+              displayName: "Alice Weather",
+              summary: "Forecasts from Alice",
+              version: "1.0.0",
+            },
+            {
+              score: 0.9,
+              slug: "weather",
+              ownerHandle: "bob",
+              displayName: "Bob Weather",
+              summary: "Forecasts from Bob",
+              version: "2.0.0",
+            },
+          ],
+        },
+        "skills.status": {
+          workspaceDir: "/tmp/openclaw-e2e/workspace",
+          managedSkillsDir: "/tmp/openclaw-e2e/skills",
+          skills: [],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}skills`);
+      await page.locator('input[name="clawhub-search"]').fill("weather");
+      await gateway.waitForRequest("skills.search");
+
+      const aliceRow = page.locator(".settings-row", { hasText: "Alice Weather" });
+      const bobRow = page.locator(".settings-row", { hasText: "Bob Weather" });
+      await expect.poll(() => aliceRow.getByText("@alice/weather").isVisible()).toBe(true);
+      await expect.poll(() => bobRow.getByText("@bob/weather").isVisible()).toBe(true);
+
+      for (const theme of ["light", "dark"] as const) {
+        await setThemeMode(page, theme);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, `same-slug-publishers-${theme}.png`),
+          });
+        }
+      }
+
+      await aliceRow.getByRole("button", { name: "Open Alice Weather details" }).click();
+      const detailRequest = await gateway.waitForRequest("skills.detail");
+      expect(detailRequest.params).toEqual({ slug: "@alice/weather" });
+      await page.getByRole("button", { name: "Close" }).click();
+
+      await bobRow.getByRole("button", { name: "Install" }).click();
+      const installRequest = await gateway.waitForRequest("skills.install");
+      expect(installRequest.params).toMatchObject({
+        source: "clawhub",
+        slug: "@bob/weather",
+      });
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/skills/clawhub-search.ts
+++ b/ui/src/lib/skills/clawhub-search.ts
@@ -3,12 +3,18 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 export type ClawHubSearchResult = {
   score: number;
   slug: string;
+  ownerHandle?: string | null;
   displayName: string;
   summary?: string;
   icon?: string | null;
   version?: string;
   updatedAt?: number;
 };
+
+export function clawHubSkillReference(result: Pick<ClawHubSearchResult, "slug" | "ownerHandle">) {
+  const ownerHandle = result.ownerHandle?.trim().toLowerCase();
+  return ownerHandle ? `@${ownerHandle}/${result.slug}` : result.slug;
+}
 
 export async function searchClawHub(
   client: GatewayBrowserClient,

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -70,7 +70,7 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
     clawhubSearchLoading: false,
     clawhubSearchError: "old error",
     clawhubDetail: null,
-    clawhubDetailSlug: null,
+    clawhubDetailRef: null,
     clawhubDetailLoading: false,
     clawhubDetailError: null,
     clawhubInstallMessage: null,
@@ -672,6 +672,7 @@ describe("searchClawHub", () => {
         {
           score: 0.95,
           slug: "github-new",
+          ownerHandle: "openclaw",
           displayName: "GitHub New",
           summary: "Fresh result",
           version: "2.0.0",
@@ -680,7 +681,7 @@ describe("searchClawHub", () => {
     });
 
     await expect(searchClawHub(state.client!, "github", controller.signal)).resolves.toEqual([
-      expect.objectContaining({ slug: "github-new" }),
+      expect.objectContaining({ slug: "github-new", ownerHandle: "openclaw" }),
     ]);
     expect(request).toHaveBeenCalledWith(
       "skills.search",
@@ -691,25 +692,31 @@ describe("searchClawHub", () => {
 });
 
 describe("loadClawHubDetail", () => {
-  it("ignores stale detail responses after slug changes", async () => {
+  it("keeps same-slug publishers distinct and ignores stale detail responses", async () => {
     const { state, request } = createState();
     const queue = createDeferredRequestQueue(request);
 
-    const firstPending = loadClawHubDetail(state, "github");
-    const secondPending = loadClawHubDetail(state, "gitlab");
+    const firstPending = loadClawHubDetail(state, "@alice/weather");
+    const secondPending = loadClawHubDetail(state, "@bob/weather");
 
     queue.resolveNext({
-      skill: { slug: "github", displayName: "GitHub", createdAt: 1, updatedAt: 2 },
+      skill: { slug: "weather", displayName: "Alice Weather", createdAt: 1, updatedAt: 2 },
+      owner: { handle: "alice" },
     });
     await firstPending;
 
     queue.resolveNext({
-      skill: { slug: "gitlab", displayName: "GitLab", createdAt: 3, updatedAt: 4 },
+      skill: { slug: "weather", displayName: "Bob Weather", createdAt: 3, updatedAt: 4 },
+      owner: { handle: "bob" },
     });
     await secondPending;
 
     expect(state.clawhubDetailLoading).toBe(false);
-    expect(state.clawhubDetail?.skill?.slug).toBe("gitlab");
+    expect(request.mock.calls).toEqual([
+      ["skills.detail", { slug: "@alice/weather" }],
+      ["skills.detail", { slug: "@bob/weather" }],
+    ]);
+    expect(state.clawhubDetail?.owner?.handle).toBe("bob");
   });
 
   it("ignores a same-client detail response from an older connection epoch", async () => {
@@ -1288,7 +1295,7 @@ describe("skill mutations", () => {
       text:
         "Review the ClawHub warning before installing this skill.\n\n" +
         "REVIEW REQUIRED - ClawHub found suspicious behavior.",
-      acknowledgeSlug: "github",
+      acknowledgeRef: "github",
       acknowledgeVersion: "1.2.3",
       acknowledgeLabel: "Acknowledge risk and install",
     });

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -91,13 +91,13 @@ type SkillsState = {
   clawhubSearchLoading: boolean;
   clawhubSearchError: string | null;
   clawhubDetail: ClawHubSkillDetail | null;
-  clawhubDetailSlug: string | null;
+  clawhubDetailRef: string | null;
   clawhubDetailLoading: boolean;
   clawhubDetailError: string | null;
   clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
-    acknowledgeSlug?: string;
+    acknowledgeRef?: string;
     acknowledgeVersion?: string;
     acknowledgeLabel?: string;
   } | null;
@@ -637,13 +637,13 @@ export async function installSkill(
   });
 }
 
-export async function loadClawHubDetail(state: SkillsState, slug: string) {
+export async function loadClawHubDetail(state: SkillsState, ref: string) {
   if (!state.client || !state.connected) {
     return;
   }
   const client = state.client;
   const agentScope = captureSkillsAgentScope(state);
-  state.clawhubDetailSlug = slug;
+  state.clawhubDetailRef = ref;
   state.clawhubDetailLoading = true;
   state.clawhubDetailError = null;
   state.clawhubDetail = null;
@@ -651,9 +651,9 @@ export async function loadClawHubDetail(state: SkillsState, slug: string) {
     () =>
       state.connected &&
       state.client === client &&
-      slug === state.clawhubDetailSlug &&
+      ref === state.clawhubDetailRef &&
       isSkillsAgentScopeCurrent(state, agentScope),
-    () => client.request<ClawHubSkillDetail>("skills.detail", { slug }),
+    () => client.request<ClawHubSkillDetail>("skills.detail", { slug: ref }),
     (res) => {
       state.clawhubDetail = res ?? null;
     },
@@ -667,7 +667,7 @@ export async function loadClawHubDetail(state: SkillsState, slug: string) {
 }
 
 export function closeClawHubDetail(state: SkillsState) {
-  state.clawhubDetailSlug = null;
+  state.clawhubDetailRef = null;
   state.clawhubDetail = null;
   state.clawhubDetailError = null;
   state.clawhubDetailLoading = false;
@@ -725,7 +725,7 @@ export async function installFromClawHub(
         text: needsAcknowledgement
           ? formatClawHubAcknowledgementMessage(trustDetails?.warning)
           : formatClawHubInstallMessage(formatUiError(err), trustDetails?.warning),
-        ...(needsAcknowledgement ? { acknowledgeSlug: slug } : {}),
+        ...(needsAcknowledgement ? { acknowledgeRef: slug } : {}),
         ...(needsAcknowledgement && trustDetails?.version
           ? { acknowledgeVersion: trustDetails.version }
           : {}),

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -73,13 +73,13 @@ class SkillsPage extends OpenClawLightDomElement {
   @state() skillsDetailTab: SkillDetailTab = "overview";
   @state() clawhubSearchQuery = "";
   @state() clawhubDetail: ClawHubSkillDetail | null = null;
-  @state() clawhubDetailSlug: string | null = null;
+  @state() clawhubDetailRef: string | null = null;
   @state() clawhubDetailLoading = false;
   @state() clawhubDetailError: string | null = null;
   @state() clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
-    acknowledgeSlug?: string;
+    acknowledgeRef?: string;
     acknowledgeVersion?: string;
     acknowledgeLabel?: string;
   } | null = null;
@@ -184,7 +184,7 @@ class SkillsPage extends OpenClawLightDomElement {
     this.skillsDetailTab = "overview";
     this.debouncedClawHubSearchQuery = "";
     this.clawhubDetail = null;
-    this.clawhubDetailSlug = null;
+    this.clawhubDetailRef = null;
     this.clawhubDetailLoading = false;
     this.clawhubDetailError = null;
     this.clawhubInstallMessage = null;
@@ -406,7 +406,7 @@ class SkillsPage extends OpenClawLightDomElement {
             clawhubSearchLoading: this.clawhubSearchLoading,
             clawhubSearchError: this.clawhubSearchError,
             clawhubDetail: this.clawhubDetail,
-            clawhubDetailSlug: this.clawhubDetailSlug,
+            clawhubDetailRef: this.clawhubDetailRef,
             clawhubDetailLoading: this.clawhubDetailLoading,
             clawhubDetailError: this.clawhubDetailError,
             clawhubInstallMessage: this.clawhubInstallMessage,

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -97,7 +97,7 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     clawhubSearchLoading: false,
     clawhubSearchError: null,
     clawhubDetail: null,
-    clawhubDetailSlug: null,
+    clawhubDetailRef: null,
     clawhubDetailLoading: false,
     clawhubDetailError: null,
     clawhubInstallMessage: null,
@@ -726,6 +726,7 @@ describe("renderSkills", () => {
             {
               score: 0.95,
               slug: "github",
+              ownerHandle: "openclaw",
               displayName: "GitHub",
               summary: "GitHub integration for OpenClaw",
               icon: `https://clawhub.ai/api/v1/skill-icons/${"a".repeat(64)}`,
@@ -750,7 +751,7 @@ describe("renderSkills", () => {
     expect(detailButton?.contains(installButton)).toBe(false);
     expect(resultItem?.querySelector(".settings-row__title")?.textContent?.trim()).toBe("GitHub");
     expect(resultItem?.querySelector(".settings-row__desc")?.textContent?.trim()).toBe(
-      "GitHub integration for OpenClaw",
+      "GitHub integration for OpenClaw · @openclaw/github",
     );
     expect(resultItem?.querySelector(".settings-row__value")?.textContent?.trim()).toBe("v1.2.3");
     expect(resultItem?.querySelector<HTMLImageElement>(".clawhub-skill-icon")?.src).toBe(
@@ -761,9 +762,9 @@ describe("renderSkills", () => {
     installButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(onClawHubDetailOpen).toHaveBeenCalledTimes(1);
-    expect(onClawHubDetailOpen).toHaveBeenCalledWith("github");
+    expect(onClawHubDetailOpen).toHaveBeenCalledWith("@openclaw/github");
     expect(onClawHubInstall).toHaveBeenCalledTimes(1);
-    expect(onClawHubInstall).toHaveBeenCalledWith("github");
+    expect(onClawHubInstall).toHaveBeenCalledWith("@openclaw/github");
 
     onClawHubInstall.mockClear();
     showModal.mockClear();
@@ -773,7 +774,7 @@ describe("renderSkills", () => {
         createProps({
           clawhubSearchError: "rate limited",
           clawhubInstallMessage: { kind: "success", text: "Installed github" },
-          clawhubDetailSlug: "github",
+          clawhubDetailRef: "@openclaw/github",
           clawhubDetail: {
             skill: {
               slug: "github",
@@ -822,7 +823,7 @@ describe("renderSkills", () => {
     detailInstallButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(onClawHubInstall).toHaveBeenCalledTimes(1);
-    expect(onClawHubInstall).toHaveBeenCalledWith("github");
+    expect(onClawHubInstall).toHaveBeenCalledWith("@openclaw/github");
   });
 
   it("renders ClawHub acknowledgement retry actions", async () => {
@@ -837,7 +838,7 @@ describe("renderSkills", () => {
           clawhubInstallMessage: {
             kind: "error",
             text: "REVIEW REQUIRED - ClawHub found suspicious behavior.",
-            acknowledgeSlug: "github",
+            acknowledgeRef: "github",
             acknowledgeVersion: "1.2.3",
           },
           onClawHubInstall,

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -34,7 +34,10 @@ import {
   isSkillAvailable,
   renderSkillStatusChips,
 } from "../../lib/skills-shared.ts";
-import type { ClawHubSearchResult } from "../../lib/skills/clawhub-search.ts";
+import {
+  clawHubSkillReference,
+  type ClawHubSearchResult,
+} from "../../lib/skills/clawhub-search.ts";
 import {
   clawhubVerdictKey,
   type ClawHubSkillSecurityVerdict,
@@ -81,13 +84,13 @@ type SkillsProps = {
   clawhubSearchLoading: boolean;
   clawhubSearchError: string | null;
   clawhubDetail: ClawHubSkillDetail | null;
-  clawhubDetailSlug: string | null;
+  clawhubDetailRef: string | null;
   clawhubDetailLoading: boolean;
   clawhubDetailError: string | null;
   clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
-    acknowledgeSlug?: string;
+    acknowledgeRef?: string;
     acknowledgeVersion?: string;
     acknowledgeLabel?: string;
   } | null;
@@ -286,7 +289,7 @@ export function renderSkills(props: SkillsProps) {
       { wide: true },
     )}
     ${detailSkill ? renderSkillDetail(detailSkill, props) : nothing}
-    ${props.clawhubDetailSlug ? renderClawHubDetailDialog(props) : nothing}
+    ${props.clawhubDetailRef ? renderClawHubDetailDialog(props) : nothing}
   `;
 }
 
@@ -421,7 +424,7 @@ function renderClawHubSection(props: SkillsProps) {
             >
               ${props.clawhubInstallMessage.text}
             </div>
-            ${props.clawhubInstallMessage.acknowledgeSlug
+            ${props.clawhubInstallMessage.acknowledgeRef
               ? html`<button
                   type="button"
                   class="btn btn--sm"
@@ -429,7 +432,7 @@ function renderClawHubSection(props: SkillsProps) {
                   ?disabled=${skillInstallLocked(props)}
                   @click=${() =>
                     props.onClawHubInstall(
-                      props.clawhubInstallMessage?.acknowledgeSlug ?? "",
+                      props.clawhubInstallMessage?.acknowledgeRef ?? "",
                       true,
                       props.clawhubInstallMessage?.acknowledgeVersion,
                     )}
@@ -455,13 +458,14 @@ function renderClawHubResults(props: SkillsProps) {
   return html`
     ${results.map((r) => {
       const iconUrl = safeExternalHref(r.icon ?? undefined);
+      const ref = clawHubSkillReference(r);
       return html`
         <div class="settings-row plugins-item plugins-item--clickable">
           <button
             type="button"
             class="settings-row__text plugins-item__detail-button clawhub-skill-result__button"
             aria-label=${t("skillsPage.openDetails", { name: r.displayName })}
-            @click=${() => props.onClawHubDetailOpen(r.slug)}
+            @click=${() => props.onClawHubDetailOpen(ref)}
           >
             ${iconUrl
               ? html`<img class="clawhub-skill-icon" src=${iconUrl} alt="" loading="lazy" />`
@@ -469,7 +473,7 @@ function renderClawHubResults(props: SkillsProps) {
             <span class="clawhub-skill-result__copy">
               <span class="settings-row__title">${r.displayName}</span>
               <span class="settings-row__desc">
-                ${r.summary ? clampText(r.summary, 120) : r.slug}
+                ${r.summary ? `${clampText(r.summary, 100)} · ${ref}` : ref}
               </span>
             </span>
           </button>
@@ -478,9 +482,9 @@ function renderClawHubResults(props: SkillsProps) {
             <button
               class="btn btn--sm"
               ?disabled=${skillInstallLocked(props)}
-              @click=${() => props.onClawHubInstall(r.slug)}
+              @click=${() => props.onClawHubInstall(ref)}
             >
-              ${activeClawHubMutation(props, r.slug)
+              ${activeClawHubMutation(props, ref)
                 ? t("skillsPage.installing")
                 : t("skillsPage.install")}
             </button>
@@ -499,7 +503,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
 
   return html`
     <openclaw-modal-dialog
-      label=${detail?.skill?.displayName ?? props.clawhubDetailSlug ?? t("skillsPage.notFound")}
+      label=${detail?.skill?.displayName ?? props.clawhubDetailRef ?? t("skillsPage.notFound")}
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onClawHubDetailClose}
     >
@@ -516,7 +520,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                 />`
               : nothing}
             <div class="md-preview-dialog__title">
-              ${detail?.skill?.displayName ?? props.clawhubDetailSlug}
+              ${detail?.skill?.displayName ?? props.clawhubDetailRef}
             </div>
           </div>
           <button class="btn btn--sm" @click=${props.onClawHubDetailClose}>
@@ -562,12 +566,12 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                       class="btn primary"
                       ?disabled=${skillInstallLocked(props)}
                       @click=${() => {
-                        if (props.clawhubDetailSlug) {
-                          props.onClawHubInstall(props.clawhubDetailSlug);
+                        if (props.clawhubDetailRef) {
+                          props.onClawHubInstall(props.clawhubDetailRef);
                         }
                       }}
                     >
-                      ${activeClawHubMutation(props, props.clawhubDetailSlug ?? "")
+                      ${activeClawHubMutation(props, props.clawhubDetailRef ?? "")
                         ? t("skillsPage.installing")
                         : t("skillsPage.installNamed", { name: detail.skill.displayName })}
                     </button>


### PR DESCRIPTION
Closes #117633

## What Problem This Solves

ClawHub allows different publishers to use the same skill slug. The skills clients kept only the bare slug after search, so selecting one publisher could open or install another publisher's skill, or fail with an ambiguous-slug response.

## Proposed fix

This PR keeps the selected ClawHub identity as `@owner/slug` from search through detail and install:

- `skills.search` exposes the publisher handle alongside the slug.
- Control UI, Apple, and Android derive one canonical `@owner/slug` reference and reuse it for selection, busy state, detail, and install.
- `skills.detail` parses that canonical reference and forwards the owner to ClawHub.
- Same-slug results visibly include their publisher-qualified reference.

The scope deliberately does not add `installRef` or `trustState` to the shared result. Source-qualified `skills.sh` detail remains a separate product/API decision tracked in the existing `skills.sh detail source-qualified` backlog item; `skills.detail` continues to reject that source instead of silently collapsing it to a bare slug.

The rebuild preserves @synthalorian's original diagnosis and patch direction; the replacement commit includes co-author credit.

## Evidence

Before the fix, the focused Gateway regression expected `{ slug: "weather", ownerHandle: "alice" }` but received `{ slug: "@Alice/weather" }`.

After the fix:

- Gateway unit tests: 11 passed.
- Control UI unit tests: 61 passed.
- Real Gateway E2E: two publishers share `weather`; Alice detail resolves Alice, and Bob install reaches the owner-qualified Bob endpoint. 2 passed in [Testbox](https://github.com/openclaw/openclaw/actions/runs/31549391729).
- Control UI Playwright: Alice detail and Bob install retain their respective canonical references. 1 passed in [Testbox](https://github.com/openclaw/openclaw/actions/runs/31550201983).
- Android `SkillManagementTest` and the Gateway protocol check passed in [Testbox](https://github.com/openclaw/openclaw/actions/runs/31549814205).
- Plugin SDK protocol baseline check passed.
- Focused autoreview found no actionable issue.

### Proposed Control UI — light

![Proposed ClawHub same-slug publisher results in light theme](https://github.com/user-attachments/assets/b79453e5-73f7-4189-9f30-d59e12d9067c)

### Proposed Control UI — dark

![Proposed ClawHub same-slug publisher results in dark theme](https://github.com/user-attachments/assets/5fefbbe1-d8ad-4d22-ba91-3543024e19bc)
