### PR TITLE
fix(ui): remeasure chat rows after panel resize

### DIFF
--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -1,0 +1,185 @@
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-panel-reflow");
+const chatSessionKey = "agent:main:main";
+
+const longReply =
+  "Additional runtime work may make an earlier benchmark misleading. " +
+  "The current implementation must preserve the visible conversation while panels resize the transcript. ";
+
+const historyMessageCount = 4;
+const historyMessages = Array.from({ length: historyMessageCount }, (_, index) => ({
+  id: `message-${index}`,
+  role: index % 2 === 0 ? "user" : "assistant",
+  content: [
+    {
+      type: "text",
+      text: `${index + 1}. ${longReply.repeat(3)}\n\n${longReply.repeat(2)}`,
+    },
+  ],
+  timestamp: Date.now() - (historyMessageCount - index) * 1_000,
+}));
+
+async function expectMessagesNotToOverlap(page: import("playwright").Page): Promise<void> {
+  await expect
+    .poll(() =>
+      page.locator(".chat-group").evaluateAll((groups) => {
+        const visible = groups
+          .map((group, index) => {
+            const rect = group.getBoundingClientRect();
+            return { bottom: rect.bottom, index, top: rect.top };
+          })
+          .filter((rect) => rect.bottom > 0 && rect.top < window.innerHeight)
+          .sort((a, b) => a.top - b.top);
+        return visible.slice(1).flatMap((current, index) => {
+          const previous = visible[index];
+          if (!previous || current.top >= previous.bottom - 1) {
+            return [];
+          }
+          return [
+            {
+              current: current.index,
+              overlap: previous.bottom - current.top,
+              previous: previous.index,
+            },
+          ];
+        });
+      }),
+    )
+    .toEqual([]);
+}
+
+let server: ControlUiE2eServer;
+let browser: Browser;
+
+describeControlUiE2e("chat transcript panel reflow", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps transcript rows separate across background-task, file, and diff panel toggles", async () => {
+    await rm(artifactDir, { force: true, recursive: true });
+    await mkdir(artifactDir, { recursive: true });
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    try {
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+        historyMessages,
+        methodResponses: {
+          "artifacts.list": { artifacts: [] },
+          "sessions.diff": {
+            additions: 1,
+            baseRef: "main",
+            branch: "feature/reflow",
+            deletions: 0,
+            files: [
+              {
+                additions: 1,
+                deletions: 0,
+                patch: [
+                  "diff --git a/src/app.ts b/src/app.ts",
+                  "--- a/src/app.ts",
+                  "+++ b/src/app.ts",
+                  "@@ -1 +1,2 @@",
+                  " current line",
+                  "+new line",
+                  "",
+                ].join("\n"),
+                path: "src/app.ts",
+                status: "modified",
+              },
+            ],
+            root: "/workspace",
+            sessionKey: "main",
+          },
+          "sessions.files.list": {
+            browser: { entries: [], path: "" },
+            files: [
+              {
+                kind: "modified",
+                missing: false,
+                name: "AGENTS.md",
+                path: "/workspace/AGENTS.md",
+                size: 2048,
+              },
+            ],
+            root: "/workspace",
+            sessionKey: "main",
+          },
+          "tasks.list": {
+            tasks: [
+              {
+                agentId: "main",
+                createdAt: Date.now() - 5_000,
+                id: "task-reflow",
+                kind: "subagent",
+                ownerKey: chatSessionKey,
+                progressSummary: "Checking transcript layout",
+                runtime: "subagent",
+                startedAt: Date.now() - 4_000,
+                status: "running",
+                taskId: "task-reflow",
+                title: "Reflow proof",
+                updatedAt: Date.now(),
+              },
+            ],
+          },
+        },
+      });
+
+      const response = await page.goto(`${server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
+      await page.locator(".chat-thread").evaluate((element) => {
+        element.scrollTop = Math.max(0, element.scrollHeight / 2);
+      });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "00-closed.png") });
+
+      await page.getByRole("button", { name: "Show background tasks" }).click();
+      await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "01-background-tasks.png") });
+
+      await page.getByRole("button", { name: "Show thread files", exact: true }).click();
+      await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "02-thread-files.png") });
+
+      await page.locator(".chat-session-diff-toggle").first().click();
+      await page.locator(".session-diff").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "03-thread-changes.png") });
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -44,7 +44,7 @@ async function expectMessagesNotToOverlap(page: import("playwright").Page): Prom
             return { bottom: rect.bottom, index, top: rect.top };
           })
           .filter((rect) => rect.bottom > 0 && rect.top < window.innerHeight)
-          .sort((a, b) => a.top - b.top);
+          .toSorted((a, b) => a.top - b.top);
         return visible.slice(1).flatMap((current, index) => {
           const previous = visible[index];
           if (!previous || current.top >= previous.bottom - 1) {

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -365,7 +365,7 @@ describe("chat transcript row measurement", () => {
     expect(observedElements.size).toBe(0);
   });
 
-  it("updates rendered row offsets from freshly wrapped heights after a width change", async () => {
+  it("updates rendered row offsets from freshly wrapped heights while scrolling", async () => {
     const transcript = createTestTranscript();
     const container = document.body.appendChild(document.createElement("div"));
     const props = threadProps("pane-width-remeasure");
@@ -380,9 +380,20 @@ describe("chat transcript row measurement", () => {
     await renderTranscript();
     expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(100px)");
 
-    measuredRowHeight = 180;
     const scrollElement = container.querySelector<HTMLElement>(".chat-thread");
     expect(scrollElement).not.toBeNull();
+    scrollElement!.scrollTop = 40;
+    scrollElement!.dispatchEvent(new Event("scroll"));
+    const virtualizer = (
+      transcript as unknown as {
+        sessionVirtualizer: {
+          virtualizerController: { getVirtualizer: () => { isScrolling: boolean } };
+        };
+      }
+    ).sessionVirtualizer.virtualizerController.getVirtualizer();
+    expect(virtualizer.isScrolling).toBe(true);
+
+    measuredRowHeight = 180;
     for (const observer of resizeObservers) {
       if (scrollElement && observer.observes(scrollElement)) {
         observer.emit(640, 600);

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -26,6 +26,7 @@ import {
 
 const observedElements = new Set<Element>();
 const resizeObservers = new Set<RecordingResizeObserver>();
+let measuredRowHeight = 100;
 
 class RecordingResizeObserver implements ResizeObserver {
   private readonly targets = new Set<Element>();
@@ -58,6 +59,10 @@ class RecordingResizeObserver implements ResizeObserver {
     if (entries.length > 0) {
       this.callback(entries, this);
     }
+  }
+
+  observes(target: Element): boolean {
+    return this.targets.has(target);
   }
 }
 
@@ -107,11 +112,14 @@ describe("chat transcript row measurement", () => {
   beforeEach(() => {
     observedElements.clear();
     resizeObservers.clear();
+    measuredRowHeight = 100;
     vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
     // jsdom reports 0x0 rects and offsetHeight 0; keep the virtualizer
     // viewport and measured row sizes non-zero so re-renders keep producing
     // virtual rows.
-    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(100);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+      () => measuredRowHeight,
+    );
     vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
       x: 0,
       y: 0,
@@ -355,6 +363,35 @@ describe("chat transcript row measurement", () => {
     expect(hostA?.measureRowRefs.size).toBe(0);
     transcript.hostDisconnected();
     expect(observedElements.size).toBe(0);
+  });
+
+  it("updates rendered row offsets from freshly wrapped heights after a width change", async () => {
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = threadProps("pane-width-remeasure");
+    const renderTranscript = async () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+      await flushDeferredRowPrune();
+    };
+
+    await renderTranscript();
+    transcript.hostConnected();
+    await renderTranscript();
+    expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(100px)");
+
+    measuredRowHeight = 180;
+    const scrollElement = container.querySelector<HTMLElement>(".chat-thread");
+    expect(scrollElement).not.toBeNull();
+    for (const observer of resizeObservers) {
+      if (scrollElement && observer.observes(scrollElement)) {
+        observer.emit(640, 600);
+      }
+    }
+    await renderTranscript();
+
+    expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(180px)");
+    transcript.hostDisconnected();
   });
 
   it("rebinds guarded transcript images when the gateway rotates its auth token", async () => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,7 +1,11 @@
 // Chat-owned message thread presentation and thread-local interaction state.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { VirtualizerController } from "@tanstack/lit-virtual";
-import { defaultRangeExtractor, observeElementRect } from "@tanstack/virtual-core";
+import {
+  defaultRangeExtractor,
+  measureElement as measureVirtualElement,
+  observeElementRect,
+} from "@tanstack/virtual-core";
 import {
   html,
   nothing,
@@ -264,12 +268,37 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   };
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private pruneDetachedRowsQueued = false;
+  private pendingRowMeasureFrame: number | null = null;
+  private measureRow(element: HTMLElement): void {
+    const instance = this.virtualizerController.getVirtualizer();
+    instance.measureElement(element);
+    const index = instance.indexFromElement(element);
+    // TanStack skips synchronous measurement while the user is scrolling.
+    // Pane toggles can replace or resize rows inside that window, so seed the
+    // cache directly after registering the ResizeObserver.
+    instance.resizeItem(index, instance.options.measureElement(element, undefined, instance));
+  }
+  private measureConnectedRows(): void {
+    for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(".chat-virtual-row") ??
+      []) {
+      this.measureRow(row);
+    }
+  }
+  private queueConnectedRowMeasure(): void {
+    if (this.pendingRowMeasureFrame !== null) {
+      return;
+    }
+    this.pendingRowMeasureFrame = requestAnimationFrame(() => {
+      this.pendingRowMeasureFrame = null;
+      this.measureConnectedRows();
+    });
+  }
   private measureRowRefFor(key: string): (element?: Element) => void {
     let callback = this.measureRowRefs.get(key);
     if (!callback) {
       callback = (element?: Element) => {
         if (element instanceof HTMLElement) {
-          this.virtualizerController.getVirtualizer().measureElement(element);
+          this.measureRow(element);
           return;
         }
         // Re-stamps (e.g. the chat<->dashboard face switch) re-invoke each
@@ -309,6 +338,13 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       getScrollElement: () => this.scrollElement,
       estimateSize: () => CHAT_TRANSCRIPT_ESTIMATED_ROW_PX,
       getItemKey: () => "",
+      // Ref callbacks and explicit pane-width resets need the current wrapped
+      // height immediately. TanStack's default no-entry path reuses its cache,
+      // which still contains the pre-reset estimate and can overlap rows.
+      measureElement: (element, entry, instance) =>
+        entry
+          ? measureVirtualElement(element, entry, instance)
+          : element[instance.options.horizontal ? "offsetWidth" : "offsetHeight"],
       initialRect: initialTranscriptRect(host),
       initialOffset: initialOffset ?? Number.MAX_SAFE_INTEGER,
       scrollMargin: initialTranscriptScrollMargin(host),
@@ -322,13 +358,11 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
           callback(rect);
           if (widthChanged) {
             // Cached offscreen sizes belong to the old wrapping width. Reset
-            // them and synchronously seed connected rows to avoid stale overlap.
+            // them, seed current rows, then repeat after any same-commit
+            // re-stamp has attached and completed layout.
             instance.measure();
-            for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(
-              ".chat-virtual-row",
-            ) ?? []) {
-              instance.measureElement(row);
-            }
+            this.measureConnectedRows();
+            this.queueConnectedRowMeasure();
           }
         }),
       rangeExtractor: (range) => {
@@ -399,6 +433,10 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   }
 
   disconnect(): void {
+    if (this.pendingRowMeasureFrame !== null) {
+      cancelAnimationFrame(this.pendingRowMeasureFrame);
+      this.pendingRowMeasureFrame = null;
+    }
     if (this.pendingScrollFrame !== null) {
       cancelAnimationFrame(this.pendingScrollFrame);
       this.pendingScrollFrame = null;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,11 +1,7 @@
 // Chat-owned message thread presentation and thread-local interaction state.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { VirtualizerController } from "@tanstack/lit-virtual";
-import {
-  defaultRangeExtractor,
-  measureElement as measureVirtualElement,
-  observeElementRect,
-} from "@tanstack/virtual-core";
+import { defaultRangeExtractor, observeElementRect } from "@tanstack/virtual-core";
 import {
   html,
   nothing,
@@ -269,19 +265,16 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private pruneDetachedRowsQueued = false;
   private pendingRowMeasureFrame: number | null = null;
-  private measureRow(element: HTMLElement): void {
-    const instance = this.virtualizerController.getVirtualizer();
-    instance.measureElement(element);
-    const index = instance.indexFromElement(element);
-    // TanStack skips synchronous measurement while the user is scrolling.
-    // Pane toggles can replace or resize rows inside that window, so seed the
-    // cache directly after registering the ResizeObserver.
-    instance.resizeItem(index, instance.options.measureElement(element, undefined, instance));
-  }
   private measureConnectedRows(): void {
+    // Only width invalidation owns forced DOM reads. Ordinary row refs stay on
+    // TanStack's observer path so resizeItem cannot perturb scroll restoration.
+    const instance = this.virtualizerController.getVirtualizer();
     for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(".chat-virtual-row") ??
       []) {
-      this.measureRow(row);
+      instance.resizeItem(
+        instance.indexFromElement(row),
+        row[instance.options.horizontal ? "offsetWidth" : "offsetHeight"],
+      );
     }
   }
   private queueConnectedRowMeasure(): void {
@@ -298,7 +291,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     if (!callback) {
       callback = (element?: Element) => {
         if (element instanceof HTMLElement) {
-          this.measureRow(element);
+          this.virtualizerController.getVirtualizer().measureElement(element);
           return;
         }
         // Re-stamps (e.g. the chat<->dashboard face switch) re-invoke each
@@ -338,13 +331,6 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       getScrollElement: () => this.scrollElement,
       estimateSize: () => CHAT_TRANSCRIPT_ESTIMATED_ROW_PX,
       getItemKey: () => "",
-      // Ref callbacks and explicit pane-width resets need the current wrapped
-      // height immediately. TanStack's default no-entry path reuses its cache,
-      // which still contains the pre-reset estimate and can overlap rows.
-      measureElement: (element, entry, instance) =>
-        entry
-          ? measureVirtualElement(element, entry, instance)
-          : element[instance.options.horizontal ? "offsetWidth" : "offsetHeight"],
       initialRect: initialTranscriptRect(host),
       initialOffset: initialOffset ?? Number.MAX_SAFE_INTEGER,
       scrollMargin: initialTranscriptScrollMargin(host),


### PR DESCRIPTION
## Summary

- reset cached transcript measurements when the chat width changes
- synchronously seed connected rows through TanStack Virtual's canonical `resizeItem` path, then repeat once on the next animation frame for same-commit re-stamps
- keep ordinary row refs on `measureElement` so observer registration and scroll restoration retain their normal ownership
- add focused and browser-level regressions for background tasks, thread files, and thread changes

Discord report: https://discord.com/channels/1456350064065904867/1458141495701012561/1533004141503320205

## Root cause

TanStack Virtual 3.17.6 deliberately skips synchronous `measureElement` sizing during ordinary user scrolling and reuses cached sizes when no `ResizeObserverEntry` is present. A side-panel toggle changes transcript width while rows are still in that scroll state, so wrapped rows can retain 120 px estimates and overlap. Width invalidation now clears the cache and owns the bounded forced refresh through `resizeItem`; ordinary refs only register and maintain observation.

## Validation

- latest-main reproduction: row heights `402 / 255 / 402 / 255` with stale offsets `0 / 120 / 240 / 360`
- unit: `ui/src/pages/chat/components/chat-thread.measure.test.ts` — **12/12 passed**
- prior failing history/restore E2E files plus the panel regression — **34/34 passed**
- full Control UI E2E — **134 files / 462 tests passed**
- `check:changed` — passed, including formatting, typechecks, lint, dead-code, and i18n
- dependency contract — inspected exact `@tanstack/virtual-core@3.17.6` source for `measureElement`, `resizeItem`, and `measure`
- autoreview on repaired head `64a0d287510` against current `origin/main` — clean, no accepted/actionable findings
- Blacksmith Testbox `tbx_01kyzv97fs657ygnczv4yjqq8r`: https://github.com/openclaw/openclaw/actions/runs/30723829616
- exact-head visual proof for Tasks, Files, and Changes: https://github.com/openclaw/openclaw/pull/117687#issuecomment-5154145055
