### PR TITLE
refactor(fal): consolidate image-generation provider test fixtures

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -97,7 +97,6 @@ extensions/discord/src/send.sends-basic-channel-messages.test.ts
 extensions/discord/src/voice/manager.e2e.test.ts
 extensions/discord/src/voice/manager.ts
 extensions/discord/src/voice/realtime.ts
-extensions/fal/image-generation-provider.test.ts
 extensions/fal/image-generation-provider.ts
 extensions/feishu/src/bot.test.ts
 extensions/feishu/src/bot.ts

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -1,4 +1,5 @@
 // Fal tests cover image generation provider plugin behavior.
+import type { ImageGenerationRequest } from "openclaw/plugin-sdk/image-generation";
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -9,36 +10,23 @@ const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
 import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
 import { setFalFetchGuardForTesting } from "./test-support.js";
 
-function mockFalImageProviderRuntime() {
-  vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-    apiKey: "fal-test-key",
-    source: "env",
-    mode: "api-key",
-  });
-  setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+const falApiKey = { apiKey: "fal-test-key", source: "env", mode: "api-key" } as const;
+
+function releasedJson(payload: unknown, release = vi.fn(async () => {})) {
+  return { response: Response.json(payload), release };
 }
 
-function mockFalGeneratedImage(fileName: string, imageData: string) {
-  fetchWithSsrFGuardMock
-    .mockResolvedValueOnce({
-      response: Response.json({
-        images: [{ url: `https://v3.fal.media/files/example/${fileName}` }],
-      }),
-      release: vi.fn(async () => {}),
-    })
-    .mockResolvedValueOnce({
-      response: new Response(Buffer.from(imageData), {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      }),
-      release: vi.fn(async () => {}),
-    });
+function releasedImage(data: BodyInit, release = vi.fn(async () => {})) {
+  return {
+    response: new Response(data, { status: 200, headers: { "content-type": "image/png" } }),
+    release,
+  };
 }
 
-function expectFalJsonPost(params: { call: number; url: string; body: Record<string, unknown> }) {
-  const request = fetchWithSsrFGuardMock.mock.calls[params.call - 1]?.[0];
+function expectFalJsonPost(params: { url: string; body: Record<string, unknown> }) {
+  const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0];
   if (!request) {
-    throw new Error(`expected fal fetch request #${params.call}`);
+    throw new Error("expected fal fetch request #1");
   }
   expect(request.url).toBe(params.url);
   expect(request.auditContext).toBe("fal-image-generate");
@@ -60,8 +48,36 @@ function expectFalDownload(params: { call: number; url: string; timeoutMs?: numb
 }
 
 describe("fal image-generation provider", () => {
+  let provider: ReturnType<typeof buildFalImageGenerationProvider>;
+
+  function sourceImage(buffer: string, mimeType = "image/png", fileName?: string) {
+    return { buffer: Buffer.from(buffer), mimeType, ...(fileName ? { fileName } : {}) };
+  }
+
+  function generateFalImage(
+    fileName: string,
+    imageData: string,
+    request: Omit<ImageGenerationRequest, "provider" | "model" | "cfg"> &
+      Partial<Pick<ImageGenerationRequest, "model" | "cfg">>,
+  ) {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: `https://v3.fal.media/files/example/${fileName}` }] }),
+      )
+      .mockResolvedValueOnce(releasedImage(Buffer.from(imageData)));
+    return provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/flux/dev",
+      cfg: {},
+      ...request,
+    });
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue(falApiKey);
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    provider = buildFalImageGenerationProvider();
   });
 
   afterEach(() => {
@@ -71,8 +87,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("publishes model-specific Grok and Nano Banana 2 Lite geometry", () => {
-    const geometry = buildFalImageGenerationProvider().capabilities.geometry;
-    const edit = buildFalImageGenerationProvider().capabilities.edit;
+    const { geometry, edit } = provider.capabilities;
     const grokRatios = geometry?.aspectRatiosByModel?.["xai/grok-imagine-image"];
     const grokResolutions = geometry?.resolutionsByModel?.["xai/grok-imagine-image"];
     const nanoResolutions = geometry?.resolutionsByModel?.["google/nano-banana-2-lite"];
@@ -100,13 +115,12 @@ describe("fal image-generation provider", () => {
   });
 
   it("generates image buffers from the fal sync API", async () => {
-    mockFalImageProviderRuntime();
     const releaseRequest = vi.fn(async () => {});
     const releaseDownload = vi.fn(async () => {});
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
+      .mockResolvedValueOnce(
+        releasedJson(
+          {
             images: [
               {
                 url: "https://v3.fal.media/files/example/generated.png",
@@ -114,23 +128,12 @@ describe("fal image-generation provider", () => {
               },
             ],
             prompt: "draw a cat",
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
           },
+          releaseRequest,
         ),
-        release: releaseRequest,
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("png-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: releaseDownload,
-      });
+      )
+      .mockResolvedValueOnce(releasedImage(Buffer.from("png-data"), releaseDownload));
 
-    const provider = buildFalImageGenerationProvider();
     const result = await provider.generateImage({
       provider: "fal",
       model: "fal-ai/flux/dev",
@@ -142,7 +145,6 @@ describe("fal image-generation provider", () => {
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
         prompt: "draw a cat",
@@ -170,50 +172,27 @@ describe("fal image-generation provider", () => {
   it("shares an explicit operation deadline across generated image downloads", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-10T00:00:00Z"));
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockImplementation(async () => {
+    vi.mocked(providerAuth.resolveApiKeyForProvider).mockImplementation(async () => {
       vi.advanceTimersByTime(5_000);
-      return {
-        apiKey: "fal-test-key",
-        source: "env",
-        mode: "api-key",
-      };
+      return falApiKey;
     });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockImplementationOnce(async () => {
         vi.advanceTimersByTime(10_000);
-        return {
-          response: new Response(
-            JSON.stringify({
-              images: [
-                { url: "https://v3.fal.media/files/example/first.png" },
-                { url: "https://v3.fal.media/files/example/second.png" },
-              ],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-          release: vi.fn(async () => {}),
-        };
+        return releasedJson({
+          images: [
+            { url: "https://v3.fal.media/files/example/first.png" },
+            { url: "https://v3.fal.media/files/example/second.png" },
+          ],
+        });
       })
       .mockImplementationOnce(async () => {
         vi.advanceTimersByTime(20_000);
-        return {
-          response: new Response(Buffer.from("first"), {
-            status: 200,
-            headers: { "content-type": "image/png" },
-          }),
-          release: vi.fn(async () => {}),
-        };
+        return releasedImage(Buffer.from("first"));
       })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("second"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+      .mockResolvedValueOnce(releasedImage(Buffer.from("second")));
 
-    const result = await buildFalImageGenerationProvider().generateImage({
+    const result = await provider.generateImage({
       provider: "fal",
       model: "fal-ai/flux/dev",
       prompt: "draw two cats",
@@ -237,29 +216,21 @@ describe("fal image-generation provider", () => {
   });
 
   it("releases a timed-out generated image download", async () => {
-    mockFalImageProviderRuntime();
     const releaseDownload = vi.fn(async () => {});
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/slow.png" }],
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: "https://v3.fal.media/files/example/slow.png" }] }),
+      )
+      .mockResolvedValueOnce(
+        releasedImage(
           new ReadableStream({
             start(controller) {
               controller.error(new DOMException("timed out", "TimeoutError"));
             },
           }),
-          { status: 200, headers: { "content-type": "image/png" } },
+          releaseDownload,
         ),
-        release: releaseDownload,
-      });
+      );
 
     await expect(
       buildFalImageGenerationProvider().generateImage({
@@ -273,29 +244,12 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects generated image downloads that exceed the configured media cap", async () => {
-    mockFalImageProviderRuntime();
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/generated.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("too-large"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: "https://v3.fal.media/files/example/generated.png" }] }),
+      )
+      .mockResolvedValueOnce(releasedImage(Buffer.from("too-large")));
 
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -307,19 +261,10 @@ describe("fal image-generation provider", () => {
   });
 
   it("wraps wrong-shape successful fal image responses", async () => {
-    mockFalImageProviderRuntime();
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(
-        JSON.stringify({ images: { url: "https://example.test/image.png" } }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      ),
-      release: vi.fn(async () => {}),
-    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce(
+      releasedJson({ images: { url: "https://example.test/image.png" } }),
+    );
 
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -331,27 +276,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("uses image-to-image endpoint and data-uri input for edits", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("edited.png", "edited-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
-      model: "fal-ai/flux/dev",
+    await generateFalImage("edited.png", "edited-data", {
       prompt: "turn this into a noir poster",
-      cfg: {},
       resolution: "2K",
-      inputImages: [
-        {
-          buffer: Buffer.from("source-image"),
-          mimeType: "image/jpeg",
-          fileName: "source.jpg",
-        },
-      ],
+      inputImages: [sourceImage("source-image", "image/jpeg", "source.jpg")],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/flux/dev/image-to-image",
       body: {
         prompt: "turn this into a noir poster",
@@ -364,24 +295,14 @@ describe("fal image-generation provider", () => {
   });
 
   it("routes GPT Image 2 edits through /edit with image_urls", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("gpt-edited.png", "gpt-edited-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("gpt-edited.png", "gpt-edited-data", {
       model: "openai/gpt-image-2",
       prompt: "combine these references",
-      cfg: {},
       aspectRatio: "16:9",
-      inputImages: [
-        { buffer: Buffer.from("first"), mimeType: "image/png" },
-        { buffer: Buffer.from("second"), mimeType: "image/jpeg" },
-      ],
+      inputImages: [sourceImage("first"), sourceImage("second", "image/jpeg")],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/openai/gpt-image-2/edit",
       body: {
         prompt: "combine these references",
@@ -397,25 +318,15 @@ describe("fal image-generation provider", () => {
   });
 
   it("allows GPT Image 2 edits up to 10 reference images", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("gpt-edited.png", "gpt-edited-data");
+    const inputImages = Array.from({ length: 10 }, (_, index) => sourceImage(`ref-${index + 1}`));
 
-    const inputImages = Array.from({ length: 10 }, (_, index) => ({
-      buffer: Buffer.from(`ref-${index + 1}`),
-      mimeType: "image/png",
-    }));
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("gpt-edited.png", "gpt-edited-data", {
       model: "openai/gpt-image-2",
       prompt: "combine all references",
-      cfg: {},
       inputImages,
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/openai/gpt-image-2/edit",
       body: {
         prompt: "combine all references",
@@ -429,9 +340,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects GPT Image 2 edits above 10 reference images", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -448,21 +356,14 @@ describe("fal image-generation provider", () => {
   });
 
   it("routes Nano Banana 2 text generation with native resolution", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("nb2-wide.png", "nb2-wide-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("nb2-wide.png", "nb2-wide-data", {
       model: "fal-ai/nano-banana-2",
       prompt: "ultrawide banana test",
-      cfg: {},
       aspectRatio: "4:1",
       resolution: "2K",
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/nano-banana-2",
       body: {
         prompt: "ultrawide banana test",
@@ -475,20 +376,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("does not synthesize Nano Banana 2 aspect ratio from resolution alone", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("nb2-auto.png", "nb2-auto-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("nb2-auto.png", "nb2-auto-data", {
       model: "fal-ai/nano-banana-2",
       prompt: "auto aspect banana test",
-      cfg: {},
       resolution: "2K",
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/nano-banana-2",
       body: {
         prompt: "auto aspect banana test",
@@ -503,25 +397,15 @@ describe("fal image-generation provider", () => {
     { model: "fal-ai/nano-banana", resolution: undefined },
     { model: "fal-ai/nano-banana-2", resolution: "2K" as const },
   ])("routes $model edits through /edit with model geometry", async ({ model, resolution }) => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("nb2-edited.png", "nb2-edited-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("nb2-edited.png", "nb2-edited-data", {
       model,
       prompt: "blend these references",
-      cfg: {},
       aspectRatio: "9:16",
       ...(resolution ? { resolution } : {}),
-      inputImages: [
-        { buffer: Buffer.from("first"), mimeType: "image/png" },
-        { buffer: Buffer.from("second"), mimeType: "image/png" },
-      ],
+      inputImages: [sourceImage("first"), sourceImage("second")],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: `https://fal.run/${model}/edit`,
       body: {
         prompt: "blend these references",
@@ -549,9 +433,6 @@ describe("fal image-generation provider", () => {
       error: "fal Nano Banana 2 supports at most 14 reference images",
     },
   ])("rejects $model edits above its reference limit", async ({ model, inputCount, error }) => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -568,9 +449,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Krea-only aspect ratios for Nano Banana 2", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -584,24 +462,14 @@ describe("fal image-generation provider", () => {
   });
 
   it("routes Nano Banana 2 Lite edits through /edit with image_urls", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("nb2-lite-edited.png", "nb2-lite-edited-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("nb2-lite-edited.png", "nb2-lite-edited-data", {
       model: "google/nano-banana-2-lite",
       prompt: "drive the man down the coastline",
-      cfg: {},
       aspectRatio: "3:2",
-      inputImages: [
-        { buffer: Buffer.from("first"), mimeType: "image/png" },
-        { buffer: Buffer.from("second"), mimeType: "image/png" },
-      ],
+      inputImages: [sourceImage("first"), sourceImage("second")],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/google/nano-banana-2-lite/edit",
       body: {
         prompt: "drive the man down the coastline",
@@ -617,9 +485,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Krea-only aspect ratios for Nano Banana 2 Lite", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -635,9 +500,6 @@ describe("fal image-generation provider", () => {
   it.each(["1K", "2K", "4K"] as const)(
     "rejects %s resolution overrides for Nano Banana 2 Lite",
     async (resolution) => {
-      mockFalImageProviderRuntime();
-
-      const provider = buildFalImageGenerationProvider();
       await expect(
         provider.generateImage({
           provider: "fal",
@@ -654,9 +516,6 @@ describe("fal image-generation provider", () => {
   );
 
   it("rejects Nano Banana 2 Lite edits above 14 reference images", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -699,43 +558,29 @@ describe("fal image-generation provider", () => {
       },
     },
   ])("keeps $label text-to-image on its base endpoint", async (testCase) => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("generated.png", "generated-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("generated.png", "generated-data", {
       model: testCase.model,
       prompt: "generate without references",
-      cfg: {},
       aspectRatio: testCase.aspectRatio,
       resolution: testCase.resolution,
     });
 
     expectFalJsonPost({
-      call: 1,
       url: `https://fal.run/${testCase.model}`,
       body: testCase.expectedBody,
     });
   });
 
   it("routes Grok Imagine edits through /edit with lowercase resolution", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("grok-edited.png", "grok-edited-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("grok-edited.png", "grok-edited-data", {
       model: "xai/grok-imagine-image",
       prompt: "make it more realistic",
-      cfg: {},
       aspectRatio: "16:9",
       resolution: "2K",
       inputImages: [{ buffer: Buffer.from("source"), mimeType: "image/jpeg" }],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/xai/grok-imagine-image/edit",
       body: {
         prompt: "make it more realistic",
@@ -749,9 +594,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects 4K resolution for Grok Imagine edits", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -767,9 +609,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Nano Banana ratios for Grok Imagine", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -783,9 +622,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Grok Imagine edits above 3 reference images", async () => {
-    mockFalImageProviderRuntime();
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -802,20 +638,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("preserves an explicit Grok Imagine /quality/edit model path", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("grok-explicit.png", "grok-explicit-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("grok-explicit.png", "grok-explicit-data", {
       model: "xai/grok-imagine-image/quality/edit",
       prompt: "explicit edit endpoint",
-      cfg: {},
       inputImages: [{ buffer: Buffer.from("source"), mimeType: "image/png" }],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/xai/grok-imagine-image/quality/edit",
       body: {
         prompt: "explicit edit endpoint",
@@ -827,20 +656,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("preserves exact custom Fal edit endpoints", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("custom-edit.png", "custom-edit-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("custom-edit.png", "custom-edit-data", {
       model: "fal-ai/custom/edit",
       prompt: "edit through custom endpoint",
-      cfg: {},
       inputImages: [{ buffer: Buffer.from("source-image"), mimeType: "image/png" }],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/custom/edit",
       body: {
         prompt: "edit through custom endpoint",
@@ -852,20 +674,12 @@ describe("fal image-generation provider", () => {
   });
 
   it("maps aspect ratio for text generation without forcing a square default", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("wide.png", "wide-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
-      model: "fal-ai/flux/dev",
+    await generateFalImage("wide.png", "wide-data", {
       prompt: "wide cinematic shot",
-      cfg: {},
       aspectRatio: "16:9",
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
         prompt: "wide cinematic shot",
@@ -877,21 +691,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("combines resolution and aspect ratio for text generation", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("portrait.png", "portrait-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
-      model: "fal-ai/flux/dev",
+    await generateFalImage("portrait.png", "portrait-data", {
       prompt: "portrait poster",
-      cfg: {},
       resolution: "2K",
       aspectRatio: "9:16",
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
         prompt: "portrait poster",
@@ -903,15 +709,9 @@ describe("fal image-generation provider", () => {
   });
 
   it("uses Krea 2 native aspect-ratio and creativity payload schema", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("krea.png", "krea-data");
-
-    const provider = buildFalImageGenerationProvider();
-    const result = await provider.generateImage({
-      provider: "fal",
+    const result = await generateFalImage("krea.png", "krea-data", {
       model: "krea/v2/medium/text-to-image",
       prompt: "expressive risograph poster",
-      cfg: {},
       aspectRatio: "9:16",
       providerOptions: {
         fal: {
@@ -921,7 +721,6 @@ describe("fal image-generation provider", () => {
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/krea/v2/medium/text-to-image",
       body: {
         prompt: "expressive risograph poster",
@@ -933,24 +732,14 @@ describe("fal image-generation provider", () => {
   });
 
   it("passes reference images to Krea 2 as style references without edit suffix", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("krea-style.png", "krea-style-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("krea-style.png", "krea-style-data", {
       model: "krea/v2/large/text-to-image",
       prompt: "portrait with the same palette and texture",
-      cfg: {},
       size: "1024x1536",
-      inputImages: [
-        { buffer: Buffer.from("style-a"), mimeType: "image/png" },
-        { buffer: Buffer.from("style-b"), mimeType: "image/jpeg" },
-      ],
+      inputImages: [sourceImage("style-a"), sourceImage("style-b", "image/jpeg")],
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/krea/v2/large/text-to-image",
       body: {
         prompt: "portrait with the same palette and texture",
@@ -965,20 +754,13 @@ describe("fal image-generation provider", () => {
   });
 
   it("maps Krea 2 size hints to the closest native aspect ratio", async () => {
-    mockFalImageProviderRuntime();
-    mockFalGeneratedImage("krea-sized.png", "krea-sized-data");
-
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
+    await generateFalImage("krea-sized.png", "krea-sized-data", {
       model: "krea/v2/medium/text-to-image",
       prompt: "portrait poster",
-      cfg: {},
       size: "1024x1536",
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "https://fal.run/krea/v2/medium/text-to-image",
       body: {
         prompt: "portrait poster",
@@ -989,13 +771,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Krea 2 resolution hints instead of dropping them", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1018,13 +793,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects multi-image count for Krea 2 single-image endpoints", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1037,13 +805,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects output format overrides for Krea 2", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1056,13 +817,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects multi-image for Flux edit", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1078,13 +832,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects aspect ratio for Flux edit", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1098,24 +845,15 @@ describe("fal image-generation provider", () => {
   });
 
   it("blocks private-network image download URLs through the SSRF guard", async () => {
-    mockFalImageProviderRuntime();
     const blocked = new Error("Blocked: resolves to private/internal/special-use IP address");
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
+      .mockResolvedValueOnce(
+        releasedJson({
+          images: [{ url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/" }],
+        }),
+      )
       .mockRejectedValueOnce(blocked);
 
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",
@@ -1132,29 +870,12 @@ describe("fal image-generation provider", () => {
   });
 
   it("does not auto-whitelist trusted private relay hosts from a configured baseUrl", async () => {
-    mockFalImageProviderRuntime();
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "http://media.relay.internal/files/generated.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("png-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: "http://media.relay.internal/files/generated.png" }] }),
+      )
+      .mockResolvedValueOnce(releasedImage(Buffer.from("png-data")));
 
-    const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
       provider: "fal",
       model: "fal-ai/flux/dev",
@@ -1172,7 +893,6 @@ describe("fal image-generation provider", () => {
     });
 
     expectFalJsonPost({
-      call: 1,
       url: "http://relay.internal:8080/fal-ai/flux/dev",
       body: {
         prompt: "draw a cat",
@@ -1183,4 +903,3 @@ describe("fal image-generation provider", () => {
     expectFalDownload({ call: 2, url: "http://media.relay.internal/files/generated.png" });
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Fal image-generation provider coverage had grown to 1,186 lines because each scenario rebuilt the same provider, auth setup, guarded HTTP responses, and source-image fixtures. That duplication made the provider-specific request, SSRF, timeout, and cleanup contracts harder to review.

## Why This Change Was Made

Consolidate only private, strongly typed test fixtures: each scenario still receives a freshly initialized provider/auth spy/SSRF guard, while response and source-image helpers preserve the real provider HTTP, deadline, download-limit, and release paths. Keep every model-specific expected HTTP request body visible and unchanged, and retire the now-obsolete grandfathered max-lines lint suppression with its exact baseline entry. No production code, public API, or runtime behavior changes.

## User Impact

No user-visible behavior changes. Developer coverage remains identical while the Fal image-provider suite shrinks from **1,186 to 905 lines (−281 test LOC; 0 production LOC)** and one grandfathered lint exception disappears (**−282 total lines**).

## Evidence

- Immutable AST parity: **38 test declarations, 43 expanded cases, the same four tables `[2, 2, 3, 2]`, and all 59 ordered matcher expressions with identical actual and expected arguments**.
  - Declaration/table SHA-256: `5ad8a84f0722cbd4674ec433efdba1a3473eb99a30b9654462382956ffc9f3b2` before and after.
  - Complete assertion-expression SHA-256: `8d29843f6d8160e41e46a699f3e2a5bb59e27ff5177b1efc059f016a906298ad` before and after.
- Trusted Blacksmith Testbox focused suite: `pnpm test extensions/fal/image-generation-provider.test.ts` — **43/43 passed**.
- Trusted Blacksmith Testbox full Fal image/video/music plus neighboring Comfy, MiniMax, xAI, and Microsoft Foundry image providers — **128/128 passed across seven files**.
- Trusted Blacksmith Testbox complete `pnpm check:changed` — **passed**, including dead-export scans, plugin-boundary checks, formatting, extension-test typechecking, and changed-file lint.
- Independent explicit `gpt-5.6-sol` / `xhigh` review: **clean**, including auth/header/body, no-network validation, shared deadlines, timed-out release, media limits, malformed responses, SSRF blocking, and private-relay non-whitelisting.
- Structured explicit `autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking xhigh`: **clean**.
