### PR TITLE
test(ci): stabilize plugin prerelease async waits

### DIFF
--- a/extensions/mistral/realtime-transcription-provider.test.ts
+++ b/extensions/mistral/realtime-transcription-provider.test.ts
@@ -378,7 +378,11 @@ describe("buildMistralRealtimeTranscriptionProvider", () => {
       { type: "transcription.segment", text: "late segment", start: 0, end: 1 },
       { type: "transcription.done", text: "late done" },
     ]);
-    const onError = vi.fn();
+    let resolveError: (() => void) | undefined;
+    const errorReceived = new Promise<void>((resolve) => {
+      resolveError = resolve;
+    });
+    const onError = vi.fn(() => resolveError?.());
     const onTranscript = vi.fn();
     let lastPartialLength = 0;
     let partialCalls = 0;
@@ -393,6 +397,7 @@ describe("buildMistralRealtimeTranscriptionProvider", () => {
     });
 
     await session.connect();
+    await errorReceived;
     await vi.waitFor(() => {
       expect(onError).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1944,7 +1944,9 @@ describe("RealtimeCallHandler path routing", () => {
         const oldClosed = waitForClose(oldWs);
         callbacks[0]?.onClose?.("error");
         await oldClosed;
-        expect(oldCloseBridge).toHaveBeenCalledOnce();
+        await waitForRealtimeTest(() => {
+          expect(oldCloseBridge).toHaveBeenCalledOnce();
+        });
         expect(replacementCloseBridge).not.toHaveBeenCalled();
         expect(hangupCall).not.toHaveBeenCalled();
         expect(


### PR DESCRIPTION
## Summary

- await server-side bridge cleanup before asserting replaced voice-call session closure
- await the actual Mistral overflow callback before polling terminal session state
- remove two resource-sensitive flakes observed in full release plugin prerelease validation

## Proof

- `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs extensions/mistral/realtime-transcription-provider.test.ts --reporter=dot`
- 10 bounded repetitions of each focused file after the fix
- autoreview clean (`gpt-5.6-sol`, high, confidence 0.99)

Release evidence: https://github.com/openclaw/openclaw/actions/runs/30721878666
