### PR TITLE
fix(gateway): hide repaired stream-error history rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway chat history:** hide a synthetic failed-before-content placeholder once later visible assistant content repairs the same turn, while keeping standalone failures visible and SSE refreshes bounded. Fixes #91503.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway chat history:** hide a synthetic failed-before-content placeholder once later visible assistant content repairs the same turn, while keeping standalone failures visible and SSE refreshes bounded. Fixes #91503.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.
 - **Microsoft Teams message-tool replies:** keep automatic live previews from duplicating a message already delivered to the current Teams conversation, while preserving distinct follow-up text and cross-conversation sends. Fixes #116397. (#116398) Thanks @a-tokyo.

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -74,20 +74,42 @@ function sanitizeAssistantErrorDisplayMessage(
     string,
     unknown
   >;
-  next.content = Array.isArray(content)
-    ? content
-        .map(
-          (block) =>
-            sanitizeChatHistoryContentBlock(block, { maxChars: Number.MAX_SAFE_INTEGER }).block,
-        )
-        .filter((block) => {
-          if (!block || typeof block !== "object" || Array.isArray(block)) {
-            return true;
-          }
-          const type = (block as { type?: unknown }).type;
-          return type !== "thinking" && type !== "reasoning" && type !== "redacted_thinking";
-        })
-    : content;
+  if (Array.isArray(content)) {
+    let firstTextBlock = true;
+    next.content = content.flatMap((block) => {
+      const sanitized = sanitizeChatHistoryContentBlock(block, {
+        maxChars: Number.MAX_SAFE_INTEGER,
+      }).block;
+      if (!sanitized || typeof sanitized !== "object" || Array.isArray(sanitized)) {
+        return [sanitized];
+      }
+      const entry = sanitized as { type?: unknown; text?: unknown };
+      if (
+        entry.type === "thinking" ||
+        entry.type === "reasoning" ||
+        entry.type === "redacted_thinking"
+      ) {
+        return [];
+      }
+      if (!firstTextBlock || !isAssistantTextContentType(entry.type)) {
+        return [sanitized];
+      }
+      firstTextBlock = false;
+      if (typeof entry.text !== "string" || !entry.text.startsWith(STREAM_ERROR_FALLBACK_TEXT)) {
+        return [sanitized];
+      }
+      const replyText = entry.text.slice(STREAM_ERROR_FALLBACK_TEXT.length);
+      return replyText ? [{ ...entry, text: replyText }] : [];
+    });
+  } else {
+    next.content =
+      typeof content === "string" && content.startsWith(STREAM_ERROR_FALLBACK_TEXT)
+        ? content.slice(STREAM_ERROR_FALLBACK_TEXT.length)
+        : content;
+  }
+  if (typeof next.text === "string" && next.text.startsWith(STREAM_ERROR_FALLBACK_TEXT)) {
+    next.text = next.text.slice(STREAM_ERROR_FALLBACK_TEXT.length);
+  }
   delete next.diagnostics;
   delete next.errorBody;
   delete next.errorCode;
@@ -109,7 +131,11 @@ function isPureStreamErrorFallbackAssistantMessage(message: Record<string, unkno
 }
 
 function hasVisibleAssistantDisplayContent(message: Record<string, unknown>): boolean {
-  if (message.role !== "assistant" || isPureStreamErrorFallbackAssistantMessage(message)) {
+  if (
+    message.role !== "assistant" ||
+    message.display === false ||
+    isPureStreamErrorFallbackAssistantMessage(message)
+  ) {
     return false;
   }
   const sanitized = sanitizeChatHistoryMessage(message, Number.MAX_SAFE_INTEGER).message as Record<

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -2,6 +2,9 @@ import { isContextOverflowError } from "../agents/embedded-agent-helpers/context
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  extractAssistantTextForSilentCheck,
+  hasAssistantDisplayableNonTextContent,
+  hasAssistantNonTextContent,
   isAssistantTextContentType,
 } from "./chat-display-projection.helpers.js";
 import {
@@ -24,11 +27,14 @@ type ChatDisplayProjectionOptions = {
   maxChars?: number;
   stripEnvelope?: boolean;
   turnBoundaryPending?: boolean;
+  streamErrorFallbackPending?: boolean;
 };
 
 type ChatDisplayProjectionResult = {
   messages: Array<Record<string, unknown>>;
   turnBoundaryPending: boolean;
+  streamErrorFallbackPending: boolean;
+  streamErrorFallbackRepaired: boolean;
 };
 
 const GATEWAY_ASSISTANT_ERROR_FALLBACK_TEXT = "The agent run failed before producing a reply.";
@@ -90,6 +96,84 @@ function sanitizeAssistantErrorDisplayMessage(
   return next;
 }
 
+function isPureStreamErrorFallbackAssistantMessage(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant" || message.stopReason !== "error") {
+    return false;
+  }
+  const text = extractAssistantTextForSilentCheck(message);
+  return (
+    text !== undefined &&
+    text.trim() === STREAM_ERROR_FALLBACK_TEXT &&
+    !hasAssistantNonTextContent(message)
+  );
+}
+
+function hasVisibleAssistantDisplayContent(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant" || isPureStreamErrorFallbackAssistantMessage(message)) {
+    return false;
+  }
+  const sanitized = sanitizeChatHistoryMessage(message, Number.MAX_SAFE_INTEGER).message as Record<
+    string,
+    unknown
+  >;
+  if (shouldDropAssistantHistoryMessage(sanitized)) {
+    return false;
+  }
+  if (hasAssistantDisplayableNonTextContent(sanitized)) {
+    return true;
+  }
+  const text = extractAssistantTextForSilentCheck(sanitized);
+  return Boolean(text?.trim()) && !isSuppressedControlReplyText(text ?? "");
+}
+
+function projectRepairedStreamErrorFallbackMessages(
+  messages: Array<Record<string, unknown>>,
+  initialPending = false,
+): {
+  messages: Array<Record<string, unknown>>;
+  pending: boolean;
+  repaired: boolean;
+} {
+  let pending = initialPending;
+  let repaired = false;
+  let changed = false;
+  let pendingIndexes: number[] = [];
+  const repairedIndexes = new Set<number>();
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+    if (message.role === "user") {
+      pending = false;
+      pendingIndexes = [];
+      continue;
+    }
+    if (isPureStreamErrorFallbackAssistantMessage(message)) {
+      pending = true;
+      pendingIndexes.push(index);
+      continue;
+    }
+    if (!pending || !hasVisibleAssistantDisplayContent(message)) {
+      continue;
+    }
+    repaired = true;
+    pending = false;
+    if (pendingIndexes.length > 0) {
+      changed = true;
+      for (const pendingIndex of pendingIndexes) {
+        repairedIndexes.add(pendingIndex);
+      }
+      pendingIndexes = [];
+    }
+  }
+  return {
+    messages: changed ? messages.filter((_, index) => !repairedIndexes.has(index)) : messages,
+    pending,
+    repaired,
+  };
+}
+
 function projectEmptyAssistantErrorMessages(
   messages: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
@@ -98,20 +182,7 @@ function projectEmptyAssistantErrorMessages(
     if (message.role !== "assistant" || message.stopReason !== "error") {
       return message;
     }
-    const hasDisplayableStructuredContent =
-      Array.isArray(message.content) &&
-      message.content.some((block) => {
-        if (!block || typeof block !== "object" || Array.isArray(block)) {
-          return false;
-        }
-        const type = (block as { type?: unknown }).type;
-        return (
-          !isAssistantTextContentType(type) &&
-          type !== "thinking" &&
-          type !== "reasoning" &&
-          type !== "redacted_thinking"
-        );
-      });
+    const hasDisplayableStructuredContent = hasAssistantDisplayableNonTextContent(message);
     if (hasDisplayableStructuredContent) {
       changed = true;
       return sanitizeAssistantErrorDisplayMessage(message);
@@ -166,7 +237,11 @@ export function projectChatDisplayMessagesWithState(
 ): ChatDisplayProjectionResult {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
   const mirrored = mirrorMessageToolVisibleReplies(source);
-  const projectedErrors = projectEmptyAssistantErrorMessages(toProjectedMessages(mirrored));
+  const repairedStreamErrors = projectRepairedStreamErrorFallbackMessages(
+    toProjectedMessages(mirrored),
+    options?.streamErrorFallbackPending,
+  );
+  const projectedErrors = projectEmptyAssistantErrorMessages(repairedStreamErrors.messages);
   const filtered = filterVisibleProjectedHistoryMessages(
     projectSessionsSendInterSessionMessages(
       toProjectedMessages(sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER)),
@@ -179,6 +254,8 @@ export function projectChatDisplayMessagesWithState(
       options?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
     ) as Array<Record<string, unknown>>,
     turnBoundaryPending: filtered.turnBoundaryPending,
+    streamErrorFallbackPending: repairedStreamErrors.pending,
+    streamErrorFallbackRepaired: repairedStreamErrors.repaired,
   };
 }
 

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1271,6 +1271,81 @@ describe("projectRecentChatDisplayMessages", () => {
     },
   );
 
+  it("drops a repaired stream-error placeholder before same-turn assistant content", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+        stopReason: "error",
+        errorMessage: "provider failed before content",
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "actual fallback response" }],
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "actual fallback response" }],
+        timestamp: 3,
+      },
+    ]);
+  });
+
+  it("keeps a stream-error placeholder when the next user turn starts first", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+        stopReason: "error",
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "fresh answer" }],
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+        stopReason: "error",
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "fresh answer" }],
+        timestamp: 3,
+      },
+    ]);
+  });
+
   it("projects sessions_send inter-session turns as forwarded assistant-side display messages", () => {
     const result = projectRecentChatDisplayMessages([
       {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1003,6 +1003,17 @@ describe("projectRecentChatDisplayMessages", () => {
       content: safeFailureContent,
     },
     {
+      name: "preserves a safe failure for a synthetic sentinel followed only by private thinking",
+      message: {
+        content: [
+          { type: "text", text: STREAM_ERROR_FALLBACK_TEXT },
+          { type: "thinking", thinking: "private upstream details" },
+        ],
+        errorMessage: privateError,
+      },
+      content: safeFailureContent,
+    },
+    {
       name: "projects reasoning-text-only assistant errors as a generic safe failure",
       message: {
         content: [{ type: "reasoning", text: "private upstream details" }],
@@ -1271,6 +1282,97 @@ describe("projectRecentChatDisplayMessages", () => {
     },
   );
 
+  it.each([
+    {
+      name: "plain string content",
+      content: `${STREAM_ERROR_FALLBACK_TEXT}I'm running on ollama-cloud now.`,
+      expected: "I'm running on ollama-cloud now.",
+    },
+    {
+      name: "one text block",
+      content: [
+        { type: "text", text: `${STREAM_ERROR_FALLBACK_TEXT}I'm running on ollama-cloud now.` },
+      ],
+      expected: [{ type: "text", text: "I'm running on ollama-cloud now." }],
+    },
+    {
+      name: "provider output-text block",
+      content: [{ type: "output_text", text: `${STREAM_ERROR_FALLBACK_TEXT}Good catch.` }],
+      expected: [{ type: "output_text", text: "Good catch." }],
+    },
+    {
+      name: "separate sentinel and reply text blocks",
+      content: [
+        { type: "text", text: STREAM_ERROR_FALLBACK_TEXT },
+        { type: "text", text: "I'm running on ollama-cloud now." },
+      ],
+      expected: [{ type: "text", text: "I'm running on ollama-cloud now." }],
+    },
+  ])("removes an internal stream-error prefix from same-message $name", ({ content, expected }) => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content,
+        stopReason: "error",
+        errorMessage: "private upstream at secret.internal.example failed",
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: expected,
+        stopReason: "error",
+        timestamp: 1,
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain(STREAM_ERROR_FALLBACK_TEXT);
+    expect(JSON.stringify(result)).not.toContain("secret.internal.example");
+  });
+
+  it("keeps intentional mentions of the internal fallback inside a real assistant reply", () => {
+    const text = `Diagnostic note: ${STREAM_ERROR_FALLBACK_TEXT}`;
+    const result = projectRecentChatDisplayMessages([
+      { role: "assistant", content: [{ type: "text", text }], stopReason: "error" },
+    ]);
+
+    expect(result[0]?.content).toEqual([{ type: "text", text }]);
+  });
+
+  it.each([undefined, "stop"])(
+    "keeps literal fallback-prefixed assistant text without error provenance %j",
+    (stopReason) => {
+      const text = `${STREAM_ERROR_FALLBACK_TEXT} actual quoted text`;
+      const result = projectRecentChatDisplayMessages([
+        {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          ...(stopReason ? { stopReason } : {}),
+        },
+      ]);
+
+      expect(result[0]?.content).toEqual([{ type: "text", text }]);
+    },
+  );
+
+  it("removes a synthetic error prefix while preserving displayable image content", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: STREAM_ERROR_FALLBACK_TEXT },
+          { type: "image", data: "AQ==" },
+        ],
+        stopReason: "error",
+        errorMessage: "private upstream at secret.internal.example failed",
+      },
+    ]);
+
+    expect(result[0]?.content).toEqual([{ type: "image", omitted: true, bytes: 1 }]);
+    expect(JSON.stringify(result)).not.toContain("secret.internal.example");
+  });
+
   it("drops a repaired stream-error placeholder before same-turn assistant content", () => {
     const result = projectRecentChatDisplayMessages([
       {
@@ -1302,6 +1404,69 @@ describe("projectRecentChatDisplayMessages", () => {
         role: "assistant",
         content: [{ type: "text", text: "actual fallback response" }],
         timestamp: 3,
+      },
+    ]);
+  });
+
+  it("keeps a genuine failed turn before a new forwarded inter-session turn", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+        stopReason: "error",
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "forwarded update" }],
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:webchat:source",
+          sourceTool: "sessions_send",
+        },
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "actual fallback response" }],
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+    });
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "forwarded update" }],
+    });
+    expect(result[2]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "actual fallback response" }],
+    });
+  });
+
+  it("keeps genuine stream-error failures when a hidden assistant row has text", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+        stopReason: "error",
+      },
+      {
+        role: "assistant",
+        display: false,
+        content: [{ type: "text", text: "internal-only assistant content" }],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+        stopReason: "error",
       },
     ]);
   });

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -479,6 +479,42 @@ describe("SessionHistorySseState", () => {
     });
   });
 
+  test("keeps an inline failed turn before a new forwarded inter-session turn", () => {
+    const state = newState([
+      {
+        role: "assistant",
+        content: textContent(STREAM_ERROR_FALLBACK_TEXT),
+        stopReason: "error",
+        __openclaw: { seq: 1 },
+      },
+    ]);
+
+    const forwarded = state.appendInlineMessage({
+      message: {
+        role: "user",
+        content: textContent("forwarded update"),
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:webchat:source",
+          sourceTool: "sessions_send",
+        },
+      },
+      messageSeq: 2,
+    });
+
+    expect(forwarded?.message).toMatchObject({
+      role: "assistant",
+      content: textContent("forwarded update"),
+    });
+    expect(appendAssistantText(state, "actual fallback response", 3)?.message).toMatchObject({
+      role: "assistant",
+      content: textContent("actual fallback response"),
+    });
+    expect(state.snapshot().messages[0]?.content).toEqual([
+      { type: "text", text: "The agent run failed before producing a reply." },
+    ]);
+  });
+
   test("requests refresh when initial SSE history ends with a repaired stream error", () => {
     const state = newState([
       userTextMessage("hello", 1),

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -3,6 +3,7 @@
  */
 import { createHash } from "node:crypto";
 import { describe, expect, test, vi } from "vitest";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import { buildSessionHistorySnapshot, SessionHistorySseState } from "./session-history-state.js";
 import * as sessionTranscriptReaders from "./session-transcript-readers.js";
@@ -453,6 +454,45 @@ describe("SessionHistorySseState", () => {
     expect(appended).toEqual({ shouldRefresh: true });
     expect(state.snapshot().messages).toHaveLength(1);
     expect(state.snapshot().messages.at(-1)?.["__openclaw"]?.seq).toBe(5);
+  });
+
+  test("requests refresh when later assistant content repairs an inline stream error", () => {
+    const state = newState([userTextMessage("hello", 1)]);
+
+    const sentinel = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: textContent(STREAM_ERROR_FALLBACK_TEXT),
+        stopReason: "error",
+        errorMessage: "provider failed before content",
+      },
+      messageSeq: 2,
+    });
+
+    expect(sentinel?.message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+      __openclaw: { seq: 2 },
+    });
+    expect(appendAssistantText(state, "actual fallback response", 3)).toEqual({
+      shouldRefresh: true,
+    });
+  });
+
+  test("requests refresh when initial SSE history ends with a repaired stream error", () => {
+    const state = newState([
+      userTextMessage("hello", 1),
+      {
+        role: "assistant",
+        content: textContent(STREAM_ERROR_FALLBACK_TEXT),
+        stopReason: "error",
+        __openclaw: { seq: 2 },
+      },
+    ]);
+
+    expect(appendAssistantText(state, "actual fallback response", 3)).toEqual({
+      shouldRefresh: true,
+    });
   });
 
   test("marks bounded tail snapshots as having older history", () => {

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -37,6 +37,7 @@ type SessionHistorySnapshot = {
   history: PaginatedSessionHistory;
   rawTranscriptSeq: number;
   turnBoundaryPending: boolean;
+  streamErrorFallbackPending: boolean;
 };
 
 type InlineSessionHistoryAppend = {
@@ -186,6 +187,7 @@ export function buildSessionHistorySnapshot(params: {
       resolveMessageSeq(rawHistoryMessages.at(-1)) ??
       rawHistoryMessages.length,
     turnBoundaryPending: projected.turnBoundaryPending,
+    streamErrorFallbackPending: projected.streamErrorFallbackPending,
   };
 }
 
@@ -198,6 +200,7 @@ export class SessionHistorySseState {
   private sentHistory: PaginatedSessionHistory;
   private rawTranscriptSeq: number;
   private turnBoundaryPending: boolean;
+  private streamErrorFallbackPending: boolean;
   private transcriptPath: string | undefined;
 
   static fromRawSnapshot(params: {
@@ -248,6 +251,7 @@ export class SessionHistorySseState {
     this.sentHistory = snapshot.history;
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
+    this.streamErrorFallbackPending = snapshot.streamErrorFallbackPending;
     this.transcriptPath = normalizeTranscriptPathForComparison(params.transcriptPath);
   }
 
@@ -297,8 +301,16 @@ export class SessionHistorySseState {
     const nextProjection = projectChatDisplayMessagesWithState([nextMessage], {
       maxChars: this.maxChars,
       turnBoundaryPending: hadPendingTurnBoundary,
+      streamErrorFallbackPending: this.streamErrorFallbackPending,
     });
     this.turnBoundaryPending = nextProjection.turnBoundaryPending;
+    this.streamErrorFallbackPending = nextProjection.streamErrorFallbackPending;
+    if (nextProjection.streamErrorFallbackRepaired) {
+      // Keep only the pending bit here: retaining raw transcript context would
+      // undo the bounded SSE memory contract. The caller rereads canonical
+      // history so full projection can remove the already-emitted placeholder.
+      return { shouldRefresh: true };
+    }
     // Projection can split, drop, or rewrite raw transcript messages. When one
     // raw append changes multiple visible rows, callers must refresh instead of
     // emitting a misleading single SSE item.
@@ -383,6 +395,7 @@ export class SessionHistorySseState {
     const snapshot = this.buildSnapshot(rawSnapshot);
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
+    this.streamErrorFallbackPending = snapshot.streamErrorFallbackPending;
     this.transcriptPath = normalizeTranscriptPathForComparison(rawSnapshot.transcriptPath);
     this.sentHistory = snapshot.history;
     return snapshot.history;


### PR DESCRIPTION
## Summary

- remove the exact internal stream-error prefix reported in #91503 when genuine assistant reply content follows it in the same string, text/output-text block, or adjacent content block
- remove a separate synthetic failure row only when later visible assistant content repairs the same user turn; retain the safe generic error for actual failed turns
- keep hidden assistant rows, private reasoning, provider diagnostics, images, forwarded sessions, and session-history SSE on their correct visibility/turn boundaries
- retain the canonical replay-safety sentinel in the persisted transcript; no configuration, protocol, database, or serialized-state shape changes

## Root cause

Gateway display projection treated the replay-only sentinel as visible content. The previous version of this PR repaired separate placeholder rows but missed the reporter's literal same-message examples. It also counted hidden assistant content as a visible repair. The canonical Gateway error-display owner now removes the internal prefix only from provenanced failed assistant turns that contain real visible content, preserves standalone failures and private reasoning safely, and retains a bounded in-memory pending bit for incremental SSE updates.

Raw `sessions_send` messages still start new user turns even though presentation renders them as forwarded assistant messages; regression coverage ensures they cannot silently erase the previous turn's genuine failure.

## Validation

- Failing-first proof on the previous PR head: all three original same-message reproductions failed (plain string, one text block, and separate marker/reply blocks).
- Exact updated head `91c6cc1494e89ccabf1edd987c2bc0321f21dce4`, rebased onto the already-landed task-listener CI fix `14322647cd6c37377833cbcc5abe1d025e3719a0`:
  - `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-gateway-117699-vitest-fs-cache-f48 node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/server-methods/tasks.test.ts`
  - **251 passed, 0 failed** across all three Gateway test files, including the unrelated task-summary regression that failed before its upstream fix landed.
  - New regressions cover both original reporter strings, string/text/output-text and multi-block messages, sanitized image content, private reasoning-only failures, hidden assistant rows, intentional literal mentions, missing/non-error provenance, real user-turn boundaries, forwarded-session new turns, and matching incremental SSE behavior.
  - Fresh independent xhigh owner/caller/sibling review: no accepted actionable findings.
  - Structured `gpt-5.6-sol` xhigh autoreview with `--max-priority P2`: clean; TruffleHog clean.
  - Targeted oxfmt and `git diff --check`: clean.

## Exact-head real Gateway JSON/RPC/SSE proof

The final committed head `91c6cc1494e89ccabf1edd987c2bc0321f21dce4` was exercised on a fresh hosted Blacksmith Testbox through an actual isolated Gateway, canonical SQLite transcript persistence, authenticated HTTP JSON, Gateway `chat.history` RPC, live history SSE, and `chat.inject`.

~~~text
HEAD=91c6cc1494e89ccabf1edd987c2bc0321f21dce4
HTTP /healthz=200
HTTP unauthenticated=401 authenticated=200
PERSISTED "[assistant turn failed before producing content]I'm running on ollama-cloud now."
JSON/RPC/SSE "I'm running on ollama-cloud now."
JSON/RPC/SSE text-block "Good catch."
SSE before repair "The agent run failed before producing a reply."
SSE after chat.inject "actual fallback response"
JSON/RPC/SSE standalone "The agent run failed before producing a reply."
ASSERT inline_json_clean=true inline_rpc_clean=true inline_sse_clean=true
ASSERT inline_block_clean=true replay_sentinel_persisted=true
ASSERT separate_row_sse_refresh_clean=true standalone_generic=true
ASSERT next_user_boundary_preserved=true forwarded_user_boundary_preserved=true
ASSERT unauthorized_rejected=true provider_diagnostics_redacted=true
~~~

Exact-head hosted real Gateway proof: https://github.com/openclaw/openclaw/actions/runs/30731814126

## Earlier real Gateway JSON/SSE proof

The earlier isolated hosted-Testbox run verifies the separate-row HTTP/SSE lifecycle through a real authenticated loopback Gateway, canonical `persistSessionTranscriptTurn`, `sessions.create`, and `chat.inject` without touching operator state or provider credentials. Its original proof head was `2ba6ca620b0638878b4e4d2bf6db675687a52b5f`; exact-head coverage for the additional same-message and boundary corrections is supplied by the 251 passing regressions above.

~~~text
HTTP /healthz=200
RPC sessions.create repaired=ok standalone=ok
RPC chat.inject repaired=ok
JSON before repair [{"role":"user","text":"prove repaired failure"},{"role":"assistant","text":"The agent run failed before producing a reply."}]
SSE history [{"role":"user","text":"prove repaired failure"},{"role":"assistant","text":"The agent run failed before producing a reply."}]
SSE history [{"role":"user","text":"prove repaired failure"},{"role":"assistant","text":"actual fallback response"}]
JSON after repair [{"role":"user","text":"prove repaired failure"},{"role":"assistant","text":"actual fallback response"}]
JSON standalone [{"role":"user","text":"prove standalone failure"},{"role":"assistant","text":"The agent run failed before producing a reply."}]
ASSERT before_generic=true sse_initial_placeholder=true sse_refresh_clean=true after_clean=true standalone_generic=true
~~~

Hosted Gateway proof: https://github.com/openclaw/openclaw/actions/runs/30726151102

Fixes #91503
