### PR TITLE
fix(voice-call): preserve transcripts across bridge replacement

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1993,6 +1993,178 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("restores the prior transcript owner when replacement bridge creation fails", async () => {
+    const callbacks: RealtimeBridgeRequest[] = [];
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks.push(request);
+      if (callbacks.length === 1) {
+        return makeBridge();
+      }
+      request.onTranscript?.("user", "Failed ", false);
+      throw new Error("replacement bridge failed");
+    });
+    const processEvent = vi.fn();
+    const sharedCallSid = "CA-transcript-rollback";
+    const call = makeCallRecord(sharedCallSid);
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => call),
+        processEvent,
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const oldServer = await startRealtimeServer(handler);
+    let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
+    let oldWs: WebSocket | undefined;
+
+    try {
+      oldWs = await connectWs(oldServer.url);
+      oldWs.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-transcript-rollback-old", callSid: sharedCallSid },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(callbacks).toHaveLength(1);
+      });
+      callbacks[0]?.onTranscript?.("user", "Old ", false);
+
+      replacementServer = await startRealtimeServer(handler);
+      const replacementWs = await connectWs(replacementServer.url);
+      try {
+        replacementWs.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-transcript-rollback-new", callSid: sharedCallSid },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalledTimes(2);
+        });
+
+        callbacks[0]?.onTranscript?.("user", "caller", true);
+        await waitForRealtimeTest(() => {
+          expect(
+            processEvent.mock.calls
+              .map(([event]) => event as NormalizedEvent)
+              .filter((event) => event.type === "call.speech")
+              .map((event) => (event.type === "call.speech" ? event.transcript : undefined)),
+          ).toEqual(["Old caller"]);
+        });
+      } finally {
+        if (
+          replacementWs.readyState !== WebSocket.CLOSED &&
+          replacementWs.readyState !== WebSocket.CLOSING
+        ) {
+          replacementWs.close();
+        }
+      }
+    } finally {
+      if (
+        oldWs &&
+        oldWs.readyState !== WebSocket.CLOSED &&
+        oldWs.readyState !== WebSocket.CLOSING
+      ) {
+        oldWs.close();
+      }
+      await replacementServer?.close();
+      await oldServer.close();
+    }
+  });
+
+  it("cleans provisional transcript state when initial bridge creation fails", async () => {
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      request.onTranscript?.("user", "orphaned", false);
+      throw new Error("initial bridge failed");
+    });
+    const call = makeCallRecord("CA-transcript-initial-failure");
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => call),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: {
+            streamSid: "MZ-transcript-initial-failure",
+            callSid: "CA-transcript-initial-failure",
+          },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(createBridge).toHaveBeenCalledOnce();
+      });
+      expect(
+        (
+          handler as unknown as {
+            userTranscriptStatesByCallId: Map<string, unknown>;
+          }
+        ).userTranscriptStatesByCallId.size,
+      ).toBe(0);
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close();
+      }
+      await server.close();
+    }
+  });
+
+  it("keeps provisional transcript ownership across synchronous provider close", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      request.onClose?.("completed");
+      return makeBridge();
+    });
+    const processEvent = vi.fn();
+    const call = makeCallRecord("CA-transcript-synchronous-close");
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => call),
+        processEvent,
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: {
+            streamSid: "MZ-transcript-synchronous-close",
+            callSid: "CA-transcript-synchronous-close",
+          },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(createBridge).toHaveBeenCalledOnce();
+      });
+      callbacks?.onTranscript?.("user", "Still listening", true);
+      await waitForRealtimeTest(() => {
+        expect(processEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            transcript: "Still listening",
+            type: "call.speech",
+          }),
+        );
+      });
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close();
+      }
+      await server.close();
+    }
+  });
+
   it("does not share a native consult with a replacement realtime session", async () => {
     const callbacks: RealtimeBridgeRequest[] = [];
     const oldSubmitToolResult = vi.fn();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1884,7 +1884,7 @@ describe("RealtimeCallHandler path routing", () => {
         throw new Error("unexpected replacement bridge");
       }
       if (callbacks.length === 2) {
-        request.onTranscript?.("user", "Fresh", false);
+        request.onTranscript?.("user", "Fresh ", false);
       }
       return bridge;
     });
@@ -1965,7 +1965,7 @@ describe("RealtimeCallHandler path routing", () => {
               .map(([event]) => event as NormalizedEvent)
               .filter((event) => event.type === "call.speech")
               .map((event) => (event.type === "call.speech" ? event.transcript : undefined)),
-          ).toEqual(["Freshcaller"]);
+          ).toEqual(["Fresh caller"]);
         });
         expect(
           processEvent.mock.calls

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1869,7 +1869,7 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("ignores late continuity reset and close from a replaced bridge", async () => {
+  it("isolates replacement transcripts and late old bridge events", async () => {
     const callbacks: RealtimeBridgeRequest[] = [];
     const oldCloseBridge = vi.fn();
     const replacementCloseBridge = vi.fn();
@@ -1882,6 +1882,9 @@ describe("RealtimeCallHandler path routing", () => {
       const bridge = bridges[callbacks.length - 1];
       if (!bridge) {
         throw new Error("unexpected replacement bridge");
+      }
+      if (callbacks.length === 2) {
+        request.onTranscript?.("user", "Fresh", false);
       }
       return bridge;
     });
@@ -1912,6 +1915,7 @@ describe("RealtimeCallHandler path routing", () => {
       await waitForRealtimeTest(() => {
         expect(callbacks).toHaveLength(1);
       });
+      callbacks[0]?.onTranscript?.("user", "Old ", false);
 
       replacementServer = await startRealtimeServer(handler);
       const replacementWs = await connectWs(replacementServer.url);
@@ -1929,7 +1933,6 @@ describe("RealtimeCallHandler path routing", () => {
           expect(callbacks).toHaveLength(2);
         });
 
-        callbacks[1]?.onTranscript?.("user", "Fresh ", false);
         callbacks[0]?.onTranscript?.("user", "stale partial", false);
         callbacks[0]?.onTranscript?.("user", "stale final", true);
         callbacks[0]?.onTranscript?.("assistant", "stale assistant", true);
@@ -1962,7 +1965,7 @@ describe("RealtimeCallHandler path routing", () => {
               .map(([event]) => event as NormalizedEvent)
               .filter((event) => event.type === "call.speech")
               .map((event) => (event.type === "call.speech" ? event.transcript : undefined)),
-          ).toEqual(["Fresh caller"]);
+          ).toEqual(["Freshcaller"]);
         });
         expect(
           processEvent.mock.calls

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -292,6 +292,14 @@ type NativeConsultState = {
 
 type NativeConsultOutcome = { kind: "completed"; result: unknown } | { kind: "cancelled" };
 
+type UserTranscriptState = {
+  partial?: string;
+  rawPartial?: string;
+  partialUpdatedAt?: number;
+  recentFinal?: string;
+  recentFinalTimer?: ReturnType<typeof setTimeout>;
+};
+
 type TelephonyCloseReason = "completed" | "error";
 
 async function waitForNativeConsult(state: NativeConsultState): Promise<NativeConsultOutcome> {
@@ -344,14 +352,7 @@ export class RealtimeCallHandler {
       close: (reason: TelephonyCloseReason) => void;
     }
   >();
-  private readonly partialUserTranscriptsByCallId = new Map<string, string>();
-  private readonly rawPartialUserTranscriptsByCallId = new Map<string, string>();
-  private readonly partialUserTranscriptUpdatedAtByCallId = new Map<string, number>();
-  private readonly recentFinalUserTranscriptsByCallId = new Map<string, string>();
-  private readonly recentFinalUserTranscriptTimersByCallId = new Map<
-    string,
-    ReturnType<typeof setTimeout>
-  >();
+  private readonly userTranscriptStatesByCallId = new Map<string, UserTranscriptState>();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
@@ -767,6 +768,10 @@ export class RealtimeCallHandler {
         : undefined;
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
+    // Adopt transcript ownership before bridge creation so synchronous callbacks
+    // belong to this session while late callbacks from replaced sessions are ignored.
+    const userTranscriptOwner: UserTranscriptState = {};
+    this.adoptUserTranscriptOwner(callId, userTranscriptOwner);
     const session = harness.createBridge({
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
@@ -801,7 +806,10 @@ export class RealtimeCallHandler {
       },
       onTranscript: (role, text, isFinal) => {
         const owner = nativeConsultOwner.current;
-        if (owner && !this.isActiveBridgeOwner(callId, owner)) {
+        if (
+          !this.getUserTranscriptState(callId, userTranscriptOwner) ||
+          (owner && !this.isActiveBridgeOwner(callId, owner))
+        ) {
           return;
         }
         const turnId = harness.ensureTurn();
@@ -830,7 +838,10 @@ export class RealtimeCallHandler {
         }
         if (!isFinal) {
           if (role === "user" && text.trim()) {
-            const transcript = this.recordPartialUserTranscript(callId, text);
+            const transcript = this.recordPartialUserTranscript(callId, userTranscriptOwner, text);
+            if (!transcript) {
+              return;
+            }
             console.log(
               `[voice-call] realtime input transcript callId=${callId} providerCallId=${callSid} final=false chars=${text.trim().length} aggregateChars=${transcript.length}`,
             );
@@ -838,13 +849,17 @@ export class RealtimeCallHandler {
           return;
         }
         if (role === "user") {
+          const state = this.getUserTranscriptState(callId, userTranscriptOwner);
+          if (!state) {
+            return;
+          }
           const transcript = resolveFinalTranscriptText({
-            partial: this.partialUserTranscriptsByCallId.get(callId),
-            rawPartial: this.rawPartialUserTranscriptsByCallId.get(callId),
+            partial: state.partial,
+            rawPartial: state.rawPartial,
             final: text,
           });
-          this.clearPartialUserTranscript(callId);
-          this.setRecentFinalUserTranscript(callId, transcript);
+          this.clearPartialUserTranscript(callId, userTranscriptOwner);
+          this.setRecentFinalUserTranscript(callId, userTranscriptOwner, transcript);
           console.log(
             `[voice-call] realtime input transcript callId=${callId} providerCallId=${callSid} final=true chars=${text.trim().length} aggregateChars=${transcript.length}`,
           );
@@ -864,6 +879,7 @@ export class RealtimeCallHandler {
             callId,
             callSid,
             transcript,
+            userTranscriptOwner,
             clearAudio: () => {
               const clearedBytes = audioPacer.clearAudio();
               console.log(
@@ -902,6 +918,7 @@ export class RealtimeCallHandler {
           toolEvent.args,
           turnId,
           harness,
+          userTranscriptOwner,
         );
       },
       onEvent: (event) => {
@@ -911,7 +928,7 @@ export class RealtimeCallHandler {
           const turnId = harness.talk.activeTurnId;
           const owner = nativeConsultOwner.current;
           if (owner && this.isActiveBridgeOwner(callId, owner)) {
-            this.clearUserTranscriptState(callId);
+            this.resetUserTranscriptState(callId, userTranscriptOwner);
             this.resetConsultSessionForContinuity(callId, owner);
           }
           harness.flushOutput(() => {
@@ -977,9 +994,7 @@ export class RealtimeCallHandler {
           this.clearActiveBridgeMappings(callId, callSid, owner);
           this.cancelConsultSession(callId, owner);
         }
-        if (ownsCallState) {
-          this.clearUserTranscriptState(callId);
-        }
+        this.clearUserTranscriptState(callId, userTranscriptOwner);
         harness.finishOutputAudio(reason);
         harness.emit({
           type: "session.closed",
@@ -1057,12 +1072,9 @@ export class RealtimeCallHandler {
       try {
         closeSession();
       } finally {
-        const ownsCallState = this.isActiveBridgeOwner(callId, session);
         this.clearActiveBridgeMappings(callId, callSid, session);
         this.cancelConsultSession(callId, session);
-        if (ownsCallState) {
-          this.clearUserTranscriptState(callId);
-        }
+        this.clearUserTranscriptState(callId, userTranscriptOwner);
         harness.close();
         audioPacer.close();
       }
@@ -1081,49 +1093,103 @@ export class RealtimeCallHandler {
     return session;
   }
 
-  private recordPartialUserTranscript(callId: string, text: string): string {
-    const current = this.partialUserTranscriptsByCallId.get(callId);
-    const next = limitPartialUserTranscript(appendTranscriptText(current, text));
-    const raw = limitPartialUserTranscript(
-      `${this.rawPartialUserTranscriptsByCallId.get(callId) ?? ""}${text}`,
-    );
-    this.partialUserTranscriptsByCallId.set(callId, next);
-    this.rawPartialUserTranscriptsByCallId.set(callId, raw);
-    this.partialUserTranscriptUpdatedAtByCallId.set(callId, Date.now());
+  private adoptUserTranscriptOwner(callId: string, owner: UserTranscriptState): void {
+    const previous = this.userTranscriptStatesByCallId.get(callId);
+    if (previous?.recentFinalTimer) {
+      clearTimeout(previous.recentFinalTimer);
+    }
+    this.userTranscriptStatesByCallId.set(callId, owner);
+  }
+
+  private getUserTranscriptState(
+    callId: string,
+    owner: UserTranscriptState,
+  ): UserTranscriptState | undefined {
+    const state = this.userTranscriptStatesByCallId.get(callId);
+    return state === owner ? state : undefined;
+  }
+
+  private recordPartialUserTranscript(
+    callId: string,
+    owner: UserTranscriptState,
+    text: string,
+  ): string | undefined {
+    const state = this.getUserTranscriptState(callId, owner);
+    if (!state) {
+      return undefined;
+    }
+    const next = limitPartialUserTranscript(appendTranscriptText(state.partial, text));
+    const raw = limitPartialUserTranscript(`${state.rawPartial ?? ""}${text}`);
+    state.partial = next;
+    state.rawPartial = raw;
+    state.partialUpdatedAt = Date.now();
     return next;
   }
 
-  private clearPartialUserTranscript(callId: string): void {
-    this.partialUserTranscriptsByCallId.delete(callId);
-    this.rawPartialUserTranscriptsByCallId.delete(callId);
-    this.partialUserTranscriptUpdatedAtByCallId.delete(callId);
+  private clearPartialUserTranscript(callId: string, owner: UserTranscriptState): void {
+    const state = this.getUserTranscriptState(callId, owner);
+    if (!state) {
+      return;
+    }
+    state.partial = undefined;
+    state.rawPartial = undefined;
+    state.partialUpdatedAt = undefined;
   }
 
-  private setRecentFinalUserTranscript(callId: string, text: string): void {
-    this.clearRecentFinalUserTranscript(callId);
-    this.recentFinalUserTranscriptsByCallId.set(callId, text);
+  private setRecentFinalUserTranscript(
+    callId: string,
+    owner: UserTranscriptState,
+    text: string,
+  ): void {
+    const state = this.getUserTranscriptState(callId, owner);
+    if (!state) {
+      return;
+    }
+    this.clearRecentFinalUserTranscript(callId, owner);
+    state.recentFinal = text;
     const timer = setTimeout(() => {
-      if (this.recentFinalUserTranscriptsByCallId.get(callId) === text) {
-        this.recentFinalUserTranscriptsByCallId.delete(callId);
+      if (this.userTranscriptStatesByCallId.get(callId) !== state) {
+        return;
       }
-      this.recentFinalUserTranscriptTimersByCallId.delete(callId);
+      if (state.recentFinal === text) {
+        state.recentFinal = undefined;
+      }
+      if (state.recentFinalTimer === timer) {
+        state.recentFinalTimer = undefined;
+      }
     }, RECENT_FINAL_USER_TRANSCRIPT_TTL_MS);
     timer.unref?.();
-    this.recentFinalUserTranscriptTimersByCallId.set(callId, timer);
+    state.recentFinalTimer = timer;
   }
 
-  private clearRecentFinalUserTranscript(callId: string): void {
-    const timer = this.recentFinalUserTranscriptTimersByCallId.get(callId);
-    if (timer) {
-      clearTimeout(timer);
-      this.recentFinalUserTranscriptTimersByCallId.delete(callId);
+  private clearRecentFinalUserTranscript(callId: string, owner: UserTranscriptState): void {
+    const state = this.getUserTranscriptState(callId, owner);
+    if (!state) {
+      return;
     }
-    this.recentFinalUserTranscriptsByCallId.delete(callId);
+    if (state.recentFinalTimer) {
+      clearTimeout(state.recentFinalTimer);
+      state.recentFinalTimer = undefined;
+    }
+    state.recentFinal = undefined;
   }
 
-  private clearUserTranscriptState(callId: string): void {
-    this.clearPartialUserTranscript(callId);
-    this.clearRecentFinalUserTranscript(callId);
+  private resetUserTranscriptState(callId: string, owner: UserTranscriptState): void {
+    this.clearPartialUserTranscript(callId, owner);
+    this.clearRecentFinalUserTranscript(callId, owner);
+  }
+
+  private clearUserTranscriptState(callId: string, owner: UserTranscriptState): void {
+    const state = this.getUserTranscriptState(callId, owner);
+    if (!state) {
+      return;
+    }
+    if (state.recentFinalTimer) {
+      clearTimeout(state.recentFinalTimer);
+    }
+    if (this.userTranscriptStatesByCallId.get(callId) === state) {
+      this.userTranscriptStatesByCallId.delete(callId);
+    }
   }
 
   private cancelNativeConsult(callId: string, owner: ActiveRealtimeVoiceBridge): void {
@@ -1198,48 +1264,58 @@ export class RealtimeCallHandler {
     }
   }
 
-  private resolveUserTranscriptContext(callId: string): string | undefined {
-    return (
-      this.partialUserTranscriptsByCallId.get(callId) ??
-      this.recentFinalUserTranscriptsByCallId.get(callId)
-    );
+  private resolveUserTranscriptContext(
+    callId: string,
+    owner: UserTranscriptState,
+  ): string | undefined {
+    const state = this.getUserTranscriptState(callId, owner);
+    return state?.partial ?? state?.recentFinal;
   }
 
-  private consumePartialUserTranscript(callId: string, consumed: string | undefined): void {
+  private consumePartialUserTranscript(
+    callId: string,
+    owner: UserTranscriptState,
+    consumed: string | undefined,
+  ): void {
     const text = consumed?.trim();
     if (!text) {
       return;
     }
-    const current = this.partialUserTranscriptsByCallId.get(callId);
+    const state = this.getUserTranscriptState(callId, owner);
+    const current = state?.partial;
     if (!current) {
       return;
     }
     if (current === text) {
-      this.clearPartialUserTranscript(callId);
+      this.clearPartialUserTranscript(callId, owner);
       return;
     }
     if (current.toLowerCase().startsWith(text.toLowerCase())) {
       const remaining = current.slice(text.length).trimStart();
       if (remaining) {
-        this.partialUserTranscriptsByCallId.set(callId, remaining);
-        this.rawPartialUserTranscriptsByCallId.set(callId, remaining);
+        state.partial = remaining;
+        state.rawPartial = remaining;
       } else {
-        this.clearPartialUserTranscript(callId);
+        this.clearPartialUserTranscript(callId, owner);
       }
     }
-    const recent = this.recentFinalUserTranscriptsByCallId.get(callId);
+    const recent = state.recentFinal;
     if (!recent) {
       return;
     }
     if (recent === text || recent.toLowerCase().startsWith(text.toLowerCase())) {
-      this.clearRecentFinalUserTranscript(callId);
+      this.clearRecentFinalUserTranscript(callId, owner);
     }
   }
 
-  private async waitForConsultTranscriptSettle(callId: string, startedAt: number): Promise<void> {
+  private async waitForConsultTranscriptSettle(
+    callId: string,
+    owner: UserTranscriptState,
+    startedAt: number,
+  ): Promise<void> {
     const deadline = startedAt + CONSULT_TRANSCRIPT_SETTLE_MAX_MS;
     while (true) {
-      const updatedAt = this.partialUserTranscriptUpdatedAtByCallId.get(callId);
+      const updatedAt = this.getUserTranscriptState(callId, owner)?.partialUpdatedAt;
       if (!updatedAt) {
         return;
       }
@@ -1273,6 +1349,7 @@ export class RealtimeCallHandler {
     callId: string;
     callSid: string;
     transcript: string;
+    userTranscriptOwner: UserTranscriptState;
     clearAudio: () => void;
   }): void {
     if (
@@ -1321,6 +1398,7 @@ export class RealtimeCallHandler {
     callId: string;
     callSid: string;
     handle: RealtimeVoiceForcedConsultHandle;
+    userTranscriptOwner: UserTranscriptState;
     clearAudio: () => void;
     handler: ToolHandlerFn;
   }): Promise<void> {
@@ -1374,7 +1452,11 @@ export class RealtimeCallHandler {
       console.log(
         `[voice-call] realtime forced agent consult completed callId=${params.callId} providerCallId=${params.callSid} elapsedMs=${Date.now() - startedAt}`,
       );
-      this.consumePartialUserTranscript(params.callId, params.handle.question);
+      this.consumePartialUserTranscript(
+        params.callId,
+        params.userTranscriptOwner,
+        params.handle.question,
+      );
     } catch (error) {
       console.warn(
         `[voice-call] realtime forced agent consult failed callId=${params.callId} providerCallId=${params.callSid} error=${formatErrorMessage(error)}`,
@@ -1488,6 +1570,7 @@ export class RealtimeCallHandler {
     args: unknown,
     turnId: string,
     harness: RealtimeVoiceSessionHarness,
+    userTranscriptOwner: UserTranscriptState,
   ): Promise<void> {
     const handler = this.toolHandlers.get(name);
     const startedAt = Date.now();
@@ -1617,14 +1700,14 @@ export class RealtimeCallHandler {
             return undefined;
           }
           await Promise.race([
-            this.waitForConsultTranscriptSettle(callId, startedAt),
+            this.waitForConsultTranscriptSettle(callId, userTranscriptOwner, startedAt),
             state.cancellation,
           ]);
           if (state.cancelled) {
             return undefined;
           }
           const context = {
-            partialUserTranscript: this.resolveUserTranscriptContext(callId),
+            partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
           };
           state.partialUserTranscript = context.partialUserTranscript;
           const handlerArgs = withFallbackConsultQuestion(args, context.partialUserTranscript);
@@ -1659,7 +1742,11 @@ export class RealtimeCallHandler {
         );
         await submitFinalToolResult(result);
         if (status === "ok") {
-          this.consumePartialUserTranscript(callId, state.partialUserTranscript);
+          this.consumePartialUserTranscript(
+            callId,
+            userTranscriptOwner,
+            state.partialUserTranscript,
+          );
         }
       } finally {
         if (this.nativeConsultsInFlightByCallId.get(callId) === state) {
@@ -1672,7 +1759,7 @@ export class RealtimeCallHandler {
       `[voice-call] realtime tool call executing callId=${callId} tool=${name} hasHandler=${Boolean(handler)}`,
     );
     const context = {
-      partialUserTranscript: this.resolveUserTranscriptContext(callId),
+      partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
     };
     const handlerArgs =
       name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME
@@ -1696,7 +1783,7 @@ export class RealtimeCallHandler {
     );
     await submitFinalToolResult(result);
     if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME && status === "ok") {
-      this.consumePartialUserTranscript(callId, context.partialUserTranscript);
+      this.consumePartialUserTranscript(callId, userTranscriptOwner, context.partialUserTranscript);
     }
   }
 }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -300,6 +300,11 @@ type UserTranscriptState = {
   recentFinalTimer?: ReturnType<typeof setTimeout>;
 };
 
+type UserTranscriptOwnerAdoption = {
+  owner: UserTranscriptState;
+  previous?: UserTranscriptState;
+};
+
 type TelephonyCloseReason = "completed" | "error";
 
 async function waitForNativeConsult(state: NativeConsultState): Promise<NativeConsultOutcome> {
@@ -768,11 +773,11 @@ export class RealtimeCallHandler {
         : undefined;
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
-    // Adopt transcript ownership before bridge creation so synchronous callbacks
-    // belong to this session while late callbacks from replaced sessions are ignored.
-    const userTranscriptOwner: UserTranscriptState = {};
-    this.adoptUserTranscriptOwner(callId, userTranscriptOwner);
-    const session = harness.createBridge({
+    // Provisional ownership accepts callbacks fired during createBridge. Commit
+    // retires the predecessor only after creation succeeds; failure restores it.
+    const userTranscriptAdoption = this.beginUserTranscriptOwnerAdoption(callId);
+    const userTranscriptOwner = userTranscriptAdoption.owner;
+    const bridgeParams: Parameters<typeof harness.createBridge>[0] = {
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
       providerConfig: this.providerConfig,
@@ -994,7 +999,9 @@ export class RealtimeCallHandler {
           this.clearActiveBridgeMappings(callId, callSid, owner);
           this.cancelConsultSession(callId, owner);
         }
-        this.clearUserTranscriptState(callId, userTranscriptOwner);
+        if (ownsCallState) {
+          this.clearUserTranscriptState(callId, userTranscriptOwner);
+        }
         harness.finishOutputAudio(reason);
         harness.emit({
           type: "session.closed",
@@ -1021,7 +1028,15 @@ export class RealtimeCallHandler {
             );
           });
       },
-    });
+    };
+    let session: ActiveRealtimeVoiceBridge;
+    try {
+      session = harness.createBridge(bridgeParams);
+    } catch (error) {
+      this.rollbackUserTranscriptOwnerAdoption(callId, userTranscriptAdoption);
+      throw error;
+    }
+    this.commitUserTranscriptOwnerAdoption(callId, userTranscriptAdoption);
     nativeConsultOwner.current = session;
     providerHandlesInputAudioBargeIn =
       session.bridge.handlesInputAudioBargeIn ?? providerHandlesInputAudioBargeIn;
@@ -1093,12 +1108,44 @@ export class RealtimeCallHandler {
     return session;
   }
 
-  private adoptUserTranscriptOwner(callId: string, owner: UserTranscriptState): void {
-    const previous = this.userTranscriptStatesByCallId.get(callId);
-    if (previous?.recentFinalTimer) {
-      clearTimeout(previous.recentFinalTimer);
+  private beginUserTranscriptOwnerAdoption(callId: string): UserTranscriptOwnerAdoption {
+    const adoption = {
+      owner: {},
+      previous: this.userTranscriptStatesByCallId.get(callId),
+    } satisfies UserTranscriptOwnerAdoption;
+    this.userTranscriptStatesByCallId.set(callId, adoption.owner);
+    return adoption;
+  }
+
+  private commitUserTranscriptOwnerAdoption(
+    callId: string,
+    adoption: UserTranscriptOwnerAdoption,
+  ): void {
+    if (this.userTranscriptStatesByCallId.get(callId) !== adoption.owner) {
+      return;
     }
-    this.userTranscriptStatesByCallId.set(callId, owner);
+    if (adoption.previous?.recentFinalTimer) {
+      clearTimeout(adoption.previous.recentFinalTimer);
+      adoption.previous.recentFinalTimer = undefined;
+    }
+  }
+
+  private rollbackUserTranscriptOwnerAdoption(
+    callId: string,
+    adoption: UserTranscriptOwnerAdoption,
+  ): void {
+    if (this.userTranscriptStatesByCallId.get(callId) !== adoption.owner) {
+      return;
+    }
+    if (adoption.owner.recentFinalTimer) {
+      clearTimeout(adoption.owner.recentFinalTimer);
+      adoption.owner.recentFinalTimer = undefined;
+    }
+    if (adoption.previous) {
+      this.userTranscriptStatesByCallId.set(callId, adoption.previous);
+      return;
+    }
+    this.userTranscriptStatesByCallId.delete(callId);
   }
 
   private getUserTranscriptState(


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where a Voice Call realtime bridge replacement could lose or mix caller transcript state when the previous bridge closed late, the replacement closed during construction, or replacement creation failed.

## Why This Change Was Made

Transcript state is now owned by the bridge generation that created it. Replacement adoption is transactional: the previous owner remains authoritative until the new bridge is created successfully, and provisional state is rolled back on failure.

The change is limited to the Voice Call webhook owner and its direct tests. It adds no provider, config, environment-variable, protocol, or SDK surface.

## User Impact

Voice Call tool context and persisted caller transcripts remain attached to the active realtime bridge during reconnect or replacement. Late callbacks from an old bridge can no longer erase or contaminate the replacement transcript.

## Evidence

- Exact head: `f478b906f64110b367d9f3f06d27a9a68e4bf495`
- Four rebased commits; all signatures verified. The test-only stale-close wait commit dropped because the identical fix is already on current `main` via #117684.
- Focused Voice Call tests: 38/38 passed.
- P1 autoreview at production head `659804b37348f6c953ad0293165dae5b123f51c7`: no accepted or actionable P0/P1 findings; correctness 0.93. The current head adds only the timing-safe test assertion.
- TruffleHog: clean.
- Changed gate and hosted CI passed on production head `659804b37348f6c953ad0293165dae5b123f51c7`; the synchronized exact head is running hosted CI now.
- QA Lab `voice-call-cli-rpc-agent-tool`: passed with one scenario and one verdict; exercised the Voice Call CLI/RPC/tool/webhook/media-stream path with mock telephony/provider and no phone mutation.
- Live OpenAI realtime talkback: three synthesized audio cycles passed on `gpt-realtime-2.1`; final user and assistant transcripts, output audio, response completion, zero late audio, and connected browser WebRTC were observed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30722691248



- ClawSweeper Rank-up move disposition: synchronized onto current `main` `2f06ed30d8b1a9ffe9493030e4d553ee4093c745`; exact merge head `f478b906f64110b367d9f3f06d27a9a68e4bf495` passed 38/38 focused Voice Call lifecycle tests, including replacement ownership, failed construction rollback, stale callbacks, and owner-scoped cleanup.
