### PR TITLE
test(qa): deduplicate WhatsApp live transport fixtures

### DIFF
--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -79,7 +79,8 @@ async function createTgz(params: { entries: Record<string, string>; root: string
   await execFileAsync("tar", ["-czf", archivePath, "-C", sourceDir, "."]);
   return await fs.readFile(archivePath, "base64");
 }
-function createGatewayTargetContext(params: { gatewayTarget: string }) {
+
+function createGatewayTargetContext(gatewayTarget: string) {
   const calls: Array<{ method: string; payload: Record<string, unknown> }> = [];
   const context = {
     gateway: {
@@ -88,7 +89,7 @@ function createGatewayTargetContext(params: { gatewayTarget: string }) {
         return {};
       },
     },
-    gatewayTarget: params.gatewayTarget,
+    gatewayTarget,
     scenarioId: "whatsapp-reply-context-isolation",
     sutAccountId: "sut",
   } satisfies Parameters<typeof testing.callWhatsAppGatewaySend>[0];
@@ -122,11 +123,40 @@ type WhatsAppMessageScenarioRun = Exclude<WhatsAppQaScenarioRun, { kind: "approv
 type WhatsAppScenarioContext = Parameters<NonNullable<WhatsAppMessageScenarioRun["afterSend"]>>[0];
 type WhatsAppQaConfigBase = Parameters<typeof testing.buildWhatsAppQaConfig>[0];
 type WhatsAppQaConfigParams = Parameters<typeof testing.buildWhatsAppQaConfig>[1];
+type WhatsAppMessageScenarioHook = "afterReply" | "afterSend" | "verify";
+
+function createWhatsAppObservedMessage<
+  const TOverrides extends Partial<WhatsAppQaDriverObservedMessage>,
+>(messageId: string, overrides: TOverrides): WhatsAppQaDriverObservedMessage & TOverrides {
+  return {
+    fromPhoneE164: "+15550000002",
+    kind: "text",
+    messageId,
+    observedAt: "2026-06-21T12:00:01.000Z",
+    text: "ok",
+    ...overrides,
+  } as WhatsAppQaDriverObservedMessage & TOverrides;
+}
+
+function createWhatsAppScenarioGateway(
+  overrides: Partial<WhatsAppScenarioContext["gateway"]> = {},
+): WhatsAppScenarioContext["gateway"] {
+  return {
+    call: async () => ({}),
+    restart: async () => {},
+    workspaceDir: "/tmp/openclaw-whatsapp-qa",
+    ...overrides,
+  };
+}
 
 function createWhatsAppScenarioContext(
-  overrides: Partial<WhatsAppScenarioContext> = {},
+  overrides: Partial<WhatsAppScenarioContext> & {
+    recordedMessages?: unknown[];
+    scenario?: WhatsAppScenarioDefinition;
+  } = {},
 ): WhatsAppScenarioContext {
-  const workspaceDir = overrides.gatewayWorkspaceDir ?? "/tmp/openclaw-whatsapp-qa";
+  const { recordedMessages, scenario, ...contextOverrides } = overrides;
+  const workspaceDir = contextOverrides.gatewayWorkspaceDir ?? "/tmp/openclaw-whatsapp-qa";
   return {
     driver: createWhatsAppQaDriverMock(),
     driverPhoneE164: "+15550000001",
@@ -139,17 +169,19 @@ function createWhatsAppScenarioContext(
     },
     gatewayTarget: "+15550000001",
     gatewayWorkspaceDir: workspaceDir,
-    recordObservedMessage: () => {},
+    recordObservedMessage: (message) => {
+      recordedMessages?.push(message);
+    },
     requestStartedAt: new Date("2026-06-21T12:00:00.000Z"),
-    scenarioId: "whatsapp-canary",
-    scenarioTitle: "WhatsApp QA scenario",
+    scenarioId: scenario?.id ?? "whatsapp-canary",
+    scenarioTitle: scenario?.title ?? "WhatsApp QA scenario",
     sent: { messageId: "driver-message-1" },
     sutAccountId: "sut",
     sutPhoneE164: "+15550000002",
     target: "+15550000002",
     targetKind: "dm",
     waitForReady: async () => {},
-    ...overrides,
+    ...contextOverrides,
   };
 }
 
@@ -164,6 +196,40 @@ function buildWhatsAppQaConfigFixture(
     ownerAllowFrom: ["+15550000001"],
     sutAccountId: "sut",
     ...options,
+  });
+}
+
+async function prepareWhatsAppFlowFixture(params: {
+  config: Parameters<
+    ReturnType<typeof createWhatsAppQaScenarioEnvironment>["prepareFlow"]
+  >[0]["config"];
+  gatewayCall: unknown;
+  scenarioId: string;
+  scenarioTitle: string;
+}) {
+  const { prepareFlow } = createWhatsAppQaScenarioEnvironment({
+    accountId: "work",
+    driverAuthDir: "/tmp/whatsapp-driver",
+    explicitScenarioSelection: true,
+    getDriver: vi.fn(() => undefined as never),
+    replaceDriver: vi.fn(),
+    runtimeEnv: {
+      driverAuthArchiveBase64: "driver-auth",
+      driverPhoneE164: "+15550000001",
+      sutAuthArchiveBase64: "sut-auth",
+      sutPhoneE164: "+15550000002",
+    },
+    sutAuthDir: "/tmp/whatsapp-sut",
+  });
+  return await prepareFlow({
+    config: params.config,
+    gateway: { call: params.gatewayCall } as never,
+    outputDir: "/tmp/whatsapp-output",
+    primaryModel: "mock-openai/gpt-5.6-luna",
+    scenarioId: params.scenarioId,
+    scenarioTitle: params.scenarioTitle,
+    timeoutMs: 60_000,
+    waitForConfigRestartSettle: vi.fn(),
   });
 }
 
@@ -201,10 +267,6 @@ function getWhatsAppScenario(id: string): WhatsAppScenarioDefinition {
 
 function findScenarios(ids: readonly string[]) {
   return ids.map(getWhatsAppScenario);
-}
-
-function findWhatsAppScenario(id: WhatsAppScenarioIdFilter) {
-  return getWhatsAppScenario(id);
 }
 
 function updateObservedMessage(
@@ -246,6 +308,173 @@ function findMockWhatsAppScenario(id: WhatsAppScenarioIdFilter) {
     throw new Error(`missing WhatsApp mock-openai scenario ${id}`);
   }
   return scenario;
+}
+
+function requireWhatsAppMessageScenario<
+  const THooks extends readonly WhatsAppMessageScenarioHook[] = [],
+>(
+  source: WhatsAppScenarioIdFilter | WhatsAppScenarioDefinition,
+  options: { hooks?: THooks; mock?: boolean } = {},
+): {
+  scenario: WhatsAppScenarioDefinition;
+  run: WhatsAppMessageScenarioRun & Required<Pick<WhatsAppMessageScenarioRun, THooks[number]>>;
+} {
+  const scenario =
+    typeof source !== "string"
+      ? source
+      : options.mock
+        ? findMockWhatsAppScenario(source)
+        : getWhatsAppScenario(source);
+  const run = scenario.buildRun();
+  if (run.kind === "approval") {
+    throw new Error(`${scenario.id} unexpectedly built an approval run`);
+  }
+  for (const hook of options.hooks ?? []) {
+    if (!run[hook]) {
+      throw new Error(`${scenario.id} missing ${hook}`);
+    }
+  }
+  return {
+    scenario,
+    run: run as WhatsAppMessageScenarioRun &
+      Required<Pick<WhatsAppMessageScenarioRun, THooks[number]>>,
+  };
+}
+
+function createWhatsAppAgentReactionFixture(params: {
+  groupJid?: string;
+  triggerMessageId: string;
+  waitForMessage: WhatsAppQaDriverSession["waitForMessage"];
+}) {
+  const scenarioId = params.groupJid
+    ? "whatsapp-group-agent-message-action-react"
+    : "whatsapp-agent-message-action-react";
+  const { scenario, run } = requireWhatsAppMessageScenario(scenarioId, {
+    hooks: ["afterSend"],
+  });
+  const expectedReaction = createWhatsAppObservedMessage("reaction-event-1", {
+    ...(params.groupJid ? { fromJid: params.groupJid } : {}),
+    kind: "reaction",
+    observedAt: "2026-06-21T12:00:02.000Z",
+    reaction: {
+      emoji: "👍",
+      messageId: params.triggerMessageId,
+      ...(params.groupJid ? { participant: "15550000001@s.whatsapp.net" } : {}),
+    },
+    text: "👍",
+  });
+  const rejectedCandidates = [
+    {
+      ...expectedReaction,
+      ...(params.groupJid
+        ? { fromJid: "120363999999999999@g.us" }
+        : { fromPhoneE164: "+15550000003" }),
+    },
+    { ...expectedReaction, reaction: { ...expectedReaction.reaction, emoji: "👎" } },
+    { ...expectedReaction, reaction: { ...expectedReaction.reaction, messageId: "other-message" } },
+  ];
+  const recordedMessages: unknown[] = [];
+  const context = createWhatsAppScenarioContext({
+    driver: createWhatsAppQaDriverMock({ waitForMessage: params.waitForMessage }),
+    ...(params.groupJid
+      ? { gatewayTarget: params.groupJid, target: params.groupJid, targetKind: "group" as const }
+      : { gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway" }),
+    recordedMessages,
+    scenarioId,
+    scenarioTitle: params.groupJid
+      ? scenario.title
+      : "WhatsApp agent message action reacts to the current message",
+    sent: { messageId: params.triggerMessageId },
+  });
+  return { context, expectedReaction, recordedMessages, rejectedCandidates, run };
+}
+
+function createWhatsAppStatusReactionFixture(...emojis: Array<"👀" | "✅">) {
+  const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-status-reaction-lifecycle", {
+    hooks: ["afterReply"],
+    mock: true,
+  });
+  const reactions = emojis.map((emoji, index) =>
+    createWhatsAppObservedMessage(emoji === "👀" ? "reaction-queued" : "reaction-done", {
+      kind: "reaction",
+      observedAt: `2026-06-21T12:00:0${index + 1}.000Z`,
+      reaction: { emoji, messageId: "trigger-1" },
+      text: "",
+    }),
+  );
+  const recorded: unknown[] = [];
+  const context = createWhatsAppScenarioContext({
+    driver: createWhatsAppQaDriverMock({ getObservedMessages: () => reactions }),
+    recordedMessages: recorded,
+    scenario,
+    sent: { messageId: "trigger-1" },
+  });
+  return { context, reactions, recorded, run };
+}
+
+async function runWhatsAppApprovalReactionFixture(params: {
+  fromJid: string;
+  participantJid?: string;
+  scenarioId: WhatsAppScenarioIdFilter;
+  turnSourceTo: string;
+}) {
+  const scenario = getWhatsAppScenario(params.scenarioId);
+  const run = scenario.buildRun();
+  if (run.kind !== "approval") {
+    throw new Error("expected approval scenario run");
+  }
+  const sendReaction = vi.fn(async () => ({ messageId: "reaction-1" }));
+  let approvalId = "";
+  let waitCount = 0;
+  const driver = createWhatsAppQaDriverMock({
+    sendReaction,
+    waitForMessage: async ({ match }) => {
+      waitCount += 1;
+      const isPending = waitCount === 1;
+      const message = createWhatsAppObservedMessage(
+        isPending ? "approval-message-1" : "approval-resolved-1",
+        {
+          fromJid: params.fromJid,
+          observedAt: isPending ? "2026-06-28T02:00:00.000Z" : "2026-06-28T02:00:01.000Z",
+          ...(params.participantJid ? { participantJid: params.participantJid } : {}),
+          text: isPending
+            ? `Exec approval required\nID: ${approvalId}\n` +
+              `Pending command:\nprintf '%s\\n' '${run.token}'\n\n` +
+              "React with:\n\n👍 Allow Once\n👎 Deny"
+            : `✅ Exec approval allow-once. ID: ${approvalId}`,
+        },
+      );
+      if (!match(message)) {
+        throw new Error(`approval test message ${waitCount} did not match`);
+      }
+      return message;
+    },
+  });
+  const gateway = {
+    call: async (method: string, payload: { id?: string }) => {
+      if (method === "exec.approval.request") {
+        approvalId = payload.id ?? "";
+        return { id: approvalId, status: "accepted" };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "allow-once" };
+      }
+      throw new Error(`unexpected gateway call ${method}`);
+    },
+  } as Parameters<typeof testing.runWhatsAppApprovalScenario>[0]["gateway"];
+
+  await testing.runWhatsAppApprovalScenario({
+    driver,
+    gateway,
+    observedMessages: [],
+    run,
+    scenario,
+    sutAccountId: "work",
+    sutPhoneE164: "+15550000002",
+    turnSourceTo: params.turnSourceTo,
+  });
+
+  return sendReaction;
 }
 
 describe("WhatsApp QA live runtime", () => {
@@ -363,11 +592,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("defines the user-path WhatsApp agent reaction scenario as mock-backed", () => {
-    const scenario = findWhatsAppScenario("whatsapp-agent-message-action-react");
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("whatsapp-agent-message-action-react unexpectedly built approval run");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-agent-message-action-react");
 
     expect(scenario.id).toBe("whatsapp-agent-message-action-react");
     expect(scenario.configOverrides).toMatchObject({ actions: true });
@@ -380,58 +605,18 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("observes the native WhatsApp reaction for the user-path agent action scenario", async () => {
-    const scenario = findWhatsAppScenario("whatsapp-agent-message-action-react");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterSend) {
-      throw new Error("whatsapp-agent-message-action-react unexpectedly omitted afterSend");
-    }
-
     const triggerMessageId = "driver-trigger-message-1";
-    const expectedReaction = {
-      fromPhoneE164: "+15550000002",
-      kind: "reaction" as const,
-      messageId: "reaction-event-1",
-      observedAt: "2026-06-21T12:00:02.000Z",
-      reaction: {
-        emoji: "👍",
-        messageId: triggerMessageId,
-      },
-      text: "👍",
-    };
-    const rejectedCandidates = [
-      {
-        ...expectedReaction,
-        fromPhoneE164: "+15550000003",
-      },
-      {
-        ...expectedReaction,
-        reaction: { ...expectedReaction.reaction, emoji: "👎" },
-      },
-      {
-        ...expectedReaction,
-        reaction: { ...expectedReaction.reaction, messageId: "other-message" },
-      },
-    ];
-    const recordedMessages: unknown[] = [];
-    const driver = createWhatsAppQaDriverMock({
-      waitForMessage: async (params) => {
-        for (const candidate of rejectedCandidates) {
-          expect(params.match(candidate)).toBe(false);
-        }
-        expect(params.match(expectedReaction)).toBe(true);
-        return expectedReaction;
-      },
-    });
-    const context = createWhatsAppScenarioContext({
-      driver,
-      gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      recordObservedMessage: (message: unknown) => {
-        recordedMessages.push(message);
-      },
-      scenarioId: "whatsapp-agent-message-action-react",
-      scenarioTitle: "WhatsApp agent message action reacts to the current message",
-      sent: { messageId: triggerMessageId },
-    });
+    const { context, expectedReaction, recordedMessages, rejectedCandidates, run } =
+      createWhatsAppAgentReactionFixture({
+        triggerMessageId,
+        waitForMessage: async (params) => {
+          for (const candidate of rejectedCandidates) {
+            expect(params.match(candidate)).toBe(false);
+          }
+          expect(params.match(expectedReaction)).toBe(true);
+          return expectedReaction;
+        },
+      });
 
     const details = await run.afterSend(context);
 
@@ -444,10 +629,7 @@ describe("WhatsApp QA live runtime", () => {
 
     expect(scenarios.map(({ id }) => id)).toEqual([...WHATSAPP_QA_HARDENING_SCENARIO_IDS]);
     for (const scenario of scenarios) {
-      const run = scenario.buildRun();
-      if (run.kind === "approval") {
-        throw new Error(`${scenario.id} unexpectedly built an approval run`);
-      }
+      const { run } = requireWhatsAppMessageScenario(scenario);
 
       expect(run.target).toBe("dm");
     }
@@ -460,10 +642,7 @@ describe("WhatsApp QA live runtime", () => {
 
     expect(scenarios.map(({ id }) => id)).toEqual([...WHATSAPP_GROUP_CAPABILITY_SCENARIO_IDS]);
     for (const scenario of scenarios) {
-      const run = scenario.buildRun();
-      if (run.kind === "approval") {
-        throw new Error(`${scenario.id} unexpectedly built an approval run`);
-      }
+      const { run } = requireWhatsAppMessageScenario(scenario);
 
       expect(scenario.requiresGroupJid).toBe(true);
       expect(run.target).toBe("group");
@@ -471,63 +650,20 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("observes native WhatsApp group reactions for the user-path action scenario", async () => {
-    const scenario = findWhatsAppScenario("whatsapp-group-agent-message-action-react");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterSend) {
-      throw new Error("whatsapp-group-agent-message-action-react unexpectedly omitted afterSend");
-    }
-
     const groupJid = "120363000000000000@g.us";
     const triggerMessageId = "group-trigger-message-1";
-    const expectedReaction = {
-      fromJid: groupJid,
-      fromPhoneE164: "+15550000002",
-      kind: "reaction" as const,
-      messageId: "reaction-event-1",
-      observedAt: "2026-06-21T12:00:02.000Z",
-      reaction: {
-        emoji: "👍",
-        messageId: triggerMessageId,
-        participant: "15550000001@s.whatsapp.net",
-      },
-      text: "👍",
-    };
-    const rejectedCandidates = [
-      {
-        ...expectedReaction,
-        fromJid: "120363999999999999@g.us",
-      },
-      {
-        ...expectedReaction,
-        reaction: { ...expectedReaction.reaction, emoji: "👎" },
-      },
-      {
-        ...expectedReaction,
-        reaction: { ...expectedReaction.reaction, messageId: "other-message" },
-      },
-    ];
-    const recordedMessages: unknown[] = [];
-    const driver = createWhatsAppQaDriverMock({
-      waitForMessage: async (params) => {
-        for (const candidate of rejectedCandidates) {
-          expect(params.match(candidate)).toBe(false);
-        }
-        expect(params.match(expectedReaction)).toBe(true);
-        return expectedReaction;
-      },
-    });
-    const context = createWhatsAppScenarioContext({
-      driver,
-      gatewayTarget: groupJid,
-      recordObservedMessage: (message: unknown) => {
-        recordedMessages.push(message);
-      },
-      scenarioId: "whatsapp-group-agent-message-action-react",
-      scenarioTitle: scenario.title,
-      sent: { messageId: triggerMessageId },
-      target: groupJid,
-      targetKind: "group",
-    });
+    const { context, expectedReaction, recordedMessages, rejectedCandidates, run } =
+      createWhatsAppAgentReactionFixture({
+        groupJid,
+        triggerMessageId,
+        waitForMessage: async (params) => {
+          for (const candidate of rejectedCandidates) {
+            expect(params.match(candidate)).toBe(false);
+          }
+          expect(params.match(expectedReaction)).toBe(true);
+          return expectedReaction;
+        },
+      });
 
     const details = await run.afterSend(context);
 
@@ -537,72 +673,58 @@ describe("WhatsApp QA live runtime", () => {
 
   it("runs WhatsApp group direct Gateway media, audio, and poll probes against the group target", async () => {
     const groupJid = "120363000000000000@g.us";
-    const mediaScenario = findMockWhatsAppScenario("whatsapp-group-outbound-media");
-    const mediaRun = mediaScenario.buildRun();
-    const audioScenario = findMockWhatsAppScenario("whatsapp-group-outbound-audio");
-    const audioRun = audioScenario.buildRun();
-    const pollScenario = findMockWhatsAppScenario("whatsapp-group-outbound-poll");
-    const pollRun = pollScenario.buildRun();
-    if (mediaRun.kind === "approval" || !mediaRun.afterReply) {
-      throw new Error("whatsapp-group-outbound-media missing afterReply");
-    }
-    if (audioRun.kind === "approval" || !audioRun.afterReply) {
-      throw new Error("whatsapp-group-outbound-audio missing afterReply");
-    }
-    if (pollRun.kind === "approval" || !pollRun.afterReply) {
-      throw new Error("whatsapp-group-outbound-poll missing afterReply");
-    }
+    const { scenario: mediaScenario, run: mediaRun } = requireWhatsAppMessageScenario(
+      "whatsapp-group-outbound-media",
+      { hooks: ["afterReply"], mock: true },
+    );
+    const { scenario: audioScenario, run: audioRun } = requireWhatsAppMessageScenario(
+      "whatsapp-group-outbound-audio",
+      { hooks: ["afterReply"], mock: true },
+    );
+    const { scenario: pollScenario, run: pollRun } = requireWhatsAppMessageScenario(
+      "whatsapp-group-outbound-poll",
+      { hooks: ["afterReply"], mock: true },
+    );
 
     const gatewayCalls: Array<{ method: string; payload: Record<string, unknown> }> = [];
     const observedMessages: WhatsAppQaDriverObservedMessage[] = [
-      {
+      createWhatsAppObservedMessage("group-image-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
         hasMedia: true,
-        kind: "media" as const,
+        kind: "media",
         mediaType: "image/png",
-        messageId: "group-image-1",
         observedAt: "2026-06-21T12:00:02.000Z",
         text: "",
-      },
-      {
+      }),
+      createWhatsAppObservedMessage("group-document-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
         hasMedia: true,
-        kind: "media" as const,
+        kind: "media",
         mediaFileName: "whatsapp-qa-group.pdf",
         mediaType: "application/pdf",
-        messageId: "group-document-1",
         observedAt: "2026-06-21T12:00:03.000Z",
         text: "",
-      },
-      {
+      }),
+      createWhatsAppObservedMessage("group-audio-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
         hasMedia: true,
-        kind: "media" as const,
+        kind: "media",
         mediaType: "audio/ogg; codecs=opus",
-        messageId: "group-audio-1",
         observedAt: "2026-06-21T12:00:04.000Z",
         text: "",
-      },
-      {
+      }),
+      createWhatsAppObservedMessage("group-audio-text-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
-        kind: "text" as const,
-        messageId: "group-audio-text-1",
         observedAt: "2026-06-21T12:00:05.000Z",
         text: "",
-      },
-      {
+      }),
+      createWhatsAppObservedMessage("group-poll-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
-        kind: "poll" as const,
-        messageId: "group-poll-1",
+        kind: "poll",
         observedAt: "2026-06-21T12:00:06.000Z",
         poll: { options: ["alpha", "beta"] },
         text: "",
-      },
+      }),
     ];
     const driver = createWhatsAppQaDriverMock({
       waitForMessage: async (params) => {
@@ -615,36 +737,32 @@ describe("WhatsApp QA live runtime", () => {
     });
     const context = createWhatsAppScenarioContext({
       driver,
-      gateway: {
+      gateway: createWhatsAppScenarioGateway({
         call: async (method, payload) => {
           gatewayCalls.push({ method, payload: payload as Record<string, unknown> });
-          const question =
-            typeof (payload as { question?: unknown }).question === "string"
-              ? (payload as { question: string }).question
-              : undefined;
-          if (question) {
+          const { message, question } = payload as Record<string, unknown>;
+          if (typeof question === "string" && question) {
             updateObservedMessage(observedMessages, 4, {
               observedAt: new Date().toISOString(),
               poll: { options: ["alpha", "beta"], question },
             });
           }
-          const message =
-            typeof (payload as { message?: unknown }).message === "string"
-              ? (payload as { message: string }).message
-              : undefined;
-          if (message?.endsWith("_IMAGE")) {
+          if (typeof message !== "string") {
+            return {};
+          }
+          if (message.endsWith("_IMAGE")) {
             updateObservedMessage(observedMessages, 0, {
               observedAt: new Date().toISOString(),
               text: message,
             });
           }
-          if (message?.endsWith("_DOCUMENT")) {
+          if (message.endsWith("_DOCUMENT")) {
             updateObservedMessage(observedMessages, 1, {
               observedAt: new Date().toISOString(),
               text: message,
             });
           }
-          if (message?.endsWith("_AUDIO")) {
+          if (message.endsWith("_AUDIO")) {
             updateObservedMessage(observedMessages, 2, {
               observedAt: new Date().toISOString(),
             });
@@ -655,37 +773,27 @@ describe("WhatsApp QA live runtime", () => {
           }
           return {};
         },
-        restart: async () => {},
         workspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      },
+      }),
       gatewayTarget: groupJid,
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      scenarioId: "whatsapp-group-outbound-media",
-      scenarioTitle: mediaScenario.title,
+      scenario: mediaScenario,
       target: groupJid,
       targetKind: "group",
     });
 
     await mediaRun.afterReply(
-      {
+      createWhatsAppObservedMessage("reply-1", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "reply-1",
-        observedAt: "2026-06-21T12:00:01.000Z",
         text: String(mediaRun.matchText),
-      },
+      }),
       context,
     );
     await audioRun.afterReply(
-      {
+      createWhatsAppObservedMessage("reply-2", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "reply-2",
-        observedAt: "2026-06-21T12:00:01.000Z",
         text: String(audioRun.matchText),
-      },
+      }),
       {
         ...context,
         scenarioId: "whatsapp-group-outbound-audio",
@@ -693,14 +801,10 @@ describe("WhatsApp QA live runtime", () => {
       },
     );
     await pollRun.afterReply(
-      {
+      createWhatsAppObservedMessage("reply-3", {
         fromJid: groupJid,
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "reply-3",
-        observedAt: "2026-06-21T12:00:01.000Z",
         text: String(pollRun.matchText),
-      },
+      }),
       { ...context, scenarioId: "whatsapp-group-outbound-poll", scenarioTitle: pollScenario.title },
     );
 
@@ -709,11 +813,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("requires the reply-context isolation quoted send to carry quote metadata", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-reply-context-isolation");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterReply) {
-      throw new Error("whatsapp-reply-context-isolation missing afterReply");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-reply-context-isolation", {
+      hooks: ["afterReply"],
+      mock: true,
+    });
 
     const gatewayCalls: Array<{ method: string; payload: Record<string, unknown> }> = [];
     let waitCount = 0;
@@ -721,13 +824,10 @@ describe("WhatsApp QA live runtime", () => {
       waitForMessage: async (params) => {
         waitCount += 1;
         const messageText = String(gatewayCalls[waitCount - 1]?.payload.message);
-        const base = {
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: `sut-reply-${waitCount}`,
+        const base = createWhatsAppObservedMessage(`sut-reply-${waitCount}`, {
           observedAt: new Date().toISOString(),
           text: messageText,
-        };
+        });
         if (waitCount === 1) {
           expect(params.match(base)).toBe(false);
           expect(params.match({ ...base, quoted: { messageId: "wrong-trigger" } })).toBe(false);
@@ -742,28 +842,20 @@ describe("WhatsApp QA live runtime", () => {
     });
     const context = createWhatsAppScenarioContext({
       driver,
-      gateway: {
+      gateway: createWhatsAppScenarioGateway({
         call: async (method, payload) => {
           gatewayCalls.push({ method, payload: payload as Record<string, unknown> });
           return {};
         },
-        restart: async () => {},
         workspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      },
+      }),
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      scenarioId: scenario.id,
-      scenarioTitle: scenario.title,
+      scenario,
       sent: { messageId: "driver-message-1" },
     });
 
     await run.afterReply(
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "initial-reply",
-        observedAt: "2026-06-21T12:00:01.000Z",
-        text: String(run.matchText),
-      },
+      createWhatsAppObservedMessage("initial-reply", { text: String(run.matchText) }),
       context,
     );
 
@@ -775,11 +867,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("asserts batched reply-to mode quotes the second queued message", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-reply-to-mode-batched");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterSend || !run.verify) {
-      throw new Error("whatsapp-reply-to-mode-batched missing message hooks");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-reply-to-mode-batched", {
+      hooks: ["afterSend", "verify"],
+      mock: true,
+    });
 
     const sentTexts: string[] = [];
     const context = createWhatsAppScenarioContext({
@@ -789,13 +880,7 @@ describe("WhatsApp QA live runtime", () => {
           return { messageId: "second-batched-message" };
         },
       }),
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa",
-      },
-      scenarioId: "whatsapp-reply-to-mode-batched",
-      scenarioTitle: scenario.title,
+      scenario,
       sent: { messageId: "first-batched-message" },
     });
 
@@ -822,11 +907,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("waits for media from the user-path WhatsApp upload-file scenario", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-agent-message-action-upload-file");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterSend) {
-      throw new Error("whatsapp-agent-message-action-upload-file missing afterSend");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario(
+      "whatsapp-agent-message-action-upload-file",
+      { hooks: ["afterSend"], mock: true },
+    );
 
     const token = /\bWHATSAPP_QA_AGENT_UPLOAD_[A-Z0-9]+\b/u.exec(run.input)?.[0];
     if (!token) {
@@ -835,26 +919,17 @@ describe("WhatsApp QA live runtime", () => {
     const observed: unknown[] = [];
     const context = createWhatsAppScenarioContext({
       driver: createWhatsAppQaDriverMock({
-        waitForMessage: async () => ({
-          fromPhoneE164: "+15550000002",
-          hasMedia: true,
-          kind: "media",
-          mediaType: "image/png",
-          messageId: "media-1",
-          observedAt: "2026-06-21T12:00:02.000Z",
-          text: token,
-        }),
+        waitForMessage: async () =>
+          createWhatsAppObservedMessage("media-1", {
+            hasMedia: true,
+            kind: "media",
+            mediaType: "image/png",
+            observedAt: "2026-06-21T12:00:02.000Z",
+            text: token,
+          }),
       }),
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa",
-      },
-      recordObservedMessage: (message) => {
-        observed.push(message);
-      },
-      scenarioId: "whatsapp-agent-message-action-upload-file",
-      scenarioTitle: scenario.title,
+      recordedMessages: observed,
+      scenario,
       sent: { messageId: "trigger-1" },
     });
 
@@ -865,56 +940,12 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("observes the WhatsApp status reaction lifecycle sequence", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-status-reaction-lifecycle");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterReply) {
-      throw new Error("whatsapp-status-reaction-lifecycle missing afterReply");
-    }
-
-    const reactions = [
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "reaction" as const,
-        messageId: "reaction-queued",
-        observedAt: "2026-06-21T12:00:01.000Z",
-        reaction: { emoji: "👀", messageId: "trigger-1" },
-        text: "",
-      },
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "reaction" as const,
-        messageId: "reaction-done",
-        observedAt: "2026-06-21T12:00:02.000Z",
-        reaction: { emoji: "✅", messageId: "trigger-1" },
-        text: "",
-      },
-    ];
-    const recorded: unknown[] = [];
-    const context = createWhatsAppScenarioContext({
-      driver: createWhatsAppQaDriverMock({
-        getObservedMessages: () => reactions,
-      }),
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa",
-      },
-      recordObservedMessage: (message) => {
-        recorded.push(message);
-      },
-      scenarioId: "whatsapp-status-reaction-lifecycle",
-      scenarioTitle: scenario.title,
-      sent: { messageId: "trigger-1" },
-    });
+    const { context, reactions, recorded, run } = createWhatsAppStatusReactionFixture("👀", "✅");
 
     const details = await run.afterReply(
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "reply-1",
+      createWhatsAppObservedMessage("reply-1", {
         observedAt: "2026-06-21T12:00:03.000Z",
-        text: "ok",
-      },
+      }),
       context,
     );
 
@@ -923,58 +954,14 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("rejects WhatsApp status lifecycle reactions observed out of order", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-status-reaction-lifecycle");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterReply) {
-      throw new Error("whatsapp-status-reaction-lifecycle missing afterReply");
-    }
-
-    const reactions = [
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "reaction" as const,
-        messageId: "reaction-done",
-        observedAt: "2026-06-21T12:00:01.000Z",
-        reaction: { emoji: "✅", messageId: "trigger-1" },
-        text: "",
-      },
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "reaction" as const,
-        messageId: "reaction-queued",
-        observedAt: "2026-06-21T12:00:02.000Z",
-        reaction: { emoji: "👀", messageId: "trigger-1" },
-        text: "",
-      },
-    ];
-    const recorded: unknown[] = [];
-    const context = createWhatsAppScenarioContext({
-      driver: createWhatsAppQaDriverMock({
-        getObservedMessages: () => reactions,
-      }),
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa",
-      },
-      recordObservedMessage: (message) => {
-        recorded.push(message);
-      },
-      scenarioId: "whatsapp-status-reaction-lifecycle",
-      scenarioTitle: scenario.title,
-      sent: { messageId: "trigger-1" },
-    });
+    const { context, recorded, run } = createWhatsAppStatusReactionFixture("✅", "👀");
 
     vi.useFakeTimers({ now: new Date("2026-06-21T12:00:00.000Z") });
     try {
       const result = run.afterReply(
-        {
-          fromPhoneE164: "+15550000002",
-          kind: "text",
-          messageId: "reply-1",
+        createWhatsAppObservedMessage("reply-1", {
           observedAt: "2026-06-21T12:00:03.000Z",
-          text: "ok",
-        },
+        }),
         context,
       );
       const rejection = expect(result).rejects.toThrow(
@@ -1013,9 +1000,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("routes WhatsApp Gateway DM helper calls to the driver peer", async () => {
-    const { calls, context } = createGatewayTargetContext({
-      gatewayTarget: "+15550000001",
-    });
+    const { calls, context } = createGatewayTargetContext("+15550000001");
 
     await testing.callWhatsAppGatewaySend(context, {
       label: "quoted",
@@ -1070,10 +1055,7 @@ describe("WhatsApp QA live runtime", () => {
 
     expect(scenarios.map(({ id }) => id)).toEqual([...PHASE2_GROUP_SCENARIO_IDS]);
     for (const scenario of scenarios) {
-      const run = scenario.buildRun();
-      if (run.kind === "approval") {
-        throw new Error(`${scenario.id} unexpectedly built an approval run`);
-      }
+      const { run } = requireWhatsAppMessageScenario(scenario);
 
       expect(scenario.requiresGroupJid).toBe(true);
       expect(run.target).toBe("group");
@@ -1088,10 +1070,7 @@ describe("WhatsApp QA live runtime", () => {
 
     expect(scenarios.map(({ id }) => id)).toEqual([...PHASE3_GROUP_SCENARIO_IDS]);
     for (const scenario of scenarios) {
-      const run = scenario.buildRun();
-      if (run.kind === "approval") {
-        throw new Error(`${scenario.id} unexpectedly built an approval run`);
-      }
+      const { run } = requireWhatsAppMessageScenario(scenario);
 
       expect(scenario.requiresGroupJid).toBe(true);
       expect(scenario.configOverrides).toMatchObject({ groupPolicy: "open" });
@@ -1137,33 +1116,14 @@ describe("WhatsApp QA live runtime", () => {
       }
       throw new Error(`unexpected gateway method: ${method}`);
     });
-    const { prepareFlow } = createWhatsAppQaScenarioEnvironment({
-      accountId: "work",
-      driverAuthDir: "/tmp/whatsapp-driver",
-      explicitScenarioSelection: true,
-      getDriver: vi.fn(() => undefined as never),
-      replaceDriver: vi.fn(),
-      runtimeEnv: {
-        driverAuthArchiveBase64: "driver-auth",
-        driverPhoneE164: "+15550000001",
-        sutAuthArchiveBase64: "sut-auth",
-        sutPhoneE164: "+15550000002",
-      },
-      sutAuthDir: "/tmp/whatsapp-sut",
-    });
-
-    const prepared = await prepareFlow({
+    const prepared = await prepareWhatsAppFlowFixture({
       config: {},
-      gateway: { call: gatewayCall } as never,
-      outputDir: "/tmp/whatsapp-output",
-      primaryModel: "mock-openai/gpt-5.6-luna",
+      gatewayCall,
       scenarioId: "whatsapp-canary",
       scenarioTitle: "WhatsApp DM canary",
-      timeoutMs: 60_000,
-      waitForConfigRestartSettle: vi.fn(),
     });
     await prepared.whatsappScenarioContext.configureScenario(
-      findWhatsAppScenario("whatsapp-canary"),
+      getWhatsAppScenario("whatsapp-canary"),
     );
 
     const patchCall = gatewayCall.mock.calls.find(([method]) => method === "config.patch");
@@ -1180,30 +1140,11 @@ describe("WhatsApp QA live runtime", () => {
 
   it("leaves generic declarative flows to their own config preparation", async () => {
     const gatewayCall = vi.fn();
-    const { prepareFlow } = createWhatsAppQaScenarioEnvironment({
-      accountId: "work",
-      driverAuthDir: "/tmp/whatsapp-driver",
-      explicitScenarioSelection: true,
-      getDriver: vi.fn(() => undefined as never),
-      replaceDriver: vi.fn(),
-      runtimeEnv: {
-        driverAuthArchiveBase64: "driver-auth",
-        driverPhoneE164: "+15550000001",
-        sutAuthArchiveBase64: "sut-auth",
-        sutPhoneE164: "+15550000002",
-      },
-      sutAuthDir: "/tmp/whatsapp-sut",
-    });
-
-    const prepared = await prepareFlow({
+    const prepared = await prepareWhatsAppFlowFixture({
       config: { policyKey: "dmPolicy", policyValue: "disabled" },
-      gateway: { call: gatewayCall } as never,
-      outputDir: "/tmp/whatsapp-output",
-      primaryModel: "mock-openai/gpt-5.6-luna",
+      gatewayCall,
       scenarioId: "whatsapp-access-control-dm-disabled",
       scenarioTitle: "WhatsApp dmPolicy disabled stays quiet",
-      timeoutMs: 60_000,
-      waitForConfigRestartSettle: vi.fn(),
     });
     expect(prepared.whatsappScenarioContext.scenario.id).toBe(
       "whatsapp-access-control-dm-disabled",
@@ -1212,38 +1153,19 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("patches the effective WhatsApp policy for default and named SUT accounts", async () => {
+    const policy = (
+      id: string,
+      policyKey: "dmPolicy" | "groupPolicy",
+      policyValue: "disabled" | "open" | "pairing",
+      staleValue: "allowlist" | "disabled" | "open",
+    ) => ({ id, policyKey, policyValue, staleValue });
     const policyScenarios = [
-      {
-        id: "whatsapp-access-control-dm-disabled",
-        policyKey: "dmPolicy",
-        policyValue: "disabled",
-        staleValue: "allowlist",
-      },
-      {
-        id: "whatsapp-access-control-dm-open",
-        policyKey: "dmPolicy",
-        policyValue: "open",
-        staleValue: "allowlist",
-      },
-      {
-        id: "whatsapp-access-control-group-disabled",
-        policyKey: "groupPolicy",
-        policyValue: "disabled",
-        staleValue: "open",
-      },
-      {
-        id: "whatsapp-access-control-group-open",
-        policyKey: "groupPolicy",
-        policyValue: "open",
-        staleValue: "disabled",
-      },
-      {
-        id: "whatsapp-pairing-block",
-        policyKey: "dmPolicy",
-        policyValue: "pairing",
-        staleValue: "allowlist",
-      },
-    ] as const;
+      policy("whatsapp-access-control-dm-disabled", "dmPolicy", "disabled", "allowlist"),
+      policy("whatsapp-access-control-dm-open", "dmPolicy", "open", "allowlist"),
+      policy("whatsapp-access-control-group-disabled", "groupPolicy", "disabled", "open"),
+      policy("whatsapp-access-control-group-open", "groupPolicy", "open", "disabled"),
+      policy("whatsapp-pairing-block", "dmPolicy", "pairing", "allowlist"),
+    ];
 
     for (const accountId of ["default", "work"]) {
       for (const policyScenario of policyScenarios) {
@@ -1293,11 +1215,9 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("models activation always through visible group behavior and restores mention gating", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-group-activation-always");
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("whatsapp-group-activation-always unexpectedly built an approval run");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-group-activation-always", {
+      mock: true,
+    });
 
     expect(run.target).toBe("group");
     expect(run.input).toBe("/activation always");
@@ -1347,14 +1267,13 @@ describe("WhatsApp QA live runtime", () => {
           "Activation: mention",
           "Status: activation always",
           "Status: activation mention",
-        ].map((text, index) => ({
-          fromJid: groupJid,
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: `sut-activation-observation-${index}`,
-          observedAt: new Date().toISOString(),
-          text: text ?? "",
-        }));
+        ].map((text, index) =>
+          createWhatsAppObservedMessage(`sut-activation-observation-${index}`, {
+            fromJid: groupJid,
+            observedAt: new Date().toISOString(),
+            text: text ?? "",
+          }),
+        );
         for (const candidate of candidates) {
           if (matches(candidate)) {
             if (candidate.text === latestProbe?.text) {
@@ -1372,19 +1291,14 @@ describe("WhatsApp QA live runtime", () => {
       driver,
       gatewayTarget: groupJid,
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-workspace",
-      scenarioId: scenario.id,
-      scenarioTitle: scenario.title,
+      scenario,
       sent: { messageId: "activation-command-message" },
       target: groupJid,
     });
-    const activationCommandReply = {
+    const activationCommandReply = createWhatsAppObservedMessage("sut-activation-command-reply", {
       fromJid: groupJid,
-      fromPhoneE164: "+15550000002",
-      kind: "text" as const,
-      messageId: "sut-activation-command-reply",
-      observedAt: "2026-06-21T12:00:01.000Z",
       text: "Activation: always",
-    };
+    });
 
     const followUp = run.afterReply ?? run.afterSend;
     expect(followUp).toEqual(expect.any(Function));
@@ -1419,11 +1333,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("restores mention gating when activation always validation fails", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-group-activation-always");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterReply) {
-      throw new Error("whatsapp-group-activation-always unexpectedly built a non-message run");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario("whatsapp-group-activation-always", {
+      hooks: ["afterReply"],
+      mock: true,
+    });
 
     const sentTextCalls: Array<{ text: string; to: string }> = [];
     const groupJid = "120363000000000000@g.us";
@@ -1440,14 +1353,11 @@ describe("WhatsApp QA live runtime", () => {
         if (!restoreSent) {
           throw new Error("forced always-mode probe failure");
         }
-        const restoreReply = {
+        const restoreReply = createWhatsAppObservedMessage("sut-activation-restore", {
           fromJid: groupJid,
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: "sut-activation-restore",
           observedAt: new Date().toISOString(),
           text: "Activation: mention",
-        };
+        });
         if (matches(restoreReply)) {
           return restoreReply;
         }
@@ -1481,11 +1391,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("quotes the observed SUT reply without an explicit mention for reply-to-bot activation", async () => {
-    const scenario = findMockWhatsAppScenario("whatsapp-group-reply-to-bot-triggers");
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("whatsapp-group-reply-to-bot-triggers unexpectedly built an approval run");
-    }
+    const { scenario, run } = requireWhatsAppMessageScenario(
+      "whatsapp-group-reply-to-bot-triggers",
+      { mock: true },
+    );
 
     expect(run.target).toBe("group");
     expect(run.input).toMatch(/\bopenclawqa\b/iu);
@@ -1517,14 +1426,11 @@ describe("WhatsApp QA live runtime", () => {
         if (!marker) {
           throw new Error("reply-to-bot scenario waited before sending the quoted trigger");
         }
-        const candidate = {
+        const candidate = createWhatsAppObservedMessage("sut-reply-to-bot-final", {
           fromJid: groupJid,
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: "sut-reply-to-bot-final",
           observedAt: new Date().toISOString(),
           text: marker ?? "",
-        };
+        });
         expect(
           matches({
             ...candidate,
@@ -1545,15 +1451,11 @@ describe("WhatsApp QA live runtime", () => {
         throw new Error("reply-to-bot scenario waited for an unexpected message");
       },
     });
-    const seedReply = {
+    const seedReply = createWhatsAppObservedMessage("sut-seed-reply", {
       fromJid: groupJid,
-      fromPhoneE164: "+15550000002",
-      kind: "text" as const,
-      messageId: "sut-seed-reply",
-      observedAt: "2026-06-21T12:00:01.000Z",
       participantJid,
       text: "WHATSAPP_QA_REPLY_TO_BOT_SEED_TEST",
-    };
+    });
 
     await run.afterReply?.(
       seedReply,
@@ -1561,8 +1463,7 @@ describe("WhatsApp QA live runtime", () => {
         driver,
         gatewayTarget: groupJid,
         gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-workspace",
-        scenarioId: scenario.id,
-        scenarioTitle: scenario.title,
+        scenario,
         sent: { messageId: "driver-seed-message" },
         target: groupJid,
       }),
@@ -1590,13 +1491,9 @@ describe("WhatsApp QA live runtime", () => {
       "whatsapp-reply-to-message",
       "whatsapp-group-reply-to-message",
     ]);
-    const runs = scenarios.map((scenario) => {
-      const run = scenario.buildRun();
-      if (run.kind === "approval" || !run.verify) {
-        throw new Error(`${scenario.id} unexpectedly built a non-message run`);
-      }
-      return { scenario, run };
-    });
+    const runs = scenarios.map((scenario) =>
+      requireWhatsAppMessageScenario(scenario, { hooks: ["verify"] }),
+    );
 
     expect(
       runs.map(({ scenario, run }) => ({
@@ -1645,14 +1542,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("seeds the structured-message location check through text context", () => {
-    const scenario = findWhatsAppScenario("whatsapp-inbound-structured-messages");
-    if (!scenario) {
-      throw new Error("missing structured WhatsApp scenario");
-    }
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("structured WhatsApp scenario unexpectedly built an approval run");
-    }
+    const { run } = requireWhatsAppMessageScenario("whatsapp-inbound-structured-messages");
 
     expect(run.input).toContain("37.774900, -122.419400");
     expect(run.input).toContain("WhatsApp location marker");
@@ -1728,15 +1618,8 @@ describe("WhatsApp QA live runtime", () => {
     const recorded: unknown[] = [];
     const context = createWhatsAppScenarioContext({
       driver,
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      },
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      recordObservedMessage: (message: unknown) => {
-        recorded.push(message);
-      },
+      recordedMessages: recorded,
       requestStartedAt: new Date("2026-06-05T01:00:00.000Z"),
       scenarioId: "whatsapp-canary",
       scenarioTitle: "WhatsApp DM canary",
@@ -1752,14 +1635,12 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("lets WhatsApp scenario waits use caller-specific sender matching", async () => {
-    const groupReply = {
+    const groupReply = createWhatsAppObservedMessage("group-reply-1", {
       fromJid: "120363000000000000@g.us",
       fromPhoneE164: null,
-      kind: "text" as const,
-      messageId: "group-reply-1",
       observedAt: "2026-06-05T01:00:01.000Z",
       text: "group token",
-    };
+    });
     const driver = createWhatsAppQaDriverMock({
       waitForMessage: async (params) => {
         expect(params.match(groupReply)).toBe(true);
@@ -1769,16 +1650,9 @@ describe("WhatsApp QA live runtime", () => {
     const recorded: unknown[] = [];
     const context = createWhatsAppScenarioContext({
       driver,
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
-        workspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      },
       gatewayTarget: "120363000000000000@g.us",
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      recordObservedMessage: (message: unknown) => {
-        recorded.push(message);
-      },
+      recordedMessages: recorded,
       requestStartedAt: new Date("2026-06-05T01:00:00.000Z"),
       scenarioId: "whatsapp-mention-gating",
       scenarioTitle: "WhatsApp group mention gating",
@@ -1795,11 +1669,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("defines WhatsApp final-message accounting as a settled two-chunk assertion", () => {
-    const scenario = findWhatsAppScenario("whatsapp-stream-final-message-accounting");
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("whatsapp-stream-final-message-accounting unexpectedly built approval run");
-    }
+    const { run } = requireWhatsAppMessageScenario("whatsapp-stream-final-message-accounting");
 
     expect(run.input).toContain("WhatsApp long final QA check");
     expect(run.matchText).toBe("WHATSAPP-LONG-FINAL-BEGIN");
@@ -1812,52 +1682,38 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("requires the long-reply delivery-shape tail marker in the second chunk", async () => {
-    const scenario = findWhatsAppScenario("whatsapp-reply-delivery-shape");
-    const run = scenario.buildRun();
-    if (run.kind === "approval" || !run.afterReply) {
-      throw new Error("whatsapp-reply-delivery-shape unexpectedly omitted afterReply");
-    }
+    const { run } = requireWhatsAppMessageScenario("whatsapp-reply-delivery-shape", {
+      hooks: ["afterReply"],
+    });
     const token = String(run.matchText);
     let waitCallCount = 0;
     const driver = createWhatsAppQaDriverMock({
       waitForMessage: async (params) => {
         waitCallCount += 1;
         if (waitCallCount === 1) {
-          const firstChunk = {
-            fromPhoneE164: "+15550000002",
-            kind: "text" as const,
-            messageId: "chunk-1",
+          const firstChunk = createWhatsAppObservedMessage("chunk-1", {
             observedAt: new Date().toISOString(),
             quoted: { messageId: "driver-message-1" },
             text: `${token}_LONG_BEGIN`,
-          };
+          });
           expect(params.match(firstChunk)).toBe(true);
           return firstChunk;
         }
 
-        const missingTailMarker = {
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: "chunk-2",
+        const missingTailMarker = createWhatsAppObservedMessage("chunk-2", {
           observedAt: new Date().toISOString(),
           quoted: { messageId: "driver-message-1" },
           text: "second chunk without the tail marker",
-        };
-        const missingQuoteChunk = {
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: "chunk-3",
+        });
+        const missingQuoteChunk = createWhatsAppObservedMessage("chunk-3", {
           observedAt: new Date().toISOString(),
           text: `${token}_LONG_END`,
-        };
-        const tailChunk = {
-          fromPhoneE164: "+15550000002",
-          kind: "text" as const,
-          messageId: "chunk-4",
+        });
+        const tailChunk = createWhatsAppObservedMessage("chunk-4", {
           observedAt: new Date().toISOString(),
           quoted: { messageId: "driver-message-1" },
           text: `${token}_LONG_END`,
-        };
+        });
         expect(params.match(missingTailMarker)).toBe(false);
         expect(params.match(missingQuoteChunk)).toBe(false);
         expect(params.match(tailChunk)).toBe(true);
@@ -1866,11 +1722,9 @@ describe("WhatsApp QA live runtime", () => {
     });
     const context = createWhatsAppScenarioContext({
       driver,
-      gateway: {
-        call: async () => ({}),
-        restart: async () => {},
+      gateway: createWhatsAppScenarioGateway({
         workspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
-      },
+      }),
       gatewayWorkspaceDir: "/tmp/openclaw-whatsapp-qa-gateway",
       requestStartedAt: new Date("2026-06-05T01:00:00.000Z"),
       scenarioId: "whatsapp-reply-delivery-shape",
@@ -1879,13 +1733,10 @@ describe("WhatsApp QA live runtime", () => {
     });
 
     await run.afterReply(
-      {
-        fromPhoneE164: "+15550000002",
-        kind: "text",
-        messageId: "initial-reply",
+      createWhatsAppObservedMessage("initial-reply", {
         observedAt: "2026-06-05T01:00:00.500Z",
         text: token,
-      },
+      }),
       context,
     );
 
@@ -1922,68 +1773,10 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("targets group approval reactions at the approval prompt participant", async () => {
-    const scenario = findWhatsAppScenario("whatsapp-approval-exec-group-reaction-native");
-    const run = scenario.buildRun();
-    if (run.kind !== "approval") {
-      throw new Error("expected approval scenario run");
-    }
-    const sendReaction = vi.fn(async () => ({ messageId: "reaction-1" }));
-    let approvalId = "";
-    let waitCount = 0;
-    const driver = createWhatsAppQaDriverMock({
-      sendReaction,
-      waitForMessage: async ({ match }) => {
-        waitCount += 1;
-        const message =
-          waitCount === 1
-            ? {
-                fromJid: "12345@g.us",
-                fromPhoneE164: "+15550000002",
-                kind: "text" as const,
-                messageId: "approval-message-1",
-                observedAt: "2026-06-28T02:00:00.000Z",
-                participantJid: "999@lid",
-                text:
-                  `Exec approval required\nID: ${approvalId}\n` +
-                  `Pending command:\nprintf '%s\\n' '${run.token}'\n\n` +
-                  "React with:\n\n👍 Allow Once\n👎 Deny",
-              }
-            : {
-                fromJid: "12345@g.us",
-                fromPhoneE164: "+15550000002",
-                kind: "text" as const,
-                messageId: "approval-resolved-1",
-                observedAt: "2026-06-28T02:00:01.000Z",
-                participantJid: "999@lid",
-                text: `✅ Exec approval allow-once. ID: ${approvalId}`,
-              };
-        if (!match(message)) {
-          throw new Error(`approval test message ${waitCount} did not match`);
-        }
-        return message;
-      },
-    });
-    const gateway = {
-      call: async (method: string, payload: { id?: string }) => {
-        if (method === "exec.approval.request") {
-          approvalId = payload.id ?? "";
-          return { id: approvalId, status: "accepted" };
-        }
-        if (method === "exec.approval.waitDecision") {
-          return { decision: "allow-once" };
-        }
-        throw new Error(`unexpected gateway call ${method}`);
-      },
-    } as Parameters<typeof testing.runWhatsAppApprovalScenario>[0]["gateway"];
-
-    await testing.runWhatsAppApprovalScenario({
-      driver,
-      gateway,
-      observedMessages: [],
-      run,
-      scenario,
-      sutAccountId: "work",
-      sutPhoneE164: "+15550000002",
+    const sendReaction = await runWhatsAppApprovalReactionFixture({
+      fromJid: "12345@g.us",
+      participantJid: "999@lid",
+      scenarioId: "whatsapp-approval-exec-group-reaction-native",
       turnSourceTo: "12345@g.us",
     });
 
@@ -1994,66 +1787,9 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("targets DM approval reactions at the approval prompt message", async () => {
-    const scenario = findWhatsAppScenario("whatsapp-approval-exec-reaction-native");
-    const run = scenario.buildRun();
-    if (run.kind !== "approval") {
-      throw new Error("expected approval scenario run");
-    }
-    const sendReaction = vi.fn(async () => ({ messageId: "reaction-1" }));
-    let approvalId = "";
-    let waitCount = 0;
-    const driver = createWhatsAppQaDriverMock({
-      sendReaction,
-      waitForMessage: async ({ match }) => {
-        waitCount += 1;
-        const message =
-          waitCount === 1
-            ? {
-                fromJid: "15550000002@s.whatsapp.net",
-                fromPhoneE164: "+15550000002",
-                kind: "text" as const,
-                messageId: "approval-message-1",
-                observedAt: "2026-06-28T02:00:00.000Z",
-                text:
-                  `Exec approval required\nID: ${approvalId}\n` +
-                  `Pending command:\nprintf '%s\\n' '${run.token}'\n\n` +
-                  "React with:\n\n👍 Allow Once\n👎 Deny",
-              }
-            : {
-                fromJid: "15550000002@s.whatsapp.net",
-                fromPhoneE164: "+15550000002",
-                kind: "text" as const,
-                messageId: "approval-resolved-1",
-                observedAt: "2026-06-28T02:00:01.000Z",
-                text: `✅ Exec approval allow-once. ID: ${approvalId}`,
-              };
-        if (!match(message)) {
-          throw new Error(`approval test message ${waitCount} did not match`);
-        }
-        return message;
-      },
-    });
-    const gateway = {
-      call: async (method: string, payload: { id?: string }) => {
-        if (method === "exec.approval.request") {
-          approvalId = payload.id ?? "";
-          return { id: approvalId, status: "accepted" };
-        }
-        if (method === "exec.approval.waitDecision") {
-          return { decision: "allow-once" };
-        }
-        throw new Error(`unexpected gateway call ${method}`);
-      },
-    } as Parameters<typeof testing.runWhatsAppApprovalScenario>[0]["gateway"];
-
-    await testing.runWhatsAppApprovalScenario({
-      driver,
-      gateway,
-      observedMessages: [],
-      run,
-      scenario,
-      sutAccountId: "work",
-      sutPhoneE164: "+15550000002",
+    const sendReaction = await runWhatsAppApprovalReactionFixture({
+      fromJid: "15550000002@s.whatsapp.net",
+      scenarioId: "whatsapp-approval-exec-reaction-native",
       turnSourceTo: "+15550000002",
     });
 
@@ -2113,7 +1849,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("enables WhatsApp action discovery for the user-path agent reaction scenario", () => {
-    const scenario = findWhatsAppScenario("whatsapp-agent-message-action-react");
+    const scenario = getWhatsAppScenario("whatsapp-agent-message-action-react");
     const cfg = buildWhatsAppQaConfigFixture({
       overrides: scenario.configOverrides,
     });
@@ -2124,11 +1860,9 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("defines the WhatsApp audio preflight scenario as mock-backed audio media", () => {
-    const scenario = findWhatsAppScenario("whatsapp-audio-preflight");
-    const scenarioRun = scenario.buildRun();
-    if (scenarioRun.kind === "approval") {
-      throw new Error("whatsapp-audio-preflight unexpectedly built an approval scenario run");
-    }
+    const { scenario, run: scenarioRun } = requireWhatsAppMessageScenario(
+      "whatsapp-audio-preflight",
+    );
 
     expect(readQaScenarioById(scenario.id).plugins).toEqual(["openai"]);
     expect(scenarioRun.expectReply).toBe(true);
@@ -2144,11 +1878,7 @@ describe("WhatsApp QA live runtime", () => {
   });
 
   it("defines group audio gating as captionless audio driven by mock transcription sentinel", () => {
-    const scenario = findWhatsAppScenario("whatsapp-group-audio-gating");
-    const scenarioRun = scenario.buildRun();
-    if (scenarioRun.kind === "approval") {
-      throw new Error("whatsapp-group-audio-gating unexpectedly built an approval scenario run");
-    }
+    const { run: scenarioRun } = requireWhatsAppMessageScenario("whatsapp-group-audio-gating");
     const triggerSentinel = Buffer.from("OPENCLAW_QA_GROUP_AUDIO_TRIGGER", "utf8");
 
     expect(scenarioRun.input).toBe("");
@@ -2260,19 +1990,15 @@ describe("WhatsApp QA live runtime", () => {
 
   it("requires pending-history group replies to expose resolved SUT phone attribution", async () => {
     const groupJid = "120363000000000000@g.us";
-    const scenario = findMockWhatsAppScenario("whatsapp-group-pending-history-context");
-    const run = scenario.buildRun();
-    if (run.kind === "approval") {
-      throw new Error("pending-history scenario unexpectedly built an approval run");
-    }
-    const unresolvedReply = {
+    const { scenario, run } = requireWhatsAppMessageScenario(
+      "whatsapp-group-pending-history-context",
+      { mock: true },
+    );
+    const unresolvedReply = createWhatsAppObservedMessage("sut-lid-reply", {
       fromJid: groupJid,
       fromPhoneE164: null,
-      kind: "text" as const,
-      messageId: "sut-lid-reply",
-      observedAt: "2026-06-21T12:00:01.000Z",
       text: run.matchText.toString(),
-    };
+    });
     const driver = createWhatsAppQaDriverMock({
       getObservedMessages: () => [unresolvedReply],
       waitForMessage: async (params) => {
@@ -2316,11 +2042,7 @@ describe("WhatsApp QA live runtime", () => {
     expect(account?.groups).toBeUndefined();
   });
   it("uses automatic visible replies for WhatsApp group mention gating", () => {
-    const scenario = findWhatsAppScenario("whatsapp-mention-gating");
-    const scenarioRun = scenario.buildRun();
-    if (scenarioRun.kind === "approval") {
-      throw new Error("whatsapp-mention-gating unexpectedly built an approval scenario run");
-    }
+    const { run: scenarioRun } = requireWhatsAppMessageScenario("whatsapp-mention-gating");
     expect(scenarioRun.input).toContain("openclawqa reply with only this exact marker");
     expect(scenarioRun.input).not.toContain("visible reply tool check");
 


### PR DESCRIPTION
## Summary

- Remove 278 lines from the WhatsApp QA live-transport runtime suite by reusing fresh, typed observed-message, scenario, gateway, reaction, approval, and flow fixtures.
- Preserve every existing test name and assertion, including archive extraction and copied-session cleanup, active-account allowlist replacement, group and direct-message quote metadata, ordered media timestamps, approval reaction participants, and fake-timer cleanup.
- Keep production code and public contracts unchanged.

## Architectural owner

The QA Lab WhatsApp live-transport test owns scenario orchestration fixtures. The duplicated observed-message envelopes, Gateway setup, direct/group reaction harnesses, approval harnesses, and mock flow environments were consolidated inside that same test file; no runtime fallback, compatibility layer, or shared mutable fixture was added.

## Exact preservation proof

- 54 ordered test names: byte-identical.
- 210 ordered `expect(...)` expressions: byte-identical.
- 427 complete expectation/matcher-chain AST expressions: identical.
- Six fake-timer operation expressions and their ordering: identical.
- Independent per-test symbolic inventory: 44 scenario `buildRun` calls, 46 scenario lookups, 26 mock-lane lookups, two fresh flow environments, 15 scenario contexts, and 34 driver-fixture constructions; every count matches the baseline.
- Group approval reactions retain `participant: "999@lid"`; direct-message approvals retain explicit `participant: undefined`.
- Direct `baileys@7.0.0-rc13` `IMessageKey`/participant/quote contracts inspected against the installed dependency.
- Production LOC delta: **0**. Test LOC delta: **-278**.

## Validation

- Trusted Blacksmith Testbox: 126 tests passed across the exact WhatsApp QA runtime suite, QA boundary suite, and adjacent WhatsApp driver, approval-reaction, quote, and account suites.
- Full remote `pnpm check:changed`: passed.
- Independent `gpt-5.6-sol` xhigh source/dependency/owner-boundary review: clean.
- `git diff --check`: passed.
- Synthetic merge against current `origin/main`: clean.
