### PR TITLE
fix(control-ui): restore sandbox media previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI sandbox media previews:** resolve persisted sandbox-relative attachment paths against their recorded workspace before chat history renders them, while preserving unanchored relative refs and distinct original URLs. Fixes #108174. Thanks @DCAIGC.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI sandbox media previews:** resolve persisted sandbox-relative attachment paths against their recorded workspace before chat history renders them, while preserving unanchored relative refs and distinct original URLs. Fixes #108174. Thanks @DCAIGC.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -129,9 +129,7 @@ function factOwnsMarkerIdentity(identity: string, media: MediaFact[]): boolean {
     // prompt marker text remains relative. Derive aliases only from an
     // explicitly recorded workspace so unrelated absolute facts stay distinct.
     const aliases = [fact.path, fact.url, ...resolveWorkspaceRelativeMarkerAliases(fact)];
-    return aliases.some(
-      (alias) => alias && normalizeMarkerIdentity(alias) === normalizedIdentity,
-    );
+    return aliases.some((alias) => alias && normalizeMarkerIdentity(alias) === normalizedIdentity);
   });
 }
 

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { buildInboundMediaNoteProjection } from "../../../auto-reply/media-note.js";
 import {
   readPersistedMediaFacts,
@@ -100,11 +101,38 @@ function replaceLegacyFactlessMediaText(text: string): string {
     .replace(LEGACY_INBOUND_MEDIA_URI_PATTERN, PRUNED_HISTORY_MEDIA_REFERENCE_MARKER);
 }
 
+function normalizeMarkerIdentity(identity: string): string {
+  return identity.replaceAll("\\", "/");
+}
+
+function resolveWorkspaceRelativeMarkerAliases(fact: MediaFact): string[] {
+  if (
+    !fact.path ||
+    !fact.workspaceDir ||
+    !path.isAbsolute(fact.path) ||
+    !path.isAbsolute(fact.workspaceDir)
+  ) {
+    return [];
+  }
+  const relativePath = path.relative(fact.workspaceDir, fact.path);
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return [];
+  }
+  const normalizedRelativePath = normalizeMarkerIdentity(relativePath);
+  return [normalizedRelativePath, `./${normalizedRelativePath}`];
+}
+
 function factOwnsMarkerIdentity(identity: string, media: MediaFact[]): boolean {
-  const normalizedIdentity = identity.replaceAll("\\", "/");
-  return media.some((fact) =>
-    [fact.path, fact.url].some((alias) => alias?.replaceAll("\\", "/") === normalizedIdentity),
-  );
+  const normalizedIdentity = normalizeMarkerIdentity(identity);
+  return media.some((fact) => {
+    // Persistence anchors sandbox paths for browser previews, while existing
+    // prompt marker text remains relative. Derive aliases only from an
+    // explicitly recorded workspace so unrelated absolute facts stay distinct.
+    const aliases = [fact.path, fact.url, ...resolveWorkspaceRelativeMarkerAliases(fact)];
+    return aliases.some(
+      (alias) => alias && normalizeMarkerIdentity(alias) === normalizedIdentity,
+    );
+  });
 }
 
 function extractMediaAttachedIdentity(marker: string): string {

--- a/src/sessions/user-turn-transcript.media-normalize.ts
+++ b/src/sessions/user-turn-transcript.media-normalize.ts
@@ -49,12 +49,12 @@ export function resolveTranscriptMediaPath(
 export function normalizeStructuredMediaEntryForTranscript(
   media: PersistedUserTurnMediaInput,
 ): MediaFactInput {
+  const workspaceDir = normalizeOptionalText(media.workspaceDir);
   const mediaPath = normalizeOptionalText(media.path);
   const mediaUrl = normalizeOptionalText(media.url);
   const kind = normalizeStructuredMediaKind(media.kind);
   const legacyKind = normalizeOptionalText(media.kind);
   const messageId = normalizeOptionalText(media.messageId);
-  const workspaceDir = normalizeOptionalText(media.workspaceDir);
   const contentType =
     normalizeOptionalText(media.contentType) ??
     (kind || !legacyKind || !MIME_TYPE_PATTERN.test(legacyKind) ? undefined : legacyKind) ??
@@ -65,7 +65,7 @@ export function normalizeStructuredMediaEntryForTranscript(
   const fileName = normalizeOptionalText(media.fileName);
   const sizeBytes = normalizeNonNegativeNumber(media.sizeBytes);
   return {
-    ...(mediaPath ? { path: mediaPath } : {}),
+    ...(mediaPath ? { path: resolveTranscriptMediaPath(mediaPath, workspaceDir) } : {}),
     ...(mediaUrl ? { url: mediaUrl } : {}),
     ...(contentType ? { contentType } : {}),
     ...(kind ? { kind } : {}),

--- a/src/sessions/user-turn-transcript.media.test.ts
+++ b/src/sessions/user-turn-transcript.media.test.ts
@@ -281,6 +281,7 @@ describe("buildPersistedUserTurnMessage media projection", () => {
       media: [
         {
           path: "media/inbound/a.png",
+          url: "https://example.test/original.png",
           contentType: "image/png",
           workspaceDir: "/tmp/workspace",
         },
@@ -293,11 +294,23 @@ describe("buildPersistedUserTurnMessage media projection", () => {
       },
       expectedMedia: [
         {
-          path: "media/inbound/a.png",
+          path: path.join("/tmp/workspace", "media/inbound/a.png"),
+          url: "https://example.test/original.png",
           contentType: "image/png",
           workspaceDir: "/tmp/workspace",
         },
       ],
+    },
+    {
+      name: "unanchored relative attachment",
+      media: [{ path: "media/inbound/unanchored.png", contentType: "image/png" }],
+      expectedLegacy: {
+        MediaPath: "media/inbound/unanchored.png",
+        MediaPaths: ["media/inbound/unanchored.png"],
+        MediaType: "image/png",
+        MediaTypes: ["image/png"],
+      },
+      expectedMedia: [{ path: "media/inbound/unanchored.png", contentType: "image/png" }],
     },
     {
       name: "hydration-suppressed attachment",

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -399,78 +399,101 @@ suite.define(() => {
     }
   });
 
-  it("renders a canonical inbound image through the ticketed media route", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const requestedMediaUrls: URL[] = [];
-    await page.route("**/__openclaw__/assistant-media?**", async (route) => {
-      const request = route.request();
-      const url = new URL(request.url());
-      requestedMediaUrls.push(url);
-      expect(url.searchParams.get("source")).toBe("media://inbound/telegram-photo.png");
-      if (url.searchParams.get("meta") === "1") {
-        expect(request.headers().authorization).toBe("Bearer e2e-device-token");
-        await route.fulfill({
-          contentType: "application/json",
-          body: JSON.stringify({
-            available: true,
-            mediaTicket: "ticket-inbound",
-            mediaTicketExpiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
-          }),
-        });
-        return;
-      }
-      expect(url.searchParams.get("mediaTicket")).toBe("ticket-inbound");
-      await route.fulfill({
-        contentType: "image/png",
-        body: Buffer.from(
-          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=",
-          "base64",
-        ),
+  it.each([
+    {
+      name: "canonical inbound",
+      source: "media://inbound/telegram-photo.png",
+      workspaceDir: undefined,
+      screenshotName: "canonical-inbound-image",
+    },
+    {
+      name: "sandbox-staged inbound",
+      source: "/workspace/media/inbound/fabricated-sandbox.png",
+      workspaceDir: "/workspace",
+      screenshotName: "sandbox-inbound-image",
+    },
+  ] as const)(
+    "renders a $name image through the ticketed media route",
+    async ({ source, workspaceDir, screenshotName }) => {
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       });
-    });
-    await installMockGateway(page, {
-      historyMessages: [
-        {
-          id: "user-inbound-media-ref",
-          role: "user",
-          content: [{ type: "text", text: "🖼️ Attached image" }],
-          __openclaw: {
-            media: [{ path: "media://inbound/telegram-photo.png", contentType: "image/png" }],
-          },
-          timestamp: Date.now(),
-        },
-      ],
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}chat`);
-      await expect.poll(() => requestedMediaUrls.length, { timeout: 10_000 }).toBe(2);
-      const image = page.locator("img.chat-message-image");
-      await image.waitFor({ state: "visible", timeout: 10_000 });
-      await expect
-        .poll(() =>
-          image.evaluate((element) =>
-            element instanceof HTMLImageElement && element.complete ? element.naturalWidth : 0,
+      const page = await context.newPage();
+      const requestedMediaUrls: URL[] = [];
+      await page.route("**/__openclaw__/assistant-media?**", async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        requestedMediaUrls.push(url);
+        expect(url.searchParams.get("source")).toBe(source);
+        if (url.searchParams.get("meta") === "1") {
+          expect(request.headers().authorization).toBe("Bearer e2e-device-token");
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({
+              available: true,
+              mediaTicket: "ticket-inbound",
+              mediaTicketExpiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+            }),
+          });
+          return;
+        }
+        expect(url.searchParams.get("mediaTicket")).toBe("ticket-inbound");
+        expect(request.headers().authorization).toBeUndefined();
+        await route.fulfill({
+          contentType: "image/png",
+          body: Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=",
+            "base64",
           ),
-        )
-        .toBe(1);
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          fullPage: true,
-          path: `${artifactDir}/canonical-inbound-image.png`,
         });
+      });
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            id: "user-inbound-media-ref",
+            role: "user",
+            content: [{ type: "text", text: "🖼️ Attached image" }],
+            __openclaw: {
+              media: [
+                {
+                  path: source,
+                  contentType: "image/png",
+                  ...(workspaceDir ? { workspaceDir } : {}),
+                },
+              ],
+            },
+            timestamp: Date.now(),
+          },
+        ],
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await expect.poll(() => requestedMediaUrls.length, { timeout: 10_000 }).toBe(2);
+        const image = page.locator("img.chat-message-image");
+        await image.waitFor({ state: "visible", timeout: 10_000 });
+        await expect
+          .poll(() =>
+            image.evaluate((element) =>
+              element instanceof HTMLImageElement && element.complete ? element.naturalWidth : 0,
+            ),
+          )
+          .toBe(1);
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            fullPage: true,
+            path: `${artifactDir}/${screenshotName}.png`,
+          });
+        }
+      } finally {
+        await suite.closeBrowserContext(context);
       }
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
-  });
+    },
+  );
 
   it("evicts and refetches managed image Blob URLs after the cache reaches capacity", async () => {
     const context = await suite.newBrowserContext({


### PR DESCRIPTION
## What Problem This Solves

Fixes #108174: sandbox-staged inbound images can be analyzed by the agent but render as broken previews in Control UI because the persisted transcript retains a workspace-relative media path.

## Why This Change Was Made

- Resolve persisted sandbox-relative media paths against the existing per-fact workspace anchor at the transcript owner boundary.
- Preserve unanchored relative paths, original URLs, and existing workspace-relative history-pruning ownership.
- Extend the existing real Chromium regression to cover both canonical inbound media and an absolute sandbox-staged attachment.

## User Impact

Sandboxed inbound image attachments now render through the existing authenticated assistant-media route in Control UI session history without introducing a separate UI-side path reconstruction rule.

## Evidence

- Original focused Blacksmith Testbox proof: `pnpm test src/sessions/user-turn-transcript.media.test.ts src/agents/embedded-agent-runner/run/history-image-prune.test.ts` passed 56/56.
- Actual Chromium browser proof: [Blacksmith Testbox run 30727650215](https://github.com/openclaw/openclaw/actions/runs/30727650215), lease `tbx_01kz02d20s9t5vasjh6q2wchbd`, executed the exact parent `d5afd92f0c6209d8b361fd802c921e66db8b72f0` with synced E2E blob `ba19112cabd3da442d5af837c35e2d4da8ad031b`; committed PR head `d41a4a01e2b20e7f1586076d4b9fae906fb796ea` contains that exact identical blob.
- Command: `OPENCLAW_UI_E2E_ARTIFACT_DIR=/tmp/openclaw-ui-pr117689 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.media-files.e2e.test.ts --testNamePattern "ticketed media route" --reporter=verbose`.
- Result: `Test Files 1 passed; Tests 2 passed | 12 skipped`; both canonical `media://inbound/telegram-photo.png` and sandbox `/workspace/media/inbound/fabricated-sandbox.png` assert the exact source query, authenticated Bearer metadata request, ticketed image-body request without Bearer authorization, and a visibly decoded image with `naturalWidth = 1`.
- The remote browser generated `canonical-inbound-image.png` (30139 bytes) and `sandbox-inbound-image.png` (30758 bytes). These screenshots stayed on the ephemeral Testbox and were not uploaded as public artifacts.
- The trusted wrapper returned timing JSON `{"exitCode":0,"runStatus":"succeeded"}` and stopped its one-shot lease. Its backing Actions run may show canceled during externally managed lease cleanup; the remote command output and wrapper exit code are the authoritative delegated Testbox result.
- Final independent Codex autoreview on the complete committed branch: `gpt-5.6-sol`, reasoning `xhigh`, 12143-byte bundle, TruffleHog clean, exit 0, no accepted or actionable findings.
- Exact-head hosted CI now includes Control UI checks and all four Control UI E2E shards because the browser regression is checked in.

Closes #108174