### PR TITLE
refactor(gateway): consolidate cron stream watcher fixtures

### DIFF
--- a/src/gateway/cron-stream-output.test.ts
+++ b/src/gateway/cron-stream-output.test.ts
@@ -1,15 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CronJob } from "../cron/types.js";
 import type {
   ManagedRun,
   ProcessSupervisor,
   RunExit,
   SpawnInput,
 } from "../process/supervisor/types.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import {
+  createCronStreamMatchingJob,
+  createCronStreamWatcherFixture,
   createWatchers,
   exitResult,
-  fakeSupervisor,
   job,
   settle,
 } from "./cron-stream-watchers.test-helpers.js";
@@ -21,31 +22,8 @@ describe("cron stream output", () => {
 
   it("batches stdout and stderr, filters match mode, and truncates at the byte cap", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.reconcile(
-      [
-        job({
-          schedule: {
-            kind: "stream",
-            command: ["stream-source"],
-            mode: "match",
-            match: "^keep",
-            batchMs: 50,
-            maxBatchBytes: 1_024,
-          },
-        }),
-      ],
-      true,
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.reconcile([createCronStreamMatchingJob("^keep")], true);
     await settle();
 
     fake.inputs[0]?.onStdout?.("drop this\nkeep one\n");
@@ -68,28 +46,8 @@ describe("cron stream output", () => {
 
   it("does not match an oversized line by its truncated prefix", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep"));
 
     // A complete line longer than the batch cap was still matched in full;
     // it fires and only the delivered batch is truncated.
@@ -114,28 +72,8 @@ describe("cron stream output", () => {
 
   it("matches an over-cap line identically whether or not callbacks split it", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep"));
 
     // A complete 1.9 KB line arriving in two callbacks must match exactly
     // like the same line in one callback: pipe chunking is not semantics.
@@ -153,28 +91,8 @@ describe("cron stream output", () => {
 
   it("treats a line over the intake bound as an unprovable prefix even when callbacks split it", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep"));
 
     // Each fragment fits the per-drain intake budget, but the assembled line
     // exceeds the 4x raw-intake bound. It must stay unmatched exactly like the
@@ -202,28 +120,8 @@ describe("cron stream output", () => {
 
   it("matches raw source text without treating the truncation marker as input", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "\\[truncated\\]$",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("\\[truncated\\]$"));
 
     fake.inputs[0]?.onStdout?.(`${"x".repeat(2_000)}\n`);
     await settle();
@@ -242,28 +140,8 @@ describe("cron stream output", () => {
 
   it("does not synthesize a line across dropped output chunks", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep$",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep$"));
 
     // Real source lines: "kee<dropped continuation>" then "p" then "keep".
     // Synchronous burst: stdout partial, stderr filler that exhausts the byte
@@ -291,28 +169,8 @@ describe("cron stream output", () => {
 
   it("does not match a retained prefix when its continuation was dropped before exit", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep$",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep$"));
 
     // The retained prefix looks like a complete match, but the dropped chunk
     // continued that source line. EOF cannot prove where the real line ended.
@@ -329,28 +187,8 @@ describe("cron stream output", () => {
 
   it("does not discard the first clean line after a drop that ended at a newline", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
-    await watchers.start(
-      job({
-        schedule: {
-          kind: "stream",
-          command: ["stream-source"],
-          mode: "match",
-          match: "^keep$",
-          batchMs: 50,
-          maxBatchBytes: 1_024,
-        },
-      }),
-    );
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
+    await watchers.start(createCronStreamMatchingJob("^keep$"));
 
     // Synchronous burst exhausts the intake budget, then a whole chunk that
     // ends at a newline is dropped. The drop closed its own broken line, so
@@ -369,10 +207,7 @@ describe("cron stream output", () => {
 
   it("buffers output emitted before the asynchronous spawn call resolves", async () => {
     vi.useFakeTimers();
-    let resolveWait!: (exit: RunExit) => void;
-    const wait = new Promise<RunExit>((resolve) => {
-      resolveWait = resolve;
-    });
+    const { promise: wait, resolve: resolveWait } = createDeferred<RunExit>();
     const run: ManagedRun = {
       runId: "early-output",
       startedAtMs: Date.now(),
@@ -415,11 +250,7 @@ describe("cron stream output", () => {
   it("keeps one bounded pending batch while a payload is busy and honors minimum spacing", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
-    const fake = fakeSupervisor();
-    let releaseFirst!: () => void;
-    const first = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
+    const { promise: first, resolve: releaseFirst } = createDeferred();
     const fireBatch = vi
       .fn()
       .mockImplementationOnce(async () => {
@@ -427,14 +258,9 @@ describe("cron stream output", () => {
         return "fired" as const;
       })
       .mockResolvedValue("fired" as const);
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 100,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
       fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -471,11 +297,7 @@ describe("cron stream output", () => {
   it("prepends a busy retry ahead of batches that arrived while it was in flight", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
-    const fake = fakeSupervisor();
-    let releaseFirst!: () => void;
-    const first = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
+    const { promise: first, resolve: releaseFirst } = createDeferred();
     const fireBatch = vi
       .fn()
       .mockImplementationOnce(async () => {
@@ -483,13 +305,9 @@ describe("cron stream output", () => {
         return "busy" as const;
       })
       .mockResolvedValue("fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
       fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.start(job());
 
@@ -517,22 +335,13 @@ describe("cron stream output", () => {
 
   it("serializes exact coalesced counter updates under sustained output", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    let releasePayload!: () => void;
-    const payload = new Promise<void>((resolve) => {
-      releasePayload = resolve;
-    });
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { promise: payload, resolve: releasePayload } = createDeferred();
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
       fireBatch: vi.fn(async () => {
         await payload;
         return "fired" as const;
       }),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -557,15 +366,9 @@ describe("cron stream output", () => {
 
   it("counts a gate drop in the serialized owner", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
       fireBatch: vi.fn(async () => "dropped" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -584,19 +387,13 @@ describe("cron stream output", () => {
 
   it("counts payload errors and rejected dispatches in the serialized owner", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
     const fireBatch = vi
       .fn<() => Promise<"error">>()
       .mockResolvedValueOnce("error")
       .mockRejectedValueOnce(new Error("dispatch failed"));
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
       fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -626,15 +423,9 @@ describe("cron stream output", () => {
 
   it("counts a batch lost when fire dispatch rejects before cron can persist it", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
       fireBatch: vi.fn(async () => await Promise.reject(new Error("transient failure"))),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -654,16 +445,7 @@ describe("cron stream output", () => {
 
   it("fires a batch for an empty line accepted by match mode", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async () => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
     await watchers.reconcile(
       [
         job({
@@ -694,16 +476,7 @@ describe("cron stream output", () => {
 
   it("preserves leading and consecutive empty lines in a batch", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async () => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
     await watchers.reconcile([job()], true);
     await settle();
 
@@ -721,14 +494,9 @@ describe("cron stream output", () => {
 
   it("stops the source when a once trigger disables its job", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
       fireBatch: vi.fn(async () => "disabled" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.reconcile([job()], true);
     await settle();
@@ -744,16 +512,7 @@ describe("cron stream output", () => {
 
   it("keeps interleaved stdout and stderr partial lines independent", async () => {
     vi.useFakeTimers();
-    const fake = fakeSupervisor();
-    const fireBatch = vi.fn(async (_job: CronJob, _batch: string) => "fired" as const);
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch,
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
     await watchers.reconcile([job()], true);
     await settle();
 

--- a/src/gateway/cron-stream-watchers.test-helpers.ts
+++ b/src/gateway/cron-stream-watchers.test-helpers.ts
@@ -31,6 +31,19 @@ export function job(overrides: Partial<CronJob> = {}): CronJob {
   };
 }
 
+export function createCronStreamMatchingJob(match: string): CronJob {
+  return job({
+    schedule: {
+      kind: "stream",
+      command: ["stream-source"],
+      mode: "match",
+      match,
+      batchMs: 50,
+      maxBatchBytes: 1_024,
+    },
+  });
+}
+
 export function exitResult(overrides: Partial<RunExit> = {}): RunExit {
   return {
     reason: "exit",
@@ -74,6 +87,21 @@ export function fakeSupervisor() {
     getRecord: vi.fn(),
   } satisfies ProcessSupervisor;
   return { inputs, runs, exits, spawn, supervisor };
+}
+
+export function createCronStreamWatcherFixture<
+  Overrides extends Partial<Parameters<typeof createWatchers>[0]>,
+>(overrides: Overrides = {} as Overrides) {
+  const fake = fakeSupervisor();
+  const callbacks = {
+    getProcessSupervisor: () => fake.supervisor,
+    updateState: vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {}),
+    recordFailure: vi.fn(async () => {}),
+    fireBatch: vi.fn(async (_job: CronJob, _batch: string) => "fired" as const),
+    logger: { info: vi.fn(), warn: vi.fn() },
+    ...overrides,
+  };
+  return { fake, ...callbacks, watchers: createWatchers(callbacks) };
 }
 
 export async function settle(): Promise<void> {

--- a/src/gateway/cron-stream-watchers.test.ts
+++ b/src/gateway/cron-stream-watchers.test.ts
@@ -2,11 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../cron/types.js";
 import { createProcessSupervisor } from "../process/supervisor/supervisor.js";
 import type { ManagedRun, ProcessSupervisor, RunExit } from "../process/supervisor/types.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { resolveStreamStopReason } from "./cron-stream-watchers.js";
 import {
+  createCronStreamWatcherFixture,
   createWatchers,
   exitResult,
-  fakeSupervisor,
   job,
   settle,
 } from "./cron-stream-watchers.test-helpers.js";
@@ -17,15 +18,10 @@ describe("cron stream watchers", () => {
   });
 
   it("keeps lifecycle ownership when a diagnostic state write fails", async () => {
-    const fake = fakeSupervisor();
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, watchers } = createCronStreamWatcherFixture({
       updateState: vi.fn(async () => {
         throw new Error("state write failed");
       }),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
 
     await watchers.reconcile([job()], true);
@@ -37,13 +33,8 @@ describe("cron stream watchers", () => {
   });
 
   it("does not spawn after the cron store explicitly rejects schedule ownership", async () => {
-    const fake = fakeSupervisor();
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, watchers } = createCronStreamWatcherFixture({
       updateState: vi.fn(async () => false),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
 
     await watchers.start(job());
@@ -53,15 +44,7 @@ describe("cron stream watchers", () => {
   });
 
   it("detaches output and awaits exit on disable, removal, and shutdown", async () => {
-    const fake = fakeSupervisor();
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      minIntervalMs: 1,
-      updateState: vi.fn(async () => {}),
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
     await watchers.reconcile([job()], true);
     await settle();
     await watchers.reconcile([job({ enabled: false })], true);
@@ -80,15 +63,7 @@ describe("cron stream watchers", () => {
   });
 
   it("does not spawn and records a clear status when trigger trust is disabled", async () => {
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture();
 
     await watchers.reconcile([job()], false);
 
@@ -105,15 +80,7 @@ describe("cron stream watchers", () => {
   });
 
   it("reports cron-disabled remediation when only cron itself is off", async () => {
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async () => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture();
 
     // cron globally disabled but triggers enabled: the remediation must name
     // cron, not point the operator at an already-enabled trigger flag.
@@ -129,15 +96,7 @@ describe("cron stream watchers", () => {
   });
 
   it("creates a quiescent owner to persist disabled status for an inactive stream job", async () => {
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async () => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
-      updateState,
-      recordFailure: vi.fn(async () => {}),
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
-    });
+    const { fake, updateState, watchers } = createCronStreamWatcherFixture();
 
     await watchers.stop("stream-job", "trust-disabled", job());
 
@@ -161,10 +120,7 @@ describe("cron stream watchers", () => {
       const jobId = input.sessionId.replace("cron-stream:", "");
       inputs.push({ jobId });
       const stubborn = jobId === "stubborn-job";
-      let resolveWait!: (result: RunExit) => void;
-      const wait = new Promise<RunExit>((resolve) => {
-        resolveWait = resolve;
-      });
+      const { promise: wait, resolve: resolveWait } = createDeferred<RunExit>();
       const cancel = vi.fn(() => {
         if (!stubborn) {
           resolveWait(exitResult({ reason: "manual-cancel" }));
@@ -214,10 +170,7 @@ describe("cron stream watchers", () => {
     const spawn = vi.fn(async (input: { sessionId: string; argv: string[] }) => {
       const jobId = input.sessionId.replace("cron-stream:", "");
       const stubborn = jobId === "stubborn-job" && input.argv[0] === "stream-source";
-      let resolveWait!: (result: RunExit) => void;
-      const wait = new Promise<RunExit>((resolve) => {
-        resolveWait = resolve;
-      });
+      const { promise: wait, resolve: resolveWait } = createDeferred<RunExit>();
       const cancel = vi.fn(() => {
         if (!stubborn) {
           resolveWait(exitResult({ reason: "manual-cancel" }));
@@ -268,16 +221,8 @@ describe("cron stream watchers", () => {
   });
 
   it("leaves an exit queued ahead of a requested stop to the stop operation", async () => {
-    const fake = fakeSupervisor();
-    const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
-    const recordFailure = vi.fn(async () => {});
-    const watchers = createWatchers({
-      getProcessSupervisor: () => fake.supervisor,
+    const { fake, updateState, recordFailure, watchers } = createCronStreamWatcherFixture({
       minIntervalMs: 1,
-      updateState,
-      recordFailure,
-      fireBatch: vi.fn(async () => "fired" as const),
-      logger: { info: vi.fn(), warn: vi.fn() },
     });
     await watchers.start(job());
 
@@ -344,14 +289,7 @@ describe("cron stream watchers", () => {
 
   describe("serialized owner interleavings", () => {
     it("starts unrelated jobs without cross-job mutation fencing", async () => {
-      const fake = fakeSupervisor();
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
-      });
+      const { fake, watchers } = createCronStreamWatcherFixture();
 
       await Promise.all([
         watchers.start(job({ id: "stream-a" })),
@@ -364,27 +302,16 @@ describe("cron stream watchers", () => {
     });
 
     it("rechecks the stop fence after a slow starting-state write and persists stopped", async () => {
-      const fake = fakeSupervisor();
-      let releaseStarting!: () => void;
-      const startingWrite = new Promise<void>((resolve) => {
-        releaseStarting = resolve;
-      });
-      let markStarting!: () => void;
-      const starting = new Promise<void>((resolve) => {
-        markStarting = resolve;
-      });
+      const { promise: startingWrite, resolve: releaseStarting } = createDeferred();
+      const { promise: starting, resolve: markStarting } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
         if (patch.streamStatus === "starting") {
           markStarting();
           await startingWrite;
         }
       });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState,
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
 
       const start = watchers.start(job());
@@ -404,22 +331,14 @@ describe("cron stream watchers", () => {
 
     it("bounds shutdown outside a stalled owner operation and pre-cancels its scope", async () => {
       vi.useFakeTimers();
-      const fake = fakeSupervisor();
-      let markStarting!: () => void;
-      const starting = new Promise<void>((resolve) => {
-        markStarting = resolve;
-      });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { promise: starting, resolve: markStarting } = createDeferred();
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState: vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
           if (patch.streamStatus === "starting") {
             markStarting();
             await new Promise<never>(() => {});
           }
         }),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
 
       void watchers.start(job());
@@ -437,27 +356,19 @@ describe("cron stream watchers", () => {
     });
 
     it("holds shutdown open until every owner stop settles before surfacing a failure", async () => {
-      const fake = fakeSupervisor();
-      let releaseSlowStop!: () => void;
-      const slowStopWrite = new Promise<void>((resolve) => {
-        releaseSlowStop = resolve;
-      });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { promise: slowStopWrite, resolve: releaseSlowStop } = createDeferred();
+      const { watchers } = createCronStreamWatcherFixture({
         updateState: vi.fn(async (jobId: string, patch: Partial<CronJob["state"]>) => {
           if (jobId === "slow-job" && patch.streamStatus === "stopped") {
             await slowStopWrite;
           }
         }),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
         retireSource: vi.fn(async (jobId: string) => {
           if (jobId === "fail-job") {
             throw new Error("retirement write lost");
           }
           return undefined;
         }),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job({ id: "slow-job" }));
       await watchers.start(job({ id: "fail-job" }));
@@ -479,27 +390,16 @@ describe("cron stream watchers", () => {
     });
 
     it("discards a queued replacement start superseded by shutdown", async () => {
-      const fake = fakeSupervisor();
       let blockStops = false;
-      let releaseStop!: () => void;
-      const stopWrite = new Promise<void>((resolve) => {
-        releaseStop = resolve;
-      });
-      let markStop!: () => void;
-      const stopStarted = new Promise<void>((resolve) => {
-        markStop = resolve;
-      });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { promise: stopWrite, resolve: releaseStop } = createDeferred();
+      const { promise: stopStarted, resolve: markStop } = createDeferred();
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState: vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
           if (blockStops && patch.streamStatus === "stopped") {
             markStop();
             await stopWrite;
           }
         }),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
       blockStops = true;
@@ -518,14 +418,8 @@ describe("cron stream watchers", () => {
 
     it("retains a late spawn handle until a later stop confirms its exit", async () => {
       vi.useFakeTimers();
-      let resolveSpawn!: (run: ManagedRun) => void;
-      const spawned = new Promise<ManagedRun>((resolve) => {
-        resolveSpawn = resolve;
-      });
-      let resolveWait!: (exit: RunExit) => void;
-      const wait = new Promise<RunExit>((resolve) => {
-        resolveWait = resolve;
-      });
+      const { promise: spawned, resolve: resolveSpawn } = createDeferred<ManagedRun>();
+      const { promise: wait, resolve: resolveWait } = createDeferred<RunExit>();
       let cancelAttempts = 0;
       const run: ManagedRun = {
         runId: "late-run",
@@ -572,15 +466,9 @@ describe("cron stream watchers", () => {
 
     it("treats process exit during stopping as expected and never restarts", async () => {
       vi.useFakeTimers();
-      const fake = fakeSupervisor();
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         minIntervalMs: 1,
         retryBackoffMs: [10],
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
 
@@ -597,15 +485,9 @@ describe("cron stream watchers", () => {
 
     it("cancels old backoff before starting an updated schedule", async () => {
       vi.useFakeTimers();
-      const fake = fakeSupervisor();
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         minIntervalMs: 1,
         retryBackoffMs: [100],
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
       fake.exits[0]?.(exitResult());
@@ -626,15 +508,8 @@ describe("cron stream watchers", () => {
     it("replaces same-schedule owners when logical source identity changes", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(1_000);
-      const fake = fakeSupervisor();
-      const fireBatch = vi.fn(async () => "fired" as const);
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, fireBatch, watchers } = createCronStreamWatcherFixture({
         minIntervalMs: 100,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch,
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(
         job({ state: { lastRunAtMs: 1_000, streamSourceIdentity: "source-a" } }),
@@ -666,15 +541,7 @@ describe("cron stream watchers", () => {
     });
 
     it("serializes rapid enable-disable-enable into one final running owner", async () => {
-      const fake = fakeSupervisor();
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
-        minIntervalMs: 1,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
-      });
+      const { fake, watchers } = createCronStreamWatcherFixture({ minIntervalMs: 1 });
 
       const enabled = watchers.start(job());
       const disabled = watchers.stop("stream-job", "disabled");
@@ -691,27 +558,16 @@ describe("cron stream watchers", () => {
     });
 
     it("fences a stale reconcile that is overtaken by shutdown", async () => {
-      const fake = fakeSupervisor();
-      let releaseStopWrite!: () => void;
-      const stopWrite = new Promise<void>((resolve) => {
-        releaseStopWrite = resolve;
-      });
-      let markStopWriteStarted!: () => void;
-      const stopWriteStarted = new Promise<void>((resolve) => {
-        markStopWriteStarted = resolve;
-      });
+      const { promise: stopWrite, resolve: releaseStopWrite } = createDeferred();
+      const { promise: stopWriteStarted, resolve: markStopWriteStarted } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
         if (patch.streamStatus === "stopped") {
           markStopWriteStarted();
           await stopWrite;
         }
       });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState,
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job({ id: "old-job" }));
 
@@ -727,26 +583,15 @@ describe("cron stream watchers", () => {
     });
 
     it("fences a stale reconcile snapshot after a newer direct update", async () => {
-      const fake = fakeSupervisor();
-      let releaseStopWrite!: () => void;
-      const stopWrite = new Promise<void>((resolve) => {
-        releaseStopWrite = resolve;
-      });
-      let markStopWriteStarted!: () => void;
-      const stopWriteStarted = new Promise<void>((resolve) => {
-        markStopWriteStarted = resolve;
-      });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { promise: stopWrite, resolve: releaseStopWrite } = createDeferred();
+      const { promise: stopWriteStarted, resolve: markStopWriteStarted } = createDeferred();
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState: vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
           if (patch.streamStatus === "stopped") {
             markStopWriteStarted();
             await stopWrite;
           }
         }),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job({ id: "blocking-job" }));
 
@@ -776,26 +621,15 @@ describe("cron stream watchers", () => {
     });
 
     it("replaces an owner retired by an older reconcile when a newer snapshot wants it", async () => {
-      const fake = fakeSupervisor();
-      let releaseStopWrite!: () => void;
-      const stopWrite = new Promise<void>((resolve) => {
-        releaseStopWrite = resolve;
-      });
-      let markStopWriteStarted!: () => void;
-      const stopWriteStarted = new Promise<void>((resolve) => {
-        markStopWriteStarted = resolve;
-      });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { promise: stopWrite, resolve: releaseStopWrite } = createDeferred();
+      const { promise: stopWriteStarted, resolve: markStopWriteStarted } = createDeferred();
+      const { fake, watchers } = createCronStreamWatcherFixture({
         updateState: vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
           if (patch.streamStatus === "stopped") {
             markStopWriteStarted();
             await stopWrite;
           }
         }),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
 
@@ -814,17 +648,11 @@ describe("cron stream watchers", () => {
     });
 
     it("lets a newer explicit start replace an owner being removed", async () => {
-      const fake = fakeSupervisor();
       const retireSource = vi.fn(async (_jobId: string, _scheduleKey: string, identity: string) => {
         return `${identity}:retired`;
       });
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         retireSource,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
 
@@ -845,14 +673,7 @@ describe("cron stream watchers", () => {
     });
 
     it("does not leak owner or mutation-epoch state across unique-id churn", async () => {
-      const fake = fakeSupervisor();
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
-        fireBatch: vi.fn(async () => "fired" as const),
-        logger: { info: vi.fn(), warn: vi.fn() },
-      });
+      const { watchers } = createCronStreamWatcherFixture();
       // Push far past MAX_MUTATION_EPOCHS (1024) distinct job ids through
       // start+remove so the LRU eviction path runs many times; a broken cap
       // would grow unbounded (or spin). Removed jobs must leave no live owner.
@@ -867,23 +688,15 @@ describe("cron stream watchers", () => {
 
     it("retires logical source identity before waiting on an in-flight batch", async () => {
       vi.useFakeTimers();
-      const fake = fakeSupervisor();
-      let releasePayload!: () => void;
-      const payload = new Promise<void>((resolve) => {
-        releasePayload = resolve;
-      });
+      const { promise: payload, resolve: releasePayload } = createDeferred();
       const retireSource = vi.fn(async () => "source-retired");
-      const watchers = createWatchers({
-        getProcessSupervisor: () => fake.supervisor,
+      const { fake, watchers } = createCronStreamWatcherFixture({
         minIntervalMs: 1,
         retireSource,
-        updateState: vi.fn(async () => {}),
-        recordFailure: vi.fn(async () => {}),
         fireBatch: vi.fn(async () => {
           await payload;
           return "fired" as const;
         }),
-        logger: { info: vi.fn(), warn: vi.fn() },
       });
       await watchers.start(job());
       fake.inputs[0]?.onStdout?.("in flight\n");


### PR DESCRIPTION
## What Problem This Solves

The cron stream output and lifecycle suites repeat the same process-supervisor mocks, callback wiring, matching schedules, and deferred setup dozens of times. This duplicates maintenance work and makes concurrency regressions harder to review.

## Why This Change Was Made

Use the existing gateway test-helper owner for fresh, typed, per-test watcher fixtures and matching jobs; reuse the canonical deferred helper. This is an explicitly maintainer-requested cleanup. Custom supervisors and real-process coverage remain explicit, and no production files change.

## User Impact

No user-visible or runtime behavior changes. Gateway maintainers retain all lifecycle and concurrency coverage while removing 400 net lines of test-only code.

## Evidence

- Remote Blacksmith Testbox tbx_01kyztzb623pbskzataxkezhq9: focused watcher, output, and unchanged interleavings suites passed 62 of 62 tests.
- Remote full pnpm check:changed passed core-test typecheck, formatting, dependency/boundary/dead-code guards, and lint with zero warnings and zero errors.
- Independent gpt-5.6-sol xhigh review and structured xhigh autoreview were clean.
- AST comparison confirms all 50 original test cases, 115 assertion chains, 40 fresh fixtures, 36 shutdown calls, 42 timer advances, and 77 settle calls remain unchanged.
- Synthetic merge against main 825a79467255de027a5215b7942f17ab2eff50cf succeeded with only three files changed: 102 additions and 502 deletions; production delta zero.
- Remote run: https://github.com/openclaw/openclaw/actions/runs/30723660153
- AI-assisted; explicitly maintainer-requested.