### PR TITLE
fix(macos): avoid self-named defaults suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS Nix defaults:** avoid asking Foundation for the app's own defaults domain as a suite while preserving the stable Nix lookup for renamed app bundles, eliminating the launch-time NSUserDefaults warning. Fixes #88909. Thanks @onlinejourno.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS Nix defaults:** avoid asking Foundation for the app's own defaults domain as a suite while preserving the stable Nix lookup for renamed app bundles, eliminating the launch-time NSUserDefaults warning. Fixes #88909. Thanks @onlinejourno.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -13,6 +13,13 @@ extension ProcessInfo {
         return String(cString: raw) == "1"
     }
 
+    static func resolveStableNixSuite(bundleIdentifier: String?, isAppBundle: Bool) -> UserDefaults? {
+        // The app's own defaults domain is already represented by UserDefaults.standard.
+        // Passing that same identifier to suiteName triggers Foundation's nonsensical-suite warning.
+        guard isAppBundle, bundleIdentifier != launchdLabel else { return nil }
+        return UserDefaults(suiteName: launchdLabel)
+    }
+
     /// Nix deployments may write defaults into a stable suite (`ai.openclaw.mac`) even if the shipped
     /// app bundle identifier changes (and therefore `UserDefaults.standard` domain changes).
     static func resolveNixMode(
@@ -33,7 +40,9 @@ extension ProcessInfo {
 
     var isNixMode: Bool {
         let isAppBundle = Bundle.main.bundleURL.pathExtension == "app"
-        let stableSuite = UserDefaults(suiteName: launchdLabel)
+        let stableSuite = Self.resolveStableNixSuite(
+            bundleIdentifier: Bundle.main.bundleIdentifier,
+            isAppBundle: isAppBundle)
         return Self.resolveNixMode(
             environment: self.environment,
             standard: .standard,

--- a/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
@@ -4,12 +4,32 @@ import Testing
 
 @Suite(.serialized)
 struct NixModeStableSuiteTests {
+    @Test func `does not create a stable suite for the app's own bundle identifier`() {
+        #expect(ProcessInfo.resolveStableNixSuite(bundleIdentifier: launchdLabel, isAppBundle: true) == nil)
+    }
+
+    @Test func `creates a stable suite for renamed app bundles`() {
+        #expect(ProcessInfo.resolveStableNixSuite(
+            bundleIdentifier: "ai.openclaw.mac.renamed",
+            isAppBundle: true) != nil)
+    }
+
+    @Test func `does not create a stable suite outside app bundles`() {
+        #expect(ProcessInfo.resolveStableNixSuite(
+            bundleIdentifier: "ai.openclaw.mac.renamed",
+            isAppBundle: false) == nil)
+    }
+
     @Test func `resolves from stable suite for app bundles`() throws {
         let suite = try #require(UserDefaults(suiteName: launchdLabel))
         let key = "openclaw.nixMode"
         let prev = suite.object(forKey: key)
         defer {
-            if let prev { suite.set(prev, forKey: key) } else { suite.removeObject(forKey: key) }
+            if let prev {
+                suite.set(prev, forKey: key)
+            } else {
+                suite.removeObject(forKey: key)
+            }
         }
 
         suite.set(true, forKey: key)
@@ -65,7 +85,11 @@ struct NixModeStableSuiteTests {
         let key = "openclaw.nixMode"
         let prev = suite.object(forKey: key)
         defer {
-            if let prev { suite.set(prev, forKey: key) } else { suite.removeObject(forKey: key) }
+            if let prev {
+                suite.set(prev, forKey: key)
+            } else {
+                suite.removeObject(forKey: key)
+            }
         }
 
         suite.set(true, forKey: key)


### PR DESCRIPTION
## What Problem This Solves

Foundation emits a launch-time warning when the macOS app opens its own `ai.openclaw.mac` bundle identifier as a separate defaults suite. Reported by @onlinejourno in #88909.

## Why This Change Was Made

`UserDefaults.standard` already owns the current bundle domain. Select the stable Nix suite only for renamed app bundles; preserve existing preference values and avoid migrations, writes, or new configuration.

## User Impact

Normal OpenClaw launches no longer trigger the nonsensical-suite Foundation warning, while renamed Nix-managed app bundles still read their existing stable defaults domain.

## Evidence

- Real signed Foundation boundary proof: Apple `/usr/bin/osascript -l JavaScript` reproduces the exact nonsensical-suite warning for its own bundle identifier; standard defaults emit no warning, and the distinct `ai.openclaw.mac` suite initializes without warning.
- Focused native regressions cover matching bundle identifiers, renamed bundles, non-app processes, and existing stable-suite Nix preference reads.
- Exact-head hosted CI run 30727517908 passed `macos-swift`, `macos-node`, and `openclaw/ci-gate` on `5ef245d86bb133c8c2f5ea31204e58d140ac47cd`. Earlier exact-code run 30723598474 also passed the release app build, OpenClawKit, full Swift tests, and required CI gate.
- Fresh final-head structured `gpt-5.6-sol` xhigh autoreview exited zero with no accepted or actionable findings and 0.99 correctness confidence.
- A direct post-fix packaged OpenClaw launch was not performed because this environment cannot produce an operator-approved signed app bundle. The signed Apple Foundation differential and hosted native tests are the executed dependency-boundary proof.

Fixes #88909.