### PR TITLE
fix(cli): exclude settled cancellations from TaskFlow pressure

### DIFF
--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -184,6 +184,27 @@ describe("flows commands", () => {
     });
   });
 
+  it("counts pending cancellation intent in TaskFlow pressure", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command",
+        goal: "Cancel pending work",
+        status: "running",
+        cancelRequestedAt: 200,
+        createdAt: 100,
+        updatedAt: 200,
+      });
+
+      const runtime = createRuntime();
+      await flowsListCommand({}, runtime);
+
+      expect(vi.mocked(runtime.log).mock.calls.map(([line]) => String(line))).toContain(
+        "TaskFlow pressure: 1 active · 0 blocked · 1 cancel-requested · 1 total",
+      );
+    });
+  });
+
   it("keeps truncated text rows UTF-16 well-formed", async () => {
     await withTaskFlowCommandStateDir(async () => {
       createManagedTaskFlow({
@@ -605,6 +626,24 @@ describe("flows commands", () => {
       expect(vi.mocked(runtime.log).mock.calls.map(([line]) => String(line))).toEqual([
         `Cancelled ${flow.flowId} (managed) with status cancelled.`,
       ]);
+
+      const listRuntime = createRuntime();
+      await flowsListCommand({}, listRuntime);
+      expect(vi.mocked(listRuntime.log).mock.calls.map(([line]) => String(line))).toContain(
+        "TaskFlow pressure: 0 active · 0 blocked · 0 cancel-requested · 1 total",
+      );
+
+      const jsonRuntime = createRuntime();
+      await flowsListCommand({ json: true }, jsonRuntime);
+      expect(vi.mocked(jsonRuntime.writeJson).mock.calls[0]?.[0]).toMatchObject({
+        flows: [
+          expect.objectContaining({
+            flowId: flow.flowId,
+            status: "cancelled",
+            cancelRequestedAt: expect.any(Number),
+          }),
+        ],
+      });
     });
   });
 });

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -17,6 +17,7 @@ import {
   listTaskFlowRecords,
   resolveTaskFlowForLookupToken,
 } from "../tasks/task-flow-runtime-internal.js";
+import { isTerminalFlowStatus } from "../tasks/task-registry-common.js";
 import { formatTaskStatusDetail } from "../tasks/task-status.js";
 
 const ID_PAD = 10;
@@ -109,7 +110,9 @@ function formatFlowListSummary(flows: TaskFlowRecord[]) {
     (flow) => flow.status === "queued" || flow.status === "running",
   ).length;
   const blocked = flows.filter((flow) => flow.status === "blocked").length;
-  const cancelRequested = flows.filter((flow) => flow.cancelRequestedAt != null).length;
+  const cancelRequested = flows.filter(
+    (flow) => flow.cancelRequestedAt != null && !isTerminalFlowStatus(flow.status),
+  ).length;
   return `${active} active · ${blocked} blocked · ${cancelRequested} cancel-requested · ${flows.length} total`;
 }
 


### PR DESCRIPTION
Closes #117713

## What Problem This Solves

Fixes an issue where operators listing TaskFlows after a completed cancellation would still see that flow counted as cancel-requested pressure, even though it was already terminal.

## Why This Change Was Made

The cancellation timestamp is intentionally durable historical evidence, so the summary now combines that fact with the canonical terminal-status predicate instead of clearing history or inventing a second state path. JSON records remain unchanged.

## User Impact

TaskFlow pressure now reflects only outstanding cancellation intent. Completed cancelled flows remain visible in history with their original cancellation timestamp, but no longer inflate the pending cancellation count.

## Evidence

Before: a settled cancelled flow printed 0 active, 0 blocked, 1 cancel-requested, 1 total.

After: the same cancel then list order prints 0 active, 0 blocked, 0 cancel-requested, 1 total, while JSON still reports status cancelled and the durable cancellation timestamp.

Blacksmith Testbox run 30724837629 passed the complete 16-test flow command suite and the full changed gate on the rebased patch. An earlier hosted run 30724784625 correctly caught a formatting error; the repository formatter fixed it before the green rerun.

Fresh post-format autoreview 019fbfd8-2b97-7b01-ab0d-dad5db9a3831 and TruffleHog were clean at 0.99. Independent source/history review found no remaining issue. Production delta is 4 additions and 1 deletion; tests add 39 lines. No config, protocol, persistence shape, or public flag changes.

This PR is AI-assisted. The implementation and proof were reviewed by the maintainer orchestrator; no agent transcript is attached.