### PR TITLE
improve(cli): attribute startup phases in diagnostics

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -249,7 +249,9 @@ async function tryRunGatewayRunFastPath(
     { beforeRun },
   );
   try {
-    await startupTrace.measure("gateway-run-parse", () => program.parseAsync(argv));
+    await startupTrace.measure("gateway-run-parse", () => program.parseAsync(argv), {
+      timeline: false,
+    });
   } catch (error) {
     if (!isCommanderParseExit(error)) {
       throw error;
@@ -1190,6 +1192,17 @@ async function runCliWithPreparedOutputMode(
     }
     return await bestEffortConfigPromise;
   };
+  const startupTraces = [startupTrace, options.additionalStartupTrace].filter(
+    (trace): trace is ReturnType<typeof createGatewayStartupTrace> => Boolean(trace),
+  );
+  if (
+    (await Promise.all(startupTraces.map((trace) => trace.requiresDiagnosticsConfig()))).some(
+      Boolean,
+    )
+  ) {
+    const config = await withConsoleLogsRoutedToStderr(readBestEffortCliConfig);
+    await Promise.all(startupTraces.map((trace) => trace.configureDiagnosticsTimeline(config)));
+  }
   if (
     !isHelpOrVersionInvocation &&
     normalizedInvocation.primary &&
@@ -1418,10 +1431,13 @@ async function runCliWithPreparedOutputMode(
     }
 
     const { tryRouteCli } = await startupTrace.measure("route-import", () => import("./route.js"));
-    const routed = await startupTrace.measure("route", () =>
-      options.builtInMachineOutput
-        ? tryRouteCli(normalizedArgv, { machineOutput: true })
-        : tryRouteCli(normalizedArgv),
+    const routed = await startupTrace.measure(
+      "route",
+      () =>
+        options.builtInMachineOutput
+          ? tryRouteCli(normalizedArgv, { machineOutput: true })
+          : tryRouteCli(normalizedArgv),
+      { timeline: false },
     );
     if (routed) {
       return;
@@ -1571,7 +1587,9 @@ async function runCliWithPreparedOutputMode(
 
       let completedHelpOrVersion = false;
       try {
-        await startupTrace.measure("parse", () => program.parseAsync(parseArgv));
+        await startupTrace.measure("parse", () => program.parseAsync(parseArgv), {
+          timeline: false,
+        });
         completedHelpOrVersion = isHelpOrVersionInvocation;
       } catch (error) {
         if (!isCommanderParseExit(error)) {

--- a/src/cli/startup-trace.test.ts
+++ b/src/cli/startup-trace.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createGatewayStartupTrace } from "./startup-trace.js";
+
+function readTimelineEvents(timelinePath: string): Record<string, unknown>[] {
+  return fs
+    .readFileSync(timelinePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("CLI startup trace", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("records entry marks and measured spans in the diagnostics timeline", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-trace-"));
+    const timelinePath = path.join(dir, "timeline.jsonl");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS", "timeline");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS_TIMELINE_PATH", timelinePath);
+
+    const trace = createGatewayStartupTrace(["node", "openclaw", "agent", "--local"], "entry");
+    trace.mark("bootstrap");
+    await trace.measure("run-main-import", async () => {
+      await Promise.resolve();
+    });
+    await expect(
+      trace.measure("command-execution", async () => "done", { timeline: false }),
+    ).resolves.toBe("done");
+
+    const events = readTimelineEvents(timelinePath);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "mark",
+          name: "entry.bootstrap",
+          phase: "cli.startup",
+          durationMs: expect.any(Number),
+          attributes: expect.objectContaining({ totalMs: expect.any(Number) }),
+        }),
+        expect.objectContaining({
+          type: "span.start",
+          name: "entry.run-main-import",
+          phase: "cli.startup",
+        }),
+        expect.objectContaining({
+          type: "span.end",
+          name: "entry.run-main-import",
+          phase: "cli.startup",
+          durationMs: expect.any(Number),
+        }),
+      ]),
+    );
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "entry.command-execution",
+        }),
+      ]),
+    );
+  });
+
+  it("flushes buffered startup phases when config enables the timeline", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-trace-config-"));
+    const timelinePath = path.join(dir, "timeline.jsonl");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS", "");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS_TIMELINE_PATH", timelinePath);
+
+    const trace = createGatewayStartupTrace(["node", "openclaw", "agent", "--local"], "entry");
+    trace.mark("bootstrap");
+    await trace.measure("run-main-import", async () => "loaded");
+
+    expect(await trace.requiresDiagnosticsConfig()).toBe(true);
+    expect(fs.existsSync(timelinePath)).toBe(false);
+
+    await trace.configureDiagnosticsTimeline({
+      diagnostics: { flags: ["timeline"] },
+    } as OpenClawConfig);
+
+    expect(readTimelineEvents(timelinePath)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "mark",
+          name: "entry.bootstrap",
+          phase: "cli.startup",
+        }),
+        expect.objectContaining({
+          type: "span.end",
+          name: "entry.run-main-import",
+          phase: "cli.startup",
+          durationMs: expect.any(Number),
+        }),
+      ]),
+    );
+  });
+});

--- a/src/cli/startup-trace.ts
+++ b/src/cli/startup-trace.ts
@@ -1,18 +1,47 @@
-// Shared gateway startup tracing for the entry wrapper and CLI dispatcher.
+// Shared startup tracing for the entry wrapper and CLI dispatcher.
 import process from "node:process";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 
 type GatewayStartupTraceSource = "entry" | "cli.main";
 type GatewayStartupTraceLineFormatter = (message: string) => string;
+type DiagnosticsTimelineModule = typeof import("../infra/diagnostics-timeline.js");
+type StartupTraceMeasureOptions = {
+  timeline?: boolean;
+};
+type PendingTimelineEvent =
+  | {
+      type: "mark";
+      name: string;
+      durationMs: number;
+      totalMs: number;
+    }
+  | {
+      type: "span";
+      name: string;
+      durationMs: number;
+    };
+
+const CLI_STARTUP_TIMELINE_PHASE = "cli.startup";
+
+function hasDiagnosticsTimelinePath(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH?.trim());
+}
 
 export function createGatewayStartupTrace(
   argv: string[],
   source: GatewayStartupTraceSource,
 ): {
   enabled: boolean;
+  requiresDiagnosticsConfig(): Promise<boolean>;
+  configureDiagnosticsTimeline(config: OpenClawConfig): Promise<void>;
   setLineFormatter(formatter: GatewayStartupTraceLineFormatter): void;
   mark(name: string): void;
-  measure<T>(name: string, run: () => T | PromiseLike<T>): Promise<T>;
+  measure<T>(
+    name: string,
+    run: () => T | PromiseLike<T>,
+    options?: StartupTraceMeasureOptions,
+  ): Promise<T>;
 } {
   const enabled =
     isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_STARTUP_TRACE) &&
@@ -21,6 +50,100 @@ export function createGatewayStartupTrace(
   let last = started;
   let lineFormatter: GatewayStartupTraceLineFormatter | null = null;
   let pendingMessages: string[] = [];
+  const timelineModule = hasDiagnosticsTimelinePath(process.env)
+    ? import("../infra/diagnostics-timeline.js").catch(() => null)
+    : null;
+  let timelineActivation: "unknown" | "enabled" | "disabled" = timelineModule
+    ? "unknown"
+    : "disabled";
+  let timelineConfig: OpenClawConfig | undefined;
+  let timelineConfigResolved = false;
+  const pendingTimelineEvents: PendingTimelineEvent[] = [];
+  let pendingTimelineWrites = Promise.resolve();
+  const timelineName = (name: string) => `${source}.${name}`;
+  const resolveTimelineActivation = async (): Promise<typeof timelineActivation> => {
+    if (timelineActivation !== "unknown" || !timelineModule) {
+      return timelineActivation;
+    }
+    const module = await timelineModule;
+    if (!module) {
+      timelineActivation = "disabled";
+      return timelineActivation;
+    }
+    if (module.isDiagnosticsTimelineEnabled({ env: process.env })) {
+      timelineActivation = "enabled";
+      return timelineActivation;
+    }
+    if (timelineConfigResolved) {
+      timelineActivation = module.isDiagnosticsTimelineEnabled({
+        config: timelineConfig,
+        env: process.env,
+      })
+        ? "enabled"
+        : "disabled";
+    }
+    return timelineActivation;
+  };
+  const writeTimelineEvent = (
+    module: DiagnosticsTimelineModule,
+    event: PendingTimelineEvent,
+  ): void => {
+    const commonOptions = {
+      ...(timelineConfig ? { config: timelineConfig } : {}),
+      env: process.env,
+    };
+    if (event.type === "mark") {
+      module.emitDiagnosticsTimelineEvent(
+        {
+          type: "mark",
+          name: event.name,
+          phase: CLI_STARTUP_TIMELINE_PHASE,
+          durationMs: event.durationMs,
+          attributes: { totalMs: event.totalMs },
+        },
+        commonOptions,
+      );
+      return;
+    }
+    module.emitCompletedDiagnosticsTimelineSpan(event.name, event.durationMs, {
+      phase: CLI_STARTUP_TIMELINE_PHASE,
+      ...commonOptions,
+    });
+  };
+  const flushPendingTimelineEvents = async (): Promise<void> => {
+    const activation = await resolveTimelineActivation();
+    if (activation === "unknown") {
+      return;
+    }
+    if (activation === "disabled") {
+      pendingTimelineEvents.length = 0;
+      return;
+    }
+    const module = await timelineModule;
+    if (!module) {
+      pendingTimelineEvents.length = 0;
+      return;
+    }
+    const events = pendingTimelineEvents.splice(0);
+    for (const event of events) {
+      writeTimelineEvent(module, event);
+    }
+  };
+  const enqueueTimelineEvent = (event: PendingTimelineEvent): void => {
+    if (!timelineModule || timelineActivation === "disabled") {
+      return;
+    }
+    if (timelineActivation === "unknown") {
+      pendingTimelineEvents.push(event);
+      return;
+    }
+    pendingTimelineWrites = pendingTimelineWrites.then(async () => {
+      const module = await timelineModule;
+      if (module) {
+        writeTimelineEvent(module, event);
+      }
+    });
+  };
   const flushPending = (formatter: GatewayStartupTraceLineFormatter) => {
     const queued = pendingMessages;
     pendingMessages = [];
@@ -55,6 +178,16 @@ export function createGatewayStartupTrace(
   };
   return {
     enabled,
+    async requiresDiagnosticsConfig() {
+      await flushPendingTimelineEvents();
+      return timelineActivation === "unknown";
+    },
+    async configureDiagnosticsTimeline(config) {
+      timelineConfig = config;
+      timelineConfigResolved = true;
+      await flushPendingTimelineEvents();
+      await pendingTimelineWrites;
+    },
     setLineFormatter(formatter) {
       lineFormatter = formatter;
       process.off("exit", flushPendingPlainOnExit);
@@ -62,15 +195,55 @@ export function createGatewayStartupTrace(
     },
     mark(name: string) {
       const now = performance.now();
-      emit(name, now - last, now - started);
+      const durationMs = now - last;
+      const totalMs = now - started;
+      emit(name, durationMs, totalMs);
+      enqueueTimelineEvent({
+        type: "mark",
+        name: timelineName(name),
+        durationMs,
+        totalMs,
+      });
       last = now;
     },
-    async measure<T>(name: string, run: () => T | PromiseLike<T>): Promise<T> {
+    async measure<T>(
+      name: string,
+      run: () => T | PromiseLike<T>,
+      options: StartupTraceMeasureOptions = {},
+    ): Promise<T> {
       const before = performance.now();
+      let bufferCompletedTimelineSpan = false;
+      let completed = false;
       try {
-        return await run();
+        if (timelineModule && options.timeline !== false) {
+          await flushPendingTimelineEvents();
+          const module = await timelineModule;
+          if (module && timelineActivation === "enabled") {
+            await pendingTimelineWrites;
+            return await module.measureDiagnosticsTimelineSpan(
+              timelineName(name),
+              () => Promise.resolve(run()),
+              {
+                phase: CLI_STARTUP_TIMELINE_PHASE,
+                ...(timelineConfig ? { config: timelineConfig } : {}),
+                env: process.env,
+              },
+            );
+          }
+          bufferCompletedTimelineSpan = timelineActivation === "unknown";
+        }
+        const result = await run();
+        completed = true;
+        return result;
       } finally {
         const now = performance.now();
+        if (bufferCompletedTimelineSpan && completed) {
+          enqueueTimelineEvent({
+            type: "span",
+            name: timelineName(name),
+            durationMs: now - before,
+          });
+        }
         emit(name, now - before, now - started);
         last = now;
       }

--- a/src/infra/diagnostics-timeline.ts
+++ b/src/infra/diagnostics-timeline.ts
@@ -202,6 +202,41 @@ export function emitDiagnosticsTimelineEvent(
   }
 }
 
+/** Replays a completed span after its activation config becomes available. */
+export function emitCompletedDiagnosticsTimelineSpan(
+  name: string,
+  durationMs: number,
+  options: DiagnosticsTimelineSpanOptions = {},
+): void {
+  if (!isDiagnosticsTimelineEnabled(options)) {
+    return;
+  }
+  const spanId = randomUUID();
+  emitDiagnosticsTimelineEvent(
+    {
+      type: "span.start",
+      name,
+      phase: options.phase,
+      spanId,
+      parentSpanId: options.parentSpanId,
+      attributes: options.attributes,
+    },
+    options,
+  );
+  emitDiagnosticsTimelineEvent(
+    {
+      type: "span.end",
+      name,
+      phase: options.phase,
+      spanId,
+      parentSpanId: options.parentSpanId,
+      durationMs,
+      attributes: options.attributes,
+    },
+    options,
+  );
+}
+
 /** Returns the currently active span so callers can preserve parentage across memoized work. */
 export function getActiveDiagnosticsTimelineSpan(): ActiveDiagnosticsTimelineSpan | undefined {
   return activeDiagnosticsTimelineSpan.getStore();


### PR DESCRIPTION
## What Problem This Solves

Kova can measure local agent startup, but most pre-provider time is currently unattributed. On exact `main` at `4153451a9a1d2cab1040e548cb33033179c51e64`, the mock lane attributed about 0.2s of roughly 3.2s, leaving about 3.0s opaque per cold or warm CLI process.

## Why This Change Was Made

The existing entry and CLI startup tracer already owns the relevant phase boundaries. This change also emits those marks and measured phases into the canonical diagnostics timeline when timeline diagnostics are enabled. Normal startup remains on the existing path and does not import the timeline module.

## User Impact

No user-visible behavior changes. Maintainers and performance tooling can attribute entry import, route, command registration, program construction, and parse time before choosing a runtime optimization.

## Evidence

- Exact-main Kova baseline: https://github.com/openclaw/openclaw/actions/runs/30723901375
- Exact-head Kova proof: https://github.com/openclaw/openclaw/actions/runs/30724930957
  - 10/10 scenarios passed
  - agent RSS median 845 MB
  - cold/warm turns 3.30s / 3.34s
  - no execution-owning `route` or `parse` spans were emitted as startup attribution
- `node scripts/run-vitest.mjs src/cli/startup-trace.test.ts src/entry.run-main.test.ts src/cli/run-main.test.ts src/infra/diagnostics-timeline.test.ts`
  - 58 tests passed across 4 shards
- `./node_modules/.bin/oxfmt --check src/cli/startup-trace.ts src/cli/startup-trace.test.ts`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- ClawSweeper: prior config-only activation finding resolved; latest review has no findings

The broad changed-file/lint route could not complete locally because Testbox routing is unavailable and current `main` has an unrelated plugin-SDK declaration failure in `packages/terminal-core/src/ansi.ts:194`.
