### PR TITLE
fix(feishu): avoid 400s on topic reaction hydration

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2837,6 +2837,75 @@ describe("handleFeishuMessage command authorization", () => {
     expectResolvedRouteCall(1, { kind: "group", id: "oc-group:topic:omt_native_topic" });
   });
 
+  it.each(
+    [
+      {
+        action: "created",
+        scope: "group_topic",
+        expectedPeerId: "oc-group:topic:omt_native_reaction",
+      },
+      {
+        action: "deleted",
+        scope: "group_topic",
+        expectedPeerId: "oc-group:topic:omt_native_reaction",
+      },
+      {
+        action: "created",
+        scope: "group_topic_sender",
+        expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
+      },
+      {
+        action: "deleted",
+        scope: "group_topic_sender",
+        expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
+      },
+    ] as const,
+  )(
+    "hydrates topic threads from the real message ID for synthetic $action reactions in $scope sessions",
+    async ({ action, scope, expectedPeerId }) => {
+      mockShouldComputeCommandAuthorized.mockReturnValue(false);
+      const reactedMessageId = `om_reacted_${action}_${scope}`;
+      mockGetMessageFeishu.mockResolvedValueOnce({
+        messageId: reactedMessageId,
+        chatId: "oc-group",
+        chatType: "topic_group",
+        content: "reacted message",
+        contentType: "text",
+        threadId: "omt_native_reaction",
+      });
+
+      await dispatchMessage({
+        cfg: createFeishuTestConfig({
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: scope,
+              replyInThread: "enabled",
+            },
+          },
+        }),
+        event: createFeishuTestEvent({
+          messageId: `${reactedMessageId}:reaction:THUMBSUP:synthetic`,
+          senderOpenId: "ou-reaction-actor",
+          chatId: "oc-group",
+          chatType: "topic_group",
+          text:
+            action === "deleted"
+              ? `[removed reaction THUMBSUP from message ${reactedMessageId}]`
+              : `[reacted with THUMBSUP to message ${reactedMessageId}]`,
+          message: {
+            reply_target_message_id: reactedMessageId,
+            typing_target_message_id: reactedMessageId,
+          },
+        }),
+      });
+
+      const getMessageRequest = mockCallArg<{ messageId?: string }>(mockGetMessageFeishu, 0, 0);
+      expect(getMessageRequest.messageId).toBe(reactedMessageId);
+      expectResolvedRouteCall(0, { kind: "group", id: expectedPeerId });
+    },
+  );
+
   it.each([
     {
       name: "replies to the topic root when handling a message inside an existing topic",

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2837,30 +2837,28 @@ describe("handleFeishuMessage command authorization", () => {
     expectResolvedRouteCall(1, { kind: "group", id: "oc-group:topic:omt_native_topic" });
   });
 
-  it.each(
-    [
-      {
-        action: "created",
-        scope: "group_topic",
-        expectedPeerId: "oc-group:topic:omt_native_reaction",
-      },
-      {
-        action: "deleted",
-        scope: "group_topic",
-        expectedPeerId: "oc-group:topic:omt_native_reaction",
-      },
-      {
-        action: "created",
-        scope: "group_topic_sender",
-        expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
-      },
-      {
-        action: "deleted",
-        scope: "group_topic_sender",
-        expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
-      },
-    ] as const,
-  )(
+  it.each([
+    {
+      action: "created",
+      scope: "group_topic",
+      expectedPeerId: "oc-group:topic:omt_native_reaction",
+    },
+    {
+      action: "deleted",
+      scope: "group_topic",
+      expectedPeerId: "oc-group:topic:omt_native_reaction",
+    },
+    {
+      action: "created",
+      scope: "group_topic_sender",
+      expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
+    },
+    {
+      action: "deleted",
+      scope: "group_topic_sender",
+      expectedPeerId: "oc-group:topic:omt_native_reaction:sender:ou-reaction-actor",
+    },
+  ] as const)(
     "hydrates topic threads from the real message ID for synthetic $action reactions in $scope sessions",
     async ({ action, scope, expectedPeerId }) => {
       mockShouldComputeCommandAuthorized.mockReturnValue(false);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -517,10 +517,10 @@ export async function handleFeishuMessage(params: {
     !effectiveThreadId &&
     isFeishuTopicSessionScope(groupSessionScope ?? "group")
   ) {
+    // Synthetic turns keep a local dedupe ID in messageId; their explicit reply target is
+    // the real Feishu message ID that topic hydration can send back to the provider.
+    const topicHydrationMessageId = ctx.replyTargetMessageId ?? ctx.messageId;
     try {
-      // Synthetic turns keep a local dedupe ID in messageId; their explicit reply target is
-      // the real Feishu message ID that topic hydration can send back to the provider.
-      const topicHydrationMessageId = ctx.replyTargetMessageId ?? ctx.messageId;
       const messageInfo = await getMessageFeishu({
         cfg,
         accountId: account.accountId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -518,22 +518,25 @@ export async function handleFeishuMessage(params: {
     isFeishuTopicSessionScope(groupSessionScope ?? "group")
   ) {
     try {
+      // Synthetic turns keep a local dedupe ID in messageId; their explicit reply target is
+      // the real Feishu message ID that topic hydration can send back to the provider.
+      const topicHydrationMessageId = ctx.replyTargetMessageId ?? ctx.messageId;
       const messageInfo = await getMessageFeishu({
         cfg,
         accountId: account.accountId,
-        messageId: ctx.messageId,
+        messageId: topicHydrationMessageId,
       });
       const hydratedThreadId = messageInfo?.threadId?.trim();
       if (hydratedThreadId) {
         ctx = { ...ctx, threadId: hydratedThreadId };
         effectiveThreadId = hydratedThreadId;
         log(
-          `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId}`,
+          `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${topicHydrationMessageId}`,
         );
       }
     } catch (err) {
       log(
-        `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
+        `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${topicHydrationMessageId}: ${String(err)}`,
       );
     }
   }


### PR DESCRIPTION
Fixes #34528

## What Problem This Solves

Fixes an issue where Feishu reactions in topic-scoped group sessions could still trigger an HTTP 400 when the reaction event did not already carry a `thread_id`. The topic hydration lookup was using OpenClaw's local synthetic reaction ID instead of the real Feishu message ID.

## Why This Change Was Made

Reaction turns intentionally keep a unique synthetic ID for local deduplication and session routing. This change keeps that internal ID intact, while the one topic-hydration API call now consumes the explicit original reply target already carried by the reaction event; ordinary messages continue to use their own message ID.

## User Impact

Feishu reaction-created and reaction-deleted events can stay in the correct topic for both `group_topic` and `group_topic_sender` session scopes without sending a `:reaction:`-suffixed ID to Feishu's message lookup API.

## Evidence

- Source trace: reaction normalization preserves the provider-issued message ID in `reply_target_message_id` while retaining the synthetic `:reaction:` ID only for local deduplication; `getMessageFeishu` forwards its argument directly to the Feishu `im.message.get` path parameter.
- Focused trusted Testbox proof on the patch-identical tree later committed as `86321dc602c`: `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts -t "hydrates topic threads from the real message ID" --reporter=verbose` passed all four created/deleted × `group_topic`/`group_topic_sender` cases. Each case asserts the lookup receives the original reacted message ID and the resolved route uses the hydrated native topic. Targeted `oxfmt --check` also passed.
- Exact-head hosted CI for `86321dc602c` passed in [run 30723728551](https://github.com/openclaw/openclaw/actions/runs/30723728551), including `check-prod-types`, `check-test-types`, `check-lint`, `check-additional-extension-package-boundary`, changed Node shards, and `build-artifacts`.
- Xhigh Codex autoreview and TruffleHog completed clean on the full branch diff.

