### PR TITLE
fix(cli): keep gateway-backed agent turns cold

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -118,10 +118,10 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
-  it("does nothing extra when plugin loading is disabled", async () => {
+  it("does not evaluate config or plugin runtimes for a gateway-backed agent turn", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,
-      commandPath: ["config", "validate"],
+      commandPath: ["agent"],
       skipConfigGuard: true,
       loadPlugins: false,
     });

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -7,6 +7,9 @@ export type CliCommandPluginLoadPolicy =
   | "text-only"
   | ((ctx: { argv: string[]; commandPath: string[]; jsonOutputMode: boolean }) => boolean);
 type CliRouteConfigGuardPolicy = "never" | "always" | "when-suppressed";
+type CliConfigGuardBypassPolicy =
+  | boolean
+  | ((ctx: { argv: string[]; commandPath: string[] }) => boolean);
 export type CliPluginRegistryScope = "all" | "channels" | "configured-channels";
 export type CliPluginRegistryPolicy = {
   scope: CliPluginRegistryScope;
@@ -33,7 +36,7 @@ type CliRoutedCommandId =
   | "plugins-list";
 
 export type CliCommandPathPolicy = {
-  bypassConfigGuard: boolean;
+  bypassConfigGuard: CliConfigGuardBypassPolicy;
   routeConfigGuard: CliRouteConfigGuardPolicy;
   loadPlugins: CliCommandPluginLoadPolicy;
   pluginRegistry: CliPluginRegistryPolicy;
@@ -84,7 +87,8 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["agent"],
     policy: {
-      loadPlugins: ({ argv, jsonOutputMode }) => hasFlag(argv, "--local") || !jsonOutputMode,
+      bypassConfigGuard: ({ argv }) => !hasFlag(argv, "--local"),
+      loadPlugins: ({ argv }) => hasFlag(argv, "--local"),
       pluginRegistry: { scope: "all" },
       networkProxy: ({ argv }) => (hasFlag(argv, "--local") ? "default" : "bypass"),
     },
@@ -481,6 +485,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["channels", "status"],
     exact: true,
     policy: {
+      bypassConfigGuard: true,
       loadPlugins: "never",
       networkProxy: ({ argv }) => (hasFlag(argv, "--probe") ? "default" : "bypass"),
     },

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -120,7 +120,7 @@ describe("command-execution-startup", () => {
         argv: ["node", "openclaw", "agent", "--agent", "main", "--message", "hi"],
         jsonOutputMode: false,
       }).startupPolicy.loadPlugins,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("uses the resolved action command path for every execution startup decision", () => {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -26,6 +26,10 @@ type LoadPluginsResolver = Extract<
   CliCommandPathPolicy["loadPlugins"],
   (ctx: { argv: string[]; commandPath: string[]; jsonOutputMode: boolean }) => unknown
 >;
+type ConfigGuardBypassResolver = Extract<
+  CliCommandPathPolicy["bypassConfigGuard"],
+  (ctx: { argv: string[]; commandPath: string[] }) => unknown
+>;
 
 function expectResolvedPolicy(
   commandPath: string[],
@@ -47,6 +51,12 @@ function expectLoadPluginsResolver(
   policy: CliCommandPathPolicy,
 ): asserts policy is CliCommandPathPolicy & { loadPlugins: LoadPluginsResolver } {
   expect(typeof policy.loadPlugins).toBe("function");
+}
+
+function expectConfigGuardBypassResolver(
+  policy: CliCommandPathPolicy,
+): asserts policy is CliCommandPathPolicy & { bypassConfigGuard: ConfigGuardBypassResolver } {
+  expect(typeof policy.bypassConfigGuard).toBe("function");
 }
 
 describe("command-path-policy", () => {
@@ -86,6 +96,7 @@ describe("command-path-policy", () => {
     const channelsStatusPolicy = resolveCliCommandPathPolicy(["channels", "status"]);
     expect(channelsStatusPolicy).toEqual({
       ...DEFAULT_EXPECTED_POLICY,
+      bypassConfigGuard: true,
       loadPlugins: "never",
       pluginRegistry: { scope: "configured-channels" },
       networkProxy: channelsStatusPolicy.networkProxy,
@@ -129,11 +140,13 @@ describe("command-path-policy", () => {
     const agentPolicy = resolveCliCommandPathPolicy(["agent"]);
     expect(agentPolicy).toEqual({
       ...DEFAULT_EXPECTED_POLICY,
+      bypassConfigGuard: agentPolicy.bypassConfigGuard,
       loadPlugins: agentPolicy.loadPlugins,
       pluginRegistry: { scope: "all" },
       networkProxy: agentPolicy.networkProxy,
     });
     expectLoadPluginsResolver(agentPolicy);
+    expectConfigGuardBypassResolver(agentPolicy);
     expectNetworkProxyResolver(agentPolicy);
     expect(
       agentPolicy.loadPlugins({
@@ -141,7 +154,7 @@ describe("command-path-policy", () => {
         commandPath: ["agent"],
         jsonOutputMode: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       agentPolicy.loadPlugins({
         argv: ["node", "openclaw", "agent", "--json"],
@@ -156,6 +169,18 @@ describe("command-path-policy", () => {
         jsonOutputMode: true,
       }),
     ).toBe(true);
+    expect(
+      agentPolicy.bypassConfigGuard({
+        argv: ["node", "openclaw", "agent"],
+        commandPath: ["agent"],
+      }),
+    ).toBe(true);
+    expect(
+      agentPolicy.bypassConfigGuard({
+        argv: ["node", "openclaw", "agent", "--local"],
+        commandPath: ["agent"],
+      }),
+    ).toBe(false);
     expect(
       agentPolicy.networkProxy({
         argv: ["node", "openclaw", "agent"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -27,6 +27,12 @@ describe("command-startup-policy", () => {
     expect(shouldBypassConfigGuardForCommandPath(["config", "schema"])).toBe(true);
     expect(shouldBypassConfigGuardForCommandPath(["docs"])).toBe(true);
     expect(shouldBypassConfigGuardForCommandPath(["agent", "exec"])).toBe(true);
+    expect(shouldBypassConfigGuardForCommandPath(["agent"], ["node", "openclaw", "agent"])).toBe(
+      true,
+    );
+    expect(
+      shouldBypassConfigGuardForCommandPath(["agent"], ["node", "openclaw", "agent", "--local"]),
+    ).toBe(false);
     expect(shouldBypassConfigGuardForCommandPath(["config", "set"])).toBe(false);
     expect(shouldBypassConfigGuardForCommandPath(["status"])).toBe(false);
   });
@@ -126,7 +132,7 @@ describe("command-startup-policy", () => {
         argv: ["node", "openclaw", "agent"],
         commandPath: ["agent"],
       }).loadPlugins,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       resolvePolicy({
         commandPath: ["agents"],

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -3,8 +3,14 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import type { CliCommandPluginLoadPolicy } from "./command-catalog.js";
 import { resolveCliCommandPathPolicy } from "./command-path-policy.js";
 
-export function shouldBypassConfigGuardForCommandPath(commandPath: string[]): boolean {
-  return resolveCliCommandPathPolicy(commandPath).bypassConfigGuard;
+export function shouldBypassConfigGuardForCommandPath(
+  commandPath: string[],
+  argv: string[] = [],
+): boolean {
+  const bypassConfigGuard = resolveCliCommandPathPolicy(commandPath).bypassConfigGuard;
+  return typeof bypassConfigGuard === "function"
+    ? bypassConfigGuard({ argv, commandPath })
+    : bypassConfigGuard;
 }
 
 function shouldLoadPlugins(params: {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -682,10 +682,7 @@ describe("registerPreActionHooks", () => {
 
     await parseProgram.parseAsync(process.argv);
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      commandPath: ["agent"],
-    });
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -778,10 +775,7 @@ describe("registerPreActionHooks", () => {
 
     await parseProgram.parseAsync(process.argv);
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      commandPath: ["agent"],
-    });
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
@@ -949,6 +943,17 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("bypasses config and plugin bootstrap for remote agent text output", async () => {
+    await runPreAction({
+      parseArgv: ["agent"],
+      processArgv: ["node", "openclaw", "agent", "--message", "hi"],
+    });
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -125,6 +125,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       jsonOutputMode,
       env: process.env,
     });
+    const bypassConfigGuard = shouldBypassConfigGuardForCommandPath(commandPath, argv);
     await applyCliExecutionStartupPresentation({
       startupPolicy,
       version: programVersion,
@@ -139,7 +140,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       process.env.NODE_NO_WARNINGS ??= "1";
     }
     if (
-      shouldBypassConfigGuardForCommandPath(commandPath) ||
+      bypassConfigGuard ||
       isGuidedConfigAction(actionCommand) ||
       isGuidedConfigCommandPath(commandPath)
     ) {
@@ -184,7 +185,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
       ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
       ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
-      skipConfigGuard: shouldBypassConfigGuardForCommandPath(commandPath),
+      skipConfigGuard: bypassConfigGuard,
     });
     if (beforeStateMigrations) {
       const { reloadTrustedGatewayRunEnvironment } =

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -242,7 +242,9 @@ function resetAgentCliCommandMocksForTest() {
   vi.stubEnv("OPENCLAW_GATEWAY_URL", "");
   agentViaGatewayTesting.resetLazyImportsForTests();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests([0, 0, 0, 0]);
-  loadAgentSessionModuleMock.mockImplementation(async () => await import("./agent/session.js"));
+  loadAgentSessionModuleMock.mockImplementation(
+    async () => await import("./agent/session.runtime.js"),
+  );
   agentViaGatewayTesting.setAgentSessionModuleLoaderForTests(loadAgentSessionModuleMock);
   originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
   loggingState.forceConsoleToStderr = false;
@@ -313,6 +315,48 @@ describe("agentCliCommand", () => {
       expect(agentModuleLoadCount).not.toHaveBeenCalled();
       expect(runtime.log).toHaveBeenCalledWith("hello");
     });
+  });
+
+  it("keeps an agent-scoped gateway turn off session and delivery runtimes", async () => {
+    await withTempStore(
+      async () => {
+        mockGatewaySuccessReply();
+
+        await agentCliCommand(
+          {
+            message: "hi",
+            agent: "ops",
+            json: true,
+            deliver: true,
+            channel: "discord",
+            replyTo: "123456789",
+            replyChannel: "slack",
+            replyAccount: "reports",
+            bestEffortDeliver: true,
+          },
+          jsonRuntime,
+        );
+
+        const request = requireRecord(
+          requireFirstCallArg(callGateway, "gateway"),
+          "gateway request",
+        );
+        expect(request.params).toMatchObject({
+          agentId: "ops",
+          sessionKey: undefined,
+          deliver: true,
+          channel: "discord",
+          replyTo: "123456789",
+          replyChannel: "slack",
+          replyAccountId: "reports",
+          bestEffortDeliver: true,
+        });
+        expect(loadAgentSessionModuleMock).not.toHaveBeenCalled();
+        expect(agentCommand).not.toHaveBeenCalled();
+        expect(jsonRuntime.writeJson).toHaveBeenCalledOnce();
+      },
+      { agents: { list: [{ id: "main" }, { id: "ops" }] } },
+    );
   });
 
   it.each([

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -103,7 +103,7 @@ type AgentGatewayCallIdentity = Pick<
   Parameters<typeof callGateway>[0],
   "clientName" | "mode" | "scopes"
 >;
-type AgentSessionModule = typeof import("./agent/session.js");
+type AgentSessionModule = typeof import("./agent/session.runtime.js");
 type AgentSessionModuleLoader = () => Promise<AgentSessionModule>;
 
 const AGENT_CLI_SIGNALS: readonly AgentCliSignal[] = ["SIGINT", "SIGTERM"];
@@ -116,7 +116,7 @@ const AGENT_CLI_SIGNAL_EXIT_CODES: Record<AgentCliSignal, number> = {
 const MESSAGE_FILE_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 const defaultAgentSessionModuleLoader: AgentSessionModuleLoader = () =>
-  import("./agent/session.js");
+  import("./agent/session.runtime.js");
 let agentSessionModuleLoader: AgentSessionModuleLoader = defaultAgentSessionModuleLoader;
 const embeddedAgentCommandLoader = createLazyPromiseLoader(
   () => import("./agent.js").then((module) => module.agentCommand),
@@ -703,13 +703,15 @@ async function agentViaGatewayCommand(
     ? undefined
     : classifySessionKeyShape(explicitSessionKey) === "agent"
       ? explicitSessionKey
-      : (await loadAgentSessionModule()).resolveSessionKeyForRequest({
-          cfg,
-          agentId,
-          to: opts.to,
-          sessionId: opts.sessionId,
-          sessionKey: explicitSessionKey,
-        }).sessionKey;
+      : explicitSessionKey || opts.to || opts.sessionId
+        ? (await loadAgentSessionModule()).resolveSessionKeyForRequest({
+            cfg,
+            agentId,
+            to: opts.to,
+            sessionId: opts.sessionId,
+            sessionKey: explicitSessionKey,
+          }).sessionKey
+        : undefined;
   const abortSessionKey = deferExplicitRecipientSession
     ? (await loadAgentSessionModule()).resolveSessionKeyForRequest({ cfg, agentId }).sessionKey
     : sessionKey;

--- a/src/commands/agent/session.runtime.ts
+++ b/src/commands/agent/session.runtime.ts
@@ -1,0 +1,8 @@
+// Full session-store resolution for gateway CLI requests that need local routing facts.
+import { resolveSessionKeyForRequest as resolveAgentSessionKeyForRequest } from "../../agents/command/session.js";
+
+export function resolveSessionKeyForRequest(
+  ...args: Parameters<typeof resolveAgentSessionKeyForRequest>
+): ReturnType<typeof resolveAgentSessionKeyForRequest> {
+  return resolveAgentSessionKeyForRequest(...args);
+}

--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -1,7 +1,7 @@
 // Agent session helper tests cover explicit session resolution through config and session stores.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveSessionKeyForRequest } from "./session.js";
+import { resolveSessionKeyForRequest } from "./session.runtime.js";
 
 const mocks = vi.hoisted(() => ({
   listSessionEntries: vi.fn(),

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -1,5 +1,0 @@
-// Public command re-export for session key helpers used by CLI and gateway dispatch paths.
-export {
-  buildExplicitSessionIdSessionKey,
-  resolveSessionKeyForRequest,
-} from "../../agents/command/session.js";

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -10,7 +10,7 @@ import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/c
 import { configMocks, offsetMocks, secretMocks } from "./channels.mock-harness.js";
 import { channelsAddCommand } from "./channels/add.js";
 import { channelsRemoveCommand } from "./channels/remove.js";
-import { formatGatewayChannelsStatusLines } from "./channels/status.js";
+import { formatGatewayChannelsStatusLines } from "./channels/status.runtime.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const runtime = createTestRuntime();

--- a/src/commands/channels.status-cold-imports.test.ts
+++ b/src/commands/channels.status-cold-imports.test.ts
@@ -1,0 +1,49 @@
+// Successful Gateway-backed channel status must not load local plugin/config runtime work.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeModuleLoaded = vi.hoisted(() => vi.fn());
+const callGatewayMock = vi.hoisted(() => vi.fn(async () => ({ channelAccounts: {} })));
+
+vi.mock("./channels/status.runtime.js", () => {
+  runtimeModuleLoaded();
+  return {
+    formatGatewayChannelsStatusLines: vi.fn(() => []),
+    renderChannelsStatusFallback: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+}));
+
+vi.mock("../cli/progress.js", () => ({
+  withProgress: vi.fn(async (_opts, run: () => Promise<unknown>) => await run()),
+}));
+
+import { channelsStatusCommand } from "./channels/status.js";
+
+describe("channelsStatusCommand cold imports", () => {
+  beforeEach(() => {
+    callGatewayMock.mockClear();
+    runtimeModuleLoaded.mockClear();
+  });
+
+  it.each([false, true])(
+    "keeps a successful JSON gateway request cold when probe=%s",
+    async (probe) => {
+      const runtime = {
+        error: vi.fn(),
+        exit: vi.fn(),
+        log: vi.fn(),
+        writeJson: vi.fn(),
+        writeStdout: vi.fn(),
+      };
+
+      await channelsStatusCommand({ json: true, probe }, runtime);
+
+      expect(callGatewayMock).toHaveBeenCalledOnce();
+      expect(runtime.writeJson).toHaveBeenCalledWith({ channelAccounts: {} }, 2);
+      expect(runtimeModuleLoaded).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
+++ b/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { collectStatusIssuesFromLastError } from "../plugin-sdk/status-helpers.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { formatGatewayChannelsStatusLines } from "./channels/status.js";
+import { formatGatewayChannelsStatusLines } from "./channels/status.runtime.js";
 
 const now = 1_700_000_000_000;
 

--- a/src/commands/channels.ts
+++ b/src/commands/channels.ts
@@ -12,4 +12,4 @@ export { channelsRemoveCommand } from "./channels/remove.js";
 export type { ChannelsResolveOptions } from "./channels/resolve.js";
 export { channelsResolveCommand } from "./channels/resolve.js";
 export type { ChannelsStatusOptions } from "./channels/status.js";
-export { channelsStatusCommand, formatGatewayChannelsStatusLines } from "./channels/status.js";
+export { channelsStatusCommand } from "./channels/status.js";

--- a/src/commands/channels/status.runtime.ts
+++ b/src/commands/channels/status.runtime.ts
@@ -1,0 +1,249 @@
+// Runtime-only rendering and config fallback for `openclaw channels status`.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { normalizeChannelId } from "../../channels/plugins/index.js";
+import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolution.js";
+import { formatCliCommand } from "../../cli/command-format.js";
+import { getConfiguredChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import { collectChannelStatusIssues } from "../../infra/channels-status-issues.js";
+import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
+import { formatPhoneNumberForCli } from "../../infra/phone-number-presentation.js";
+import { listConfiguredAnnounceChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import {
+  appendBaseUrlBit,
+  appendEnabledConfiguredLinkedBits,
+  appendModeBit,
+  appendTokenSourceBits,
+  buildChannelAccountLine,
+  type ChatChannel,
+  requireValidConfigSnapshot,
+} from "./shared.js";
+import { formatConfigChannelsStatusLines } from "./status-config-format.js";
+import type { ChannelsStatusOptions } from "./status.js";
+
+function formatEventLoopBits(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.degraded !== true) {
+    return null;
+  }
+  const reasons = Array.isArray(record.reasons)
+    ? record.reasons.filter((reason): reason is string => typeof reason === "string")
+    : [];
+  const delayMaxMs =
+    typeof record.delayMaxMs === "number" && Number.isFinite(record.delayMaxMs)
+      ? Math.round(record.delayMaxMs)
+      : null;
+  const utilization =
+    typeof record.utilization === "number" && Number.isFinite(record.utilization)
+      ? record.utilization
+      : null;
+  const cpuCoreRatio =
+    typeof record.cpuCoreRatio === "number" && Number.isFinite(record.cpuCoreRatio)
+      ? record.cpuCoreRatio
+      : null;
+  return [
+    reasons.length ? `reasons=${reasons.join(",")}` : null,
+    delayMaxMs != null ? `eventLoopDelayMaxMs=${delayMaxMs}` : null,
+    utilization != null ? `eventLoopUtilization=${utilization}` : null,
+    cpuCoreRatio != null ? `cpuCoreRatio=${cpuCoreRatio}` : null,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+}
+
+/** Render gateway channel status payloads into terminal-friendly lines. */
+export function formatGatewayChannelsStatusLines(payload: Record<string, unknown>): string[] {
+  const lines: string[] = [];
+  lines.push(theme.success("Gateway reachable."));
+  const eventLoopLine = formatEventLoopBits(payload.eventLoop);
+  if (eventLoopLine) {
+    lines.push(theme.warn(`Gateway event loop degraded: ${eventLoopLine}`));
+  }
+  const channelLabels =
+    payload.channelLabels && typeof payload.channelLabels === "object"
+      ? (payload.channelLabels as Record<string, unknown>)
+      : {};
+  const accountLines = (provider: ChatChannel, accounts: Array<Record<string, unknown>>) =>
+    accounts.map((account) => {
+      const bits: string[] = [];
+      appendEnabledConfiguredLinkedBits(bits, account);
+      if (typeof account.running === "boolean") {
+        bits.push(account.running ? "running" : "stopped");
+      }
+      if (typeof account.connected === "boolean") {
+        bits.push(account.connected ? "connected" : "disconnected");
+      }
+      const inboundAt =
+        typeof account.lastInboundAt === "number" && Number.isFinite(account.lastInboundAt)
+          ? account.lastInboundAt
+          : null;
+      const outboundAt =
+        typeof account.lastOutboundAt === "number" && Number.isFinite(account.lastOutboundAt)
+          ? account.lastOutboundAt
+          : null;
+      const transportAt =
+        typeof account.lastTransportActivityAt === "number" &&
+        Number.isFinite(account.lastTransportActivityAt)
+          ? account.lastTransportActivityAt
+          : null;
+      if (inboundAt) {
+        bits.push(`in:${formatTimeAgo(Date.now() - inboundAt)}`);
+      }
+      if (outboundAt) {
+        bits.push(`out:${formatTimeAgo(Date.now() - outboundAt)}`);
+      }
+      if (transportAt) {
+        bits.push(`transport:${formatTimeAgo(Date.now() - transportAt)}`);
+      }
+      appendModeBit(bits, account);
+      const botUsername = (() => {
+        const bot = account.bot as { username?: string | null } | undefined;
+        const probeBot = (account.probe as { bot?: { username?: string | null } } | undefined)?.bot;
+        const raw = bot?.username ?? probeBot?.username ?? "";
+        if (typeof raw !== "string") {
+          return "";
+        }
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          return "";
+        }
+        return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+      })();
+      if (botUsername) {
+        bits.push(`bot:${botUsername}`);
+      }
+      if (typeof account.dmPolicy === "string" && account.dmPolicy.length > 0) {
+        bits.push(`dm:${account.dmPolicy}`);
+      }
+      if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
+        const allowFrom = account.allowFrom
+          .slice(0, 2)
+          .map((entry) => formatPhoneNumberForCli(String(entry)));
+        bits.push(`allow:${allowFrom.join(",")}`);
+      }
+      appendTokenSourceBits(bits, account);
+      const application = account.application as
+        | { intents?: { messageContent?: string } }
+        | undefined;
+      const messageContent = application?.intents?.messageContent;
+      if (
+        typeof messageContent === "string" &&
+        messageContent.length > 0 &&
+        messageContent !== "enabled"
+      ) {
+        bits.push(`intents:content=${messageContent}`);
+      }
+      if (account.allowUnmentionedGroups === true) {
+        bits.push("groups:unmentioned");
+      }
+      if (typeof account.healthState === "string" && account.healthState) {
+        bits.push(`health:${account.healthState}`);
+      }
+      appendBaseUrlBit(bits, account);
+      const probe = account.probe as { ok?: boolean } | undefined;
+      if (probe && typeof probe.ok === "boolean") {
+        bits.push(probe.ok ? "works" : "probe failed");
+      }
+      const audit = account.audit as { ok?: boolean } | undefined;
+      if (audit && typeof audit.ok === "boolean") {
+        bits.push(audit.ok ? "audit ok" : "audit failed");
+      }
+      const rawChannelLabel = channelLabels[provider];
+      return buildChannelAccountLine(provider, account, bits, {
+        channelLabel: typeof rawChannelLabel === "string" ? rawChannelLabel : provider,
+      });
+    });
+
+  const accountsByChannel = payload.channelAccounts as Record<string, unknown> | undefined;
+  const accountPayloads: Partial<Record<string, Array<Record<string, unknown>>>> = {};
+  for (const channelId of Object.keys(accountsByChannel ?? {}).toSorted()) {
+    const raw = accountsByChannel?.[channelId];
+    if (Array.isArray(raw)) {
+      accountPayloads[channelId] = raw as Array<Record<string, unknown>>;
+    }
+  }
+  for (const channelId of Object.keys(accountPayloads).toSorted()) {
+    const accounts = accountPayloads[channelId];
+    if (accounts && accounts.length > 0) {
+      lines.push(...accountLines(channelId, accounts));
+    }
+  }
+
+  lines.push("");
+  const issues = collectChannelStatusIssues(payload);
+  if (issues.length > 0) {
+    lines.push(theme.warn("Warnings:"));
+    for (const issue of issues) {
+      lines.push(
+        `- ${issue.channel} ${issue.accountId}: ${issue.message}${issue.fix ? ` (${issue.fix})` : ""}`,
+      );
+    }
+    lines.push(`- Run: ${formatCliCommand("openclaw doctor")}`);
+    lines.push("");
+  }
+  lines.push(
+    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+  );
+  return lines;
+}
+
+export async function renderChannelsStatusFallback(params: {
+  opts: ChannelsStatusOptions;
+  runtime: RuntimeEnv;
+  safeError: string;
+  gatewayAuthUnavailable: boolean;
+}): Promise<void> {
+  const { opts, runtime, safeError, gatewayAuthUnavailable } = params;
+  const fallbackReason = gatewayAuthUnavailable
+    ? "Gateway auth unavailable; showing config-only status."
+    : "Gateway not reachable; showing config-only status.";
+  runtime.error(
+    `${gatewayAuthUnavailable ? "Gateway auth unavailable" : "Gateway not reachable"}: ${safeError}`,
+  );
+  const cfg = await requireValidConfigSnapshot(runtime);
+  if (!cfg) {
+    return;
+  }
+  const { resolvedConfig } = await resolveCommandConfigWithSecrets({
+    config: cfg,
+    commandName: "channels status",
+    targetIds: getConfiguredChannelsCommandSecretTargetIds(cfg),
+    mode: "read_only_status",
+    runtime,
+  });
+  const snapshot = await readConfigFileSnapshot();
+  const mode = cfg.gateway?.mode === "remote" ? "remote" : "local";
+  const requestedChannel = opts.channel
+    ? (normalizeChannelId(opts.channel) ?? normalizeOptionalLowercaseString(opts.channel))
+    : null;
+  if (opts.json) {
+    writeRuntimeJson(runtime, {
+      gatewayReachable: false,
+      error: safeError,
+      gatewayAuthUnavailable,
+      configOnly: true,
+      config: { path: snapshot.path, mode },
+      configuredChannels: listConfiguredAnnounceChannelIdsForConfig({
+        config: resolvedConfig,
+        activationSourceConfig: cfg,
+        env: process.env,
+      }).filter((channelId) => !requestedChannel || channelId === requestedChannel),
+    });
+    return;
+  }
+  runtime.log(
+    (
+      await formatConfigChannelsStatusLines(
+        resolvedConfig,
+        { path: snapshot.path, mode },
+        { sourceConfig: cfg, channel: opts.channel, fallbackReason },
+      )
+    ).join("\n"),
+  );
+}

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -1,33 +1,14 @@
 // Implements `openclaw channels status` with gateway status and config-only fallback.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
-import { theme } from "../../../packages/terminal-core/src/theme.js";
-import { normalizeChannelId } from "../../channels/plugins/index.js";
-import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolution.js";
-import { formatCliCommand } from "../../cli/command-format.js";
-import { getConfiguredChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
 import { parseTimeoutMsWithFallback } from "../../cli/parse-timeout.js";
 import { withProgress } from "../../cli/progress.js";
-import { readConfigFileSnapshot } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { isGatewaySecretRefUnavailableError } from "../../gateway/credentials.js";
-import { collectChannelStatusIssues } from "../../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
-import { formatPhoneNumberForCli } from "../../infra/phone-number-presentation.js";
-import { listConfiguredAnnounceChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
-import {
-  appendBaseUrlBit,
-  appendEnabledConfiguredLinkedBits,
-  appendModeBit,
-  appendTokenSourceBits,
-  buildChannelAccountLine,
-  type ChatChannel,
-  requireValidConfigSnapshot,
-} from "./shared.js";
-import { formatConfigChannelsStatusLines } from "./status-config-format.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
+
+const loadChannelsStatusRuntime = createLazyRuntimeModule(() => import("./status.runtime.js"));
 
 export type ChannelsStatusOptions = {
   channel?: string;
@@ -46,176 +27,6 @@ function formatChannelsStatusError(err: unknown): string {
   return redactGatewayUrlSecretsInText(formatErrorMessage(err));
 }
 
-function formatEventLoopBits(value: unknown): string | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  if (record.degraded !== true) {
-    return null;
-  }
-  const reasons = Array.isArray(record.reasons)
-    ? record.reasons.filter((reason): reason is string => typeof reason === "string")
-    : [];
-  const delayMaxMs =
-    typeof record.delayMaxMs === "number" && Number.isFinite(record.delayMaxMs)
-      ? Math.round(record.delayMaxMs)
-      : null;
-  const utilization =
-    typeof record.utilization === "number" && Number.isFinite(record.utilization)
-      ? record.utilization
-      : null;
-  const cpuCoreRatio =
-    typeof record.cpuCoreRatio === "number" && Number.isFinite(record.cpuCoreRatio)
-      ? record.cpuCoreRatio
-      : null;
-  return [
-    reasons.length ? `reasons=${reasons.join(",")}` : null,
-    delayMaxMs != null ? `eventLoopDelayMaxMs=${delayMaxMs}` : null,
-    utilization != null ? `eventLoopUtilization=${utilization}` : null,
-    cpuCoreRatio != null ? `cpuCoreRatio=${cpuCoreRatio}` : null,
-  ]
-    .filter((part): part is string => Boolean(part))
-    .join(" ");
-}
-
-/** Render gateway channel status payloads into terminal-friendly lines. */
-export function formatGatewayChannelsStatusLines(payload: Record<string, unknown>): string[] {
-  const lines: string[] = [];
-  lines.push(theme.success("Gateway reachable."));
-  const eventLoopLine = formatEventLoopBits(payload.eventLoop);
-  if (eventLoopLine) {
-    lines.push(theme.warn(`Gateway event loop degraded: ${eventLoopLine}`));
-  }
-  const channelLabels =
-    payload.channelLabels && typeof payload.channelLabels === "object"
-      ? (payload.channelLabels as Record<string, unknown>)
-      : {};
-  const accountLines = (provider: ChatChannel, accounts: Array<Record<string, unknown>>) =>
-    accounts.map((account) => {
-      const bits: string[] = [];
-      appendEnabledConfiguredLinkedBits(bits, account);
-      if (typeof account.running === "boolean") {
-        bits.push(account.running ? "running" : "stopped");
-      }
-      if (typeof account.connected === "boolean") {
-        bits.push(account.connected ? "connected" : "disconnected");
-      }
-      const inboundAt =
-        typeof account.lastInboundAt === "number" && Number.isFinite(account.lastInboundAt)
-          ? account.lastInboundAt
-          : null;
-      const outboundAt =
-        typeof account.lastOutboundAt === "number" && Number.isFinite(account.lastOutboundAt)
-          ? account.lastOutboundAt
-          : null;
-      const transportAt =
-        typeof account.lastTransportActivityAt === "number" &&
-        Number.isFinite(account.lastTransportActivityAt)
-          ? account.lastTransportActivityAt
-          : null;
-      if (inboundAt) {
-        bits.push(`in:${formatTimeAgo(Date.now() - inboundAt)}`);
-      }
-      if (outboundAt) {
-        bits.push(`out:${formatTimeAgo(Date.now() - outboundAt)}`);
-      }
-      if (transportAt) {
-        bits.push(`transport:${formatTimeAgo(Date.now() - transportAt)}`);
-      }
-      appendModeBit(bits, account);
-      const botUsername = (() => {
-        const bot = account.bot as { username?: string | null } | undefined;
-        const probeBot = (account.probe as { bot?: { username?: string | null } } | undefined)?.bot;
-        const raw = bot?.username ?? probeBot?.username ?? "";
-        if (typeof raw !== "string") {
-          return "";
-        }
-        const trimmed = raw.trim();
-        if (!trimmed) {
-          return "";
-        }
-        return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
-      })();
-      if (botUsername) {
-        bits.push(`bot:${botUsername}`);
-      }
-      if (typeof account.dmPolicy === "string" && account.dmPolicy.length > 0) {
-        bits.push(`dm:${account.dmPolicy}`);
-      }
-      if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
-        const allowFrom = account.allowFrom
-          .slice(0, 2)
-          .map((entry) => formatPhoneNumberForCli(String(entry)));
-        bits.push(`allow:${allowFrom.join(",")}`);
-      }
-      appendTokenSourceBits(bits, account);
-      const application = account.application as
-        | { intents?: { messageContent?: string } }
-        | undefined;
-      const messageContent = application?.intents?.messageContent;
-      if (
-        typeof messageContent === "string" &&
-        messageContent.length > 0 &&
-        messageContent !== "enabled"
-      ) {
-        bits.push(`intents:content=${messageContent}`);
-      }
-      if (account.allowUnmentionedGroups === true) {
-        bits.push("groups:unmentioned");
-      }
-      if (typeof account.healthState === "string" && account.healthState) {
-        bits.push(`health:${account.healthState}`);
-      }
-      appendBaseUrlBit(bits, account);
-      const probe = account.probe as { ok?: boolean } | undefined;
-      if (probe && typeof probe.ok === "boolean") {
-        bits.push(probe.ok ? "works" : "probe failed");
-      }
-      const audit = account.audit as { ok?: boolean } | undefined;
-      if (audit && typeof audit.ok === "boolean") {
-        bits.push(audit.ok ? "audit ok" : "audit failed");
-      }
-      const rawChannelLabel = channelLabels[provider];
-      return buildChannelAccountLine(provider, account, bits, {
-        channelLabel: typeof rawChannelLabel === "string" ? rawChannelLabel : provider,
-      });
-    });
-
-  const accountsByChannel = payload.channelAccounts as Record<string, unknown> | undefined;
-  const accountPayloads: Partial<Record<string, Array<Record<string, unknown>>>> = {};
-  for (const channelId of Object.keys(accountsByChannel ?? {}).toSorted()) {
-    const raw = accountsByChannel?.[channelId];
-    if (Array.isArray(raw)) {
-      accountPayloads[channelId] = raw as Array<Record<string, unknown>>;
-    }
-  }
-
-  for (const channelId of Object.keys(accountPayloads).toSorted()) {
-    const accounts = accountPayloads[channelId];
-    if (accounts && accounts.length > 0) {
-      lines.push(...accountLines(channelId, accounts));
-    }
-  }
-
-  lines.push("");
-  const issues = collectChannelStatusIssues(payload);
-  if (issues.length > 0) {
-    lines.push(theme.warn("Warnings:"));
-    for (const issue of issues) {
-      lines.push(
-        `- ${issue.channel} ${issue.accountId}: ${issue.message}${issue.fix ? ` (${issue.fix})` : ""}`,
-      );
-    }
-    lines.push(`- Run: ${formatCliCommand("openclaw doctor")}`);
-    lines.push("");
-  }
-  lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
-  );
-  return lines;
-}
-
 /** Query gateway channel status, falling back to config-only output when unavailable. */
 export async function channelsStatusCommand(
   opts: ChannelsStatusOptions,
@@ -224,9 +35,6 @@ export async function channelsStatusCommand(
   const timeoutMs = parseTimeoutMsWithFallback(opts.timeout, opts.probe ? 30_000 : 10_000, {
     invalidType: "error",
   });
-  const requestedChannel = opts.channel
-    ? (normalizeChannelId(opts.channel) ?? normalizeOptionalLowercaseString(opts.channel))
-    : null;
   const statusLabel = opts.probe ? "Checking channel status (probe)…" : "Checking channel status…";
   const shouldLogStatus = opts.json !== true && !process.stderr.isTTY;
   if (shouldLogStatus) {
@@ -258,58 +66,12 @@ export async function channelsStatusCommand(
       writeRuntimeJson(runtime, payload);
       return;
     }
+    const { formatGatewayChannelsStatusLines } = await loadChannelsStatusRuntime();
     runtime.log(formatGatewayChannelsStatusLines(payload).join("\n"));
   } catch (err) {
     const safeError = formatChannelsStatusError(err);
     const gatewayAuthUnavailable = isGatewaySecretRefUnavailableError(err);
-    const fallbackReason = gatewayAuthUnavailable
-      ? "Gateway auth unavailable; showing config-only status."
-      : "Gateway not reachable; showing config-only status.";
-    runtime.error(
-      `${gatewayAuthUnavailable ? "Gateway auth unavailable" : "Gateway not reachable"}: ${safeError}`,
-    );
-    const cfg = await requireValidConfigSnapshot(runtime);
-    if (!cfg) {
-      return;
-    }
-    const { resolvedConfig } = await resolveCommandConfigWithSecrets({
-      config: cfg,
-      commandName: "channels status",
-      targetIds: getConfiguredChannelsCommandSecretTargetIds(cfg),
-      mode: "read_only_status",
-      runtime,
-    });
-    const snapshot = await readConfigFileSnapshot();
-    const mode = cfg.gateway?.mode === "remote" ? "remote" : "local";
-    if (opts.json) {
-      writeRuntimeJson(runtime, {
-        gatewayReachable: false,
-        error: safeError,
-        gatewayAuthUnavailable,
-        configOnly: true,
-        config: {
-          path: snapshot.path,
-          mode,
-        },
-        configuredChannels: listConfiguredAnnounceChannelIdsForConfig({
-          config: resolvedConfig,
-          activationSourceConfig: cfg,
-          env: process.env,
-        }).filter((channelId) => !requestedChannel || channelId === requestedChannel),
-      });
-      return;
-    }
-    runtime.log(
-      (
-        await formatConfigChannelsStatusLines(
-          resolvedConfig,
-          {
-            path: snapshot.path,
-            mode,
-          },
-          { sourceConfig: cfg, channel: opts.channel, fallbackReason },
-        )
-      ).join("\n"),
-    );
+    const { renderChannelsStatusFallback } = await loadChannelsStatusRuntime();
+    await renderChannelsStatusFallback({ opts, runtime, safeError, gatewayAuthUnavailable });
   }
 }

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -12,7 +12,7 @@ import type {
   ChannelId,
   ChannelPlugin,
 } from "../channels/plugins/types.public.js";
-import { formatGatewayChannelsStatusLines } from "../commands/channels/status.js";
+import { formatGatewayChannelsStatusLines } from "../commands/channels/status.runtime.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import {
   createSubsystemLogger,


### PR DESCRIPTION
## What Problem This Solves

Every gateway-backed `openclaw agent` turn paid a large fixed startup tax before the request ever reached the Gateway. On a production host (Hetzner, 48 cores, Node 26.5, ~150 installed plugins, idle) an ordinary turn took **13.0 s wall** while the Gateway-measured turn itself (`meta.durationMs`) was only **3.3–4.9 s**. Roughly 9 s was pure client-side startup for a command whose work happens in another process.

Genuinely cold CLI commands on the same host show what the baseline should be:

| Command | Wall |
| --- | --- |
| `openclaw --version` | 36 ms |
| `openclaw automations list --json` | 1392 ms |
| `openclaw gateway status --json` | 1589 ms |
| `openclaw gateway call health` | 1811 ms |
| `openclaw agent … --json` | **13045 ms** |
| `openclaw channels status --json` (no probe) | **9968 ms** |

A CPU profile of one `agent` run (13.6 s sampled) showed ~5 s of module transform/compile plus filesystem walking: `jiti` 2540 ms, `package_json_reader.get` 913 ms, `compileSourceTextModule` 531 ms, `node:vm Script` 496 ms, `lstat` 683 ms, GC 693 ms, alongside a legitimate 3451 ms idle wait for the Gateway's answer.

This is not the jiti transform cache underperforming. That cache (#117355) is populated and effective: `~/.cache/openclaw/jiti/<version>` holds 9221 files and a repeat `plugins list` adds **zero** new files, yet three consecutive runs still take 9.6 / 9.9 / 9.8 s with no warming. The remaining cost is reading, compiling, and executing plugin modules in every short-lived CLI process. Caching transforms cannot remove that; not importing them can.

This is a default-path cost: every scripted turn, cron-invoked turn, and operator `openclaw agent` call pays it.

## Why This Change Was Made

The eager work came from the global pre-action hook, not from anything the turn needs:

`src/cli/program/preaction.ts` → `command-execution-startup.ts` → `command-bootstrap.ts` → `config-guard.ts` → `doctor-config-preflight.ts` → `doctor-state-migrations.ts` → `state-migrations.doctor.ts`

`config-guard.ts` classified **every** `agent` invocation as migration-sensitive. The doctor migration module then eagerly imported bundled channel registries and plugin doctor contracts; the contract registry scanned installed manifests and loaded their modules through the jiti-backed loader.

Two edges compounded it: text-mode agent calls selected full plugin activation, and `agent-via-gateway.ts` unconditionally loaded the session resolver, whose re-export chain reached SQLite session maintenance and the bundled channel runtime.

For a remote turn the Gateway — not the CLI — owns config migration, plugin resolution, and session-key derivation. The already-cold commands prove the intended shape: `gateway call` explicitly skips state migration, and `automations` bypasses local Gateway config bootstrap.

The fix follows the existing catalog-policy convention rather than adding a new mechanism. `bypassConfigGuard` becomes invocation-aware (the same predicate form `loadPlugins` and `networkProxy` already use), so remote turns skip config migration and plugin activation while `--local` retains both. The session resolver moves behind a real `*.runtime.ts` lazy boundary; ordinary `--agent` turns omit `sessionKey` because the Gateway already derives it from `agentId`. Explicit session IDs, recipients, and non-agent session keys still load it. The same owner fix covers successful JSON `channels status`, which returns the Gateway payload before loading local rendering; text formatting and the unreachable-Gateway fallback stay behind the runtime boundary.

`plugins list` is intentionally unchanged: it is a local plugin-inventory command, not an RPC-only client.

## User Impact

Gateway-backed `openclaw agent` turns and successful `openclaw channels status --json` requests no longer pay local config-migration and plugin-runtime startup. Local cold repro (isolated state dir, unreachable loopback Gateway): **5.38 s → 0.52 s**. That machine does not have the production fleet's ~150 plugins, so the production win should be larger.

No behavior change to `--local` runs, `--deliver`, reply channel/account routing, best-effort delivery, the JSON envelope, or text rendering. Delivery fields are untouched.

## Evidence

- Focused CLI suites: 6 files, 88/88 passed.
- Agent Gateway suites: 77 passed, 1 pre-existing skip.
- Channel command tests: 37/37. Gateway channel tests: 81/81.
- New cold-import guards assert **zero** config/plugin/session runtime module evaluations on an ordinary Gateway-backed turn, and on both probe and non-probe JSON `channels status` success paths. These are the scale-independent proof; they fail if the eager import returns.
- `pnpm build` passed including `check-cli-bootstrap-imports`, with zero `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings.
- `git diff --check` and targeted `oxfmt` clean.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings, "patch is correct" (0.87).

Known proof gap: the broad `node scripts/run-vitest.mjs src/cli` directory composition did not finish cleanly on the authoring host — an unconstrained run produced unrelated cross-file failures and hung. The first reported failures pass independently at 195/195 and 181/181, indicating order-dependent shared suite-state contamination rather than a changed-path failure. Remote confirmation was unavailable (Blacksmith Testbox binary missing; AWS Crabbox broker login unavailable), so CI is the arbiter for the full composition.

Production delta `+293/-265`, net **+28 lines**; most churn is a 249-line channels formatter moving behind its runtime boundary. Tests `+146/-17`.
