### PR TITLE
fix(media): clean CLI scratch after setup failure

### DIFF
--- a/src/media-understanding/runner.cli-audio.test.ts
+++ b/src/media-understanding/runner.cli-audio.test.ts
@@ -8,13 +8,22 @@ import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { CLI_OUTPUT_MAX_BUFFER } from "./defaults.constants.js";
 import { createMediaAttachmentCache, normalizeMediaAttachments } from "./runner.attachments.js";
-import { createSafeAudioFixtureBuffer, withAudioFixture } from "./runner.test-utils.js";
+import {
+  createSafeAudioFixtureBuffer,
+  withAudioFixture,
+  withMediaFixture,
+} from "./runner.test-utils.js";
 import type { MediaAttachment } from "./types.js";
 
 const runExecMock = vi.hoisted(() => vi.fn());
+const runFfmpegMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../process/exec.js", () => ({
   runExec: (...args: unknown[]) => runExecMock(...args),
+}));
+
+vi.mock("../media/media-services.js", () => ({
+  runFfmpeg: (...args: unknown[]) => runFfmpegMock(...args),
 }));
 
 let runCliEntry: typeof import("./runner.entries.js").runCliEntry;
@@ -120,6 +129,7 @@ describe("media-understanding CLI audio entry", () => {
 
   beforeEach(() => {
     runExecMock.mockReset().mockResolvedValue({ stdout: "cli transcript" });
+    runFfmpegMock.mockReset();
   });
 
   afterEach(() => {
@@ -272,6 +282,47 @@ describe("media-understanding CLI audio entry", () => {
     const result = await runAudioEntry(testCase);
 
     expect(result?.text).toBe("file transcript");
+  });
+
+  it("removes the CLI scratch directory when audio conversion fails", async () => {
+    let scratchDir = "";
+    runFfmpegMock.mockImplementationOnce(async (args: string[]) => {
+      const outputPath = args.at(-1);
+      if (!outputPath) {
+        throw new Error("expected ffmpeg output path");
+      }
+      scratchDir = path.dirname(outputPath);
+      throw new Error("ffmpeg conversion failed");
+    });
+
+    await withMediaFixture(
+      {
+        filePrefix: "openclaw-cli-whisper-conversion-failure",
+        extension: "mp3",
+        mediaType: "audio/mpeg",
+        fileContents: createSafeAudioFixtureBuffer(),
+      },
+      async ({ ctx, media, cache }) => {
+        await expect(
+          runCliEntry({
+            capability: "audio",
+            entry: {
+              type: "cli",
+              command: "whisper-cli",
+              args: ["-otxt", "-of", "{{OutputBase}}", "{{MediaPath}}"],
+            },
+            cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
+            ctx,
+            attachment: requireFirstAttachment(media),
+            cache,
+            config: {} as never,
+          }),
+        ).rejects.toThrow("ffmpeg conversion failed");
+      },
+    );
+
+    expect(scratchDir).not.toBe("");
+    await expect(fs.stat(scratchDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("records the backend observed during a whisper.cpp model run", async () => {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -1038,45 +1038,45 @@ export async function runCliEntry(params: {
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
   );
-  const mediaPath = await resolveCliMediaPath({
-    capability,
-    command,
-    mediaPath: pathResult.path,
-    outputDir,
-  });
-  const outputBase = path.join(outputDir, path.parse(mediaPath).name);
-
-  const templCtx: TemplateContext = {
-    ...ctx,
-    AttachmentPath: mediaPath,
-    AttachmentUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
-    AttachmentContentType: params.attachment.mime,
-    AttachmentDir: path.dirname(mediaPath),
-    AttachmentIndex: params.attachment.index,
-    MediaPath: mediaPath,
-    MediaUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
-    MediaType: params.attachment.mime,
-    MediaDir: path.dirname(mediaPath),
-    OutputDir: outputDir,
-    OutputBase: outputBase,
-    Prompt: requestOverrides.prompt ?? prompt,
-    ...(requestOverrides.language ? { Language: requestOverrides.language } : {}),
-    MaxChars: maxChars,
-  };
-  for (const key of [
-    "MediaPaths",
-    "MediaUrls",
-    "MediaTypes",
-    "MediaWorkspaceDir",
-    "MediaTranscribedIndexes",
-    "MediaStaged",
-  ]) {
-    delete (templCtx as unknown as Record<string, unknown>)[key];
-  }
-  const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
-  );
   try {
+    const mediaPath = await resolveCliMediaPath({
+      capability,
+      command,
+      mediaPath: pathResult.path,
+      outputDir,
+    });
+    const outputBase = path.join(outputDir, path.parse(mediaPath).name);
+
+    const templCtx: TemplateContext = {
+      ...ctx,
+      AttachmentPath: mediaPath,
+      AttachmentUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
+      AttachmentContentType: params.attachment.mime,
+      AttachmentDir: path.dirname(mediaPath),
+      AttachmentIndex: params.attachment.index,
+      MediaPath: mediaPath,
+      MediaUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
+      MediaType: params.attachment.mime,
+      MediaDir: path.dirname(mediaPath),
+      OutputDir: outputDir,
+      OutputBase: outputBase,
+      Prompt: requestOverrides.prompt ?? prompt,
+      ...(requestOverrides.language ? { Language: requestOverrides.language } : {}),
+      MaxChars: maxChars,
+    };
+    for (const key of [
+      "MediaPaths",
+      "MediaUrls",
+      "MediaTypes",
+      "MediaWorkspaceDir",
+      "MediaTranscribedIndexes",
+      "MediaStaged",
+    ]) {
+      delete (templCtx as unknown as Record<string, unknown>)[key];
+    }
+    const argv = [command, ...args].map((part, index) =>
+      index === 0 ? part : applyTemplate(part, templCtx),
+    );
     if (shouldLogVerbose()) {
       logVerbose(`Media understanding via CLI: ${argv.join(" ")}`);
     }


### PR DESCRIPTION
Closes #117715

## What Problem This Solves

Fixes an issue where a failed non-WAV conversion or other setup error in a CLI media-understanding attempt could leave an openclaw-media-cli scratch directory and staged attachment data behind.

## Why This Change Was Made

The attempt already owns one cleanup finally block. This change moves that existing owner to begin immediately after scratch allocation, before conversion, templating, command execution, and output parsing, rather than adding another cleanup path or masking the failure downstream.

## User Impact

Operators can retry or fall through to another media backend without accumulating abandoned scratch directories after setup failures. The original backend error remains visible, and successful CLI transcription behavior is unchanged.

## Evidence

A deterministic non-WAV whisper-cli regression injects FFmpeg failure after scratch allocation, captures the staged output directory, verifies the original conversion error is preserved, and proves the scratch directory is gone afterward.

Blacksmith Testbox focused run 30724536184 passed all 30 media CLI audio tests. Blacksmith Testbox changed-gate run 30724579547 completed green. Exact-head CI run 30725547536 completed green. Fresh autoreview was clean at 0.99, independent owner/history review found no findings, and git diff check passed.

Real built-runtime proof in Blacksmith Testbox run 30726464764 invoked the production CLI media entry with a non-WAV attachment and no mocked filesystem or converter. The real system setup error remained visible and the private scratch scan showed no allocation left behind:

{"conversionErrorVisible":true,"errorSummary":"ffmpeg not found in trusted system directories. Install it via your system package manager (e.g. apt install ffmpeg / dnf install ffmpeg).","scratchBefore":0,"scratchAfter":0,"newScratchDirs":[]}

Production is a pure ownership-boundary move: 38 additions and 38 deletions, net zero. Tests add 52 lines and remove 1. No config, protocol, provider API, fallback policy, or persistence changes.

This PR is AI-assisted. The implementation and proof were reviewed by the maintainer orchestrator; no agent transcript is attached.