### PR TITLE
fix(talk): stop late audio after realtime session close

### DIFF
--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -452,6 +452,7 @@ describe("realtime voice bridge session runtime", () => {
     callbacks?.onAudio(Buffer.from("next-output"));
     callbacks?.onClose?.("completed");
     callbacks?.onClose?.("completed");
+    await expect(session.connect()).rejects.toThrow("Realtime voice connection is closed");
 
     expect(connect).toHaveBeenCalledTimes(1);
     expect(onReady).toHaveBeenCalledWith(session);
@@ -462,9 +463,10 @@ describe("realtime voice bridge session runtime", () => {
     expect(sendSinkAudio).toHaveBeenCalledExactlyOnceWith(Buffer.from("next-output"));
   });
 
-  it("does not report an old-generation tool failure after reconnect", async () => {
+  it("rejects reconnect and ignores tool failures after an established provider close", async () => {
     let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
     let rejectToolCall: ((error: Error) => void) | undefined;
+    const connect = vi.fn(async () => {});
     const onError = vi.fn();
     const provider: RealtimeVoiceProviderPlugin = {
       id: "test",
@@ -472,7 +474,7 @@ describe("realtime voice bridge session runtime", () => {
       isConfigured: () => true,
       createBridge: (request) => {
         callbacks = request;
-        return makeBridge();
+        return makeBridge({ connect });
       },
     };
     const session = createRealtimeVoiceBridgeSession({
@@ -493,10 +495,11 @@ describe("realtime voice bridge session runtime", () => {
       args: {},
     });
     callbacks?.onClose?.("error");
-    await session.connect();
+    await expect(session.connect()).rejects.toThrow("Realtime voice connection is closed");
     rejectToolCall?.(new Error("late tool callback failure"));
     await Promise.resolve();
 
+    expect(connect).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -443,6 +443,7 @@ describe("realtime voice bridge session runtime", () => {
 
     session.sendAudio(Buffer.from("closed-input"));
     callbacks?.onAudio(Buffer.from("closed-output"));
+    callbacks?.onClose?.("error");
     callbacks?.onReady?.();
     expect(onReady).not.toHaveBeenCalled();
 

--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -343,6 +343,70 @@ describe("realtime voice bridge session runtime", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("stops audio admission and closes the provider once after local close", () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const close = vi.fn();
+    const sendProviderAudio = vi.fn();
+    const sendSinkAudio = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        callbacks = request;
+        return makeBridge({ close, sendAudio: sendProviderAudio });
+      },
+    };
+    const session = createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: sendSinkAudio },
+    });
+
+    session.close();
+    session.close();
+    session.sendAudio(Buffer.from("late-input"));
+    callbacks?.onAudio(Buffer.from("late-output"));
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(sendProviderAudio).not.toHaveBeenCalled();
+    expect(sendSinkAudio).not.toHaveBeenCalled();
+  });
+
+  it("stops audio admission after the provider reports a terminal close", () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const close = vi.fn();
+    const sendProviderAudio = vi.fn();
+    const sendSinkAudio = vi.fn();
+    const onClose = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        callbacks = request;
+        return makeBridge({ close, sendAudio: sendProviderAudio });
+      },
+    };
+    const session = createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: sendSinkAudio },
+      onClose,
+    });
+
+    callbacks?.onClose?.("completed");
+    callbacks?.onClose?.("completed");
+    session.sendAudio(Buffer.from("late-input"));
+    callbacks?.onAudio(Buffer.from("late-output"));
+    session.close();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+    expect(sendProviderAudio).not.toHaveBeenCalled();
+    expect(sendSinkAudio).not.toHaveBeenCalled();
+  });
+
   it("forwards tool result continuation options and async acceptance to the provider bridge", () => {
     const acceptance = Promise.resolve();
     const submitToolResult = vi.fn(() => acceptance);

--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -343,37 +343,45 @@ describe("realtime voice bridge session runtime", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  it("stops audio admission and closes the provider once after local close", () => {
+  it("permanently closes once while preserving synchronous transcript flush", async () => {
     let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
-    const close = vi.fn();
+    const close = vi.fn(() => {
+      callbacks?.onTranscript?.("assistant", "final transcript", true);
+    });
+    const connect = vi.fn(async () => {});
     const sendProviderAudio = vi.fn();
     const sendSinkAudio = vi.fn();
+    const onTranscript = vi.fn();
     const provider: RealtimeVoiceProviderPlugin = {
       id: "test",
       label: "Test",
       isConfigured: () => true,
       createBridge: (request) => {
         callbacks = request;
-        return makeBridge({ close, sendAudio: sendProviderAudio });
+        return makeBridge({ close, connect, sendAudio: sendProviderAudio });
       },
     };
     const session = createRealtimeVoiceBridgeSession({
       provider,
       providerConfig: {},
       audioSink: { sendAudio: sendSinkAudio },
+      onTranscript,
     });
 
     session.close();
     session.close();
     session.sendAudio(Buffer.from("late-input"));
     callbacks?.onAudio(Buffer.from("late-output"));
+    await expect(session.connect()).rejects.toThrow("Realtime voice session is closed");
 
     expect(close).toHaveBeenCalledTimes(1);
+    expect(connect).not.toHaveBeenCalled();
     expect(sendProviderAudio).not.toHaveBeenCalled();
     expect(sendSinkAudio).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledExactlyOnceWith("assistant", "final transcript", true);
   });
 
-  it("stops audio admission after the provider reports a terminal close", () => {
+  it("stops audio admission after provider close and still closes the provider once", () => {
     let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
     const close = vi.fn();
     const sendProviderAudio = vi.fn();
@@ -400,11 +408,96 @@ describe("realtime voice bridge session runtime", () => {
     session.sendAudio(Buffer.from("late-input"));
     callbacks?.onAudio(Buffer.from("late-output"));
     session.close();
+    session.close();
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(close).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
     expect(sendProviderAudio).not.toHaveBeenCalled();
     expect(sendSinkAudio).not.toHaveBeenCalled();
+  });
+
+  it("reopens audio and close reporting for an explicit connection generation", async () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const connect = vi.fn(async () => {});
+    const sendProviderAudio = vi.fn();
+    const sendSinkAudio = vi.fn();
+    const onClose = vi.fn();
+    const onReady = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        callbacks = request;
+        request.onClose?.("error");
+        return makeBridge({ connect, sendAudio: sendProviderAudio });
+      },
+    };
+    const session = createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: sendSinkAudio },
+      onClose,
+      onReady,
+    });
+
+    session.sendAudio(Buffer.from("closed-input"));
+    callbacks?.onAudio(Buffer.from("closed-output"));
+    callbacks?.onReady?.();
+    expect(onReady).not.toHaveBeenCalled();
+
+    await session.connect();
+    callbacks?.onReady?.();
+    session.sendAudio(Buffer.from("next-input"));
+    callbacks?.onAudio(Buffer.from("next-output"));
+    callbacks?.onClose?.("completed");
+    callbacks?.onClose?.("completed");
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(session);
+    expect(onClose).toHaveBeenNthCalledWith(1, "error");
+    expect(onClose).toHaveBeenNthCalledWith(2, "completed");
+    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(sendProviderAudio).toHaveBeenCalledExactlyOnceWith(Buffer.from("next-input"));
+    expect(sendSinkAudio).toHaveBeenCalledExactlyOnceWith(Buffer.from("next-output"));
+  });
+
+  it("does not report an old-generation tool failure after reconnect", async () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    let rejectToolCall: ((error: Error) => void) | undefined;
+    const onError = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        callbacks = request;
+        return makeBridge();
+      },
+    };
+    const session = createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+      onToolCall: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectToolCall = reject;
+        }),
+      onError,
+    });
+
+    callbacks?.onToolCall?.({
+      itemId: "item-1",
+      callId: "call-1",
+      name: "lookup",
+      args: {},
+    });
+    callbacks?.onClose?.("error");
+    await session.connect();
+    rejectToolCall?.(new Error("late tool callback failure"));
+    await Promise.resolve();
+
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("forwards tool result continuation options and async acceptance to the provider bridge", () => {

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -87,11 +87,11 @@ export function createRealtimeVoiceBridgeSession(
   params: RealtimeVoiceBridgeSessionParams,
 ): RealtimeVoiceBridgeSession {
   const bridgeRef: { current?: RealtimeVoiceBridge } = {};
-  // Local disposal owns provider cleanup; provider terminal state remains reconnectable.
-  // The generation scopes audio admission and terminal reporting across explicit reconnects.
+  // Local disposal owns provider cleanup. Only a terminal callback fired before bridge
+  // adoption may reopen; adopted bridges own reconnects and stale-event fencing internally.
   let phase: RealtimeVoiceSessionPhase = "admitting";
-  let connectionGeneration = 0;
-  let closeReportedGeneration: number | undefined;
+  let terminalBeforeBridgeAdoption = false;
+  let closeReported = false;
   const isAdmitting = () => phase === "admitting";
   const requireBridge = () => {
     if (!bridgeRef.current) {
@@ -119,8 +119,12 @@ export function createRealtimeVoiceBridgeSession(
         return Promise.reject(new Error("Realtime voice session is closed"));
       }
       if (phase === "provider-terminal") {
+        if (!terminalBeforeBridgeAdoption) {
+          return Promise.reject(new Error("Realtime voice connection is closed"));
+        }
+        terminalBeforeBridgeAdoption = false;
         phase = "admitting";
-        connectionGeneration += 1;
+        closeReported = false;
       }
       return requireBridge().connect();
     },
@@ -144,10 +148,10 @@ export function createRealtimeVoiceBridgeSession(
   // Session inactivity is the shared admission boundary for both audio directions.
   // Provider and transport callbacks may still race after close, but cannot retain new audio.
   const canSendAudio = () => isAdmitting() && (params.audioSink.isOpen?.() ?? true);
-  const reportCallbackError = (error: unknown, expectedGeneration: number) => {
+  const reportCallbackError = (error: unknown) => {
     // Async tool handlers can settle after the provider closes. Once inactive, no
     // callback may report stale failures into the next session lifecycle.
-    if (!isAdmitting() || connectionGeneration !== expectedGeneration) {
+    if (!isAdmitting()) {
       return;
     }
     try {
@@ -195,16 +199,13 @@ export function createRealtimeVoiceBridgeSession(
       if (!bridgeRef.current || !isAdmitting()) {
         return;
       }
-      const eventGeneration = connectionGeneration;
       try {
         const pending = params.onToolCall?.(event, session);
         if (pending) {
-          void pending.catch((error: unknown) => {
-            reportCallbackError(error, eventGeneration);
-          });
+          void pending.catch(reportCallbackError);
         }
       } catch (error) {
-        reportCallbackError(error, eventGeneration);
+        reportCallbackError(error);
       }
     },
     onReady: () => {
@@ -218,13 +219,14 @@ export function createRealtimeVoiceBridgeSession(
     },
     onError: params.onError,
     onClose: (reason) => {
+      terminalBeforeBridgeAdoption = !bridgeRef.current;
       if (phase !== "disposed") {
         phase = "provider-terminal";
       }
-      if (closeReportedGeneration === connectionGeneration) {
+      if (closeReported) {
         return;
       }
-      closeReportedGeneration = connectionGeneration;
+      closeReported = true;
       params.onClose?.(reason);
     },
   });

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -219,7 +219,9 @@ export function createRealtimeVoiceBridgeSession(
     },
     onError: params.onError,
     onClose: (reason) => {
-      terminalBeforeBridgeAdoption = !bridgeRef.current;
+      if (!bridgeRef.current) {
+        terminalBeforeBridgeAdoption = true;
+      }
       if (phase !== "disposed") {
         phase = "provider-terminal";
       }

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -86,6 +86,7 @@ export function createRealtimeVoiceBridgeSession(
 ): RealtimeVoiceBridgeSession {
   const bridgeRef: { current?: RealtimeVoiceBridge } = {};
   let isActive = true;
+  let closeReported = false;
   const requireBridge = () => {
     if (!bridgeRef.current) {
       throw new Error("Realtime voice bridge is not ready");
@@ -100,12 +101,19 @@ export function createRealtimeVoiceBridgeSession(
     },
     acknowledgeMark: (markName) => requireBridge().acknowledgeMark(markName),
     close: () => {
+      if (!isActive) {
+        return;
+      }
       const bridge = requireBridge();
       isActive = false;
       bridge.close();
     },
     connect: () => requireBridge().connect(),
-    sendAudio: (audio) => requireBridge().sendAudio(audio),
+    sendAudio: (audio) => {
+      if (isActive) {
+        requireBridge().sendAudio(audio);
+      }
+    },
     sendUserMessage: (text) => requireBridge().sendUserMessage?.(text),
     handleBargeIn: (options) => requireBridge().handleBargeIn?.(options),
     setMediaTimestamp: (ts) => requireBridge().setMediaTimestamp(ts),
@@ -118,7 +126,9 @@ export function createRealtimeVoiceBridgeSession(
     },
     triggerGreeting: (instructions) => requireBridge().triggerGreeting?.(instructions),
   };
-  const canSendAudio = () => params.audioSink.isOpen?.() ?? true;
+  // Session inactivity is the shared admission boundary for both audio directions.
+  // Provider and transport callbacks may still race after close, but cannot retain new audio.
+  const canSendAudio = () => isActive && (params.audioSink.isOpen?.() ?? true);
   const reportCallbackError = (error: unknown) => {
     // Async tool handlers can settle after the provider closes. Once inactive, no
     // callback may report stale failures into the next session lifecycle.
@@ -191,6 +201,10 @@ export function createRealtimeVoiceBridgeSession(
     onError: params.onError,
     onClose: (reason) => {
       isActive = false;
+      if (closeReported) {
+        return;
+      }
+      closeReported = true;
       params.onClose?.(reason);
     },
   });

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -78,6 +78,8 @@ export type RealtimeVoiceBridgeSessionParams = {
   onClose?: (reason: RealtimeVoiceCloseReason) => void;
 };
 
+type RealtimeVoiceSessionPhase = "admitting" | "provider-terminal" | "disposed";
+
 /**
  * Creates a realtime voice bridge session and wires provider events to the configured audio sink.
  */
@@ -85,8 +87,12 @@ export function createRealtimeVoiceBridgeSession(
   params: RealtimeVoiceBridgeSessionParams,
 ): RealtimeVoiceBridgeSession {
   const bridgeRef: { current?: RealtimeVoiceBridge } = {};
-  let isActive = true;
-  let closeReported = false;
+  // Local disposal owns provider cleanup; provider terminal state remains reconnectable.
+  // The generation scopes audio admission and terminal reporting across explicit reconnects.
+  let phase: RealtimeVoiceSessionPhase = "admitting";
+  let connectionGeneration = 0;
+  let closeReportedGeneration: number | undefined;
+  const isAdmitting = () => phase === "admitting";
   const requireBridge = () => {
     if (!bridgeRef.current) {
       throw new Error("Realtime voice bridge is not ready");
@@ -101,16 +107,25 @@ export function createRealtimeVoiceBridgeSession(
     },
     acknowledgeMark: (markName) => requireBridge().acknowledgeMark(markName),
     close: () => {
-      if (!isActive) {
+      if (phase === "disposed") {
         return;
       }
       const bridge = requireBridge();
-      isActive = false;
+      phase = "disposed";
       bridge.close();
     },
-    connect: () => requireBridge().connect(),
+    connect: () => {
+      if (phase === "disposed") {
+        return Promise.reject(new Error("Realtime voice session is closed"));
+      }
+      if (phase === "provider-terminal") {
+        phase = "admitting";
+        connectionGeneration += 1;
+      }
+      return requireBridge().connect();
+    },
     sendAudio: (audio) => {
-      if (isActive) {
+      if (isAdmitting()) {
         requireBridge().sendAudio(audio);
       }
     },
@@ -128,11 +143,11 @@ export function createRealtimeVoiceBridgeSession(
   };
   // Session inactivity is the shared admission boundary for both audio directions.
   // Provider and transport callbacks may still race after close, but cannot retain new audio.
-  const canSendAudio = () => isActive && (params.audioSink.isOpen?.() ?? true);
-  const reportCallbackError = (error: unknown) => {
+  const canSendAudio = () => isAdmitting() && (params.audioSink.isOpen?.() ?? true);
+  const reportCallbackError = (error: unknown, expectedGeneration: number) => {
     // Async tool handlers can settle after the provider closes. Once inactive, no
     // callback may report stale failures into the next session lifecycle.
-    if (!isActive) {
+    if (!isAdmitting() || connectionGeneration !== expectedGeneration) {
       return;
     }
     try {
@@ -177,20 +192,23 @@ export function createRealtimeVoiceBridgeSession(
     onTranscript: params.onTranscript,
     onEvent: params.onEvent,
     onToolCall: (event) => {
-      if (!bridgeRef.current || !isActive) {
+      if (!bridgeRef.current || !isAdmitting()) {
         return;
       }
+      const eventGeneration = connectionGeneration;
       try {
         const pending = params.onToolCall?.(event, session);
         if (pending) {
-          void pending.catch(reportCallbackError);
+          void pending.catch((error: unknown) => {
+            reportCallbackError(error, eventGeneration);
+          });
         }
       } catch (error) {
-        reportCallbackError(error);
+        reportCallbackError(error, eventGeneration);
       }
     },
     onReady: () => {
-      if (!bridgeRef.current) {
+      if (!bridgeRef.current || !isAdmitting()) {
         return;
       }
       if (params.triggerGreetingOnReady) {
@@ -200,11 +218,13 @@ export function createRealtimeVoiceBridgeSession(
     },
     onError: params.onError,
     onClose: (reason) => {
-      isActive = false;
-      if (closeReported) {
+      if (phase !== "disposed") {
+        phase = "provider-terminal";
+      }
+      if (closeReportedGeneration === connectionGeneration) {
         return;
       }
-      closeReported = true;
+      closeReportedGeneration = connectionGeneration;
       params.onClose?.(reason);
     },
   });


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where realtime Talk sessions could continue admitting late input or output audio after provider or local closure, retaining audio in provider or transport queues and allowing repeated close notifications.

## Why This Change Was Made

The shared Talk bridge now uses an explicit `admitting` / `provider-terminal` / `disposed` lifecycle. Local close remains idempotent and owns provider cleanup, while reconnect and stale-socket fencing stay provider-owned; only the existing synchronous pre-adoption terminal callback may proceed to its initial connection.

No provider, config, environment-variable, protocol, or plugin SDK surface changes.

## User Impact

Closed realtime Talk sessions stop accepting audio immediately, repeated close is harmless, and provider cleanup still runs exactly once. Existing OpenAI, Google, and xAI reconnect behavior remains owned by their adapters.

## Evidence

- Focused Talk session/runtime and harness tests: 23/23 passed.
- Gateway synchronous-terminal tests: 6/6 passed across gateway core/server/client.
- Voice-call synchronous-create-close regression: 1/1 passed.
- Provider stale-event fencing: OpenAI 2/2, Google 1/1, xAI 1/1.
- Exact-head changed gate: passed in 5m38.868s.
  - https://github.com/openclaw/openclaw/actions/runs/30722440779
- Exact-head live OpenAI smoke using the hydrated Testbox key: passed in 14.353s.
  - `gpt-realtime-2.1` connected.
  - Sent 192000 audio bytes across 200 chunks; received 43200 output audio bytes.
  - Transcript received, response completed, and post-close late audio remained 0 bytes.
  - Browser WebRTC applied the remote description and reached `connected`.
- Clean-path P1 autoreview: no P0/P1 findings, patch correctness 0.93.
- TruffleHog: clean.
